### PR TITLE
chore(agents): add adding-sdk-integrations skill

### DIFF
--- a/.agents/skills/adding-sdk-integrations/SKILL.md
+++ b/.agents/skills/adding-sdk-integrations/SKILL.md
@@ -3,7 +3,7 @@ name: adding-sdk-integrations
 description: >
   How to surface a PostHog SDK inside the PostHog app: the SDK setup picker in project settings, per-product onboarding install steps, and the backend `$lib` lists that decide whether the SDK's traffic is recognised.
   Use when adding a new SDK, extending an existing one to another product (session replay, feature flags, experiments, web analytics, surveys, logs, error tracking), or when an SDK is "already added" but does not appear in a picker.
-  Covers the two independent pickers, the `docs/onboarding` step components, the integration points that fail silently because nothing renders them, and how to verify snippets against the real SDK.
+  Covers the two independent pickers, the `docs/onboarding` step components, the integration points that fail silently because nothing renders them, the posthog.com and wizard repos, and how to verify snippets against the real SDK.
   Treat the file list here as a checklist to check against the tree, not a spec — rediscover it with the trace command below and update this skill when it drifts.
 ---
 
@@ -95,7 +95,17 @@ Nothing renders these, so skipping them fails silently in production rather than
 
 **Icons:** `frontend/src/lib/lemon-ui/icons/categories.ts`, `frontend/src/lib/integrations/GitHubIntegrationHelpers.tsx`.
 
