### PR TITLE
test(onboarding): assert composed onboarding step titles resolve

### DIFF
--- a/frontend/src/scenes/onboarding/stepComposition.test.ts
+++ b/frontend/src/scenes/onboarding/stepComposition.test.ts
@@ -6,53 +6,86 @@ import path from 'path'
  * step's display title, e.g. `paSteps.filter((step) => step.title !== 'Send events')`. Nothing ties
  * that string to the step it targets, and a miss is silent: `filter` drops nothing and `map`
  * replaces nothing, so the product quietly loses a step. This asserts every such title resolves.
+ *
+ * A composition can key on a title in the file that imports the product-analytics steps, or in a
+ * shared helper that receives the steps getter as an argument (session replay does the latter for
+ * all of its web SDKs). Both are resolved here, and a title key that resolves to neither fails.
  */
 const ONBOARDING_DOCS = path.resolve(__dirname, '../../../../docs/onboarding')
+const PRODUCT_ANALYTICS_DIR = path.join(ONBOARDING_DOCS, 'product-analytics')
 
-const PRODUCT_ANALYTICS_IMPORT = /from '\.\.\/product-analytics\/([\w.-]+)'/
 const TITLE_KEY = /step\.title\s*[!=]==\s*'([^']+)'/g
 const TITLE_DECLARATION = /title:\s*'([^']+)'/g
+const RELATIVE_IMPORT = /from '(\.[^']*)'/g
 
 const matchAll = (source: string, pattern: RegExp): string[] => [...source.matchAll(pattern)].map((m) => m[1])
 
-const readSource = (file: string): string => fs.readFileSync(file, 'utf-8')
+const walk = (dir: string): string[] =>
+    fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+        const entryPath = path.join(dir, entry.name)
+        if (entry.isDirectory()) {
+            return entry.name === 'node_modules' ? [] : walk(entryPath)
+        }
+        return entry.name.endsWith('.tsx') ? [entryPath] : []
+    })
+
+const sourceFiles = walk(ONBOARDING_DOCS)
+const sources = new Map(sourceFiles.map((file) => [file, fs.readFileSync(file, 'utf-8')]))
+const label = (file: string): string => path.relative(ONBOARDING_DOCS, file)
+
+/** Import targets resolved to absolute paths, extensionless — what `path.resolve` gives us. */
+const importsOf = new Map(
+    sourceFiles.map((file) => [
+        file,
+        matchAll(sources.get(file)!, RELATIVE_IMPORT).map((specifier) => path.resolve(path.dirname(file), specifier)),
+    ])
+)
+
+const isProductAnalytics = (file: string): boolean => file.startsWith(PRODUCT_ANALYTICS_DIR + path.sep)
+
+/** The files that compose: everything except product-analytics itself, which is what they compose from. */
+const composingFiles = sourceFiles.filter((file) => !isProductAnalytics(file))
+
+const productAnalyticsImportsOf = (file: string): string[] =>
+    importsOf.get(file)!.filter((target) => isProductAnalytics(`${target}.tsx`))
+
+const importersOf = (file: string): string[] =>
+    composingFiles.filter((candidate) => importsOf.get(candidate)!.includes(file.replace(/\.tsx$/, '')))
 
 interface CompositionKey {
+    /** The file whose onboarding breaks when the title stops resolving. */
     composedFile: string
-    sourceFile: string
+    /** Set when the title is keyed on in a shared helper rather than in `composedFile` itself. */
+    via: string | null
     title: string
+    sourceFile: string
 }
 
