### PR TITLE
chore(devex): pass contract DTOs through instead of unpacked fields

### DIFF
--- a/posthog/test/dataclass_frozen_baseline.txt
+++ b/posthog/test/dataclass_frozen_baseline.txt
@@ -225,7 +225,6 @@
 1 products/tasks/backend/temporal/task_management/activities/ensure_execute_sandbox_started.py
 1 products/tasks/backend/tests/agent_log_fixtures.py
 1 products/visual_review/backend/diff.py
-1 products/visual_review/backend/logic.py
 1 products/warehouse_sources/backend/models/ssh_tunnel.py
 1 products/warehouse_sources/backend/temporal/data_imports/cdc/workflows.py
 1 products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/memory_governor.py

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -2281,7 +2281,12 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             command_payload["id"] = request_id
 
         try:
-            agent_response = self._proxy_command_to_agent_server(connection, payload=command_payload)
+            agent_response = self._proxy_command_to_agent_server(
+                sandbox_url=connection.sandbox_url,
+                connection_token=connection.connection_token,
+                sandbox_connect_token=connection.sandbox_connect_token,
+                payload=command_payload,
+            )
 
             tasks_facade.capture_relay_command_telemetry(
                 pk, task_id, self.team_id, method=method, params=params, success=agent_response.ok
@@ -2367,27 +2372,25 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
 
     @staticmethod
     def _proxy_command_to_agent_server(
-        connection: tasks_contracts.TaskRunSandboxConnectionDTO,
+        sandbox_url: str,
+        connection_token: str | None,
+        sandbox_connect_token: str | None,
         payload: dict,
     ) -> http_requests.Response:
-        # The caller has already rejected runs without an active sandbox.
-        if not connection.sandbox_url:
-            raise ValueError("Cannot proxy a command without a sandbox URL")
-
         headers = {
             "Content-Type": "application/json",
-            "Authorization": f"Bearer {connection.connection_token}",
+            "Authorization": f"Bearer {connection_token}",
         }
 
-        command_url = f"{connection.sandbox_url.rstrip('/')}/command"
+        command_url = f"{sandbox_url.rstrip('/')}/command"
 
         # Modal connect tokens use Authorization: Bearer for tunnel auth,
         # which conflicts with the JWT auth the agent server expects.
         # Pass the Modal token as a query parameter instead so both
         # auth mechanisms can coexist.
         params = {}
-        if connection.sandbox_connect_token:
-            params["_modal_connect_token"] = connection.sandbox_connect_token
+        if sandbox_connect_token:
+            params["_modal_connect_token"] = sandbox_connect_token
 
         return http_requests.post(
             command_url,

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -2281,12 +2281,7 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             command_payload["id"] = request_id
 
         try:
-            agent_response = self._proxy_command_to_agent_server(
-                sandbox_url=connection.sandbox_url,
-                connection_token=connection.connection_token,
-                sandbox_connect_token=connection.sandbox_connect_token,
-                payload=command_payload,
-            )
+            agent_response = self._proxy_command_to_agent_server(connection, payload=command_payload)
 
             tasks_facade.capture_relay_command_telemetry(
                 pk, task_id, self.team_id, method=method, params=params, success=agent_response.ok
@@ -2372,25 +2367,27 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
 
     @staticmethod
     def _proxy_command_to_agent_server(
-        sandbox_url: str,
-        connection_token: str | None,
-        sandbox_connect_token: str | None,
+        connection: tasks_contracts.TaskRunSandboxConnectionDTO,
         payload: dict,
     ) -> http_requests.Response:
+        # The caller has already rejected runs without an active sandbox.
+        if not connection.sandbox_url:
+            raise ValueError("Cannot proxy a command without a sandbox URL")
+
         headers = {
             "Content-Type": "application/json",
-            "Authorization": f"Bearer {connection_token}",
+            "Authorization": f"Bearer {connection.connection_token}",
         }
 
-        command_url = f"{sandbox_url.rstrip('/')}/command"
+        command_url = f"{connection.sandbox_url.rstrip('/')}/command"
 
         # Modal connect tokens use Authorization: Bearer for tunnel auth,
         # which conflicts with the JWT auth the agent server expects.
         # Pass the Modal token as a query parameter instead so both
         # auth mechanisms can coexist.
         params = {}
-        if sandbox_connect_token:
-            params["_modal_connect_token"] = sandbox_connect_token
+        if connection.sandbox_connect_token:
+            params["_modal_connect_token"] = connection.sandbox_connect_token
 
         return http_requests.post(
             command_url,

--- a/products/visual_review/backend/facade/api.py
+++ b/products/visual_review/backend/facade/api.py
@@ -15,6 +15,7 @@ Do NOT:
 - Return ORM instances or QuerySets
 """
 
+from dataclasses import replace
 from uuid import UUID
 
 from django.contrib.auth import get_user_model
@@ -235,12 +236,7 @@ def create_repo(team_id: int, repo_external_id: int, repo_full_name: str) -> con
 
 
 def update_repo(input: contracts.UpdateRepoInput, team_id: int) -> contracts.Repo:
-    repo = logic.update_repo(
-        repo_id=input.repo_id,
-        team_id=team_id,
-        baseline_file_paths=input.baseline_file_paths,
-        enable_pr_comments=input.enable_pr_comments,
-    )
+    repo = logic.update_repo(input, team_id=team_id)
     return _to_repo(repo)
 
 
@@ -345,32 +341,9 @@ def get_review_state_counts(team_id: int, repo_id: UUID | None = None) -> dict[s
 
 
 def create_run(input: contracts.CreateRunInput, team_id: int) -> contracts.CreateRunResult:
-    snapshots = [
-        {
-            "identifier": s.identifier,
-            "content_hash": s.content_hash,
-            "width": s.width,
-            "height": s.height,
-            "metadata": dict(s.metadata) if s.metadata else {},
-        }
-        for s in input.snapshots
-    ]
-
-    run, uploads = logic.create_run(
-        repo_id=input.repo_id,
-        team_id=team_id,
-        run_type=input.run_type,
-        commit_sha=input.commit_sha,
-        branch=input.branch,
-        pr_number=input.pr_number,
-        snapshots=snapshots,
-        baseline_hashes=input.baseline_hashes,
-        unchanged_count=input.unchanged_count,
-        removed_identifiers=list(input.removed_identifiers),
-        purpose=input.purpose,
-        metadata=_sanitize_run_metadata(input.metadata),
-        is_partial=input.is_partial,
-    )
+    # Sanitize metadata at the facade boundary before handing the DTO to logic.
+    input = replace(input, metadata=_sanitize_run_metadata(input.metadata))
+    run, uploads = logic.create_run(input, team_id=team_id)
 
     upload_targets = [
         contracts.UploadTarget(

--- a/products/visual_review/backend/logic.py
+++ b/products/visual_review/backend/logic.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
 
     from posthog.models.integration import GitHubIntegration
 
+from posthog.dataclasses import frozen
 from posthog.egress.github.transport import GitHubRateLimitError
 from posthog.helpers.trigram_search import (
     TrigramSearchField,
@@ -46,6 +47,7 @@ from posthog.ph_client import ph_scoped_capture
 from .classifier import SnapshotClassifier
 from .db import READER_DB, WRITER_DB
 from .diff_metadata import DiffMetadata
+from .facade.contracts import CreateRunInput, UpdateRepoInput
 from .facade.enums import (
     ChangeKind,
     ReviewDecision,
@@ -157,17 +159,12 @@ def create_repo(team_id: int, repo_external_id: int, repo_full_name: str) -> Rep
     )
 
 
-def update_repo(
-    repo_id: UUID,
-    team_id: int,
-    baseline_file_paths: dict[str, str] | None = None,
-    enable_pr_comments: bool | None = None,
-) -> Repo:
-    repo = get_repo(repo_id, team_id)
-    if baseline_file_paths is not None:
-        repo.baseline_file_paths = baseline_file_paths
-    if enable_pr_comments is not None:
-        repo.enable_pr_comments = enable_pr_comments
+def update_repo(input: UpdateRepoInput, team_id: int) -> Repo:
+    repo = get_repo(input.repo_id, team_id)
+    if input.baseline_file_paths is not None:
+        repo.baseline_file_paths = input.baseline_file_paths
+    if input.enable_pr_comments is not None:
+        repo.enable_pr_comments = input.enable_pr_comments
     repo.save()
     return repo
 
@@ -710,63 +707,28 @@ def _tombstoned_identifiers(repo: Repo, run_type: str, branch: str, source_pr_nu
     )
 
 
-def create_run(
-    repo_id: UUID,
-    team_id: int,
-    run_type: str,
-    commit_sha: str,
-    branch: str,
-    pr_number: int | None,
-    snapshots: list[dict],
-    baseline_hashes: dict[str, str] | None = None,
-    unchanged_count: int = 0,
-    removed_identifiers: list[str] | None = None,
-    purpose: str = RunPurpose.REVIEW,
-    metadata: dict | None = None,
-    is_partial: bool = False,
-) -> tuple[Run, list[dict]]:
+def create_run(input: CreateRunInput, team_id: int) -> tuple[Run, list[dict]]:
     """
     Create a new run with its snapshots.
 
     Returns the run and list of upload targets for missing artifacts.
     Each upload target has: content_hash, url, fields
 
-    baseline_hashes, unchanged_count, removed_identifiers are deprecated —
-    the backend fetches baselines from GitHub and computes everything.
-    Params kept for backward compat with older CLI versions.
+    input.baseline_hashes, input.unchanged_count and input.removed_identifiers
+    are deprecated and ignored: the backend fetches baselines from GitHub and
+    computes everything. The fields are kept for backward compat with older
+    CLI versions.
 
-    is_partial tags the run as a subset; the classifier then leaves baseline
+    input.is_partial tags the run as a subset; the classifier then leaves baseline
     identifiers we didn't touch alone instead of marking them as removed.
     """
-    repo = get_repo(repo_id, team_id)
+    repo = get_repo(input.repo_id, team_id)
 
-    return _create_run_inner(
-        repo,
-        team_id,
-        run_type,
-        commit_sha,
-        branch,
-        pr_number,
-        snapshots,
-        purpose,
-        metadata,
-        is_partial,
-    )
+    return _create_run_inner(repo, team_id, input)
 
 
 @transaction.atomic(using=WRITER_DB)
-def _create_run_inner(
-    repo,
-    team_id,
-    run_type,
-    commit_sha,
-    branch,
-    pr_number,
-    snapshots,
-    purpose,
-    metadata,
-    is_partial: bool = False,
-) -> tuple[Run, list[dict]]:
+def _create_run_inner(repo: Repo, team_id: int, input: CreateRunInput) -> tuple[Run, list[dict]]:
     # Supersede ALL old runs before inserting the new one. The unique
     # partial index on (repo, branch, run_type) WHERE superseded_by IS NULL
     # requires the slot to be free before the insert. A new CI push always
@@ -774,8 +736,8 @@ def _create_run_inner(
     # their respective UI filters via REVIEW_STATE_FILTERS.
     supersede_filter = Run.objects.using(WRITER_DB).filter(
         repo_id=repo.id,
-        branch=branch,
-        run_type=run_type,
+        branch=input.branch,
+        run_type=input.run_type,
         superseded_by__isnull=True,
     )
     # Collect IDs before mutating, then self-reference to clear the slot
@@ -788,20 +750,30 @@ def _create_run_inner(
     run = Run.objects.create(
         repo=repo,
         team_id=repo.team_id,
-        run_type=run_type,
-        commit_sha=commit_sha,
-        branch=branch,
-        pr_number=pr_number,
-        purpose=purpose,
-        total_snapshots=len(snapshots),
-        metadata=metadata or {},
-        is_partial=is_partial,
+        run_type=input.run_type,
+        commit_sha=input.commit_sha,
+        branch=input.branch,
+        pr_number=input.pr_number,
+        purpose=input.purpose,
+        total_snapshots=len(input.snapshots),
+        metadata=input.metadata or {},
+        is_partial=input.is_partial,
     )
 
     # Fix up the sentinel pointers to reference the actual new run
     if superseded_ids:
         Run.objects.using(WRITER_DB).filter(id__in=superseded_ids, team_id=team_id).update(superseded_by=run)
 
+    snapshots = [
+        {
+            "identifier": s.identifier,
+            "content_hash": s.content_hash,
+            "width": s.width,
+            "height": s.height,
+            "metadata": dict(s.metadata) if s.metadata else {},
+        }
+        for s in input.snapshots
+    ]
     _added, uploads = _register_snapshots(run, repo, snapshots)
     _update_run_counts(run, using=WRITER_DB)
 
@@ -2841,7 +2813,7 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
     )
 
 
-@dataclass
+@frozen
 class _BaselineOverviewRaw:
     """Internal raw shape — the facade layer reshapes this into the public DTOs.
 

--- a/products/visual_review/backend/tests/test_gating.py
+++ b/products/visual_review/backend/tests/test_gating.py
@@ -22,7 +22,7 @@ from parameterized import parameterized
 
 from products.visual_review.backend import logic
 from products.visual_review.backend.facade import api
-from products.visual_review.backend.facade.contracts import CreateRunInput
+from products.visual_review.backend.facade.contracts import CreateRunInput, SnapshotManifestItem
 from products.visual_review.backend.facade.enums import ReviewState, RunStatus, RunType, SnapshotResult
 from products.visual_review.backend.models import QuarantinedIdentifier, Run
 from products.visual_review.backend.tests.conftest import PRODUCT_DATABASES
@@ -66,18 +66,18 @@ class TestGatingInvariants:
         mocker.patch("products.visual_review.backend.tasks.tasks.process_run_diffs.delay")
 
     def _build_run(self, result: str, action: str | None, purpose: str = "review") -> Run:
-        snapshots: list[dict] = []
+        snapshots: list[SnapshotManifestItem] = []
         baseline: dict[str, str] = {}
 
         if result == "changed":
-            snapshots = [{"identifier": "target", "content_hash": "current_hash"}]
+            snapshots = [SnapshotManifestItem(identifier="target", content_hash="current_hash")]
             baseline = {"target": "baseline_hash"}
         elif result == "new":
-            snapshots = [{"identifier": "target", "content_hash": "current_hash"}]
+            snapshots = [SnapshotManifestItem(identifier="target", content_hash="current_hash")]
         elif result == "removed":
             baseline = {"target": "baseline_hash"}
         elif result == "unchanged":
-            snapshots = [{"identifier": "target", "content_hash": "same_hash"}]
+            snapshots = [SnapshotManifestItem(identifier="target", content_hash="same_hash")]
             baseline = {"target": "same_hash"}
 
         self.mocker.patch(

--- a/products/visual_review/backend/tests/test_gating.py
+++ b/products/visual_review/backend/tests/test_gating.py
@@ -22,6 +22,7 @@ from parameterized import parameterized
 
 from products.visual_review.backend import logic
 from products.visual_review.backend.facade import api
+from products.visual_review.backend.facade.contracts import CreateRunInput
 from products.visual_review.backend.facade.enums import ReviewState, RunStatus, RunType, SnapshotResult
 from products.visual_review.backend.models import QuarantinedIdentifier, Run
 from products.visual_review.backend.tests.conftest import PRODUCT_DATABASES
@@ -85,14 +86,16 @@ class TestGatingInvariants:
         )
 
         run, _ = logic.create_run(
-            repo_id=self.repo.id,
+            CreateRunInput(
+                repo_id=self.repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc123",
+                branch="feat/test",
+                pr_number=1,
+                snapshots=snapshots,
+                purpose=purpose,
+            ),
             team_id=self.team.id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="abc123",
-            branch="feat/test",
-            pr_number=1,
-            snapshots=snapshots,
-            purpose=purpose,
         )
         logic.complete_run(run.id)
         run.refresh_from_db()

--- a/products/visual_review/backend/tests/test_logic.py
+++ b/products/visual_review/backend/tests/test_logic.py
@@ -12,7 +12,7 @@ from parameterized import parameterized
 
 from products.visual_review.backend import logic
 from products.visual_review.backend.db import WRITER_DB
-from products.visual_review.backend.facade.contracts import CreateRunInput
+from products.visual_review.backend.facade.contracts import CreateRunInput, SnapshotManifestItem
 from products.visual_review.backend.facade.enums import ReviewDecision, ReviewState, RunStatus, RunType, SnapshotResult
 from products.visual_review.backend.models import Repo, Run, RunSnapshot
 from products.visual_review.backend.tests.conftest import PRODUCT_DATABASES
@@ -139,8 +139,8 @@ class TestRunOperations:
                 branch="main",
                 pr_number=42,
                 snapshots=[
-                    {"identifier": "Button-primary", "content_hash": "hash1"},
-                    {"identifier": "Button-secondary", "content_hash": "hash2"},
+                    SnapshotManifestItem(identifier="Button-primary", content_hash="hash1"),
+                    SnapshotManifestItem(identifier="Button-secondary", content_hash="hash2"),
                 ],
                 baseline_hashes={},
             ),
@@ -169,8 +169,8 @@ class TestRunOperations:
                 branch="feat",
                 pr_number=None,
                 snapshots=[
-                    {"identifier": "snap1", "content_hash": "existing"},
-                    {"identifier": "snap2", "content_hash": "new"},
+                    SnapshotManifestItem(identifier="snap1", content_hash="existing"),
+                    SnapshotManifestItem(identifier="snap2", content_hash="new"),
                 ],
                 baseline_hashes={},
             ),
@@ -193,7 +193,7 @@ class TestRunOperations:
                 commit_sha="abc",
                 branch="main",
                 pr_number=None,
-                snapshots=[{"identifier": "Button", "content_hash": "new_hash"}],
+                snapshots=[SnapshotManifestItem(identifier="Button", content_hash="new_hash")],
                 baseline_hashes={"Button": "baseline_hash"},
             ),
             team_id=repo.team_id,
@@ -225,9 +225,9 @@ class TestRunOperations:
                 branch="main",
                 pr_number=None,
                 snapshots=[
-                    {"identifier": "unchanged", "content_hash": "same_hash"},
-                    {"identifier": "new", "content_hash": "brand_new"},
-                    {"identifier": "changed", "content_hash": "different"},
+                    SnapshotManifestItem(identifier="unchanged", content_hash="same_hash"),
+                    SnapshotManifestItem(identifier="new", content_hash="brand_new"),
+                    SnapshotManifestItem(identifier="changed", content_hash="different"),
                 ],
                 baseline_hashes={
                     "unchanged": "same_hash",
@@ -358,7 +358,7 @@ class TestRunOperations:
                 commit_sha="abc",
                 branch="main",
                 pr_number=None,
-                snapshots=[{"identifier": "kept", "content_hash": "h1"}],
+                snapshots=[SnapshotManifestItem(identifier="kept", content_hash="h1")],
             ),
             team_id=repo.team_id,
         )
