### PR TITLE
feat(warehouse-sources): promote WorkOS source to beta

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/workos/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/workos/source.py
@@ -3,6 +3,7 @@ from typing import Optional, cast
 from posthog.schema import (
     DataWarehouseSourceCategory,
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
     SourceFieldInputConfig,
     SourceFieldInputConfigType,
@@ -42,7 +43,7 @@ class WorkOSSource(ResumableSource[WorkOSSourceConfig, WorkOSResumeConfig]):
             name=SchemaExternalDataSourceType.WORK_OS,
             category=DataWarehouseSourceCategory.ENGINEERING___MONITORING,
             label="WorkOS",
-            releaseStatus="alpha",
+            releaseStatus=ReleaseStatus.BETA,
             caption="""Enter your WorkOS API key to sync your WorkOS data into the PostHog Data warehouse.
 
 You can find your API key in the [WorkOS Dashboard](https://dashboard.workos.com/) under **API Keys**.


### PR DESCRIPTION
## Problem

A user connecting a data-warehouse source saw WorkOS labelled Alpha, signalling it was new and lightly tested. It now meets the bar for Beta.

- Used by at least 30 teams over the last 7 days.
- Import error rate under 5% over the last 7 days (well below the threshold).

## Changes

- Set the WorkOS source `releaseStatus` to `ReleaseStatus.BETA`, so `/api/public_source_configs/` reports it as beta.
- Switched the field from the literal `"alpha"` to the `ReleaseStatus` enum, matching every other source and the warehouse-sources skill.
- No connector behaviour, schema, or sync logic changed. WorkOS has no feature-flag or `unreleasedSource` gating, so none was touched.

## How did you test this code?

- Ran the WorkOS source tests: `products/warehouse_sources/backend/temporal/data_imports/sources/workos/tests/test_workos_source.py` (15 passed).
- Confirmed `WorkOSSource().get_source_config.releaseStatus` resolves to `beta`.
- Ran `ruff check` and `ruff format --check` on the changed file.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (actually Claude) made this change. I invoked `/implementing-warehouse-sources` for the source conventions and `/writing-pr-descriptions` for this body.

The skill's guidance is to use the `ReleaseStatus` enum rather than a bare string literal, and the rest of the codebase does the same, so I converted the field while promoting it rather than leaving the pre-existing string literal in place. I checked for an existing human-authored PR promoting WorkOS (by source name, "releaseStatus", "promote beta", and the maintainer's open PRs) and found none.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
