### PR TITLE
fix(data-warehouse): size the source-icon loading placeholder

### DIFF
--- a/products/data_warehouse/frontend/shared/components/SourceIcon.tsx
+++ b/products/data_warehouse/frontend/shared/components/SourceIcon.tsx
@@ -141,15 +141,22 @@ export function SourceIcon({
         return component ?? null
     }, [availableSources, engine, type])
 
+    const sizePx = sizePxProps ?? SIZE_PX_MAP[size]
+
     if (availableSourcesLoading || !availableSources) {
-        return <LemonSkeleton />
+        // A bare LemonSkeleton defaults to w-full, so it balloons to fill its container while the
+        // source configs load. Constrain it to the icon's footprint so the placeholder matches.
+        return (
+            // eslint-disable-next-line react/forbid-dom-props
+            <div className="shrink-0" style={{ width: sizePx, height: sizePx }}>
+                <LemonSkeleton className="w-full h-full rounded" />
+            </div>
+        )
     }
 
     if (!icon) {
         return null
     }
-
-    const sizePx = sizePxProps ?? SIZE_PX_MAP[size]
 
     if (disableTooltip) {
         return (


### PR DESCRIPTION
## Problem

Someone adding a data warehouse source could see the source icon render as an oversized grey bar instead of a small square, both in the source list and in the connect wizard header. It looked like a broken layout until the source configs finished loading.

The `SourceIcon` component returned a bare `LemonSkeleton` while `availableSources` was loading. That skeleton defaults to `w-full`, so it stretched to fill its container rather than the icon's footprint.

## Changes

- Constrain the `SourceIcon` loading placeholder to the icon's resolved size (px) so it occupies the same small square as the icon it replaces.

## How did you test this code?

- Traced the cause: `LemonSkeleton` with no `className` falls back to `h-4 w-full`, so a bare skeleton fills its container's width.
- Ran the frontend linter and formatter over the touched file.
- I did not run Storybook or the app; the change is a size constraint on the loading branch only and does not alter the loaded-icon rendering.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Found while reviewing data-warehouse new-source onboarding for friction: a session showed oversized icons in the source selection/wizard while configs loaded. Root cause is the unconstrained loading skeleton in `SourceIcon`. Fix sizes the skeleton to match the icon. No skills were required for this small UI fix.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