-const collectCompositionKeys = (): CompositionKey[] => {
-    const keys: CompositionKey[] = []
-
-    for (const product of fs.readdirSync(ONBOARDING_DOCS)) {
-        const productDir = path.join(ONBOARDING_DOCS, product)
-        if (product === 'product-analytics' || !fs.statSync(productDir).isDirectory()) {
-            continue
-        }
-
-        for (const file of fs.readdirSync(productDir)) {
-            if (!file.endsWith('.tsx')) {
-                continue
-            }
-
-            const source = readSource(path.join(productDir, file))
-            const importedFrom = PRODUCT_ANALYTICS_IMPORT.exec(source)?.[1]
-            if (!importedFrom) {
-                continue
-            }
-
-            for (const title of new Set(matchAll(source, TITLE_KEY))) {
-                keys.push({ composedFile: `${product}/${file}`, sourceFile: `${importedFrom}.tsx`, title })
-            }
-        }
+/**
+ * Where a file keying on titles gets its product-analytics steps from: its own import, or — for a
+ * shared helper taking the getter as an argument — the imports of each file that calls it.
+ */
+const resolveSources = (file: string): Pick<CompositionKey, 'composedFile' | 'via' | 'sourceFile'>[] => {
+    const own = productAnalyticsImportsOf(file)
+    if (own.length) {
+        return own.map((sourceFile) => ({ composedFile: label(file), via: null, sourceFile }))
     }
-
-    return keys
+    return importersOf(file).flatMap((caller) =>
+        productAnalyticsImportsOf(caller).map((sourceFile) => ({
+            composedFile: label(caller),
+            via: label(file),
+            sourceFile,
+        }))
+    )
 }
 
-const compositionKeys = collectCompositionKeys()
+const filesKeyingOnTitles = composingFiles.filter((file) => matchAll(sources.get(file)!, TITLE_KEY).length > 0)
+
+const compositionKeys: CompositionKey[] = filesKeyingOnTitles.flatMap((file) =>
+    [...new Set(matchAll(sources.get(file)!, TITLE_KEY))].flatMap((title) =>
+        resolveSources(file).map((resolved) => ({ ...resolved, title }))
+    )
+)
 
 describe('onboarding step composition', () => {
     // Without this the suite passes vacuously if the files move or the patterns above stop matching.
@@ -60,12 +93,34 @@ describe('onboarding step composition', () => {
         expect(compositionKeys.length).toBeGreaterThan(20)
     })
 
-    it.each(compositionKeys.map((k) => [k.composedFile, k.title, k.sourceFile, k] as const))(
-        '%s composes on a step titled "%s", which product-analytics/%s defines',
-        (_composedFile, _title, _sourceFile, key) => {
-            const sourcePath = path.join(ONBOARDING_DOCS, 'product-analytics', key.sourceFile)
-            expect(fs.existsSync(sourcePath)).toBe(true)
-            expect(matchAll(readSource(sourcePath), TITLE_DECLARATION)).toContain(key.title)
-        }
-    )
+    // A file keying on a title that resolves to no source is a composition this suite cannot check,
+    // which is the silent gap it exists to close — a new shared helper with no caller reaching
+    // product-analytics lands here rather than passing by producing nothing.
+    it('resolves a product-analytics source for every file keying on a step title', () => {
+        const unresolved = filesKeyingOnTitles.filter((file) => !resolveSources(file).length).map(label)
+        expect(unresolved).toEqual([])
+    })
+
+    // resolveSources takes every product-analytics import, so a second one is checked rather than
+    // ignored — but it would mean one of the two sources does not declare the title, so flag it.
+    it('imports product-analytics steps from a single file', () => {
+        const multiple = composingFiles.filter((file) => productAnalyticsImportsOf(file).length > 1).map(label)
+        expect(multiple).toEqual([])
+    })
+
+    it.each(
+        compositionKeys.map(
+            (key) =>
+                [
+                    key.via ? `${key.composedFile} (via ${key.via})` : key.composedFile,
+                    key.title,
+                    label(`${key.sourceFile}.tsx`),
+                    key,
+                ] as const
+        )
+    )('%s composes on a step titled "%s", which %s defines', (_composedFile, _title, _sourceFile, key) => {
+        const sourcePath = `${key.sourceFile}.tsx`
+        expect(fs.existsSync(sourcePath)).toBe(true)
+        expect(matchAll(fs.readFileSync(sourcePath, 'utf-8'), TITLE_DECLARATION)).toContain(key.title)
+    })
 })

--- a/frontend/src/scenes/onboarding/stepComposition.test.ts
+++ b/frontend/src/scenes/onboarding/stepComposition.test.ts
@@ -1,0 +1,71 @@
+import fs from 'fs'
+import path from 'path'
+
+/**
+ * Per-product install steps are composed by reusing the product-analytics steps and matching on a
+ * step's display title, e.g. `paSteps.filter((step) => step.title !== 'Send events')`. Nothing ties
+ * that string to the step it targets, and a miss is silent: `filter` drops nothing and `map`
+ * replaces nothing, so the product quietly loses a step. This asserts every such title resolves.
+ */
+const ONBOARDING_DOCS = path.resolve(__dirname, '../../../../docs/onboarding')
+
+const PRODUCT_ANALYTICS_IMPORT = /from '\.\.\/product-analytics\/([\w.-]+)'/
+const TITLE_KEY = /step\.title\s*[!=]==\s*'([^']+)'/g
+const TITLE_DECLARATION = /title:\s*'([^']+)'/g
+
+const matchAll = (source: string, pattern: RegExp): string[] => [...source.matchAll(pattern)].map((m) => m[1])
+
+const readSource = (file: string): string => fs.readFileSync(file, 'utf-8')
+
+interface CompositionKey {
+    composedFile: string
+    sourceFile: string
+    title: string
+}
+
+const collectCompositionKeys = (): CompositionKey[] => {
+    const keys: CompositionKey[] = []
+
+    for (const product of fs.readdirSync(ONBOARDING_DOCS)) {
+        const productDir = path.join(ONBOARDING_DOCS, product)
+        if (product === 'product-analytics' || !fs.statSync(productDir).isDirectory()) {
+            continue
+        }
+
+        for (const file of fs.readdirSync(productDir)) {
+            if (!file.endsWith('.tsx')) {
+                continue
+            }
+
+            const source = readSource(path.join(productDir, file))
+            const importedFrom = PRODUCT_ANALYTICS_IMPORT.exec(source)?.[1]
+            if (!importedFrom) {
+                continue
+            }
+
+            for (const title of new Set(matchAll(source, TITLE_KEY))) {
+                keys.push({ composedFile: `${product}/${file}`, sourceFile: `${importedFrom}.tsx`, title })
+            }
+        }
+    }
+
+    return keys
+}
+
+const compositionKeys = collectCompositionKeys()
+
+describe('onboarding step composition', () => {
+    // Without this the suite passes vacuously if the files move or the patterns above stop matching.
+    it('finds composed step files to check', () => {
+        expect(compositionKeys.length).toBeGreaterThan(20)
+    })
+
+    it.each(compositionKeys.map((k) => [k.composedFile, k.title, k.sourceFile, k] as const))(
+        '%s composes on a step titled "%s", which product-analytics/%s defines',
+        (_composedFile, _title, _sourceFile, key) => {
+            const sourcePath = path.join(ONBOARDING_DOCS, 'product-analytics', key.sourceFile)
+            expect(fs.existsSync(sourcePath)).toBe(true)
+            expect(matchAll(readSource(sourcePath), TITLE_DECLARATION)).toContain(key.title)
+        }
+    )
+})