@@ -383,7 +383,7 @@ class TestRunOperations:
                 commit_sha="abc",
                 branch="feature-x",
                 pr_number=7,
-                snapshots=[{"identifier": "kept", "content_hash": "h1"}],
+                snapshots=[SnapshotManifestItem(identifier="kept", content_hash="h1")],
                 is_partial=True,
             ),
             team_id=repo.team_id,
@@ -408,7 +408,7 @@ class TestRunOperations:
                 commit_sha="abc",
                 branch="master",
                 pr_number=None,
-                snapshots=[{"identifier": "kept", "content_hash": "h1"}],
+                snapshots=[SnapshotManifestItem(identifier="kept", content_hash="h1")],
                 is_partial=True,
             ),
             team_id=repo.team_id,
@@ -439,7 +439,7 @@ class TestRunOperations:
                 commit_sha="deadbeef123",
                 branch="master",
                 pr_number=None,
-                snapshots=[{"identifier": "A", "content_hash": "h1"}],
+                snapshots=[SnapshotManifestItem(identifier="A", content_hash="h1")],
             ),
             team_id=repo.team_id,
         )
@@ -476,7 +476,7 @@ class TestRunOperations:
                 commit_sha="abc",
                 branch="main",
                 pr_number=None,
-                snapshots=[{"identifier": "btn", "content_hash": "h1"}],
+                snapshots=[SnapshotManifestItem(identifier="btn", content_hash="h1")],
                 purpose="observe",
             ),
             team_id=repo.team_id,
