### PR TITLE
feat(signals): carry GitHub issue author into the signal

### DIFF
--- a/products/signals/backend/contracts.py
+++ b/products/signals/backend/contracts.py
@@ -139,11 +139,13 @@ class GithubIssueSignalExtra(SignalExtraBase):
     updated_at: str
     locked: bool
     state: str
-    author_login: str | None
+    # Defaulted, unlike the fields above: payloads emitted before these columns existed carry
+    # neither key, and an author is context for triage rather than something a signal needs.
+    author_login: str | None = None
     # GitHub's own enum — OWNER, MEMBER, COLLABORATOR, CONTRIBUTOR, FIRST_TIME_CONTRIBUTOR,
     # FIRST_TIMER, MANNEQUIN, NONE. Kept as a plain string so a value GitHub adds later widens the
     # taxonomy instead of failing validation and dropping the signal.
-    author_association: str | None
+    author_association: str | None = None
 
 
 class GithubIssueSignalInput(SignalInputBase):

--- a/products/signals/backend/contracts.py
+++ b/products/signals/backend/contracts.py
@@ -139,6 +139,11 @@ class GithubIssueSignalExtra(SignalExtraBase):
     updated_at: str
     locked: bool
     state: str
+    author_login: str | None
+    # GitHub's own enum — OWNER, MEMBER, COLLABORATOR, CONTRIBUTOR, FIRST_TIME_CONTRIBUTOR,
+    # FIRST_TIMER, MANNEQUIN, NONE. Kept as a plain string so a value GitHub adds later widens the
+    # taxonomy instead of failing validation and dropping the signal.
+    author_association: str | None
 
 
 class GithubIssueSignalInput(SignalInputBase):

--- a/products/signals/backend/emission/AGENTS.md
+++ b/products/signals/backend/emission/AGENTS.md
@@ -67,6 +67,8 @@ Users enable sources via the Inbox Sources modal.
    write a pure emitter function that transforms a record dict into a signal output (or `None` if data is insufficient), define a `record_fetcher` (use `data_warehouse_record_fetcher` for warehouse sources, or write a new fetcher for other sources), optionally define an LLM actionability prompt and/or a summarization prompt with threshold, and export the final config as a module-level constant.
    **Avoid querying PII fields** (user IDs, email addresses, names, organization IDs, etc.) unless they are strictly required to locate the entity in the source system later.
    Prefer opaque record IDs and URLs over fields that identify people or organizations.
+   The deliberate exception is the author of a record: `github_issues.py` carries `author_login` and `author_association`, because who filed a report is what separates a maintainer's bug report from a drive-by one on a public repo, and triage can't weigh the two without it.
+   Reach for the same pair on other issue-tracker sources, and keep it to the handle and the relationship — not emails, real names, or the rest of the nested user object.
 2. **Register in `registry.py`** — import the config and add it inside `_register_all_emitters()`.
    For external sources, use the `ExternalDataSourceType` value as the source type.
    For internal sources, use a descriptive string identifier.

--- a/products/signals/backend/emission/AGENTS.md
+++ b/products/signals/backend/emission/AGENTS.md
@@ -72,6 +72,8 @@ Users enable sources via the Inbox Sources modal.
    Prefer opaque record IDs and URLs over fields that identify people or organizations.
    The deliberate exception is the author of a record: `github_issues.py` carries `author_login` and `author_association`, because who filed a report is what separates a maintainer's bug report from a drive-by one on a public repo, and triage can't weigh the two without it.
    Reach for the same pair on other issue-tracker sources, and keep it to the handle and the relationship — not emails, real names, or the rest of the nested user object.
+   A source that SELECTs a column carrying more identity than it keeps declares that column in `unloggable_fields`, which strips it from the record this pipeline logs when an emitter raises.
+   Identity keys are also excluded from lifecycle telemetry by `_TELEMETRY_EXCLUDED_EXTRA_KEYS` in `facade/api.py`, which otherwise copies every top-level scalar on `extra` into the emission events.
 2. **Register in `registry.py`** — import the config and add it inside `_register_all_emitters()`.
    For external sources, use the `ExternalDataSourceType` value as the source type.
    For internal sources, use a descriptive string identifier.

--- a/products/signals/backend/emission/AGENTS.md
+++ b/products/signals/backend/emission/AGENTS.md
@@ -23,6 +23,9 @@ The core signal pipeline (`products/signals/backend/emission/pipeline.py`) is so
 4. **Actionability filter** — optionally filters non-actionable records via LLM.
    Teams can steer this gate per source via two keys on `SignalSourceConfig.config`: `steering` (plain-language rules injected into the canonical prompt) and `default_not_actionable` (flips the "when in doubt" posture from keep to filter).
    See `steering.py` — the injection escapes braces and caps length so team text can never break the prompt's one-word output contract, and every canonical actionability prompt must keep the `When in doubt, classify as ACTIONABLE` posture line the injection anchors on.
+   The gate runs before a signal exists, so it sees only the description unless the record carries the verdict elsewhere.
+   A source whose verdict depends on metadata the description doesn't carry declares those `extra` keys in `actionability_context_fields`, and they arrive in a `<record_metadata>` block inside the description (see `github_issues.py`, which declares the issue author).
+   A steered gate gets all of `extra` in that block instead; a source declaring nothing keeps a byte-identical prompt.
 5. **Emission** — emits surviving outputs as Signals via `products/signals/backend/api/emit_signal`
 
 ### Registry

--- a/products/signals/backend/emission/github_issues.py
+++ b/products/signals/backend/emission/github_issues.py
@@ -4,7 +4,7 @@ from typing import Any
 from structlog import get_logger
 
 from products.signals.backend.emission.fetchers.data_warehouse import data_warehouse_record_fetcher
