### PR TITLE
chore(insights): document scatter plot in assistant chart guidance

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -2187,7 +2187,7 @@
                     "description": "Settings for the right Y axis. Only applies when a Y series uses `settings.display.yAxisPosition: \"right\"`."
                 },
                 "seriesBreakdownColumn": {
-                    "description": "Column that splits a single Y series into multiple colored series — e.g. breaking down a line chart by `country`. Set to `null` or omit to disable.",
+                    "description": "Column that splits a single Y series into multiple colored series — e.g. breaking down a line chart by `country`. Set to `null` or omit to disable. A breakdown buckets rows by x value, so it is ignored when `display` is `ScatterPlot`.",
                     "type": ["string", "null"]
                 },
                 "showLegend": {
@@ -2212,7 +2212,7 @@
                 },
                 "xAxis": {
                     "$ref": "#/definitions/AssistantDataVisualizationAxis",
-                    "description": "Column used as the X axis. Typically a time bucket or categorical column."
+                    "description": "Column used as the X axis. Typically a time bucket or categorical column, but `ScatterPlot` plots two measures against each other, so it needs a numeric column here too."
                 },
                 "xAxisLabel": {
                     "description": "Label rendered under the X axis.",
@@ -2268,7 +2268,7 @@
                 },
                 "display": {
                     "$ref": "#/definitions/AssistantDataVisualizationDisplayType",
-                    "description": "Visualization type. Defaults to `ActionsTable` when omitted.\n\nGuidance:\n- Single-value result (one numeric column, one row) → `BoldNumber`.\n- Time series → `ActionsLineGraph` or `ActionsAreaGraph`.\n- Categorical proportions → `ActionsPie`.\n- Categorical comparison → `ActionsBar` or `ActionsStackedBar`.\n- Two-dimensional aggregation → `TwoDimensionalHeatmap`.\n- Otherwise → `ActionsTable`."
+                    "description": "Visualization type. Defaults to `ActionsTable` when omitted.\n\nGuidance:\n- Single-value result (one numeric column, one row) → `BoldNumber`.\n- Time series → `ActionsLineGraph` or `ActionsAreaGraph`.\n- Categorical proportions → `ActionsPie`.\n- Categorical comparison → `ActionsBar` or `ActionsStackedBar`.\n- Two-dimensional aggregation → `TwoDimensionalHeatmap`.\n- Relationship between two numeric measures, one point per row → `ScatterPlot`.\n- Otherwise → `ActionsTable`."
                 },
                 "kind": {
                     "const": "DataVisualizationNode",

--- a/frontend/src/queries/schema/schema-assistant-queries.ts
+++ b/frontend/src/queries/schema/schema-assistant-queries.ts
@@ -1793,7 +1793,10 @@ export interface AssistantDataVisualizationYAxisSettings {
 }
 
 export interface AssistantDataVisualizationChartSettings {
-    /** Column used as the X axis. Typically a time bucket or categorical column. */
+    /**
+     * Column used as the X axis. Typically a time bucket or categorical column, but `ScatterPlot`
+     * plots two measures against each other, so it needs a numeric column here too.
+     */
     xAxis?: AssistantDataVisualizationAxis
     /** Label rendered under the X axis. */
     xAxisLabel?: string
@@ -1805,7 +1808,8 @@ export interface AssistantDataVisualizationChartSettings {
     rightYAxisSettings?: AssistantDataVisualizationYAxisSettings
     /**
      * Column that splits a single Y series into multiple colored series — e.g. breaking down
-     * a line chart by `country`. Set to `null` or omit to disable.
+     * a line chart by `country`. Set to `null` or omit to disable. A breakdown buckets rows by
+     * x value, so it is ignored when `display` is `ScatterPlot`.
      */
     seriesBreakdownColumn?: string | null
     /** Horizontal goal lines drawn across the chart. */
@@ -1852,6 +1856,7 @@ export interface AssistantDataVisualizationNode {
      * - Categorical proportions → `ActionsPie`.
      * - Categorical comparison → `ActionsBar` or `ActionsStackedBar`.
      * - Two-dimensional aggregation → `TwoDimensionalHeatmap`.
+     * - Relationship between two numeric measures, one point per row → `ScatterPlot`.
      * - Otherwise → `ActionsTable`.
      */
     display?: AssistantDataVisualizationDisplayType

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -3287,7 +3287,8 @@ class AssistantDataVisualizationChartSettings(BaseModel):
         description=(
             "Column that splits a single Y series into multiple colored series — e.g."
             " breaking down a line chart by `country`. Set to `null` or omit to"
-            " disable."
+            " disable. A breakdown buckets rows by x value, so it is ignored when"
+            " `display` is `ScatterPlot`."
         ),
     )
     showLegend: bool | None = Field(default=None, description="Show the chart legend.")
@@ -3306,7 +3307,11 @@ class AssistantDataVisualizationChartSettings(BaseModel):
     )
     xAxis: AssistantDataVisualizationAxis | None = Field(
         default=None,
-        description=("Column used as the X axis. Typically a time bucket or categorical column."),
+        description=(
+            "Column used as the X axis. Typically a time bucket or categorical column,"
+            " but `ScatterPlot` plots two measures against each other, so it needs a"
+            " numeric column here too."
+        ),
     )
     xAxisLabel: str | None = Field(default=None, description="Label rendered under the X axis.")
     yAxis: list[AssistantDataVisualizationAxis] | None = Field(
@@ -8956,8 +8961,9 @@ class AssistantDataVisualizationNode(BaseModel):
             " row) → `BoldNumber`.\n- Time series → `ActionsLineGraph` or"
             " `ActionsAreaGraph`.\n- Categorical proportions → `ActionsPie`.\n-"
             " Categorical comparison → `ActionsBar` or `ActionsStackedBar`.\n-"
-            " Two-dimensional aggregation → `TwoDimensionalHeatmap`.\n- Otherwise →"
-            " `ActionsTable`."
+            " Two-dimensional aggregation → `TwoDimensionalHeatmap`.\n- Relationship"
+            " between two numeric measures, one point per row → `ScatterPlot`.\n-"
+            " Otherwise → `ActionsTable`."
         ),
     )
     kind: Literal["DataVisualizationNode"] = "DataVisualizationNode"

--- a/services/mcp/src/tools/generated/product_analytics.ts
+++ b/services/mcp/src/tools/generated/product_analytics.ts
@@ -105,7 +105,7 @@ const AssistantDataVisualizationChartSettings = z.object({
         .string()
         .nullable()
         .describe(
-            'Column that splits a single Y series into multiple colored series — e.g. breaking down a line chart by `country`. Set to `null` or omit to disable.'
+            'Column that splits a single Y series into multiple colored series — e.g. breaking down a line chart by `country`. Set to `null` or omit to disable. A breakdown buckets rows by x value, so it is ignored when `display` is `ScatterPlot`.'
         )
         .optional(),
     showLegend: z.coerce.boolean().describe('Show the chart legend.').optional(),
@@ -123,7 +123,7 @@ const AssistantDataVisualizationChartSettings = z.object({
         .describe('Stack bars to 100% of the total. Only meaningful with `ActionsStackedBar`.')
         .optional(),
     xAxis: AssistantDataVisualizationAxis.describe(
-        'Column used as the X axis. Typically a time bucket or categorical column.'
+        'Column used as the X axis. Typically a time bucket or categorical column, but `ScatterPlot` plots two measures against each other, so it needs a numeric column here too.'
     ).optional(),
     xAxisLabel: z.string().describe('Label rendered under the X axis.').optional(),
     yAxis: z
@@ -158,7 +158,7 @@ const AssistantDataVisualizationNode = z.object({
         'Chart configuration. Ignored when `display` is `ActionsTable` or `BoldNumber`.'
     ).optional(),
     display: AssistantDataVisualizationDisplayType.describe(
-        'Visualization type. Defaults to `ActionsTable` when omitted.\n\nGuidance:\n- Single-value result (one numeric column, one row) → `BoldNumber`.\n- Time series → `ActionsLineGraph` or `ActionsAreaGraph`.\n- Categorical proportions → `ActionsPie`.\n- Categorical comparison → `ActionsBar` or `ActionsStackedBar`.\n- Two-dimensional aggregation → `TwoDimensionalHeatmap`.\n- Otherwise → `ActionsTable`.'
+        'Visualization type. Defaults to `ActionsTable` when omitted.\n\nGuidance:\n- Single-value result (one numeric column, one row) → `BoldNumber`.\n- Time series → `ActionsLineGraph` or `ActionsAreaGraph`.\n- Categorical proportions → `ActionsPie`.\n- Categorical comparison → `ActionsBar` or `ActionsStackedBar`.\n- Two-dimensional aggregation → `TwoDimensionalHeatmap`.\n- Relationship between two numeric measures, one point per row → `ScatterPlot`.\n- Otherwise → `ActionsTable`.'
     ).optional(),
     kind: z.literal('DataVisualizationNode').default('DataVisualizationNode'),
     source: z.record(z.string(), z.unknown()).describe('HogQL query object that produces the rows to visualize.'),

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/insight-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/insight-create.json
@@ -141,7 +141,7 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "description": "Column that splits a single Y series into multiple colored series — e.g. breaking down a line chart by `country`. Set to `null` or omit to disable."
+                                    "description": "Column that splits a single Y series into multiple colored series — e.g. breaking down a line chart by `country`. Set to `null` or omit to disable. A breakdown buckets rows by x value, so it is ignored when `display` is `ScatterPlot`."
                                 },
                                 "showLegend": {
                                     "description": "Show the chart legend.",
@@ -164,7 +164,7 @@
                                     "type": "boolean"
                                 },
                                 "xAxis": {
-                                    "description": "Column used as the X axis. Typically a time bucket or categorical column.",
+                                    "description": "Column used as the X axis. Typically a time bucket or categorical column, but `ScatterPlot` plots two measures against each other, so it needs a numeric column here too.",
                                     "properties": {
                                         "column": {
                                             "description": "Name of a column returned by the SQL query to map onto this axis.",
@@ -310,7 +310,7 @@
                             "type": "object"
                         },
                         "display": {
-                            "description": "Visualization type. Defaults to `ActionsTable` when omitted.\n\nGuidance:\n- Single-value result (one numeric column, one row) → `BoldNumber`.\n- Time series → `ActionsLineGraph` or `ActionsAreaGraph`.\n- Categorical proportions → `ActionsPie`.\n- Categorical comparison → `ActionsBar` or `ActionsStackedBar`.\n- Two-dimensional aggregation → `TwoDimensionalHeatmap`.\n- Otherwise → `ActionsTable`.",
+                            "description": "Visualization type. Defaults to `ActionsTable` when omitted.\n\nGuidance:\n- Single-value result (one numeric column, one row) → `BoldNumber`.\n- Time series → `ActionsLineGraph` or `ActionsAreaGraph`.\n- Categorical proportions → `ActionsPie`.\n- Categorical comparison → `ActionsBar` or `ActionsStackedBar`.\n- Two-dimensional aggregation → `TwoDimensionalHeatmap`.\n- Relationship between two numeric measures, one point per row → `ScatterPlot`.\n- Otherwise → `ActionsTable`.",
                             "enum": [
                                 "ActionsTable",
                                 "BoldNumber",

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/insight-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/insight-update.json
@@ -152,7 +152,7 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "description": "Column that splits a single Y series into multiple colored series — e.g. breaking down a line chart by `country`. Set to `null` or omit to disable."
+                                    "description": "Column that splits a single Y series into multiple colored series — e.g. breaking down a line chart by `country`. Set to `null` or omit to disable. A breakdown buckets rows by x value, so it is ignored when `display` is `ScatterPlot`."
                                 },
                                 "showLegend": {
                                     "description": "Show the chart legend.",
@@ -175,7 +175,7 @@
                                     "type": "boolean"
                                 },
                                 "xAxis": {
-                                    "description": "Column used as the X axis. Typically a time bucket or categorical column.",
+                                    "description": "Column used as the X axis. Typically a time bucket or categorical column, but `ScatterPlot` plots two measures against each other, so it needs a numeric column here too.",
                                     "properties": {
                                         "column": {
                                             "description": "Name of a column returned by the SQL query to map onto this axis.",
@@ -321,7 +321,7 @@
                             "type": "object"
                         },
                         "display": {
-                            "description": "Visualization type. Defaults to `ActionsTable` when omitted.\n\nGuidance:\n- Single-value result (one numeric column, one row) → `BoldNumber`.\n- Time series → `ActionsLineGraph` or `ActionsAreaGraph`.\n- Categorical proportions → `ActionsPie`.\n- Categorical comparison → `ActionsBar` or `ActionsStackedBar`.\n- Two-dimensional aggregation → `TwoDimensionalHeatmap`.\n- Otherwise → `ActionsTable`.",
+                            "description": "Visualization type. Defaults to `ActionsTable` when omitted.\n\nGuidance:\n- Single-value result (one numeric column, one row) → `BoldNumber`.\n- Time series → `ActionsLineGraph` or `ActionsAreaGraph`.\n- Categorical proportions → `ActionsPie`.\n- Categorical comparison → `ActionsBar` or `ActionsStackedBar`.\n- Two-dimensional aggregation → `TwoDimensionalHeatmap`.\n- Relationship between two numeric measures, one point per row → `ScatterPlot`.\n- Otherwise → `ActionsTable`.",
                             "enum": [
                                 "ActionsTable",
                                 "BoldNumber",


### PR DESCRIPTION
## Problem

An agent creating a SQL insight over MCP or in the assistant could never pick a scatter plot, even when the query was two numeric measures asking to be plotted against each other.

`ScatterPlot` is in the `display` enum on `AssistantDataVisualizationNode` and the renderer supports it fully. But the guidance list attached to that field — the thing an agent actually reads to choose a chart type — has a bullet for every other display type and none for scatter. So agents concluded there was no scatter option and fell back to `ActionsTable` or `ActionsLineGraph`.

The in-app assistant's own SQL prompt (`ee/hogai/chat_agent/sql/prompts.py`) already documents scatter correctly. Only the schema docstring, which feeds the MCP tool descriptions, was missing it.

## Changes

- Adds the missing `ScatterPlot` bullet to the `display` guidance list.
- Documents the two constraints a scatter actually has, which the surrounding docstrings implied the opposite of:
  - `xAxis` needs a numeric column, where the text previously said "typically a time bucket or categorical column".
  - `seriesBreakdownColumn` is ignored, because a breakdown buckets rows by x value.
- Regenerates the downstream artifacts: `schema.json`, `posthog/schema.py`, the MCP tool zod, and the two tool-schema snapshots.

Docstring and generated-output only — no behavior change.

## How did you test this code?

Before writing anything, I confirmed over MCP that the display type already works end to end: created a SQL insight with `display: "ScatterPlot"`, checked it round-tripped with the display type intact and computed results, then deleted it. So this PR is documentation for a working feature, not a fix for a broken one.

Automated, run locally:

- `services/mcp` tool-schema snapshot test (`tests/unit/tool-schema-snapshots.test.ts`), updated and passing — this is what pins the description strings agents receive.
- `hogli ci:preflight --fix` — clean, no failures.
- Regeneration is reproducible: the codegen produced exactly the three changed description strings in each artifact and no unrelated drift.

Not done, and worth a reviewer's attention:

- `pnpm --filter=@posthog/mcp typecheck` fails in this environment with 83 pre-existing errors, all cascading from an unbuilt nested `@posthog/quill` workspace. None are in the files this PR touches. I did not get a clean typecheck run to compare against.
- Repo-wide mypy not run. Preflight flagged it as advisory for `posthog/schema.py`; the change there is string content inside `Field(description=...)`, so it can't move a type.
- No new tests. The existing snapshot test already covers these strings, and a test asserting a docstring's wording would just restate the diff.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code. Started as a question — whether the MCP supports scatter plots for SQL insights — and the check turned up that it does, but that nothing tells an agent so. Zero of this project's several thousand saved SQL insights use `ScatterPlot`, while `TwoDimensionalHeatmap`, comparably new but with a guidance bullet, is in use. That pointed at the docs gap rather than the feature.

I first filed this through `agent-feedback` and was redirected to fix it directly, so the feedback item is redundant.

Two decisions worth flagging for review:

- I grepped for other copies of this guidance list before editing. `prompts.py` and `toolkit.py` in the assistant's SQL toolkit already document scatter, so the fix belongs in one place, and `schema-assistant-queries.ts` is the source of truth the generated artifacts flow from.
- Regenerating the MCP tool zod needs the OpenAPI spec, so I stood up postgres and ClickHouse and ran `spectacular` locally rather than leaning on CI's auto-commit-on-drift job. That keeps the generated files in the same commit as their source.

Repo skill `/writing-code-comments` is registered as mandatory for comment edits; it isn't loadable in this environment, so I read `.agents/skills/writing-code-comments/SKILL.md` directly and followed it — which is why the added lines state why a constraint exists rather than restating the enum.

Public artifact: nothing here draws on non-public material. The insight I created to verify was a throwaway over `system.insights` row ids and has been deleted.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
