### PR TITLE
fix(slack_app): deliver slack follow-ups sent while the sandbox boots

### DIFF
--- a/posthog/temporal/ai/slack_app/activities/task_creation.py
+++ b/posthog/temporal/ai/slack_app/activities/task_creation.py
@@ -863,17 +863,6 @@ def forward_posthog_code_followup_activity(
             user_text_prefix=followup_user_text_prefix,
         )
 
-    sandbox_url = (task_run.state or {}).get("sandbox_url")
-    if not sandbox_url:
-        logger.info("posthog_code_followup_sandbox_not_ready", channel=channel, thread_ts=thread_ts)
-        post_slack_thread_reply(
-            slack.client,
-            channel=channel,
-            thread_ts=thread_ts,
-            text="The agent is still starting up. Give it a moment and try again.",
-        )
-        return True
-
     from products.slack_app.backend.services.slack_messages import (  # noqa: PLC0415
         collect_thread_messages,
         decode_slack_event_text,

--- a/products/slack_app/backend/tests/test_followup_forwarding.py
+++ b/products/slack_app/backend/tests/test_followup_forwarding.py
@@ -1038,8 +1038,12 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
         assert new_run.state["model"] == SLACK_DEFAULT_MODEL
         assert new_run.state["runtime_adapter"]
 
+    @patch("products.tasks.backend.facade.api.signal_task_run_user_message", return_value=True)
     @patch("posthog.models.integration.SlackIntegration")
-    def test_sandbox_not_ready_returns_true_with_message(self, mock_slack_cls):
+    def test_forwards_while_sandbox_is_still_provisioning(self, mock_slack_cls, mock_signal):
+        # A run that has started but not yet written `sandbox_url` is mid-provisioning.
+        # Delivery is a signal onto the run's workflow, which is already running and
+        # queues the message, so the follow-up must be forwarded rather than refused.
         self.task_run.state = {}
         self.task_run.save()
         self._create_mapping()
@@ -1050,9 +1054,11 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
         result = forward_posthog_code_followup_activity(
             inputs, "C123", "1234.5678", "U_ALICE", "do something", "1234.5679"
         )
+
         assert result is True
-        call_kwargs = mock_slack_instance.client.chat_postMessage.call_args.kwargs
-        assert "still starting up" in call_kwargs["text"]
+        mock_signal.assert_called_once()
+        assert mock_signal.call_args.kwargs["content"] == "do something"
+        mock_slack_instance.client.chat_postMessage.assert_not_called()
 
     @patch("products.tasks.backend.facade.api.signal_task_run_user_message", return_value=True)
     @patch("posthog.models.integration.SlackIntegration")


### PR DESCRIPTION
## Problem

Reply to the bot in a thread while its sandbox is still booting and you get "The agent is still starting up. Give it a moment and try again." — then it never acts on what you said. You have to notice it was ignored and send it again.

Easy to hit: a follow-up on a finished thread resumes the task onto a new run, and anything you send during that run's provisioning trips the check.

## Changes

Removed the `sandbox_url` precondition in `forward_posthog_code_followup_activity`.

- Follow-ups are delivered by `signal_task_run_user_message`, which signals the run's workflow and queues the message for the agent.
- That workflow is running throughout provisioning, so a reachable sandbox was never needed.
- The check is a leftover from when follow-ups were POSTed to `{sandbox_url}/command`; all it did was drop replies sent during boot.
- Undeliverable messages are unaffected — the existing failure branch below still catches a rejected signal.

## How did you test this code?

No manual testing against a live Slack workspace.

`test_sandbox_not_ready_returns_true_with_message` asserted the removed behavior, so it becomes `test_forwards_while_sandbox_is_still_provisioning` — same setup, opposite expectation. It catches reinstating any readiness precondition; verified by re-adding the guard locally, where it fails on the signal never being sent.

`uv run mypy --cache-fine-grained .` is clean.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5). Skills invoked: `/writing-tests`.

An earlier revision also dropped the duplicate `message.channels` delivery of a reply that already `@`-mentions the bot. Cut after checking the tasks workflow: it already dedups follow-ups on a `message_id` derived from channel and message ts, so the second copy is discarded there for a live run. What's left is a duplicated turn when a resume is involved, better fixed at the resume path than at the webhook.

No content from the originating Slack thread is reproduced here; test fixtures are invented.
