### PR TITLE
feat(canvas): grid canvas MCP tools and composing-grid-canvases skill

### DIFF
--- a/products/canvas/mcp/tools.yaml
+++ b/products/canvas/mcp/tools.yaml
@@ -138,9 +138,6 @@ tools:
             `expected_current_version_id` so concurrent edits are not overwritten. A grid canvas with no versions yet
             returns the default empty layout with a null version id. Placements reference component canvases
             (kind=component) — resolve their contracts via canvas-list.
-        # Historical version browsing is a viewer feature, not an agent one: the response's
-        # current_version_id is always the live head, so an old layout paired with that guard
-        # would publish over newer versions without a 409.
         exclude_params:
             - version_id
         param_overrides:
@@ -191,11 +188,11 @@ tools:
             id:
                 description: ID of the grid canvas whose layout to publish.
             expected_current_version_id:
-                required: true
                 description:
-                    'The `current_version_id` this document was built on, from canvas-layout-get (null only for a grid
-                    canvas that has never published a layout). A whole document replaces the head, so without the guard
-                    a layout the user changed after you read it is silently discarded.'
+                    The `current_version_id` this document was built on, from canvas-layout-get (null only for a grid canvas
+                    that has never published a layout). A whole document replaces the head, so without the guard a
+                    layout the user changed after you read it is silently discarded.
+                required: true
     canvas-list:
         operation: canvases_list
         enabled: true

--- a/products/canvas/mcp/tools.yaml
+++ b/products/canvas/mcp/tools.yaml
@@ -133,11 +133,16 @@ tools:
             idempotent: true
         title: Read grid canvas layout
         description: >
-            Read a grid canvas's layout document (grid definition + placements) and its `current_version_id`. Always
-            call this before patching or publishing: pass the returned version id as `expected_current_version_id` so
-            concurrent edits are not overwritten. A grid canvas with no versions yet returns the default empty layout
-            with a null version id. Placements reference component canvases (kind=component) — resolve their contracts
-            via canvas-list.
+            Read a grid canvas's live layout document (grid definition + placements) and its `current_version_id`.
+            Always call this before patching or publishing: pass the returned version id as
+            `expected_current_version_id` so concurrent edits are not overwritten. A grid canvas with no versions yet
+            returns the default empty layout with a null version id. Placements reference component canvases
+            (kind=component) — resolve their contracts via canvas-list.
+        # Historical version browsing is a viewer feature, not an agent one: the response's
+        # current_version_id is always the live head, so an old layout paired with that guard
+        # would publish over newer versions without a 409.
+        exclude_params:
+            - version_id
         param_overrides:
             id:
                 description: ID of the grid canvas whose layout to read.
@@ -179,11 +184,18 @@ tools:
             incremental changes — full publish is for creating an initial layout or restructuring the whole grid. The
             layout is validated first (grid bounds, overlaps, component references, per-placement config against each
             component's configSchema); errors reject the publish and leave the canvas untouched. The new version is live
-            immediately — no build. Pass `expected_current_version_id` from canvas-layout-get so a concurrent edit is
-            rejected with 409 version_conflict instead of overwritten.
+            immediately — no build. `expected_current_version_id` is REQUIRED (from canvas-layout-get; null only before
+            the first layout publish) — a stale base is rejected with 409 version_conflict; re-read the layout, rebuild
+            the document on the new head, and publish again.
         param_overrides:
             id:
                 description: ID of the grid canvas whose layout to publish.
+            expected_current_version_id:
+                required: true
+                description:
+                    'The `current_version_id` this document was built on, from canvas-layout-get (null only for a grid
+                    canvas that has never published a layout). A whole document replaces the head, so without the guard
+                    a layout the user changed after you read it is silently discarded.'
     canvas-list:
         operation: canvases_list
         enabled: true

--- a/products/canvas/mcp/tools.yaml
+++ b/products/canvas/mcp/tools.yaml
@@ -49,6 +49,16 @@ tools:
                     "Id of the channel to create the canvas in — the channel the task was created in, from the task's context.
                     Use channel-list only to resolve a channel the user named; never pick a channel from the listing
                     yourself (the personal #me channel is not a default)."
+            kind:
+                description:
+                    "What to create: 'freeform' (a standalone app — the default), 'component' (a reusable widget for
+                    grid canvases; its published project must declare a `component` placement contract), or 'grid'
+                    (a composition of components, edited via canvas-layout-patch). See canvas-list (kind=component)
+                    before creating a component."
+            description:
+                description:
+                    "Short prose describing the canvas. For components this is the store-search text — say what the
+                    widget shows and what its config controls, so future searches find it."
     canvas-draft-create:
         operation: canvases_draft_create
         enabled: true
@@ -124,11 +134,19 @@ tools:
         title: List canvases
         description: >
             List the project's canvases (newest first), optionally scoped to one channel via `channel`. Use this to
-            resolve which canvas a request refers to before reading or publishing source. Each row's `url` is that
-            canvas's only valid link — share it verbatim; never construct a canvas URL yourself.
+            resolve which canvas a request refers to before reading or publishing source. With `kind=component` this
+            is the COMPONENT STORE: reusable widgets grid canvases place. Before building a new widget, ALWAYS search
+            here first (`kind=component` plus `search=<what the widget shows>`) — placing an existing component with
+            the right `config` beats authoring a duplicate. A component is placeable when `component_meta` (its size
+            contract and configSchema) and `published_build_id` are both set. Each row's `url` is that canvas's only
+            valid link — share it verbatim; never construct a canvas URL yourself.
         param_overrides:
             channel:
                 description: Only return canvases in this channel (channel id).
+            kind:
+                description: Only return canvases of this kind. kind=component lists the component store.
+            search:
+                description: Case-insensitive match on name and description — use to find store components by what they show.
     canvas-promote-create:
         operation: canvases_promote_create
         enabled: true
@@ -247,15 +265,68 @@ tools:
     canvases-home-create:
         operation: canvases_home_create
         enabled: false
-    canvases-layout-patch-create:
+    canvas-layout-patch:
         operation: canvases_layout_patch_create
-        enabled: false
-    canvases-layout-publish-create:
+        enabled: true
+        scopes:
+            - canvas:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        title: Patch grid canvas layout
+        description: >
+            Apply surgical operations to a grid canvas's layout — the DEFAULT way to change one: add_placement (a new
+            widget box), update_placement (fill a box with a component, move/resize it, change its status or config),
+            remove_placement, set_grid. Operations apply in order to the current layout, the result is validated
+            atomically, and the new version is live immediately (layout is data — no build).
+            `expected_current_version_id` is REQUIRED (from canvas-layout-get; null only before the first layout
+            publish) — a stale base is rejected with 409 version_conflict; re-read the layout, re-apply, and patch
+            again. To fill a drawn box: update_placement with changes {status: "live", component: <component canvas
+            id>, config: {...}}. The component must be published (canvas-list kind=component shows component_meta and
+            published_build_id) and the config must match its configSchema.
+        param_overrides:
+            id:
+                description: ID of the grid canvas whose layout to patch.
+    canvas-layout-publish:
         operation: canvases_layout_publish_create
-        enabled: false
-    canvases-layout-retrieve:
+        enabled: true
+        scopes:
+            - canvas:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        title: Publish grid canvas layout
+        description: >
+            Publish a COMPLETE layout document as a grid canvas's new head version. Prefer canvas-layout-patch for
+            incremental changes — full publish is for creating an initial layout or restructuring the whole grid.
+            The layout is validated first (grid bounds, overlaps, component references, per-placement config against
+            each component's configSchema); errors reject the publish and leave the canvas untouched. The new version
+            is live immediately — no build. Pass `expected_current_version_id` from canvas-layout-get so a concurrent
+            edit is rejected with 409 version_conflict instead of overwritten.
+        param_overrides:
+            id:
+                description: ID of the grid canvas whose layout to publish.
+    canvas-layout-get:
         operation: canvases_layout_retrieve
-        enabled: false
+        enabled: true
+        scopes:
+            - canvas:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Read grid canvas layout
+        description: >
+            Read a grid canvas's layout document (grid definition + placements) and its `current_version_id`. Always
+            call this before patching or publishing: pass the returned version id as `expected_current_version_id` so
+            concurrent edits are not overwritten. A grid canvas with no versions yet returns the default empty layout
+            with a null version id. Placements reference component canvases (kind=component) — resolve their
+            contracts via canvas-list.
+        param_overrides:
+            id:
+                description: ID of the grid canvas whose layout to read.
     canvases-partial-update:
         operation: canvases_partial_update
         enabled: false

--- a/products/canvas/mcp/tools.yaml
+++ b/products/canvas/mcp/tools.yaml
@@ -51,14 +51,14 @@ tools:
                     yourself (the personal #me channel is not a default)."
             kind:
                 description:
-                    "What to create: 'freeform' (a standalone app — the default), 'component' (a reusable widget for
-                    grid canvases; its published project must declare a `component` placement contract), or 'grid'
-                    (a composition of components, edited via canvas-layout-patch). See canvas-list (kind=component)
-                    before creating a component."
+                    "What to create: 'freeform' (a standalone app — the default), 'component' (a reusable widget for grid
+                    canvases; its published project must declare a `component` placement contract), or 'grid' (a
+                    composition of components, edited via canvas-layout-patch). See canvas-list (kind=component) before
+                    creating a component."
             description:
                 description:
-                    "Short prose describing the canvas. For components this is the store-search text — say what the
-                    widget shows and what its config controls, so future searches find it."
+                    Short prose describing the canvas. For components this is the store-search text — say what the widget shows
+                    and what its config controls, so future searches find it.
     canvas-draft-create:
         operation: canvases_draft_create
         enabled: true
@@ -122,6 +122,68 @@ tools:
         param_overrides:
             id:
                 description: ID of the canvas whose source to edit.
