### PR TITLE
fix(experiments): skip redundant test-account scan on recordings tab

### DIFF
--- a/posthog/session_recordings/queries/session_recording_list_from_query.py
+++ b/posthog/session_recordings/queries/session_recording_list_from_query.py
@@ -276,6 +276,9 @@ class SessionRecordingListFromQuery(SessionRecordingsListingBaseQuery):
 
     @tracer.start_as_current_span("SessionRecordingListFromQuery.get_query")
     def get_query(self):
+        # Resolved before predicate construction, not just before the join: resolution can clear
+        # the redundant test-account filters, which _where_predicates otherwise bakes in.
+        self._resolve_experiment_exposure()
         parsed_query = parse_select(
             self.BASE_QUERY,
             {
@@ -318,8 +321,8 @@ class SessionRecordingListFromQuery(SessionRecordingsListingBaseQuery):
         """Resolve the experiment-exposure linkage once per query instance.
 
         run() resolves eagerly, but composition callers (to_query(), the replay-vision
-        candidate query) consume get_query() without run(), so _join_experiment_exposure
-        resolves too; the cached linkage keeps the resolution from running twice.
+        candidate query) consume get_query() without run(), so get_query() resolves too;
+        the cached linkage keeps the resolution from running twice.
         """
         if self._query.experiment_exposure is None or self._experiment_exposure_linkage is not None:
             return
@@ -341,6 +344,15 @@ class SessionRecordingListFromQuery(SessionRecordingsListingBaseQuery):
             experiment_id=self._query.experiment_exposure.experiment_id,
             variant=self._query.experiment_exposure.variant,
         )
+        if self._experiment_exposure_linkage.population_filters_test_accounts:
+            # The exposure population already applies the team's test-account filters on the
+            # exposure events, and the listing inner-joins to that population, so the
+            # recordings-side copy would only rescan the whole events window to re-drop persons
+            # the experiment's analysis counts. The query copy is cleared too, so everything
+            # derived from it (scoped exclusion queries, blocklist probes) agrees with the
+            # main query.
+            self._test_account_filters = []
+            self._query.filter_test_accounts = False
 
     def _join_experiment_exposure(self, parsed_query: ast.SelectQuery) -> None:
         """Restrict the list to sessions of persons exposed to the queried experiment.

--- a/posthog/session_recordings/queries/test/listing_recordings/test_session_recordings_list_by_experiment_exposure.py
+++ b/posthog/session_recordings/queries/test/listing_recordings/test_session_recordings_list_by_experiment_exposure.py
@@ -188,6 +188,67 @@ class TestSessionRecordingsListByExperimentExposure(ClickhouseTestMixin, APIBase
             ["session-control", "session-test"],
         )
 
+    def test_test_accounts_stay_excluded_through_exposure_criteria_alone(self) -> None:
+        self.team.test_account_filters = [
+            {"key": "$host", "type": "event", "value": ["localhost"], "operator": "is_not"}
+        ]
+        self.team.save()
+        experiment = self._create_experiment(exposure_criteria={"filterTestAccounts": True})
+        create_person(team=self.team, distinct_ids=["real-user"])
+        create_person(team=self.team, distinct_ids=["test-account-user"])
+        exposure_time = BASE_TIME + timedelta(hours=1)
+        self._create_exposure_event("real-user", exposure_time, "test", properties={"$host": "example.com"})
+        self._create_exposure_event("test-account-user", exposure_time, "test", properties={"$host": "localhost"})
+        flush_persons_and_events()
+
+        self._produce_recording("real-user", "real-user-session", exposure_time, exposure_time + timedelta(hours=1))
+        self._produce_recording(
+            "test-account-user", "test-account-session", exposure_time, exposure_time + timedelta(hours=1)
+        )
+
+        self._assert_query_matches_session_ids(
+            {"experiment_exposure": {"experiment_id": experiment.id}, "filter_test_accounts": True},
+            ["real-user-session"],
+        )
+
+    @parameterized.expand(
+        [
+            ("criteria_filter_test_accounts", True, ["exposed-user-session"]),
+            ("criteria_allow_test_accounts", False, []),
+        ]
+    )
+    def test_recordings_side_test_filter_defers_to_exposure_criteria(
+        self, _name: str, criteria_filter_test_accounts: bool, expected_sessions: list[str]
+    ) -> None:
+        self.team.test_account_filters = [
+            {"key": "$host", "type": "event", "value": ["localhost"], "operator": "is_not"}
+        ]
+        self.team.save()
+        experiment = self._create_experiment(exposure_criteria={"filterTestAccounts": criteria_filter_test_accounts})
+        create_person(team=self.team, distinct_ids=["exposed-user"])
+        exposure_time = BASE_TIME + timedelta(hours=1)
+        self._create_exposure_event("exposed-user", exposure_time, "test", properties={"$host": "example.com"})
+        # An in-session event matching the test-account filters. When the criteria filter test
+        # accounts, the person already passed at exposure and their session must stay; when the
+        # criteria allow test accounts, the query's own filter_test_accounts must still drop it.
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id="exposed-user",
+            timestamp=exposure_time + timedelta(minutes=10),
+            properties={"$host": "localhost", "$session_id": "exposed-user-session"},
+        )
+        flush_persons_and_events()
+
+        self._produce_recording(
+            "exposed-user", "exposed-user-session", exposure_time, exposure_time + timedelta(hours=1)
+        )
+
+        self._assert_query_matches_session_ids(
+            {"experiment_exposure": {"experiment_id": experiment.id}, "filter_test_accounts": True},
+            expected_sessions,
+        )
+
     def test_links_server_side_exposures_through_the_person(self) -> None:
         # The case the person-scoped linkage exists for: the exposure event is captured
         # server-side under a backend distinct id and without a usable $session_id, while the

--- a/products/experiments/backend/replay_linkage.py
+++ b/products/experiments/backend/replay_linkage.py
@@ -137,6 +137,10 @@ class ExperimentExposureLinkage:
     # through their own async or batch pipelines run under those pipelines' limits and may
     # ignore it.
     live_scan_max_memory_bytes: int | None = None
+    # True when the exposure criteria apply the team's test-account filters, so the exposed
+    # population is already test-filtered at the person level. Queries that restrict their rows
+    # to this population can skip re-applying the same filters to their own rows.
+    population_filters_test_accounts: bool = False
 
 
 def resolve_exposure_linkage(team: Team, *, experiment_id: int, variant: str | None) -> ExperimentExposureLinkage:
@@ -208,6 +212,7 @@ def resolve_exposure_linkage(team: Team, *, experiment_id: int, variant: str | N
         requested_variants=requested_variants,
         preaggregation_job_ids=read.preaggregation_job_ids,
         live_scan_max_memory_bytes=read.live_scan_max_memory_bytes,
+        population_filters_test_accounts=exposure_params.filter_test_accounts,
     )
 
 


### PR DESCRIPTION
## Problem

The experiments recordings tab gets slower the longer an experiment runs, and on large projects it is slow from day one.

When a recordings query carries the person-scoped `experiment_exposure` filter (#82578, #82588) together with `filter_test_accounts`, the listing re-applies the team's test-account filters as events-table scans.
Those scans can't prune by event name, so they read the project's whole events window for the experiment — even though the exposure population the listing inner-joins against already applied the same filters to the exposure events, on all three read paths (live scan, activation, precomputed).
The redundant scan dominates the listing query's reads on large projects and grows linearly with experiment age.

## Changes

- `resolve_exposure_linkage` now reports whether the exposure criteria filter test accounts (`population_filters_test_accounts` on the linkage).
- When they do, `SessionRecordingListFromQuery` drops its recordings-side test-account filters at resolution time, so the main query, the scoped exclusion queries, and the blocklist probes all skip the redundant events scans.
- When the criteria do not filter test accounts, a query-level `filter_test_accounts` still applies exactly as before.
- Linkage resolution moved ahead of predicate construction in `get_query()`, so composition callers build the same SQL as `run()`.
- Semantics note: with criteria-level filtering on, a session of an exposed person is no longer hidden just because it contains a test-matching event (for example a stray localhost event). Person-level filtering at exposure matches who the experiment's analysis counts, which is the population the tab promises.

## How did you test this code?

Ran the full exposure listing suite locally (`hogli test posthog/session_recordings/queries/test/listing_recordings/test_session_recordings_list_by_experiment_exposure.py`): 35 passed, including three new cases:

- Test-account persons stay excluded through the exposure criteria alone — catches the exposure builder losing its test-account filter, or the skip misfiring, since then nothing would filter.
- With criteria filtering on, an exposed person's session containing a test-matching event stays listed — guards the skip itself.
- With criteria filtering off, the query-level filter still drops that session — guards the explicit ask.

- Checked locally against seeded data that the query runs

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude in a PostHog Desktop cloud task, directed by a PostHog engineer, following a query-log investigation of slow exposure-filtered recordings queries: the test-account blocklist scans and the distinct-id expansion dominated the listing query's reads, and this PR removes the redundant former.
Skills consulted: /writing-tests, /writing-code-comments, /writing-pr-descriptions.
Decisions along the way: a criteria-conditional skip instead of unconditionally ignoring `filter_test_accounts` whenever `experiment_exposure` is set (preserves the explicit ask when the criteria don't filter), and resolution moved ahead of predicate construction so `get_query()`-only callers agree with `run()`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