@@ -537,8 +537,8 @@ class TestRunOperations:
                 branch="main",
                 pr_number=None,
                 snapshots=[
-                    {"identifier": "changed1", "content_hash": "h1"},
-                    {"identifier": "new1", "content_hash": "h2"},
+                    SnapshotManifestItem(identifier="changed1", content_hash="h1"),
+                    SnapshotManifestItem(identifier="new1", content_hash="h2"),
                 ],
                 baseline_hashes={"changed1": "old"},
             ),
@@ -636,7 +636,7 @@ class TestApproveRun:
                 commit_sha="abc",
                 branch="main",
                 pr_number=None,
-                snapshots=[{"identifier": "Button", "content_hash": "new_hash"}],
+                snapshots=[SnapshotManifestItem(identifier="Button", content_hash="new_hash")],
                 baseline_hashes={"Button": "old_hash"},
             ),
             team_id=repo.team_id,
@@ -676,7 +676,10 @@ class TestApproveRun:
                 commit_sha="abc",
                 branch="main",
                 pr_number=None,
-                snapshots=[{"identifier": "A", "content_hash": "ha"}, {"identifier": "B", "content_hash": "hb"}],
+                snapshots=[
+                    SnapshotManifestItem(identifier="A", content_hash="ha"),
+                    SnapshotManifestItem(identifier="B", content_hash="hb"),
+                ],
                 baseline_hashes={"A": "olda", "B": "oldb"},
             ),
             team_id=repo.team_id,
@@ -767,7 +770,7 @@ class TestApproveSnapshots:
                 commit_sha="abc",
                 branch="main",
                 pr_number=None,
-                snapshots=[{"identifier": "Button", "content_hash": "new_hash"}],
+                snapshots=[SnapshotManifestItem(identifier="Button", content_hash="new_hash")],
                 baseline_hashes={"Button": "old_hash"},
             ),
             team_id=repo.team_id,
@@ -813,7 +816,7 @@ class TestToleratedHashes:
                 commit_sha="abc",
                 branch="main",
                 pr_number=None,
-                snapshots=[{"identifier": identifier, "content_hash": current_hash}],
+                snapshots=[SnapshotManifestItem(identifier=identifier, content_hash=current_hash)],
                 baseline_hashes={identifier: baseline_hash},
             ),
             team_id=repo.team_id,
@@ -851,7 +854,7 @@ class TestToleratedHashes:
                 commit_sha="abc",
                 branch="main",
                 pr_number=None,
-                snapshots=[{"identifier": "Button", "content_hash": "same"}],
+                snapshots=[SnapshotManifestItem(identifier="Button", content_hash="same")],
                 baseline_hashes={"Button": "same"},
             ),
             team_id=repo.team_id,
@@ -959,9 +962,9 @@ class TestGetRunSnapshots:
                 branch="main",
                 pr_number=None,
                 snapshots=[
-                    {"identifier": "A-component", "content_hash": "h1"},
-                    {"identifier": "B-component", "content_hash": "h2"},
-                    {"identifier": "C-component", "content_hash": "h3"},
+                    SnapshotManifestItem(identifier="A-component", content_hash="h1"),
+                    SnapshotManifestItem(identifier="B-component", content_hash="h2"),
+                    SnapshotManifestItem(identifier="C-component", content_hash="h3"),
                 ],
                 baseline_hashes={},
             ),
@@ -996,7 +999,7 @@ class TestCommitStatusChecks:
                 commit_sha="abc123",
                 branch="main",
                 pr_number=1,
-                snapshots=[{"identifier": "snap", "content_hash": "h1"}],
+                snapshots=[SnapshotManifestItem(identifier="snap", content_hash="h1")],
                 baseline_hashes={},
             ),
             team_id=github_repo.team_id,
@@ -1016,7 +1019,7 @@ class TestCommitStatusChecks:
                 commit_sha="abc123",
                 branch="main",
                 pr_number=1,
-                snapshots=[{"identifier": "snap", "content_hash": "same"}],
+                snapshots=[SnapshotManifestItem(identifier="snap", content_hash="same")],
                 baseline_hashes={"snap": "same"},
             ),
             team_id=github_repo.team_id,
@@ -1042,7 +1045,7 @@ class TestCommitStatusChecks:
                 commit_sha="abc123",
                 branch="feature-x",
                 pr_number=7,
-                snapshots=[{"identifier": "snap", "content_hash": "same"}],
+                snapshots=[SnapshotManifestItem(identifier="snap", content_hash="same")],
                 baseline_hashes={"snap": "same"},
                 is_partial=True,
             ),
@@ -1079,8 +1082,8 @@ class TestCommitStatusChecks:
                 branch="main",
                 pr_number=1,
                 snapshots=[
-                    {"identifier": "changed", "content_hash": "new_h"},
-                    {"identifier": "added", "content_hash": "brand_new"},
+                    SnapshotManifestItem(identifier="changed", content_hash="new_h"),
+                    SnapshotManifestItem(identifier="added", content_hash="brand_new"),
                 ],
                 baseline_hashes={"changed": "old_h"},
             ),
@@ -1120,7 +1123,7 @@ class TestCommitStatusChecks:
                 commit_sha="abc111",
                 branch="main",
                 pr_number=1,
-                snapshots=[{"identifier": "changed", "content_hash": "new_h"}],
+                snapshots=[SnapshotManifestItem(identifier="changed", content_hash="new_h")],
                 baseline_hashes={"changed": "old_h"},
             ),
             team_id=github_repo.team_id,
@@ -1134,7 +1137,7 @@ class TestCommitStatusChecks:
                 commit_sha="abc222",
                 branch="main",
                 pr_number=1,
-                snapshots=[{"identifier": "changed", "content_hash": "newer_h"}],
+                snapshots=[SnapshotManifestItem(identifier="changed", content_hash="newer_h")],
                 baseline_hashes={"changed": "old_h"},
             ),
             team_id=github_repo.team_id,
@@ -1158,7 +1161,7 @@ class TestCommitStatusChecks:
                 commit_sha="abc123",
                 branch="main",
                 pr_number=1,
-                snapshots=[{"identifier": "changed", "content_hash": "new_h"}],
+                snapshots=[SnapshotManifestItem(identifier="changed", content_hash="new_h")],
                 baseline_hashes={"changed": "old_h"},
             ),
             team_id=github_repo.team_id,
@@ -1172,10 +1175,28 @@ class TestCommitStatusChecks:
     @pytest.mark.parametrize(
         "enable_pr_comments, pr_number, snapshots, baseline_hashes, purpose",
         [
-            (False, 1, [{"identifier": "changed", "content_hash": "new_h"}], {"changed": "old_h"}, "review"),
-            (True, None, [{"identifier": "changed", "content_hash": "new_h"}], {"changed": "old_h"}, "review"),
-            (True, 1, [{"identifier": "snap", "content_hash": "same"}], {"snap": "same"}, "review"),
-            (True, 1, [{"identifier": "changed", "content_hash": "new_h"}], {"changed": "old_h"}, "observe"),
+            (
+                False,
+                1,
+                [SnapshotManifestItem(identifier="changed", content_hash="new_h")],
+                {"changed": "old_h"},
+                "review",
+            ),
+            (
+                True,
+                None,
+                [SnapshotManifestItem(identifier="changed", content_hash="new_h")],
+                {"changed": "old_h"},
+                "review",
+            ),
+            (True, 1, [SnapshotManifestItem(identifier="snap", content_hash="same")], {"snap": "same"}, "review"),
+            (
+                True,
+                1,
+                [SnapshotManifestItem(identifier="changed", content_hash="new_h")],
+                {"changed": "old_h"},
+                "observe",
+            ),
         ],
         ids=["toggle_off", "no_pr", "no_changes", "observe_purpose"],
     )
@@ -1245,8 +1266,8 @@ class TestCommitStatusChecks:
                 branch="master",
                 pr_number=None,
                 snapshots=[
-                    {"identifier": "changed", "content_hash": "new_h"},
-                    {"identifier": "added", "content_hash": "brand_new"},
+                    SnapshotManifestItem(identifier="changed", content_hash="new_h"),
+                    SnapshotManifestItem(identifier="added", content_hash="brand_new"),
                 ],
                 baseline_hashes={"changed": "old_h"},
                 purpose="observe",
@@ -1280,7 +1301,7 @@ class TestCommitStatusChecks:
                 commit_sha="abc123",
                 branch="master",
                 pr_number=None,
-                snapshots=[{"identifier": "snap", "content_hash": "same"}],
+                snapshots=[SnapshotManifestItem(identifier="snap", content_hash="same")],
                 baseline_hashes={"snap": "same"},
                 purpose="observe",
             ),
@@ -1307,7 +1328,7 @@ class TestCommitStatusChecks:
                 commit_sha="abc123",
                 branch="main",
                 pr_number=None,
-                snapshots=[{"identifier": "snap", "content_hash": "new_h"}],
+                snapshots=[SnapshotManifestItem(identifier="snap", content_hash="new_h")],
                 baseline_hashes={"snap": "old_h"},
             ),
             team_id=github_repo.team_id,
@@ -1331,7 +1352,7 @@ class TestCommitStatusChecks:
                 commit_sha="abc123",
                 branch="main",
                 pr_number=None,
-                snapshots=[{"identifier": "snap", "content_hash": "new_h"}],
+                snapshots=[SnapshotManifestItem(identifier="snap", content_hash="new_h")],
                 baseline_hashes={"snap": "old_h"},
             ),
             team_id=github_repo.team_id,
@@ -1365,7 +1386,7 @@ class TestCommitStatusChecks:
                 commit_sha="abc123",
                 branch="main",
                 pr_number=1,
-                snapshots=[{"identifier": "snap", "content_hash": "h1"}],
+                snapshots=[SnapshotManifestItem(identifier="snap", content_hash="h1")],
                 baseline_hashes={},
             ),
             team_id=repo.team_id,