+    canvas-layout-get:
+        operation: canvases_layout_retrieve
+        enabled: true
+        scopes:
+            - canvas:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Read grid canvas layout
+        description: >
+            Read a grid canvas's layout document (grid definition + placements) and its `current_version_id`. Always
+            call this before patching or publishing: pass the returned version id as `expected_current_version_id` so
+            concurrent edits are not overwritten. A grid canvas with no versions yet returns the default empty layout
+            with a null version id. Placements reference component canvases (kind=component) — resolve their contracts
+            via canvas-list.
+        param_overrides:
+            id:
+                description: ID of the grid canvas whose layout to read.
+    canvas-layout-patch:
+        operation: canvases_layout_patch_create
+        enabled: true
+        scopes:
+            - canvas:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        title: Patch grid canvas layout
+        description: >
+            Apply surgical operations to a grid canvas's layout — the DEFAULT way to change one: add_placement (a new
+            widget box), update_placement (fill a box with a component, move/resize it, change its status or config),
+            remove_placement, set_grid. Operations apply in order to the current layout, the result is validated
+            atomically, and the new version is live immediately (layout is data — no build).
+            `expected_current_version_id` is REQUIRED (from canvas-layout-get; null only before the first layout
+            publish) — a stale base is rejected with 409 version_conflict; re-read the layout, re-apply, and patch
+            again. To fill a drawn box: update_placement with changes {status: "live", component: <component canvas id>,
+            config: {...}}. The component must be published (canvas-list kind=component shows component_meta and
+            published_build_id) and the config must match its configSchema.
+        param_overrides:
+            id:
+                description: ID of the grid canvas whose layout to patch.
+    canvas-layout-publish:
+        operation: canvases_layout_publish_create
+        enabled: true
+        scopes:
+            - canvas:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        title: Publish grid canvas layout
+        description: >
+            Publish a COMPLETE layout document as a grid canvas's new head version. Prefer canvas-layout-patch for
+            incremental changes — full publish is for creating an initial layout or restructuring the whole grid. The
+            layout is validated first (grid bounds, overlaps, component references, per-placement config against each
+            component's configSchema); errors reject the publish and leave the canvas untouched. The new version is live
+            immediately — no build. Pass `expected_current_version_id` from canvas-layout-get so a concurrent edit is
+            rejected with 409 version_conflict instead of overwritten.
+        param_overrides:
+            id:
+                description: ID of the grid canvas whose layout to publish.
     canvas-list:
         operation: canvases_list
         enabled: true
@@ -134,10 +196,10 @@ tools:
         title: List canvases
         description: >
             List the project's canvases (newest first), optionally scoped to one channel via `channel`. Use this to
-            resolve which canvas a request refers to before reading or publishing source. With `kind=component` this
-            is the COMPONENT STORE: reusable widgets grid canvases place. Before building a new widget, ALWAYS search
-            here first (`kind=component` plus `search=<what the widget shows>`) — placing an existing component with
-            the right `config` beats authoring a duplicate. A component is placeable when `component_meta` (its size
+            resolve which canvas a request refers to before reading or publishing source. With `kind=component` this is
+            the COMPONENT STORE: reusable widgets grid canvases place. Before building a new widget, ALWAYS search here
+            first (`kind=component` plus `search=<what the widget shows>`) — placing an existing component with the
+            right `config` beats authoring a duplicate. A component is placeable when `component_meta` (its size
             contract and configSchema) and `published_build_id` are both set. Each row's `url` is that canvas's only
             valid link — share it verbatim; never construct a canvas URL yourself.
         param_overrides:
@@ -265,68 +327,6 @@ tools:
     canvases-home-create:
         operation: canvases_home_create
         enabled: false
-    canvas-layout-patch:
-        operation: canvases_layout_patch_create
-        enabled: true
-        scopes:
-            - canvas:write
-        annotations:
-            readOnly: false
-            destructive: false
-            idempotent: false
-        title: Patch grid canvas layout
-        description: >
-            Apply surgical operations to a grid canvas's layout — the DEFAULT way to change one: add_placement (a new
-            widget box), update_placement (fill a box with a component, move/resize it, change its status or config),
-            remove_placement, set_grid. Operations apply in order to the current layout, the result is validated
-            atomically, and the new version is live immediately (layout is data — no build).
-            `expected_current_version_id` is REQUIRED (from canvas-layout-get; null only before the first layout
-            publish) — a stale base is rejected with 409 version_conflict; re-read the layout, re-apply, and patch
-            again. To fill a drawn box: update_placement with changes {status: "live", component: <component canvas
-            id>, config: {...}}. The component must be published (canvas-list kind=component shows component_meta and
-            published_build_id) and the config must match its configSchema.
-        param_overrides:
-            id:
-                description: ID of the grid canvas whose layout to patch.
-    canvas-layout-publish:
-        operation: canvases_layout_publish_create
-        enabled: true
-        scopes:
-            - canvas:write
-        annotations:
-            readOnly: false
-            destructive: false
-            idempotent: false
-        title: Publish grid canvas layout
-        description: >
-            Publish a COMPLETE layout document as a grid canvas's new head version. Prefer canvas-layout-patch for
-            incremental changes — full publish is for creating an initial layout or restructuring the whole grid.
-            The layout is validated first (grid bounds, overlaps, component references, per-placement config against
-            each component's configSchema); errors reject the publish and leave the canvas untouched. The new version
-            is live immediately — no build. Pass `expected_current_version_id` from canvas-layout-get so a concurrent
-            edit is rejected with 409 version_conflict instead of overwritten.
-        param_overrides:
-            id:
-                description: ID of the grid canvas whose layout to publish.
-    canvas-layout-get:
-        operation: canvases_layout_retrieve
-        enabled: true
-        scopes:
-            - canvas:read
-        annotations:
-            readOnly: true
-            destructive: false
-            idempotent: true
-        title: Read grid canvas layout
-        description: >
-            Read a grid canvas's layout document (grid definition + placements) and its `current_version_id`. Always
-            call this before patching or publishing: pass the returned version id as `expected_current_version_id` so
-            concurrent edits are not overwritten. A grid canvas with no versions yet returns the default empty layout
-            with a null version id. Placements reference component canvases (kind=component) — resolve their
-            contracts via canvas-list.
-        param_overrides:
-            id:
-                description: ID of the grid canvas whose layout to read.
     canvases-partial-update:
         operation: canvases_partial_update
         enabled: false

--- a/products/canvas/skills/building-canvases/SKILL.md
+++ b/products/canvas/skills/building-canvases/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: building-canvases
 description: >
-  Create or edit a PostHog canvas — a sandboxed browser application (data board, document, form,
-  small tool, graphics experiment) stored in PostHog and rendered by the desktop/web app. Use when
-  a task asks to build, generate, update, or fix a canvas, or when a canvas id is given as the
-  publish target. Covers resolving or creating the target canvas, choosing an implementation
-  approach (React + Quill vs plain HTML/browser APIs), the read → edit → validate → publish →
-  build loop, and which companion canvas skills to load for the details.
+  Create or edit a PostHog freeform canvas — a sandboxed browser application (data board, document,
+  form, small tool, graphics experiment) stored in PostHog and rendered by the desktop/web app. Use
+  when a task asks to build, generate, update, or fix a standalone canvas app, or when a freeform
+  canvas id is given as the publish target. For grid/home canvases, widget placements, or reusable
+  components, use composing-grid-canvases instead. Covers resolving or creating the target canvas,
+  choosing an implementation approach (React + Quill vs plain HTML/browser APIs), the read → edit →
+  validate → publish → build loop, and which companion canvas skills to load for the details.
 ---
 
 # Building canvases
@@ -19,6 +20,13 @@ saves it.
 Canvas work can start from any ordinary task. A dedicated canvas mode or pre-created canvas is
 not required. When the user asks for a board, document, form, visualization, or small app that
 should live in PostHog, treat that as a canvas request and follow this skill.
+
+This skill owns `freeform` canvases (standalone apps). Two other canvas kinds exist: `grid`
+canvases (widget grids, including the user's home canvas) and `component` canvases (reusable
+widgets grids place). When the target is a grid or home canvas, a placement, or a reusable
+widget/component, load `composing-grid-canvases` instead — it owns the store search → configure →
+fork → build ladder and the layout patch loop. Authoring a component's source still uses the
+implementation companions below.
 
 ## Resolve the target canvas
 

--- a/products/canvas/skills/composing-grid-canvases/SKILL.md
+++ b/products/canvas/skills/composing-grid-canvases/SKILL.md
@@ -66,6 +66,7 @@ with three additions:
   vocabulary is an allowlist — `type`, `title`, `description`, `default`, `properties`, `required`,
   `additionalProperties`, `items`, `enum`, `const`, `minimum`, `maximum`, `minLength`, `maxLength`,
   `minItems`, `maxItems`, `format`. No `$ref`, no `pattern` — validation rejects them.
+
 - **Design for the size range.** A 2×1 placement is a glanceable tile; a 6×4 is a full app surface.
   Render usefully at `minW`×`minH`, and treat `config` as the only per-placement input.
 
@@ -86,7 +87,7 @@ Operations:
   extend past `grid.columns`.
 - `update_placement` — merge `changes` into the placement with `id`. Filling a drawn box is
   `{"op": "update_placement", "id": "p1", "changes": {"status": "live", "component": "<component
-  canvas id>", "config": {...}}}`.
+canvas id>", "config": {...}}}`.
 - `remove_placement`, `set_grid`.
 
 ## The placement lifecycle

--- a/products/canvas/skills/composing-grid-canvases/SKILL.md
+++ b/products/canvas/skills/composing-grid-canvases/SKILL.md
@@ -3,10 +3,11 @@ name: composing-grid-canvases
 description: >
   Compose PostHog grid canvases — widget grids (including the user's home canvas) built from
   reusable component canvases. Use when a task asks to add, fill, move, resize, or remove a widget
-  on a grid or home canvas, to build a reusable widget/component, or when a placement id or grid
-  canvas id is the target. Covers the component store search → configure → fork → build ladder,
-  the component placement contract (size, configSchema), the placement lifecycle
-  (pending/generating/live/failed), and the guarded layout patch loop.
+  on a grid or home canvas, to compose a whole canvas of widgets from one ask, to build a reusable
+  widget/component, or when a placement id or grid canvas id is the target. Covers the component
+  store search → configure → fork → build ladder, the component placement contract (size,
+  configSchema), the placement lifecycle (pending/generating/live/failed), the guarded layout
+  patch loop, and reading the canvas's comment threads.
 ---
 
 # Composing grid canvases
@@ -75,6 +76,18 @@ with three additions:
 
 Publish and wait for the build like any canvas — a component with no ready build cannot go live on
 a grid.
+
+## Composing a whole canvas
+
+A whole-canvas ask ("a home canvas that summarizes my work in progress") usually means several widgets, not one.
+Plan the full set first — one placement per concern — then resolve each with the ladder above.
+Lay them out together: no overlaps, sizes matched to what each widget shows, the grid filled deliberately rather than tiles scattered in a corner.
+Batch the layout writes (one publish for an initial layout, surgical patches after) instead of one write per widget, and finish with every placement live or failed — never generating.
+
+## Canvas comments
+
+Users leave feedback as comment threads on the canvas, anchored to its conversation task.
+List them with the task comment tools (`tasks-comments-list`, `tasks-comments-retrieve`) on your task before and after changing the canvas, and address the open ones — a comment naming a broken widget is your brief for fixing it.
 
 ## Editing a grid
 

--- a/products/canvas/skills/composing-grid-canvases/SKILL.md
+++ b/products/canvas/skills/composing-grid-canvases/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: composing-grid-canvases
+description: >
+  Compose PostHog grid canvases — widget grids (including the user's home canvas) built from
+  reusable component canvases. Use when a task asks to add, fill, move, resize, or remove a widget
+  on a grid or home canvas, to build a reusable widget/component, or when a placement id or grid
+  canvas id is the target. Covers the component store search → configure → fork → build ladder,
+  the component placement contract (size, configSchema), the placement lifecycle
+  (pending/generating/live/failed), and the guarded layout patch loop.
+---
+
+# Composing grid canvases
+
+A grid canvas is a composition, not an app: a grid of placements, each rendering a **component
+canvas** (a reusable widget with its own source, build, and placement contract). The user's home
+canvas is an ordinary grid canvas in their personal channel. Layout is data — publishing or
+patching one is live immediately, with no build.
+
+Three canvas kinds share one lifecycle:
+
+- `freeform` — a standalone app (the `building-canvases` skill owns these).
+- `component` — a reusable widget. Same source/build pipeline as freeform, plus a placement
+  contract. Visibility rides its channel: personal channel = private, team channel = shared.
+- `grid` — a layout of placements referencing components. No file source; layout only.
+
+## The resolution ladder: configure, fork, build
+
+When a grid placement needs content ("a weather widget here", "a kanban of my tasks"), resolve in
+this order — placing an existing component beats authoring a duplicate:
+
+1. **Search the store**: `canvas-list` with `kind=component` and `search=<what the widget shows>`.
+   A component is placeable when both `component_meta` and `published_build_id` are set. If its
+   `configSchema` can express the request ("weather for Lisbon" → existing weather component with
+   `config: {"location": "Lisbon"}`), place and configure it — write no code.
+2. **Fork** when a component is close but its config cannot express the ask: read its source
+   (`canvas-source-retrieve`), create a new component (`canvas-create` with `kind=component`),
+   adapt, publish. Name the difference in the new component's description.
+3. **Build new** when nothing fits — see "Building a component" below.
+
+New components land in the channel you create them in. Create them in the same channel as the grid
+they serve unless the user asks to share them more widely.
+
+## Building a component
+
+A component is authored exactly like a freeform canvas — load `building-react-quill-canvases` (or
+`building-html-canvases`) plus `querying-canvas-data` and `validating-and-publishing-canvases` —
+with three additions:
+
+- **Create with `kind=component`** and a `description` written for store search: say what the
+  widget shows and what its config controls. Future placements are found by this text.
+- **Declare the placement contract** in the project's top-level `component` key:
+
+  ```json
+  {
+    "component": {
+      "size": { "defaultW": 2, "defaultH": 1, "minW": 1, "minH": 1, "maxW": 4 },
+      "configSchema": {
+        "type": "object",
+        "properties": { "location": { "type": "string", "description": "City to show weather for" } }
+      }
+    }
+  }
+  ```
+
+  Size is in grid units (widths 1–12, heights 1–40); `minW <= defaultW <= maxW`. The config schema
+  vocabulary is an allowlist — `type`, `title`, `description`, `default`, `properties`, `required`,
+  `additionalProperties`, `items`, `enum`, `const`, `minimum`, `maximum`, `minLength`, `maxLength`,
+  `minItems`, `maxItems`, `format`. No `$ref`, no `pattern` — validation rejects them.
+- **Design for the size range.** A 2×1 placement is a glanceable tile; a 6×4 is a full app surface.
+  Render usefully at `minW`×`minH`, and treat `config` as the only per-placement input.
+
+Publish and wait for the build like any canvas — a component with no ready build cannot go live on
+a grid.
+
+## Editing a grid
+
+The loop is read → patch, guarded exactly as `validating-and-publishing-canvases` describes for
+source publishes — with `canvas-layout-get` in place of `canvas-source-retrieve`, and
+`canvas-layout-patch` (surgical ops, guard required) or `canvas-layout-publish` (complete
+document, for an initial layout or full restructure) as the write. On a 409, re-read the layout,
+re-apply your change, and patch again.
+
+Operations:
+
+- `add_placement` — a new box: `{id, status, x, y, w, h, ...}`. Placements must not overlap or
+  extend past `grid.columns`.
+- `update_placement` — merge `changes` into the placement with `id`. Filling a drawn box is
+  `{"op": "update_placement", "id": "p1", "changes": {"status": "live", "component": "<component
+  canvas id>", "config": {...}}}`.
+- `remove_placement`, `set_grid`.
+
+## The placement lifecycle
+
+A placement's `status` tells the renderer what to show:
+
+- `pending` — the user drew a box but hasn't described it (or the prompt awaits dispatch).
+- `generating` — an agent task is filling it; `generationTaskId` links the task and `prompt`
+  records the ask. Set this when you start working on a placement from a task.
+- `live` — renders its `component` at `version` (`"latest"` by default; a pinned version id is
+  allowed). Requires the component to be published and visible to the acting user.
+- `failed` — generation failed; keep the `prompt` so the user can retry or re-describe.
+
+When a task asks you to fill a placement, its prompt and the box's size are your brief: honor the
+drawn `w`×`h` (the component's size contract must admit it) and keep the placement's `prompt`
+intact for provenance.
+
+## Validation you will hit
+
+Layout publishes validate atomically; every error names its placement. The common ones:
+
+- `component_not_found` — the id is wrong, deleted, not a component, or not visible to the acting
+  user (a component in someone else's personal channel is not placeable).
+- `component_not_published` — the component has never published a placement contract.
+- `placement_config_invalid` — `config` does not match the component's `configSchema`.
+- `placement_size_out_of_contract` — the box's `w`/`h` falls outside the component's size range.
+- `placements_overlap` / `invalid_placement` — geometry; fix coordinates rather than removing the
+  other widget.
+
+End your reply by linking the grid canvas with the `url` field the canvas tools return — never
+construct a canvas URL yourself.

--- a/products/canvas/skills/composing-grid-canvases/SKILL.md
+++ b/products/canvas/skills/composing-grid-canvases/SKILL.md
@@ -62,13 +62,16 @@ with three additions:
   }
   ```
 
-  Size is in grid units (widths 1–12, heights 1–40); `minW <= defaultW <= maxW`. The config schema
+  Size is in grid units (widths 1–12, heights 1–40); `minW <= defaultW <= maxW`. The range is
+  advisory: users may resize a placement to any size, so it informs defaults and warnings, never
+  rejections. The config schema
   vocabulary is an allowlist — `type`, `title`, `description`, `default`, `properties`, `required`,
   `additionalProperties`, `items`, `enum`, `const`, `minimum`, `maximum`, `minLength`, `maxLength`,
   `minItems`, `maxItems`, `format`. No `$ref`, no `pattern` — validation rejects them.
 
-- **Design for the size range.** A 2×1 placement is a glanceable tile; a 6×4 is a full app surface.
-  Render usefully at `minW`×`minH`, and treat `config` as the only per-placement input.
+- **Design responsively.** Fill 100% of the box's width and height, and adapt the layout to any
+  size the user drags: a 2×1 placement is a glanceable tile; a 6×4 is a full app surface. Render
+  usefully at `minW`×`minH`, and treat `config` as the only per-placement input.
 
 Publish and wait for the build like any canvas — a component with no ready build cannot go live on
 a grid.
@@ -102,7 +105,7 @@ A placement's `status` tells the renderer what to show:
 - `failed` — generation failed; keep the `prompt` so the user can retry or re-describe.
 
 When a task asks you to fill a placement, its prompt and the box's size are your brief: honor the
-drawn `w`×`h` (the component's size contract must admit it) and keep the placement's `prompt`
+drawn `w`×`h` and keep the placement's `prompt`
 intact for provenance.
 
 ## Validation you will hit
@@ -113,7 +116,8 @@ Layout publishes validate atomically; every error names its placement. The commo
   user (a component in someone else's personal channel is not placeable).
 - `component_not_published` — the component has never published a placement contract.
 - `placement_config_invalid` — `config` does not match the component's `configSchema`.
-- `placement_size_out_of_contract` — the box's `w`/`h` falls outside the component's size range.
+- `placement_size_out_of_contract` — a warning, not an error: the box's `w`/`h` is outside the
+  component's suggested range. The publish still succeeds; the component must render responsively.
 - `placements_overlap` / `invalid_placement` — geometry; fix coordinates rather than removing the
   other widget.
 

--- a/products/canvas/skills/composing-grid-canvases/SKILL.md
+++ b/products/canvas/skills/composing-grid-canvases/SKILL.md
@@ -45,7 +45,8 @@ they serve unless the user asks to share them more widely.
 
 A component is authored exactly like a freeform canvas — load `building-react-quill-canvases` (or
 `building-html-canvases`) plus `querying-canvas-data` and `validating-and-publishing-canvases` —
-with three additions:
+with three additions.
+Start from the complete, buildable project in [references/component-example.md](references/component-example.md); its envelope, placement contract, capability declarations, and defensive `ph.state` access are the parts that break when improvised.
 
 - **Create with `kind=component`** and a `description` written for store search: say what the
   widget shows and what its config controls. Future placements are found by this text.

--- a/products/canvas/skills/composing-grid-canvases/references/component-example.md
+++ b/products/canvas/skills/composing-grid-canvases/references/component-example.md
@@ -1,6 +1,7 @@
 # A known-good component
 
-This is a complete, buildable component project — the same shape as the welcome checklist PostHog seeds onto new home canvases (`products/canvas/backend/welcome.py`, verified against the real canvas builder).
+This is a complete, buildable component project — the welcome checklist PostHog seeds onto new home canvases (`products/canvas/backend/welcome.py`, verified against the real canvas builder).
+The envelope below shows the fields you author; its `index.html` and `dependencies` come from `canvas-source-retrieve` and are kept exactly as returned (see [validating-and-publishing-canvases](../../validating-and-publishing-canvases/SKILL.md)) — the placeholders below stand in for them.
 Start from it when building a checklist, settings, or any state-carrying widget, and keep its structure even when you replace the content: the project envelope, the placement contract, the capability declarations, and the defensive `ph.state` access are the parts that break when improvised.
 
 ## The project envelope
@@ -9,12 +10,14 @@ Start from it when building a checklist, settings, or any state-carrying widget,
 {
   "schemaVersion": 1,
   "entryHtml": "index.html",
-  "files": { "index.html": "<!-- synthetic entry -->", "src/canvas.tsx": "<the component below>" },
+  "files": { "index.html": "<synthetic shell from canvas-source-retrieve — loads /src/canvas.tsx as a module>", "src/canvas.tsx": "<the component below>" },
+  "dependencies": { "react": "<pinned>", "react-dom": "<pinned>", "@posthog/quill": "<pinned>", "lucide-react": "<pinned>" },
   "capabilities": { "posthog": { "state": ["user"] }, "network": { "origins": [] } },
   "component": { "size": { "defaultW": 3, "defaultH": 5, "minW": 2, "minH": 3 } }
 }
 ```
 
+- `index.html` must load `/src/canvas.tsx` as a module and every imported package must be in `dependencies` — the retrieved shell and dependency map already satisfy both. Improvising a comment-only entry fails the build with `no_entry_module`; dropping the `@posthog/quill` or `lucide-react` entries fails it with `import_not_declared`.
 - `capabilities.posthog.state` must name every scope the code passes to `ph.state.*` — validation rejects an undeclared scope.
 - `component.size` is in grid units and advisory; the component still has to render at any size the user drags.
 

--- a/products/canvas/skills/composing-grid-canvases/references/component-example.md
+++ b/products/canvas/skills/composing-grid-canvases/references/component-example.md
@@ -12,12 +12,13 @@ Start from it when building a checklist, settings, or any state-carrying widget,
   "entryHtml": "index.html",
   "files": { "index.html": "<synthetic shell from canvas-source-retrieve — loads /src/canvas.tsx as a module>", "src/canvas.tsx": "<the component below>" },
   "dependencies": { "react": "<pinned>", "react-dom": "<pinned>", "@posthog/quill": "<pinned>", "lucide-react": "<pinned>" },
-  "capabilities": { "posthog": { "state": ["user"] }, "network": { "origins": [] } },
+  "capabilities": { "posthog": { "insights": [], "inlineQueries": false, "captureEvents": [], "state": ["user"], "actions": [] }, "network": { "origins": [] } },
   "component": { "size": { "defaultW": 3, "defaultH": 5, "minW": 2, "minH": 3 } }
 }
 ```
 
 - `index.html` must load `/src/canvas.tsx` as a module and every imported package must be in `dependencies` — the retrieved shell and dependency map already satisfy both. Improvising a comment-only entry fails the build with `no_entry_module`; dropping the `@posthog/quill` or `lucide-react` entries fails it with `import_not_declared`.
+- Declare the full `capabilities.posthog` shape (`insights`, `inlineQueries`, `captureEvents`, `state`, `actions`) even when a field is empty, as this example does — the build freezes the declared capabilities into the artifact manifest, which older clients read expecting every field. Populate only what the code calls and leave the rest empty.
 - `capabilities.posthog.state` must name every scope the code passes to `ph.state.*` — validation rejects an undeclared scope.
 - `component.size` is in grid units and advisory; the component still has to render at any size the user drags.
 

--- a/products/canvas/skills/composing-grid-canvases/references/component-example.md
+++ b/products/canvas/skills/composing-grid-canvases/references/component-example.md
@@ -10,9 +10,20 @@ Start from it when building a checklist, settings, or any state-carrying widget,
 {
   "schemaVersion": 1,
   "entryHtml": "index.html",
-  "files": { "index.html": "<synthetic shell from canvas-source-retrieve — loads /src/canvas.tsx as a module>", "src/canvas.tsx": "<the component below>" },
-  "dependencies": { "react": "<pinned>", "react-dom": "<pinned>", "@posthog/quill": "<pinned>", "lucide-react": "<pinned>" },
-  "capabilities": { "posthog": { "insights": [], "inlineQueries": false, "captureEvents": [], "state": ["user"], "actions": [] }, "network": { "origins": [] } },
+  "files": {
+    "index.html": "<synthetic shell from canvas-source-retrieve — loads /src/canvas.tsx as a module>",
+    "src/canvas.tsx": "<the component below>"
+  },
+  "dependencies": {
+    "react": "<pinned>",
+    "react-dom": "<pinned>",
+    "@posthog/quill": "<pinned>",
+    "lucide-react": "<pinned>"
+  },
+  "capabilities": {
+    "posthog": { "insights": [], "inlineQueries": false, "captureEvents": [], "state": ["user"], "actions": [] },
+    "network": { "origins": [] }
+  },
   "component": { "size": { "defaultW": 3, "defaultH": 5, "minW": 2, "minH": 3 } }
 }
 ```
@@ -25,77 +36,67 @@ Start from it when building a checklist, settings, or any state-carrying widget,
 ## The component (`src/canvas.tsx`)
 
 ```tsx
-import { useEffect, useState } from "react";
-import {
-  Checkbox,
-  SkeletonText,
-  Text,
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@posthog/quill";
-import { Info } from "lucide-react";
+import { useEffect, useState } from 'react'
+import { Checkbox, SkeletonText, Text, Tooltip, TooltipContent, TooltipTrigger } from '@posthog/quill'
+import { Info } from 'lucide-react'
 
 const ITEMS = [
-  { id: "download-desktop", label: "Download PostHog Desktop", hint: null },
+  { id: 'download-desktop', label: 'Download PostHog Desktop', hint: null },
   {
-    id: "add-widget",
-    label: "Add a widget to this canvas",
-    hint: "Select Edit in the top right, then click and drag anywhere on the dotted grid and describe what should go there.",
+    id: 'add-widget',
+    label: 'Add a widget to this canvas',
+    hint: 'Select Edit in the top right, then click and drag anywhere on the dotted grid and describe what should go there.',
   },
   {
-    id: "start-task",
-    label: "Start your first task",
-    hint: "Open a space and tell the agent what you want done. It picks the task up and reports back.",
+    id: 'start-task',
+    label: 'Start your first task',
+    hint: 'Open a space and tell the agent what you want done. It picks the task up and reports back.',
   },
-];
+]
 
 // Persistence needs both the SDK surface and a host that answers it. An old
 // runtime without ph.state must degrade to session-only ticks, never crash
 // the tile.
-const stateApi =
-  typeof ph !== "undefined" && ph.state && typeof ph.state.get === "function"
-    ? ph.state
-    : null;
+const stateApi = typeof ph !== 'undefined' && ph.state && typeof ph.state.get === 'function' ? ph.state : null
 
 export default function WelcomeChecklist() {
-  const [checked, setChecked] = useState(null);
+  const [checked, setChecked] = useState(null)
 
   useEffect(() => {
-    let cancelled = false;
+    let cancelled = false
     if (!stateApi) {
-      setChecked({ "download-desktop": true });
+      setChecked({ 'download-desktop': true })
     } else {
       stateApi
-        .get("checked", { scope: "user" })
+        .get('checked', { scope: 'user' })
         .then((value) => {
           if (!cancelled) {
-            setChecked(value && typeof value === "object" ? value : {});
+            setChecked(value && typeof value === 'object' ? value : {})
           }
         })
         .catch(() => {
           if (!cancelled) {
-            setChecked({});
+            setChecked({})
           }
-        });
+        })
     }
     return () => {
-      cancelled = true;
-    };
-  }, []);
+      cancelled = true
+    }
+  }, [])
 
   const toggle = (id, value) => {
     if (!checked) {
-      return;
+      return
     }
-    const next = { ...checked, [id]: value };
-    setChecked(next);
+    const next = { ...checked, [id]: value }
+    setChecked(next)
     if (stateApi) {
-      stateApi.set("checked", next, { scope: "user" }).catch(() => {});
+      stateApi.set('checked', next, { scope: 'user' }).catch(() => {})
     }
-  };
+  }
 
-  const done = checked ? ITEMS.filter((item) => checked[item.id]).length : 0;
+  const done = checked ? ITEMS.filter((item) => checked[item.id]).length : 0
 
   return (
     <div className="flex h-full flex-col gap-2 overflow-y-auto p-3">
@@ -113,21 +114,13 @@ export default function WelcomeChecklist() {
         <div className="flex flex-col gap-1.5">
           {ITEMS.map((item) => (
             <div key={item.id} className="flex items-center gap-2">
-              <Checkbox
-                checked={!!checked[item.id]}
-                onCheckedChange={(value) => toggle(item.id, value === true)}
-              />
-              <Text
-                size="sm"
-                className={checked[item.id] ? "text-muted-foreground line-through" : ""}
-              >
+              <Checkbox checked={!!checked[item.id]} onCheckedChange={(value) => toggle(item.id, value === true)} />
+              <Text size="sm" className={checked[item.id] ? 'text-muted-foreground line-through' : ''}>
                 {item.label}
               </Text>
               {item.hint ? (
                 <Tooltip>
-                  <TooltipTrigger
-                    render={<Info size={13} className="shrink-0 text-muted-foreground" />}
-                  />
+                  <TooltipTrigger render={<Info size={13} className="shrink-0 text-muted-foreground" />} />
                   <TooltipContent>
                     <div className="max-w-60">{item.hint}</div>
                   </TooltipContent>
@@ -138,7 +131,7 @@ export default function WelcomeChecklist() {
         </div>
       )}
     </div>
-  );
+  )
 }
 ```
 

--- a/products/canvas/skills/composing-grid-canvases/references/component-example.md
+++ b/products/canvas/skills/composing-grid-canvases/references/component-example.md
@@ -1,0 +1,147 @@
+# A known-good component
+
+This is a complete, buildable component project — the same shape as the welcome checklist PostHog seeds onto new home canvases (`products/canvas/backend/welcome.py`, verified against the real canvas builder).
+Start from it when building a checklist, settings, or any state-carrying widget, and keep its structure even when you replace the content: the project envelope, the placement contract, the capability declarations, and the defensive `ph.state` access are the parts that break when improvised.
+
+## The project envelope
+
+```json
+{
+  "schemaVersion": 1,
+  "entryHtml": "index.html",
+  "files": { "index.html": "<!-- synthetic entry -->", "src/canvas.tsx": "<the component below>" },
+  "capabilities": { "posthog": { "state": ["user"] }, "network": { "origins": [] } },
+  "component": { "size": { "defaultW": 3, "defaultH": 5, "minW": 2, "minH": 3 } }
+}
+```
+
+- `capabilities.posthog.state` must name every scope the code passes to `ph.state.*` — validation rejects an undeclared scope.
+- `component.size` is in grid units and advisory; the component still has to render at any size the user drags.
+
+## The component (`src/canvas.tsx`)
+
+```tsx
+import { useEffect, useState } from "react";
+import {
+  Checkbox,
+  SkeletonText,
+  Text,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@posthog/quill";
+import { Info } from "lucide-react";
+
+const ITEMS = [
+  { id: "download-desktop", label: "Download PostHog Desktop", hint: null },
+  {
+    id: "add-widget",
+    label: "Add a widget to this canvas",
+    hint: "Select Edit in the top right, then click and drag anywhere on the dotted grid and describe what should go there.",
+  },
+  {
+    id: "start-task",
+    label: "Start your first task",
+    hint: "Open a space and tell the agent what you want done. It picks the task up and reports back.",
+  },
+];
+
+// Persistence needs both the SDK surface and a host that answers it. An old
+// runtime without ph.state must degrade to session-only ticks, never crash
+// the tile.
+const stateApi =
+  typeof ph !== "undefined" && ph.state && typeof ph.state.get === "function"
+    ? ph.state
+    : null;
+
+export default function WelcomeChecklist() {
+  const [checked, setChecked] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!stateApi) {
+      setChecked({ "download-desktop": true });
+    } else {
+      stateApi
+        .get("checked", { scope: "user" })
+        .then((value) => {
+          if (!cancelled) {
+            setChecked(value && typeof value === "object" ? value : {});
+          }
+        })
+        .catch(() => {
+          if (!cancelled) {
+            setChecked({});
+          }
+        });
+    }
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const toggle = (id, value) => {
+    if (!checked) {
+      return;
+    }
+    const next = { ...checked, [id]: value };
+    setChecked(next);
+    if (stateApi) {
+      stateApi.set("checked", next, { scope: "user" }).catch(() => {});
+    }
+  };
+
+  const done = checked ? ITEMS.filter((item) => checked[item.id]).length : 0;
+
+  return (
+    <div className="flex h-full flex-col gap-2 overflow-y-auto p-3">
+      <div className="flex items-baseline justify-between gap-2">
+        <Text weight="medium">Welcome to PostHog</Text>
+        {checked ? (
+          <Text size="sm" className="text-muted-foreground">
+            {done} of {ITEMS.length} done
+          </Text>
+        ) : null}
+      </div>
+      {checked === null ? (
+        <SkeletonText lines={5} className="text-sm" />
+      ) : (
+        <div className="flex flex-col gap-1.5">
+          {ITEMS.map((item) => (
+            <div key={item.id} className="flex items-center gap-2">
+              <Checkbox
+                checked={!!checked[item.id]}
+                onCheckedChange={(value) => toggle(item.id, value === true)}
+              />
+              <Text
+                size="sm"
+                className={checked[item.id] ? "text-muted-foreground line-through" : ""}
+              >
+                {item.label}
+              </Text>
+              {item.hint ? (
+                <Tooltip>
+                  <TooltipTrigger
+                    render={<Info size={13} className="shrink-0 text-muted-foreground" />}
+                  />
+                  <TooltipContent>
+                    <div className="max-w-60">{item.hint}</div>
+                  </TooltipContent>
+                </Tooltip>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+## The rules the example encodes
+
+- One file, one `export default` React component, no props, no `createRoot` — the host mounts it.
+- Imports only from the platform allowlist (`react`, `@posthog/quill`, `lucide-react`, `recharts`, `dayjs`).
+- `ph` is a host-injected global — never import it, and feature-detect optional surfaces like `ph.state` so the widget degrades instead of crashing on an older runtime.
+- Loading state renders a skeleton, never a blank; every async access has a `.catch` that lands in a renderable state.
+- Fill 100% of the box (`h-full`) and let content scroll; the user controls the placement's size.

--- a/products/canvas/skills/composing-grid-canvases/references/component-example.md
+++ b/products/canvas/skills/composing-grid-canvases/references/component-example.md
@@ -18,7 +18,7 @@ Start from it when building a checklist, settings, or any state-carrying widget,
 ```
 
 - `index.html` must load `/src/canvas.tsx` as a module and every imported package must be in `dependencies` — the retrieved shell and dependency map already satisfy both. Improvising a comment-only entry fails the build with `no_entry_module`; dropping the `@posthog/quill` or `lucide-react` entries fails it with `import_not_declared`.
-- Declare the full `capabilities.posthog` shape (`insights`, `inlineQueries`, `captureEvents`, `state`, `actions`) even when a field is empty, as this example does — the build freezes the declared capabilities into the artifact manifest, which older clients read expecting every field. Populate only what the code calls and leave the rest empty.
+- Declare the full `capabilities.posthog` shape (`insights`, `inlineQueries`, `captureEvents`, `state`, `actions`) even when a field is empty, as this example does — the build freezes the declared capabilities into the artifact manifest, which older clients read expecting every field. `insights`, `inlineQueries`, and `captureEvents` are also required by the API: a partial `posthog` object is rejected with a 400 before source validation runs. Populate only what the code calls and leave the rest empty.
 - `capabilities.posthog.state` must name every scope the code passes to `ph.state.*` — validation rejects an undeclared scope.
 - `component.size` is in grid units and advisory; the component still has to render at any size the user drags.
 

--- a/products/canvas/skills/querying-canvas-data/SKILL.md
+++ b/products/canvas/skills/querying-canvas-data/SKILL.md
@@ -2,7 +2,7 @@
 name: querying-canvas-data
 description: >
   Get PostHog data into a canvas correctly: the host-injected `ph` SDK (loadInsight, query,
-  capture, openExternal, navigate), the data hierarchy (saved insights first, typed query nodes
+  capture, state, openExternal, navigate), the data hierarchy (saved insights first, typed query nodes
   second, inline HogQL last), per-insight-type result shapes, date-range wiring, and event capture
   from a canvas. Use whenever a canvas shows metrics, charts, tables, or any PostHog data, or
   needs to send analytics events.

--- a/products/canvas/skills/validating-and-publishing-canvases/SKILL.md
+++ b/products/canvas/skills/validating-and-publishing-canvases/SKILL.md
@@ -104,6 +104,13 @@ every few seconds (up to ~2 minutes) until the build you queued is terminal:
   build never replaces the last good one, so the canvas keeps rendering the previous version —
   finishing the task here would leave the user with a stale canvas and a silent failure.
 
+Runtime error reports (filed on the authoring task when a rendered canvas throws) name the build
+they came from. A report from an **older build id** is history, not evidence about your current
+code — check it against the build you just published before acting on it. In particular, a report
+that a documented `ph` API is undefined (e.g. `ph.state`) means that artifact was baked by an
+older host runtime: republish so a current build replaces it. Never "fix" it by removing the API
+or its capability declaration.
+
 ## Draft, then promote
 
 Publishing goes live the moment its build is ready. For a canvas that **already has a live

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -1096,8 +1096,50 @@
             "readOnlyHint": false
         }
     },
+    "canvas-layout-get": {
+        "description": "Read a grid canvas's layout document (grid definition + placements) and its `current_version_id`. Always call this before patching or publishing: pass the returned version id as `expected_current_version_id` so concurrent edits are not overwritten. A grid canvas with no versions yet returns the default empty layout with a null version id. Placements reference component canvases (kind=component) — resolve their contracts via canvas-list.",
+        "category": "Canvas",
+        "feature": "canvas",
+        "summary": "Read grid canvas layout",
+        "title": "Read grid canvas layout",
+        "required_scopes": ["canvas:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "canvas-layout-patch": {
+        "description": "Apply surgical operations to a grid canvas's layout — the DEFAULT way to change one: add_placement (a new widget box), update_placement (fill a box with a component, move/resize it, change its status or config), remove_placement, set_grid. Operations apply in order to the current layout, the result is validated atomically, and the new version is live immediately (layout is data — no build). `expected_current_version_id` is REQUIRED (from canvas-layout-get; null only before the first layout publish) — a stale base is rejected with 409 version_conflict; re-read the layout, re-apply, and patch again. To fill a drawn box: update_placement with changes {status: \"live\", component: <component canvas id>, config: {...}}. The component must be published (canvas-list kind=component shows component_meta and published_build_id) and the config must match its configSchema.",
+        "category": "Canvas",
+        "feature": "canvas",
+        "summary": "Patch grid canvas layout",
+        "title": "Patch grid canvas layout",
+        "required_scopes": ["canvas:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "canvas-layout-publish": {
+        "description": "Publish a COMPLETE layout document as a grid canvas's new head version. Prefer canvas-layout-patch for incremental changes — full publish is for creating an initial layout or restructuring the whole grid. The layout is validated first (grid bounds, overlaps, component references, per-placement config against each component's configSchema); errors reject the publish and leave the canvas untouched. The new version is live immediately — no build. Pass `expected_current_version_id` from canvas-layout-get so a concurrent edit is rejected with 409 version_conflict instead of overwritten.",
+        "category": "Canvas",
+        "feature": "canvas",
+        "summary": "Publish grid canvas layout",
+        "title": "Publish grid canvas layout",
+        "required_scopes": ["canvas:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "canvas-list": {
-        "description": "List the project's canvases (newest first), optionally scoped to one channel via `channel`. Use this to resolve which canvas a request refers to before reading or publishing source. Each row's `url` is that canvas's only valid link — share it verbatim; never construct a canvas URL yourself.",
+        "description": "List the project's canvases (newest first), optionally scoped to one channel via `channel`. Use this to resolve which canvas a request refers to before reading or publishing source. With `kind=component` this is the COMPONENT STORE: reusable widgets grid canvases place. Before building a new widget, ALWAYS search here first (`kind=component` plus `search=<what the widget shows>`) — placing an existing component with the right `config` beats authoring a duplicate. A component is placeable when `component_meta` (its size contract and configSchema) and `published_build_id` are both set. Each row's `url` is that canvas's only valid link — share it verbatim; never construct a canvas URL yourself.",
         "category": "Canvas",
         "feature": "canvas",
         "summary": "List canvases",

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -1097,7 +1097,7 @@
         }
     },
     "canvas-layout-get": {
-        "description": "Read a grid canvas's layout document (grid definition + placements) and its `current_version_id`. Always call this before patching or publishing: pass the returned version id as `expected_current_version_id` so concurrent edits are not overwritten. A grid canvas with no versions yet returns the default empty layout with a null version id. Placements reference component canvases (kind=component) — resolve their contracts via canvas-list.",
+        "description": "Read a grid canvas's live layout document (grid definition + placements) and its `current_version_id`. Always call this before patching or publishing: pass the returned version id as `expected_current_version_id` so concurrent edits are not overwritten. A grid canvas with no versions yet returns the default empty layout with a null version id. Placements reference component canvases (kind=component) — resolve their contracts via canvas-list.",
         "category": "Canvas",
         "feature": "canvas",
         "summary": "Read grid canvas layout",
@@ -1125,7 +1125,7 @@
         }
     },
     "canvas-layout-publish": {
-        "description": "Publish a COMPLETE layout document as a grid canvas's new head version. Prefer canvas-layout-patch for incremental changes — full publish is for creating an initial layout or restructuring the whole grid. The layout is validated first (grid bounds, overlaps, component references, per-placement config against each component's configSchema); errors reject the publish and leave the canvas untouched. The new version is live immediately — no build. Pass `expected_current_version_id` from canvas-layout-get so a concurrent edit is rejected with 409 version_conflict instead of overwritten.",
+        "description": "Publish a COMPLETE layout document as a grid canvas's new head version. Prefer canvas-layout-patch for incremental changes — full publish is for creating an initial layout or restructuring the whole grid. The layout is validated first (grid bounds, overlaps, component references, per-placement config against each component's configSchema); errors reject the publish and leave the canvas untouched. The new version is live immediately — no build. `expected_current_version_id` is REQUIRED (from canvas-layout-get; null only before the first layout publish) — a stale base is rejected with 409 version_conflict; re-read the layout, rebuild the document on the new head, and publish again.",
         "category": "Canvas",
         "feature": "canvas",
         "summary": "Publish grid canvas layout",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -1112,7 +1112,7 @@
         }
     },
     "canvas-layout-get": {
-        "description": "Read a grid canvas's layout document (grid definition + placements) and its `current_version_id`. Always call this before patching or publishing: pass the returned version id as `expected_current_version_id` so concurrent edits are not overwritten. A grid canvas with no versions yet returns the default empty layout with a null version id. Placements reference component canvases (kind=component) — resolve their contracts via canvas-list.",
+        "description": "Read a grid canvas's live layout document (grid definition + placements) and its `current_version_id`. Always call this before patching or publishing: pass the returned version id as `expected_current_version_id` so concurrent edits are not overwritten. A grid canvas with no versions yet returns the default empty layout with a null version id. Placements reference component canvases (kind=component) — resolve their contracts via canvas-list.",
         "category": "Canvas",
         "feature": "canvas",
         "summary": "Read grid canvas layout",
@@ -1140,7 +1140,7 @@
         }
     },
     "canvas-layout-publish": {
-        "description": "Publish a COMPLETE layout document as a grid canvas's new head version. Prefer canvas-layout-patch for incremental changes — full publish is for creating an initial layout or restructuring the whole grid. The layout is validated first (grid bounds, overlaps, component references, per-placement config against each component's configSchema); errors reject the publish and leave the canvas untouched. The new version is live immediately — no build. Pass `expected_current_version_id` from canvas-layout-get so a concurrent edit is rejected with 409 version_conflict instead of overwritten.",
+        "description": "Publish a COMPLETE layout document as a grid canvas's new head version. Prefer canvas-layout-patch for incremental changes — full publish is for creating an initial layout or restructuring the whole grid. The layout is validated first (grid bounds, overlaps, component references, per-placement config against each component's configSchema); errors reject the publish and leave the canvas untouched. The new version is live immediately — no build. `expected_current_version_id` is REQUIRED (from canvas-layout-get; null only before the first layout publish) — a stale base is rejected with 409 version_conflict; re-read the layout, rebuild the document on the new head, and publish again.",
         "category": "Canvas",
         "feature": "canvas",
         "summary": "Publish grid canvas layout",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -1111,8 +1111,50 @@
             "readOnlyHint": false
         }
     },
