### PR TITLE
fix(cohorts): treat JSON null as unset for is_set/is_not_set

### DIFF
--- a/ee/clickhouse/models/test/test_property.py
+++ b/ee/clickhouse/models/test/test_property.py
@@ -1702,7 +1702,10 @@ def test_prop_filter_json_extract_materialized(
 
     query, params = prop_filter_json_extract(property, 0, allow_denormalized_props=True, use_new_events_schema=False)
 
-    assert "JSONExtract" not in query
+    # is_set / is_not_set always read JSONExtractRaw so explicit JSON null is handled correctly (#29916),
+    # even when a materialized column exists.
+    if property.operator not in ("is_set", "is_not_set"):
+        assert "JSONExtract" not in query
     events_table = events_read_table(False)
 
     uuids = sorted(
@@ -1752,6 +1755,106 @@ def test_prop_filter_json_extract_nullable_materialized_is_set_uses_json(
         assert uuids == expected
 
 
+@pytest.mark.parametrize(
+    "property,expected_query",
+    [
+        (
+            Property(key="email", operator="is_set", value="is_set"),
+            "(JSONHas(properties, %(k_0)s) AND JSONExtractRaw(properties, %(k_0)s) != 'null')",
+        ),
+        (
+            Property(key="email", operator="is_not_set", value="is_not_set"),
+            "(isNull(replaceRegexpAll(JSONExtractRaw(properties, %(k_0)s), '^\"|\"$', '')) OR JSONExtractRaw(properties, %(k_0)s) = 'null' OR NOT JSONHas(properties, %(k_0)s))",
+        ),
+    ],
+)
+def test_prop_filter_json_extract_set_operators_handle_json_null_values(property, expected_query):
+    query, params = prop_filter_json_extract(property, 0, allow_denormalized_props=False)
+
+    assert expected_query in query
+    assert params == {"k_0": "email", "v_0": property.value}
+
+
+@pytest.mark.parametrize(
+    "property,expected_query,unexpected_query",
+    [
+        (
+            Property(key="email", operator="is_set", value="is_set"),
+            "JSONExtractRaw(properties, %(k_0)s) != 'null'",
+            "materialized_email != 'null'",
+        ),
+        (
+            Property(key="email", operator="is_not_set", value="is_not_set"),
+            "JSONExtractRaw(properties, %(k_0)s) = 'null'",
+            "materialized_email = 'null'",
+        ),
+    ],
+)
+def test_prop_filter_json_extract_set_operators_use_raw_json_when_materialized(
+    monkeypatch, property, expected_query, unexpected_query
+):
+    monkeypatch.setattr(
+        "posthog.models.property.util.get_property_string_expr",
+        lambda *args, **kwargs: ("materialized_email", True),
+    )
+
+    query, _ = prop_filter_json_extract(property, 0, allow_denormalized_props=True)
+
+    assert expected_query in query
+    assert unexpected_query not in query
+
+
+@freeze_time("2021-04-01T01:00:00.000Z")
+def test_prop_filter_json_extract_is_set_excludes_explicit_json_null(clean_up_materialised_columns, team):
+    # Regression for #29916: explicit JSON null must not match is_set, and must match is_not_set.
+    # The string value "null" remains set (distinct from JSON null).
+    events = [
+        _create_event(
+            event="$pageview",
+            team=team,
+            distinct_id="whatever",
+            properties={"email": "test@posthog.com"},
+        ),
+        _create_event(
+            event="$pageview",
+            team=team,
+            distinct_id="whatever",
+            properties={"email": None},
+        ),
+        _create_event(
+            event="$pageview",
+            team=team,
+            distinct_id="whatever",
+            properties={"email": "null"},
+        ),
+        _create_event(
+            event="$pageview",
+            team=team,
+            distinct_id="whatever",
+            properties={"attr": "unrelated"},
+        ),
+    ]
+
+    cases = [
+        (Property(key="email", operator="is_set", value="is_set"), [0, 2]),
+        (Property(key="email", operator="is_not_set", value="is_not_set"), [1, 3]),
+    ]
+
+    for property, expected_event_indexes in cases:
+        query, params = prop_filter_json_extract(property, 0, allow_denormalized_props=False)
+        uuids = sorted(
+            [
+                str(uuid)
+                for (uuid,) in sync_execute(
+                    f"SELECT uuid FROM events WHERE team_id = %(team_id)s {query}",
+                    {"team_id": team.pk, **params},
+                )
+            ]
+        )
+        expected = sorted([events[index] for index in expected_event_indexes])
+        assert uuids == expected, f"operator={property.operator}"
+
+
 @pytest.mark.parametrize("property,expected_event_indexes", TEST_PROPERTIES)
 @freeze_time("2021-04-01T01:00:00.000Z")
 def test_prop_filter_json_extract_person_on_events_materialized(
@@ -1774,7 +1877,9 @@ def test_prop_filter_json_extract_person_on_events_materialized(
         use_event_column="group2_properties",
         use_new_events_schema=False,
     )
-    assert "JSON" not in query
+    # is_set / is_not_set always consult JSONExtractRaw for null semantics (#29916).
+    if property.operator not in ("is_set", "is_not_set"):
+        assert "JSON" not in query
     events_table = events_read_table(False)
 
     uuids = sorted(

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -1161,7 +1161,7 @@ class TestPrinter(BaseTest):
             (
                 self._json_dynamic_property_expr("foo")
                 if settings.CLICKHOUSE_HOGQL_USE_NEW_EVENTS_SCHEMA
-                else "if(has(events.properties_group_custom, %(hogql_val_0)s), events.properties_group_custom[%(hogql_val_1)s], NULL)"
+                else "nullIf(if(has(events.properties_group_custom, %(hogql_val_0)s), events.properties_group_custom[%(hogql_val_1)s], NULL), '')"
             ),
         )
         if settings.CLICKHOUSE_HOGQL_USE_NEW_EVENTS_SCHEMA:
@@ -1196,7 +1196,7 @@ class TestPrinter(BaseTest):
             (
                 self._json_dynamic_person_property_expr("foo")
                 if settings.CLICKHOUSE_HOGQL_USE_NEW_EVENTS_SCHEMA
-                else "if(has(events.person_properties_map_custom, %(hogql_val_0)s), events.person_properties_map_custom[%(hogql_val_1)s], NULL)"
+                else "nullIf(if(has(events.person_properties_map_custom, %(hogql_val_0)s), events.person_properties_map_custom[%(hogql_val_1)s], NULL), '')"
             ),
         )
         if settings.CLICKHOUSE_HOGQL_USE_NEW_EVENTS_SCHEMA:
@@ -1369,43 +1369,41 @@ class TestPrinter(BaseTest):
         )
 
     def test_property_groups_optimized_null_comparisons(self) -> None:
-        # NOT NULL comparisons should check to see if the key exists within the map (and should use the bloom filter to
-        # optimize the check), but do not need to load the values subcolumn.
+        # is_set / is_not_set must treat JSON null (stored as '' in Map(String, String)) as unset (#29916),
+        # so these read both the keys and values subcolumns.
         self._test_property_group_comparison(
             "properties.key is not null as p",
-            "has(events.properties_group_custom, %(hogql_val_0)s) AS p",
-            {"hogql_val_0": "key"},
-            expected_skip_indexes_used={"properties_group_custom_keys_bf"},
+            "and(has(events.properties_group_custom, %(hogql_val_0)s), notEquals(events.properties_group_custom[%(hogql_val_1)s], '')) AS p",
+            {"hogql_val_0": "key", "hogql_val_1": "key"},
+            expected_skip_indexes_used={"properties_group_custom_keys_bf", "properties_group_custom_values_bf"},
         )
         self._test_property_group_comparison(
             "properties.key != null as p",
-            "has(events.properties_group_custom, %(hogql_val_0)s) AS p",
-            {"hogql_val_0": "key"},
-            expected_skip_indexes_used={"properties_group_custom_keys_bf"},
+            "and(has(events.properties_group_custom, %(hogql_val_0)s), notEquals(events.properties_group_custom[%(hogql_val_1)s], '')) AS p",
+            {"hogql_val_0": "key", "hogql_val_1": "key"},
+            expected_skip_indexes_used={"properties_group_custom_keys_bf", "properties_group_custom_values_bf"},
         )
         self._test_property_group_comparison(
             "isNotNull(properties.key) as p",
-            "has(events.properties_group_custom, %(hogql_val_0)s) AS p",
-            {"hogql_val_0": "key"},
-            expected_skip_indexes_used={"properties_group_custom_keys_bf"},
+            "not(or(not(has(events.properties_group_custom, %(hogql_val_0)s)), equals(events.properties_group_custom[%(hogql_val_1)s], ''))) AS p",
+            {"hogql_val_0": "key", "hogql_val_1": "key"},
+            expected_skip_indexes_used={"properties_group_custom_keys_bf", "properties_group_custom_values_bf"},
         )
 
-        # NULL comparisons don't really benefit from the bloom filter index like NOT NULL comparisons do, but like
-        # above, only need to check the keys subcolumn and not the values subcolumn.
         self._test_property_group_comparison(
             "properties.key is null as p",
-            "not(has(events.properties_group_custom, %(hogql_val_0)s)) AS p",
-            {"hogql_val_0": "key"},
+            "or(not(has(events.properties_group_custom, %(hogql_val_0)s)), equals(events.properties_group_custom[%(hogql_val_1)s], '')) AS p",
+            {"hogql_val_0": "key", "hogql_val_1": "key"},
         )
         self._test_property_group_comparison(
             "properties.key = null as p",
-            "not(has(events.properties_group_custom, %(hogql_val_0)s)) AS p",
-            {"hogql_val_0": "key"},
+            "or(not(has(events.properties_group_custom, %(hogql_val_0)s)), equals(events.properties_group_custom[%(hogql_val_1)s], '')) AS p",
+            {"hogql_val_0": "key", "hogql_val_1": "key"},
         )
         self._test_property_group_comparison(
             "isNull(properties.key) as p",
-            "not(has(events.properties_group_custom, %(hogql_val_0)s)) AS p",
-            {"hogql_val_0": "key"},
+            "or(not(has(events.properties_group_custom, %(hogql_val_0)s)), equals(events.properties_group_custom[%(hogql_val_1)s], '')) AS p",
+            {"hogql_val_0": "key", "hogql_val_1": "key"},
         )
 
     def test_property_groups_optimized_has(self) -> None:
@@ -1566,19 +1564,19 @@ class TestPrinter(BaseTest):
         )  # if changing this assumption, you'll need to change the printer too
         self._test_property_group_comparison(
             "properties.key in NULL",
-            "in(if(has(events.properties_group_custom, %(hogql_val_0)s), events.properties_group_custom[%(hogql_val_1)s], NULL), NULL)",
+            "in(nullIf(if(has(events.properties_group_custom, %(hogql_val_0)s), events.properties_group_custom[%(hogql_val_1)s], NULL), ''), NULL)",
         )
         self._test_property_group_comparison(
             "properties.key in (NULL)",
-            "in(if(has(events.properties_group_custom, %(hogql_val_0)s), events.properties_group_custom[%(hogql_val_1)s], NULL), NULL)",
+            "in(nullIf(if(has(events.properties_group_custom, %(hogql_val_0)s), events.properties_group_custom[%(hogql_val_1)s], NULL), ''), NULL)",
         )
         self._test_property_group_comparison(
             "properties.key in (NULL, NULL, NULL)",
-            "in(if(has(events.properties_group_custom, %(hogql_val_0)s), events.properties_group_custom[%(hogql_val_1)s], NULL), tuple(NULL, NULL, NULL))",
+            "in(nullIf(if(has(events.properties_group_custom, %(hogql_val_0)s), events.properties_group_custom[%(hogql_val_1)s], NULL), ''), tuple(NULL, NULL, NULL))",
         )
         self._test_property_group_comparison(
             "properties.key in [NULL, NULL, NULL]",
-            "in(if(has(events.properties_group_custom, %(hogql_val_0)s), events.properties_group_custom[%(hogql_val_1)s], NULL), [NULL, NULL, NULL])",
+            "in(nullIf(if(has(events.properties_group_custom, %(hogql_val_0)s), events.properties_group_custom[%(hogql_val_1)s], NULL), ''), [NULL, NULL, NULL])",
         )
 
         # Don't optimize comparisons to types that require additional type conversions.
@@ -1732,7 +1730,7 @@ class TestPrinter(BaseTest):
             assert "properties_group_custom" not in printed
         else:
             assert printed == (
-                "SELECT if(has(events.properties_group_custom, %(hogql_val_0)s), events.properties_group_custom[%(hogql_val_1)s], NULL) AS ft "
+                "SELECT nullIf(if(has(events.properties_group_custom, %(hogql_val_0)s), events.properties_group_custom[%(hogql_val_1)s], NULL), '') AS ft "
                 "FROM events "
                 f"WHERE and(equals(events.team_id, {self.team.pk}), equals(events.properties_group_custom[%(hogql_val_2)s], %(hogql_val_3)s)) "
                 "LIMIT 50000"

--- a/posthog/hogql/test/__snapshots__/test_property_skip_indexes.ambr
+++ b/posthog/hogql/test/__snapshots__/test_property_skip_indexes.ambr
@@ -447,7 +447,7 @@
   '''
   SELECT count() AS `count()`
   FROM events
-  WHERE and(equals(events.team_id, 99999), has(events.properties_group_custom, 'test_prop'))
+  WHERE and(equals(events.team_id, 99999), and(has(events.properties_group_custom, 'test_prop'), notEquals(events.properties_group_custom['test_prop'], '')))
   LIMIT 50000
   '''
 # ---
@@ -455,7 +455,7 @@
   '''
   SELECT count() AS `count()`
   FROM events
-  WHERE and(equals(events.team_id, 99999), not(has(events.properties_group_custom, 'test_prop')))
+  WHERE and(equals(events.team_id, 99999), or(not(has(events.properties_group_custom, 'test_prop')), equals(events.properties_group_custom['test_prop'], '')))
   LIMIT 50000
   '''
 # ---
@@ -471,7 +471,7 @@
   '''
   SELECT count() AS `count()`
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(less(if(has(events.properties_group_custom, 'test_prop'), events.properties_group_custom['test_prop'], NULL), '5'), 0))
+  WHERE and(equals(events.team_id, 99999), ifNull(less(nullIf(if(has(events.properties_group_custom, 'test_prop'), events.properties_group_custom['test_prop'], NULL), ''), '5'), 0))
   LIMIT 50000
   '''
 # ---
@@ -479,7 +479,7 @@
   '''
   SELECT count() AS `count()`
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(ilike(toString(if(has(events.properties_group_custom, 'test_prop'), events.properties_group_custom['test_prop'], NULL)), '%5%'), 0))
+  WHERE and(equals(events.team_id, 99999), ifNull(ilike(toString(nullIf(if(has(events.properties_group_custom, 'test_prop'), events.properties_group_custom['test_prop'], NULL), '')), '%5%'), 0))
   LIMIT 50000
   '''
 # ---
@@ -599,7 +599,7 @@
   '''
   SELECT count() AS `count()`
   FROM events
-  WHERE and(equals(events.team_id, 99999), has(events.person_properties_map_custom, 'test_prop'))
+  WHERE and(equals(events.team_id, 99999), and(has(events.person_properties_map_custom, 'test_prop'), notEquals(events.person_properties_map_custom['test_prop'], '')))
   LIMIT 50000
   '''
 # ---
@@ -615,7 +615,7 @@
   '''
   SELECT count() AS `count()`
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(less(if(has(events.person_properties_map_custom, 'test_prop'), events.person_properties_map_custom['test_prop'], NULL), '5'), 0))
+  WHERE and(equals(events.team_id, 99999), ifNull(less(nullIf(if(has(events.person_properties_map_custom, 'test_prop'), events.person_properties_map_custom['test_prop'], NULL), ''), '5'), 0))
   LIMIT 50000
   '''
 # ---

--- a/posthog/hogql/test/test_property_skip_indexes.py
+++ b/posthog/hogql/test/test_property_skip_indexes.py
@@ -705,10 +705,10 @@ class TestEventPropertySkipIndexes(_PropertySkipIndexTestBase):
         [
             # ``equals(map[key], 'v')`` — both keys and values bloom filters apply.
             ("eq_string", PropertyOperator.EXACT, "5", {PG_KEYS_INDEX, PG_VALUES_INDEX}, set()),
-            # is_set → ``has(map, key)`` — keys bloom filter applies.
-            ("is_set", PropertyOperator.IS_SET, None, {PG_KEYS_INDEX}, {PG_VALUES_INDEX}),
-            # is_not_set → ``not(has(map, key))`` — keys bloom filter still applies (proves granules where the key is definitely absent).
-            ("is_not_set", PropertyOperator.IS_NOT_SET, None, {PG_KEYS_INDEX}, {PG_VALUES_INDEX}),
+            # is_set → ``and(has(map, key), map[key] != '')`` — keys + values (JSON null is stored as '').
+            ("is_set", PropertyOperator.IS_SET, None, {PG_KEYS_INDEX, PG_VALUES_INDEX}, set()),
+            # is_not_set → ``or(not(has(map, key)), map[key] = '')`` — keys + values bloom filters.
+            ("is_not_set", PropertyOperator.IS_NOT_SET, None, {PG_KEYS_INDEX, PG_VALUES_INDEX}, set()),
             # Multi-value IN → ``and(has(map, key), in(map[key], tuple(...)))`` — keys only; ``transform_null_in`` defaults break a direct values-bloom probe.
             ("in_multi", PropertyOperator.IN_, ["2", "5"], {PG_KEYS_INDEX}, {PG_VALUES_INDEX}),
             # Range ops fall back to the unoptimized ``has(map, key) ? map[key] : null`` form — no bloom filter applies.
@@ -881,7 +881,7 @@ class TestPersonOnEventsPropertySkipIndexes(_PropertySkipIndexTestBase):
     @parameterized.expand(
         [
             ("eq_string", PropertyOperator.EXACT, "5", {PG_KEYS_INDEX, PG_VALUES_INDEX}, set()),
-            ("is_set", PropertyOperator.IS_SET, None, {PG_KEYS_INDEX}, {PG_VALUES_INDEX}),
+            ("is_set", PropertyOperator.IS_SET, None, {PG_KEYS_INDEX, PG_VALUES_INDEX}, set()),
             ("in_multi", PropertyOperator.IN_, ["2", "5"], {PG_KEYS_INDEX}, {PG_VALUES_INDEX}),
             ("lt", PropertyOperator.LT, "5", set(), {PG_KEYS_INDEX, PG_VALUES_INDEX}),
         ]

--- a/posthog/hogql/transforms/clickhouse_property_resolution.py
+++ b/posthog/hogql/transforms/clickhouse_property_resolution.py
@@ -318,11 +318,13 @@ def _materialized_head_expr(
 
     if source.kind == "property_group":
         # has(map, key) ? map[key] : null — guard the map read so a missing key returns NULL, not the map's '' default.
+        # JSONExtractKeysAndValues(..., 'String') stores JSON null as '', so scrub '' → NULL. Leave the literal
+        # string "null" intact so is_set matches HogQL JSON semantics (string "null" is set; JSON null is not).
         has_field = _synthetic_column_field(field_type, source.column, is_nullable=True)
         get_field = _synthetic_column_field(field_type, source.column, is_nullable=True)
         if has_field is None or get_field is None:
             return None
-        return ast.Call(
+        raw = ast.Call(
             name="if",
             args=[
                 ast.Call(name="has", args=[has_field, ast.Constant(value=first_key)]),
@@ -330,6 +332,7 @@ def _materialized_head_expr(
                 ast.Constant(value=None),
             ],
         )
+        return ast.Call(name="nullIf", args=[raw, _sentinel("")])
 
     column_field = _synthetic_column_field(field_type, source.column, is_nullable=source.is_nullable)
     if column_field is None:
@@ -898,8 +901,8 @@ class ClickHousePropertyResolver(CloningVisitor):
         if optimized_json_has is not None:
             return optimized_json_has
 
-        # `isNull` / `isNotNull` / `JSONHas` on a property-group property can be answered by `has(map, key)` alone,
-        # without reading the values subcolumn — so it stays eligible for the keys bloom-filter index.
+        # `isNull` / `isNotNull` / `JSONHas` on a property-group property can usually be answered from the map.
+        # For is-set / is-not-set we also inspect the value: JSON null is stored as '' in Map(String, String).
         optimized = self._optimize_property_group_call(node)
         if optimized is not None:
             return optimized
@@ -1232,8 +1235,11 @@ class ClickHousePropertyResolver(CloningVisitor):
             prop = self._property_group_property(node.args[0])
             if prop is None:
                 return None
-            has_expr = prop.group_has()
-            return _call("not", [has_expr]) if node.name == "isNull" else has_expr
+            # JSON null is stored as '' in Map(String, String) property groups. Key presence alone is not enough:
+            # is_set requires a non-empty value; is_not_set includes missing keys and empty (JSON-null) values.
+            value_is_empty = _call("equals", [prop.group_value(), _sentinel("")])
+            is_not_set = _call("or", [_call("not", [prop.group_has()]), value_is_empty])
+            return is_not_set if node.name == "isNull" else _call("not", [is_not_set])
 
         if node.name == "JSONHas" and len(node.args) == 2 and isinstance(node.args[1], ast.Constant):
             # JSONHas(blob, key): the key is the literal second arg, and the first arg is the blob Field. Resolve the
@@ -1281,8 +1287,8 @@ class ClickHousePropertyResolver(CloningVisitor):
         value = constant_expr.value
         if node.op == ast.CompareOperationOp.Eq:
             if value is None:
-                # `= NULL` means the key is absent: not(has(map, key)). Avoids reading the values subcolumn.
-                return _call("not", [prop.group_has()])
+                # is_not_set: missing key OR empty map value (JSON null is stored as '').
+                return _call("or", [_call("not", [prop.group_has()]), _call("equals", [prop.group_value(), _sentinel("")])])
             if value is True:
                 # Booleans are stored as the strings 'true'/'false' in the group map; compare against those so the
                 # comparison stays index-eligible.
@@ -1299,8 +1305,11 @@ class ClickHousePropertyResolver(CloningVisitor):
 
         # NotEq
         if value is None:
-            # `!= NULL` means the key is present: has(map, key). Uses the keys index, skips the values subcolumn.
-            return prop.group_has()
+            # is_set: key present with a non-empty value. JSON null → '' must not count as set (#29916).
+            return _call(
+                "and",
+                [prop.group_has(), _call("notEquals", [prop.group_value(), _sentinel("")])],
+            )
         return None
 
     def _optimize_property_group_in(self, node: ast.CompareOperation) -> ast.Expr | None:

--- a/posthog/hogql_queries/test/test_hogql_cohort_query.py
+++ b/posthog/hogql_queries/test/test_hogql_cohort_query.py
@@ -657,3 +657,108 @@ class TestHogQLCohortQuery(ClickhouseTestMixin, APIBaseTest):
         hogql_query = HogQLCohortQuery(cohort=cohort)
         with self.assertRaises(Cohort.DoesNotExist):
             hogql_query.query_str("clickhouse")
+
+    def test_person_property_is_set_excludes_null_values(self) -> None:
+        """Regression for #29916: cohort is_set must exclude persons whose property is JSON null."""
+        p_with_value = _create_person(
+            team_id=self.team.pk,
+            distinct_ids=["p-set"],
+            properties={"custom_prop": "hello"},
+            immediate=True,
+        )
+        _create_person(
+            team_id=self.team.pk,
+            distinct_ids=["p-null"],
+            properties={"custom_prop": None},
+            immediate=True,
+        )
+        _create_person(
+            team_id=self.team.pk,
+            distinct_ids=["p-missing"],
+            properties={},
+            immediate=True,
+        )
+        flush_persons_and_events()
+
+        cohort = Cohort.objects.create(
+            team=self.team,
+            name="is_set excludes null",
+            filters={
+                "properties": {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "type": "AND",
+                            "values": [
+                                {
+                                    "key": "custom_prop",
+                                    "type": "person",
+                                    "operator": "is_set",
+                                    "value": "is_set",
+                                    "negation": False,
+                                }
+                            ],
+                        }
+                    ],
+                }
+            },
+        )
+
+        hogql_query = HogQLCohortQuery(cohort=cohort)
+        query_str = hogql_query.query_str("clickhouse")
+        # HogQL lowers is_set to isNotNull over the scrubbed property read (JSON null → NULL).
+        self.assertIn("isNotNull", query_str)
+
+        result = hogql_query.get_query_executor().execute()
+        matched_ids = {row[0] for row in (result.results or [])}
+        self.assertEqual(matched_ids, {p_with_value.uuid})
+
+    def test_person_property_is_not_set_includes_null_values(self) -> None:
+        """Regression for #29916: cohort is_not_set must include persons whose property is JSON null."""
+        _create_person(
+            team_id=self.team.pk,
+            distinct_ids=["p-set"],
+            properties={"custom_prop": "hello"},
+            immediate=True,
+        )
+        p_null = _create_person(
+            team_id=self.team.pk,
+            distinct_ids=["p-null"],
+            properties={"custom_prop": None},
+            immediate=True,
+        )
+        p_missing = _create_person(
+            team_id=self.team.pk,
+            distinct_ids=["p-missing"],
+            properties={},
+            immediate=True,
+        )
+        flush_persons_and_events()
+
+        cohort = Cohort.objects.create(
+            team=self.team,
+            name="is_not_set includes null",
+            filters={
+                "properties": {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "type": "AND",
+                            "values": [
+                                {
+                                    "key": "custom_prop",
+                                    "type": "person",
+                                    "operator": "is_not_set",
+                                    "value": "is_not_set",
+                                    "negation": False,
+                                }
+                            ],
+                        }
+                    ],
+                }
+            },
+        )
+
+        result = HogQLCohortQuery(cohort=cohort).get_query_executor().execute()
+        matched_ids = {row[0] for row in (result.results or [])}
+        self.assertEqual(matched_ids, {p_null.uuid, p_missing.uuid})

--- a/posthog/models/property/util.py
+++ b/posthog/models/property/util.py
@@ -520,13 +520,13 @@ def prop_filter_json_extract(
                 f" {property_operator} {events_json_property_exists_expr}",
                 params,
             )
-        if is_denormalized:
-            return (
-                " {property_operator} {left} != ''".format(left=property_expr, property_operator=property_operator),
-                params,
-            )
+        # Always consult the raw JSON value so an explicit JSON `null` counts as unset.
+        # Compare against untrimmed JSONExtractRaw ('null'), not the quote-trimmed property
+        # expression — otherwise the string value "null" would be misclassified (see #29916).
+        # Skip the denormalized-column shortcut for the same reason: mat columns store JSON null
+        # as '', which is indistinguishable from a real empty string without the JSON blob.
         return (
-            " {property_operator} JSONHas({prop_var}, %(k{prepend}_{idx})s)".format(
+            " {property_operator} (JSONHas({prop_var}, %(k{prepend}_{idx})s) AND JSONExtractRaw({prop_var}, %(k{prepend}_{idx})s) != 'null')".format(
                 idx=idx,
                 prepend=prepend,
                 prop_var=prop_var,
@@ -544,13 +544,8 @@ def prop_filter_json_extract(
                 f" {property_operator} NOT ({events_json_property_exists_expr})",
                 params,
             )
-        if is_denormalized:
-            return (
-                " {property_operator} {left} = ''".format(left=property_expr, property_operator=property_operator),
-                params,
-            )
         return (
-            " {property_operator} (isNull({left}) OR NOT JSONHas({prop_var}, %(k{prepend}_{idx})s))".format(
+            " {property_operator} (isNull({left}) OR JSONExtractRaw({prop_var}, %(k{prepend}_{idx})s) = 'null' OR NOT JSONHas({prop_var}, %(k{prepend}_{idx})s))".format(
                 idx=idx,
                 prepend=prepend,
                 prop_var=prop_var,

--- a/rust/feature-flags/src/properties/property_matching.rs
+++ b/rust/feature-flags/src/properties/property_matching.rs
@@ -185,16 +185,19 @@ pub fn match_property(
 
     // first match operators that don't require a value
     match operator {
-        OperatorType::IsSet => return Ok(matching_property_values.contains_key(key)),
+        // Explicit JSON null counts as unset, matching HogQL / cohort filter semantics (#29916).
+        OperatorType::IsSet => {
+            return Ok(matches!(match_value, Some(value) if !value.is_null()));
+        }
         OperatorType::IsNotSet => {
             return if partial_props {
-                if matching_property_values.contains_key(key) {
-                    Ok(false)
-                } else {
-                    Err(FlagMatchingError::InconclusiveOperatorMatch)
+                match match_value {
+                    Some(value) if value.is_null() => Ok(true),
+                    Some(_) => Ok(false),
+                    None => Err(FlagMatchingError::InconclusiveOperatorMatch),
                 }
             } else {
-                Ok(!matching_property_values.contains_key(key))
+                Ok(match_value.map_or(true, |value| value.is_null()))
             }
         }
         _ => {}
@@ -1125,7 +1128,7 @@ mod test_match_properties {
         )
         .expect("expected match to exist"));
 
-        assert!(match_property(
+        assert!(!match_property(
             &property_a,
             &HashMap::from([("key".to_string(), json!(null))]),
             true
@@ -2016,7 +2019,7 @@ mod test_match_properties {
             extra: Default::default(),
         };
 
-        assert!(match_property(
+        assert!(!match_property(
             &property_b,
             &HashMap::from([("key".to_string(), json!(null))]),
             true


### PR DESCRIPTION
## Summary
- Make `is_set` exclude explicit JSON `null` (and `is_not_set` include it) so cohorts match filter semantics.
- Fix three paths that still treated key presence as “set”: legacy `prop_filter_json_extract`, HogQL property-group null optimizations, and the Rust feature-flag property matcher.
- Keep the string value `"null"` distinct from JSON null (via untrimmed `JSONExtractRaw`), matching HogQL JSON behavior.

## Test plan
- [x] Added regression tests for `prop_filter_json_extract` covering JSON null vs string `"null"` vs missing key
- [x] Added HogQL cohort membership tests for person-property `is_set` / `is_not_set` with null values
- [x] Updated property-group printer + skip-index expectations/snapshots
- [x] Updated Rust `IsSet` matcher tests for null values
- [ ] CI: `ee/clickhouse/models/test/test_property.py`, `posthog/hogql_queries/test/test_hogql_cohort_query.py`, `posthog/hogql/printer/test/test_printer.py`, `posthog/hogql/test/test_property_skip_indexes.py`
- [ ] CI: Rust feature-flags `property_matching` tests

Fixes #29916
