### PR TITLE
fix(retention): keep the flat event-name filter in the single-scan WHERE

### DIFF
--- a/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
@@ -435,6 +435,14 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
             return filters
 
         return_branch = self._first_time_role_branch(self.return_event, "return") or self.events_timestamp_filter()
+        # The OR below implies this flat name filter, but the planner's index analysis and
+        # PREWHERE staging work on top-level conjuncts. Without it, a property matcher inside
+        # the OR can force the fat properties column to be decompressed for every scanned row
+        # instead of only name-matching rows, multiplying bytes read. The legacy shape carries
+        # the same redundant conjunct.
+        name_filter = self.runner.event_name_filter([self.start_event, self.return_event])
+        if name_filter is not None:
+            filters.append(name_filter)
         filters.append(ast.Or(exprs=[start_branch, return_branch]))
         return filters
 

--- a/posthog/hogql_queries/insights/retention/test/__snapshots__/test_retention_query_runner.ambr
+++ b/posthog/hogql_queries/insights/retention/test/__snapshots__/test_retention_query_runner.ambr
@@ -1471,7 +1471,7 @@
         WHERE equals(person_distinct_id_overrides.team_id, 99999)
         GROUP BY person_distinct_id_overrides.distinct_id
         HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), or(in(events.event, tuple('signup')), and(in(events.event, tuple('act_a')), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))))))
+     WHERE and(equals(events.team_id, 99999), in(events.event, tuple('act_a', 'signup')), or(in(events.event, tuple('signup')), and(in(events.event, tuple('act_a')), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))))))
      GROUP BY actor_id
      HAVING 1) AS actor_activity
   GROUP BY start_event_matching_interval,


### PR DESCRIPTION
## TL;DR

The new retention query hid the "which events do we care about" filter inside a big OR. ClickHouse's planner only spots such filters when they stand on their own, so on some insights it read the huge properties column for every row instead of just the relevant ones. We now state the filter twice: once standalone for the planner, once inside the OR. Same results, far less data read.

## Problem

First-time retention insights with a breakdown and entity property filters read over 10× more bytes under the DWH-variant builder than under the legacy one, with identical results. This is the byte-read tail found by the production perf comparison gating the `retention-fixed-interval-base-query-dwh-variant` rollout (follow-up to [#82103](https://github.com/PostHog/posthog/pull/82103)).

The variant's single scan puts every event-name condition inside the OR of per-role branches. The legacy WHERE also carries the flat `event IN (...)` as its own top-level conjunct. ClickHouse's index analysis and PREWHERE staging key on top-level conjuncts, so with property matchers buried in the OR the planner decompresses the fat `properties` column for every scanned row instead of only name-matching rows.

## Changes

- `_single_scan_filters` appends the flat event-name filter (union of both entities' events) ahead of the OR. The OR implies it, so results are unchanged; the WHERE is now structurally identical to legacy's.
- One snapshot updated (the WHERE-shape pin for the single-scan path).

First-ever same-entity shapes already collapse to the flat filter and are untouched; the two-arm scan path is untouched.

## How did you test this code?

- Retention suite: 171 tests pass, with the parity mixin comparing legacy and variant results in every test.
- Local ClickHouse bench, 20M synthetic rows loaded so per-(day, event) sorted runs exceed the 8192-row granule (required to exercise index pruning): with the conjunct, the variant's bytes read match legacy exactly on the propertied shape, and the no-props shape additionally gains index-level window pruning on the return branch (~9% fewer rows). All numbers from synthetic data.
- The local ClickHouse (26.6) planner tolerates the OR-only form, so the production amplification does not reproduce locally; production verification happens post-deploy with the rollout's comparison tool on an affected insight.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal query builder change behind the rollout flag.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Diagnosed from the rollout's production perf report (per-insight bytes/rows deltas), reproduced structurally by printing both builders' SQL, and validated on a local 20M-row bench with hybrid WHERE-swapped queries. Skills invoked: /writing-pr-descriptions, /writing-code-comments, /writing-tests. Session: PostHog Desktop task thread for the retention DWH-variant rollout.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