+    "canvas-layout-get": {
+        "description": "Read a grid canvas's layout document (grid definition + placements) and its `current_version_id`. Always call this before patching or publishing: pass the returned version id as `expected_current_version_id` so concurrent edits are not overwritten. A grid canvas with no versions yet returns the default empty layout with a null version id. Placements reference component canvases (kind=component) — resolve their contracts via canvas-list.",
+        "category": "Canvas",
+        "feature": "canvas",
+        "summary": "Read grid canvas layout",
+        "title": "Read grid canvas layout",
+        "required_scopes": ["canvas:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "canvas-layout-patch": {
+        "description": "Apply surgical operations to a grid canvas's layout — the DEFAULT way to change one: add_placement (a new widget box), update_placement (fill a box with a component, move/resize it, change its status or config), remove_placement, set_grid. Operations apply in order to the current layout, the result is validated atomically, and the new version is live immediately (layout is data — no build). `expected_current_version_id` is REQUIRED (from canvas-layout-get; null only before the first layout publish) — a stale base is rejected with 409 version_conflict; re-read the layout, re-apply, and patch again. To fill a drawn box: update_placement with changes {status: \"live\", component: <component canvas id>, config: {...}}. The component must be published (canvas-list kind=component shows component_meta and published_build_id) and the config must match its configSchema.",
+        "category": "Canvas",
+        "feature": "canvas",
+        "summary": "Patch grid canvas layout",
+        "title": "Patch grid canvas layout",
+        "required_scopes": ["canvas:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "canvas-layout-publish": {
+        "description": "Publish a COMPLETE layout document as a grid canvas's new head version. Prefer canvas-layout-patch for incremental changes — full publish is for creating an initial layout or restructuring the whole grid. The layout is validated first (grid bounds, overlaps, component references, per-placement config against each component's configSchema); errors reject the publish and leave the canvas untouched. The new version is live immediately — no build. Pass `expected_current_version_id` from canvas-layout-get so a concurrent edit is rejected with 409 version_conflict instead of overwritten.",
+        "category": "Canvas",
+        "feature": "canvas",
+        "summary": "Publish grid canvas layout",
+        "title": "Publish grid canvas layout",
+        "required_scopes": ["canvas:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "canvas-list": {
-        "description": "List the project's canvases (newest first), optionally scoped to one channel via `channel`. Use this to resolve which canvas a request refers to before reading or publishing source. Each row's `url` is that canvas's only valid link — share it verbatim; never construct a canvas URL yourself.",
+        "description": "List the project's canvases (newest first), optionally scoped to one channel via `channel`. Use this to resolve which canvas a request refers to before reading or publishing source. With `kind=component` this is the COMPONENT STORE: reusable widgets grid canvases place. Before building a new widget, ALWAYS search here first (`kind=component` plus `search=<what the widget shows>`) — placing an existing component with the right `config` beats authoring a duplicate. A component is placeable when `component_meta` (its size contract and configSchema) and `published_build_id` are both set. Each row's `url` is that canvas's only valid link — share it verbatim; never construct a canvas URL yourself.",
         "category": "Canvas",
         "feature": "canvas",
         "summary": "List canvases",

--- a/services/mcp/src/generated/canvas/api.ts
+++ b/services/mcp/src/generated/canvas/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 11 enabled ops
+ * PostHog API - MCP 14 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -395,6 +395,385 @@ export const CanvasesEditCreateBody = /* @__PURE__ */ zod
             ),
     })
     .describe("Payload for publishing per-file edits against the canvas's current source.")
+
+/**
+ * Read a grid canvas's layout document and its `current_version_id`.
+ *
+ * Always call this before editing: pass the returned version id as
+ * `expected_current_version_id` on publish/patch so concurrent edits are
+ * not overwritten. A grid canvas with no versions yet returns the
+ * default empty layout with a null version id.
+ */
+export const CanvasesLayoutRetrieveParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this canvas.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const CanvasesLayoutRetrieveQueryParams = /* @__PURE__ */ zod.object({
+    version_id: zod
+        .string()
+        .optional()
+        .describe('Read this historical layout version instead of the head (for version browsing).'),
+})
+
+/**
+ * Apply surgical operations to the grid canvas's current layout.
+ *
+ * The default write path for both the editor and agents: add, move,
+ * resize, fill, or remove one placement without resending the layout.
+ * `expected_current_version_id` is mandatory so an agent filling a box
+ * and a user rearranging widgets cannot overwrite each other.
+ */
+export const CanvasesLayoutPatchCreateParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this canvas.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const canvasesLayoutPatchCreateBodyOperationsItemGridOneColumnsMin = 4
+export const canvasesLayoutPatchCreateBodyOperationsItemGridOneColumnsMax = 12
+
+export const canvasesLayoutPatchCreateBodyOperationsItemGridOneRowHeightMin = 24
+export const canvasesLayoutPatchCreateBodyOperationsItemGridOneRowHeightMax = 400
+
+export const canvasesLayoutPatchCreateBodyOperationsItemGridOneGapMin = 0
+export const canvasesLayoutPatchCreateBodyOperationsItemGridOneGapMax = 48
+
+export const canvasesLayoutPatchCreateBodyOperationsItemPlacementOneIdMax = 64
+
+export const canvasesLayoutPatchCreateBodyOperationsItemPlacementOneXMin = 0
+
+export const canvasesLayoutPatchCreateBodyOperationsItemPlacementOneYMin = 0
+
+export const canvasesLayoutPatchCreateBodyOperationsItemPlacementOnePromptMax = 10000
+
+export const canvasesLayoutPatchCreateBodyOperationsItemIdMax = 64
+
+export const canvasesLayoutPatchCreateBodyOperationsItemChangesOneXMin = 0
+
+export const canvasesLayoutPatchCreateBodyOperationsItemChangesOneYMin = 0
+
+export const canvasesLayoutPatchCreateBodyOperationsItemChangesOnePromptMax = 10000
+
+export const CanvasesLayoutPatchCreateBody = /* @__PURE__ */ zod
+    .object({
+        operations: zod
+            .array(
+                zod
+                    .object({
+                        op: zod
+                            .enum(['set_grid', 'add_placement', 'update_placement', 'remove_placement'])
+                            .describe(
+                                '\* `set_grid` - set_grid\n\* `add_placement` - add_placement\n\* `update_placement` - update_placement\n\* `remove_placement` - remove_placement'
+                            )
+                            .describe(
+                                'The operation to apply.\n\n\* `set_grid` - set_grid\n\* `add_placement` - add_placement\n\* `update_placement` - update_placement\n\* `remove_placement` - remove_placement'
+                            ),
+                        grid: zod
+                            .object({
+                                columns: zod
+                                    .number()
+                                    .min(canvasesLayoutPatchCreateBodyOperationsItemGridOneColumnsMin)
+                                    .max(canvasesLayoutPatchCreateBodyOperationsItemGridOneColumnsMax)
+                                    .describe('Grid width in columns. One of 4, 6, 8, 10, or 12.'),
+                                rowHeight: zod
+                                    .number()
+                                    .min(canvasesLayoutPatchCreateBodyOperationsItemGridOneRowHeightMin)
+                                    .max(canvasesLayoutPatchCreateBodyOperationsItemGridOneRowHeightMax)
+                                    .describe('Height of one grid row, in pixels.'),
+                                gap: zod
+                                    .number()
+                                    .min(canvasesLayoutPatchCreateBodyOperationsItemGridOneGapMin)
+                                    .max(canvasesLayoutPatchCreateBodyOperationsItemGridOneGapMax)
+                                    .describe('Gap between placements, in pixels.'),
+                            })
+                            .describe('The grid a grid canvas lays its placements out on.')
+                            .optional()
+                            .describe('For set_grid: the new grid definition.'),
+                        placement: zod
+                            .object({
+                                id: zod
+                                    .string()
+                                    .max(canvasesLayoutPatchCreateBodyOperationsItemPlacementOneIdMax)
+                                    .describe(
+                                        "Stable placement id, unique within the layout. 1-64 characters of letters, digits, '_', or '-'."
+                                    ),
+                                status: zod
+                                    .enum(['pending', 'generating', 'live', 'failed'])
+                                    .describe(
+                                        '\* `pending` - pending\n\* `generating` - generating\n\* `live` - live\n\* `failed` - failed'
+                                    )
+                                    .describe(
+                                        "Placement lifecycle: 'pending' (box drawn, no prompt yet), 'generating' (an agent task is filling it), 'live' (renders its component), 'failed' (generation failed; re-prompt or remove).\n\n\* `pending` - pending\n\* `generating` - generating\n\* `live` - live\n\* `failed` - failed"
+                                    ),
+                                component: zod
+                                    .string()
+                                    .nullish()
+                                    .describe(
+                                        'Id of the component canvas this placement renders. Required once the placement is live.'
+                                    ),
+                                version: zod
+                                    .string()
+                                    .nullish()
+                                    .describe(
+                                        'Component version to render: \"latest\" (the default — follows the component\'s published build) or a pinned source version id.'
+                                    ),
+                                x: zod
+                                    .number()
+                                    .min(canvasesLayoutPatchCreateBodyOperationsItemPlacementOneXMin)
+                                    .describe('Left edge, in grid columns (0-based).'),
+                                y: zod
+                                    .number()
+                                    .min(canvasesLayoutPatchCreateBodyOperationsItemPlacementOneYMin)
+                                    .describe('Top edge, in grid rows (0-based).'),
+                                w: zod.number().min(1).describe('Width, in grid columns.'),
+                                h: zod.number().min(1).describe('Height, in grid rows.'),
+                                config: zod
+                                    .record(zod.string(), zod.unknown())
+                                    .nullish()
+                                    .describe(
+                                        "Per-placement settings, validated against the component's configSchema."
+                                    ),
+                                prompt: zod
+                                    .string()
+                                    .max(canvasesLayoutPatchCreateBodyOperationsItemPlacementOnePromptMax)
+                                    .nullish()
+                                    .describe(
+                                        'For pending\/generating\/failed placements: what the user asked this box to become.'
+                                    ),
+                                generationTaskId: zod
+                                    .string()
+                                    .nullish()
+                                    .describe(
+                                        'Id of the agent task currently filling this placement, when one is running.'
+                                    ),
+                            })
+                            .describe('One placed widget on a grid canvas.')
+                            .optional()
+                            .describe('For add_placement: the placement to add.'),
+                        id: zod
+                            .string()
+                            .max(canvasesLayoutPatchCreateBodyOperationsItemIdMax)
+                            .optional()
+                            .describe('For update_placement\/remove_placement: the target placement id.'),
+                        changes: zod
+                            .object({
+                                status: zod
+                                    .enum(['pending', 'generating', 'live', 'failed'])
+                                    .describe(
+                                        '\* `pending` - pending\n\* `generating` - generating\n\* `live` - live\n\* `failed` - failed'
+                                    )
+                                    .optional()
+                                    .describe(
+                                        "Placement lifecycle: 'pending' (box drawn, no prompt yet), 'generating' (an agent task is filling it), 'live' (renders its component), 'failed' (generation failed; re-prompt or remove).\n\n\* `pending` - pending\n\* `generating` - generating\n\* `live` - live\n\* `failed` - failed"
+                                    ),
+                                component: zod
+                                    .string()
+                                    .nullish()
+                                    .describe(
+                                        'Id of the component canvas this placement renders. Required once the placement is live.'
+                                    ),
+                                version: zod
+                                    .string()
+                                    .nullish()
+                                    .describe(
+                                        'Component version to render: \"latest\" (the default — follows the component\'s published build) or a pinned source version id.'
+                                    ),
+                                x: zod
+                                    .number()
+                                    .min(canvasesLayoutPatchCreateBodyOperationsItemChangesOneXMin)
+                                    .optional()
+                                    .describe('Left edge, in grid columns (0-based).'),
+                                y: zod
+                                    .number()
+                                    .min(canvasesLayoutPatchCreateBodyOperationsItemChangesOneYMin)
+                                    .optional()
+                                    .describe('Top edge, in grid rows (0-based).'),
+                                w: zod.number().min(1).optional().describe('Width, in grid columns.'),
+                                h: zod.number().min(1).optional().describe('Height, in grid rows.'),
+                                config: zod
+                                    .record(zod.string(), zod.unknown())
+                                    .nullish()
+                                    .describe(
+                                        "Per-placement settings, validated against the component's configSchema."
+                                    ),
+                                prompt: zod
+                                    .string()
+                                    .max(canvasesLayoutPatchCreateBodyOperationsItemChangesOnePromptMax)
+                                    .nullish()
+                                    .describe(
+                                        'For pending\/generating\/failed placements: what the user asked this box to become.'
+                                    ),
+                                generationTaskId: zod
+                                    .string()
+                                    .nullish()
+                                    .describe(
+                                        'Id of the agent task currently filling this placement, when one is running.'
+                                    ),
+                            })
+                            .describe('Fields to merge into an existing placement (all optional; id cannot change).')
+                            .optional()
+                            .describe('For update_placement: the fields to merge into the placement.'),
+                    })
+                    .describe('One surgical layout operation.')
+            )
+            .describe("Operations applied in order to the canvas's current layout."),
+        prompt: zod
+            .string()
+            .optional()
+            .describe('Short description of the change, stored on the appended version history entry.'),
+        expected_current_version_id: zod
+            .string()
+            .nullable()
+            .describe(
+                'Required optimistic-concurrency guard: the current_version_id the operations are based on (null when the canvas has no layout versions yet). A moved head is rejected with 409 version_conflict — patches cannot apply unguarded.'
+            ),
+    })
+    .describe("Payload for applying surgical operations to the canvas's current layout.")
+
+/**
+ * Publish a complete layout document as the grid canvas's new head version.
+ *
+ * Layout is data, not code: the new version is live immediately, with no
+ * build. Validation errors reject the publish (400) and leave the canvas
+ * untouched; a stale `expected_current_version_id` is rejected with 409.
+ */
+export const CanvasesLayoutPublishCreateParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this canvas.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const canvasesLayoutPublishCreateBodyLayoutOneGridOneColumnsMin = 4
+export const canvasesLayoutPublishCreateBodyLayoutOneGridOneColumnsMax = 12
+
+export const canvasesLayoutPublishCreateBodyLayoutOneGridOneRowHeightMin = 24
+export const canvasesLayoutPublishCreateBodyLayoutOneGridOneRowHeightMax = 400
+
+export const canvasesLayoutPublishCreateBodyLayoutOneGridOneGapMin = 0
+export const canvasesLayoutPublishCreateBodyLayoutOneGridOneGapMax = 48
+
+export const canvasesLayoutPublishCreateBodyLayoutOnePlacementsItemIdMax = 64
+
+export const canvasesLayoutPublishCreateBodyLayoutOnePlacementsItemXMin = 0
+
+export const canvasesLayoutPublishCreateBodyLayoutOnePlacementsItemYMin = 0
+
+export const canvasesLayoutPublishCreateBodyLayoutOnePlacementsItemPromptMax = 10000
+
+export const CanvasesLayoutPublishCreateBody = /* @__PURE__ */ zod
+    .object({
+        layout: zod
+            .object({
+                schemaVersion: zod.number().describe('Layout schema version. Currently always 1.'),
+                grid: zod
+                    .object({
+                        columns: zod
+                            .number()
+                            .min(canvasesLayoutPublishCreateBodyLayoutOneGridOneColumnsMin)
+                            .max(canvasesLayoutPublishCreateBodyLayoutOneGridOneColumnsMax)
+                            .describe('Grid width in columns. One of 4, 6, 8, 10, or 12.'),
+                        rowHeight: zod
+                            .number()
+                            .min(canvasesLayoutPublishCreateBodyLayoutOneGridOneRowHeightMin)
+                            .max(canvasesLayoutPublishCreateBodyLayoutOneGridOneRowHeightMax)
+                            .describe('Height of one grid row, in pixels.'),
+                        gap: zod
+                            .number()
+                            .min(canvasesLayoutPublishCreateBodyLayoutOneGridOneGapMin)
+                            .max(canvasesLayoutPublishCreateBodyLayoutOneGridOneGapMax)
+                            .describe('Gap between placements, in pixels.'),
+                    })
+                    .describe('The grid a grid canvas lays its placements out on.')
+                    .describe('The grid placements are laid out on.'),
+                placements: zod
+                    .array(
+                        zod
+                            .object({
+                                id: zod
+                                    .string()
+                                    .max(canvasesLayoutPublishCreateBodyLayoutOnePlacementsItemIdMax)
+                                    .describe(
+                                        "Stable placement id, unique within the layout. 1-64 characters of letters, digits, '_', or '-'."
+                                    ),
+                                status: zod
+                                    .enum(['pending', 'generating', 'live', 'failed'])
+                                    .describe(
+                                        '\* `pending` - pending\n\* `generating` - generating\n\* `live` - live\n\* `failed` - failed'
+                                    )
+                                    .describe(
+                                        "Placement lifecycle: 'pending' (box drawn, no prompt yet), 'generating' (an agent task is filling it), 'live' (renders its component), 'failed' (generation failed; re-prompt or remove).\n\n\* `pending` - pending\n\* `generating` - generating\n\* `live` - live\n\* `failed` - failed"
+                                    ),
+                                component: zod
+                                    .string()
+                                    .nullish()
+                                    .describe(
+                                        'Id of the component canvas this placement renders. Required once the placement is live.'
+                                    ),
+                                version: zod
+                                    .string()
+                                    .nullish()
+                                    .describe(
+                                        'Component version to render: \"latest\" (the default — follows the component\'s published build) or a pinned source version id.'
+                                    ),
+                                x: zod
+                                    .number()
+                                    .min(canvasesLayoutPublishCreateBodyLayoutOnePlacementsItemXMin)
+                                    .describe('Left edge, in grid columns (0-based).'),
+                                y: zod
+                                    .number()
+                                    .min(canvasesLayoutPublishCreateBodyLayoutOnePlacementsItemYMin)
+                                    .describe('Top edge, in grid rows (0-based).'),
+                                w: zod.number().min(1).describe('Width, in grid columns.'),
+                                h: zod.number().min(1).describe('Height, in grid rows.'),
+                                config: zod
+                                    .record(zod.string(), zod.unknown())
+                                    .nullish()
+                                    .describe(
+                                        "Per-placement settings, validated against the component's configSchema."
+                                    ),
+                                prompt: zod
+                                    .string()
+                                    .max(canvasesLayoutPublishCreateBodyLayoutOnePlacementsItemPromptMax)
+                                    .nullish()
+                                    .describe(
+                                        'For pending\/generating\/failed placements: what the user asked this box to become.'
+                                    ),
+                                generationTaskId: zod
+                                    .string()
+                                    .nullish()
+                                    .describe(
+                                        'Id of the agent task currently filling this placement, when one is running.'
+                                    ),
+                            })
+                            .describe('One placed widget on a grid canvas.')
+                    )
+                    .describe('The placed widgets. Placements may not overlap or extend past the grid.'),
+            })
+            .describe("A grid canvas's layout document — its entire 'source'.")
+            .describe('The complete layout document to publish.'),
+        prompt: zod
+            .string()
+            .optional()
+            .describe('Short description of the change, stored on the appended version history entry.'),
+        expected_current_version_id: zod
+            .string()
+            .nullish()
+            .describe(
+                'Optimistic-concurrency guard: the current_version_id the layout was based on (null when the canvas has no versions yet). A moved head is rejected with 409 version_conflict. Omit to publish unguarded.'
+            ),
+    })
+    .describe('Payload for publishing a complete layout document.')
 
 /**
  * Make a draft version the canvas's live head.

--- a/services/mcp/src/generated/canvas/api.ts
+++ b/services/mcp/src/generated/canvas/api.ts
@@ -437,9 +437,6 @@ export const CanvasesLayoutPatchCreateParams = /* @__PURE__ */ zod.object({
         ),
 })
 