-from products.signals.backend.emission.registry import SignalEmitterOutput, SignalSourceTableConfig
+from products.signals.backend.emission.registry import SignalEmitterOutput, SignalSourceTableConfig, redacted_record
 
 logger = get_logger(__name__)
 
@@ -62,13 +62,15 @@ PASSTHROUGH_FIELDS = ("html_url", "number", "labels", "created_at", "updated_at"
 # that triage has no use for.
 AUTHOR_FIELDS = ("author_association", "user")
 
+# `user` never belongs in a log line: the emitter keeps the handle and drops the numeric id and the
+# avatar and API URLs, and the shared pipeline logs whole records when an emitter raises.
+UNLOGGABLE_FIELDS = ("user",)
+
 EXTRA_FIELDS = (*PASSTHROUGH_FIELDS, "author_login", "author_association")
 
 
 def _loggable(record: dict[str, Any]) -> dict[str, Any]:
-    """The record minus the nested user object, whose numeric id and URLs identify a person well
-    beyond the handle triage needs."""
-    return {k: v for k, v in record.items() if k != "user"}
+    return redacted_record(record, UNLOGGABLE_FIELDS)
 
 
 def github_issue_emitter(team_id: int, record: dict[str, Any]) -> SignalEmitterOutput | None:
@@ -165,6 +167,7 @@ GITHUB_ISSUES_CONFIG = SignalSourceTableConfig(
     first_sync_lookback_days=1,  # 24 hours
     actionability_prompt=GITHUB_ACTIONABILITY_PROMPT,
     actionability_context_fields=("author_login", "author_association"),
+    unloggable_fields=UNLOGGABLE_FIELDS,
     summarization_prompt=GITHUB_SUMMARIZATION_PROMPT,
     description_summarization_threshold_chars=2000,
 )

--- a/products/signals/backend/emission/github_issues.py
+++ b/products/signals/backend/emission/github_issues.py
@@ -51,9 +51,16 @@ Respond with exactly one word: ACTIONABLE or NOT_ACTIONABLE"""
 
 REQUIRED_FIELDS = ("id", "title", "body")
 
-EXTRA_FIELDS = ("html_url", "number", "labels", "created_at", "updated_at", "locked", "state")
+PASSTHROUGH_FIELDS = ("html_url", "number", "labels", "created_at", "updated_at", "locked", "state")
 # TODO: Add "comments", but they can be pretty heavy, so better to iterate on them later,
 # either when adding weight-defining logic, or when we decide to include them into the description
+
+# Columns behind the author identity on `extra`. `author_association` lands verbatim; `author_login`
+# is lifted out of the nested `user` object, which otherwise carries a pile of avatar and API URLs
+# that triage has no use for.
+AUTHOR_FIELDS = ("author_association", "user")
+
+EXTRA_FIELDS = (*PASSTHROUGH_FIELDS, "author_login", "author_association")
 
 
 def github_issue_emitter(team_id: int, record: dict[str, Any]) -> SignalEmitterOutput | None:
@@ -84,8 +91,34 @@ def github_issue_emitter(team_id: int, record: dict[str, Any]) -> SignalEmitterO
     )
 
 
+def _author_login(raw_user: Any) -> str | None:
+    """Lift `login` out of a GitHub user object, which the warehouse stores as a JSON string.
+
+    Unlike labels, a user object we can't read degrades to an unknown author rather than raising:
+    the author is context for triage, not something the signal is meaningless without.
+    """
+    if isinstance(raw_user, str):
+        try:
+            raw_user = json.loads(raw_user)
+        except (json.JSONDecodeError, TypeError):
+            # The blob itself names a person, so log only enough to spot a shape change upstream.
+            logger.warning(
+                "Ignoring unparseable GitHub issue user field",
+                signals_type="data-import-signals",
+                raw_user_length=len(raw_user),
+            )
+            return None
+    if not isinstance(raw_user, dict):
+        return None
+    login = raw_user.get("login")
+    return login if isinstance(login, str) and login else None
+
+
 def _build_extra(record: dict[str, Any]) -> dict[str, Any]:
-    extra = {k: v for k, v in record.items() if k in EXTRA_FIELDS}
+    extra = {k: v for k, v in record.items() if k in PASSTHROUGH_FIELDS}
+    # Always present, so the contract shape doesn't shift when a repo or a sync withholds the author.
+    extra["author_login"] = _author_login(record.get("user"))
+    extra["author_association"] = record.get("author_association") or None
     raw_labels = extra.get("labels")
     if raw_labels is None:
         extra["labels"] = []
@@ -115,7 +148,7 @@ GITHUB_ISSUES_CONFIG = SignalSourceTableConfig(
     record_fetcher=data_warehouse_record_fetcher,
     partition_field="created_at",
     partition_field_is_datetime_string=True,
-    fields=REQUIRED_FIELDS + EXTRA_FIELDS,
+    fields=REQUIRED_FIELDS + PASSTHROUGH_FIELDS + AUTHOR_FIELDS,
     where_clause=f"state NOT IN ({', '.join(repr(s) for s in GITHUB_IGNORED_STATES)})",
     max_records=1000,
     first_sync_lookback_days=1,  # 24 hours

--- a/products/signals/backend/emission/github_issues.py
+++ b/products/signals/backend/emission/github_issues.py
@@ -65,6 +65,12 @@ AUTHOR_FIELDS = ("author_association", "user")
 EXTRA_FIELDS = (*PASSTHROUGH_FIELDS, "author_login", "author_association")
 
 
+def _loggable(record: dict[str, Any]) -> dict[str, Any]:
+    """The record minus the nested user object, whose numeric id and URLs identify a person well
+    beyond the handle triage needs."""
+    return {k: v for k, v in record.items() if k != "user"}
+
+
 def github_issue_emitter(team_id: int, record: dict[str, Any]) -> SignalEmitterOutput | None:
     try:
         issue_id = record["id"]
@@ -72,15 +78,18 @@ def github_issue_emitter(team_id: int, record: dict[str, Any]) -> SignalEmitterO
         body = record["body"]
     except KeyError as e:
         msg = f"GitHub issue record missing required field {e}"
-        logger.exception(msg, record=record, team_id=team_id, signals_type="data-import-signals")
+        logger.exception(msg, record=_loggable(record), team_id=team_id, signals_type="data-import-signals")
         raise ValueError(msg) from e
     if not issue_id or not title:
         msg = f"GitHub issue record has empty required field: id={issue_id!r}, title={title!r}"
-        logger.exception(msg, record=record, team_id=team_id, signals_type="data-import-signals")
+        logger.exception(msg, record=_loggable(record), team_id=team_id, signals_type="data-import-signals")
         raise ValueError(msg)
     if not body:
         logger.info(
-            "Ignoring GitHub issue without a body", record=record, team_id=team_id, signals_type="data-import-signals"
+            "Ignoring GitHub issue without a body",
+            record=_loggable(record),
+            team_id=team_id,
+            signals_type="data-import-signals",
         )
         return None
     return SignalEmitterOutput(
@@ -129,16 +138,16 @@ def _build_extra(record: dict[str, Any]) -> dict[str, Any]:
             parsed = json.loads(raw_labels)
         except (json.JSONDecodeError, TypeError) as e:
             msg = f"GitHub issue labels field is not valid JSON: {raw_labels!r}"
-            logger.exception(msg, record=record, signals_type="data-import-signals")
+            logger.exception(msg, record=_loggable(record), signals_type="data-import-signals")
             raise ValueError(msg) from e
         if not isinstance(parsed, list):
             msg = f"GitHub issue labels field is not a JSON array: {raw_labels!r}"
-            logger.exception(msg, record=record, signals_type="data-import-signals")
+            logger.exception(msg, record=_loggable(record), signals_type="data-import-signals")
             raise ValueError(msg)
         extra["labels"] = [label["name"] for label in parsed if isinstance(label, dict) and "name" in label]
     else:
         msg = f"GitHub issue labels field has unexpected type {type(raw_labels).__name__}: {raw_labels!r}"
-        logger.exception(msg, record=record, signals_type="data-import-signals")
+        logger.exception(msg, record=_loggable(record), signals_type="data-import-signals")
         raise ValueError(msg)
     return extra
 

--- a/products/signals/backend/emission/github_issues.py
+++ b/products/signals/backend/emission/github_issues.py
@@ -41,6 +41,8 @@ An issue is NOT_ACTIONABLE if it is:
 - A meta/tracking issue with no substantive feedback — issues that contain only a title and a bare link or a short reminder without describing a problem, use case, or solution (release checklists, sprint trackers, experiment-to-do notes)
 - A duplicate that only says "same as #X" with no new information
 
+The issue may end with a record_metadata block naming its author. `author_login` is the GitHub handle that filed it, and `author_association` is that account's relationship to the repository: OWNER, MEMBER, and COLLABORATOR are maintainers, while CONTRIBUTOR, FIRST_TIME_CONTRIBUTOR, and NONE are reporters from outside the org. A handle ending in [bot] is automation, so treat what it files as bot-generated. Beyond that, the author is context and not a verdict — a bug report from an outside reporter is exactly the feedback worth capturing, so never classify an issue as NOT_ACTIONABLE just because its author isn't a maintainer.
+
 When in doubt, classify as ACTIONABLE. GitHub issues are filed intentionally, so err on the side of capturing the signal. However, if an issue clearly matches one of the NOT_ACTIONABLE categories above, classify it as NOT_ACTIONABLE regardless.
 
 <issue>
@@ -153,6 +155,7 @@ GITHUB_ISSUES_CONFIG = SignalSourceTableConfig(
     max_records=1000,
     first_sync_lookback_days=1,  # 24 hours
     actionability_prompt=GITHUB_ACTIONABILITY_PROMPT,
+    actionability_context_fields=("author_login", "author_association"),
     summarization_prompt=GITHUB_SUMMARIZATION_PROMPT,
     description_summarization_threshold_chars=2000,
 )

--- a/products/signals/backend/emission/pipeline.py
+++ b/products/signals/backend/emission/pipeline.py
@@ -16,7 +16,12 @@ from posthog.llm.gateway_client import build_async_anthropic_client, resolve_ai_
 from posthog.models import Organization, Team
 from posthog.sync import database_sync_to_async
 
-from products.signals.backend.emission.registry import SignalEmitter, SignalEmitterOutput, SignalSourceTableConfig
+from products.signals.backend.emission.registry import (
+    SignalEmitter,
+    SignalEmitterOutput,
+    SignalSourceTableConfig,
+    redacted_record,
+)
 from products.signals.backend.emission.steering import apply_steering, steering_from_config
 from products.signals.backend.facade.api import emit_signal
 from products.signals.backend.temporal import metrics
@@ -129,6 +134,7 @@ def build_emitter_outputs(
     team_id: int,
     records: list[dict[str, Any]],
     emitter: SignalEmitter,
+    unloggable_fields: tuple[str, ...] = (),
 ) -> tuple[list[SignalEmitterOutput], int]:
     outputs = []
     error_count = 0
@@ -139,7 +145,7 @@ def build_emitter_outputs(
             logger.exception(
                 "Emitter failed for record, skipping",
                 team_id=team_id,
-                record=record,
+                record=redacted_record(record, unloggable_fields),
                 signals_type="data-import-signals",
             )
             error_count += 1
@@ -512,6 +518,7 @@ async def run_signal_pipeline(
         team_id=team.id,
         records=records,
         emitter=config.emitter,
+        unloggable_fields=config.unloggable_fields,
     )
     # Only fail if every record raised — emitters may return None as a benign skip,
     # so a mix of skips and errors should fall through to the no_actionable_records path.

--- a/products/signals/backend/emission/pipeline.py
+++ b/products/signals/backend/emission/pipeline.py
@@ -292,7 +292,10 @@ async def _check_actionability(
     # Steering rules often reference metadata (labels, state, priority) that emitters keep in `extra`
     # rather than in the description, so the steered gate sees all of it. An unsteered gate sees only
     # the keys its source declared, keeping every other source's prompt byte-identical.
-    metadata_fields = output.extra if include_record_metadata else _declared_context(output.extra, context_fields)
+    declared = _declared_context(output.extra, context_fields)
+    # Declared keys lead the block so the length cap below trims the rest of `extra` first — a source
+    # that asked for a key shouldn't lose it to a record that happens to carry heavy labels.
+    metadata_fields = {**declared, **output.extra} if include_record_metadata else declared
     if metadata_fields:
         # Bounded, and substituted through the `{description}` placeholder so it is never
         # format-processed.

--- a/products/signals/backend/emission/pipeline.py
+++ b/products/signals/backend/emission/pipeline.py
@@ -274,6 +274,11 @@ async def summarize_long_descriptions(
     return result
 
 
+def _declared_context(extra: dict[str, Any], context_fields: tuple[str, ...]) -> dict[str, Any]:
+    """The subset of `extra` a source declared for its gate, dropping keys with nothing to say."""
+    return {key: extra[key] for key in context_fields if extra.get(key) is not None}
+
+
 async def _check_actionability(
     client: AsyncAnthropic,
     team_id: int,
@@ -281,13 +286,17 @@ async def _check_actionability(
     actionability_prompt: str,
     gateway_mode: bool | None = None,
     include_record_metadata: bool = False,
+    context_fields: tuple[str, ...] = (),
 ) -> bool:
     description = output.description
-    if include_record_metadata and output.extra:
-        # Steering rules often reference metadata (labels, state, priority) that emitters keep in
-        # `extra` rather than in the description, so the steered gate gets to see it. Bounded, and
-        # substituted through the `{description}` placeholder so it is never format-processed.
-        metadata = json.dumps(output.extra, default=str)[:RECORD_METADATA_MAX_CHARS]
+    # Steering rules often reference metadata (labels, state, priority) that emitters keep in `extra`
+    # rather than in the description, so the steered gate sees all of it. An unsteered gate sees only
+    # the keys its source declared, keeping every other source's prompt byte-identical.
+    metadata_fields = output.extra if include_record_metadata else _declared_context(output.extra, context_fields)
+    if metadata_fields:
+        # Bounded, and substituted through the `{description}` placeholder so it is never
+        # format-processed.
+        metadata = json.dumps(metadata_fields, default=str)[:RECORD_METADATA_MAX_CHARS]
         description = f"{description}\n\n<record_metadata>\n{metadata}\n</record_metadata>"
     prompt = actionability_prompt.format(description=description)
     extra_headers = _signals_extra_headers(output, stage="actionability", gateway_mode=gateway_mode, team_id=team_id)
@@ -329,6 +338,7 @@ async def filter_actionable(
     actionability_prompt: str,
     extra: dict[str, Any],
     include_record_metadata: bool = False,
+    context_fields: tuple[str, ...] = (),
 ) -> list[SignalEmitterOutput]:
     client = build_async_anthropic_client(product="signals", ai_product=EMISSION_AI_PRODUCT, team_id=team.id)
     gateway_mode = resolve_ai_gateway_config() is not None
@@ -347,6 +357,7 @@ async def filter_actionable(
                     actionability_prompt,
                     gateway_mode=gateway_mode,
                     include_record_metadata=include_record_metadata,
+                    context_fields=context_fields,
                 )
             except Exception:
                 logger.exception(
@@ -535,8 +546,10 @@ async def run_signal_pipeline(
             outputs=outputs,
             actionability_prompt=apply_steering(config.actionability_prompt, steering),
             extra=extra,
-            # Only steered teams get the metadata block, so unsteered prompts stay byte-identical.
+            # Steered teams get all of `extra`; everyone else gets only what the source declared, so
+            # a prompt with nothing declared stays byte-identical.
             include_record_metadata=steering.active,
+            context_fields=config.actionability_context_fields,
         )
         post_filter_ids = {o.source_id for o in outputs}
         for source_id, output in pre_filter_by_id.items():

--- a/products/signals/backend/emission/registry.py
+++ b/products/signals/backend/emission/registry.py
@@ -59,6 +59,11 @@ class SignalSourceTableConfig(BaseModel):
     first_sync_lookback_days: int = 7
     # LLM prompt to check if a record is actionable before emitting. If None, all records == actionable.
     actionability_prompt: str | None = None
+    # `extra` keys the actionability gate needs alongside the description, for sources whose verdict
+    # depends on metadata the description doesn't carry (e.g. who filed a GitHub issue). Declared per
+    # source rather than dumping all of `extra`, so a prompt only ever widens where its source asked.
+    # Steered teams already see all of `extra`, so this is what unsteered teams get.
+    actionability_context_fields: tuple[str, ...] = ()
     # LLM prompt to summarize descriptions that exceed the threshold. If None, no summarization is performed.
     summarization_prompt: str | None = None
     # How large the description can be before emitting

--- a/products/signals/backend/emission/registry.py
+++ b/products/signals/backend/emission/registry.py
@@ -36,6 +36,13 @@ SignalEmitter = Callable[[int, dict[str, Any]], SignalEmitterOutput | None]
 RecordFetcher = Callable[[Any, "SignalSourceTableConfig", dict[str, Any]], list[dict[str, Any]]]
 
 
+def redacted_record(record: dict[str, Any], unloggable_fields: tuple[str, ...]) -> dict[str, Any]:
+    """A record safe to log, with the source's declared identity columns dropped."""
+    if not unloggable_fields:
+        return record
+    return {k: v for k, v in record.items() if k not in unloggable_fields}
+
+
 class SignalSourceTableConfig(BaseModel):
     model_config = ConfigDict(frozen=True)
 
@@ -64,6 +71,10 @@ class SignalSourceTableConfig(BaseModel):
     # source rather than dumping all of `extra`, so a prompt only ever widens where its source asked.
     # Steered teams already see all of `extra`, so this is what unsteered teams get.
     actionability_context_fields: tuple[str, ...] = ()
+    # Source columns to strip before a record reaches a log line, for columns carrying more identity
+    # than the emitter keeps on `extra` (e.g. GitHub's nested user object, of which only the handle
+    # survives). The shared pipeline logs whole records when an emitter fails.
+    unloggable_fields: tuple[str, ...] = ()
     # LLM prompt to summarize descriptions that exceed the threshold. If None, no summarization is performed.
     summarization_prompt: str | None = None
     # How large the description can be before emitting

--- a/products/signals/backend/emission/tests/conftest.py
+++ b/products/signals/backend/emission/tests/conftest.py
@@ -18,6 +18,10 @@ MOCK_GITHUB_ISSUE_RECORD: dict = {
     "updated_at": "2025-06-11T09:15:00Z",
     "comments": 3,
     "locked": False,
+    "author_association": "CONTRIBUTOR",
+    # The warehouse stores GitHub's nested user object as a JSON string. Trimmed to the key the
+    # emitter reads plus ones it must leave behind.
+    "user": '{"login": "octocat", "id": 583231, "type": "User", "avatar_url": "https://example.com/a.png"}',
 }
 
 

--- a/products/signals/backend/emission/tests/test_emit_signals.py
+++ b/products/signals/backend/emission/tests/test_emit_signals.py
@@ -309,6 +309,26 @@ class TestCheckActionability:
         assert "<record_metadata>" not in prompt
 
     @pytest.mark.asyncio
+    async def test_declared_context_survives_the_steered_metadata_cap(self):
+        # A steered gate serializes all of `extra` and truncates it, so declared keys have to lead
+        # the block. Ordered behind a record's labels they fall off the end and the gate goes blind.
+        mock_client = MagicMock()
+        mock_client.messages.create = AsyncMock(return_value=_make_llm_response("ACTIONABLE"))
+        output = _make_output(extra={"labels": ["x" * 100] * 40, "author_login": "octocat"})
+
+        await _check_actionability(
+            mock_client,
+            1,
+            output,
+            "prompt {description}",
+            include_record_metadata=True,
+            context_fields=("author_login",),
+        )
+
+        prompt = mock_client.messages.create.call_args.kwargs["messages"][0]["content"]
+        assert '"author_login": "octocat"' in prompt
+
+    @pytest.mark.asyncio
     async def test_assumes_actionable_after_retries_exhausted(self):
         mock_client = MagicMock()
         mock_client.messages.create = AsyncMock(side_effect=Exception("API error"))

--- a/products/signals/backend/emission/tests/test_emit_signals.py
+++ b/products/signals/backend/emission/tests/test_emit_signals.py
@@ -74,14 +74,16 @@ def _make_llm_response(content: str | None, stop_reason: str = "end_turn") -> Ma
     return response
 
 
-def _make_output(source_id: str = "1", description: str = "test signal") -> SignalEmitterOutput:
+def _make_output(
+    source_id: str = "1", description: str = "test signal", extra: dict[str, Any] | None = None
+) -> SignalEmitterOutput:
     return SignalEmitterOutput(
         source_product="test_product",
         source_type="test",
         source_id=source_id,
         description=description,
         weight=0.5,
-        extra={},
+        extra=extra or {},
     )
 
 
@@ -274,6 +276,37 @@ class TestCheckActionability:
         is_actionable = await _check_actionability(mock_client, 1, output, "Is this actionable? {description}")
 
         assert is_actionable is expected
+
+    @pytest.mark.asyncio
+    async def test_declared_context_fields_reach_an_unsteered_gate(self):
+        # The gate decides before a signal exists, so anything it needs beyond the description has to
+        # be threaded from the source config. Without this the GitHub gate can't see who filed an
+        # issue, and a bot's dependency bump is indistinguishable from a maintainer's bug report.
+        mock_client = MagicMock()
+        mock_client.messages.create = AsyncMock(return_value=_make_llm_response("ACTIONABLE"))
+        output = _make_output(extra={"author_login": "dependabot[bot]", "state": "open"})
+
+        await _check_actionability(mock_client, 1, output, "prompt {description}", context_fields=("author_login",))
+
+        prompt = mock_client.messages.create.call_args.kwargs["messages"][0]["content"]
+        assert '"author_login": "dependabot[bot]"' in prompt
+        # Undeclared keys stay out, so a source widens its prompt only where it asked to.
+        assert "state" not in prompt
+
+    @pytest.mark.asyncio
+    async def test_declared_context_field_without_a_value_is_omitted(self):
+        # A rendered `"author_login": null` reads to the model as a fact about the author rather than
+        # as an absent field, so an unknown author must leave the block out entirely.
+        mock_client = MagicMock()
+        mock_client.messages.create = AsyncMock(return_value=_make_llm_response("ACTIONABLE"))
+        output = _make_output(extra={"author_login": None, "author_association": None})
+
+        await _check_actionability(
+            mock_client, 1, output, "prompt {description}", context_fields=("author_login", "author_association")
+        )
+
+        prompt = mock_client.messages.create.call_args.kwargs["messages"][0]["content"]
+        assert "<record_metadata>" not in prompt
 
     @pytest.mark.asyncio
     async def test_assumes_actionable_after_retries_exhausted(self):

--- a/products/signals/backend/emission/tests/test_github_issues.py
+++ b/products/signals/backend/emission/tests/test_github_issues.py
@@ -2,8 +2,12 @@ import pytest
 from unittest.mock import patch
 
 from products.signals.backend.contracts import GithubIssueSignalExtra
-from products.signals.backend.emission import github_issues as github_issues_module
+from products.signals.backend.emission import (
+    github_issues as github_issues_module,
+    pipeline,
+)
 from products.signals.backend.emission.github_issues import EXTRA_FIELDS, GITHUB_ISSUES_CONFIG, github_issue_emitter
+from products.signals.backend.emission.pipeline import build_emitter_outputs
 
 
 class TestGithubIssueEmitter:
@@ -91,8 +95,8 @@ class TestGithubIssueEmitter:
         ],
     )
     def test_author_degrades_to_none_without_raising(self, github_issue_record, record_overrides):