--- a/frontend/src/scenes/onboarding/stepComposition.test.ts
+++ b/frontend/src/scenes/onboarding/stepComposition.test.ts
@@ -1,126 +1,156 @@
 import fs from 'fs'
 import path from 'path'
 
+import { OnboardingComponentsContext } from './shared/OnboardingDocsContentWrapper'
+
 /**
  * Per-product install steps are composed by reusing the product-analytics steps and matching on a
  * step's display title, e.g. `paSteps.filter((step) => step.title !== 'Send events')`. Nothing ties
  * that string to the step it targets, and a miss is silent: `filter` drops nothing and `map`
- * replaces nothing, so the product quietly loses a step. This asserts every such title resolves.
+ * replaces nothing, so the product quietly loses a step, with no error and no type error.
  *
- * A composition can key on a title in the file that imports the product-analytics steps, or in a
- * shared helper that receives the steps getter as an argument (session replay does the latter for
- * all of its web SDKs). Both are resolved here, and a title key that resolves to neither fails.
+ * This runs each composition against the product-analytics steps it consumes, and asserts it still
+ * changes one of them. A step the composition keeps comes through as the same object, so a step it
+ * dropped or replaced is one the product-analytics array holds and the composed array does not.
+ * Nothing here names a title, so the check holds however the match is written.
  */
 const ONBOARDING_DOCS = path.resolve(__dirname, '../../../../docs/onboarding')
