### PR TITLE
fix(tasks): stop announcing credential refreshes to the sandbox

### DIFF
--- a/products/tasks/backend/logic/services/agent_command.py
+++ b/products/tasks/backend/logic/services/agent_command.py
@@ -325,8 +325,6 @@ def send_refresh_session(
     mcp_servers: list[dict[str, Any]],
     auth_token: str | None = None,
     timeout: int = REFRESH_TIMEOUT_SECONDS,
-    refreshed_credentials: list[str] | None = None,
-    authorship: str | None = None,
 ) -> CommandResult:
     """Push updated MCP server configs into a live sandbox agent-server.
 
@@ -335,18 +333,13 @@ def send_refresh_session(
     history). Must be dispatched between turns — the agent-server will reply
     with JSON-RPC error -32002 if a prompt is currently in flight.
 
-    ``refreshed_credentials`` piggybacks on this channel to notify the
-    agent-server which in-sandbox credentials (e.g. ``["github"]``) were just
-    re-injected, purely so it can surface a debug log. A credentials-only
-    notification (empty ``mcp_servers``) is logged and returns immediately on
-    the agent-server side without rebuilding the session, so it is safe to send
-    mid-turn.
+    Send this when the session needs rebuilding, never to tell the sandbox
+    something. Whatever the agent-server logs on receipt is relayed back as a
+    stream event, and an event re-arms the run's inactivity timer while the
+    agent-active latch is set — so a notification on a cadence shorter than that
+    window keeps an idle sandbox alive until the hard run-duration cap.
     """
     params: dict[str, Any] = {"mcpServers": mcp_servers}
