### PR TITLE
chore(devex): pass evaluation and grouping inputs as dataclasses

### DIFF
--- a/posthog/tasks/alerts/test/alert_check_helpers.py
+++ b/posthog/tasks/alerts/test/alert_check_helpers.py
@@ -24,17 +24,7 @@ def run_alert_check(alert_id: str) -> None:
 
     should_run_metrics_investigation = False
     with transaction.atomic():
-        alert_check, notify = alert_utils.add_alert_check(
-            alert,
-            value=result.value if result else None,
-            breaches=result.breaches if result else None,
-            error=error,
-            anomaly_scores=result.anomaly_scores if result else None,
-            triggered_points=result.triggered_points if result else None,
-            triggered_dates=result.triggered_dates if result else None,
-            interval=result.interval if result else None,
-            triggered_metadata=result.triggered_metadata if result else None,
-        )
+        alert_check, notify = alert_utils.add_alert_check(alert, result, error)
 
         # Claim the cooldown slot inside the transaction (read-then-write stays
         # consistent with the check insert), mirroring the detector path.

--- a/posthog/tasks/alerts/utils.py
+++ b/posthog/tasks/alerts/utils.py
@@ -1,6 +1,5 @@
 from collections.abc import Collection
 from contextlib import ExitStack
-from dataclasses import dataclass
 from datetime import UTC, datetime
 from zoneinfo import ZoneInfo
 
@@ -11,6 +10,7 @@ import structlog
 
 from posthog.schema import AlertCalculationInterval, AlertState, ChartDisplayType, NodeKind, TrendsQuery
 
+from posthog.dataclasses import frozen
 from posthog.ph_client import ph_background_capture
 from posthog.rbac.user_access_control import UserAccessControl
 from posthog.slo.context import get_current_slo
@@ -48,7 +48,7 @@ logger = structlog.get_logger(__name__)
 INSIGHT_ALERT_FIRING_EVENT = "$insight_alert_firing"
 
 
-@dataclass
+@frozen
 class AlertEvaluationResult:
     value: float | None
     breaches: list[str] | None
