### PR TITLE
fix(frontend): refresh currentOrganization after project/team creation

### DIFF
--- a/frontend/src/scenes/projectLogic.test.ts
+++ b/frontend/src/scenes/projectLogic.test.ts
@@ -1,0 +1,63 @@
+import { MOCK_DEFAULT_ORGANIZATION, MOCK_DEFAULT_PROJECT, MOCK_ORGANIZATION_ID } from 'lib/api.mock'
+
+import { expectLogic } from 'kea-test-utils'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+
+import { organizationLogic } from './organizationLogic'
+import { projectLogic } from './projectLogic'
+
+describe('projectLogic', () => {
+    let logic: ReturnType<typeof projectLogic.build>
+
+    describe('createProject', () => {
+        const newProject = {
+            ...MOCK_DEFAULT_PROJECT,
+            id: MOCK_DEFAULT_PROJECT.id + 1,
+            name: 'Brand new project',
+        }
+
+        beforeEach(() => {
+            useMocks({
+                post: {
+                    '/api/projects/': () => [200, newProject],
+                },
+                get: {
+                    '/api/organizations/@current': () => [
+                        200,
+                        {
+                            ...MOCK_DEFAULT_ORGANIZATION,
+                            teams: [...MOCK_DEFAULT_ORGANIZATION.teams!, newProject],
+                            projects: [...MOCK_DEFAULT_ORGANIZATION.projects!, newProject],
+                        },
+                    ],
+                },
+            })
+            initKeaTests()
+            logic = projectLogic()
+            logic.mount()
+            organizationLogic.mount()
+        })
+
+        it('refreshes currentOrganization so the new project appears without a page reload', async () => {
+            expect(organizationLogic.values.currentOrganization?.teams?.map((t) => t.id)).toEqual([
+                MOCK_DEFAULT_PROJECT.id,
+            ])
+
+            await expectLogic(logic, () => {
+                logic.actions.createProject({ name: 'Brand new project' })
+            }).toDispatchActions([
+                'createProjectSuccess',
+                organizationLogic.actionTypes.loadCurrentOrganization,
+                organizationLogic.actionTypes.loadCurrentOrganizationSuccess,
+            ])
+
+            expect(organizationLogic.values.currentOrganization?.id).toBe(MOCK_ORGANIZATION_ID)
+            expect(organizationLogic.values.currentOrganization?.teams?.map((t) => t.id)).toEqual([
+                MOCK_DEFAULT_PROJECT.id,
+                newProject.id,
+            ])
+        })
+    })
+})

