### PR TITLE
fix(langfuse): keep exhausted read-timeout errors out of error tracking

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/langfuse/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/langfuse/source.py
@@ -128,6 +128,20 @@ Find your project API keys in your Langfuse **Project settings > API Keys**. Set
             REPEATED_CURSOR_ERROR: "The Langfuse host repeated a pagination cursor, so the sync was stopped to avoid looping. Check that the host points at a real Langfuse instance.",
         }
 
+    def get_retryable_errors(self) -> set[str]:
+        # `get_rows`'s tenacity retry already retries a 429/422/5xx (the "Langfuse API error
+        # (retryable)" sentinel), a dropped connection, and a read timeout up to MAX_RETRIES. Once
+        # that budget exhausts, urllib3 wraps the failure as "Max retries exceeded with url" (with
+        # the read timeout nested inside as its cause), and Temporal retries the whole activity from
+        # the saved pagination checkpoint, so the failure is transient and self-recovering. The host
+        # is customer-controlled (self-hosted Langfuse), so match only the stable, host-independent
+        # parts of the message.
+        return {
+            "Langfuse API error (retryable)",
+            "Read timed out",
+            "Max retries exceeded with url",
+        }
+
     def get_schemas(
         self,
         config: LangfuseSourceConfig,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/langfuse/tests/test_langfuse_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/langfuse/tests/test_langfuse_source.py
@@ -71,6 +71,25 @@ class TestLangfuseSource:
     def test_non_retryable_errors(self, expected_key):
         assert expected_key in self.source.get_non_retryable_errors()
 
+    @pytest.mark.parametrize(
+        "expected_pattern", ["Langfuse API error (retryable)", "Read timed out", "Max retries exceeded with url"]
+    )
+    def test_retryable_errors(self, expected_pattern):
+        assert expected_pattern in self.source.get_retryable_errors()
+
+    def test_exhausted_connection_pool_error_is_classified_retryable(self):
+        # Matches the message urllib3 raises once `get_rows`'s tenacity retry (which covers read
+        # timeouts and connection failures, not just 429/422/5xx) exhausts its budget — keeps this
+        # transient, self-recovering failure out of error tracking instead of reaching
+        # `logger.aexception`.
+        observed_error = (
+            "HTTPSConnectionPool(host='us.cloud.langfuse.com', port=443): Max retries exceeded with "
+            "url: /api/public/traces?limit=50&orderBy=timestamp.asc&page=5339 (Caused by "
+            "ReadTimeoutError(\"HTTPSConnectionPool(host='us.cloud.langfuse.com', port=443): "
+            'Read timed out. (read timeout=60)"))'
+        )
+        assert any(pattern in observed_error for pattern in self.source.get_retryable_errors())
+
     def test_get_schemas_returns_all_endpoints(self):
         schemas = self.source.get_schemas(self.config, self.team_id)
         assert {s.name for s in schemas} == set(ENDPOINTS)


### PR DESCRIPTION
## Problem

A Langfuse traces sync hit a read timeout deep in pagination, and the resulting `ConnectionError` showed up in [error tracking](https://us.posthog.com/project/2/error_tracking/01a00f06-5f55-76c3-b8e0-3bbc1409d4ad) as if it were a bug.

The failure is transient and self-recovering: `get_rows`'s own tenacity retry already retries read timeouts and connection failures, and once that budget exhausts, Temporal retries the whole activity from the saved pagination checkpoint. The Langfuse source never told the shared error handler that, so every occurrence logs at exception level and reaches error tracking as noise.

## Changes

- Add `get_retryable_errors()` to `LangfuseSource`, matching the host-independent parts of the exhausted-retry messages: the `LangfuseRetryableError` sentinel, and the wrapped `ConnectionError`/`ReadTimeoutError` text.
- Host-independent matching is required because the Langfuse host is customer-controlled (cloud region or self-hosted) — mirrors the existing pattern in the SigNoz source, whose host is likewise customer-controlled.
- Matching entries log at `warning` instead of reaching error tracking; Temporal's retry and resume-from-checkpoint behavior is unchanged.

Not classified as non-retryable: this is a transient infrastructure error, not a credential or config problem the user can fix, so it stays retryable rather than disabling the source.

## How did you test this code?

Added `test_retryable_errors` (parametrized, mirrors the existing `test_non_retryable_errors`) and `test_exhausted_connection_pool_error_is_classified_retryable`, which reproduces the exact message shape from the error tracking issue's stack trace. Ran the full `test_langfuse_source.py` suite locally (78 passed), `ruff check`/`ruff format`, and repo-wide `mypy` on the changed module (clean).

Not run: a live sync against Langfuse's API, since this is a message-matching change with no behavioral effect on retry timing or request handling.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal error classification only, no user-facing or documented behavior changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog's error tracking MCP tools to confirm the failure originates in `langfuse.py`'s `fetch_page` → `get_rows`, then read the tenacity retry policy and the Temporal activity retry/resume configuration in `external_data_job.py`. Found the precedent while checking for duplicate PRs: [#83428](https://github.com/PostHog/posthog/pull/83428) applied the identical fix to the Adjust source, and the SigNoz source already classifies the same exhausted-connection-pool shape for a customer-controlled host. No open PR addressed this for Langfuse. Invoked `/writing-tests` before adding test coverage and `/writing-pr-descriptions` before writing this body.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*