@@ -445,14 +445,8 @@ def record_alert_delivery(
 
 def add_alert_check(
     alert: AlertConfiguration,
-    value: float | None,
-    breaches: list[str] | None,
+    evaluation_result: AlertEvaluationResult | None,
     error: dict | None,
-    anomaly_scores: list[float | None] | None = None,
-    triggered_points: list[int] | None = None,
-    triggered_dates: list[str] | None = None,
-    interval: str | None = None,
-    triggered_metadata: dict | None = None,
 ) -> tuple[AlertCheck, bool]:
     """Persist an AlertCheck row and return it plus a decision on whether notification is needed.
 
@@ -460,10 +454,12 @@ def add_alert_check(
     successful delivery and treats a non-empty value as the idempotency sentinel on retry.
     ``last_notified_at`` is likewise set by the notify activity on success, not here.
     """
+    # Evaluation never ran (query error): record an all-empty result so the check row still lands.
+    result = evaluation_result if evaluation_result is not None else AlertEvaluationResult(value=None, breaches=None)
     error_message = error.get("message") if error else None
     outcome = evaluate_alert_check(
         alert,
-        threshold_breached=bool(breaches),
+        threshold_breached=bool(result.breaches),
         error_message=error_message,
         now=datetime.now(UTC),
     )
@@ -475,16 +471,16 @@ def add_alert_check(
 
     alert_check = AlertCheck.objects.create(
         alert_configuration=alert,
-        calculated_value=value,
+        calculated_value=result.value,
         condition=alert.condition,
         targets_notified={},
         state=alert.state,
-        triggered_metadata=triggered_metadata,
+        triggered_metadata=result.triggered_metadata,
         error=error,
-        anomaly_scores=anomaly_scores,
-        triggered_points=triggered_points,
-        triggered_dates=triggered_dates,
-        interval=interval,
+        anomaly_scores=result.anomaly_scores,
+        triggered_points=result.triggered_points,
+        triggered_dates=result.triggered_dates,
+        interval=result.interval,
     )
 
     alert.save(update_fields=[*state_fields, "last_checked_at", "next_check_at"])

--- a/posthog/temporal/alerts/activities.py
+++ b/posthog/temporal/alerts/activities.py
@@ -208,7 +208,7 @@ def _write_errored_alert_check(alert: AlertConfiguration, error: dict) -> tuple[
     Both evaluate_alert's failure path and the retry-exhausted record_failed_evaluation activity go
     through here, so the errored-check write stays in one place.
     """
-    return add_alert_check(alert, None, None, error)
+    return add_alert_check(alert, None, error)
 
 
 @temporalio.activity.defn
@@ -245,14 +245,12 @@ async def evaluate_alert(inputs: EvaluateAlertActivityInputs) -> EvaluateAlertRe
             alert_config_type=(alert.config or {}).get("type"),
         )
 
-        value: float | None = None
         breaches: list[str] | None = None
         error: dict | None = None
         alert_evaluation_result = None
 
         try:
             alert_evaluation_result = check_alert_for_insight(alert)
-            value = alert_evaluation_result.value
             breaches = alert_evaluation_result.breaches
         except CH_TRANSIENT_ERRORS:
             raise
@@ -319,12 +317,6 @@ async def evaluate_alert(inputs: EvaluateAlertActivityInputs) -> EvaluateAlertRe
                 new_state=AlertState.ERRORED,
             )
 
-        anomaly_scores = alert_evaluation_result.anomaly_scores if alert_evaluation_result else None
-        triggered_points = alert_evaluation_result.triggered_points if alert_evaluation_result else None
-        triggered_dates = alert_evaluation_result.triggered_dates if alert_evaluation_result else None
-        interval = alert_evaluation_result.interval if alert_evaluation_result else None
-        triggered_metadata = alert_evaluation_result.triggered_metadata if alert_evaluation_result else None
-
         should_start_investigation = False
         should_gate_notification = False
         should_run_metrics_investigation = False
@@ -335,17 +327,7 @@ async def evaluate_alert(inputs: EvaluateAlertActivityInputs) -> EvaluateAlertRe
                 .get(id=inputs.alert_id)
             )
             previous_state = alert.state
-            alert_check, should_notify = add_alert_check(
-                alert,
-                value,
-                breaches,
-                error,
-                anomaly_scores,
-                triggered_points,
-                triggered_dates,
-                interval,
-                triggered_metadata,
-            )
+            alert_check, should_notify = add_alert_check(alert, alert_evaluation_result, error)
 
             if should_trigger_investigation(
                 alert,

--- a/posthog/test/dataclass_frozen_baseline.txt
+++ b/posthog/test/dataclass_frozen_baseline.txt
@@ -57,7 +57,6 @@
 1 posthog/storage/hypercache_verifier.py
 1 posthog/tasks/alerts/detector.py
 1 posthog/tasks/alerts/detectors/base.py
-1 posthog/tasks/alerts/utils.py
 1 posthog/taxonomy/property_definition_api.py
 1 posthog/temporal/ai/anomaly_investigation/notebook.py
 1 posthog/temporal/ai/anomaly_investigation/runner.py
@@ -1378,7 +1377,7 @@
 10 products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
 104 posthog/hogql/ast.py
 12 ee/clickhouse/materialized_columns/columns.py
-12 products/signals/backend/temporal/grouping.py
+10 products/signals/backend/temporal/grouping.py
 14 products/marketing_analytics/backend/hogql_queries/adapters/base.py
 16 posthog/temporal/ai_observability/eval_reports/types.py
 17 products/exports/backend/temporal/subscriptions/types.py

--- a/products/signals/backend/temporal/grouping.py
+++ b/products/signals/backend/temporal/grouping.py
@@ -158,41 +158,7 @@ def _build_query_generation_system_prompt(signal_type_examples: list[SignalTypeE
     )
 
 
-async def generate_search_queries(
-    team_id: int | None,
-    description: str,
-    source_product: str,
-    source_type: str,
-    signal_type_examples: list[SignalTypeExample] | None = None,
-) -> list[str]:
-    """
-    Use LLM to generate 1-3 search queries for finding related signals.
-    Returns queries truncated to fit within embedding token limits.
-    """
-
-    system_prompt = _build_query_generation_system_prompt(signal_type_examples or [])
-
-    user_prompt = f"""NEW SIGNAL:
-- Source: {source_product} / {source_type}
-- Description: {description}"""
-
-    def validate(text: str) -> list[str]:
-        data = json.loads(text)
-        result = QueryGenerationResponse.model_validate(data)
-        return [truncate_query_to_token_limit(q) for q in result.queries]
-
-    return await call_llm(
-        team_id=team_id,
-        system_prompt=system_prompt,
-        user_prompt=user_prompt,
-        validate=validate,
-        temperature=0.7,
-        stage="query_generation",
-        ai_product="signals_grouping",
-    )
-
-
-@dataclass
+@frozen
 class GenerateSearchQueriesInput:
     description: str
     source_product: str
@@ -201,6 +167,34 @@ class GenerateSearchQueriesInput:
     # Optional with a default so workflows mid-flight across a deploy (whose activity input was
     # serialized before this field existed) still deserialize; missing => gateway key owner's team.
     team_id: int | None = None
+
+
+async def generate_search_queries(input: GenerateSearchQueriesInput) -> list[str]:
+    """
+    Use LLM to generate 1-3 search queries for finding related signals.
+    Returns queries truncated to fit within embedding token limits.
+    """
+
+    system_prompt = _build_query_generation_system_prompt(input.signal_type_examples)
+
+    user_prompt = f"""NEW SIGNAL:
+- Source: {input.source_product} / {input.source_type}
+- Description: {input.description}"""
+
+    def validate(text: str) -> list[str]:
+        data = json.loads(text)
+        result = QueryGenerationResponse.model_validate(data)
+        return [truncate_query_to_token_limit(q) for q in result.queries]
+
+    return await call_llm(
+        team_id=input.team_id,
+        system_prompt=system_prompt,
+        user_prompt=user_prompt,
+        validate=validate,
+        temperature=0.7,
+        stage="query_generation",
+        ai_product="signals_grouping",
+    )
 
 
 @dataclass
@@ -214,13 +208,7 @@ class GenerateSearchQueriesOutput:
 async def generate_search_queries_activity(input: GenerateSearchQueriesInput) -> GenerateSearchQueriesOutput:
     """Use LLM to generate 1-3 search queries for finding related signals."""
     try:
-        queries = await generate_search_queries(
-            team_id=input.team_id,
-            description=input.description,
-            source_product=input.source_product,
-            source_type=input.source_type,
-            signal_type_examples=input.signal_type_examples,
-        )
+        queries = await generate_search_queries(input)
         logger.debug(
             f"Generated {len(queries)} search queries",
             source_product=input.source_product,
@@ -428,15 +416,19 @@ Write a PR title covering ALL the above signals (existing + new), then judge if 
     return prompt
 
 
-async def match_signal_to_report(
-    team_id: int | None,
-    description: str,
-    source_product: str,
-    source_type: str,
-    queries: list[str],
-    query_results: list[list[SignalCandidate]],
-    report_contexts: dict[str, ReportContext],
-) -> MatchResult:
+@frozen
+class MatchSignalToReportInput:
+    description: str
+    source_product: str
+    source_type: str
+    queries: list[str]
+    query_results: list[list[SignalCandidate]]
+    report_contexts: dict[str, ReportContext]
+    # Optional with a default for deploy-time backward compatibility (see GenerateSearchQueriesInput).
+    team_id: int | None = None
+
+
+async def match_signal_to_report(input: MatchSignalToReportInput) -> MatchResult:
     """
     Determine if a new signal matches an existing report or needs a new one.
 
@@ -444,12 +436,17 @@ async def match_signal_to_report(
         ExistingReportMatch if a match is found, NewReportMatch otherwise
     """
     candidates_by_id: dict[str, SignalCandidate] = {}
-    for candidates in query_results:
+    for candidates in input.query_results:
         for c in candidates:
             candidates_by_id[c.signal_id] = c
 
     user_prompt = _build_matching_prompt(
-        description, source_product, source_type, queries, query_results, report_contexts
+        input.description,
+        input.source_product,
+        input.source_type,
+        input.queries,
+        input.query_results,
+        input.report_contexts,
     )
 
     def validate(text: str) -> MatchResult:
@@ -460,13 +457,13 @@ async def match_signal_to_report(
             matched = candidates_by_id.get(result.signal_id)
             if matched is None:
                 raise ValueError(f"signal_id {result.signal_id} not found in candidates")
-            if result.query_index < 0 or result.query_index >= len(queries):
-                raise ValueError(f"query_index {result.query_index} out of range (0-{len(queries) - 1})")
+            if result.query_index < 0 or result.query_index >= len(input.queries):
+                raise ValueError(f"query_index {result.query_index} out of range (0-{len(input.queries) - 1})")
             return ExistingReportMatch(
                 report_id=matched.report_id,
                 match_metadata=MatchedMetadata(
                     parent_signal_id=result.signal_id,
-                    match_query=queries[result.query_index],
+                    match_query=input.queries[result.query_index],
                     reason=result.reason,
                 ),
             )
@@ -481,7 +478,7 @@ async def match_signal_to_report(
         )
 
     return await call_llm(
-        team_id=team_id,
+        team_id=input.team_id,
         system_prompt=MATCHING_SYSTEM_PROMPT,
         user_prompt=user_prompt,
         validate=validate,
@@ -491,33 +488,13 @@ async def match_signal_to_report(
     )
 
 
-@dataclass
-class MatchSignalToReportInput:
-    description: str
-    source_product: str
-    source_type: str
-    queries: list[str]
-    query_results: list[list[SignalCandidate]]
-    report_contexts: dict[str, ReportContext]
-    # Optional with a default for deploy-time backward compatibility — see GenerateSearchQueriesInput.
-    team_id: int | None = None
-
-
 @temporalio.activity.defn
 @scoped_temporal()
 @close_db_connections
 async def match_signal_to_report_activity(input: MatchSignalToReportInput) -> MatchResult:
     """Determine if a new signal matches an existing report or needs a new one."""
     try:
-        result = await match_signal_to_report(
-            team_id=input.team_id,
-            description=input.description,
-            source_product=input.source_product,
-            source_type=input.source_type,
-            queries=input.queries,
-            query_results=input.query_results,
-            report_contexts=input.report_contexts,
-        )
+        result = await match_signal_to_report(input)
         total_candidates = sum(len(r) for r in input.query_results)
         logger.debug(
             f"Match result: matched={isinstance(result, ExistingReportMatch)}",

--- a/products/signals/eval/eval_grouping_e2e.py
+++ b/products/signals/eval/eval_grouping_e2e.py
@@ -43,6 +43,8 @@ from products.signals.backend.emission.pipeline import (
     summarize_long_descriptions as _summarize_long_descriptions,
 )
 from products.signals.backend.temporal.grouping import (
+    GenerateSearchQueriesInput,
+    MatchSignalToReportInput,
     generate_search_queries,
     match_signal_to_report,
     verify_match_specificity,
@@ -178,11 +180,13 @@ class EvalGroupingPipeline:
         """Generate search queries and compute all embeddings. No store mutations."""
 
         queries = await generate_search_queries(
-            team_id=EVAL_TEAM_ID,
-            description=description,
-            source_product=case.signal.config.source_product,
-            source_type=case.signal.config.source_type,
-            signal_type_examples=self.store.get_type_examples(),
+            GenerateSearchQueriesInput(
+                team_id=EVAL_TEAM_ID,
+                description=description,
+                source_product=case.signal.config.source_product,
+                source_type=case.signal.config.source_type,
+                signal_type_examples=self.store.get_type_examples(),
+            )
         )
 
         all_embeddings = await asyncio.gather(
@@ -206,13 +210,15 @@ class EvalGroupingPipeline:
         candidates = [self.store.search(emb) for emb in query_embeddings]
 
         match_result = await match_signal_to_report(
-            team_id=EVAL_TEAM_ID,
-            description=description,
-            source_product=case.signal.config.source_product,
-            source_type=case.signal.config.source_type,
-            queries=queries,
-            query_results=candidates,
-            report_contexts=self.report_store.get_contexts(),
+            MatchSignalToReportInput(
+                team_id=EVAL_TEAM_ID,
+                description=description,
+                source_product=case.signal.config.source_product,
+                source_type=case.signal.config.source_type,
+                queries=queries,
+                query_results=candidates,
+                report_contexts=self.report_store.get_contexts(),
+            )
         )
         specificity_match_result = match_result
 


### PR DESCRIPTION
## Problem

- Alert checks receive five same-typed optional fields positionally; a silently swapped pair would still type-check.
- `add_alert_check` takes 9 parameters, 7 of which mirror `AlertEvaluationResult` from the same file, so every caller unpacks the dataclass field by field.
- The signals grouping helpers `generate_search_queries` and `match_signal_to_report` mirror their existing activity input dataclasses (5 and 7 fields); the activity wrappers unpack every field only to rebuild the same argument list.

## Changes

- `add_alert_check` now takes the `AlertEvaluationResult | None` plus the alert and error; callers pass the result through instead of unpacking it.
- `generate_search_queries` and `match_signal_to_report` now take `GenerateSearchQueriesInput` / `MatchSignalToReportInput`; the `@activity.defn` wrappers pass `input` through unchanged.
- Activity wire signatures and payload shapes are unchanged.
- The two input dataclasses move above their helpers so the annotations resolve; the three touched dataclasses get `@frozen` (construction is keyword-only everywhere already), and the dataclass frozen baseline ratchets down for the two touched files only.
- No behavior change intended.

## How did you test this code?

- Ran locally: `posthog/tasks/alerts/test/` (includes the updated `run_alert_check` helper path), `posthog/temporal/tests/test_alerts_activities.py`, `posthog/temporal/tests/test_alerts_workflows.py`, `products/alerts/backend/evaluation/test/`, `posthog/temporal/tests/ai/test_module_integrity.py`.
- Verified both input dataclasses round-trip through Temporal's default `DataConverter`, including a payload without `team_id` (the pre-deploy in-flight shape).
- `python posthog/test/test_dataclass_defaults.py` ratchet passes with the adjusted baseline; ruff check and format are clean.
- Not run locally: `products/signals/eval/eval_grouping_e2e.py` (needs OpenAI and LLM gateway credentials); its two call sites were updated mechanically.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Generated by Claude Fable 5 (Claude Code) from a pre-triaged refactor task. Skills applied: `/writing-code-comments`, `/writing-pr-descriptions`, `/writing-tests` (gate only; no new tests, existing ones updated mechanically). Only the two clusters named in the task were touched; the frozen-baseline diff was restricted to the two files this PR changes.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
