### PR TITLE
chore(experiments): return a frozen dataclass from the CUPED adjustment

### DIFF
--- a/products/experiments/backend/hogql_queries/utils.py
+++ b/products/experiments/backend/hogql_queries/utils.py
@@ -23,6 +23,7 @@ from posthog.hogql.modifiers import create_default_modifiers_for_team
 from posthog.hogql.query import HogQLQueryExecutor
 
 from posthog.clickhouse.client.escape import substitute_params_for_display
+from posthog.dataclasses import frozen
 from posthog.models import Team, User
 
 from products.experiments.backend.hogql_queries import CONTROL_VARIANT_KEY
@@ -396,6 +397,13 @@ def _copy_cuped_fields(
 ExperimentStatistic = SampleMeanStatistic | ProportionStatistic | RatioStatistic
 
 
+@frozen
+class CupedAdjustment:
+    test_stat: ExperimentStatistic
+    control_stat: ExperimentStatistic
+    control_unadjusted_mean: float | None
+
+
 def _apply_cuped_adjustment_if_enabled(
     metric: ExperimentMeanMetric | ExperimentFunnelMetric | ExperimentRatioMetric | ExperimentRetentionMetric,
     cuped_config: CupedQueryConfig,
@@ -403,18 +411,20 @@ def _apply_cuped_adjustment_if_enabled(
     control_stat: ExperimentStatistic,
     test_variant: ExperimentStatsBaseValidated,
     control_variant: ExperimentStatsBaseValidated,
-) -> tuple[ExperimentStatistic, ExperimentStatistic, float | None]:
+) -> CupedAdjustment:
+    unadjusted = CupedAdjustment(test_stat=test_stat, control_stat=control_stat, control_unadjusted_mean=None)
+
     if not cuped_config.enabled:
-        return test_stat, control_stat, None
+        return unadjusted
 
     if not isinstance(metric, (ExperimentMeanMetric, ExperimentFunnelMetric)):
-        return test_stat, control_stat, None
+        return unadjusted
 
     # cuped_adjust supports SampleMeanStatistic and ProportionStatistic, but not RatioStatistic.
     if not isinstance(test_stat, (SampleMeanStatistic, ProportionStatistic)) or not isinstance(
         control_stat, (SampleMeanStatistic, ProportionStatistic)
     ):
-        return test_stat, control_stat, None
+        return unadjusted
 
     cuped_result = cuped_adjust(
         test_stat,
@@ -423,10 +433,10 @@ def _apply_cuped_adjustment_if_enabled(
         metric_variant_to_cuped_data(control_variant),
     )
 
-    return (
-        cuped_result.treatment_adjusted,
-        cuped_result.control_adjusted,
-        cuped_result.control_unadjusted_mean,
+    return CupedAdjustment(
+        test_stat=cuped_result.treatment_adjusted,
+        control_stat=cuped_result.control_adjusted,
+        control_unadjusted_mean=cuped_result.control_unadjusted_mean,
     )
 
 
@@ -529,7 +539,7 @@ def get_frequentist_experiment_result(
         if control_stat and not test_variant_validated.validation_failures:
             try:
                 test_stat = metric_variant_to_statistic(metric, test_variant_validated)
-                test_stat_for_result, control_stat_for_result, unadjusted_mean = _apply_cuped_adjustment_if_enabled(
+                cuped_adjustment = _apply_cuped_adjustment_if_enabled(
                     metric,
                     resolved_cuped_config,
                     test_stat,
@@ -538,13 +548,13 @@ def get_frequentist_experiment_result(
                     control_variant_validated,
                 )
 
-                if unadjusted_mean is None:
-                    result = method.run_test(test_stat_for_result, control_stat_for_result)
+                if cuped_adjustment.control_unadjusted_mean is None:
+                    result = method.run_test(cuped_adjustment.test_stat, cuped_adjustment.control_stat)
                 else:
                     result = method.run_test(
-                        test_stat_for_result,
-                        control_stat_for_result,
-                        unadjusted_mean=unadjusted_mean,
+                        cuped_adjustment.test_stat,
+                        cuped_adjustment.control_stat,
+                        unadjusted_mean=cuped_adjustment.control_unadjusted_mean,
                     )
 
                 confidence_interval = [result.confidence_interval[0], result.confidence_interval[1]]
@@ -632,7 +642,7 @@ def get_bayesian_experiment_result(
         if control_stat and not test_variant_validated.validation_failures:
             try:
                 test_stat = metric_variant_to_statistic(metric, test_variant_validated)
-                test_stat_for_result, control_stat_for_result, unadjusted_mean = _apply_cuped_adjustment_if_enabled(
+                cuped_adjustment = _apply_cuped_adjustment_if_enabled(
                     metric,
                     resolved_cuped_config,
                     test_stat,
@@ -641,13 +651,13 @@ def get_bayesian_experiment_result(
                     control_variant_validated,
                 )
 
-                if unadjusted_mean is None:
-                    result = method.run_test(test_stat_for_result, control_stat_for_result)
+                if cuped_adjustment.control_unadjusted_mean is None:
+                    result = method.run_test(cuped_adjustment.test_stat, cuped_adjustment.control_stat)
                 else:
                     result = method.run_test(
-                        test_stat_for_result,
-                        control_stat_for_result,
-                        unadjusted_mean=unadjusted_mean,
+                        cuped_adjustment.test_stat,
+                        cuped_adjustment.control_stat,
+                        unadjusted_mean=cuped_adjustment.control_unadjusted_mean,
                     )
 
                 # Convert credible interval to percentage


### PR DESCRIPTION
## Problem

A positional swap of the CUPED test and control statistics at a call site would silently invert experiment results, since both sides of the tuple share a type. Nothing guarded against it.

`_apply_cuped_adjustment_if_enabled` in `products/experiments/backend/hogql_queries/utils.py` returned `(test_stat, control_stat, unadjusted_mean)`.

## Changes

- Test and control CUPED values can no longer swap positionally: the function returns `CupedAdjustment`, a `@frozen` keyword-only dataclass.
- Both call sites (the frequentist and Bayesian result builders) read the fields by name instead of unpacking.
- Behavior unchanged. No test changes: no test references the private function, and the public result functions keep their signatures.

## How did you test this code?

- Ran `get_frequentist_experiment_result` and `get_bayesian_experiment_result` on master and on this branch, across CUPED on/off and covariate data present/absent. All 8 outputs were identical, and CUPED-on produced different p-values than CUPED-off, so the adjusted branch ran.
- `products/experiments/backend/hogql_queries/test/test_experiment_utils.py` passed locally (48 tests).
- Not run: the DB-backed suites (`test_stats_config.py`, `test_cuped_*_metric.py`). This machine has no local Postgres/ClickHouse; they fail in fixture setup on master too.
- The dataclass ratchet (`posthog/test/test_dataclass_defaults.py`) passes with the baseline untouched, since `@frozen` adds no baseline entry.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Generated by Claude Code (Fable 5). Skills invoked: /writing-pr-descriptions. Single commit created via the GitHub `createCommitOnBranch` API (verified signature). The old-vs-new output comparison above was scripted by the agent; transcripts stayed local.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