-        # Both keys are required by the contract, so an author the emitter can't read has to become
-        # None rather than drop the issue or fail validation downstream.
+        # An author the emitter can't read has to become None rather than drop the issue, so a shape
+        # change upstream costs triage the context and nothing else.
         github_issue_record.pop("user")
         github_issue_record.pop("author_association")
         github_issue_record.update(record_overrides)
@@ -112,6 +116,22 @@ class TestGithubIssueEmitter:
             github_issue_emitter(team_id=1, record=github_issue_record)
 
         assert "user" not in log_info.call_args.kwargs["record"]
+
+    def test_a_failed_record_reaches_the_pipeline_log_without_the_user_object(self, github_issue_record):
+        # The emitter raises on malformed labels, and the shared pipeline logs the record it handed
+        # over — the whole warehouse row, unless the source declares `user` unloggable.
+        github_issue_record["labels"] = "not-json"
+
+        with patch.object(pipeline.logger, "exception") as log_exception:
+            _, error_count = build_emitter_outputs(
+                team_id=1,
+                records=[github_issue_record],
+                emitter=GITHUB_ISSUES_CONFIG.emitter,
+                unloggable_fields=GITHUB_ISSUES_CONFIG.unloggable_fields,
+            )
+
+        assert error_count == 1
+        assert "user" not in log_exception.call_args.kwargs["record"]
 
     def test_labels_parsed_from_json_string(self, github_issue_record):
         result = github_issue_emitter(team_id=1, record=github_issue_record)

