### PR TITLE
fix(warehouse-sources): retry a Framer handshake that closes before an HTTP response

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/framer/framer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/framer/framer.py
@@ -18,7 +18,7 @@ from typing import Any, Optional, Protocol
 from urllib.parse import unquote, urlencode, urljoin, urlsplit
 
 from structlog.types import FilteringBoundLogger
-from websockets.exceptions import ConnectionClosed, InvalidStatus
+from websockets.exceptions import ConnectionClosed, InvalidMessage, InvalidStatus
 from websockets.headers import build_authorization_basic
 from websockets.sync.client import connect as websocket_connect
 from websockets.uri import Proxy, get_proxy, parse_proxy, parse_uri
@@ -183,6 +183,13 @@ class FramerClient:
             if status in (401, 403):
                 raise FramerAPIError("Framer rejected the API key", code="UNAUTHORIZED") from e
             raise FramerAPIError(f"Connection rejected with HTTP {status}", code="INTERNAL", retryable=True) from e
+        except InvalidMessage as e:
+            # The server accepted the TCP/TLS connection but closed it before sending a
+            # parseable HTTP response (e.g. an EOF while reading the status line) — a
+            # headless-pool hiccup on Framer's side, not a credential or config problem.
+            raise FramerAPIError(
+                f"Connection closed during handshake: {e}", code="CONNECTION_CLOSED", retryable=True
+            ) from e
 
         deadline = time.monotonic() + CONNECT_TIMEOUT_SECONDS
         while True:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/framer/tests/test_framer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/framer/tests/test_framer.py
@@ -11,6 +11,7 @@ from typing import Any, Optional, cast
 import pytest
 
 from parameterized import parameterized
+from websockets.exceptions import InvalidMessage
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.framer import devalue
 from products.warehouse_sources.backend.temporal.data_imports.sources.framer.framer import (
@@ -276,6 +277,16 @@ class TestFramer:
         client = FramerClient(PROJECT_ID, "key", protocol_version="0.1.29", connect_fn=server)
         with pytest.raises(FramerAPIError) as exc_info:
             client.connect()
+        assert exc_info.value.retryable
+
+    def test_client_wraps_handshake_eof_as_retryable(self) -> None:
+        def connect_fn(*args: Any, **kwargs: Any) -> Any:
+            raise InvalidMessage("did not receive a valid HTTP response")
+
+        client = FramerClient(PROJECT_ID, "test-key", protocol_version="0.1.29", connect_fn=connect_fn)
+        with pytest.raises(FramerAPIError) as exc_info:
+            client.connect()
+        assert exc_info.value.code == "CONNECTION_CLOSED"
         assert exc_info.value.retryable
 
     def test_client_raises_on_method_error(self) -> None:


### PR DESCRIPTION
## Problem

A Framer sync fails and error tracking gets a fresh, confusing exception every time the headless WebSocket server closes the connection before sending a parseable HTTP status line during the handshake. [Issue](https://us.posthog.com/project/2/error_tracking/01a00c9f-8d7c-7872-a0d0-473693e5e7f3): `InvalidMessage: did not receive a valid HTTP response`.

`FramerClient.connect()` already wraps a bad HTTP status from the handshake (`InvalidStatus`) as a retryable `FramerAPIError`, but that except clause never catches `websockets.exceptions.InvalidMessage` — the exception `websockets` raises when the connection closes before any status line arrives at all (an `EOFError` while reading it). That left the raw exception unclassified: it wasn't retried through the source's retryable-error path and reported as a raw exception on every attempt instead of the one clean, actionable error the other transient handshake conditions get.

## Changes

- Catch `InvalidMessage` in `FramerClient.connect()` and wrap it as `FramerAPIError(code="CONNECTION_CLOSED", retryable=True)`.
- `CONNECTION_CLOSED` is already in `RETRYABLE_ERROR_CODES` and `FramerSource.get_retryable_errors()`, so this reuses the existing retry classification rather than adding a new one.

## How did you test this code?

Added `test_client_wraps_handshake_eof_as_retryable` in `test_framer.py`: a fake `connect_fn` raises `InvalidMessage`, and the test asserts `connect()` re-raises it as a `FramerAPIError` with `code == "CONNECTION_CLOSED"` and `retryable == True`. This is the regression the fix closes — before the change, `connect()` let the raw exception propagate.

Ran the full `framer` test suite locally (`pytest products/warehouse_sources/backend/temporal/data_imports/sources/framer/tests/`) — 61 passed. Not run: a live Framer sync, since this reproduces only on a transient server-side handshake drop.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — this changes retry classification for an internal error path, not documented behavior.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog error tracking MCP tools (issue details, sampled exception events with stack trace) to locate the failing frame in `framer.py`'s `connect()`. Read the websockets library source to confirm `InvalidMessage` is raised whenever the handshake response can't be parsed, including on a connection-closed `EOFError`. Invoked `/writing-tests` before adding the regression test and `/writing-pr-descriptions` before writing this body.