### PR TITLE
fix(workflows): rebuild the email html wrap when the html changes

### DIFF
--- a/frontend/src/scenes/hog-functions/email-templater/emailTemplaterLogic.test.ts
+++ b/frontend/src/scenes/hog-functions/email-templater/emailTemplaterLogic.test.ts
@@ -9,6 +9,7 @@ import {
     EditorRef,
     EmailTemplate,
     EmailTemplaterLogicProps,
+    buildHtmlWrapDesign,
     emailTemplaterLogic,
 } from './emailTemplaterLogic'
 
@@ -201,6 +202,95 @@ describe('emailTemplaterLogic', () => {
             logic.actions.onEmailEditorReady()
 
             expect(loadDesign).not.toHaveBeenCalled()
+        })
+
+        it('loads the current html when it changed after the wrap was generated', () => {
+            const loadDesign = jest.fn()
+            logic = emailTemplaterLogic(
+                makeProps({
+                    // An html edit that left the generated wrap behind: an API or agent patch
+                    // touching html alone.
+                    value: {
+                        ...DEFAULT_EMAIL_TEMPLATE,
+                        html: '<p>new</p>',
+                        design: buildHtmlWrapDesign('<p>old</p>'),
+                    },
+                })
+            )
+            logic.mount()
+            logic.actions.setEmailEditorRef({
+                editor: { loadDesign, addEventListener: jest.fn() },
+            } as unknown as EditorRef)
+            logic.actions.onEmailEditorReady()
+
+            expect(loadDesign).toHaveBeenCalledWith(buildHtmlWrapDesign('<p>new</p>'))
+        })
+
+        it.each([
+            ['a design built in the visual editor', { body: { id: 'u_body', rows: [{ id: 'u_row_1' }] } }],
+            [
+                'a wrap the visual editor has since normalized',
+                {
+                    ...buildHtmlWrapDesign('<p>old</p>'),
+                    body: { ...buildHtmlWrapDesign('<p>old</p>').body, values: { backgroundColor: '#ffffff' } },
+                },
+            ],
+        ])('loads %s as stored, even when the html no longer matches it', (_description, design) => {
+            const loadDesign = jest.fn()
+            logic = emailTemplaterLogic(makeProps({ value: { ...DEFAULT_EMAIL_TEMPLATE, html: '<p>new</p>', design } }))
+            logic.mount()
+            logic.actions.setEmailEditorRef({
+                editor: { loadDesign, addEventListener: jest.fn() },
+            } as unknown as EditorRef)
+            logic.actions.onEmailEditorReady()
+
+            expect(loadDesign).toHaveBeenCalledWith(design)
+        })
+
+        it('reloads the open canvas when the html changes under a generated wrap', async () => {
+            const loadDesign = jest.fn()
+            const onChange = jest.fn()
+            logic = emailTemplaterLogic(
+                makeProps({
+                    value: { ...DEFAULT_EMAIL_TEMPLATE, html: '<p>old</p>', design: null },
+                    onChange,
+                    liveChanges: true,
+                })
+            )
+            logic.mount()
+            logic.actions.setEmailEditorRef({
+                editor: { loadDesign, addEventListener: jest.fn() },
+            } as unknown as EditorRef)
+            logic.actions.onEmailEditorReady()
+            expect(loadDesign).toHaveBeenCalledWith(buildHtmlWrapDesign('<p>old</p>'))
+
+            // The html changes elsewhere (the AI assistant, another tab) while the editor is open.
+            emailTemplaterLogic(
+                makeProps({
+                    value: { ...DEFAULT_EMAIL_TEMPLATE, html: '<p>new</p>', design: buildHtmlWrapDesign('<p>old</p>') },
+                    onChange,
+                    liveChanges: true,
+                })
+            )
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(loadDesign).toHaveBeenLastCalledWith(buildHtmlWrapDesign('<p>new</p>'))
+        })
+
+        it('shows an html-only template on the canvas when one is applied', () => {
+            const loadDesign = jest.fn()
+            logic = emailTemplaterLogic(makeProps())
+            logic.mount()
+            logic.actions.setEmailEditorRef({
+                editor: { loadDesign, addEventListener: jest.fn() },
+            } as unknown as EditorRef)
+            logic.actions.onEmailEditorReady()
+
+            logic.actions.applyTemplate({
+                content: { email: { subject: 'Picked', html: '<p>picked</p>' } },
+            } as any)
+
+            expect(loadDesign).toHaveBeenLastCalledWith(buildHtmlWrapDesign('<p>picked</p>'))
         })
     })
 