@@ -1388,7 +1409,7 @@ class TestCommitStatusChecks:
                 commit_sha="abc123",
                 branch="main",
                 pr_number=1,
-                snapshots=[{"identifier": "snap", "content_hash": "h1"}],
+                snapshots=[SnapshotManifestItem(identifier="snap", content_hash="h1")],
                 baseline_hashes={},
             ),
             team_id=repo.team_id,
@@ -1415,7 +1436,7 @@ class TestRunSupersession:
                 commit_sha=commit_sha,
                 branch=branch,
                 pr_number=1,
-                snapshots=[{"identifier": "snap", "content_hash": commit_sha}],
+                snapshots=[SnapshotManifestItem(identifier="snap", content_hash=commit_sha)],
                 baseline_hashes={},
             ),
             team_id=repo.team_id,
@@ -1525,7 +1546,7 @@ class TestRunSupersession:
                 commit_sha="clean",
                 branch="feat/x",
                 pr_number=1,
-                snapshots=[{"identifier": "snap", "content_hash": "same"}],
+                snapshots=[SnapshotManifestItem(identifier="snap", content_hash="same")],
                 baseline_hashes={"snap": "same"},
             ),
             team_id=repo.team_id,
@@ -1573,7 +1594,7 @@ class TestQuarantineStamping:
         identifiers_and_hashes: list of (identifier, content_hash)
         baseline: dict of identifier -> baseline_hash (for _resolve_baselines mock)
         """
-        snapshots = [{"identifier": ident, "content_hash": h} for ident, h in identifiers_and_hashes]
+        snapshots = [SnapshotManifestItem(identifier=ident, content_hash=h) for ident, h in identifiers_and_hashes]
         run, _ = logic.create_run(
             CreateRunInput(
                 repo_id=repo.id,
@@ -1778,7 +1799,7 @@ class TestRecomputeRun:
         return logic.create_repo(team_id=team.id, repo_external_id=77777, repo_full_name="org/test-repo")
 
     def _create_completed_run(self, repo, mocker, identifiers_and_hashes, baseline=None, metadata=None):
-        snapshots = [{"identifier": ident, "content_hash": h} for ident, h in identifiers_and_hashes]
+        snapshots = [SnapshotManifestItem(identifier=ident, content_hash=h) for ident, h in identifiers_and_hashes]
         run, _ = logic.create_run(
             CreateRunInput(
                 repo_id=repo.id,
@@ -2266,8 +2287,8 @@ class TestMergeBaseBaselineHealing:
                 branch="my-branch",
                 pr_number=1,
                 snapshots=[
-                    {"identifier": "existing", "content_hash": "h1"},
-                    {"identifier": "healed", "content_hash": "h2"},
+                    SnapshotManifestItem(identifier="existing", content_hash="h1"),
+                    SnapshotManifestItem(identifier="healed", content_hash="h2"),
                 ],
             ),
             team_id=repo.team_id,
@@ -2324,9 +2345,9 @@ class TestMergeBaseBaselineHealing:
                 branch="master",
                 pr_number=None,
                 snapshots=[
-                    {"identifier": "story1", "content_hash": "h1"},
-                    {"identifier": "story2", "content_hash": "h2"},
-                    {"identifier": "story3", "content_hash": "h3"},
+                    SnapshotManifestItem(identifier="story1", content_hash="h1"),
+                    SnapshotManifestItem(identifier="story2", content_hash="h2"),
+                    SnapshotManifestItem(identifier="story3", content_hash="h3"),
                 ],
             ),
             team_id=repo.team_id,
@@ -2354,7 +2375,7 @@ class TestMergeBaseBaselineHealing:
                 commit_sha="abc",
                 branch="my-branch",
                 pr_number=1,
-                snapshots=[{"identifier": "flaky", "content_hash": "branch_hash"}],
+                snapshots=[SnapshotManifestItem(identifier="flaky", content_hash="branch_hash")],
             ),
             team_id=repo.team_id,
         )
@@ -2604,7 +2625,7 @@ class TestVerifyUploadsAndCreateArtifacts:
                 commit_sha="sha",
                 branch="main",
                 pr_number=None,
-                snapshots=[{"identifier": "Card", "content_hash": server_hash}],
+                snapshots=[SnapshotManifestItem(identifier="Card", content_hash=server_hash)],
             ),
             team_id=repo.team_id,
         )
@@ -2629,12 +2650,14 @@ class TestVerifyUploadsAndCreateArtifacts:
 
         def create_run_with_images(count: int, color_offset: int) -> tuple[Run, dict[str, bytes]]:
             images: dict[str, bytes] = {}
-            snapshots: list[dict[str, str]] = []
+            snapshots: list[SnapshotManifestItem] = []
             for index in range(count):
                 png = self._png((color_offset + index, 20, 30, 255))
                 content_hash = hash_image(png)
                 images[content_hash] = png
-                snapshots.append({"identifier": f"Card-{color_offset}-{index}", "content_hash": content_hash})
+                snapshots.append(
+                    SnapshotManifestItem(identifier=f"Card-{color_offset}-{index}", content_hash=content_hash)
+                )
 
             run, _ = logic.create_run(
                 CreateRunInput(
@@ -2668,11 +2691,11 @@ class TestVerifyUploadsAndCreateArtifacts:
         from products.visual_review.backend.hashing import hash_image
 
         mocker.patch.object(logic, "ARTIFACT_HASH_BATCH_SIZE", 2)
-        snapshots: list[dict[str, str]] = []
+        snapshots: list[SnapshotManifestItem] = []
         for index, color in enumerate([(10, 20, 30, 255), (40, 50, 60, 255), (70, 80, 90, 255)]):
             content_hash = hash_image(self._png(color))
             logic.get_or_create_artifact(repo.id, content_hash, f"visual_review/{content_hash}")
-            snapshots.append({"identifier": f"Card-{index}", "content_hash": content_hash})
+            snapshots.append(SnapshotManifestItem(identifier=f"Card-{index}", content_hash=content_hash))
 
         run, _ = logic.create_run(
             CreateRunInput(
@@ -2708,8 +2731,8 @@ class TestVerifyUploadsAndCreateArtifacts:
                 branch="main",
                 pr_number=None,
                 snapshots=[
-                    {"identifier": "Good", "content_hash": good_hash},
-                    {"identifier": "Bad", "content_hash": bad_claim},
+                    SnapshotManifestItem(identifier="Good", content_hash=good_hash),
+                    SnapshotManifestItem(identifier="Bad", content_hash=bad_claim),
                 ],
             ),
             team_id=repo.team_id,
@@ -2734,7 +2757,7 @@ class TestVerifyUploadsAndCreateArtifacts:
                 commit_sha="sha",
                 branch="main",
                 pr_number=None,
-                snapshots=[{"identifier": "Card", "content_hash": "a" * 64}],
+                snapshots=[SnapshotManifestItem(identifier="Card", content_hash="a" * 64)],
             ),
             team_id=repo.team_id,
         )

--- a/products/visual_review/backend/tests/test_logic.py
+++ b/products/visual_review/backend/tests/test_logic.py
@@ -12,6 +12,7 @@ from parameterized import parameterized
 
 from products.visual_review.backend import logic
 from products.visual_review.backend.db import WRITER_DB
+from products.visual_review.backend.facade.contracts import CreateRunInput
 from products.visual_review.backend.facade.enums import ReviewDecision, ReviewState, RunStatus, RunType, SnapshotResult
 from products.visual_review.backend.models import Repo, Run, RunSnapshot
 from products.visual_review.backend.tests.conftest import PRODUCT_DATABASES
@@ -131,17 +132,19 @@ class TestRunOperations:
 
     def test_create_run_basic(self, repo):
         run, uploads = logic.create_run(
-            repo_id=repo.id,
+            CreateRunInput(
+                repo_id=repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc123def456",
+                branch="main",
+                pr_number=42,
+                snapshots=[
+                    {"identifier": "Button-primary", "content_hash": "hash1"},
+                    {"identifier": "Button-secondary", "content_hash": "hash2"},
+                ],
+                baseline_hashes={},
+            ),
             team_id=repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="abc123def456",
-            branch="main",
-            pr_number=42,
-            snapshots=[
-                {"identifier": "Button-primary", "content_hash": "hash1"},
-                {"identifier": "Button-secondary", "content_hash": "hash2"},
-            ],
-            baseline_hashes={},
         )
 
         assert run.repo_id == repo.id
@@ -159,17 +162,19 @@ class TestRunOperations:
         logic.get_or_create_artifact(repo_id=repo.id, content_hash="existing", storage_path="p/existing")
 
         run, uploads = logic.create_run(
-            repo_id=repo.id,
+            CreateRunInput(
+                repo_id=repo.id,
+                run_type=RunType.PLAYWRIGHT,
+                commit_sha="abc",
+                branch="feat",
+                pr_number=None,
+                snapshots=[
+                    {"identifier": "snap1", "content_hash": "existing"},
+                    {"identifier": "snap2", "content_hash": "new"},
+                ],
+                baseline_hashes={},
+            ),
             team_id=repo.team_id,
-            run_type=RunType.PLAYWRIGHT,
-            commit_sha="abc",
-            branch="feat",
-            pr_number=None,
-            snapshots=[
-                {"identifier": "snap1", "content_hash": "existing"},
-                {"identifier": "snap2", "content_hash": "new"},
-            ],
-            baseline_hashes={},
         )
 
         # Only "new" needs upload, "existing" already has artifact
@@ -182,14 +187,16 @@ class TestRunOperations:
         )
 
         run, _uploads = logic.create_run(
-            repo_id=repo.id,
+            CreateRunInput(
+                repo_id=repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc",
+                branch="main",
+                pr_number=None,
+                snapshots=[{"identifier": "Button", "content_hash": "new_hash"}],
+                baseline_hashes={"Button": "baseline_hash"},
+            ),
             team_id=repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="abc",
-            branch="main",
-            pr_number=None,
-            snapshots=[{"identifier": "Button", "content_hash": "new_hash"}],
-            baseline_hashes={"Button": "baseline_hash"},
         )
 
         # Classification happens at complete_run time, not create_run time
@@ -211,21 +218,23 @@ class TestRunOperations:
         )
 
         run, _ = logic.create_run(
-            repo_id=repo.id,
+            CreateRunInput(
+                repo_id=repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc",
+                branch="main",
+                pr_number=None,
+                snapshots=[
+                    {"identifier": "unchanged", "content_hash": "same_hash"},
+                    {"identifier": "new", "content_hash": "brand_new"},
+                    {"identifier": "changed", "content_hash": "different"},
+                ],
+                baseline_hashes={
+                    "unchanged": "same_hash",
+                    "changed": "old_hash",
+                },
+            ),
             team_id=repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="abc",
-            branch="main",
-            pr_number=None,
-            snapshots=[
-                {"identifier": "unchanged", "content_hash": "same_hash"},
-                {"identifier": "new", "content_hash": "brand_new"},
-                {"identifier": "changed", "content_hash": "different"},
-            ],
-            baseline_hashes={
-                "unchanged": "same_hash",
-                "changed": "old_hash",
-            },
         )
 
         # Classification happens at complete_run time
@@ -243,13 +252,15 @@ class TestRunOperations:
 
     def test_create_run_empty(self, repo):
         run, uploads = logic.create_run(
-            repo_id=repo.id,
+            CreateRunInput(
+                repo_id=repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc",
+                branch="main",
+                pr_number=None,
+                snapshots=[],
+            ),
             team_id=repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="abc",
-            branch="main",
-            pr_number=None,
-            snapshots=[],
         )
 
         assert run.total_snapshots == 0
@@ -261,13 +272,15 @@ class TestRunOperations:
 
     def test_add_snapshots_to_run(self, repo):
         run, _ = logic.create_run(
-            repo_id=repo.id,
+            CreateRunInput(
+                repo_id=repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc",
+                branch="main",
+                pr_number=None,
+                snapshots=[],
+            ),
             team_id=repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="abc",
-            branch="main",
-            pr_number=None,
-            snapshots=[],
         )
         assert run.total_snapshots == 0
 
@@ -296,13 +309,15 @@ class TestRunOperations:
 
     def test_add_snapshots_idempotent(self, repo):
         run, _ = logic.create_run(
-            repo_id=repo.id,
+            CreateRunInput(
+                repo_id=repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc",
+                branch="main",
+                pr_number=None,
+                snapshots=[],
+            ),
             team_id=repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="abc",
-            branch="main",
-            pr_number=None,
-            snapshots=[],
         )
 
         for _ in range(2):
@@ -316,13 +331,15 @@ class TestRunOperations:
 
     def test_add_snapshots_rejects_non_pending(self, repo):
         run, _ = logic.create_run(
-            repo_id=repo.id,
+            CreateRunInput(
+                repo_id=repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc",
+                branch="main",
+                pr_number=None,
+                snapshots=[],
+            ),
             team_id=repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="abc",
-            branch="main",
-            pr_number=None,
-            snapshots=[],
         )
         logic.finish_processing(run.id)
 
@@ -335,13 +352,15 @@ class TestRunOperations:
 
     def test_complete_run_detects_removals(self, repo, mocker):
         run, _ = logic.create_run(
-            repo_id=repo.id,
+            CreateRunInput(
+                repo_id=repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc",
+                branch="main",
+                pr_number=None,
+                snapshots=[{"identifier": "kept", "content_hash": "h1"}],
+            ),
             team_id=repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="abc",
-            branch="main",
-            pr_number=None,
-            snapshots=[{"identifier": "kept", "content_hash": "h1"}],
         )
 
         # Mock baseline to include an identifier not in the run
@@ -358,14 +377,16 @@ class TestRunOperations:
 
     def test_complete_run_partial_skips_removals_off_default_branch(self, repo, mocker):
         run, _ = logic.create_run(
-            repo_id=repo.id,
+            CreateRunInput(
+                repo_id=repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc",
+                branch="feature-x",
+                pr_number=7,
+                snapshots=[{"identifier": "kept", "content_hash": "h1"}],
+                is_partial=True,
+            ),
             team_id=repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="abc",
-            branch="feature-x",
-            pr_number=7,
-            snapshots=[{"identifier": "kept", "content_hash": "h1"}],
-            is_partial=True,
         )
 
         mocker.patch(
@@ -381,14 +402,16 @@ class TestRunOperations:
 
     def test_complete_run_partial_ignored_on_default_branch(self, repo, mocker):
         run, _ = logic.create_run(
-            repo_id=repo.id,
+            CreateRunInput(
+                repo_id=repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc",
+                branch="master",
+                pr_number=None,
+                snapshots=[{"identifier": "kept", "content_hash": "h1"}],
+                is_partial=True,
+            ),
             team_id=repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="abc",
-            branch="master",
-            pr_number=None,
-            snapshots=[{"identifier": "kept", "content_hash": "h1"}],
-            is_partial=True,
         )
 
         mocker.patch(
@@ -410,13 +433,15 @@ class TestRunOperations:
     def test_complete_run_passes_commit_sha_to_baseline_resolution(self, repo, mocker):
         """complete_run passes run.commit_sha so default-branch baselines are pinned."""
         run, _ = logic.create_run(
-            repo_id=repo.id,
+            CreateRunInput(
+                repo_id=repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="deadbeef123",
+                branch="master",
+                pr_number=None,
+                snapshots=[{"identifier": "A", "content_hash": "h1"}],
+            ),
             team_id=repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="deadbeef123",
-            branch="master",
-            pr_number=None,
-            snapshots=[{"identifier": "A", "content_hash": "h1"}],
         )
 
         mock_resolve = mocker.patch(
@@ -430,27 +455,31 @@ class TestRunOperations:
 
     def test_create_run_with_purpose(self, repo):
         run, _ = logic.create_run(
-            repo_id=repo.id,
+            CreateRunInput(
+                repo_id=repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc",
+                branch="main",
+                pr_number=None,
+                snapshots=[],
+                purpose="observe",
+            ),
             team_id=repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="abc",
-            branch="main",
-            pr_number=None,
-            snapshots=[],
-            purpose="observe",
         )
         assert run.purpose == "observe"
 
     def test_approve_rejects_observe_runs(self, repo):
         run, _ = logic.create_run(
-            repo_id=repo.id,
+            CreateRunInput(
+                repo_id=repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc",
+                branch="main",
+                pr_number=None,
+                snapshots=[{"identifier": "btn", "content_hash": "h1"}],
+                purpose="observe",
+            ),
             team_id=repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="abc",
-            branch="main",
-            pr_number=None,
-            snapshots=[{"identifier": "btn", "content_hash": "h1"}],
-            purpose="observe",
         )
         logic.finish_processing(run.id)
 
@@ -459,14 +488,16 @@ class TestRunOperations:
 
     def test_get_run(self, repo):
         run, _ = logic.create_run(
-            repo_id=repo.id,
+            CreateRunInput(
+                repo_id=repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc",
+                branch="main",
+                pr_number=None,
+                snapshots=[],
+                baseline_hashes={},
+            ),
             team_id=repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="abc",
-            branch="main",
-            pr_number=None,
-            snapshots=[],
-            baseline_hashes={},
         )
 
         retrieved = logic.get_run(run.id)
@@ -481,14 +512,16 @@ class TestRunOperations:
 
     def test_mark_run_processing(self, repo):
         run, _ = logic.create_run(
-            repo_id=repo.id,
+            CreateRunInput(
+                repo_id=repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc",
+                branch="main",
+                pr_number=None,
+                snapshots=[],
+                baseline_hashes={},
+            ),
             team_id=repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="abc",
-            branch="main",
-            pr_number=None,
-            snapshots=[],
-            baseline_hashes={},
         )
 
         updated = logic.mark_run_processing(run.id)
@@ -497,17 +530,19 @@ class TestRunOperations:
 
     def test_finish_processing_success(self, repo, mocker):
         run, _ = logic.create_run(
-            repo_id=repo.id,
+            CreateRunInput(
+                repo_id=repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc",
+                branch="main",
+                pr_number=None,
+                snapshots=[
+                    {"identifier": "changed1", "content_hash": "h1"},
+                    {"identifier": "new1", "content_hash": "h2"},
+                ],
+                baseline_hashes={"changed1": "old"},
+            ),
             team_id=repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="abc",
-            branch="main",
-            pr_number=None,
-            snapshots=[
-                {"identifier": "changed1", "content_hash": "h1"},
-                {"identifier": "new1", "content_hash": "h2"},
-            ],
-            baseline_hashes={"changed1": "old"},
         )
 
         # Classification happens at complete_run time
@@ -530,14 +565,16 @@ class TestRunOperations:
 
     def test_finish_processing_with_error(self, repo):
         run, _ = logic.create_run(
-            repo_id=repo.id,
+            CreateRunInput(
+                repo_id=repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc",
+                branch="main",
+                pr_number=None,
+                snapshots=[],
+                baseline_hashes={},
+            ),
             team_id=repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="abc",
-            branch="main",
-            pr_number=None,
-            snapshots=[],
-            baseline_hashes={},
         )
 
         updated = logic.finish_processing(run.id, error_message="Something failed")
@@ -547,14 +584,16 @@ class TestRunOperations:
 
     def test_update_run_counts_reads_and_writes_through_requested_db(self, repo, mocker):
         run, _ = logic.create_run(
-            repo_id=repo.id,
+            CreateRunInput(
+                repo_id=repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc",
+                branch="main",
+                pr_number=None,
+                snapshots=[],
+                baseline_hashes={},
+            ),
             team_id=repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="abc",
-            branch="main",
-            pr_number=None,
-            snapshots=[],
-            baseline_hashes={},
         )
 
         snapshot_queryset = mocker.Mock()
@@ -591,14 +630,16 @@ class TestApproveRun:
             repo_id=repo.id, content_hash="new_hash", storage_path="p/new"
         )
         run, _ = logic.create_run(
-            repo_id=repo.id,
+            CreateRunInput(
+                repo_id=repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc",
+                branch="main",
+                pr_number=None,
+                snapshots=[{"identifier": "Button", "content_hash": "new_hash"}],
+                baseline_hashes={"Button": "old_hash"},
+            ),
             team_id=repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="abc",
-            branch="main",
-            pr_number=None,
-            snapshots=[{"identifier": "Button", "content_hash": "new_hash"}],
-            baseline_hashes={"Button": "old_hash"},
         )
 
         # Classification happens at complete_run time
@@ -629,14 +670,16 @@ class TestApproveRun:
         logic.get_or_create_artifact(repo_id=repo.id, content_hash="ha", storage_path="p/a")
         logic.get_or_create_artifact(repo_id=repo.id, content_hash="hb", storage_path="p/b")
         run, _ = logic.create_run(
-            repo_id=repo.id,
+            CreateRunInput(
+                repo_id=repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc",
+                branch="main",
+                pr_number=None,
+                snapshots=[{"identifier": "A", "content_hash": "ha"}, {"identifier": "B", "content_hash": "hb"}],
+                baseline_hashes={"A": "olda", "B": "oldb"},
+            ),
             team_id=repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="abc",
-            branch="main",
-            pr_number=None,
-            snapshots=[{"identifier": "A", "content_hash": "ha"}, {"identifier": "B", "content_hash": "hb"}],
-            baseline_hashes={"A": "olda", "B": "oldb"},
         )
         mocker.patch(
             "products.visual_review.backend.logic._resolve_baselines_with_merge_base",
@@ -718,14 +761,16 @@ class TestApproveSnapshots:
     def test_approve_single_snapshot_db_only(self, repo, user, mocker):
         logic.get_or_create_artifact(repo_id=repo.id, content_hash="new_hash", storage_path="p/new")
         run, _ = logic.create_run(
-            repo_id=repo.id,
+            CreateRunInput(
+                repo_id=repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc",
+                branch="main",
+                pr_number=None,
+                snapshots=[{"identifier": "Button", "content_hash": "new_hash"}],
+                baseline_hashes={"Button": "old_hash"},
+            ),
             team_id=repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="abc",
-            branch="main",
-            pr_number=None,
-            snapshots=[{"identifier": "Button", "content_hash": "new_hash"}],
-            baseline_hashes={"Button": "old_hash"},
         )
         mocker.patch(
             "products.visual_review.backend.logic._resolve_baselines_with_merge_base",
@@ -762,14 +807,16 @@ class TestToleratedHashes:
     ):
         logic.get_or_create_artifact(repo_id=repo.id, content_hash=current_hash, storage_path=f"p/{current_hash}")
         run, _ = logic.create_run(
-            repo_id=repo.id,
+            CreateRunInput(
+                repo_id=repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc",
+                branch="main",
+                pr_number=None,
+                snapshots=[{"identifier": identifier, "content_hash": current_hash}],
+                baseline_hashes={identifier: baseline_hash},
+            ),
             team_id=repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="abc",
-            branch="main",
-            pr_number=None,
-            snapshots=[{"identifier": identifier, "content_hash": current_hash}],
-            baseline_hashes={identifier: baseline_hash},
         )
         mocker.patch(
             "products.visual_review.backend.logic._resolve_baselines_with_merge_base",
@@ -798,14 +845,16 @@ class TestToleratedHashes:
     def test_mark_unchanged_snapshot_rejected(self, repo, user, mocker):
         logic.get_or_create_artifact(repo_id=repo.id, content_hash="same", storage_path="p/same")
         run, _ = logic.create_run(
-            repo_id=repo.id,
+            CreateRunInput(
+                repo_id=repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc",
+                branch="main",
+                pr_number=None,
+                snapshots=[{"identifier": "Button", "content_hash": "same"}],
+                baseline_hashes={"Button": "same"},
+            ),
             team_id=repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="abc",
-            branch="main",
-            pr_number=None,
-            snapshots=[{"identifier": "Button", "content_hash": "same"}],
-            baseline_hashes={"Button": "same"},
         )
         mocker.patch(
             "products.visual_review.backend.logic._resolve_baselines_with_merge_base",
@@ -903,18 +952,20 @@ class TestGetRunSnapshots:
 
     def test_get_run_snapshots(self, repo):
         run, _ = logic.create_run(
-            repo_id=repo.id,
+            CreateRunInput(
+                repo_id=repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc",
+                branch="main",
+                pr_number=None,
+                snapshots=[
+                    {"identifier": "A-component", "content_hash": "h1"},
+                    {"identifier": "B-component", "content_hash": "h2"},
+                    {"identifier": "C-component", "content_hash": "h3"},
+                ],
+                baseline_hashes={},
+            ),
             team_id=repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="abc",
-            branch="main",
-            pr_number=None,
-            snapshots=[
-                {"identifier": "A-component", "content_hash": "h1"},
-                {"identifier": "B-component", "content_hash": "h2"},
-                {"identifier": "C-component", "content_hash": "h3"},
-            ],
-            baseline_hashes={},
         )
 
         snapshots = logic.get_run_snapshots(run.id)
@@ -939,14 +990,16 @@ class TestCommitStatusChecks:
 
     def test_create_run_posts_pending_status(self, github_repo, mock_github_api):
         run, _ = logic.create_run(
-            repo_id=github_repo.id,
+            CreateRunInput(
+                repo_id=github_repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc123",
+                branch="main",
+                pr_number=1,
+                snapshots=[{"identifier": "snap", "content_hash": "h1"}],
+                baseline_hashes={},
+            ),
             team_id=github_repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="abc123",
-            branch="main",
-            pr_number=1,
-            snapshots=[{"identifier": "snap", "content_hash": "h1"}],
-            baseline_hashes={},
         )
 
         assert len(mock_github_api.status_checks) == 1
@@ -957,14 +1010,16 @@ class TestCommitStatusChecks:
 
     def test_complete_run_posts_success_when_no_changes(self, github_repo, mock_github_api, mocker):
         run, _ = logic.create_run(
-            repo_id=github_repo.id,
+            CreateRunInput(
+                repo_id=github_repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc123",
+                branch="main",
+                pr_number=1,
+                snapshots=[{"identifier": "snap", "content_hash": "same"}],
+                baseline_hashes={"snap": "same"},
+            ),
             team_id=github_repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="abc123",
-            branch="main",
-            pr_number=1,
-            snapshots=[{"identifier": "snap", "content_hash": "same"}],
-            baseline_hashes={"snap": "same"},
         )
 
         mocker.patch(
@@ -981,15 +1036,17 @@ class TestCommitStatusChecks:
 
     def test_complete_run_partial_annotates_posted_status(self, github_repo, mock_github_api, mocker):
         run, _ = logic.create_run(
-            repo_id=github_repo.id,
+            CreateRunInput(
+                repo_id=github_repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc123",
+                branch="feature-x",
+                pr_number=7,
+                snapshots=[{"identifier": "snap", "content_hash": "same"}],
+                baseline_hashes={"snap": "same"},
+                is_partial=True,
+            ),
             team_id=github_repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="abc123",
-            branch="feature-x",
-            pr_number=7,
-            snapshots=[{"identifier": "snap", "content_hash": "same"}],
-            baseline_hashes={"snap": "same"},
-            is_partial=True,
         )
 
         mocker.patch(
@@ -1015,17 +1072,19 @@ class TestCommitStatusChecks:
         github_repo.save(update_fields=["enable_pr_comments"])
 
         run, _ = logic.create_run(
-            repo_id=github_repo.id,
+            CreateRunInput(
+                repo_id=github_repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc123",
+                branch="main",
+                pr_number=1,
+                snapshots=[
+                    {"identifier": "changed", "content_hash": "new_h"},
+                    {"identifier": "added", "content_hash": "brand_new"},
+                ],
+                baseline_hashes={"changed": "old_h"},
+            ),
             team_id=github_repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="abc123",
-            branch="main",
-            pr_number=1,
-            snapshots=[
-                {"identifier": "changed", "content_hash": "new_h"},
-                {"identifier": "added", "content_hash": "brand_new"},
-            ],
-            baseline_hashes={"changed": "old_h"},
         )
 
         mocker.patch(
@@ -1055,26 +1114,30 @@ class TestCommitStatusChecks:
         github_repo.save(update_fields=["enable_pr_comments"])
 
         run1, _ = logic.create_run(
-            repo_id=github_repo.id,
+            CreateRunInput(
+                repo_id=github_repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc111",
+                branch="main",
+                pr_number=1,
+                snapshots=[{"identifier": "changed", "content_hash": "new_h"}],
+                baseline_hashes={"changed": "old_h"},
+            ),
             team_id=github_repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="abc111",
-            branch="main",
-            pr_number=1,
-            snapshots=[{"identifier": "changed", "content_hash": "new_h"}],
-            baseline_hashes={"changed": "old_h"},
         )
         logic.finish_processing(run1.id)
 
         run2, _ = logic.create_run(
-            repo_id=github_repo.id,
+            CreateRunInput(
+                repo_id=github_repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc222",
+                branch="main",
+                pr_number=1,
+                snapshots=[{"identifier": "changed", "content_hash": "newer_h"}],
+                baseline_hashes={"changed": "old_h"},
+            ),
             team_id=github_repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="abc222",
-            branch="main",
-            pr_number=1,
-            snapshots=[{"identifier": "changed", "content_hash": "newer_h"}],
-            baseline_hashes={"changed": "old_h"},
         )
         logic.finish_processing(run2.id)
 
@@ -1089,14 +1152,16 @@ class TestCommitStatusChecks:
         github_repo.save(update_fields=["enable_pr_comments"])
 
         run, _ = logic.create_run(
-            repo_id=github_repo.id,
+            CreateRunInput(
+                repo_id=github_repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc123",
+                branch="main",
+                pr_number=1,
+                snapshots=[{"identifier": "changed", "content_hash": "new_h"}],
+                baseline_hashes={"changed": "old_h"},
+            ),
             team_id=github_repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="abc123",
-            branch="main",
-            pr_number=1,
-            snapshots=[{"identifier": "changed", "content_hash": "new_h"}],
-            baseline_hashes={"changed": "old_h"},
         )
 
         logic.finish_processing(run.id)
@@ -1128,15 +1193,17 @@ class TestCommitStatusChecks:
         )
 
         run, _ = logic.create_run(
-            repo_id=github_repo.id,
+            CreateRunInput(
+                repo_id=github_repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc123",
+                branch="main",
+                pr_number=pr_number,
+                snapshots=snapshots,
+                baseline_hashes=baseline_hashes,
+                purpose=purpose,
+            ),
             team_id=github_repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="abc123",
-            branch="main",
-            pr_number=pr_number,
-            snapshots=snapshots,
-            baseline_hashes=baseline_hashes,
-            purpose=purpose,
         )
 
         logic.complete_run(run.id)
@@ -1145,14 +1212,16 @@ class TestCommitStatusChecks:
 
     def test_complete_run_posts_error_on_failure(self, github_repo, mock_github_api):
         run, _ = logic.create_run(
-            repo_id=github_repo.id,
+            CreateRunInput(
+                repo_id=github_repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc123",
+                branch="main",
+                pr_number=1,
+                snapshots=[],
+                baseline_hashes={},
+            ),
             team_id=github_repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="abc123",
-            branch="main",
-            pr_number=1,
-            snapshots=[],
-            baseline_hashes={},
         )
 
         logic.finish_processing(run.id, error_message="Diff processing failed")
@@ -1169,18 +1238,20 @@ class TestCommitStatusChecks:
         github_repo.save(update_fields=["enable_pr_comments"])
 
         run, _ = logic.create_run(
-            repo_id=github_repo.id,
+            CreateRunInput(
+                repo_id=github_repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc123",
+                branch="master",
+                pr_number=None,
+                snapshots=[
+                    {"identifier": "changed", "content_hash": "new_h"},
+                    {"identifier": "added", "content_hash": "brand_new"},
+                ],
+                baseline_hashes={"changed": "old_h"},
+                purpose="observe",
+            ),
             team_id=github_repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="abc123",
-            branch="master",
-            pr_number=None,
-            snapshots=[
-                {"identifier": "changed", "content_hash": "new_h"},
-                {"identifier": "added", "content_hash": "brand_new"},
-            ],
-            baseline_hashes={"changed": "old_h"},
-            purpose="observe",
         )
 
         mocker.patch(
@@ -1203,15 +1274,17 @@ class TestCommitStatusChecks:
 
     def test_observe_run_without_changes_posts_green_tracking_status(self, github_repo, mock_github_api, mocker):
         run, _ = logic.create_run(
-            repo_id=github_repo.id,
+            CreateRunInput(
+                repo_id=github_repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc123",
+                branch="master",
+                pr_number=None,
+                snapshots=[{"identifier": "snap", "content_hash": "same"}],
+                baseline_hashes={"snap": "same"},
+                purpose="observe",
+            ),
             team_id=github_repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="abc123",
-            branch="master",
-            pr_number=None,
-            snapshots=[{"identifier": "snap", "content_hash": "same"}],
-            baseline_hashes={"snap": "same"},
-            purpose="observe",
         )
 
         mocker.patch(
@@ -1228,14 +1301,16 @@ class TestCommitStatusChecks:
     def test_approve_run_posts_success(self, github_repo, mock_github_api, user):
         logic.get_or_create_artifact(repo_id=github_repo.id, content_hash="new_h", storage_path="p/new")
         run, _ = logic.create_run(
-            repo_id=github_repo.id,
+            CreateRunInput(
+                repo_id=github_repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc123",
+                branch="main",
+                pr_number=None,
+                snapshots=[{"identifier": "snap", "content_hash": "new_h"}],
+                baseline_hashes={"snap": "old_h"},
+            ),
             team_id=github_repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="abc123",
-            branch="main",
-            pr_number=None,
-            snapshots=[{"identifier": "snap", "content_hash": "new_h"}],
-            baseline_hashes={"snap": "old_h"},
         )
         logic.finish_processing(run.id)
 
@@ -1250,14 +1325,16 @@ class TestCommitStatusChecks:
         # otherwise re-running CI would re-detect the change. Only finalize (which commits) greens it.
         logic.get_or_create_artifact(repo_id=github_repo.id, content_hash="new_h", storage_path="p/new")
         run, _ = logic.create_run(
-            repo_id=github_repo.id,
+            CreateRunInput(
+                repo_id=github_repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc123",
+                branch="main",
+                pr_number=None,
+                snapshots=[{"identifier": "snap", "content_hash": "new_h"}],
+                baseline_hashes={"snap": "old_h"},
+            ),
             team_id=github_repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="abc123",
-            branch="main",
-            pr_number=None,
-            snapshots=[{"identifier": "snap", "content_hash": "new_h"}],
-            baseline_hashes={"snap": "old_h"},
         )
         mocker.patch(
             "products.visual_review.backend.logic._resolve_baselines_with_merge_base",
@@ -1282,14 +1359,16 @@ class TestCommitStatusChecks:
 
         # No mock_github_api/mock_github_integration — should not raise
         run, _ = logic.create_run(
-            repo_id=repo.id,
+            CreateRunInput(
+                repo_id=repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc123",
+                branch="main",
+                pr_number=1,
+                snapshots=[{"identifier": "snap", "content_hash": "h1"}],
+                baseline_hashes={},
+            ),
             team_id=repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="abc123",
-            branch="main",
-            pr_number=1,
-            snapshots=[{"identifier": "snap", "content_hash": "h1"}],
-            baseline_hashes={},
         )
 
         logic.finish_processing(run.id)
@@ -1303,14 +1382,16 @@ class TestCommitStatusChecks:
         )
 
         run, _ = logic.create_run(
-            repo_id=repo.id,
+            CreateRunInput(
+                repo_id=repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc123",
+                branch="main",
+                pr_number=1,
+                snapshots=[{"identifier": "snap", "content_hash": "h1"}],
+                baseline_hashes={},
+            ),
             team_id=repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="abc123",
-            branch="main",
-            pr_number=1,
-            snapshots=[{"identifier": "snap", "content_hash": "h1"}],
-            baseline_hashes={},
         )
 
         logic.finish_processing(run.id)
@@ -1328,14 +1409,16 @@ class TestRunSupersession:
 
     def _create_run(self, repo, *, branch="feat/x", run_type=RunType.STORYBOOK, commit_sha="abc"):
         run, _ = logic.create_run(
-            repo_id=repo.id,
+            CreateRunInput(
+                repo_id=repo.id,
+                run_type=run_type,
+                commit_sha=commit_sha,
+                branch=branch,
+                pr_number=1,
+                snapshots=[{"identifier": "snap", "content_hash": commit_sha}],
+                baseline_hashes={},
+            ),
             team_id=repo.team_id,
-            run_type=run_type,
-            commit_sha=commit_sha,
-            branch=branch,
-            pr_number=1,
-            snapshots=[{"identifier": "snap", "content_hash": commit_sha}],
-            baseline_hashes={},
         )
         logic.finish_processing(run.id)
         run.refresh_from_db()
@@ -1436,14 +1519,16 @@ class TestRunSupersession:
 
     def test_clean_run_superseded_but_stays_clean(self, repo, team, mocker):
         clean_run, _ = logic.create_run(
-            repo_id=repo.id,
+            CreateRunInput(
+                repo_id=repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="clean",
+                branch="feat/x",
+                pr_number=1,
+                snapshots=[{"identifier": "snap", "content_hash": "same"}],
+                baseline_hashes={"snap": "same"},
+            ),
             team_id=repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="clean",
-            branch="feat/x",
-            pr_number=1,
-            snapshots=[{"identifier": "snap", "content_hash": "same"}],
-            baseline_hashes={"snap": "same"},
         )
 
         # Classification happens at complete_run time
@@ -1490,13 +1575,15 @@ class TestQuarantineStamping:
         """
         snapshots = [{"identifier": ident, "content_hash": h} for ident, h in identifiers_and_hashes]
         run, _ = logic.create_run(
-            repo_id=repo.id,
+            CreateRunInput(
+                repo_id=repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc",
+                branch="main",
+                pr_number=1,
+                snapshots=snapshots,
+            ),
             team_id=repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="abc",
-            branch="main",
-            pr_number=1,
-            snapshots=snapshots,
         )
 
         mocker.patch(
@@ -1693,14 +1780,16 @@ class TestRecomputeRun:
     def _create_completed_run(self, repo, mocker, identifiers_and_hashes, baseline=None, metadata=None):
         snapshots = [{"identifier": ident, "content_hash": h} for ident, h in identifiers_and_hashes]
         run, _ = logic.create_run(
-            repo_id=repo.id,
+            CreateRunInput(
+                repo_id=repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc",
+                branch="my-branch",
+                pr_number=1,
+                snapshots=snapshots,
+                metadata=metadata or {},
+            ),
             team_id=repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="abc",
-            branch="my-branch",
-            pr_number=1,
-            snapshots=snapshots,
-            metadata=metadata or {},
         )
         mocker.patch(
             "products.visual_review.backend.logic._resolve_baselines_with_merge_base",
@@ -1760,13 +1849,10 @@ class TestRecomputeRun:
 
     def test_recompute_run_rejects_non_completed_run(self, repo, team, mocker):
         run, _ = logic.create_run(
-            repo_id=repo.id,
+            CreateRunInput(
+                repo_id=repo.id, run_type=RunType.STORYBOOK, commit_sha="abc", branch="main", pr_number=1, snapshots=[]
+            ),
             team_id=repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="abc",
-            branch="main",
-            pr_number=1,
-            snapshots=[],
         )
 
         with pytest.raises(ValueError, match="Can only recompute completed runs"):
@@ -1850,14 +1936,16 @@ class TestRerunGithubJob:
         if workflow_run_id is not None:
             metadata["github_run_id"] = workflow_run_id
         run, _ = logic.create_run(
-            repo_id=repo.id,
+            CreateRunInput(
+                repo_id=repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha=commit_sha,
+                branch="feature",
+                pr_number=1,
+                snapshots=[],
+                metadata=metadata,
+            ),
             team_id=repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha=commit_sha,
-            branch="feature",
-            pr_number=1,
-            snapshots=[],
-            metadata=metadata,
         )
         return run
 
@@ -2171,16 +2259,18 @@ class TestMergeBaseBaselineHealing:
         logic.get_or_create_artifact(repo_id=repo.id, content_hash="h1", storage_path="p/h1")
         logic.get_or_create_artifact(repo_id=repo.id, content_hash="h2", storage_path="p/h2")
         run, _ = logic.create_run(
-            repo_id=repo.id,
+            CreateRunInput(
+                repo_id=repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc",
+                branch="my-branch",
+                pr_number=1,
+                snapshots=[
+                    {"identifier": "existing", "content_hash": "h1"},
+                    {"identifier": "healed", "content_hash": "h2"},
+                ],
+            ),
             team_id=repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="abc",
-            branch="my-branch",
-            pr_number=1,
-            snapshots=[
-                {"identifier": "existing", "content_hash": "h1"},
-                {"identifier": "healed", "content_hash": "h2"},
-            ],
         )
         mocker.patch("products.visual_review.backend.tasks.tasks.process_run_diffs.delay")
         logic.complete_run(run.id)
@@ -2227,17 +2317,19 @@ class TestMergeBaseBaselineHealing:
 
         # Commit A's run only has the 3 original stories
         run, _ = logic.create_run(
-            repo_id=repo.id,
+            CreateRunInput(
+                repo_id=repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="commit_a_sha",
+                branch="master",
+                pr_number=None,
+                snapshots=[
+                    {"identifier": "story1", "content_hash": "h1"},
+                    {"identifier": "story2", "content_hash": "h2"},
+                    {"identifier": "story3", "content_hash": "h3"},
+                ],
+            ),
             team_id=repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="commit_a_sha",
-            branch="master",
-            pr_number=None,
-            snapshots=[
-                {"identifier": "story1", "content_hash": "h1"},
-                {"identifier": "story2", "content_hash": "h2"},
-                {"identifier": "story3", "content_hash": "h3"},
-            ],
         )
 
         logic.complete_run(run.id)
@@ -2256,13 +2348,15 @@ class TestMergeBaseBaselineHealing:
         logic.get_or_create_artifact(repo_id=repo.id, content_hash="master_hash", storage_path="p/master")
         logic.get_or_create_artifact(repo_id=repo.id, content_hash="branch_hash", storage_path="p/branch")
         run, _ = logic.create_run(
-            repo_id=repo.id,
+            CreateRunInput(
+                repo_id=repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc",
+                branch="my-branch",
+                pr_number=1,
+                snapshots=[{"identifier": "flaky", "content_hash": "branch_hash"}],
+            ),
             team_id=repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="abc",
-            branch="my-branch",
-            pr_number=1,
-            snapshots=[{"identifier": "flaky", "content_hash": "branch_hash"}],
         )
         mocker.patch("products.visual_review.backend.tasks.tasks.process_run_diffs.delay")
         logic.complete_run(run.id)
@@ -2504,13 +2598,15 @@ class TestVerifyUploadsAndCreateArtifacts:
         server_hash = hash_image(png)
 
         run, _ = logic.create_run(
-            repo_id=repo.id,
+            CreateRunInput(
+                repo_id=repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="sha",
+                branch="main",
+                pr_number=None,
+                snapshots=[{"identifier": "Card", "content_hash": server_hash}],
+            ),
             team_id=repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="sha",
-            branch="main",
-            pr_number=None,
-            snapshots=[{"identifier": "Card", "content_hash": server_hash}],
         )
 
         mocker.patch(
@@ -2541,13 +2637,15 @@ class TestVerifyUploadsAndCreateArtifacts:
                 snapshots.append({"identifier": f"Card-{color_offset}-{index}", "content_hash": content_hash})
 
             run, _ = logic.create_run(
-                repo_id=repo.id,
+                CreateRunInput(
+                    repo_id=repo.id,
+                    run_type=RunType.STORYBOOK,
+                    commit_sha=f"sha-{count}-{color_offset}",
+                    branch="main",
+                    pr_number=None,
+                    snapshots=snapshots,
+                ),
                 team_id=repo.team_id,
-                run_type=RunType.STORYBOOK,
-                commit_sha=f"sha-{count}-{color_offset}",
-                branch="main",
-                pr_number=None,
-                snapshots=snapshots,
             )
             return run, images
 
@@ -2577,13 +2675,15 @@ class TestVerifyUploadsAndCreateArtifacts:
             snapshots.append({"identifier": f"Card-{index}", "content_hash": content_hash})
 
         run, _ = logic.create_run(
-            repo_id=repo.id,
+            CreateRunInput(
+                repo_id=repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="sha-retry",
+                branch="main",
+                pr_number=None,
+                snapshots=snapshots,
+            ),
             team_id=repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="sha-retry",
-            branch="main",
-            pr_number=None,
-            snapshots=snapshots,
         )
 
         assert logic.verify_uploads_and_create_artifacts(run.id) == 0
@@ -2601,16 +2701,18 @@ class TestVerifyUploadsAndCreateArtifacts:
         bad_claim = "f" * 64  # nothing hashes to this
 
         run, _ = logic.create_run(
-            repo_id=repo.id,
+            CreateRunInput(
+                repo_id=repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="sha",
+                branch="main",
+                pr_number=None,
+                snapshots=[
+                    {"identifier": "Good", "content_hash": good_hash},
+                    {"identifier": "Bad", "content_hash": bad_claim},
+                ],
+            ),
             team_id=repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="sha",
-            branch="main",
-            pr_number=None,
-            snapshots=[
-                {"identifier": "Good", "content_hash": good_hash},
-                {"identifier": "Bad", "content_hash": bad_claim},
-            ],
         )
 
         def _read(self, content_hash):
@@ -2626,13 +2728,15 @@ class TestVerifyUploadsAndCreateArtifacts:
 
     def test_corrupt_png_raises_hash_integrity_error(self, repo, mocker):
         run, _ = logic.create_run(
-            repo_id=repo.id,
+            CreateRunInput(
+                repo_id=repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="sha",
+                branch="main",
+                pr_number=None,
+                snapshots=[{"identifier": "Card", "content_hash": "a" * 64}],
+            ),
             team_id=repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="sha",
-            branch="main",
-            pr_number=None,
-            snapshots=[{"identifier": "Card", "content_hash": "a" * 64}],
         )
 
         mocker.patch(

--- a/products/visual_review/backend/tests/test_tasks.py
+++ b/products/visual_review/backend/tests/test_tasks.py
@@ -93,13 +93,15 @@ class TestProcessRunDiffs:
 
     def test_metrics_event_uses_run_id_as_uuid(self, repo, mocker):
         run, _ = logic.create_run(
-            repo_id=repo.id,
+            CreateRunInput(
+                repo_id=repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="metrics-uuid",
+                branch="main",
+                pr_number=None,
+                snapshots=[],
+            ),
             team_id=repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha="metrics-uuid",
-            branch="main",
-            pr_number=None,
-            snapshots=[],
         )
         capture = mocker.Mock()
 
@@ -418,13 +420,15 @@ class TestCountProcessedDiffs(VisualReviewTeamScopedTestMixin, BaseTest):
     def test_from_persisted_state(self, _name: str, snapshot_fields: dict[str, object], expected: int) -> None:
         repo = api.create_repo(team_id=self.team.id, repo_external_id=99999, repo_full_name="org/test")
         run, _ = logic.create_run(
-            repo_id=repo.id,
+            CreateRunInput(
+                repo_id=repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha=f"count-{_name}",
+                branch=f"count-{_name}",
+                pr_number=None,
+                snapshots=[{"identifier": _name, "content_hash": f"hash-{_name}"}],
+            ),
             team_id=repo.team_id,
-            run_type=RunType.STORYBOOK,
-            commit_sha=f"count-{_name}",
-            branch=f"count-{_name}",
-            pr_number=None,
-            snapshots=[{"identifier": _name, "content_hash": f"hash-{_name}"}],
         )
         RunSnapshot.objects.filter(run=run).update(**snapshot_fields)
 

--- a/products/visual_review/backend/tests/test_tasks.py
+++ b/products/visual_review/backend/tests/test_tasks.py
@@ -426,7 +426,7 @@ class TestCountProcessedDiffs(VisualReviewTeamScopedTestMixin, BaseTest):
                 commit_sha=f"count-{_name}",
                 branch=f"count-{_name}",
                 pr_number=None,
-                snapshots=[{"identifier": _name, "content_hash": f"hash-{_name}"}],
+                snapshots=[SnapshotManifestItem(identifier=_name, content_hash=f"hash-{_name}")],
             ),
             team_id=repo.team_id,
         )


### PR DESCRIPTION
Two internal helpers now accept the contract DTO their callers already hold, instead of the DTO being unpacked into loose parameters and re-threaded field by field. No HTTP view signatures, serializer shapes, or facade contracts change; behavior is unchanged and all call sites including tests are updated.

- `visual_review`: `logic.create_run` and `_create_run_inner` take `CreateRunInput` (12 fields were unpacked into 13 params, 10 re-threaded positionally). The facade sanitizes run metadata on the DTO via `dataclasses.replace` and passes it through; the snapshot dict conversion for `_register_snapshots` moves into logic.
- `visual_review`: `logic.update_repo` takes `UpdateRepoInput` (was a 1:1 field unpack in the facade).
- `tasks`: an earlier revision also passed `TaskRunSandboxConnectionDTO` into `_proxy_command_to_agent_server`; reverted, because the DTO's `sandbox_url` is `str | None` while the helper needs a `str`, and widening the parameter to add a runtime guard trades a typecheck for a `ValueError`. Invariants win over mirroring (see `/writing-dataclasses`).

Touching `logic.py` required an explicit frozen choice for its one bare `@dataclass` (`_BaselineOverviewRaw`, internal, constructed with kwargs only), so it moves to `@frozen` and drops out of `posthog/test/dataclass_frozen_baseline.txt`. The baseline change is that single line.

Generated by Claude Fable 5.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*