-export const canvasesLayoutPatchCreateBodyOperationsItemGridOneColumnsMin = 4
-export const canvasesLayoutPatchCreateBodyOperationsItemGridOneColumnsMax = 12
-
 export const canvasesLayoutPatchCreateBodyOperationsItemGridOneRowHeightMin = 24
 export const canvasesLayoutPatchCreateBodyOperationsItemGridOneRowHeightMax = 400
 
@@ -448,6 +445,7 @@ export const canvasesLayoutPatchCreateBodyOperationsItemGridOneGapMax = 48
 
 export const canvasesLayoutPatchCreateBodyOperationsItemPlacementOneIdMax = 64
 
+export const canvasesLayoutPatchCreateBodyOperationsItemPlacementOneIdRegExp = new RegExp('^[A-Za-z0-9_-]{1,64}$')
 export const canvasesLayoutPatchCreateBodyOperationsItemPlacementOneXMin = 0
 
 export const canvasesLayoutPatchCreateBodyOperationsItemPlacementOneYMin = 0
@@ -479,10 +477,17 @@ export const CanvasesLayoutPatchCreateBody = /* @__PURE__ */ zod
                         grid: zod
                             .object({
                                 columns: zod
-                                    .number()
-                                    .min(canvasesLayoutPatchCreateBodyOperationsItemGridOneColumnsMin)
-                                    .max(canvasesLayoutPatchCreateBodyOperationsItemGridOneColumnsMax)
-                                    .describe('Grid width in columns. One of 4, 6, 8, 10, or 12.'),
+                                    .union([
+                                        zod.literal(4),
+                                        zod.literal(6),
+                                        zod.literal(8),
+                                        zod.literal(10),
+                                        zod.literal(12),
+                                    ])
+                                    .describe('\* `4` - 4\n\* `6` - 6\n\* `8` - 8\n\* `10` - 10\n\* `12` - 12')
+                                    .describe(
+                                        'Grid width in columns. One of 4, 6, 8, 10, or 12.\n\n\* `4` - 4\n\* `6` - 6\n\* `8` - 8\n\* `10` - 10\n\* `12` - 12'
+                                    ),
                                 rowHeight: zod
                                     .number()
                                     .min(canvasesLayoutPatchCreateBodyOperationsItemGridOneRowHeightMin)
@@ -502,6 +507,7 @@ export const CanvasesLayoutPatchCreateBody = /* @__PURE__ */ zod
                                 id: zod
                                     .string()
                                     .max(canvasesLayoutPatchCreateBodyOperationsItemPlacementOneIdMax)
+                                    .regex(canvasesLayoutPatchCreateBodyOperationsItemPlacementOneIdRegExp)
                                     .describe(
                                         "Stable placement id, unique within the layout. 1-64 characters of letters, digits, '_', or '-'."
                                     ),
@@ -624,7 +630,7 @@ export const CanvasesLayoutPatchCreateBody = /* @__PURE__ */ zod
                     })
                     .describe('One surgical layout operation.')
             )