--- a/products/signals/backend/emission/tests/test_github_issues.py
+++ b/products/signals/backend/emission/tests/test_github_issues.py
@@ -1,6 +1,8 @@
 import pytest
+from unittest.mock import patch
 
 from products.signals.backend.contracts import GithubIssueSignalExtra
+from products.signals.backend.emission import github_issues as github_issues_module
 from products.signals.backend.emission.github_issues import EXTRA_FIELDS, GITHUB_ISSUES_CONFIG, github_issue_emitter
 
 
@@ -100,6 +102,16 @@ class TestGithubIssueEmitter:
         assert result is not None
         assert result.extra["author_login"] is None
         assert result.extra["author_association"] is None
+
+    def test_logged_records_leave_the_user_object_out(self, github_issue_record):
+        # The record reaches the logs on every skipped or malformed issue, and the nested user object
+        # carries a numeric id and avatar URLs that identify a person well beyond the handle.
+        github_issue_record["body"] = ""
+
+        with patch.object(github_issues_module.logger, "info") as log_info:
+            github_issue_emitter(team_id=1, record=github_issue_record)
+
+        assert "user" not in log_info.call_args.kwargs["record"]
 
     def test_labels_parsed_from_json_string(self, github_issue_record):
         result = github_issue_emitter(team_id=1, record=github_issue_record)

