### PR TITLE
feat(insights): capture an event when date exclusions change

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -1507,6 +1507,15 @@ export interface eventUsageLogicActions {
     reportInsightCompareChanged: (queryKind: string | undefined) => {
         queryKind: string | undefined
     }
+    reportInsightDateExclusionsChanged: (
+        queryKind: string | undefined,
+        excludeIncompletePeriods: boolean,
+        excludedDaysOfWeekCount: number
+    ) => {
+        excludedDaysOfWeekCount: number
+        excludeIncompletePeriods: boolean
+        queryKind: string | undefined
+    }
     reportInsightDatePickerOpened: (queryKind: string | undefined) => {
         queryKind: string | undefined
     }
@@ -2253,6 +2262,11 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         reportPropertyGroupFilterRemoved: true,
         reportPropertyGroupFilterDuplicated: true,
         reportInsightDateRangeChanged: (queryKind: string | undefined) => ({ queryKind }),
+        reportInsightDateExclusionsChanged: (
+            queryKind: string | undefined,
+            excludeIncompletePeriods: boolean,
+            excludedDaysOfWeekCount: number
+        ) => ({ queryKind, excludeIncompletePeriods, excludedDaysOfWeekCount }),
         reportInsightDatePickerOpened: (queryKind: string | undefined) => ({ queryKind }),
         reportInsightDragToZoomed: (queryKind: string | undefined) => ({ queryKind }),
         reportInsightBreakdownChanged: (queryKind: string | undefined) => ({ queryKind }),
@@ -3945,6 +3959,13 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         },
         reportInsightDateRangeChanged: ({ queryKind }) => {
             posthog.capture('insight date range changed', { query_kind: queryKind })
+        },
+        reportInsightDateExclusionsChanged: ({ queryKind, excludeIncompletePeriods, excludedDaysOfWeekCount }) => {
+            posthog.capture('insight date exclusions changed', {
+                query_kind: queryKind,
+                exclude_incomplete_periods: excludeIncompletePeriods,
+                excluded_days_of_week_count: excludedDaysOfWeekCount,
+            })
         },
         reportInsightDatePickerOpened: ({ queryKind }) => {
             posthog.capture('insight date picker opened', { query_kind: queryKind })

--- a/frontend/src/scenes/insights/filters/InsightDateFilter/InsightDateFilter.tsx
+++ b/frontend/src/scenes/insights/filters/InsightDateFilter/InsightDateFilter.tsx
@@ -56,14 +56,17 @@ export function InsightDateFilter({ disabled }: InsightDateFilterProps): JSX.Ele
         const nextExcludedDaysOfWeek = parseIsoDaysOfWeek(next.days)
         const daysChanged = showDaysOfWeekExclusions && !daysOfWeekSetsEqual(nextExcludedDaysOfWeek, excludedDaysOfWeek)
         const incompleteChanged = next.incomplete !== exclusions.incomplete
-        if (daysChanged) {
-            updateQuerySource(computeDaysOfWeekUpdate(nextExcludedDaysOfWeek, dateRange))
+        const daysUpdate = daysChanged ? computeDaysOfWeekUpdate(nextExcludedDaysOfWeek, dateRange) : null
+        if (daysUpdate) {
+            updateQuerySource(daysUpdate)
         }
         if (incompleteChanged) {
             updateDateRange({ excludeIncompletePeriods: next.incomplete ? true : null }, true)
         }
         if (daysChanged || incompleteChanged) {
-            reportInsightDateExclusionsChanged(querySource?.kind, next.incomplete, nextExcludedDaysOfWeek.length)
+            // Report what got persisted, not what was picked: a full-week selection normalizes back to "exclude nothing"
+            const persistedExcludedDays = daysUpdate ? getExcludedDaysOfWeek(daysUpdate.dateRange) : excludedDaysOfWeek
+            reportInsightDateExclusionsChanged(querySource?.kind, next.incomplete, persistedExcludedDays.length)
         }
     }
 

--- a/frontend/src/scenes/insights/filters/InsightDateFilter/InsightDateFilter.tsx
+++ b/frontend/src/scenes/insights/filters/InsightDateFilter/InsightDateFilter.tsx
@@ -28,7 +28,7 @@ export function InsightDateFilter({ disabled }: InsightDateFilterProps): JSX.Ele
     const { dateRange, interval, querySource, trendsFilter, isTrends } = useValues(insightVizDataLogic(insightProps))
     const { updateDateRange, updateQuerySource } = useActions(insightVizDataLogic(insightProps))
     const { insightData } = useValues(insightVizDataLogic(insightProps))
-    const { reportInsightDatePickerOpened } = useActions(eventUsageLogic)
+    const { reportInsightDatePickerOpened, reportInsightDateExclusionsChanged } = useActions(eventUsageLogic)
 
     // The picker speaks excluded days; the query schema stores included days
     const excludedDaysOfWeek = getExcludedDaysOfWeek(dateRange)
@@ -54,11 +54,16 @@ export function InsightDateFilter({ disabled }: InsightDateFilterProps): JSX.Ele
     }
     const handleExclusionsChange = (next: DateFilterExclusions): void => {
         const nextExcludedDaysOfWeek = parseIsoDaysOfWeek(next.days)
-        if (showDaysOfWeekExclusions && !daysOfWeekSetsEqual(nextExcludedDaysOfWeek, excludedDaysOfWeek)) {
+        const daysChanged = showDaysOfWeekExclusions && !daysOfWeekSetsEqual(nextExcludedDaysOfWeek, excludedDaysOfWeek)
+        const incompleteChanged = next.incomplete !== exclusions.incomplete
+        if (daysChanged) {
             updateQuerySource(computeDaysOfWeekUpdate(nextExcludedDaysOfWeek, dateRange))
         }
-        if (next.incomplete !== exclusions.incomplete) {
+        if (incompleteChanged) {
             updateDateRange({ excludeIncompletePeriods: next.incomplete ? true : null }, true)
+        }
+        if (daysChanged || incompleteChanged) {
+            reportInsightDateExclusionsChanged(querySource?.kind, next.incomplete, nextExcludedDaysOfWeek.length)
         }
     }
 


### PR DESCRIPTION
## Problem

Nobody can tell how many people use the date picker's "Incomplete periods" toggle. The control shipped with no instrumentation, so the only two available signals both mislead:

- Autocapture clicks on `data-attr="date-filter-exclude-incomplete-periods"` measure clicks, not state — a user who toggles on then off looks identical to one who kept it on.
- Counting insights that store `dateRange.excludeIncompletePeriods` measures the *field*, not the control. That field is part of the public query schema, so the API, the MCP `insight-create` tool, and Max all write it. Insights carried it months before the toggle existed, which makes stored-field counts a wild overcount of UI adoption.

Answering "is this toggle discoverable?" currently takes a warehouse investigation, and the answer changes depending on which proxy you pick. The same gap applies to the day-of-week exclusion chips in the same flyout.

## Changes

- Adds `reportInsightDateExclusionsChanged` to `eventUsageLogic`, capturing `insight date exclusions changed` with `exclude_incomplete_periods`, `excluded_days_of_week_count`, and `query_kind`.
- Fires it from `InsightDateFilter` only when an exclusion actually changes, so re-opening the flyout or re-picking the same days emits nothing.
- Reports resulting state rather than a click, so on/off and keep/revert are distinguishable, and `query_kind` shows which insight types the control matters for.

Deliberately not changed: `data-attr` values stay frozen, per the `frontend/src/CLAUDE.md` rule that they are API. `LemonSwitch` also puts `data-attr` on its inner button while `label` renders as a sibling, so autocapture misses clicks on the label text — measured at 1 label click against 200 switch clicks, and this event makes that leak irrelevant for this control rather than worth a change to a shared design-system component.

No UI change, so no screenshots.

## How did you test this code?

No tests added. The change is one capture call on an existing kea action path; its siblings (`reportInsightDatePickerOpened`, `reportInsightDateRangeChanged`) have no tests either, and a test asserting "this action calls `posthog.capture`" would assert the implementation rather than a regression anyone could hit.

What I actually ran:

- `pnpm --filter=@posthog/frontend typescript:check` — no errors in either touched file. The run does report pre-existing errors elsewhere from unbuilt workspace packages (`@posthog/quill*`, `@posthog/hogvm`) in this environment; CI builds those.
- `pnpm --filter=@posthog/frontend typegen:file frontend/src/lib/utils/eventUsageLogic.ts` then `pnpm --filter=@posthog/frontend fix`, so the generated action type and formatting are in sync.

Not done: no manual browser verification, and `hogli ci:preflight` was unavailable in this environment.

Verifying the event after deploy: it should appear as `insight date exclusions changed`, with `exclude_incomplete_periods` splitting enables from disables.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal analytics event, no user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude Code) from a Slack thread asking how many users had touched the incomplete-periods toggle.

The investigation is why this PR exists. Three successive attempts to answer that question from existing data each produced a different number, and each was wrong for a different reason: a project-scoped `system.insights` query undercounted by looking only at PostHog's own project; the cross-team fix then overcounted by attributing API- and agent-written `excludeIncompletePeriods` fields to the toggle; and the autocapture click count can't distinguish keeping the setting from reverting it. That's what convinced me the fix is an event rather than a better query.

I also checked and ruled out two theories along the way: the second exclusions control in the Quill date picker (`DateFilterExclusionsControl`) is not a live surface — its `quill-date-picker` flag has never returned `true` for any user — and the `LemonSwitch` label-click blind spot is real but immaterial here.

Skills invoked: none of the repo skills matched this change; I read `.github/pull_request_template.md`, `.agents/skills/writing-pr-descriptions/SKILL.md`, and `frontend/src/CLAUDE.md` directly for shape and conventions.

Nothing in this diff or description carries material from the originating session: the change touches only this repo's own code, and no customer names, identifiers, or figures from the analytics queries appear here.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0368RPHLQH/p1786955154540149?thread_ts=1786955154.540149&cid=C0368RPHLQH)*