-**Setup wizard:** `legacy/sdks/skillBadge.tsx` `WIZARD_SKILL_IDS` — only when the CLI repo ships a matching skill id. Flutter is not in it, so this is usually skipped.
+**AI setup wizard:** if [PostHog/wizard](https://github.com/PostHog/wizard) has a `src/frameworks/<sdk>/` directory, set `wizardIntegrationName` on the `SDK_CONFIGS` entry. That renders the "Run the following command from the root of your X project" banner above the manual steps. It is display text only, so it does not have to match the wizard's framework id — but do not set it when the wizard cannot handle the SDK.
+
+## Other repos
+
+Two repos have to change too. Their file lists are not reproduced here, because this skill cannot verify them and a stale list is worse than a pointer — read the tree when you get there.
+
+**[PostHog/posthog.com](https://github.com/PostHog/posthog.com) — required.** Every `docsLink` in this repo points at it, so shipping the app wiring without the docs page gives customers a 404 from the picker. Trace an existing SDK with `git grep -Il "flutter" -- '*.ts' '*.tsx' '*.mdx' '*.js'`. As of writing that is five places: the page at `contents/docs/libraries/<sdk>/index.mdx` (whose frontmatter `features` block drives the support matrices), a `platformLogo` entry in `src/constants/logos.ts`, an entry in `src/constants/installation-taxonomy.ts`, the sidebar in `src/navs/index.js`, and the grid in `src/components/Docs/Integrate.tsx`.
+
+**[PostHog/wizard](https://github.com/PostHog/wizard) — optional.** A framework under `src/frameworks/<sdk>/` plus a `SkillId` entry lets the AI setup wizard install the SDK. Only then set `wizardIntegrationName` here, or the banner promises something the wizard cannot do.
+
+The SDK's own repo is out of scope for this skill.
 
 ## Known dead ends
 
@@ -103,6 +113,7 @@ Confirm before relying on these; both were true when this skill was written.
 
 - `legacy/sdks/sdk-install-instructions/` — unimported, see above.
 - `SDK_KEY_TO_SNIPPET_LANGUAGE` in `frontend/src/lib/constants.tsx` — zero consumers.
+- `legacy/sdks/skillBadge.tsx`, including `WIZARD_SKILL_IDS` and `WIZARD_SKILL_TO_SDK_KEY` — nothing imports the module. Use `wizardIntegrationName` instead, above.
 
 ## Verify the snippets, do not trust the docs page
 

--- a/.agents/skills/adding-sdk-integrations/SKILL.md
+++ b/.agents/skills/adding-sdk-integrations/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: adding-sdk-integrations
+description: >
+  How to surface a PostHog SDK inside the PostHog app: the SDK setup picker in project settings, per-product onboarding install steps, and the backend `$lib` lists that decide whether the SDK's traffic is recognised.
+  Use when adding a new SDK, extending an existing one to another product (session replay, feature flags, experiments, web analytics, surveys, logs, error tracking), or when an SDK is "already added" but does not appear in a picker.
+  Covers the two independent pickers, the `docs/onboarding` step components, the integration points that fail silently because nothing renders them, and how to verify snippets against the real SDK.
+  Treat the file list here as a checklist to check against the tree, not a spec — rediscover it with the trace command below and update this skill when it drifts.
+---
+
+# Adding SDK integrations
+
+An SDK reaches customers through two independent surfaces that do **not** share a list:
+
+1. **SDK setup** in project settings — built from `SDK_CONFIGS` in
+   [frontend/src/scenes/settings/environment/SDKSetupInstructions.tsx](../../../frontend/src/scenes/settings/environment/SDKSetupInstructions.tsx).
+   `ProxySDKSetup.tsx` reuses it, so one entry covers both.
+2. **Onboarding** — built from `ALL_SDKS` intersected with a per-product instructions map.
+   An SDK in `ALL_SDKS` with no map entry is invisible for that product.
+
+Adding the enum key and the catalogue entry is the half that looks finished and isn't. That is the usual bug: the SDK exists in the type system, and every picker is still empty.
+
+## Two traps
+
+**`legacy/` is the live default, not dead code.** The onboarding maps live under
+`frontend/src/scenes/onboarding/legacy/sdks/`. `DEFAULT_VARIANT` in
+[onboardingVariants.ts](../../../frontend/src/scenes/onboarding/onboardingVariants.ts) is `'legacy'`, so this is what most customers see. Skipping it because of the directory name ships an SDK nobody can select.
+
+**`legacy/sdks/sdk-install-instructions/` really is dead.** Nothing outside that directory imports it. Do not add a file there. Confirm before trusting this:
+
+```bash
+rg -l "sdk-install-instructions" frontend/src products --glob '!**/sdk-install-instructions/**'
+```
+
+## Verify against the tree first
+
+This list drifts. Before following it, trace an SDK that is already wired into every product and diff that against what you are adding:
+
+```bash
+# Flutter is wired end-to-end; android/ios/react-native work too
+git grep -il "flutter" origin/master -- ':!*.lock' ':!*.ambr' ':!**/generated/**' ':!*.md'
+```
+
+Read the hits rather than pattern-matching the paths. Two known collisions: **Flutterwave** (a data warehouse source) is unrelated, and so is anything under `products/warehouse_sources/`.
+
+## Tier 1 — required, or the SDK does not appear at all
+
+| File                                                                    | Change                                                                                      |
+| ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `frontend/src/types.ts`                                                 | `SDKKey` enum entry                                                                         |
+| `frontend/src/scenes/onboarding/legacy/sdks/allSDKs.tsx`                | catalogue entry: `name`, `key`, `tags: SDKTag[]`, `image`, `docsLink`                       |
+| `frontend/src/scenes/onboarding/shared/logos/<sdk>.svg`                 | logo, unless `image` points at a Cloudinary URL (KMP does this — no asset needed)           |
+| `docs/onboarding/product-analytics/<sdk>.tsx`                           | `get<Sdk>Steps(ctx)` + `export const <Sdk>Installation = createInstallation(get<Sdk>Steps)` |
+| `docs/onboarding/product-analytics/index.ts`                            | barrel export                                                                               |
+| `frontend/src/scenes/settings/environment/SDKSetupInstructions.tsx`     | `SDK_CONFIGS` entry: `Installation`, `name`, `docsLink`, `category`                         |
+| `.../legacy/sdks/product-analytics/ProductAnalyticsSDKInstructions.tsx` | wrapper (`withMobileReplay` or `withOnboardingDocsWrapper`) + map entry                     |
+
+## Tier 2 — one set per product you support
+
+For each of session replay, feature flags, experiments, web analytics, surveys, logs, error tracking, workflows:
+
+- `docs/onboarding/<product>/<sdk>.tsx`
+- `docs/onboarding/<product>/index.ts` — barrel export
+- `.../legacy/sdks/<product>/<Product>SDKInstructions.tsx` — wrapper + map entry
+
+Only add products the SDK actually supports. Claiming one it doesn't is worse than omitting it.
+
+Conventions worth copying rather than inventing:
+
+- Feature flags, experiments and web analytics compose off the product-analytics steps. Session replay does **not** — every mobile SDK there is standalone.
+- Composition selects a step by its **display title**, e.g. `.filter((step) => step.title !== 'Send events')`. A miss is silent, so keep your product-analytics step titles identical to the SDK you copied from. `frontend/src/scenes/onboarding/stepComposition.test.ts` guards this if present.
+- Surveys prefixes its export: `Surveys<Sdk>Installation`.
+- Mobile SDKs want a `case` in `legacy/sdks/session-replay/AdvertiseMobileReplay.tsx`, which otherwise falls back to "Mobile".
+- `ctx` supplies `CodeBlock`, `Markdown`, `CalloutBox`, `Tab`, `dedent`, `snippets`. `Tab.Group tabs={[...]}` renders the tab bar itself; `Tab.List` is an inert website-compat shim.
+
+## Tier 3 — the ones that get forgotten
+
+Nothing renders these, so skipping them fails silently in production rather than in review.
+
+**Backend `$lib` lists.** All keyed on the string the SDK reports. Check what the SDK actually sends — a wrapper SDK may override `$lib` on every platform, so it will not match the SDK it delegates to.
+
+- [posthog/api/utils.py](../../../posthog/api/utils.py) — mobile-client check in `on_permitted_recording_domain`. Miss it and session recording is rejected for teams with authorized domains set.
+- [posthog/models/team/production_event_activation.py](../../../posthog/models/team/production_event_activation.py) — `MOBILE_SIDE_LIBS` / `SERVER_SIDE_LIBS`
+- `posthog/tasks/usage_report.py` + `posthog/temporal/usage_report/queries.py` — per-lib event and exception counters. **Regenerates `posthog/tasks/test/__snapshots__/test_usage_report.ambr`**, and moves billing counters, so this is often its own PR.
+- `products/feature_flags/backend/flag_analytics.py`
+- `nodejs/src/common/utils/utils.ts`
+- `rust/feature-flags/src/utils/user_agent.rs` — user agent to lib name and `RuntimeType`
+
+**SDK health and versions:** `products/growth/backend/{constants.py,sdk_health.py}`, `products/growth/dags/github_sdk_versions.py`, `frontend/src/scenes/onboarding/shared/sdkHealth/sdkConstants.ts`.
+
+**Error tracking runtime:** `frontend/src/lib/components/Errors/{types.ts,utils.ts,displayOrder.ts}`, `products/error_tracking/frontend/components/RuntimeIcon.tsx`, and the hardcoded tile list in `products/error_tracking/frontend/components/SetupPrompt/SetupPrompt.tsx`. Add to `rust/cymbal/src/modes/processing/normalization.rs` only if stack frames need flipping.
+
+**Feature flag and experiment detail pages** keep their own lists, separate from onboarding: `frontend/src/scenes/feature-flags/{FeatureFlagCodeOptions,FeatureFlagSnippets}.tsx`, `frontend/src/scenes/experiments/{ExperimentImplementationDetails,ExperimentCodeSnippets}.tsx`.
+
+**Capability matrices:** `frontend/src/lib/components/SupportedPlatforms/{types.ts,SupportedPlatforms.tsx,featureSupport.tsx}`. For surveys also `frontend/src/scenes/surveys/surveyVersionRequirements.ts` and `frontend/bin/docs/build-survey-sdk-docs.ts`.
+
+**Icons:** `frontend/src/lib/lemon-ui/icons/categories.ts`, `frontend/src/lib/integrations/GitHubIntegrationHelpers.tsx`.
+
+**Setup wizard:** `legacy/sdks/skillBadge.tsx` `WIZARD_SKILL_IDS` — only when the CLI repo ships a matching skill id. Flutter is not in it, so this is usually skipped.
+
+## Known dead ends
+
+Confirm before relying on these; both were true when this skill was written.
+
+- `legacy/sdks/sdk-install-instructions/` — unimported, see above.
+- `SDK_KEY_TO_SNIPPET_LANGUAGE` in `frontend/src/lib/constants.tsx` — zero consumers.
+
+## Verify the snippets, do not trust the docs page
+
+Onboarding snippets are copied into real projects, so a wrong one costs a customer an afternoon.
+
+For a compiled SDK (Kotlin, Swift, Java, C#), paste each snippet into a scratch source file in the SDK repo and build it against every target the snippet claims to support. Delete the scratch files afterward. Check the check has teeth by breaking one parameter name and confirming the build fails.
+
+Compiling is necessary and not sufficient. It cannot catch a call that compiles everywhere and **throws on one platform** — the KMP SDK's no-argument `PostHogContext()` throws on Android, so a snippet using it compiled cleanly and crashed on launch. Read the platform-specific implementation of anything a snippet calls.
+
+Also check defaults rather than repeating the marketing line. "PostHog automatically captures events" is false for an SDK that defaults `autocapture` and `captureScreenViews` to `false`.
+
+## Verify the wiring
+
+Add a test that asserts the SDK is selectable in every product you wired plus the settings picker. It catches an entry added to one map and forgotten in another, which is the failure mode here.
+
+```ts
+it.each(productsSupportingSdk)('makes <Sdk> selectable in %s onboarding', (_product, instructions) => {
+    const sdk = getAvailableSDKs(instructions, {}, {}).find(({ key }) => key === SDKKey.<SDK>)
+    expect(instructions[SDKKey.<SDK>]).not.toBeUndefined()
+    expect(sdk).toMatchObject({ key: SDKKey.<SDK>, docsLink: DOCS_LINK })
+})
+```
+
+Then assert `SDK_CONFIGS[SDKKey.<SDK>]` matches the name, docsLink and category. `ErrorTrackingSDKInstructions.test.ts` in the same directory is the closest existing example.
+
+`docs/onboarding` is not a jest root, so tests that read those files live under `frontend/src`.
+
+## Keep this skill current
+
+These integration points move. When you add an SDK and find a file this skill does not list, or find a listed one gone or newly dead, update this skill in the same PR and say so in the description. A checklist that silently rots is worse than no checklist, because the next person trusts it.

--- a/.agents/skills/adding-sdk-integrations/SKILL.md
+++ b/.agents/skills/adding-sdk-integrations/SKILL.md
@@ -99,9 +99,11 @@ Nothing renders these, so skipping them fails silently in production rather than
 
 ## Other repos
 
-Two repos have to change too. Their file lists are not reproduced here, because this skill cannot verify them and a stale list is worse than a pointer — read the tree when you get there.
+**The Tier 1 and Tier 2 step components are also the public docs.** Each posthog.com installation page is a stub that imports `<Sdk>Installation` from this repo, so a snippet you write here is published at `posthog.com/docs/<product>/installation/<sdk>` as well as shown in the picker. Write them to that standard.
 
-**[PostHog/posthog.com](https://github.com/PostHog/posthog.com) — required.** Every `docsLink` in this repo points at it, so shipping the app wiring without the docs page gives customers a 404 from the picker. Trace an existing SDK with `git grep -Il "flutter" -- '*.ts' '*.tsx' '*.mdx' '*.js'`. As of writing that is five places: the page at `contents/docs/libraries/<sdk>/index.mdx` (whose frontmatter `features` block drives the support matrices), a `platformLogo` entry in `src/constants/logos.ts`, an entry in `src/constants/installation-taxonomy.ts`, the sidebar in `src/navs/index.js`, and the grid in `src/components/Docs/Integrate.tsx`.
+**[PostHog/posthog.com](https://github.com/PostHog/posthog.com) — required.** Follow the runbook at [handbook/wizard-and-docs/onboarding-docs](https://posthog.com/handbook/wizard-and-docs/onboarding-docs), which owns this procedure: a wrapper export in `contents/docs/<product>/installation/_snippets/<prefix>-installation-wrapper.tsx`, an `.mdx` stub per SDK, local testing with `GATSBY_POSTHOG_BRANCH=<your-branch> pnpm start`, and merging both PRs together. Do not re-derive those steps from this file — the runbook is maintained and this is not.
+
+The runbook covers the per-product installation pages. The SDK's own library page is separate and also required, because every `docsLink` in this repo points at it and a missing page is a 404 straight from the picker: `contents/docs/libraries/<sdk>/index.mdx`, whose frontmatter `features` block drives the support matrices, plus entries in `src/constants/logos.ts`, `src/constants/installation-taxonomy.ts`, `src/navs/index.js` and `src/components/Docs/Integrate.tsx`. Check `src/components/SdkReferences/utils.ts` too if the SDK has reference docs.
 
 **[PostHog/wizard](https://github.com/PostHog/wizard) — optional.** A framework under `src/frameworks/<sdk>/` plus a `SkillId` entry lets the AI setup wizard install the SDK. Only then set `wizardIntegrationName` here, or the banner promises something the wizard cannot do.
 

--- a/.agents/skills/adding-sdk-integrations/SKILL.md
+++ b/.agents/skills/adding-sdk-integrations/SKILL.md
@@ -107,15 +107,20 @@ The runbook covers the per-product installation pages. The SDK's own library pag
 
 **[PostHog/wizard](https://github.com/PostHog/wizard) — optional.** A framework under `src/frameworks/<sdk>/` plus a `SkillId` entry lets the AI setup wizard install the SDK. Only then set `wizardIntegrationName` here, or the banner promises something the wizard cannot do.
 
-The SDK's own repo is out of scope for this skill.
+**[PostHog/context-mill](https://github.com/PostHog/context-mill) — recommended.** It packages docs, prompts and example apps into the manifest the PostHog MCP server and the AI wizard consume, so an SDK missing here is invisible to every agent-driven install. Add an entry to `context/skills/integration/config.yaml` and to `context/commandments.yaml`. An SDK with no example app can ship a docs-only template — see `description-kmp-docs-only.md`.
+
+**[PostHog/squeak-strapi](https://github.com/PostHog/squeak-strapi) — rarely.** Only when the SDK gains HogRef reference docs, which most SDKs do not have. The generated JSON lives in the SDK's own repo under `references/`, and a Strapi cron in `config/cron-tasks.ts` fetches it. See [handbook/wizard-and-docs/sdk-reference-docs](https://posthog.com/handbook/wizard-and-docs/sdk-reference-docs) before starting; it also needs an entry in `src/components/SdkReferences/utils.ts` on posthog.com.
+
+The SDK's own repo is out of scope for this skill, with one hard dependency: the package has to be published to its registry before any of this, because the install snippets name a real artifact.
 
 ### This is several PRs, and the order matters
 
 One SDK means one PR per repo, and they cannot land in any order. `gatsby-source-git` pulls the shared components from this repo's **`master`**, so a posthog.com stub importing `<Sdk>Installation` cannot build until the component exists on master. Opening it early is fine; merging it early breaks the docs build.
 
+0. **The SDK release.** The package must be on its registry first — Maven Central, npm, PyPI — or the install snippet names an artifact nobody can resolve. Check the published versions rather than a local checkout: reading a version out of an unfetched working tree is how a snippet ends up pinning a release that predates the feature it describes.
 1. **This repo** — the app wiring and the step components, together in one PR. Nothing else can merge before it.
 2. **posthog.com** — the installation stubs. Open it as a draft alongside, link the blocking PR in the body, and merge it after step 1. `GATSBY_POSTHOG_BRANCH=<your-branch> pnpm start` renders it locally in the meantime; it does not fix the deployed preview.
-3. **PostHog/wizard** — independent of both. Merge it whenever, but only set `wizardIntegrationName` in step 1 once a framework exists.
+3. **PostHog/wizard** and **PostHog/context-mill** — independent of both, and of each other. Merge whenever, but only set `wizardIntegrationName` in step 1 once a wizard framework exists.
 
 Cross-link the PRs in both directions so whoever reviews one can see the other. Say in the blocked PR's body why it is red, or a reviewer reads a failing build as broken work.
 
@@ -138,6 +143,8 @@ For a compiled SDK (Kotlin, Swift, Java, C#), paste each snippet into a scratch 
 Compiling is necessary and not sufficient. It cannot catch a call that compiles everywhere and **throws on one platform** — the KMP SDK's no-argument `PostHogContext()` throws on Android, so a snippet using it compiled cleanly and crashed on launch. Read the platform-specific implementation of anything a snippet calls.
 
 Also check defaults rather than repeating the marketing line. "PostHog automatically captures events" is false for an SDK that defaults `autocapture` and `captureScreenViews` to `false`.
+
+Prefer a version range over a hardcoded version — `3.+` for a stable major, `0.+` for a pre-release, matching `product-analytics/android.tsx` and `surveys/android.tsx`. Nobody refreshes a pinned version in onboarding docs, and a stale pin sends new users to a release that predates the feature the surrounding text describes. Note in prose that a `0.x` API can change between minor versions, and say how to pin deliberately.
 
 ## Verify the wiring
 

--- a/.agents/skills/adding-sdk-integrations/SKILL.md
+++ b/.agents/skills/adding-sdk-integrations/SKILL.md
@@ -109,6 +109,18 @@ The runbook covers the per-product installation pages. The SDK's own library pag
 
 The SDK's own repo is out of scope for this skill.
 
+### This is several PRs, and the order matters
+
+One SDK means one PR per repo, and they cannot land in any order. `gatsby-source-git` pulls the shared components from this repo's **`master`**, so a posthog.com stub importing `<Sdk>Installation` cannot build until the component exists on master. Opening it early is fine; merging it early breaks the docs build.
+
+1. **This repo** — the app wiring and the step components, together in one PR. Nothing else can merge before it.
+2. **posthog.com** — the installation stubs. Open it as a draft alongside, link the blocking PR in the body, and merge it after step 1. `GATSBY_POSTHOG_BRANCH=<your-branch> pnpm start` renders it locally in the meantime; it does not fix the deployed preview.
+3. **PostHog/wizard** — independent of both. Merge it whenever, but only set `wizardIntegrationName` in step 1 once a framework exists.
+
+Cross-link the PRs in both directions so whoever reviews one can see the other. Say in the blocked PR's body why it is red, or a reviewer reads a failing build as broken work.
+
+Keep the pieces in their own PRs rather than one branch across repos: a docs stub landing without its component is a broken page, and the reverse is only a missing page.
+
 ## Known dead ends
 
 Confirm before relying on these; both were true when this skill was written.


### PR DESCRIPTION
## Problem

Surfacing an SDK in the app touches about 40 files across four languages, and nothing writes that down. Each new SDK rediscovers the surface, and the parts that get missed are the ones nothing renders.

- Two pickers share no list. **SDK setup** in project settings builds from `SDK_CONFIGS`; **onboarding** builds from `ALL_SDKS` intersected with a per-product instructions map.
- Adding the `SDKKey` and the `ALL_SDKS` entry looks finished and leaves every picker empty. The SDK exists in the type system and a customer still cannot select it.
- The backend `$lib` lists have no UI at all, so skipping one fails in production rather than in review. Kotlin Multiplatform was absent from the mobile-client check in `on_permitted_recording_domain`, which rejects session recording for teams with authorized domains set.

## Changes

- Adds `.agents/skills/adding-sdk-integrations/SKILL.md`, a checklist in three tiers: required to appear at all, per product supported, and the ones that fail silently.
- Leads with the `git grep` trace command that regenerates the list from a reference SDK, so the method outlives the file paths.
- Records two traps from wiring the KMP SDK. `frontend/src/scenes/onboarding/legacy/sdks/` is the `DEFAULT_VARIANT` and must be updated despite the directory name; `legacy/sdks/sdk-install-instructions/` is genuinely unimported and must not be.
- Lists known dead ends with the command to re-confirm each, so nobody re-adds them: the directory above, and `SDK_KEY_TO_SNIPPET_LANGUAGE`, which has zero consumers.
- Closes with a self-update clause: find a file this misses, or a listed one gone, and update it in the same PR.

I wrote this as a checklist to check the tree against, not a spec. A list of 40 paths in a repo this active is wrong within a quarter, so the trace command and the update clause matter more than the table.

## How did you test this code?

No code, so nothing to execute. What I can show instead:

- I scripted a check over every path the skill names: **28 paths, all resolve on `master`**. Two did not and were removed — they were files from unmerged PRs of mine, which would have made the skill broken on the day it landed.
- I re-verified each factual claim against `origin/master` rather than from the session: `DEFAULT_VARIANT` is `'legacy'`, the `Surveys<Sdk>Installation` export prefix, `MOBILE_SIDE_LIBS`, `on_permitted_recording_domain`, `WIZARD_SKILL_IDS`, and that Flutter is absent from the wizard list.
- `rg -l "sdk-install-instructions"` outside that directory returns nothing, and `SDK_KEY_TO_SNIPPET_LANGUAGE` has no consumers outside its own declaration.

The checklist itself came out of wiring Kotlin Multiplatform end to end in #83572, so every tier has been walked once rather than assembled from grep alone.

Not checked: the Tier 3 backend lists are traced from Flutter's integration, not exercised. I changed two of them in #83572 and did not verify the rest against live traffic.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5). Skills invoked: `/writing-pr-descriptions`.

Two things changed while writing it. It started as a flat file list and became tiered once it was clear the list would rot, which is where the trace command and the update clause came from. It also originally linked to two test files as examples; the path audit caught that both live in unmerged branches, so the test pattern is inlined instead and points at `ErrorTrackingSDKInstructions.test.ts`, which exists today.