--- a/products/signals/backend/emission/tests/test_github_issues.py
+++ b/products/signals/backend/emission/tests/test_github_issues.py
@@ -1,5 +1,6 @@
 import pytest
 
+from products.signals.backend.contracts import GithubIssueSignalExtra
 from products.signals.backend.emission.github_issues import EXTRA_FIELDS, GITHUB_ISSUES_CONFIG, github_issue_emitter
 
 
@@ -58,6 +59,47 @@ class TestGithubIssueEmitter:
         assert result is not None
         assert result.extra["html_url"] == "https://github.com/acme/analytics/issues/87"
         assert result.extra["number"] == 87
+
+    def test_author_lifted_out_of_nested_user_object(self, github_issue_record):
+        result = github_issue_emitter(team_id=1, record=github_issue_record)
+
+        assert result is not None
+        assert result.extra["author_login"] == "octocat"
+        assert result.extra["author_association"] == "CONTRIBUTOR"
+        # The rest of the user object is avatar and API URLs; only the handle belongs in `extra`.
+        assert "user" not in result.extra
+
+    def test_author_satisfies_extra_contract(self, github_issue_record):
+        # The eval fixtures predate the author columns, so this is the only coverage of a populated
+        # author against a contract that forbids unknown keys.
+        result = github_issue_emitter(team_id=1, record=github_issue_record)
+
+        assert result is not None
+        GithubIssueSignalExtra(**result.extra)
+
+    @pytest.mark.parametrize(
+        "record_overrides",
+        [
+            pytest.param({}, id="columns_absent"),
+            pytest.param({"user": None, "author_association": None}, id="null_columns"),
+            pytest.param({"user": "not-json"}, id="unparseable_user"),
+            pytest.param({"user": '["not", "an", "object"]'}, id="non_object_user"),
+            pytest.param({"user": '{"id": 583231}'}, id="user_without_login"),
+            pytest.param({"author_association": ""}, id="blank_association"),
+        ],
+    )
+    def test_author_degrades_to_none_without_raising(self, github_issue_record, record_overrides):
+        # Both keys are required by the contract, so an author the emitter can't read has to become
+        # None rather than drop the issue or fail validation downstream.
+        github_issue_record.pop("user")
+        github_issue_record.pop("author_association")
+        github_issue_record.update(record_overrides)
+
+        result = github_issue_emitter(team_id=1, record=github_issue_record)
+
+        assert result is not None
+        assert result.extra["author_login"] is None
+        assert result.extra["author_association"] is None
 
     def test_labels_parsed_from_json_string(self, github_issue_record):
         result = github_issue_emitter(team_id=1, record=github_issue_record)

