### PR TITLE
Drop GLM 5.2 context window override in gateway models (#76192)

### DIFF
--- a/products/desktop/packages/shared/src/cloud-task-models.test.ts
+++ b/products/desktop/packages/shared/src/cloud-task-models.test.ts
@@ -50,12 +50,20 @@ describe("formatGatewayModelName", () => {
 });
 
 describe("normalizeGatewayModelsResponse", () => {
-  it("corrects stale GLM 5.2 context-window metadata", () => {
+  it("passes through the gateway's advertised context window for GLM 5.2 unmodified", () => {
     const models = normalizeGatewayModelsResponse([
       model("@cf/zai-org/glm-5.2", "cloudflare"),
     ]);
 
-    expect(models[0]?.context_window).toBe(1_000_000);
+    expect(models[0]?.context_window).toBe(128000);
+  });
+
+  it("does not override any model's context window", () => {
+    const models = normalizeGatewayModelsResponse([
+      { ...model("@cf/zai-org/glm-5.2", "cloudflare"), context_window: 256000 },
+    ]);
+
+    expect(models[0]?.context_window).toBe(256000);
   });
 });
 

--- a/products/desktop/packages/shared/src/cloud-task-models.ts
+++ b/products/desktop/packages/shared/src/cloud-task-models.ts
@@ -103,9 +103,6 @@ const PROVIDER_NAMES: Record<string, string> = {
 const MODEL_FAMILY_ORDER = ["fable", "opus", "sonnet", "haiku"];
 const PROVIDER_PREFIXES = ["anthropic/", "openai/", "google-vertex/"];
 const KNOWN_ACRONYMS = new Set(["gpt", "glm"]);
-const MODEL_CONTEXT_WINDOW_OVERRIDES: Readonly<Record<string, number>> = {
-  "@cf/zai-org/glm-5.2": 1_000_000,
-};
 
 export function getCloudTaskGatewayUrl(posthogHost: string): string {
   const url = new URL(posthogHost);
@@ -151,10 +148,7 @@ export function normalizeGatewayModelsResponse(value: unknown): GatewayModel[] {
     .map((model) => ({
       id: model.id,
       owned_by: model.owned_by ?? "",
-      context_window: Math.max(
-        model.context_window ?? 0,
-        MODEL_CONTEXT_WINDOW_OVERRIDES[model.id] ?? 0,
-      ),
+      context_window: model.context_window ?? 0,
       supports_streaming: model.supports_streaming ?? false,
       supports_vision: model.supports_vision ?? false,
       allowed: model.allowed !== false,


### PR DESCRIPTION
## Problem

`MODEL_CONTEXT_WINDOW_OVERRIDES` in `products/desktop/packages/shared/src/cloud-task-models.ts` forced the advertised context window for `@cf/zai-org/glm-5.2` to `1_000_000` via `Math.max(gatewayValue, override)` inside `normalizeGatewayModelsResponse()`. The backend Modal-served GLM 5.2 model actually serves a context window in the 256k-262144 range, so sessions were allowed to grow well past what the backend would accept, and every turn started failing once the real limit was hit:

```
The estimated number of input and maximum output tokens (44xxxx) exceeded this model context window limit (262144)
Requested token count exceeds the model's maximum context length of 256000 tokens
```

Once GLM rejected the turn, the SDK retried under the fallback model with a request body assembled for a non-thinking model, surfacing a confusing, unrelated 400 error to the user instead of the real problem (an oversized transcript).

## Fix

Drop the override entirely rather than replace the hardcoded value with a different hardcoded number — the two values reported for what the backend actually serves (262144 vs 256000) conflict, and hardcoding either risks the same class of bug recurring if the backend's served window changes again. `normalizeGatewayModelsResponse()` now passes the gateway's advertised `context_window` through unmodified for every model, including GLM 5.2.

## Test plan

- Updated `cloud-task-models.test.ts`: replaced the test asserting the override "corrects" GLM 5.2 to 1,000,000 with a test asserting the gateway's advertised value passes through unmodified, plus an explicit test that no override is applied regardless of the gateway-advertised context window.
- `npx vitest run src/cloud-task-models.test.ts` — 36/36 passing.
- `npx tsc --noEmit` — clean.

Fixes #76192