--- a/frontend/src/scenes/hog-functions/email-templater/emailTemplaterLogic.tsx
+++ b/frontend/src/scenes/hog-functions/email-templater/emailTemplaterLogic.tsx
@@ -147,6 +147,39 @@ export function buildHtmlWrapDesign(html: string): JSONTemplate {
     } as unknown as JSONTemplate
 }
 
+/**
+ * The html a design wraps, when the design is exactly one buildHtmlWrapDesign produced. Once a
+ * design has been through the visual editor unlayer has rewritten it, so it no longer matches
+ * and counts as authored content rather than a view of the html.
+ */
+function generatedWrapHtml(design: JSONTemplate): string | null {
+    const html = (design as any)?.body?.rows?.[0]?.columns?.[0]?.contents?.[0]?.values?.html
+    if (typeof html !== 'string' || !objectsEqual(design, buildHtmlWrapDesign(html))) {
+        return null
+    }
+    return html
+}
+
+/**
+ * The design the canvas should open for an email. A design authored in the visual editor always
+ * wins, because it is the source the html was rendered from. A wrap we generated is only a view
+ * of the html, so it is rebuilt whenever the html moves on (an API or agent patch that sets html
+ * alone); otherwise the canvas keeps showing the content the wrap was built from while sends use
+ * the new html. Mirrors resolve_html_wrap_design in posthog/cdp/validation.py.
+ */
+function resolveDesignToLoad(value: EmailTemplate | null): JSONTemplate | null {
+    const html = value?.html
+    const design = (value?.design ?? null) as JSONTemplate | null
+    if (!html) {
+        return design
+    }
+    if (!design) {
+        return buildHtmlWrapDesign(html)
+    }
+    const wrapped = generatedWrapHtml(design)
+    return wrapped === null || wrapped === html ? design : buildHtmlWrapDesign(html)
+}
+
 // URL reflection for the fullscreen editor (?editor=email), so back, Escape, and deep links work.
 const EMAIL_EDITOR_URL_PARAM = 'editor'
 const EMAIL_EDITOR_URL_VALUE = 'email'