--- a/products/signals/backend/facade/api.py
+++ b/products/signals/backend/facade/api.py
@@ -342,12 +342,19 @@ def set_sources(team_id: int, user_id: int | None, selected_keys: list[str]) -> 
 # the product output rather than an arbitrary nested blob; see `scout_harness/tools/report.py`.
 _MAX_TELEMETRY_STR_LEN = 256
 
+# Keys that name a person rather than attribute a signal. A source may carry one on `extra` because
+# triage needs it (a GitHub issue's `author_login` separates a maintainer's report from a stranger's),
+# but no lifecycle event needs the identity, so the scalar passthrough drops it.
+_TELEMETRY_EXCLUDED_EXTRA_KEYS = frozenset({"author_login"})
+
 
 def _telemetry_props_from_extra(extra: dict | None) -> dict:
     if not extra:
         return {}
     props: dict = {}
     for key, value in extra.items():
+        if key in _TELEMETRY_EXCLUDED_EXTRA_KEYS:
+            continue
         if isinstance(value, str):
             props[key] = value[:_MAX_TELEMETRY_STR_LEN]
         elif isinstance(value, (bool, int, float)):

--- a/products/signals/backend/test/test_api.py
+++ b/products/signals/backend/test/test_api.py
@@ -306,6 +306,7 @@ class TestTelemetryPropsFromExtra:
                 "labels": ["bug", "p1"],  # list — dropped
                 "references": [{"queryText": "SELECT * FROM customers"}],  # nested — dropped
                 "time_range": {"date_from": "a", "date_to": "b"},  # dict — dropped
