### PR TITLE
fix(first-promoter): explain a 404 as an unresolved account id

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/first_promoter/first_promoter.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/first_promoter/first_promoter.py
@@ -273,4 +273,12 @@ def validate_credentials(api_key: str, account_id: str, api_version: str) -> tup
             "FirstPromoter rejected these credentials. Check the API key and account ID under "
             "Settings > Integrations > Manage API keys.",
         )
+    # The key was accepted (else 401/403), so a 404 on the fixed v2 path means the account id
+    # doesn't resolve to a company — point the user at the account id rather than a raw status.
+    if response.status_code == 404:
+        return (
+            False,
+            "FirstPromoter couldn't find an account for that account ID. Check the account ID "
+            "under Settings > Integrations > Manage API keys, then try again.",
+        )
     return False, f"FirstPromoter API returned an unexpected status code: {response.status_code}"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/first_promoter/tests/test_first_promoter.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/first_promoter/tests/test_first_promoter.py
@@ -189,6 +189,7 @@ class TestFirstPromoterTransport:
             (200, True, None),
             (401, False, "rejected these credentials"),
             (403, False, "rejected these credentials"),
+            (404, False, "couldn't find an account for that account ID"),
             (500, False, "unexpected status code"),
         ]
     )


### PR DESCRIPTION
## Problem

- Someone connecting a FirstPromoter source with an account id that FirstPromoter can't resolve saw a raw "FirstPromoter API returned an unexpected status code: 404" and had nothing to act on.
- Credential validation already mapped 401 and 403 to a message naming the API key and account id, but a 404 fell through to the generic status-code fallback.

## Changes

- Map a 404 from the credential probe to an actionable message: the account id doesn't resolve, so check it under Settings > Integrations > Manage API keys.
- The key was accepted (otherwise the response is 401/403) and the v2 path is fixed, so the account id is the remaining cause of a 404.
- Other unexpected statuses keep the existing generic fallback.
- Added a 404 case to the existing parameterized validation test, guarding against a regression that drops the mapping back to the raw status.

## How did you test this code?

- Ran the `test_validate_credentials_status_mapping` cases locally (5 pass, including the new 404).
- Not run: the wider warehouse-sources suites, which need a database this sandbox lacks.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Authored by Claude (Claude Code) while triaging a batch of data-warehouse source-creation failures. This source's 404 was the one that surfaced a raw status code instead of guidance.
- Skills invoked: /writing-user-facing-copy, /writing-tests, /writing-pr-descriptions.
- The error strings that prompted this came from customer input and are not reproduced here; the test asserts a stable, non-sensitive substring only.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
