### PR TITLE
fix(desktop): copy Codex config into private home

### DIFF
--- a/products/desktop/packages/workspace-server/src/services/agent/codex-home.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/codex-home.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { mkdir, mkdtemp, readlink, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -84,7 +84,7 @@ describe("prepareCodexHome", () => {
     );
   });
 
-  it("symlinks the user's ~/.codex/config.toml when present", async () => {
+  it("copies the user's ~/.codex/config.toml when present", async () => {
     const codexConfigDir = path.join(testHome.dir, ".codex");
     await mkdir(codexConfigDir, { recursive: true });
     const configPath = path.join(codexConfigDir, "config.toml");
@@ -97,9 +97,10 @@ describe("prepareCodexHome", () => {
       log: noopLog,
     });
 
-    const link = path.join(codexHome, "config.toml");
-    expect(existsSync(link)).toBe(true);
-    expect(await readlink(link)).toBe(realpathSync(configPath));
+    const privateConfig = path.join(codexHome, "config.toml");
+    expect(readFileSync(privateConfig, "utf-8")).toBe(
+      'model = "gpt-5-codex"\n',
+    );
   });
 
   it("rebuilds the skills dir, dropping stale links", async () => {

--- a/products/desktop/packages/workspace-server/src/services/agent/codex-home.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/codex-home.ts
@@ -46,8 +46,8 @@ export async function cleanupCodexHome(
  * codex scans `$CODEX_HOME/skills` plus `$HOME/.agents/skills`. By pointing
  * CODEX_HOME at this app-private dir we feed our skills through the former while
  * the user's own Codex skills still load from the latter (it is keyed off
- * `$HOME`, not `$CODEX_HOME`). The user's real `~/.codex/config.toml` is
- * symlinked in so their Codex configuration still applies.
+ * `$HOME`, not `$CODEX_HOME`). The user's real `~/.codex/config.toml` is copied
+ * in so their Codex configuration still applies without Windows symlink privileges.
  *
  * Returns the CODEX_HOME path to hand to the spawned process.
  */
@@ -76,17 +76,14 @@ export async function prepareCodexHome(options: {
     for (const name of ok) linked.add(name);
   }
 
-  const configLink = path.join(codexHome, "config.toml");
-  await fs.promises.rm(configLink, { force: true });
+  const privateConfig = path.join(codexHome, "config.toml");
+  await fs.promises.rm(privateConfig, { force: true });
   const userConfig = path.join(os.homedir(), ".codex", "config.toml");
   if (fs.existsSync(userConfig)) {
     try {
-      await fs.promises.symlink(
-        await fs.promises.realpath(userConfig),
-        configLink,
-      );
+      await fs.promises.copyFile(userConfig, privateConfig);
     } catch (err) {
-      options.log.warn("Failed to link codex config into codex home", {
+      options.log.warn("Failed to copy codex config into codex home", {
         error: err instanceof Error ? err.message : String(err),
       });
     }


### PR DESCRIPTION
## Problem

On Windows, local Codex sessions can start with a private `CODEX_HOME` that lacks the user MCP transport definitions because creating the config symlink requires privileges. The harness still disables those named servers, so Codex rejects the resulting transport-less tables during startup.

## Changes

Copy the user Codex config into the per-run private home instead of symlinking it. This keeps ambient MCP servers disabled and does not change the separate cloud-run setup