### PR TITLE
fix(desktop): say how long a running turn has been silent

### DIFF
--- a/products/desktop/packages/ui/src/features/sessions/components/ConversationView.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ConversationView.tsx
@@ -148,6 +148,7 @@ export function ConversationView({
     isCompacting,
     isClearing,
     completedToolCallCount,
+    lastActivityAt,
   } = useConversationItems(events, isPromptPending, {
     showDebugLogs,
   });
@@ -495,6 +496,7 @@ export function ConversationView({
         isCompacting={isCompacting}
         isClearing={isClearing}
         completedToolCallCount={completedToolCallCount}
+        lastActivityAt={lastActivityAt}
       />
     </div>
   );

--- a/products/desktop/packages/ui/src/features/sessions/components/GeneratingIndicator.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/GeneratingIndicator.tsx
@@ -3,7 +3,7 @@ import {
   pickNextThinkingActivity,
   pickThinkingActivity,
 } from "@posthog/core/sessions/thinkingActivities";
-import { Flex, Text } from "@radix-ui/themes";
+import { Text } from "@posthog/quill";
 import { useEffect, useRef, useState } from "react";
 
 function getRandomThinkingMessage(): string {
@@ -15,6 +15,11 @@ function getRandomThinkingMessage(): string {
 function getNextThinkingMessage(current: string): string {
   return pickNextThinkingActivity(current, Math.random());
 }
+
+/** How long the thread has to stay silent before the hint says so. Long enough
+ *  that a normally chatty turn never trips it, short enough to land well inside
+ *  a slow tool call. */
+const QUIET_AFTER_MS = 10_000;
 
 export function formatDuration(ms: number, fractionDigits = 2): string {
   const totalSeconds = Math.floor(ms / 1000);
@@ -44,23 +49,36 @@ interface GeneratingIndicatorProps {
    *  each time this changes, so it tracks real work completing rather than a
    *  timer — a stalled agent keeps the same word. */
   activityKey?: number;
+  /** Timestamp (ms) of the newest event in the thread. Once it falls far enough
+   *  behind, the hint adds a ticking "quiet for Ns" so a turn that renders
+   *  nothing for minutes still reads as running rather than hung. */
+  lastActivityAt?: number | null;
 }
 
 export function GeneratingIndicator({
   startedAt,
   pausedDurationMs,
   activityKey,
+  lastActivityAt,
 }: GeneratingIndicatorProps) {
   const [elapsed, setElapsed] = useState(0);
+  const [quietFor, setQuietFor] = useState(0);
   const [activity, setActivity] = useState(getRandomThinkingMessage);
 
   const pausedRef = useRef(pausedDurationMs ?? 0);
   pausedRef.current = pausedDurationMs ?? 0;
+  const lastActivityRef = useRef(lastActivityAt ?? null);
+  lastActivityRef.current = lastActivityAt ?? null;
 
   useEffect(() => {
     const startTime = startedAt ?? Date.now();
     const interval = setInterval(() => {
-      setElapsed(Math.max(0, Date.now() - startTime - pausedRef.current));
+      const now = Date.now();
+      setElapsed(Math.max(0, now - startTime - pausedRef.current));
+      // Measured from the last event rather than the turn's start, so a turn
+      // that streamed for a minute and then went silent still reads as quiet.
+      const since = lastActivityRef.current;
+      setQuietFor(since === null ? 0 : Math.max(0, now - since));
     }, 100);
 
     return () => clearInterval(interval);
@@ -76,27 +94,43 @@ export function GeneratingIndicator({
     setActivity((current) => getNextThinkingMessage(current));
   }
 
+  const dot = (
+    <Circle
+      size={4}
+      weight="fill"
+      className="mx-1 inline-block align-middle text-gray-9"
+    />
+  );
+
   return (
-    <Flex
-      align="center"
-      gap="2"
-      className="min-w-0 select-none"
+    <div
+      className="flex min-w-0 select-none items-center gap-2"
       style={{ WebkitUserSelect: "none" }}
     >
       <Brain size={12} className="ph-pulse shrink-0" />
-      <Text className="truncate text-[13px] text-accent-11">{activity}...</Text>
-      {/* The hint shrinks (and truncates) well before the activity word does. */}
-      <Text color="gray" className="shrink-[8] truncate text-[13px]">
-        (Esc to stop
-        <Circle
-          size={4}
-          weight="fill"
-          className="mx-1 inline-block align-middle text-gray-9"
-        />
-        <span style={{ fontVariantNumeric: "tabular-nums" }}>
-          {formatDuration(elapsed, 1)})
-        </span>
+      <Text render={<span />} className="truncate text-[13px] text-accent-11">
+        {activity}...
       </Text>
-    </Flex>
+      {/* The hint shrinks (and truncates) well before the activity word does. */}
+      <Text
+        render={<span />}
+        className="shrink-[8] truncate text-(--gray-11) text-[13px]"
+      >
+        (Esc to stop
+        {dot}
+        <span style={{ fontVariantNumeric: "tabular-nums" }}>
+          {formatDuration(elapsed, 1)}
+        </span>
+        {quietFor >= QUIET_AFTER_MS && (
+          <>
+            {dot}
+            <span style={{ fontVariantNumeric: "tabular-nums" }}>
+              quiet for {formatDuration(quietFor, 0)}
+            </span>
+          </>
+        )}
+        )
+      </Text>
+    </div>
   );
 }

--- a/products/desktop/packages/ui/src/features/sessions/components/SessionFooter.stories.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/SessionFooter.stories.tsx
@@ -52,6 +52,17 @@ export const GeneratingAtNarrowWidths: Story = {
   render: (args) => <AtWidths args={args} />,
 };
 
+/** A turn that has rendered nothing for a while — one long tool call, or a
+ *  thinking block the model kept to itself. */
+export const GeneratingWhileQuietAtNarrowWidths: Story = {
+  args: {
+    ...generatingArgs,
+    promptStartedAt: Date.now() - 128_000,
+    lastActivityAt: Date.now() - 47_000,
+  },
+  render: (args) => <AtWidths args={args} />,
+};
+
 export const GeneratingWithQueueAtNarrowWidths: Story = {
   args: { ...generatingArgs, queuedCount: 2 },
   render: (args) => <AtWidths args={args} />,

--- a/products/desktop/packages/ui/src/features/sessions/components/SessionFooter.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/SessionFooter.tsx
@@ -25,6 +25,9 @@ interface SessionFooterProps {
   /** Number of tool calls finished so far; the generating indicator advances
    *  its status word each time this changes. */
   completedToolCallCount?: number;
+  /** Timestamp (ms) of the newest event in the thread; the generating indicator
+   *  says how long it has been since one arrived. */
+  lastActivityAt?: number | null;
 }
 
 export function SessionFooter({
@@ -39,6 +42,7 @@ export function SessionFooter({
   isCompacting = false,
   isClearing = false,
   completedToolCallCount,
+  lastActivityAt,
 }: SessionFooterProps) {
   const rightSide = (
     <Flex align="center" gap="3" className="ml-auto shrink-0">
@@ -78,6 +82,7 @@ export function SessionFooter({
               startedAt={promptStartedAt}
               pausedDurationMs={pausedDurationMs}
               activityKey={completedToolCallCount}
+              lastActivityAt={lastActivityAt}
             />
             {queuedCount > 0 && (
               <Text className="truncate text-[13px] text-muted-foreground">

--- a/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.test.ts
@@ -920,6 +920,23 @@ describe("buildConversationItems", () => {
     });
   });
 
+  describe("lastActivityAt", () => {
+    it("is null when the thread has no events", () => {
+      expect(buildConversationItems([], null).lastActivityAt).toBeNull();
+    });
+
+    // The footer measures silence against this, so a late-arriving event must
+    // not be able to drag it backwards and report a turn as quieter than it is.
+    it("reports the newest timestamp even when an event arrives late", () => {
+      const events = [
+        userPromptMsg(10, 1, "hello"),
+        consoleMsg(30, "second"),
+        consoleMsg(20, "late arrival"),
+      ];
+      expect(buildConversationItems(events, true).lastActivityAt).toBe(30);
+    });
+  });
+
   describe("session_update timestamps", () => {
     const toolCallMsg = (ts: number, toolCallId: string): AcpMessage => ({
       type: "acp_message",

--- a/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.ts
@@ -85,6 +85,11 @@ export interface BuildResult {
   /** Number of tool calls settled into a terminal status so far. Monotonic
    *  within a thread; consumers treat a change as "a tool/MCP call finished". */
   completedToolCallCount: number;
+  /** Timestamp (ms) of the most recent event applied to the thread, or null
+   *  when none have been. Lets the footer say how long the agent has been
+   *  silent: a turn can sit minutes inside one tool call or thinking block
+   *  with nothing new to render, and a frozen status word reads as a hang. */
+  lastActivityAt: number | null;
 }
 
 interface ProgressCardState {
@@ -142,6 +147,9 @@ export interface ItemBuilder {
    *  Drives the generating indicator's status word so it advances on real work
    *  finishing rather than on a timer. */
   completedToolCallCount: number;
+  /** Timestamp (ms) of the newest event fed to this builder. See the field of
+   *  the same name on `BuildResult`. */
+  lastActivityAt: number | null;
   /** Runs that emitted `_posthog/run_started`; until then the setup card's
    *  "agent" step stays in_progress rather than completing at HTTP-boot time. */
   runStartedRunIds: Set<string>;
@@ -161,8 +169,17 @@ export function createItemBuilder(): ItemBuilder {
     progressCards: new Map(),
     lowestTouchedProgressIndex: Number.POSITIVE_INFINITY,
     completedToolCallCount: 0,
+    lastActivityAt: null,
     runStartedRunIds: new Set(),
   };
+}
+
+/** Record that an event landed at `ts`. Events are usually fed in order, but a
+ *  rebuild sorts them and an append can carry a stale ts, so keep the max. */
+function noteActivity(b: ItemBuilder, ts: number) {
+  if (b.lastActivityAt === null || ts > b.lastActivityAt) {
+    b.lastActivityAt = ts;
+  }
 }
 
 const TERMINAL_TOOL_STATUSES = new Set(["completed", "failed", "cancelled"]);
@@ -278,6 +295,7 @@ export function buildConversationItems(
     isCompacting: b.isCompacting,
     isClearing: b.isClearing,
     completedToolCallCount: b.completedToolCallCount,
+    lastActivityAt: b.lastActivityAt,
   };
 }
 
@@ -292,6 +310,7 @@ export function processEvent(
   options?: BuildConversationOptions,
 ) {
   const msg = event.message;
+  noteActivity(b, event.ts);
 
   if (isJsonRpcNotification(msg)) {
     handleNotification(b, msg, event.ts, options);
@@ -333,6 +352,7 @@ export function buildAgentConversationItems(
     isCompacting: b.isCompacting,
     isClearing: b.isClearing,
     completedToolCallCount: b.completedToolCallCount,
+    lastActivityAt: b.lastActivityAt,
   };
 }
 
@@ -340,6 +360,8 @@ export function processAgentConversationEvent(
   b: ItemBuilder,
   event: AgentConversationEvent,
 ): void {
+  noteActivity(b, event.timestamp);
+
   if (event.type === "user_message") {
     handlePromptRequest(
       b,

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThreadFooter.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThreadFooter.tsx
@@ -51,6 +51,8 @@ export function ChatThreadFooter({
   const completedToolCallCount =
     footerState?.completedToolCallCount ??
     eventFooterState.completedToolCallCount;
+  const lastActivityAt =
+    footerState?.lastActivityAt ?? eventFooterState.lastActivityAt;
   const pendingPermissions = usePendingPermissionsForTask(taskId ?? "");
   const pendingPermissionVisible = resolvePendingPermissionVisibility(
     hasPendingPermission,
@@ -78,6 +80,7 @@ export function ChatThreadFooter({
         isCompacting={isCompacting}
         isClearing={isClearing}
         completedToolCallCount={completedToolCallCount}
+        lastActivityAt={lastActivityAt}
       />
     </div>
   );

--- a/products/desktop/packages/ui/src/features/sessions/components/incrementalConversationItems.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/incrementalConversationItems.test.ts
@@ -198,6 +198,7 @@ function normalize(result: BuildResult) {
     lastTurnInfo: result.lastTurnInfo,
     isCompacting: result.isCompacting,
     completedToolCallCount: result.completedToolCallCount,
+    lastActivityAt: result.lastActivityAt,
   };
 }
 

--- a/products/desktop/packages/ui/src/features/sessions/components/incrementalConversationItems.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/incrementalConversationItems.ts
@@ -100,6 +100,7 @@ export function createIncrementalConversationBuilder() {
           isCompacting: builder.isCompacting,
           isClearing: builder.isClearing,
           completedToolCallCount: builder.completedToolCallCount,
+          lastActivityAt: builder.lastActivityAt,
         };
         // A finalized builder can't be safely continued; the next streaming
         // call rebuilds fresh.
@@ -181,6 +182,7 @@ export function createIncrementalConversationBuilder() {
       isCompacting: builder.isCompacting,
       isClearing: builder.isClearing,
       completedToolCallCount: builder.completedToolCallCount,
+      lastActivityAt: builder.lastActivityAt,
     };
   }
 


### PR DESCRIPTION
## Problem

A desktop turn that runs for minutes with nothing to render looks hung — the footer's status word freezes and the transcript stops moving, so people assume the agent died and kill it.

- The word only advances when a tool call reaches a terminal status ([#2717](https://github.com/PostHog/code/pull/2717) tied it to `completedToolCallCount`, deliberately, so a stalled agent keeps the same word).
- The Claude adapter has two stretches where it emits nothing at all: a long tool call (no incremental output until the PostToolUse hook fires) and a thinking block the model returns with `thinking.display: "omitted"`.
- Together those mean a working agent and a hung one look identical. Codex avoids it by streaming reasoning deltas and command output while a call runs.

Raised in a Slack thread by someone hitting it on the desktop app: https://posthog.slack.com/archives/C09G8Q32R6F/p1786940188428079?thread_ts=1786940188.428079&cid=C09G8Q32R6F

## Changes

- After 10s with no new event, the footer hint gains a ticking `quiet for 48s` next to the elapsed time.
- `BuildResult` carries `lastActivityAt`, the newest event timestamp, threaded to `GeneratingIndicator` through both footers.
- The status word still advances only on completed tool calls, so it keeps saying what it said before — silence is now reported rather than mimed.
- `GeneratingIndicator` drops its Radix imports for quill `Text` + `div`, per the repo's replace-as-you-go rule. Verified pixel-identical against master in Storybook.

Screenshot: I could not upload one — `hogli` is not available in this environment. At 720px the hint reads `(Esc to stop · 2m 09s · quiet for 48s)`; at 340px and below the quiet segment truncates first, before the elapsed time and the status word. A `GeneratingWhileQuietAtNarrowWidths` story renders it at all six widths.

> [!NOTE]
> This treats the symptom. The cause is that the Claude adapter goes silent where Codex doesn't. The real fix is streaming live tool output — `claude-agent.ts` already has a `terminal_output` capability path, but the desktop client never advertises it and no UI consumes `terminalId`, so it's inert. Worth a follow-up.

## How did you test this code?

Automated, run locally:

- `pnpm --filter @posthog/ui typecheck` and `test` — pass.
- New: `lastActivityAt` is null on an empty thread, and takes the newest timestamp when an event arrives out of order. Catches a late event dragging the clock backwards and under-reporting silence.
- Changed: `normalize()` in the incremental builder's equivalence suite now includes `lastActivityAt`, so every existing prefix/finalize/out-of-order case asserts the incremental and full builders agree. Catches the streaming path dropping the field while the batch path keeps it — the app only uses the streaming path.

Not tested: I did not run the desktop app. The threshold behavior was checked by rendering `SessionFooter` in Storybook at fixed `lastActivityAt` values, not by watching a real turn go quiet.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app from a thread report. Left unassigned: I could not verify the reporter's GitHub handle from Slack, and guessing one tags the wrong account.

The session started as a diagnosis — bisecting the regression to [#2717](https://github.com/PostHog/code/pull/2717) (word tied to tool completions) and [#3076](https://github.com/PostHog/code/pull/3076) (Claude thinking blocks arriving empty) — and only then turned into a fix.

Two alternatives were considered and dropped. Resuming the pre-#2717 timer rotation during silence restores the feel but reintroduces exactly the lie #2717 removed: a hung agent would animate. Naming the in-flight tool call in the footer duplicates the spinner `ToolGroup` already shows on the pending row. Reporting the silence itself is the only signal here that is both new and true.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

Public artifact: nothing here carries session material. The Slack link is auth-gated and nothing from the thread is quoted.