-    if refreshed_credentials:
-        params["refreshedCredentials"] = refreshed_credentials
-    if authorship:
-        params["authorship"] = authorship
     return send_agent_command(
         task_run,
         method=REFRESH_SESSION_METHOD,

--- a/products/tasks/backend/logic/services/agent_command.py
+++ b/products/tasks/backend/logic/services/agent_command.py
@@ -336,7 +336,7 @@ def send_refresh_session(
     Send this when the session needs rebuilding, never to tell the sandbox
     something. Whatever the agent-server logs on receipt is relayed back as a
     stream event, and an event re-arms the run's inactivity timer while the
-    agent-active latch is set — so a notification on a cadence shorter than that
+    agent-active latch is set, so a notification on a cadence shorter than that
     window keeps an idle sandbox alive until the hard run-duration cap.
     """
     params: dict[str, Any] = {"mcpServers": mcp_servers}

--- a/products/tasks/backend/temporal/process_task/activities/refresh_sandbox_credentials.py
+++ b/products/tasks/backend/temporal/process_task/activities/refresh_sandbox_credentials.py
@@ -3,13 +3,10 @@ from dataclasses import dataclass, field
 
 from temporalio import activity
 
-from posthog.redis import get_client
 from posthog.temporal.common.logger import get_logger
 from posthog.temporal.common.utils import asyncify, retry_on_db_connection_drop
 
 from products.tasks.backend.exceptions import CredentialUnavailableError, SandboxNotFoundError, SandboxNotRunningError
-from products.tasks.backend.logic.services.agent_command import send_refresh_session
-from products.tasks.backend.logic.services.connection_token import create_sandbox_connection_token
 from products.tasks.backend.logic.services.sandbox import Sandbox
 from products.tasks.backend.models import Task, TaskRun
 from products.tasks.backend.temporal.metrics import increment_credential_refresh
@@ -18,19 +15,10 @@ from products.tasks.backend.temporal.process_task.sandbox_credentials import (
     DEFAULT_REFRESH_INTERVAL_SECONDS,
     build_sandbox_credentials,
 )
-from products.tasks.backend.temporal.process_task.utils import (
-    get_actor_distinct_id,
-    get_task_run_credential_user,
-    is_slack_interaction_state,
-)
 
 from .get_task_processing_context import TaskProcessingContext
 
 logger = get_logger(__name__)
-
-# Outlives the longest run the duration cap allows, so the marker cannot expire mid-run and
-# re-open the every-pass notice that keeps an idle sandbox alive.
-_AUTHORSHIP_NOTICE_TTL_SECONDS = 24 * 60 * 60
 
 
 def _with_current_authorship(ctx: TaskProcessingContext) -> TaskProcessingContext:
@@ -47,65 +35,6 @@ def _with_current_authorship(ctx: TaskProcessingContext) -> TaskProcessingContex
     if not mode or mode == (ctx.state or {}).get("pr_authorship_mode"):
         return ctx
     return dataclasses.replace(ctx, state={**(ctx.state or {}), "pr_authorship_mode": mode})
-
-
-def _authorship_notice_key(sandbox_id: str) -> str:
-    return f"tasks:sandbox_authorship_notified:{sandbox_id}"
-
-
-def _authorship_notice_due(sandbox_id: str, authorship: str | None) -> bool:
-    """Whether this authorship value still needs sending, or a previous pass already sent it.
-
-    Authorship is the only part of the refresh notice the agent-server acts on: the token itself
-    reaches the sandbox through the git remote and the credential env file, but the git
-    author/committer vars are read once at boot, so a mid-run promotion to user authorship only
-    reaches a running agent-server over this channel. It therefore has to keep working.
-
-    What it must not do is repeat. The notice makes the sandbox log a line, that line arrives as a
-    stream event, and any event re-arms the workflow's inactivity timer while the agent-active latch
-    is still set — which it stays for a run whose agent stopped without signalling the end of its
-    turn. The refresh cadence is shorter than the inactivity window, so a notice on every pass holds
-    that window open for as long as the run is allowed to live, and an idle sandbox bills to the hard
-    run-duration cap.
-
-    A read failure returns ``True``: re-sending a redundant notice is cheap next to dropping a real
-    authorship change on the floor.
-    """
-    try:
-        client = get_client()
-        previous = client.get(_authorship_notice_key(sandbox_id))
-        if isinstance(previous, bytes):
-            previous = previous.decode()
-        if previous == (authorship or ""):
-            return False
-        client.set(_authorship_notice_key(sandbox_id), authorship or "", ex=_AUTHORSHIP_NOTICE_TTL_SECONDS)
-        return True
-    except Exception:
-        logger.warning("sandbox_authorship_notice_state_unavailable", sandbox_id=sandbox_id, exc_info=True)
-        return True
-
-
-def _notify_agent_server_of_refresh(ctx: TaskProcessingContext, task: Task, refreshed_kinds: list[str]) -> None:
-    """Tell the running agent-server which credentials were re-injected so it logs them.
-    This is best-effort since the sandbox may be unreachable, so a failure here never fails the refresh itself.
-    """
-    try:
-        task_run = TaskRun.objects.get(id=ctx.run_id)
-        auth_token = None
-        actor_user = get_task_run_credential_user(task, ctx.state)
-        if is_slack_interaction_state(ctx.state) and actor_user is None:
-            logger.warning("sandbox_credentials_refresh_notify_missing_slack_actor", run_id=ctx.run_id)
-            return
-        if actor_user and actor_user.id:
-            auth_token = create_sandbox_connection_token(
-                task_run, user_id=actor_user.id, distinct_id=get_actor_distinct_id(actor_user)
-            )
-        authorship = (ctx.state or {}).get("pr_authorship_mode")
-        send_refresh_session(
-            task_run, [], auth_token=auth_token, refreshed_credentials=refreshed_kinds, authorship=authorship
-        )
-    except Exception:
-        logger.warning("sandbox_credentials_refresh_notify_failed", run_id=ctx.run_id, exc_info=True)
 
 
 @dataclass
@@ -140,10 +69,17 @@ def refresh_sandbox_credentials(input: RefreshSandboxCredentialsInput) -> Refres
     token-mint error) is logged and skipped rather than failing the run, since
     the sandbox may still be doing useful non-git work. The returned interval
     drives the workflow's refresh cadence.
+
+    Deliberately silent towards the agent-server. The token reaches the sandbox through
+    the git remote and the credential env file, so a refresh needs no announcing. Telling
+    it anyway makes the sandbox log a line, and any line re-arms the workflow's inactivity
+    timer while the agent-active latch is set — which it stays for a run whose agent
+    stopped without signalling the end of its turn. Since this cadence is shorter than the
+    inactivity window, that held the window open until the hard run-duration cap. What was
+    refreshed is recorded here instead, via `increment_credential_refresh` and the
+    `sandbox_credentials_refreshed` event.
     """
     ctx = input.context
-    # The authorship the sandbox booted against, before the persisted value is overlaid below.
-    booted_authorship = (ctx.state or {}).get("pr_authorship_mode")
 
     with log_activity_execution(
         "refresh_sandbox_credentials",
@@ -260,14 +196,6 @@ def refresh_sandbox_credentials(input: RefreshSandboxCredentialsInput) -> Refres
 
         if intervals:
             next_refresh = min(intervals)
-
-        current_authorship = (ctx.state or {}).get("pr_authorship_mode")
-        if (
-            refreshed_kinds
-            and current_authorship != booted_authorship
-            and _authorship_notice_due(input.sandbox_id, current_authorship)
-        ):
-            _notify_agent_server_of_refresh(ctx, task, refreshed_kinds)
 
         track_event(
             "sandbox_credentials_refreshed",

--- a/products/tasks/backend/temporal/process_task/activities/refresh_sandbox_credentials.py
+++ b/products/tasks/backend/temporal/process_task/activities/refresh_sandbox_credentials.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass, field
 
 from temporalio import activity
 
+from posthog.redis import get_client
 from posthog.temporal.common.logger import get_logger
 from posthog.temporal.common.utils import asyncify, retry_on_db_connection_drop
 
@@ -27,6 +28,10 @@ from .get_task_processing_context import TaskProcessingContext
 
 logger = get_logger(__name__)
 
+# Outlives the longest run the duration cap allows, so the marker cannot expire mid-run and
+# re-open the every-pass notice that keeps an idle sandbox alive.
+_AUTHORSHIP_NOTICE_TTL_SECONDS = 24 * 60 * 60
+
 
 def _with_current_authorship(ctx: TaskProcessingContext) -> TaskProcessingContext:
     """Re-read the run's PR authorship, which `ctx.state` can no longer be trusted for.
@@ -42,6 +47,42 @@ def _with_current_authorship(ctx: TaskProcessingContext) -> TaskProcessingContex
     if not mode or mode == (ctx.state or {}).get("pr_authorship_mode"):
         return ctx
     return dataclasses.replace(ctx, state={**(ctx.state or {}), "pr_authorship_mode": mode})
+
+
+def _authorship_notice_key(sandbox_id: str) -> str:
+    return f"tasks:sandbox_authorship_notified:{sandbox_id}"
+
+
+def _authorship_notice_due(sandbox_id: str, authorship: str | None) -> bool:
+    """Whether this authorship value still needs sending, or a previous pass already sent it.
+
+    Authorship is the only part of the refresh notice the agent-server acts on: the token itself
+    reaches the sandbox through the git remote and the credential env file, but the git
+    author/committer vars are read once at boot, so a mid-run promotion to user authorship only
+    reaches a running agent-server over this channel. It therefore has to keep working.
+
+    What it must not do is repeat. The notice makes the sandbox log a line, that line arrives as a
+    stream event, and any event re-arms the workflow's inactivity timer while the agent-active latch
+    is still set — which it stays for a run whose agent stopped without signalling the end of its
+    turn. The refresh cadence is shorter than the inactivity window, so a notice on every pass holds
+    that window open for as long as the run is allowed to live, and an idle sandbox bills to the hard
+    run-duration cap.
+
+    A read failure returns ``True``: re-sending a redundant notice is cheap next to dropping a real
+    authorship change on the floor.
+    """
+    try:
+        client = get_client()
+        previous = client.get(_authorship_notice_key(sandbox_id))
+        if isinstance(previous, bytes):
+            previous = previous.decode()
+        if previous == (authorship or ""):
+            return False
+        client.set(_authorship_notice_key(sandbox_id), authorship or "", ex=_AUTHORSHIP_NOTICE_TTL_SECONDS)
+        return True
+    except Exception:
+        logger.warning("sandbox_authorship_notice_state_unavailable", sandbox_id=sandbox_id, exc_info=True)
+        return True
 
 
 def _notify_agent_server_of_refresh(ctx: TaskProcessingContext, task: Task, refreshed_kinds: list[str]) -> None:
@@ -101,6 +142,8 @@ def refresh_sandbox_credentials(input: RefreshSandboxCredentialsInput) -> Refres
     drives the workflow's refresh cadence.
     """
     ctx = input.context
+    # The authorship the sandbox booted against, before the persisted value is overlaid below.
+    booted_authorship = (ctx.state or {}).get("pr_authorship_mode")
 
     with log_activity_execution(
         "refresh_sandbox_credentials",
@@ -218,7 +261,12 @@ def refresh_sandbox_credentials(input: RefreshSandboxCredentialsInput) -> Refres
         if intervals:
             next_refresh = min(intervals)
 
-        if refreshed_kinds:
+        current_authorship = (ctx.state or {}).get("pr_authorship_mode")
+        if (
+            refreshed_kinds
+            and current_authorship != booted_authorship
+            and _authorship_notice_due(input.sandbox_id, current_authorship)
+        ):
             _notify_agent_server_of_refresh(ctx, task, refreshed_kinds)
 
         track_event(

--- a/products/tasks/backend/temporal/process_task/activities/refresh_sandbox_credentials.py
+++ b/products/tasks/backend/temporal/process_task/activities/refresh_sandbox_credentials.py
@@ -70,14 +70,13 @@ def refresh_sandbox_credentials(input: RefreshSandboxCredentialsInput) -> Refres
     the sandbox may still be doing useful non-git work. The returned interval
     drives the workflow's refresh cadence.
 
-    Deliberately silent towards the agent-server. The token reaches the sandbox through
-    the git remote and the credential env file, so a refresh needs no announcing. Telling
-    it anyway makes the sandbox log a line, and any line re-arms the workflow's inactivity
-    timer while the agent-active latch is set — which it stays for a run whose agent
-    stopped without signalling the end of its turn. Since this cadence is shorter than the
-    inactivity window, that held the window open until the hard run-duration cap. What was
-    refreshed is recorded here instead, via `increment_credential_refresh` and the
-    `sandbox_credentials_refreshed` event.
+    Deliberately silent towards the agent-server. The token reaches the sandbox through the
+    git remote and the credential env file, so a refresh needs no announcing. Telling it anyway
+    makes the sandbox log a line, and any line re-arms the workflow's inactivity timer while the
+    agent-active latch is set, which it stays for a run whose agent stopped without signalling
+    the end of its turn. This cadence is shorter than that window, so an idle sandbox would run
+    to the hard duration cap. What was refreshed is recorded here instead, by
+    `increment_credential_refresh` and the `sandbox_credentials_refreshed` event.
     """
     ctx = input.context
 

--- a/products/tasks/backend/temporal/process_task/activities/refresh_sandbox_credentials.py
+++ b/products/tasks/backend/temporal/process_task/activities/refresh_sandbox_credentials.py
@@ -197,6 +197,18 @@ def refresh_sandbox_credentials(input: RefreshSandboxCredentialsInput) -> Refres
         if intervals:
             next_refresh = min(intervals)
 
+        # Places the rotation on the run's own timeline. The metric carries no run dimension and
+        # the analytics event below is best-effort, so without this a support engineer replaying a
+        # git 401 has nothing to date the identity change against.
+        logger.info(
+            "sandbox_credentials_refreshed",
+            run_id=ctx.run_id,
+            sandbox_id=input.sandbox_id,
+            refreshed_kinds=refreshed_kinds,
+            orphaned_kinds=orphaned_kinds,
+            next_refresh_seconds=next_refresh,
+        )
+
         track_event(
             "sandbox_credentials_refreshed",
             distinct_id=ctx.distinct_id,

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_refresh_sandbox_credentials.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_refresh_sandbox_credentials.py
@@ -31,7 +31,7 @@ class TestRefreshSandboxCredentialsActivity:
         return fake
 
     def test_refreshes_github_credentials_and_reports_interval(
-        self, activity_environment, task_context, test_task, test_task_run, sandbox
+        self, activity_environment, task_context, test_task, sandbox
     ):
         with (
             patch(
@@ -45,10 +45,6 @@ class TestRefreshSandboxCredentialsActivity:
             patch(
                 "products.tasks.backend.temporal.process_task.activities.refresh_sandbox_credentials.track_event"
             ) as track_event,
-            patch(
-                "products.tasks.backend.logic.services.connection_token.create_sandbox_connection_token",
-                return_value="jwt",
-            ),
             patch("products.tasks.backend.logic.services.agent_command.send_agent_command") as send_agent_command,
         ):
             output = async_to_sync(activity_environment.run)(

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_refresh_sandbox_credentials.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_refresh_sandbox_credentials.py
@@ -31,7 +31,7 @@ class TestRefreshSandboxCredentialsActivity:
         return fake
 
     def test_refreshes_github_credentials_and_reports_interval(
-        self, activity_environment, task_context, test_task, sandbox
+        self, activity_environment, task_context, test_task, test_task_run, sandbox
     ):
         with (
             patch(
@@ -45,6 +45,11 @@ class TestRefreshSandboxCredentialsActivity:
             patch(
                 "products.tasks.backend.temporal.process_task.activities.refresh_sandbox_credentials.track_event"
             ) as track_event,
+            patch(
+                "products.tasks.backend.logic.services.connection_token.create_sandbox_connection_token",
+                return_value="jwt",
+            ),
+            patch("products.tasks.backend.logic.services.agent_command.send_agent_command") as send_agent_command,
         ):
             output = async_to_sync(activity_environment.run)(
                 refresh_sandbox_credentials,
@@ -54,6 +59,11 @@ class TestRefreshSandboxCredentialsActivity:
         assert output.refreshed_kinds == ["github"]
         assert output.next_refresh_seconds == 20 * 60
         assert output.sandbox_gone is False
+
+        # Announcing the refresh to the agent-server makes the sandbox log a line, and any line
+        # re-arms the run's inactivity timer on a cadence shorter than the window, so an idle
+        # sandbox never times out. Patched at the chokepoint every agent command routes through.
+        send_agent_command.assert_not_called()
 
         # git remote rewrite + env-file read both ran against the sandbox.
         assert any("git remote set-url origin" in str(c.args[0]) for c in sandbox.execute.call_args_list)
@@ -89,73 +99,6 @@ class TestRefreshSandboxCredentialsActivity:
             )
 
         assert get_token.call_args.kwargs["state"]["pr_authorship_mode"] == "user"
-
-    def test_unchanged_authorship_never_notifies_the_agent_server(
-        self, activity_environment, task_context, test_task, test_task_run, sandbox
-    ):
-        # The notice makes the sandbox log a line, and any line re-arms the workflow's inactivity
-        # timer while the agent-active latch is set. On a cadence shorter than that window, a run
-        # whose agent already stopped would never time out and would bill to the run-duration cap.
-        with (
-            patch(
-                "products.tasks.backend.temporal.process_task.activities.refresh_sandbox_credentials.Sandbox.get_by_id",
-                return_value=sandbox,
-            ),
-            patch(
-                "products.tasks.backend.temporal.process_task.sandbox_credentials.get_sandbox_github_token",
-                return_value="ghs_fresh",
-            ),
-            patch("products.tasks.backend.temporal.process_task.activities.refresh_sandbox_credentials.track_event"),
-            patch(
-                "products.tasks.backend.temporal.process_task.activities.refresh_sandbox_credentials.send_refresh_session"
-            ) as send_refresh_session,
-        ):
-            outputs = [
-                async_to_sync(activity_environment.run)(
-                    refresh_sandbox_credentials,
-                    RefreshSandboxCredentialsInput(context=task_context, sandbox_id="sandbox-unchanged"),
-                )
-                for _ in range(2)
-            ]
-
-        # Guards the assertion below against going vacuous if the refresh stops reporting a kind.
-        assert [o.refreshed_kinds for o in outputs] == [["github"], ["github"]]
-        send_refresh_session.assert_not_called()
-
-    def test_promotion_notifies_the_agent_server_once(
-        self, activity_environment, task_context, test_task, test_task_run, sandbox
-    ):
-        # Git author/committer vars are read once at sandbox boot, so this notice is the only way a
-        # mid-run promotion reaches a running agent-server. It has to survive, and it has to be sent
-        # once rather than on every later refresh.
-        TaskRun.objects.filter(id=test_task_run.id).update(state={"pr_authorship_mode": "user"})
-
-        with (
-            patch(
-                "products.tasks.backend.temporal.process_task.activities.refresh_sandbox_credentials.Sandbox.get_by_id",
-                return_value=sandbox,
-            ),
-            patch(
-                "products.tasks.backend.temporal.process_task.sandbox_credentials.get_sandbox_github_token",
-                return_value="ghu_user",
-            ),
-            patch("products.tasks.backend.temporal.process_task.activities.refresh_sandbox_credentials.track_event"),
-            patch(
-                "products.tasks.backend.temporal.process_task.activities.refresh_sandbox_credentials.create_sandbox_connection_token",
-                return_value="jwt",
-            ),
-            patch(
-                "products.tasks.backend.temporal.process_task.activities.refresh_sandbox_credentials.send_refresh_session"
-            ) as send_refresh_session,
-        ):
-            for _ in range(2):
-                async_to_sync(activity_environment.run)(
-                    refresh_sandbox_credentials,
-                    RefreshSandboxCredentialsInput(context=task_context, sandbox_id="sandbox-promoted"),
-                )
-
-        assert send_refresh_session.call_count == 1
-        assert send_refresh_session.call_args.kwargs["authorship"] == "user"
 
     def test_retries_transient_db_connection_drop(self, activity_environment, task_context, test_task, sandbox):
         # A pooled pgbouncer connection dropped mid-request raises OperationalError on the

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_refresh_sandbox_credentials.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_refresh_sandbox_credentials.py
@@ -90,6 +90,73 @@ class TestRefreshSandboxCredentialsActivity:
 
         assert get_token.call_args.kwargs["state"]["pr_authorship_mode"] == "user"
 
+    def test_unchanged_authorship_never_notifies_the_agent_server(
+        self, activity_environment, task_context, test_task, test_task_run, sandbox
+    ):
+        # The notice makes the sandbox log a line, and any line re-arms the workflow's inactivity
+        # timer while the agent-active latch is set. On a cadence shorter than that window, a run
+        # whose agent already stopped would never time out and would bill to the run-duration cap.
+        with (
+            patch(
+                "products.tasks.backend.temporal.process_task.activities.refresh_sandbox_credentials.Sandbox.get_by_id",
+                return_value=sandbox,
+            ),
+            patch(
+                "products.tasks.backend.temporal.process_task.sandbox_credentials.get_sandbox_github_token",
+                return_value="ghs_fresh",
+            ),
+            patch("products.tasks.backend.temporal.process_task.activities.refresh_sandbox_credentials.track_event"),
+            patch(
+                "products.tasks.backend.temporal.process_task.activities.refresh_sandbox_credentials.send_refresh_session"
+            ) as send_refresh_session,
+        ):
+            outputs = [
+                async_to_sync(activity_environment.run)(
+                    refresh_sandbox_credentials,
+                    RefreshSandboxCredentialsInput(context=task_context, sandbox_id="sandbox-unchanged"),
+                )
+                for _ in range(2)
+            ]
+
+        # Guards the assertion below against going vacuous if the refresh stops reporting a kind.
+        assert [o.refreshed_kinds for o in outputs] == [["github"], ["github"]]
+        send_refresh_session.assert_not_called()
+
+    def test_promotion_notifies_the_agent_server_once(
+        self, activity_environment, task_context, test_task, test_task_run, sandbox
+    ):
+        # Git author/committer vars are read once at sandbox boot, so this notice is the only way a
+        # mid-run promotion reaches a running agent-server. It has to survive, and it has to be sent
+        # once rather than on every later refresh.
+        TaskRun.objects.filter(id=test_task_run.id).update(state={"pr_authorship_mode": "user"})
+
+        with (
+            patch(
+                "products.tasks.backend.temporal.process_task.activities.refresh_sandbox_credentials.Sandbox.get_by_id",
+                return_value=sandbox,
+            ),
+            patch(
+                "products.tasks.backend.temporal.process_task.sandbox_credentials.get_sandbox_github_token",
+                return_value="ghu_user",
+            ),
+            patch("products.tasks.backend.temporal.process_task.activities.refresh_sandbox_credentials.track_event"),
+            patch(
+                "products.tasks.backend.temporal.process_task.activities.refresh_sandbox_credentials.create_sandbox_connection_token",
+                return_value="jwt",
+            ),
+            patch(
+                "products.tasks.backend.temporal.process_task.activities.refresh_sandbox_credentials.send_refresh_session"
+            ) as send_refresh_session,
+        ):
+            for _ in range(2):
+                async_to_sync(activity_environment.run)(
+                    refresh_sandbox_credentials,
+                    RefreshSandboxCredentialsInput(context=task_context, sandbox_id="sandbox-promoted"),
+                )
+
+        assert send_refresh_session.call_count == 1
+        assert send_refresh_session.call_args.kwargs["authorship"] == "user"
+
     def test_retries_transient_db_connection_drop(self, activity_environment, task_context, test_task, sandbox):
         # A pooled pgbouncer connection dropped mid-request raises OperationalError on the
         # activity's early Task read. The retry-once guard must evict the dead connection and


### PR DESCRIPTION
## Problem

A cloud task whose agent goes quiet holds its sandbox open until the hard run-duration cap and then ends as `failed`, instead of timing out when it actually stopped working.

- A run that ends without signalling the end of its turn leaves the agent-active latch set.
- While that latch is set, the event ingest path heartbeats the workflow on any inbound event.
- Every heartbeat re-arms the full inactivity window.
- The periodic credential refresh announces itself to the agent-server, which logs a line, and that log is relayed back as an event.
- That cadence is shorter than the inactivity window, so the window never closes.

This lands hardest on tasks created from a workflow. A client that drives its own run can signal completion when the agent finishes, which is what keeps those sandboxes short-lived. A task created generically has nothing doing that, so it depends entirely on the inactivity timeout, which the above prevents from ever firing. Those runs reach the cap every time, and nothing about the task's own configuration changes that.

#74038 fixed this defect on the log-append path. It deliberately left the event ingest path, which holds the latch in Redis — and that is the path runs take today. #74316 documented the same mechanism; it was closed when wizard cloud runs were turned off, but the mechanism is not specific to that origin.

## Changes

- Remove the credential-refresh notice to the agent-server, so an idle sandbox emits nothing from housekeeping.
- Record the rotation in the worker log instead, so a run keeps a per-run record of when its identity changed.
- Drop `refreshed_credentials` and `authorship` from `send_refresh_session`; both lost their last caller, and the docstring still told the next reader that a credentials-only notification is safe to send mid-turn.

The notice carried nothing the sandbox acts on. In `agent-server.ts` its `authorship` field is interpolated into a `logger.debug` string, the handler returns early when `mcpServers` is empty (always true here), and the agent sets no git identity anywhere. The token itself reaches the sandbox through the git remote and the credential env file.

`send_refresh_session` still stands in `send_followup_to_sandbox.py`, where it carries a real MCP server list and rebuilds the session.

### Known trade-off

The notice was also an incidental keep-alive. An agent that is genuinely working but emits nothing at all for the full inactivity window will now be timed out, where before it was kept alive by the 20-minute notice. The agent-proxy heartbeat is event-driven rather than periodic, so nothing else covers that case today.

The run is marked `completed` and stays resumable, so this reclaims a sandbox rather than losing work. A follow-up will let the workflow ask the agent-server whether a turn is in flight before terminating, which fixes this properly and lets the latch itself be bounded.

## How did you test this code?

Automated tests only. I did not exercise this against a live sandbox.

The existing refresh test asserts the activity issues no agent command, patched at `send_agent_command` — the chokepoint every command routes through, so it holds however a future notice is imported. Against `master` it fails with `Expected 'send_agent_command' to not have been called. Called 1 times.`, so it is not vacuous.

`test_refresh_sandbox_credentials.py`, `test_credential_refresh.py`, and `test_agent_command.py` pass locally.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code via PostHog Desktop. Skills read from disk: `writing-tests`, `writing-pr-descriptions`, `qa-team`.

This PR first shipped a larger change: the notice was gated on an authorship change behind a per-sandbox Redis marker, on the assumption that `authorship` propagated a mid-run bot-to-user promotion to a running agent-server. A multi-agent review read the agent-server source and showed that assumption was false, which removed the reason for the machinery, so the gating was replaced by removal. That earlier version also carried a real defect the review found independently: the marker was written before a send whose failure is swallowed, so one unreachable moment would have suppressed a promotion notice permanently.

A second review of the rewritten change surfaced the observability gap and the stale helper docstring, both fixed here. Its two open findings — the keep-alive trade-off above, and the underlying latch — are the follow-up.

Public artifact: the investigation ran on production data and an internal document. Neither appears in the code, tests, commit messages, or this description.