-            .describe("Operations applied in order to the canvas's current layout."),
+            .describe("Operations applied in order to the canvas's current layout, at most 64."),
         prompt: zod
             .string()
             .optional()
@@ -654,9 +660,6 @@ export const CanvasesLayoutPublishCreateParams = /* @__PURE__ */ zod.object({
         ),
 })
 
-export const canvasesLayoutPublishCreateBodyLayoutOneGridOneColumnsMin = 4
-export const canvasesLayoutPublishCreateBodyLayoutOneGridOneColumnsMax = 12
-
 export const canvasesLayoutPublishCreateBodyLayoutOneGridOneRowHeightMin = 24
 export const canvasesLayoutPublishCreateBodyLayoutOneGridOneRowHeightMax = 400
 
@@ -665,6 +668,7 @@ export const canvasesLayoutPublishCreateBodyLayoutOneGridOneGapMax = 48
 
 export const canvasesLayoutPublishCreateBodyLayoutOnePlacementsItemIdMax = 64
 
+export const canvasesLayoutPublishCreateBodyLayoutOnePlacementsItemIdRegExp = new RegExp('^[A-Za-z0-9_-]{1,64}$')
 export const canvasesLayoutPublishCreateBodyLayoutOnePlacementsItemXMin = 0
 
 export const canvasesLayoutPublishCreateBodyLayoutOnePlacementsItemYMin = 0