--- a/frontend/src/scenes/projectLogic.ts
+++ b/frontend/src/scenes/projectLogic.ts
@@ -312,6 +312,9 @@ export const projectLogic = kea<projectLogicType>([
         },
         createProjectSuccess: ({ currentProject }) => {
             if (currentProject) {
+                // Refresh currentOrganization (which lists its projects) so the project switcher
+                // shows the new project even if it's reopened before switchTeam's page navigation lands.
+                actions.loadCurrentOrganization()
                 actions.switchTeam(currentProject.id, urls.projectHomepage())
             }
         },

--- a/frontend/src/scenes/teamLogic.test.ts
+++ b/frontend/src/scenes/teamLogic.test.ts
@@ -1,4 +1,4 @@
-import { MOCK_DEFAULT_PROJECT, MOCK_DEFAULT_TEAM, MOCK_TEAM_ID } from 'lib/api.mock'
+import { MOCK_DEFAULT_ORGANIZATION, MOCK_DEFAULT_PROJECT, MOCK_DEFAULT_TEAM, MOCK_TEAM_ID } from 'lib/api.mock'
 
 import { expectLogic } from 'kea-test-utils'
 
@@ -7,6 +7,7 @@ import { ProductIntentContext, ProductKey } from '~/queries/schema/schema-genera
 import { initKeaTests } from '~/test/init'
 import { AppContext, TeamType } from '~/types'
 
+import { organizationLogic } from './organizationLogic'
 import { projectLogic } from './projectLogic'
 import { teamLogic } from './teamLogic'
 
@@ -157,6 +158,53 @@ describe('teamLogic', () => {
                 product_type: ProductKey.ERROR_TRACKING,
                 intent_context: ProductIntentContext.ONBOARDING_PRODUCT_SELECTED_PRIMARY,
             })
+        })
+    })
+
+    describe('createTeam', () => {
+        const newTeam = {
+            ...MOCK_DEFAULT_TEAM,
+            id: MOCK_TEAM_ID + 1,
+            name: 'Brand new environment',
+        }
+
+        beforeEach(() => {
+            useMocks({
+                post: {
+                    '/api/projects/:id/environments/': () => [200, newTeam],
+                },
+                get: {
+                    '/api/organizations/@current': () => [
+                        200,
+                        {
+                            ...MOCK_DEFAULT_ORGANIZATION,
+                            teams: [...MOCK_DEFAULT_ORGANIZATION.teams!, newTeam],
+                        },
+                    ],
+                },
+            })
+            initKeaTests()
+            logic = teamLogic()
+            logic.mount()
+            organizationLogic.mount()
+        })
+
+        it('refreshes currentOrganization so the new team appears without a page reload', async () => {
+            await expectLogic(logic).toDispatchActions(['loadCurrentTeamSuccess'])
+            expect(organizationLogic.values.currentOrganization?.teams?.map((t) => t.id)).toEqual([MOCK_TEAM_ID])
+
+            await expectLogic(logic, () => {
+                logic.actions.createTeam({ name: 'Brand new environment', is_demo: false })
+            }).toDispatchActions([
+                'createTeamSuccess',
+                organizationLogic.actionTypes.loadCurrentOrganization,
+                organizationLogic.actionTypes.loadCurrentOrganizationSuccess,
+            ])
+
+            expect(organizationLogic.values.currentOrganization?.teams?.map((t) => t.id)).toEqual([
+                MOCK_TEAM_ID,
+                newTeam.id,
+            ])
         })
     })
 

--- a/frontend/src/scenes/teamLogic.tsx
+++ b/frontend/src/scenes/teamLogic.tsx
@@ -637,6 +637,9 @@ export const teamLogic = kea<teamLogicType>([
         },
         createTeamSuccess: ({ currentTeam }) => {
             if (currentTeam) {
+                // Refresh currentOrganization (which lists its teams) so the project switcher
+                // shows the new environment even if it's reopened before switchTeam's page navigation lands.
+                actions.loadCurrentOrganization()
                 actions.switchTeam(currentTeam.id)
             }
         },


### PR DESCRIPTION
Fixes #26150

`createProjectSuccess` and `createTeamSuccess` relied solely on `switchTeam`'s page navigation to eventually reflect a newly created project/team in the project switcher — `organizationLogic`'s `currentOrganization.teams`/`projects` was never updated directly, so a manual browser refresh was needed before the new project/environment showed up.

## Fix
Dispatch `organizationLogic.actions.loadCurrentOrganization()` from both success listeners, so the switcher updates immediately rather than depending on `switchTeam`'s navigation timing (and works correctly even if that navigation is interrupted/reopened before it lands).

## Test plan
- Added `frontend/src/scenes/projectLogic.test.ts` (new) — asserts `currentOrganization.teams` includes the new project immediately after `createProjectSuccess`, via the `loadCurrentOrganization`/`loadCurrentOrganizationSuccess` action sequence.
- Updated `frontend/src/scenes/teamLogic.test.ts` — added the equivalent case for `createTeamSuccess`.
- Could not execute the Jest suite in this environment (pnpm workspace test filter timed out resolving in the available shell) — tests are written against the existing `kea-test-utils`/`useMocks` conventions used by adjacent tests in the same files, but unverified locally. Flagging this explicitly for CI/review rather than claiming a pass I didn't observe.