### PR TITLE
fix(tasks): expose slack delivery keys in run-detail state

### DIFF
--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -397,6 +397,8 @@ _TASK_RUN_PUBLIC_STATE_KEYS = frozenset(
         "run_source",
         "runtime_adapter",
         "sandbox_environment_id",
+        "slack_artifact_delivery",
+        "slack_chart_delivery",
         "slack_thread_url",
     }
 )

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -1407,13 +1407,23 @@ class TestTaskAPI(BaseTaskAPITest):
                 "sandbox_connect_token": "secret-token",
                 "sandbox_url": "https://sandbox.example.com",
                 "pending_dispatch": {"user_id": self.user.id},
+                # Slack delivery routing the sandbox agent reads back over this endpoint.
+                "slack_artifact_delivery": "canvas_file",
+                "slack_chart_delivery": True,
             },
         )
 
         response = self.client.get(f"/api/projects/@current/tasks/{task.id}/runs/{run.id}/")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json()["state"], {"mode": "interactive"})
+        self.assertEqual(
+            response.json()["state"],
+            {
+                "mode": "interactive",
+                "slack_artifact_delivery": "canvas_file",
+                "slack_chart_delivery": True,
+            },
+        )
 
     def test_create_task(self):
         response = self.client.post(


### PR DESCRIPTION
## Problem

The Slack app can be configured to deliver charts and rich artifacts back into a thread, but that delivery never happened — the bot kept falling back to plain matplotlib image uploads even in workspaces where the feature was enabled.

The sandbox agent learns which Slack delivery routes a workspace has by reading two run-state keys (`slack_artifact_delivery`, `slack_chart_delivery`) back over the run-detail endpoint. That endpoint filters run state through the `_TASK_RUN_PUBLIC_STATE_KEYS` allowlist, and neither key was on it. So the agent always read them as absent and dropped its delivery constraints entirely — the write path set the keys correctly, the read path silently stripped them.

## Changes

- Add `slack_artifact_delivery` and `slack_chart_delivery` to `_TASK_RUN_PUBLIC_STATE_KEYS` in `products/tasks/backend/facade/api.py` so they survive the run-detail DTO.
- Extend the existing run-detail round-trip test to assert both keys pass through the endpoint (it previously only asserted that secrets are stripped).

## How did you test this code?

Extended `test_run_response_excludes_connection_credentials_from_state` to cover the delivery keys. This is the seam the bug lived in: the write-side and agent-read-side each had passing unit tests in isolation, but nothing exercised the HTTP round-trip between them, so the missing allowlist entries went unnoticed. `ruff check` passes.

The agent could not run the Python test suite in its environment (no `pytest`/`hogli` available) — CI will run it here.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Diagnosed and authored by the PostHog Slack app agent while investigating why a chart request came back as a matplotlib upload instead of native Slack delivery. A PostHog employee directed the work from a Slack thread; their GitHub handle was not resolved this session, so the PR is left unassigned for the owning team to assign the DRI.

The fix is one allowlist addition; the diagnosis was the work. The write path (`_artifact_delivery_state_updates`) and the agent read path (`readSlackArtifactDelivery` / `readSlackChartDelivery`) were both correct and independently tested — the gap was the read-path allowlist between them. No repo skills were invoked (the `/writing-tests` skill is not available in this environment); the test was folded into an existing round-trip test rather than added as a near-duplicate.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0368RPHLQH/p1786602577876919)*