-const PRODUCT_ANALYTICS_DIR = path.join(ONBOARDING_DOCS, 'product-analytics')
+const PRODUCT_ANALYTICS = path.join(ONBOARDING_DOCS, 'product-analytics')
 
-const TITLE_KEY = /step\.title\s*[!=]==\s*'([^']+)'/g
-const TITLE_DECLARATION = /title:\s*'([^']+)'/g
-const RELATIVE_IMPORT = /from '(\.[^']*)'/g
+/**
+ * Compositions that only add steps, inside a product whose other compositions transform one. They
+ * carry every product-analytics step through untouched, so they have no match that can stop
+ * matching. The list is asserted to be exact, so a composition that stops transforming cannot hide.
+ */
+const ADD_ONLY = [
+    // Appends its own step instead of replacing one.
+    'web-analytics/wordpress.tsx',
+    // These three build on their SDK's client steps, which hold no event step for the shared session
+    // replay helper to drop. The helper's filter is a no-op for them, so it cannot regress either.
+    'session-replay/nextjs.tsx',
+    'session-replay/nuxt.tsx',
+    'session-replay/svelte.tsx',
+]
 
-const matchAll = (source: string, pattern: RegExp): string[] => [...source.matchAll(pattern)].map((m) => m[1])
+const stub = (name: string): (() => null) => Object.defineProperty((): null => null, 'name', { value: name })
 
-const walk = (dir: string): string[] =>
-    fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
-        const entryPath = path.join(dir, entry.name)
-        if (entry.isDirectory()) {
-            return entry.name === 'node_modules' ? [] : walk(entryPath)
-        }
-        return entry.name.endsWith('.tsx') ? [entryPath] : []
-    })
+/** Every field is a component the steps render into, so distinct no-op components are enough. */
+const ctx = {
+    Steps: stub('Steps'),
+    Step: stub('Step'),
+    CodeBlock: stub('CodeBlock'),
+    CalloutBox: stub('CalloutBox'),
+    ProductScreenshot: stub('ProductScreenshot'),
+    OSButton: stub('OSButton'),
+    Markdown: stub('Markdown'),
+    Blockquote: stub('Blockquote'),
+    Tab: Object.assign(stub('Tab'), {
+        Group: stub('TabGroup'),
+        List: stub('TabList'),
+        Panels: stub('TabPanels'),
+        Panel: stub('TabPanel'),
+    }),
+    dedent: (strings: TemplateStringsArray | string, ...values: unknown[]): string =>
+        typeof strings === 'string' ? strings : String.raw({ raw: strings }, ...values),
+    // Steps pull snippets by name and render the ones they use, so serve any name asked for.
+    snippets: new Proxy({} as Record<string, () => null>, {
+        get: (target, key: string) => (target[key] ??= stub(key)),
+        has: () => true,
+    }),
+} as unknown as OnboardingComponentsContext
 