@@ -594,13 +627,10 @@ export const emailTemplaterLogic = kea<emailTemplaterLogicType>([
             // Both layouts rebaseline on load: the modal submit compares its export against the
             // baseline to tell a no-op save from a real edit.
             values.emailEditorRef?.editor?.addEventListener('design:loaded', () => actions.designLoaded())
-            if (props.value?.design) {
-                cache.lastEditorDesign = props.value.design
-                values.emailEditorRef?.editor?.loadDesign(props.value.design)
-            } else if (props.value?.html) {
-                const wrapped = buildHtmlWrapDesign(props.value.html)
-                cache.lastEditorDesign = wrapped
-                values.emailEditorRef?.editor?.loadDesign(wrapped)
+            const design = resolveDesignToLoad(props.value)
+            if (design) {
+                cache.lastEditorDesign = design
+                values.emailEditorRef?.editor?.loadDesign(design)
             }
         },
 
@@ -698,10 +728,13 @@ export const emailTemplaterLogic = kea<emailTemplaterLogicType>([
             const emailTemplateContent = template.content.email
             actions.setEmailTemplateValues(emailTemplateContent)
 
-            // Load the design into the editor if it's ready and has a design
-            if (values.isEmailEditorReady && emailTemplateContent.design) {
-                cache.lastEditorDesign = emailTemplateContent.design
-                values.emailEditorRef?.editor?.loadDesign(emailTemplateContent.design)
+            // Load the template's content into the editor if it's ready. Templates saved before
+            // emails carried designs are html-only, and one wrapped for the canvas still beats
+            // leaving the previous email on screen while the form fields say otherwise.
+            const design = values.isEmailEditorReady ? resolveDesignToLoad(emailTemplateContent) : null
+            if (design) {
+                cache.lastEditorDesign = design
+                values.emailEditorRef?.editor?.loadDesign(design)
             }
         },
 
@@ -867,7 +900,7 @@ export const emailTemplaterLogic = kea<emailTemplaterLogicType>([
                 values.isEmailEditorReady &&
                 !cache.pendingDesignEdit
             ) {
-                const design = props.value.design ?? (props.value.html ? buildHtmlWrapDesign(props.value.html) : null)
+                const design = resolveDesignToLoad(props.value)
                 if (
                     design &&
                     !objectsEqual(design, cache.lastEditorDesign) &&

--- a/posthog/cdp/test/test_validation.py
+++ b/posthog/cdp/test/test_validation.py
@@ -13,6 +13,7 @@ from posthog.cdp.validation import (
     InputsSchemaItemSerializer,
     MappingsSerializer,
     RecordAliasRewriter,
+    build_html_wrap_design,
     compile_hog,
     generate_template_bytecode,
 )
@@ -32,6 +33,17 @@ def validate_inputs(schema, inputs, function_type="destination", is_dwh_source=F
     )
     serializer.is_valid(raise_exception=True)
     return serializer.validated_data["inputs"]
+
+
+def _edited_html_wrap():
+    # What a wrap looks like once the visual editor has loaded and re-exported it: Unlayer fills
+    # in its own defaults, so the design is no longer the one we generated.
+    design = build_html_wrap_design("<p>old</p>")
+    design["body"]["values"] = {"backgroundColor": "#ffffff"}
+    return design
+
+
+EDITED_HTML_WRAP = _edited_html_wrap()
 
 
 def validate_inputs_schema(data):
@@ -448,6 +460,17 @@ class TestHogFunctionValidation(ClickhouseTestMixin, APIBaseTest, QueryMatchingT
                 {"from": "hi@posthog.com", "to": "a@b.com", "subject": "hi", "text": "hi"},
                 None,
             ),
+            (
+                "wrap_the_editor_has_edited_is_untouched",
+                {
+                    "from": "hi@posthog.com",
+                    "to": "a@b.com",
+                    "subject": "hi",
+                    "html": "<p>new</p>",
+                    "design": EDITED_HTML_WRAP,
+                },
+                EDITED_HTML_WRAP,
+            ),
         ]
     )
     def test_email_value_wrap_no_ops(self, _name, value, expected_design):
@@ -456,6 +479,23 @@ class TestHogFunctionValidation(ClickhouseTestMixin, APIBaseTest, QueryMatchingT
         validated = validate_inputs(inputs_schema, {"email": {"value": value}})
 
         assert validated["email"]["value"].get("design") == expected_design
+
+    def test_stale_html_wrap_is_rebuilt_from_the_current_html(self):
+        # A patch that sets html alone leaves the wrap we generated behind. Left as-is, the
+        # visual editor keeps opening the html the wrap was built from while sends use the new
+        # html, so the two never agree.
+        inputs_schema = [{"key": "email", "type": "native_email", "required": True, "templating": "liquid"}]
+        value = {
+            "from": "hi@posthog.com",
+            "to": "a@b.com",
+            "subject": "hi",
+            "html": "<p>new</p>",
+            "design": build_html_wrap_design("<p>old</p>"),
+        }
+
+        validated = validate_inputs(inputs_schema, {"email": {"value": value}})
+
+        assert validated["email"]["value"]["design"] == build_html_wrap_design("<p>new</p>")
 
     def test_html_only_email_wrap_is_deterministic(self):
         # Callers resend the same html-only value on every save; a fresh design each time would

--- a/posthog/cdp/validation.py
+++ b/posthog/cdp/validation.py
@@ -80,6 +80,45 @@ def build_html_wrap_design(html: str) -> dict:
     }
 
 
+def _generated_wrap_html(design: Any) -> str | None:
+    """The html a design wraps, when the design is exactly one build_html_wrap_design produced.
+
+    Byte-equality against a rebuilt wrap is the test. Once a design has been through the visual
+    editor Unlayer has rewritten it (defaults filled in, blocks added), so it no longer matches
+    and counts as authored content rather than a view of the html.
+    """
+
+    if not isinstance(design, dict):
+        return None
+    try:
+        html = design["body"]["rows"][0]["columns"][0]["contents"][0]["values"]["html"]
+    except (KeyError, IndexError, TypeError):
+        return None
+    if not isinstance(html, str) or design != build_html_wrap_design(html):
+        return None
+    return html
+
+
+def resolve_html_wrap_design(html: str, design: Any) -> Any:
+    """The design the visual editor should open for an email carrying this html.
+
+    A design authored in the visual editor always wins, because it is the source the html was
+    rendered from. A wrap we generated is only a view of the html, so it is rebuilt whenever the
+    html moves on (an API or agent patch that sets html alone). Left stale, the editor would keep
+    opening the content the wrap was built from while sends use the new html, so the only way to
+    see an edit would be to send yourself a test email.
+    """
+
+    if not html:
+        return design
+    if not design:
+        return build_html_wrap_design(html)
+    wrapped = _generated_wrap_html(design)
+    if wrapped is None or wrapped == html:
+        return design
+    return build_html_wrap_design(html)
+
+
 def register_supported_function(name: str) -> None:
     PRODUCT_ASYNC_FUNCTIONS.add(name)
 
@@ -470,11 +509,14 @@ class InputsItemSerializer(serializers.Serializer):
                 label = "value" if len(missing) == 1 else "values"
                 raise serializers.ValidationError({"input": f"Missing {label} for {', '.join(missing)}."})
 
-            if isinstance(value.get("html"), str) and value["html"] and not value.get("design"):
+            if isinstance(value.get("html"), str) and value["html"]:
                 # Programmatically authored emails often supply html without a design, which the
-                # visual editor can't open. Wrap it so every stored email has an editable design.
-                value = {**value, "design": build_html_wrap_design(value["html"])}
-                attrs["value"] = value
+                # visual editor can't open. Wrap it so every stored email has an editable design,
+                # and keep that wrap tracking the html on later html-only edits.
+                design = resolve_html_wrap_design(value["html"], value.get("design"))
+                if design is not value.get("design"):
+                    value = {**value, "design": design}
+                    attrs["value"] = value
         elif item_type == "non_failure_status_codes":
             if not isinstance(value, list):
                 raise serializers.ValidationError({"input": "Value must be a list of status codes."})

--- a/products/messaging/backend/api/message_templates.py
+++ b/products/messaging/backend/api/message_templates.py
@@ -15,7 +15,7 @@ from posthog.api.forbid_destroy_model import ForbidDestroyModel
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.scoped_related_fields import TeamScopedPrimaryKeyRelatedField
 from posthog.api.shared import UserBasicSerializer
-from posthog.cdp.validation import build_html_wrap_design
+from posthog.cdp.validation import resolve_html_wrap_design
 
 from products.messaging.backend.api.design_operations import apply_design_operations
 from products.messaging.backend.api.design_validation import validate_design
@@ -145,9 +145,10 @@ class MessageTemplateSerializer(serializers.ModelSerializer):
             )
         # Programmatically authored templates often supply html without a design, which the
         # visual editor can't open. Wrap the html in a single custom HTML block; the stored
-        # html stays untouched, so nothing about the sent email changes.
-        if email and email.get("html") and not email.get("design"):
-            email["design"] = build_html_wrap_design(email["html"])
+        # html stays untouched, so nothing about the sent email changes. A wrap kept alongside
+        # an html the caller has since changed is rebuilt, so the editor never falls behind.
+        if email and email.get("html"):
+            email["design"] = resolve_html_wrap_design(email["html"], email.get("design"))
         # Design-only saves get their html rendered server-side (the send path uses html
         # verbatim). A submitted html is trusted as-is — that's the visual editor's own export.
         if email and email.get("design") and not email.get("html"):

--- a/products/messaging/backend/api/test/test_message_templates.py
+++ b/products/messaging/backend/api/test/test_message_templates.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from parameterized import parameterized
 from rest_framework import status
 
+from posthog.cdp.validation import build_html_wrap_design
 from posthog.models import Organization, Team
 
 from products.messaging.backend.models.message_category import MessageCategory
@@ -133,6 +134,31 @@ class TestMessageTemplatesAPI(APIBaseTest):
         contents = email["design"]["body"]["rows"][0]["columns"][0]["contents"]
         assert contents[0]["type"] == "html"
         assert contents[0]["values"]["html"] == "<p>Hello</p>"
+
+    def test_update_with_stale_wrap_rebuilds_the_design_from_the_submitted_html(self):
+        # A caller that patches html and sends the design back untouched (an agent edit, an
+        # older client) would otherwise keep the visual editor on the previous content forever.
+        self.message_template.content = {"email": {"subject": "Hi", "html": "<p>old</p>"}}
+        self.message_template.save()
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/messaging_templates/{self.message_template.id}/",
+            data={
+                "content": {
+                    "email": {
+                        "subject": "Hi",
+                        "html": "<p>new</p>",
+                        "design": build_html_wrap_design("<p>old</p>"),
+                    }
+                }
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        email = response.json()["content"]["email"]
+        assert email["html"] == "<p>new</p>"
+        assert email["design"] == build_html_wrap_design("<p>new</p>")
 
     def test_create_email_template_without_email_content_succeeds(self):
         response = self.client.post(


### PR DESCRIPTION
## Problem

- Someone who changes a workflow email's HTML outside the visual editor still sees the previous version on the canvas, and only a test send shows the new content.
- An email that carries `html` without a `design` gets a generated Unlayer wrap, so the visual editor has something to open.
- Nothing rebuilt that wrap. A later change to `html` alone left the canvas on the html the wrap was built from.
- Sends read `html`, so the stored email and the canvas disagreed until someone edited the canvas.

## Changes

- `resolve_html_wrap_design` rebuilds a generated wrap whenever the submitted html no longer matches the html inside it. Both the hog function input serializer and the message template serializer use it.
- The email templater resolves the same way before it loads a design, so emails already stored with a stale wrap recover on open without a data migration.
- A design counts as rebuildable only when it is byte-identical to a freshly generated wrap. Unlayer rewrites a design the moment it loads one, so anything the visual editor has touched counts as authored and still wins over html.
- Applying a saved template that has html and no design now loads that html onto the canvas, instead of leaving the previous email on screen while the form fields change.

No visual change: the same canvas, showing the current content.

## How did you test this code?

Automated only. This environment has no browser session, so I did not open the editor or send a test email.

- Jest, `emailTemplaterLogic.test.ts`: the stale wrap on editor open, on an external html change to an open canvas, and on template apply. Two guard cases assert an authored design and an editor-normalized wrap load unchanged, which is what keeps the rebuild from clobbering real designs.
- pytest: one case each in `posthog/cdp/test/test_validation.py` and `products/messaging/backend/api/test/test_message_templates.py`. I confirmed both fail without the source change by stashing it, and a parameterized case covers the editor-normalized wrap staying untouched.
- Also ran, without failures: the full `test_validation.py`, `test_message_templates.py` and `products/workflows/backend/api/test/test_hog_flow.py`, repo-wide mypy, and the frontend typecheck.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I am the PostHog Slack app (Claude Opus), asked from a Slack thread to reproduce the reported behavior in tests first and then fix the cause. The origin thread is linked in the footer. The PR is unassigned because the request reached me over Slack and I could not verify the requester's GitHub handle from this session.

Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

Two decisions worth a reviewer's attention. I detect a rebuildable wrap by byte-equality against a freshly generated one rather than by its sentinel ids, because an id check would also match a wrap the user has since edited in the visual editor and would replace their design with the exported document. And I fixed the frontend as well as the serializers, so the roughly-correct canvas appears on the next open rather than after the next save.

No customer data, session material, or internal context is in this diff or description.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C06GG249PR6/p1786945491593549?thread_ts=1786945491.593549&cid=C06GG249PR6)*