+                "author_login": "octocat",  # identifies a person — dropped
             }
         )
         assert props == {"scout_run_id": "run-1", "number": 42, "confidence": 0.9, "locked": False}

--- a/products/signals/eval/eval_grouping_e2e.py
+++ b/products/signals/eval/eval_grouping_e2e.py
@@ -296,7 +296,11 @@ class EvalGroupingPipeline:
 
         if config.actionability_prompt:
             is_actionable = await _check_actionability(
-                self.gateway_client, EVAL_TEAM_ID, output, config.actionability_prompt
+                self.gateway_client,
+                EVAL_TEAM_ID,
+                output,
+                config.actionability_prompt,
+                context_fields=config.actionability_context_fields,
             )
             await self._capture_pre_emit_actionability(case, None, is_actionable)
             if not is_actionable:

--- a/products/signals/frontend/generated/api.schemas.ts
+++ b/products/signals/frontend/generated/api.schemas.ts
@@ -839,6 +839,8 @@ export interface GithubIssueSignalExtraApi {
     updated_at: string
     locked: boolean
     state: string
+    author_login: string | null
+    author_association: string | null
 }
 
 export interface LinearIssueSignalExtraApi {

--- a/products/signals/frontend/generated/api.schemas.ts
+++ b/products/signals/frontend/generated/api.schemas.ts
@@ -839,8 +839,8 @@ export interface GithubIssueSignalExtraApi {
     updated_at: string
     locked: boolean
     state: string
-    author_login: string | null
-    author_association: string | null
+    author_login?: string | null
+    author_association?: string | null
 }
 
 export interface LinearIssueSignalExtraApi {

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -37462,6 +37462,8 @@ export namespace Schemas {
       updated_at: string;
       locked: boolean;
       state: string;
+      author_login: string | null;
+      author_association: string | null;
     }
 
     export interface GitlabIssueSignalExtra {

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -37462,8 +37462,8 @@ export namespace Schemas {
       updated_at: string;
       locked: boolean;
       state: string;
-      author_login: string | null;
-      author_association: string | null;
+      author_login?: string | null;
+      author_association?: string | null;
     }
 
     export interface GitlabIssueSignalExtra {


### PR DESCRIPTION
## Problem

Triage on a GitHub-sourced signal can't tell a maintainer's bug report from a drive-by report by a stranger on a public repo — the author never reaches the signal.

- `github_issues.py` SELECTs a strict column allowlist, and the author wasn't in it, so `extra` carried no handle and no repo relationship.
- Everything downstream reads that allowlist. `_render_extra_to_text` renders `extra` into the research agent's prompt, so the agent assessing actionability and priority saw the issue title, body, labels, state, and timestamps — and nothing about who filed it.
- The actionability gate was blinder still. It runs before a signal exists and only ever saw the description, so even metadata that was on `extra` never reached the point where records get filtered.
- `GithubIssueSignalExtra` sets `extra="forbid"`, so the omission was locked in rather than incidental.

## Changes

- A GitHub issue signal's `extra` now carries `author_login` and `author_association`. The research agent picks both up with no prompt change, since it renders every `extra` key.
- The actionability gate sees them too. Sources declare which `extra` keys their gate needs via a new `actionability_context_fields`, and those arrive in the same `<record_metadata>` block steered teams already get, substituted through the `{description}` placeholder so values are never format-processed. A source declaring nothing keeps a byte-identical prompt, so only GitHub's gate widens here.
- GitHub's prompt explains what `author_association` means and that a `[bot]` handle marks automation. It also guards the obvious misread: an outside reporter's bug report is exactly the feedback worth capturing, so the author is context and never a verdict on its own.
- `author_association` is GitHub's own enum (`OWNER`, `MEMBER`, `COLLABORATOR`, `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, `FIRST_TIMER`, `MANNEQUIN`, `NONE`), typed as a plain string so a value GitHub adds later widens the taxonomy instead of failing validation and dropping the signal.
- `author_login` is lifted out of the nested `user` object. The rest of that object is avatar and API URLs, so it is SELECTed and dropped rather than copied into `extra` — that split is why `EXTRA_FIELDS` is now derived from `PASSTHROUGH_FIELDS` plus the two author keys.
- `author_login` and `author_association` default to `None` on the contract, so a payload emitted before these columns existed still validates.
- Logs of a GitHub issue record drop the nested `user` object, keeping its numeric id and its avatar and API URLs out of application logs. A source declares such columns in `unloggable_fields`, which the shared pipeline strips before logging a record its emitter rejected.
- Emission telemetry drops `author_login`. The `extra` passthrough copies every top-level scalar onto the lifecycle events, and those events need the attribution rather than the identity.
- The grouping eval passes the source's declared context fields, so it measures the gate production runs.
- Declared context leads the `<record_metadata>` block, so the gate's 2,000-character cap trims a record's other metadata first.
- An author the emitter can't read degrades to `None` instead of raising, unlike `labels`. The author is context for triage, not something the signal is meaningless without, so a shape change upstream must not drop actionable issues.
- Records the author carve-out in the emission PII guidance, which otherwise tells the next author to keep identifying fields out. Without that note the fields read like a mistake.
- Regenerated OpenAPI types are the last two files and are mechanical.

Deliberately not in this PR, each a reasonable follow-up:

- No deterministic bot drop. A `[bot]` handle is now legible to the gate, but skipping the LLM call entirely for automation is a filtering change worth its own review.
- `weight` stays at `1.0`, so ranking does not yet favor maintainers.
- The inbox card shows no author, so human triagers still don't see it in the UI.
- The shared warehouse fetcher still can't tolerate a column a schema's `enabled_columns` omits. It fails the same way today for `labels` or `state`, so widening it belongs with the fetcher.

## How did you test this code?

Automated, run locally — `products/signals/backend/emission/tests/` and `products/signals/backend/test/test_api.py` pass in full, 511 tests. The four `test_api.py` failures CI reported on the first pass are the ones the contract defaults fix.

New tests and the regression each catches:

- The author arriving as a JSON string in the nested `user` column. A naive passthrough would put the whole blob in `extra`.
- A record with no author still satisfying a contract that forbids unknown keys. The eval fixtures predate these columns, so they only exercise the absent-author path.
- Declared context fields surviving the three hops from source config to rendered gate prompt. If any hop is dropped the gate goes blind again, silently.
- A declared key with no value being omitted rather than rendered as `"author_login": null`, which reads to the model as a fact about the author instead of an absent field.
- Declared context surviving the steered gate's 2,000-character cap. A record with heavy labels used to push the author off the end.
- A record its emitter rejected reaching the shared pipeline's log without the `user` object. The emitter rethrows, so redacting inside it alone left the blob in the logs.
- A logged record leaving the `user` object out. The emitter logs the whole record on every skipped or malformed issue.
- `author_login` staying out of telemetry props, added to the existing `extra`-passthrough case rather than as a new test.

The byte-identical guarantee for undeclared sources is already covered by the existing `test_without_source_config_prompt_is_unchanged`.

Verified by hand:

- Rendered the real GitHub gate prompt through `_declared_context` and confirmed the `<record_metadata>` block lands inside the `<issue>` tags with the author pair, and that the posture line steering anchors on is intact.
- Ran the exact HogQL select list the fetcher now builds against a synced `github.<repo>.issues` warehouse table, confirming the added `user` and `author_association` columns resolve and that `author_association` distinguishes org members from outside reporters on real rows. `user` was the risk — a bare column of that name could have collided in HogQL.
- Confirmed the raw records never cross a Temporal activity boundary (`emit_data_import_signals_activity` fetches and runs the pipeline in one activity), so pulling the larger `user` blob doesn't move the payload toward the 2 MB limit.
- `uv run mypy --cache-fine-grained .` is clean repo-wide.

Not checked:

- The pipeline end to end. Summarization, the actionability gate, and emission need LLM and Temporal, which this environment doesn't have, so the gate's new prompt has not been run against a real model.
- `pnpm --filter=@posthog/mcp run typecheck` fails on 83 pre-existing `Cannot find module '@posthog/quill'` errors because the nested quill workspace isn't built. None reference the generated types or signals.
- The frontend generated types were produced by a local schema build that came out lossy for other products. Only the signals file's diff matched the checked-in state exactly, so that one was kept and the rest reverted; the MCP type was edited to the shape the generator produces for an identical `str | None = None` contract field (see `SessionProblemSignalExtra`).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`products/signals/backend/emission/AGENTS.md` covers both the new gate knob and the author carve-out in the PII guidance.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app, prompted from a Slack thread asking whether the signals pipeline can see who created a GitHub issue when deciding whether to action it. It could not, at any stage.

Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

Decisions worth a reviewer's attention:

- The first pass only put the author on `extra`, which reaches the research agent but not the gate. Extending the gate came second, and the per-source declaration was chosen over flipping the existing steered-only metadata block on for everyone, which would have changed roughly fifty prompts at once.
- Putting the author in the `description` instead was rejected. That text is embedded for semantic search and grouping, so author handles in it would degrade dedupe across people reporting the same bug.
- Still no behavior change to filtering or ranking. Dropping bot-authored issues and weighting by `author_association` both came up and were left out as separate concerns.
- `author_login` is a public GitHub handle, but it cuts against the emission guidance to keep identifying fields out of signals, so the carve-out is documented next to the rule it bends.
- Two rounds answered the bot review: the contract defaults, the log redaction across both paths, the metadata ordering, the telemetry exclusion, and the eval wiring are all fixes to this PR's own earlier passes. Two findings are answered in their threads instead: the `enabled_columns` fragility belongs to the shared fetcher, and seeding authors into the grouping eval's cases is a dataset decision.
- The grouping eval's cases still carry no author, so the eval's rendered prompt is unchanged today. The wiring fix is what keeps it honest once they do.
- Nothing from the originating thread reached the diff or this description; the test fixture author is an invented handle.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1786953058169079)*