-const sourceFiles = walk(ONBOARDING_DOCS)
-const sources = new Map(sourceFiles.map((file) => [file, fs.readFileSync(file, 'utf-8')]))
-const label = (file: string): string => path.relative(ONBOARDING_DOCS, file)
-
-/** Import targets resolved to absolute paths, extensionless — what `path.resolve` gives us. */
-const importsOf = new Map(
-    sourceFiles.map((file) => [
-        file,
-        matchAll(sources.get(file)!, RELATIVE_IMPORT).map((specifier) => path.resolve(path.dirname(file), specifier)),
-    ])
-)
-
-const isProductAnalytics = (file: string): boolean => file.startsWith(PRODUCT_ANALYTICS_DIR + path.sep)
-
-/** The files that compose: everything except product-analytics itself, which is what they compose from. */
-const composingFiles = sourceFiles.filter((file) => !isProductAnalytics(file))
-
-const productAnalyticsImportsOf = (file: string): string[] =>
-    importsOf.get(file)!.filter((target) => isProductAnalytics(`${target}.tsx`))
-
-const importersOf = (file: string): string[] =>
-    composingFiles.filter((candidate) => importsOf.get(candidate)!.includes(file.replace(/\.tsx$/, '')))
-
-interface CompositionKey {
-    /** The file whose onboarding breaks when the title stops resolving. */
-    composedFile: string
-    /** Set when the title is keyed on in a shared helper rather than in `composedFile` itself. */
-    via: string | null
+interface Step {
     title: string
-    sourceFile: string
+}
+
+type StepsGetter = (ctx: OnboardingComponentsContext) => Step[]
+type StepsModule = Record<string, StepsGetter>
+
+const stepsExports = (module: StepsModule): string[] =>
+    Object.keys(module).filter((key) => /^get.*Steps$/.test(key) && typeof module[key] === 'function')
+
+const tsxFilesIn = (dir: string): string[] => fs.readdirSync(dir).filter((file) => file.endsWith('.tsx'))
+
+/**
+ * Spies on every product-analytics steps getter. A composition then reveals which one it consumes
+ * by calling it, and the spy holds the exact array it received.
+ */
+const productAnalyticsSpies = tsxFilesIn(PRODUCT_ANALYTICS).flatMap((file) => {
+    const module: StepsModule = require(path.join(PRODUCT_ANALYTICS, file))
+    return stepsExports(module).map((getter) => jest.spyOn(module, getter))
+})
+
+interface Composition {
+    name: string
+    consumed: Step[]
+    composed: Step[]
 }
 
 /**
- * Where a file keying on titles gets its product-analytics steps from: its own import, or — for a
- * shared helper taking the getter as an argument — the imports of each file that calls it.
+ * The product-analytics steps a composition built on. Getters call each other, so the outermost
+ * call is the one whose result the composition actually received.
  */
-const resolveSources = (file: string): Pick<CompositionKey, 'composedFile' | 'via' | 'sourceFile'>[] => {
-    const own = productAnalyticsImportsOf(file)
-    if (own.length) {
-        return own.map((sourceFile) => ({ composedFile: label(file), via: null, sourceFile }))
-    }
-    return importersOf(file).flatMap((caller) =>
-        productAnalyticsImportsOf(caller).map((sourceFile) => ({
-            composedFile: label(caller),
-            via: label(file),
-            sourceFile,
-        }))
+const consumedSteps = (): Step[] | null => {
+    const calls = productAnalyticsSpies.flatMap((spy) =>
+        spy.mock.results.map((result, index) => ({ order: spy.mock.invocationCallOrder[index], result }))
     )
+    if (!calls.length) {
+        return null
+    }
+    return calls.reduce((first, call) => (call.order < first.order ? call : first)).result.value as Step[]
 }
 
-const filesKeyingOnTitles = composingFiles.filter((file) => matchAll(sources.get(file)!, TITLE_KEY).length > 0)
+const runCompositions = (file: string): Composition[] => {
+    const module: StepsModule = require(path.join(ONBOARDING_DOCS, file))
 
-const compositionKeys: CompositionKey[] = filesKeyingOnTitles.flatMap((file) =>
-    [...new Set(matchAll(sources.get(file)!, TITLE_KEY))].flatMap((title) =>
-        resolveSources(file).map((resolved) => ({ ...resolved, title }))
-    )
+    return stepsExports(module).flatMap((getter) => {
+        productAnalyticsSpies.forEach((spy) => spy.mockClear())
+        const composed = module[getter](ctx)
+        const consumed = consumedSteps()
+        return consumed ? [{ name: file, consumed, composed }] : []
+    })
+}
+
+const productDirs = fs
+    .readdirSync(ONBOARDING_DOCS, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && !['product-analytics', 'node_modules'].includes(entry.name))
+
+const compositions = productDirs.flatMap((product) =>
+    tsxFilesIn(path.join(ONBOARDING_DOCS, product.name)).flatMap((file) => runCompositions(`${product.name}/${file}`))
+)
+
+/** Steps the composition dropped or replaced: in the array it consumed, absent from the one it returned. */
+const transformed = (composition: Composition): Step[] =>
+    composition.consumed.filter((step) => !composition.composed.includes(step))
+
+const productOf = (composition: Composition): string => composition.name.split('/')[0]
+
+/** Products where compositions transform a step, so every composition in them is expected to. */
+const transformingProducts = new Set(compositions.filter((c) => transformed(c).length).map(productOf))
+
+const expectedToTransform = compositions.filter(
+    (composition) => transformingProducts.has(productOf(composition)) && !ADD_ONLY.includes(composition.name)
 )
 
 describe('onboarding step composition', () => {
-    // Without this the suite passes vacuously if the files move or the patterns above stop matching.
-    it('finds composed step files to check', () => {
-        expect(compositionKeys.length).toBeGreaterThan(20)
+    // Without this the suite passes vacuously if the files move or stop exporting a steps getter.
+    it('finds compositions to check', () => {
+        expect(expectedToTransform.length).toBeGreaterThan(20)
     })
 
-    // A file keying on a title that resolves to no source is a composition this suite cannot check,
-    // which is the silent gap it exists to close — a new shared helper with no caller reaching
-    // product-analytics lands here rather than passing by producing nothing.
-    it('resolves a product-analytics source for every file keying on a step title', () => {
-        const unresolved = filesKeyingOnTitles.filter((file) => !resolveSources(file).length).map(label)
-        expect(unresolved).toEqual([])
+    // Keeps the exemption honest both ways: a new add-only composition in a transforming product
+    // fails until it is listed, and a listed one that starts transforming fails until it is removed.
+    it('lists every composition that only adds steps to a transforming product', () => {
+        const addOnly = compositions
+            .filter((c) => transformingProducts.has(productOf(c)) && !transformed(c).length)
+            .map((c) => c.name)
+        expect(addOnly.sort()).toEqual([...ADD_ONLY].sort())
     })
 
-    // resolveSources takes every product-analytics import, so a second one is checked rather than
-    // ignored — but it would mean one of the two sources does not declare the title, so flag it.
-    it('imports product-analytics steps from a single file', () => {
-        const multiple = composingFiles.filter((file) => productAnalyticsImportsOf(file).length > 1).map(label)
-        expect(multiple).toEqual([])
-    })
-
-    it.each(
-        compositionKeys.map(
-            (key) =>
-                [
-                    key.via ? `${key.composedFile} (via ${key.via})` : key.composedFile,
-                    key.title,
-                    label(`${key.sourceFile}.tsx`),
-                    key,
-                ] as const
-        )
-    )('%s composes on a step titled "%s", which %s defines', (_composedFile, _title, _sourceFile, key) => {
-        const sourcePath = `${key.sourceFile}.tsx`
-        expect(fs.existsSync(sourcePath)).toBe(true)
-        expect(matchAll(fs.readFileSync(sourcePath, 'utf-8'), TITLE_DECLARATION)).toContain(key.title)
-    })
+    it.each(expectedToTransform.map((composition) => [composition.name, composition] as const))(
+        '%s drops or replaces a product-analytics step',
+        (_name, composition) => {
+            expect(transformed(composition)).not.toHaveLength(0)
+        }
+    )
 })


### PR DESCRIPTION
## Problem

A one-word copy edit in onboarding can delete a step from a different product, and nothing tells anyone.

- Per-product install steps reuse the product-analytics steps and select one by its display title: `paSteps.filter((step) => step.title !== 'Send events')` in experiments, and the matching `.map` in web analytics.
- Session replay does the same for 13 web SDKs, from one shared helper that takes the steps getter as an argument.
- A miss is silent. `filter` drops nothing, `map` replaces nothing, so the product loses a step with no error, no type error, and no failing test.
- Renaming `Send events` in `product-analytics/react.tsx` leaves experiments showing an event step it meant to remove, drops the pageview guidance from web analytics, and leaves session replay with a step it meant to filter.

Every composition works today. I checked before writing this, so nothing here is broken. The point is that nothing would tell us when it breaks.

## Changes

- Adds `stepComposition.test.ts`, which calls each composition and asserts it still drops or replaces one of the product-analytics steps it consumed.
- Finds the product-analytics steps a composition consumed by spying on the product-analytics getters, so the check follows the real call path. Session replay's shared helper is covered through the 13 SDK files that call it.
- Identifies a dropped or replaced step by object identity. A step the composition keeps comes through as the same object, so no title string appears anywhere in the test.
- Reads no source text. A composition written with a constant, a template literal or a destructured parameter is checked the same as one written with a literal.
- Records the four compositions that only add steps, and asserts that list is exact, so a composition that stops transforming cannot join it silently.

> [!NOTE]
> Three of those four are `session-replay/{nextjs,nuxt,svelte}.tsx`. They build on their SDK's client steps, which hold no event step for the shared helper to drop, so its filter is a no-op for them. That is correct behavior, not a bug, and it is worth knowing.

The alternative is a shared step id or an exported constant, which removes the coupling instead of guarding it. I did not do that here. It edits 47 files, conflicts with anyone touching onboarding docs, and is only as good as the next person who copies `flutter.tsx` rather than importing the constant.

## How did you test this code?

- 58 assertions pass, in about 1.4 s. The test calls the step getters with stub components and never renders, so it needs no DOM and no `OnboardingComponentsContext` provider.
- Renaming `title: 'Send events'` in `product-analytics/react.tsx` fails the three compositions that depend on it:

<details><summary>Output with the title renamed</summary>

```
✕ experiments/react.tsx drops or replaces a product-analytics step
✕ session-replay/react.tsx drops or replaces a product-analytics step
✕ web-analytics/react.tsx drops or replaces a product-analytics step
```

</details>

- Replacing the literal in `experiments/react.tsx` with a mistyped constant also fails, which is the case a source-matching test cannot see:

<details><summary>Output with the filter keyed on a constant</summary>

```
const SEND_EVENTS = 'Send event'
const installationSteps = getReactStepsPA(ctx).filter((step) => step.title !== SEND_EVENTS)

✕ experiments/react.tsx drops or replaces a product-analytics step
```

</details>

- The regression it catches that no existing test did: a product-analytics step edit that silently changes a different product's onboarding. The four existing onboarding test files assert on SDK maps and selectability, never on composed step lists.
- Not checked: I did not run the app or Storybook. This change adds a test and touches no product code.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5). Skills invoked: `/monitor-ci` (which surfaced the Greptile finding on #83572), `/code-review`, `/writing-tests`, and `/writing-pr-descriptions`.

This took three passes, and the first two were worse.

The first commit matched title literals out of the source with a regex. It missed session replay entirely: the title key sits in a `_snippets/` file the discovery did not walk, and that file has no product-analytics import to key on, because it receives the getter as an argument.

The second commit walked the tree and resolved shared helpers through their callers. It still matched source text, so it only saw a composition spelled `step.title === 'literal'`, and it asserted that a string existed in a file rather than that the composition did anything. On `session-replay/{nextjs,nuxt,svelte}.tsx` it passed for the wrong reason: the title it looked for exists in the product-analytics file, in a step those compositions never receive.

The third runs the code. Writing it also surfaced two vacuous assertions in my own drafts, both of which passed until I checked that they failed on a deliberate break.