@@ -675,14 +679,18 @@ export const CanvasesLayoutPublishCreateBody = /* @__PURE__ */ zod
     .object({
         layout: zod
             .object({
-                schemaVersion: zod.number().describe('Layout schema version. Currently always 1.'),
+                schemaVersion: zod
+                    .literal(1)
+                    .describe('\* `1` - 1')
+                    .describe('Layout schema version. Currently always 1.\n\n\* `1` - 1'),
                 grid: zod
                     .object({
                         columns: zod
-                            .number()
-                            .min(canvasesLayoutPublishCreateBodyLayoutOneGridOneColumnsMin)
-                            .max(canvasesLayoutPublishCreateBodyLayoutOneGridOneColumnsMax)
-                            .describe('Grid width in columns. One of 4, 6, 8, 10, or 12.'),
+                            .union([zod.literal(4), zod.literal(6), zod.literal(8), zod.literal(10), zod.literal(12)])
+                            .describe('\* `4` - 4\n\* `6` - 6\n\* `8` - 8\n\* `10` - 10\n\* `12` - 12')
+                            .describe(
+                                'Grid width in columns. One of 4, 6, 8, 10, or 12.\n\n\* `4` - 4\n\* `6` - 6\n\* `8` - 8\n\* `10` - 10\n\* `12` - 12'
+                            ),
                         rowHeight: zod
                             .number()
                             .min(canvasesLayoutPublishCreateBodyLayoutOneGridOneRowHeightMin)
@@ -703,6 +711,7 @@ export const CanvasesLayoutPublishCreateBody = /* @__PURE__ */ zod
                                 id: zod
                                     .string()
                                     .max(canvasesLayoutPublishCreateBodyLayoutOnePlacementsItemIdMax)
+                                    .regex(canvasesLayoutPublishCreateBodyLayoutOnePlacementsItemIdRegExp)
                                     .describe(
                                         "Stable placement id, unique within the layout. 1-64 characters of letters, digits, '_', or '-'."
                                     ),
@@ -758,7 +767,7 @@ export const CanvasesLayoutPublishCreateBody = /* @__PURE__ */ zod
                             })
                             .describe('One placed widget on a grid canvas.')
                     )
-                    .describe('The placed widgets. Placements may not overlap or extend past the grid.'),
+                    .describe('The placed widgets, at most 24. Placements may not overlap or extend past the grid.'),
             })
             .describe("A grid canvas's layout document — its entire 'source'.")
             .describe('The complete layout document to publish.'),

--- a/services/mcp/src/tools/generated/canvas.ts
+++ b/services/mcp/src/tools/generated/canvas.ts
@@ -12,6 +12,12 @@ import {
     CanvasesDraftsRetrieveQueryParams,
     CanvasesEditCreateBody,
     CanvasesEditCreateParams,
+    CanvasesLayoutPatchCreateBody,
+    CanvasesLayoutPatchCreateParams,
+    CanvasesLayoutPublishCreateBody,
+    CanvasesLayoutPublishCreateParams,
+    CanvasesLayoutRetrieveParams,
+    CanvasesLayoutRetrieveQueryParams,
     CanvasesListQueryParams,
     CanvasesPromoteCreateBody,
     CanvasesPromoteCreateParams,
@@ -49,6 +55,12 @@ const canvasBuildsRetrieve = (): ToolBase<typeof CanvasBuildsRetrieveSchema, Sch
 const CanvasCreateSchema = CanvasesCreateBody.extend({
     channel_id: CanvasesCreateBody.shape['channel_id'].describe(
         "Id of the channel to create the canvas in — the channel the task was created in, from the task's context. Use channel-list only to resolve a channel the user named; never pick a channel from the listing yourself (the personal #me channel is not a default)."
+    ),
+    kind: CanvasesCreateBody.shape['kind'].describe(
+        "What to create: 'freeform' (a standalone app — the default), 'component' (a reusable widget for grid canvases; its published project must declare a `component` placement contract), or 'grid' (a composition of components, edited via canvas-layout-patch). Search the store (canvas-list kind=component) before creating a new component."
+    ),
+    description: CanvasesCreateBody.shape['description'].describe(
+        'Short prose describing the canvas. For components this is the store-search text — say what the widget shows and what its config controls, so future searches find it.'
     ),
 })
 
@@ -161,6 +173,12 @@ const canvasEditCreate = (): ToolBase<typeof CanvasEditCreateSchema, Schemas.Can
 
 const CanvasListSchema = CanvasesListQueryParams.extend({
     channel: CanvasesListQueryParams.shape['channel'].describe('Only return canvases in this channel (channel id).'),
+    kind: CanvasesListQueryParams.shape['kind'].describe(
+        'Only return canvases of this kind. kind=component lists the component store.'
+    ),
+    search: CanvasesListQueryParams.shape['search'].describe(
+        'Case-insensitive match on name and description — use to find store components by what they show.'
+    ),
 })
 
 const canvasList = (): ToolBase<typeof CanvasListSchema, Schemas.PaginatedCanvasList> => ({
@@ -303,6 +321,86 @@ const canvasValidateCreate = (): ToolBase<typeof CanvasValidateCreateSchema, Sch
     },
 })
 
+const CanvasLayoutPatchSchema = CanvasesLayoutPatchCreateParams.omit({ project_id: true })
+    .extend(CanvasesLayoutPatchCreateBody.shape)
+    .extend({
+        id: CanvasesLayoutPatchCreateParams.shape['id'].describe('ID of the grid canvas whose layout to patch.'),
+    })
+
+const canvasLayoutPatch = (): ToolBase<typeof CanvasLayoutPatchSchema, Schemas.CanvasLayoutPublishResponse> => ({
+    name: 'canvas-layout-patch',
+    schema: CanvasLayoutPatchSchema,
+    handler: async (context: Context, params: z.infer<typeof CanvasLayoutPatchSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.operations !== undefined) {
+            body['operations'] = params.operations
+        }
+        if (params.prompt !== undefined) {
+            body['prompt'] = params.prompt
+        }
+        if (params.expected_current_version_id !== undefined) {
+            body['expected_current_version_id'] = params.expected_current_version_id
+        }
+        const result = await context.api.request<Schemas.CanvasLayoutPublishResponse>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/canvases/${encodeURIComponent(String(params.id))}/layout/patch/`,
+            body,
+        })
+        return result
+    },
+})
+
+const CanvasLayoutPublishSchema = CanvasesLayoutPublishCreateParams.omit({ project_id: true })
+    .extend(CanvasesLayoutPublishCreateBody.shape)
+    .extend({
+        id: CanvasesLayoutPublishCreateParams.shape['id'].describe('ID of the grid canvas whose layout to publish.'),
+    })
+
+const canvasLayoutPublish = (): ToolBase<typeof CanvasLayoutPublishSchema, Schemas.CanvasLayoutPublishResponse> => ({
+    name: 'canvas-layout-publish',
+    schema: CanvasLayoutPublishSchema,
+    handler: async (context: Context, params: z.infer<typeof CanvasLayoutPublishSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.layout !== undefined) {
+            body['layout'] = params.layout
+        }
+        if (params.prompt !== undefined) {
+            body['prompt'] = params.prompt
+        }
+        if (params.expected_current_version_id !== undefined) {
+            body['expected_current_version_id'] = params.expected_current_version_id
+        }
+        const result = await context.api.request<Schemas.CanvasLayoutPublishResponse>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/canvases/${encodeURIComponent(String(params.id))}/layout/publish/`,
+            body,
+        })
+        return result
+    },
+})
+
+const CanvasLayoutGetSchema = CanvasesLayoutRetrieveParams.omit({ project_id: true })
+    .extend(CanvasesLayoutRetrieveQueryParams.shape)
+    .extend({ id: CanvasesLayoutRetrieveParams.shape['id'].describe('ID of the grid canvas whose layout to read.') })
+
+const canvasLayoutGet = (): ToolBase<typeof CanvasLayoutGetSchema, Schemas.CanvasLayoutResponse> => ({
+    name: 'canvas-layout-get',
+    schema: CanvasLayoutGetSchema,
+    handler: async (context: Context, params: z.infer<typeof CanvasLayoutGetSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.CanvasLayoutResponse>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/canvases/${encodeURIComponent(String(params.id))}/layout/`,
+            query: {
+                version_id: params.version_id,
+            },
+        })
+        return result
+    },
+})
+
 export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'canvas-builds-retrieve': canvasBuildsRetrieve,
     'canvas-create': canvasCreate,
@@ -315,4 +413,7 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'canvas-publish-current-version': canvasPublishCurrentVersion,
     'canvas-source-retrieve': canvasSourceRetrieve,
     'canvas-validate-create': canvasValidateCreate,
+    'canvas-layout-patch': canvasLayoutPatch,
+    'canvas-layout-publish': canvasLayoutPublish,
+    'canvas-layout-get': canvasLayoutGet,
 }

--- a/services/mcp/src/tools/generated/canvas.ts
+++ b/services/mcp/src/tools/generated/canvas.ts
@@ -57,7 +57,7 @@ const CanvasCreateSchema = CanvasesCreateBody.extend({
         "Id of the channel to create the canvas in — the channel the task was created in, from the task's context. Use channel-list only to resolve a channel the user named; never pick a channel from the listing yourself (the personal #me channel is not a default)."
     ),
     kind: CanvasesCreateBody.shape['kind'].describe(
-        "What to create: 'freeform' (a standalone app — the default), 'component' (a reusable widget for grid canvases; its published project must declare a `component` placement contract), or 'grid' (a composition of components, edited via canvas-layout-patch). Search the store (canvas-list kind=component) before creating a new component."
+        "What to create: 'freeform' (a standalone app — the default), 'component' (a reusable widget for grid canvases; its published project must declare a `component` placement contract), or 'grid' (a composition of components, edited via canvas-layout-patch). See canvas-list (kind=component) before creating a component."
     ),
     description: CanvasesCreateBody.shape['description'].describe(
         'Short prose describing the canvas. For components this is the store-search text — say what the widget shows and what its config controls, so future searches find it.'

--- a/services/mcp/src/tools/generated/canvas.ts
+++ b/services/mcp/src/tools/generated/canvas.ts
@@ -17,7 +17,6 @@ import {
     CanvasesLayoutPublishCreateBody,
     CanvasesLayoutPublishCreateParams,
     CanvasesLayoutRetrieveParams,
-    CanvasesLayoutRetrieveQueryParams,
     CanvasesListQueryParams,
     CanvasesPromoteCreateBody,
     CanvasesPromoteCreateParams,
@@ -171,9 +170,9 @@ const canvasEditCreate = (): ToolBase<typeof CanvasEditCreateSchema, Schemas.Can
     },
 })
 
-const CanvasLayoutGetSchema = CanvasesLayoutRetrieveParams.omit({ project_id: true })
-    .extend(CanvasesLayoutRetrieveQueryParams.shape)
-    .extend({ id: CanvasesLayoutRetrieveParams.shape['id'].describe('ID of the grid canvas whose layout to read.') })
+const CanvasLayoutGetSchema = CanvasesLayoutRetrieveParams.omit({ project_id: true }).extend({
+    id: CanvasesLayoutRetrieveParams.shape['id'].describe('ID of the grid canvas whose layout to read.'),
+})
 
 const canvasLayoutGet = (): ToolBase<typeof CanvasLayoutGetSchema, Schemas.CanvasLayoutResponse> => ({
     name: 'canvas-layout-get',
@@ -183,9 +182,6 @@ const canvasLayoutGet = (): ToolBase<typeof CanvasLayoutGetSchema, Schemas.Canva
         const result = await context.api.request<Schemas.CanvasLayoutResponse>({
             method: 'GET',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/canvases/${encodeURIComponent(String(params.id))}/layout/`,
-            query: {
-                version_id: params.version_id,
-            },
         })
         return result
     },
