### PR TITLE
fix(canvas): reject org-deactivated agent requests with an error

### DIFF
--- a/products/canvas/backend/presentation/views.py
+++ b/products/canvas/backend/presentation/views.py
@@ -1105,6 +1105,13 @@ class CanvasViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                 {"detail": "The authoring task for this canvas no longer exists."},
                 status=status.HTTP_409_CONFLICT,
             )
+        if outcome == "organization_deactivated":
+            return Response(
+                {
+                    "detail": "Your organization has been deactivated. Contact PostHog support if you think this is a mistake."
+                },
+                status=status.HTTP_429_TOO_MANY_REQUESTS,
+            )
         if outcome == "quota_exhausted":
             return Response(
                 {"detail": "The team's compute quota is exhausted; retry later."},

--- a/products/canvas/backend/presentation/views.py
+++ b/products/canvas/backend/presentation/views.py
@@ -1063,7 +1063,12 @@ class CanvasViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             202: CanvasAgentRequestResultSerializer,
             403: OpenApiResponse(description="Agent requests are not declared or the caller is a sandbox."),
             409: OpenApiResponse(description="The canvas has no authoring task."),
-            429: OpenApiResponse(description="The team's compute quota is exhausted; retry later."),
+            429: OpenApiResponse(
+                description=(
+                    "The request was denied for compute: the team's quota is exhausted (retry later), "
+                    "or the organization is deactivated (not retryable)."
+                )
+            ),
         },
     )
     # task:write as well: the dispatched run executes with the creator's

--- a/products/canvas/backend/tests/test_canvas_api.py
+++ b/products/canvas/backend/tests/test_canvas_api.py
@@ -1511,6 +1511,28 @@ class TestCanvasErrorReports(CanvasAPIBaseTest):
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
+    @parameterized.expand(
+        [
+            ("deactivated", ComputeQuotaDenialReason.ORGANIZATION_DEACTIVATED, "deactivated"),
+            ("quota_exhausted", ComputeQuotaDenialReason.COMPUTE_QUOTA_EXHAUSTED, "compute quota"),
+        ]
+    )
+    def test_request_agent_reports_compute_denial_with_distinct_copy(self, _name, reason, expected_detail):
+        # Every denial must be an error response: a denial outcome reaching the
+        # 202 path would ship a request_outcome outside the response contract's
+        # choices, which API clients validate against.
+        canvas_id, _, _ = self._authored_canvas(agent_requests=True)
+
+        with patch(
+            "products.tasks.backend.logic.services.compute_quota.get_compute_quota_denial_reason",
+            return_value=reason,
+        ):
+            response = self._request_agent(canvas_id, "Make it blue.")
+
+        assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS, response.json()
+        assert expected_detail in response.json()["detail"].lower()
+        assert not TaskRun.objects.exists()
+
     def test_request_fix_prompt_never_carries_unsafe_error_type(self):
         # The requester's error_type flows into the agent prompt; a hostile
         # value must be coerced, not interpolated.


### PR DESCRIPTION
## Problem

A canvas viewer whose organization has been deactivated gets a 202 from `request_agent` whose `request_outcome` is `organization_deactivated` — a value outside the response contract's choices, so API clients that validate the response (like the desktop app) fail on a request that was actually refused.

Bottom layer of a stack; the desktop-side handling is [#83541](https://github.com/PostHog/posthog/pull/83541). Split from that PR so backend and frontend CI run on their own layers.

## Changes

- `request_agent` answers the `organization_deactivated` outcome with a 429 and distinct copy, mirroring the sibling `request_fix` handler.

## How did you test this code?

- New parameterized test: a compute-denied `request_agent` returns 429 with distinct copy per denial reason. Written red first — it failed with the 202 carrying the out-of-contract outcome — and passed after the fix. No existing test covered denial outcomes on this endpoint.
- Ran all `request_agent` tests and the full `TestCanvasErrorReports` class, plus ruff and `hogli ci:preflight`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None: the endpoint only gained an already-documented 429 case.

## 🤖 Agent context

**Autonomy:** Agent-driven (human-approved)

Split out of the reviewed follow-up work on canvas agent requests. Skills invoked: stacking-prs, improving-drf-endpoints, writing-tests, writing-pr-descriptions.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*