@@ -225,6 +221,11 @@ const CanvasLayoutPublishSchema = CanvasesLayoutPublishCreateParams.omit({ proje
     .extend(CanvasesLayoutPublishCreateBody.shape)
     .extend({
         id: CanvasesLayoutPublishCreateParams.shape['id'].describe('ID of the grid canvas whose layout to publish.'),
+        expected_current_version_id: CanvasesLayoutPublishCreateBody.shape['expected_current_version_id']
+            .unwrap()
+            .describe(
+                'The `current_version_id` this document was built on, from canvas-layout-get (null only for a grid canvas that has never published a layout). A whole document replaces the head, so without the guard a layout the user changed after you read it is silently discarded.'
+            ),
     })
 
 const canvasLayoutPublish = (): ToolBase<typeof CanvasLayoutPublishSchema, Schemas.CanvasLayoutPublishResponse> => ({

--- a/services/mcp/src/tools/generated/canvas.ts
+++ b/services/mcp/src/tools/generated/canvas.ts
@@ -171,6 +171,86 @@ const canvasEditCreate = (): ToolBase<typeof CanvasEditCreateSchema, Schemas.Can
     },
 })
 
+const CanvasLayoutGetSchema = CanvasesLayoutRetrieveParams.omit({ project_id: true })
+    .extend(CanvasesLayoutRetrieveQueryParams.shape)
+    .extend({ id: CanvasesLayoutRetrieveParams.shape['id'].describe('ID of the grid canvas whose layout to read.') })
+
+const canvasLayoutGet = (): ToolBase<typeof CanvasLayoutGetSchema, Schemas.CanvasLayoutResponse> => ({
+    name: 'canvas-layout-get',
+    schema: CanvasLayoutGetSchema,
+    handler: async (context: Context, params: z.infer<typeof CanvasLayoutGetSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.CanvasLayoutResponse>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/canvases/${encodeURIComponent(String(params.id))}/layout/`,
+            query: {
+                version_id: params.version_id,
+            },
+        })
+        return result
+    },
+})
+
+const CanvasLayoutPatchSchema = CanvasesLayoutPatchCreateParams.omit({ project_id: true })
+    .extend(CanvasesLayoutPatchCreateBody.shape)
+    .extend({
+        id: CanvasesLayoutPatchCreateParams.shape['id'].describe('ID of the grid canvas whose layout to patch.'),
+    })
+
+const canvasLayoutPatch = (): ToolBase<typeof CanvasLayoutPatchSchema, Schemas.CanvasLayoutPublishResponse> => ({
+    name: 'canvas-layout-patch',
+    schema: CanvasLayoutPatchSchema,
+    handler: async (context: Context, params: z.infer<typeof CanvasLayoutPatchSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.operations !== undefined) {
+            body['operations'] = params.operations
+        }
+        if (params.prompt !== undefined) {
+            body['prompt'] = params.prompt
+        }
+        if (params.expected_current_version_id !== undefined) {
+            body['expected_current_version_id'] = params.expected_current_version_id
+        }
+        const result = await context.api.request<Schemas.CanvasLayoutPublishResponse>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/canvases/${encodeURIComponent(String(params.id))}/layout/patch/`,
+            body,
+        })
+        return result
+    },
+})
+
+const CanvasLayoutPublishSchema = CanvasesLayoutPublishCreateParams.omit({ project_id: true })
+    .extend(CanvasesLayoutPublishCreateBody.shape)
+    .extend({
+        id: CanvasesLayoutPublishCreateParams.shape['id'].describe('ID of the grid canvas whose layout to publish.'),
+    })
+
+const canvasLayoutPublish = (): ToolBase<typeof CanvasLayoutPublishSchema, Schemas.CanvasLayoutPublishResponse> => ({
+    name: 'canvas-layout-publish',
+    schema: CanvasLayoutPublishSchema,
+    handler: async (context: Context, params: z.infer<typeof CanvasLayoutPublishSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.layout !== undefined) {
+            body['layout'] = params.layout
+        }
+        if (params.prompt !== undefined) {
+            body['prompt'] = params.prompt
+        }
+        if (params.expected_current_version_id !== undefined) {
+            body['expected_current_version_id'] = params.expected_current_version_id
+        }
+        const result = await context.api.request<Schemas.CanvasLayoutPublishResponse>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/canvases/${encodeURIComponent(String(params.id))}/layout/publish/`,
+            body,
+        })
+        return result
+    },
+})
+
 const CanvasListSchema = CanvasesListQueryParams.extend({
     channel: CanvasesListQueryParams.shape['channel'].describe('Only return canvases in this channel (channel id).'),
     kind: CanvasesListQueryParams.shape['kind'].describe(
@@ -321,99 +401,19 @@ const canvasValidateCreate = (): ToolBase<typeof CanvasValidateCreateSchema, Sch
     },
 })
 
-const CanvasLayoutPatchSchema = CanvasesLayoutPatchCreateParams.omit({ project_id: true })
-    .extend(CanvasesLayoutPatchCreateBody.shape)
-    .extend({
-        id: CanvasesLayoutPatchCreateParams.shape['id'].describe('ID of the grid canvas whose layout to patch.'),
-    })
-
-const canvasLayoutPatch = (): ToolBase<typeof CanvasLayoutPatchSchema, Schemas.CanvasLayoutPublishResponse> => ({
-    name: 'canvas-layout-patch',
-    schema: CanvasLayoutPatchSchema,
-    handler: async (context: Context, params: z.infer<typeof CanvasLayoutPatchSchema>) => {
-        const projectId = await context.stateManager.getProjectId()
-        const body: Record<string, unknown> = {}
-        if (params.operations !== undefined) {
-            body['operations'] = params.operations
-        }
-        if (params.prompt !== undefined) {
-            body['prompt'] = params.prompt
-        }
-        if (params.expected_current_version_id !== undefined) {
-            body['expected_current_version_id'] = params.expected_current_version_id
-        }
-        const result = await context.api.request<Schemas.CanvasLayoutPublishResponse>({
-            method: 'POST',
-            path: `/api/projects/${encodeURIComponent(String(projectId))}/canvases/${encodeURIComponent(String(params.id))}/layout/patch/`,
-            body,
-        })
-        return result
-    },
-})
-
-const CanvasLayoutPublishSchema = CanvasesLayoutPublishCreateParams.omit({ project_id: true })
-    .extend(CanvasesLayoutPublishCreateBody.shape)
-    .extend({
-        id: CanvasesLayoutPublishCreateParams.shape['id'].describe('ID of the grid canvas whose layout to publish.'),
-    })
-
-const canvasLayoutPublish = (): ToolBase<typeof CanvasLayoutPublishSchema, Schemas.CanvasLayoutPublishResponse> => ({
-    name: 'canvas-layout-publish',
-    schema: CanvasLayoutPublishSchema,
-    handler: async (context: Context, params: z.infer<typeof CanvasLayoutPublishSchema>) => {
-        const projectId = await context.stateManager.getProjectId()
-        const body: Record<string, unknown> = {}
-        if (params.layout !== undefined) {
-            body['layout'] = params.layout
-        }
-        if (params.prompt !== undefined) {
-            body['prompt'] = params.prompt
-        }
-        if (params.expected_current_version_id !== undefined) {
-            body['expected_current_version_id'] = params.expected_current_version_id
-        }
-        const result = await context.api.request<Schemas.CanvasLayoutPublishResponse>({
-            method: 'POST',
-            path: `/api/projects/${encodeURIComponent(String(projectId))}/canvases/${encodeURIComponent(String(params.id))}/layout/publish/`,
-            body,
-        })
-        return result
-    },
-})
-
-const CanvasLayoutGetSchema = CanvasesLayoutRetrieveParams.omit({ project_id: true })
-    .extend(CanvasesLayoutRetrieveQueryParams.shape)
-    .extend({ id: CanvasesLayoutRetrieveParams.shape['id'].describe('ID of the grid canvas whose layout to read.') })
-
-const canvasLayoutGet = (): ToolBase<typeof CanvasLayoutGetSchema, Schemas.CanvasLayoutResponse> => ({
-    name: 'canvas-layout-get',
-    schema: CanvasLayoutGetSchema,
-    handler: async (context: Context, params: z.infer<typeof CanvasLayoutGetSchema>) => {
-        const projectId = await context.stateManager.getProjectId()
-        const result = await context.api.request<Schemas.CanvasLayoutResponse>({
-            method: 'GET',
-            path: `/api/projects/${encodeURIComponent(String(projectId))}/canvases/${encodeURIComponent(String(params.id))}/layout/`,
-            query: {
-                version_id: params.version_id,
-            },
-        })
-        return result
-    },
-})
-
 export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'canvas-builds-retrieve': canvasBuildsRetrieve,
     'canvas-create': canvasCreate,
     'canvas-draft-create': canvasDraftCreate,
     'canvas-drafts-retrieve': canvasDraftsRetrieve,
     'canvas-edit-create': canvasEditCreate,
+    'canvas-layout-get': canvasLayoutGet,
+    'canvas-layout-patch': canvasLayoutPatch,
+    'canvas-layout-publish': canvasLayoutPublish,
     'canvas-list': canvasList,
     'canvas-promote-create': canvasPromoteCreate,
     'canvas-publish-create': canvasPublishCreate,
     'canvas-publish-current-version': canvasPublishCurrentVersion,
     'canvas-source-retrieve': canvasSourceRetrieve,
     'canvas-validate-create': canvasValidateCreate,
-    'canvas-layout-patch': canvasLayoutPatch,
-    'canvas-layout-publish': canvasLayoutPublish,
-    'canvas-layout-get': canvasLayoutGet,
 }

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/canvas-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/canvas-create.json
@@ -12,7 +12,7 @@
         },
         "kind": {
             "default": "freeform",
-            "description": "What to create: 'freeform' (a standalone app — the default), 'component' (a reusable widget for grid canvases; its published project must declare a `component` placement contract), or 'grid' (a composition of components, edited via canvas-layout-patch). Search the store (canvas-list kind=component) before creating a new component.",
+            "description": "What to create: 'freeform' (a standalone app — the default), 'component' (a reusable widget for grid canvases; its published project must declare a `component` placement contract), or 'grid' (a composition of components, edited via canvas-layout-patch). See canvas-list (kind=component) before creating a component.",
             "enum": ["freeform", "grid", "component"],
             "type": "string"
         },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/canvas-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/canvas-create.json
@@ -7,12 +7,12 @@
         },
         "description": {
             "default": "",
-            "description": "Short prose describing the canvas. For components this is the store-search text agents match against — say what the widget shows and what its config controls.",
+            "description": "Short prose describing the canvas. For components this is the store-search text — say what the widget shows and what its config controls, so future searches find it.",
             "type": "string"
         },
         "kind": {
             "default": "freeform",
-            "description": "What to create: 'freeform' (a standalone app), 'component' (a reusable widget for grids — its published project must declare a `component` placement contract), or 'grid' (a composition of components, edited through the layout endpoints).\n\n* `freeform` - freeform\n* `grid` - grid\n* `component` - component",
+            "description": "What to create: 'freeform' (a standalone app — the default), 'component' (a reusable widget for grid canvases; its published project must declare a `component` placement contract), or 'grid' (a composition of components, edited via canvas-layout-patch). Search the store (canvas-list kind=component) before creating a new component.",
             "enum": ["freeform", "grid", "component"],
             "type": "string"
         },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/canvas-layout-get.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/canvas-layout-get.json
@@ -4,10 +4,6 @@
         "id": {
             "description": "ID of the grid canvas whose layout to read.",
             "type": "string"
-        },
-        "version_id": {
-            "description": "Read this historical layout version instead of the head (for version browsing).",
-            "type": "string"
         }
     },
     "required": ["id"],

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/canvas-layout-get.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/canvas-layout-get.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "id": {
+            "description": "ID of the grid canvas whose layout to read.",
+            "type": "string"
+        },
+        "version_id": {
+            "description": "Read this historical layout version instead of the head (for version browsing).",
+            "type": "string"
+        }
+    },
+    "required": ["id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/canvas-layout-patch.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/canvas-layout-patch.json
@@ -1,0 +1,260 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "expected_current_version_id": {
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Required optimistic-concurrency guard: the current_version_id the operations are based on (null when the canvas has no layout versions yet). A moved head is rejected with 409 version_conflict — patches cannot apply unguarded."
+        },
+        "id": {
+            "description": "ID of the grid canvas whose layout to patch.",
+            "type": "string"
+        },
+        "operations": {
+            "description": "Operations applied in order to the canvas's current layout.",
+            "items": {
+                "description": "One surgical layout operation.",
+                "properties": {
+                    "changes": {
+                        "description": "For update_placement: the fields to merge into the placement.",
+                        "properties": {
+                            "component": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ],
+                                "description": "Id of the component canvas this placement renders. Required once the placement is live."
+                            },
+                            "config": {
+                                "anyOf": [
+                                    {
+                                        "additionalProperties": {},
+                                        "propertyNames": {
+                                            "type": "string"
+                                        },
+                                        "type": "object"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ],
+                                "description": "Per-placement settings, validated against the component's configSchema."
+                            },
+                            "generationTaskId": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ],
+                                "description": "Id of the agent task currently filling this placement, when one is running."
+                            },
+                            "h": {
+                                "description": "Height, in grid rows.",
+                                "minimum": 1,
+                                "type": "number"
+                            },
+                            "prompt": {
+                                "anyOf": [
+                                    {
+                                        "maxLength": 10000,
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ],
+                                "description": "For pending/generating/failed placements: what the user asked this box to become."
+                            },
+                            "status": {
+                                "description": "Placement lifecycle: 'pending' (box drawn, no prompt yet), 'generating' (an agent task is filling it), 'live' (renders its component), 'failed' (generation failed; re-prompt or remove).\n\n* `pending` - pending\n* `generating` - generating\n* `live` - live\n* `failed` - failed",
+                                "enum": ["pending", "generating", "live", "failed"],
+                                "type": "string"
+                            },
+                            "version": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ],
+                                "description": "Component version to render: \"latest\" (the default — follows the component's published build) or a pinned source version id."
+                            },
+                            "w": {
+                                "description": "Width, in grid columns.",
+                                "minimum": 1,
+                                "type": "number"
+                            },
+                            "x": {
+                                "description": "Left edge, in grid columns (0-based).",
+                                "minimum": 0,
+                                "type": "number"
+                            },
+                            "y": {
+                                "description": "Top edge, in grid rows (0-based).",
+                                "minimum": 0,
+                                "type": "number"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "grid": {
+                        "description": "For set_grid: the new grid definition.",
+                        "properties": {
+                            "columns": {
+                                "description": "Grid width in columns. One of 4, 6, 8, 10, or 12.",
+                                "maximum": 12,
+                                "minimum": 4,
+                                "type": "number"
+                            },
+                            "gap": {
+                                "description": "Gap between placements, in pixels.",
+                                "maximum": 48,
+                                "minimum": 0,
+                                "type": "number"
+                            },
+                            "rowHeight": {
+                                "description": "Height of one grid row, in pixels.",
+                                "maximum": 400,
+                                "minimum": 24,
+                                "type": "number"
+                            }
+                        },
+                        "required": ["columns", "rowHeight", "gap"],
+                        "type": "object"
+                    },
+                    "id": {
+                        "description": "For update_placement/remove_placement: the target placement id.",
+                        "maxLength": 64,
+                        "type": "string"
+                    },
+                    "op": {
+                        "description": "The operation to apply.\n\n* `set_grid` - set_grid\n* `add_placement` - add_placement\n* `update_placement` - update_placement\n* `remove_placement` - remove_placement",
+                        "enum": ["set_grid", "add_placement", "update_placement", "remove_placement"],
+                        "type": "string"
+                    },
+                    "placement": {
+                        "description": "For add_placement: the placement to add.",
+                        "properties": {
+                            "component": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ],
+                                "description": "Id of the component canvas this placement renders. Required once the placement is live."
+                            },
+                            "config": {
+                                "anyOf": [
+                                    {
+                                        "additionalProperties": {},
+                                        "propertyNames": {
+                                            "type": "string"
+                                        },
+                                        "type": "object"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ],
+                                "description": "Per-placement settings, validated against the component's configSchema."
+                            },
+                            "generationTaskId": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ],
+                                "description": "Id of the agent task currently filling this placement, when one is running."
+                            },
+                            "h": {
+                                "description": "Height, in grid rows.",
+                                "minimum": 1,
+                                "type": "number"
+                            },
+                            "id": {
+                                "description": "Stable placement id, unique within the layout. 1-64 characters of letters, digits, '_', or '-'.",
+                                "maxLength": 64,
+                                "type": "string"
+                            },
+                            "prompt": {
+                                "anyOf": [
+                                    {
+                                        "maxLength": 10000,
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ],
+                                "description": "For pending/generating/failed placements: what the user asked this box to become."
+                            },
+                            "status": {
+                                "description": "Placement lifecycle: 'pending' (box drawn, no prompt yet), 'generating' (an agent task is filling it), 'live' (renders its component), 'failed' (generation failed; re-prompt or remove).\n\n* `pending` - pending\n* `generating` - generating\n* `live` - live\n* `failed` - failed",
+                                "enum": ["pending", "generating", "live", "failed"],
+                                "type": "string"
+                            },
+                            "version": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ],
+                                "description": "Component version to render: \"latest\" (the default — follows the component's published build) or a pinned source version id."
+                            },
+                            "w": {
+                                "description": "Width, in grid columns.",
+                                "minimum": 1,
+                                "type": "number"
+                            },
+                            "x": {
+                                "description": "Left edge, in grid columns (0-based).",
+                                "minimum": 0,
+                                "type": "number"
+                            },
+                            "y": {
+                                "description": "Top edge, in grid rows (0-based).",
+                                "minimum": 0,
+                                "type": "number"
+                            }
+                        },
+                        "required": ["id", "status", "x", "y", "w", "h"],
+                        "type": "object"
+                    }
+                },
+                "required": ["op"],
+                "type": "object"
+            },
+            "type": "array"
+        },
+        "prompt": {
+            "description": "Short description of the change, stored on the appended version history entry.",
+            "type": "string"
+        }
+    },
+    "required": ["id", "operations", "expected_current_version_id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/canvas-layout-patch.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/canvas-layout-patch.json
@@ -17,7 +17,7 @@
             "type": "string"
         },
         "operations": {
-            "description": "Operations applied in order to the canvas's current layout.",
+            "description": "Operations applied in order to the canvas's current layout, at most 64.",
             "items": {
                 "description": "One surgical layout operation.",
                 "properties": {
@@ -116,10 +116,29 @@
                         "description": "For set_grid: the new grid definition.",
                         "properties": {
                             "columns": {
-                                "description": "Grid width in columns. One of 4, 6, 8, 10, or 12.",
-                                "maximum": 12,
-                                "minimum": 4,
-                                "type": "number"
+                                "anyOf": [
+                                    {
+                                        "const": 4,
+                                        "type": "number"
+                                    },
+                                    {
+                                        "const": 6,
+                                        "type": "number"
+                                    },
+                                    {
+                                        "const": 8,
+                                        "type": "number"
+                                    },
+                                    {
+                                        "const": 10,
+                                        "type": "number"
+                                    },
+                                    {
+                                        "const": 12,
+                                        "type": "number"
+                                    }
+                                ],
+                                "description": "Grid width in columns. One of 4, 6, 8, 10, or 12.\n\n* `4` - 4\n* `6` - 6\n* `8` - 8\n* `10` - 10\n* `12` - 12"
                             },
                             "gap": {
                                 "description": "Gap between placements, in pixels.",
@@ -195,6 +214,7 @@
                             "id": {
                                 "description": "Stable placement id, unique within the layout. 1-64 characters of letters, digits, '_', or '-'.",
                                 "maxLength": 64,
+                                "pattern": "^[A-Za-z0-9_-]{1,64}$",
                                 "type": "string"
                             },
                             "prompt": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/canvas-layout-publish.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/canvas-layout-publish.json
@@ -10,7 +10,7 @@
                     "type": "null"
                 }
             ],
-            "description": "Optimistic-concurrency guard: the current_version_id the layout was based on (null when the canvas has no versions yet). A moved head is rejected with 409 version_conflict. Omit to publish unguarded."
+            "description": "The `current_version_id` this document was built on, from canvas-layout-get (null only for a grid canvas that has never published a layout). A whole document replaces the head, so without the guard a layout the user changed after you read it is silently discarded."
         },
         "id": {
             "description": "ID of the grid canvas whose layout to publish.",
@@ -158,6 +158,6 @@
             "type": "string"
         }
     },
-    "required": ["id", "layout"],
+    "required": ["id", "layout", "expected_current_version_id"],
     "type": "object"
 }

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/canvas-layout-publish.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/canvas-layout-publish.json
@@ -1,0 +1,163 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "expected_current_version_id": {
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Optimistic-concurrency guard: the current_version_id the layout was based on (null when the canvas has no versions yet). A moved head is rejected with 409 version_conflict. Omit to publish unguarded."
+        },
+        "id": {
+            "description": "ID of the grid canvas whose layout to publish.",
+            "type": "string"
+        },
+        "layout": {
+            "description": "The complete layout document to publish.",
+            "properties": {
+                "grid": {
+                    "description": "The grid placements are laid out on.",
+                    "properties": {
+                        "columns": {
+                            "description": "Grid width in columns. One of 4, 6, 8, 10, or 12.",
+                            "maximum": 12,
+                            "minimum": 4,
+                            "type": "number"
+                        },
+                        "gap": {
+                            "description": "Gap between placements, in pixels.",
+                            "maximum": 48,
+                            "minimum": 0,
+                            "type": "number"
+                        },
+                        "rowHeight": {
+                            "description": "Height of one grid row, in pixels.",
+                            "maximum": 400,
+                            "minimum": 24,
+                            "type": "number"
+                        }
+                    },
+                    "required": ["columns", "rowHeight", "gap"],
+                    "type": "object"
+                },
+                "placements": {
+                    "description": "The placed widgets. Placements may not overlap or extend past the grid.",
+                    "items": {
+                        "description": "One placed widget on a grid canvas.",
+                        "properties": {
+                            "component": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ],
+                                "description": "Id of the component canvas this placement renders. Required once the placement is live."
+                            },
+                            "config": {
+                                "anyOf": [
+                                    {
+                                        "additionalProperties": {},
+                                        "propertyNames": {
+                                            "type": "string"
+                                        },
+                                        "type": "object"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ],
+                                "description": "Per-placement settings, validated against the component's configSchema."
+                            },
+                            "generationTaskId": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ],
+                                "description": "Id of the agent task currently filling this placement, when one is running."
+                            },
+                            "h": {
+                                "description": "Height, in grid rows.",
+                                "minimum": 1,
+                                "type": "number"
+                            },
+                            "id": {
+                                "description": "Stable placement id, unique within the layout. 1-64 characters of letters, digits, '_', or '-'.",
+                                "maxLength": 64,
+                                "type": "string"
+                            },
+                            "prompt": {
+                                "anyOf": [
+                                    {
+                                        "maxLength": 10000,
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ],
+                                "description": "For pending/generating/failed placements: what the user asked this box to become."
+                            },
+                            "status": {
+                                "description": "Placement lifecycle: 'pending' (box drawn, no prompt yet), 'generating' (an agent task is filling it), 'live' (renders its component), 'failed' (generation failed; re-prompt or remove).\n\n* `pending` - pending\n* `generating` - generating\n* `live` - live\n* `failed` - failed",
+                                "enum": ["pending", "generating", "live", "failed"],
+                                "type": "string"
+                            },
+                            "version": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ],
+                                "description": "Component version to render: \"latest\" (the default — follows the component's published build) or a pinned source version id."
+                            },
+                            "w": {
+                                "description": "Width, in grid columns.",
+                                "minimum": 1,
+                                "type": "number"
+                            },
+                            "x": {
+                                "description": "Left edge, in grid columns (0-based).",
+                                "minimum": 0,
+                                "type": "number"
+                            },
+                            "y": {
+                                "description": "Top edge, in grid rows (0-based).",
+                                "minimum": 0,
+                                "type": "number"
+                            }
+                        },
+                        "required": ["id", "status", "x", "y", "w", "h"],
+                        "type": "object"
+                    },
+                    "type": "array"
+                },
+                "schemaVersion": {
+                    "description": "Layout schema version. Currently always 1.",
+                    "type": "number"
+                }
+            },
+            "required": ["schemaVersion", "grid", "placements"],
+            "type": "object"
+        },
+        "prompt": {
+            "description": "Short description of the change, stored on the appended version history entry.",
+            "type": "string"
+        }
+    },
+    "required": ["id", "layout"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/canvas-layout-publish.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/canvas-layout-publish.json
@@ -23,10 +23,29 @@
                     "description": "The grid placements are laid out on.",
                     "properties": {
                         "columns": {
-                            "description": "Grid width in columns. One of 4, 6, 8, 10, or 12.",
-                            "maximum": 12,
-                            "minimum": 4,
-                            "type": "number"
+                            "anyOf": [
+                                {
+                                    "const": 4,
+                                    "type": "number"
+                                },
+                                {
+                                    "const": 6,
+                                    "type": "number"
+                                },
+                                {
+                                    "const": 8,
+                                    "type": "number"
+                                },
+                                {
+                                    "const": 10,
+                                    "type": "number"
+                                },
+                                {
+                                    "const": 12,
+                                    "type": "number"
+                                }
+                            ],
+                            "description": "Grid width in columns. One of 4, 6, 8, 10, or 12.\n\n* `4` - 4\n* `6` - 6\n* `8` - 8\n* `10` - 10\n* `12` - 12"
                         },
                         "gap": {
                             "description": "Gap between placements, in pixels.",
@@ -45,7 +64,7 @@
                     "type": "object"
                 },
                 "placements": {
-                    "description": "The placed widgets. Placements may not overlap or extend past the grid.",
+                    "description": "The placed widgets, at most 24. Placements may not overlap or extend past the grid.",
                     "items": {
                         "description": "One placed widget on a grid canvas.",
                         "properties": {
@@ -94,6 +113,7 @@
                             "id": {
                                 "description": "Stable placement id, unique within the layout. 1-64 characters of letters, digits, '_', or '-'.",
                                 "maxLength": 64,
+                                "pattern": "^[A-Za-z0-9_-]{1,64}$",
                                 "type": "string"
                             },
                             "prompt": {
@@ -146,7 +166,8 @@
                     "type": "array"
                 },
                 "schemaVersion": {
-                    "description": "Layout schema version. Currently always 1.",
+                    "const": 1,
+                    "description": "Layout schema version. Currently always 1.\n\n* `1` - 1",
                     "type": "number"
                 }
             },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/canvas-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/canvas-list.json
@@ -19,7 +19,7 @@
             "type": "number"
         },
         "search": {
-            "description": "Only return canvases whose name or description contains this text (case-insensitive).",
+            "description": "Case-insensitive match on name and description — use to find store components by what they show.",
             "type": "string"
         }
     },


### PR DESCRIPTION
## Problem

The grid layout API exists ([#83546](https://github.com/PostHog/posthog/pull/83546)) but agents cannot reach it: no MCP tools expose the layout endpoints, and no skill teaches the intended behavior — search the component store before building a duplicate widget, respect the placement lifecycle, and patch layouts under the concurrency guard.

## Changes

- Enables three MCP tools: `canvas-layout-get`, `canvas-layout-patch` (the default write path, guard required), and `canvas-layout-publish` (initial layout / full restructure).
- `canvas-list` now teaches the component store: `kind=component` + `search=` is the picker, and a component is placeable when its contract and a ready build exist. `canvas-create` documents the three kinds.
- New `composing-grid-canvases` skill: the configure → fork → build resolution ladder, the component placement contract (size, allowlisted configSchema), the placement lifecycle (pending/generating/live/failed), and the guarded patch loop. One skill rather than several — the jobs share one trigger surface.
- `building-canvases` narrows to freeform canvases and routes grid/component work to the new skill (frontmatter too, since routing reads it).
- `canvases-home-create` stays disabled: home is a viewer surface and the endpoint rejects sandbox tokens.

## How did you test this code?

- `hogli lint:skills` and `hogli build:skills` pass with the new skill included; `pnpm --filter=@posthog/mcp lint-tool-names` passes.
- MCP handlers and schemas regenerated via `hogli build:openapi`.
- The doc review surfaced a real gap this PR's stack parent now closes: layout validation accepted live placements for components with no ready build. That fix and its test landed on [#83546](https://github.com/PostHog/posthog/pull/83546).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The skill files are the docs for this surface.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Layer 4 of the composable grid canvases stack. Skills invoked: /stacking-prs, /implementing-mcp-tools, /writing-skills, /writing-pr-descriptions, /simplify. The simplify pass caught a doc-vs-behavior contradiction (placeability claimed a ready build the backend didn't require) — resolved by enforcing it server-side rather than weakening the docs — and deduplicated the store-search rule and the guard-loop prose.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
