### PR TITLE
fix(data-modeling): relayout filtered DAG nodes

### DIFF
--- a/frontend/src/scenes/data-warehouse/scene/dataModelingLogic.test.ts
+++ b/frontend/src/scenes/data-warehouse/scene/dataModelingLogic.test.ts
@@ -8,6 +8,7 @@ import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 
 import { dataModelingLogic } from './dataModelingLogic'
+import type { Edge, Node } from './modeling/types'
 
 describe('dataModelingLogic', () => {
     let logic: ReturnType<typeof dataModelingLogic.build>
@@ -71,5 +72,68 @@ describe('dataModelingLogic', () => {
         logic.mount()
 
         expect(logic.values.selectedDagId).toBe('dag-123')
+    })
+
+    it('lays out only the nodes matched by a lineage search', async () => {
+        logic = dataModelingLogic()
+        logic.mount()
+        await expectLogic(logic)
+            .toDispatchActions(['loadDataModelingNodesSuccess', 'loadDataModelingEdgesSuccess'])
+            .toFinishAllListeners()
+
+        const nodes: Node[] = [
+            {
+                id: 'source',
+                type: 'model',
+                position: { x: 0, y: 0 },
+                data: {
+                    id: 'source',
+                    name: 'this_view',
+                    type: 'view',
+                    upstreamCount: 0,
+                    downstreamCount: 1,
+                },
+            },
+            {
+                id: 'unrelated',
+                type: 'model',
+                position: { x: 5000, y: 0 },
+                data: {
+                    id: 'unrelated',
+                    name: 'unrelated_view',
+                    type: 'view',
+                    upstreamCount: 0,
+                    downstreamCount: 0,
+                },
+            },
+            {
+                id: 'target',
+                type: 'model',
+                position: { x: 10000, y: 0 },
+                data: {
+                    id: 'target',
+                    name: 'dependent_view',
+                    type: 'view',
+                    upstreamCount: 1,
+                    downstreamCount: 0,
+                },
+            },
+        ]
+        const edges: Edge[] = [
+            {
+                id: 'source->target',
+                source: 'source',
+                target: 'target',
+            },
+        ]
+
+        logic.actions.setNodesRaw(nodes)
+        logic.actions.setEdges(edges)
+        logic.actions.setDebouncedSearchTerm('this_view+')
+        await expectLogic(logic).toFinishAllListeners()
+
+        expect(logic.values.enrichedNodes.map((node) => node.id)).toEqual(['source', 'target'])
+        const [source, target] = logic.values.enrichedNodes
+        expect(Math.abs(target.position.x - source.position.x)).toBeLessThan(1000)
     })
 })

--- a/frontend/src/scenes/data-warehouse/scene/dataModelingLogic.ts
+++ b/frontend/src/scenes/data-warehouse/scene/dataModelingLogic.ts
@@ -140,6 +140,7 @@ export interface dataModelingLogicValues {
     reactFlowWrapper: RefObject<HTMLDivElement> | null
     runningNodeIds: Set<string>
     savedViewport: Viewport | null
+    searchLayoutNodes: Node[] | null
     searchMatchedNodeIds: Set<string> | null
     searchTerm: string
     selectedDag: DataModelingDAG | null
@@ -155,6 +156,9 @@ export interface dataModelingLogicActions {
         value: true
     }
     clearFilterTypes: () => {
+        value: true
+    }
+    layoutSearchResults: () => {
         value: true
     }
     loadDags: () => any
@@ -313,6 +317,9 @@ export interface dataModelingLogicActions {
     setSavedViewport: (viewport: Viewport) => {
         viewport: Viewport
     }
+    setSearchLayoutNodes: (nodes: Node[] | null) => {
+        nodes: Node[] | null
+    }
     setSearchTerm: (searchTerm: string) => {
         searchTerm: string
     }
@@ -364,6 +371,7 @@ export interface dataModelingLogicMeta {
         >
         enrichedNodes: (
             nodes: Node[],
+            searchLayoutNodes: Node[] | null,
             runningNodeIds: Set<string>,
             highlightedNodeType: DataModelingNodeType | null,
             latestJobMetadataByNodeId: Record<
@@ -414,7 +422,9 @@ export const dataModelingLogic = kea<dataModelingLogicType>([
         onNodesChange: (nodes: NodeChange<Node>[]) => ({ nodes }),
         setNodes: (nodes: Node[], fitViewAfter?: boolean) => ({ nodes, fitViewAfter }),
         setNodesRaw: (nodes: Node[]) => ({ nodes }),
+        setSearchLayoutNodes: (nodes: Node[] | null) => ({ nodes }),
         setEdges: (edges: Edge[]) => ({ edges }),
+        layoutSearchResults: true,
         setReactFlowInstance: (reactFlowInstance: ReactFlowInstance<Node, Edge>) => ({
             reactFlowInstance,
         }),
@@ -502,6 +512,14 @@ export const dataModelingLogic = kea<dataModelingLogicType>([
             [] as Node[],
             {
                 setNodesRaw: (_, { nodes }) => nodes,
+            },
+        ],
+        searchLayoutNodes: [
+            null as Node[] | null,
+            {
+                setSearchLayoutNodes: (_, { nodes }) => nodes,
+                setDebouncedSearchTerm: () => null,
+                resetGraph: () => null,
             },
         ],
         highlightedNodeType: [
@@ -711,6 +729,7 @@ export const dataModelingLogic = kea<dataModelingLogicType>([
         enrichedNodes: [
             (s) => [
                 s.nodes,
+                s.searchLayoutNodes,
                 s.runningNodeIds,
                 s.highlightedNodeType,
                 s.latestJobMetadataByNodeId,
@@ -718,6 +737,7 @@ export const dataModelingLogic = kea<dataModelingLogicType>([
             ],
             (
                 nodes: Node[],
+                searchLayoutNodes: Node[] | null,
                 runningNodeIds: Set<string>,
                 highlightedNodeType: DataModelingNodeType | null,
                 latestJobMetadataByNodeId: Record<
@@ -729,9 +749,10 @@ export const dataModelingLogic = kea<dataModelingLogicType>([
                 >,
                 searchMatchedNodeIds: Set<string> | null
             ): Node[] => {
+                const layoutNodes = searchLayoutNodes ?? nodes
                 const visibleNodes = searchMatchedNodeIds
-                    ? nodes.filter((node) => searchMatchedNodeIds.has(node.id))
-                    : nodes
+                    ? layoutNodes.filter((node) => searchMatchedNodeIds.has(node.id))
+                    : layoutNodes
                 return visibleNodes.map((node) => {
                     const isRunning = runningNodeIds.has(node.id)
                     const isTypeHighlighted = highlightedNodeType !== null && highlightedNodeType === node.data.type
@@ -1024,10 +1045,27 @@ export const dataModelingLogic = kea<dataModelingLogicType>([
             }
             const formattedNodes = await getFormattedNodes(nodes, values.edges, values.layoutDirection)
             actions.setNodesRaw(formattedNodes)
+            if (values.debouncedSearchTerm.length > 0) {
+                actions.layoutSearchResults()
+            }
             if (fitViewAfter) {
                 values.reactFlowInstance?.fitView({ padding: 0.2, maxZoom: 1 })
             }
             actions.setGraphReady(true)
+        },
+        layoutSearchResults: async (_, breakpoint) => {
+            const matchedNodeIds = values.searchMatchedNodeIds
+            if (matchedNodeIds === null) {
+                actions.setSearchLayoutNodes(null)
+                return
+            }
+            const matchedNodes = values.nodes.filter((node) => matchedNodeIds.has(node.id))
+            const matchedEdges = values.edges.filter(
+                (edge) => matchedNodeIds.has(edge.source) && matchedNodeIds.has(edge.target)
+            )
+            const formattedNodes = await getFormattedNodes(matchedNodes, matchedEdges, values.layoutDirection)
+            await breakpoint()
+            actions.setSearchLayoutNodes(formattedNodes)
         },
         setLayoutDirection: () => {
             if (values.dataModelingNodes.length > 0) {
@@ -1040,6 +1078,9 @@ export const dataModelingLogic = kea<dataModelingLogicType>([
             }
             await breakpoint(150)
             actions.setDebouncedSearchTerm(searchTerm)
+        },
+        setDebouncedSearchTerm: () => {
+            actions.layoutSearchResults()
         },
         runNode: async ({ nodeId, direction }) => {
             const { upstream, downstream } = buildAdjacencyMaps(values.edges)

--- a/frontend/src/scenes/data-warehouse/scene/modeling/GraphView.tsx
+++ b/frontend/src/scenes/data-warehouse/scene/modeling/GraphView.tsx
@@ -157,7 +157,8 @@ export function NodeTypePanel(): JSX.Element {
 function GraphViewContent(): JSX.Element {
     const { isDarkModeOn } = useValues(themeLogic)
 
-    const { enrichedNodes, enrichedEdges, debouncedSearchTerm, savedViewport } = useValues(dataModelingLogic)
+    const { enrichedNodes, enrichedEdges, debouncedSearchTerm, savedViewport, searchLayoutNodes } =
+        useValues(dataModelingLogic)
     const { onEdgesChange, onNodesChange, setReactFlowInstance, setReactFlowWrapper } = useActions(dataModelingLogic)
 
     const reactFlowWrapper = useRef<HTMLDivElement>(null)
@@ -172,15 +173,14 @@ function GraphViewContent(): JSX.Element {
     }, [setReactFlowWrapper])
 
     useEffect(() => {
-        // enrichedNodes is already filtered down to the search matches, so fit to whatever remains
-        if (debouncedSearchTerm.length > 0 && enrichedNodes.length > 0) {
+        if (debouncedSearchTerm.length > 0 && searchLayoutNodes && searchLayoutNodes.length > 0) {
             reactFlowInstance.fitView({
-                nodes: enrichedNodes,
+                nodes: searchLayoutNodes,
                 duration: 400,
                 maxZoom: 1,
             })
         }
-    }, [debouncedSearchTerm, enrichedNodes, reactFlowInstance])
+    }, [debouncedSearchTerm, reactFlowInstance, searchLayoutNodes])
 
     return (
         <div ref={reactFlowWrapper} className="relative w-full border rounded-lg overflow-hidden h-[calc(100vh-17rem)]">

--- a/products/data_modeling/frontend/lineage/LineageNode.tsx
+++ b/products/data_modeling/frontend/lineage/LineageNode.tsx
@@ -183,85 +183,91 @@ export function LineageNode({ data }: { data: LineageNodeData }): JSX.Element {
     }
 
     return (
-        <div
-            className={clsx(
-                'relative rounded-lg border bg-bg-light cursor-pointer min-w-[180px]',
-                state.isRunning && 'border-warning ring-2 ring-warning/30 animate-pulse',
-                !state.isRunning && state.isHighlighted && 'border-link ring-2 ring-link/30',
-                !state.isRunning && !state.isHighlighted && !state.isCurrent && 'border-border',
-                state.isCurrent && 'border-2'
-            )}
-            // eslint-disable-next-line react/forbid-dom-props
-            style={{
-                borderColor: state.isCurrent ? color : undefined,
-            }}
-            onMouseEnter={handleMouseEnter}
-            onMouseLeave={handleMouseLeave}
-            onClick={callbacks.onClick}
-        >
-            {data.handles.map((handle) => (
-                <Handle
-                    key={handle.id}
-                    id={handle.id}
-                    type={handle.type}
-                    position={handle.position ?? (handle.type === 'target' ? Position.Left : Position.Right)}
-                    className="opacity-0"
-                    isConnectable={false}
-                />
-            ))}
+        <Tooltip title={node.name} delayMs={500}>
+            <div
+                className={clsx(
+                    'relative rounded-lg border bg-bg-light cursor-pointer min-w-[180px]',
+                    state.isRunning && 'border-warning ring-2 ring-warning/30 animate-pulse',
+                    !state.isRunning && state.isHighlighted && 'border-link ring-2 ring-link/30',
+                    !state.isRunning && !state.isHighlighted && !state.isCurrent && 'border-border',
+                    state.isCurrent && 'border-2'
+                )}
+                // eslint-disable-next-line react/forbid-dom-props
+                style={{
+                    borderColor: state.isCurrent ? color : undefined,
+                }}
+                onMouseEnter={handleMouseEnter}
+                onMouseLeave={handleMouseLeave}
+                onClick={callbacks.onClick}
+            >
+                {data.handles.map((handle) => (
+                    <Handle
+                        key={handle.id}
+                        id={handle.id}
+                        type={handle.type}
+                        position={handle.position ?? (handle.type === 'target' ? Position.Left : Position.Right)}
+                        className="opacity-0"
+                        isConnectable={false}
+                    />
+                ))}
 
-            {showRunArrows && node.upstream_count > 0 && callbacks.onRunUpstream && (
-                <RunArrow direction="upstream" layoutDirection={direction} onClick={stop(callbacks.onRunUpstream)} />
-            )}
-            {showRunArrows && node.downstream_count > 0 && callbacks.onRunDownstream && (
-                <RunArrow
-                    direction="downstream"
-                    layoutDirection={direction}
-                    onClick={stop(callbacks.onRunDownstream)}
-                />
-            )}
+                {showRunArrows && node.upstream_count > 0 && callbacks.onRunUpstream && (
+                    <RunArrow
+                        direction="upstream"
+                        layoutDirection={direction}
+                        onClick={stop(callbacks.onRunUpstream)}
+                    />
+                )}
+                {showRunArrows && node.downstream_count > 0 && callbacks.onRunDownstream && (
+                    <RunArrow
+                        direction="downstream"
+                        layoutDirection={direction}
+                        onClick={stop(callbacks.onRunDownstream)}
+                    />
+                )}
 
-            <div className="px-3 pt-3">
-                <div className="flex items-center justify-between gap-2">
-                    <div className="flex items-center gap-1 min-w-0">
-                        {state.isCurrent && (
-                            <Tooltip title="This is the currently viewed node">
-                                <IconTarget className="text-warning text-sm shrink-0" />
+                <div className="px-3 pt-3">
+                    <div className="flex items-center justify-between gap-2">
+                        <div className="flex items-center gap-1 min-w-0">
+                            {state.isCurrent && (
+                                <Tooltip title="This is the currently viewed node">
+                                    <IconTarget className="text-warning text-sm shrink-0" />
+                                </Tooltip>
+                            )}
+                            <NodeTypeTag type={node.type} />
+                        </div>
+                        {node.user_tag && (
+                            <span className="text-[10px] text-muted lowercase tracking-wide px-1 rounded bg-primary dark:bg-primary/20 border-1 border-black/20">
+                                #{node.user_tag}
+                            </span>
+                        )}
+                    </div>
+                    <div className="flex items-center justify-between gap-2 py-2">
+                        <span className="font-medium text-sm truncate">{node.name}</span>
+                        {callbacks.onEdit && (
+                            <LemonButton
+                                size="xxsmall"
+                                type="secondary"
+                                icon={<IconPencil />}
+                                onClick={stop(callbacks.onEdit)}
+                            />
+                        )}
+                        {callbacks.onMaterialize && (node.type === 'matview' || node.type === 'endpoint') && (
+                            <Tooltip title={state.isRunning ? null : 'Run this node'}>
+                                <LemonButton
+                                    size="xsmall"
+                                    type="secondary"
+                                    onClick={stop(callbacks.onMaterialize)}
+                                    disabledReason={state.isRunning && 'This node is already running...'}
+                                    icon={state.isRunning ? <Spinner textColored /> : <IconPlay className="w-3 h-3" />}
+                                />
                             </Tooltip>
                         )}
-                        <NodeTypeTag type={node.type} />
                     </div>
-                    {node.user_tag && (
-                        <span className="text-[10px] text-muted lowercase tracking-wide px-1 rounded bg-primary dark:bg-primary/20 border-1 border-black/20">
-                            #{node.user_tag}
-                        </span>
-                    )}
                 </div>
-                <div className="flex items-center justify-between gap-2 py-2">
-                    <span className="font-medium text-sm truncate">{node.name}</span>
-                    {callbacks.onEdit && (
-                        <LemonButton
-                            size="xxsmall"
-                            type="secondary"
-                            icon={<IconPencil />}
-                            onClick={stop(callbacks.onEdit)}
-                        />
-                    )}
-                    {callbacks.onMaterialize && (node.type === 'matview' || node.type === 'endpoint') && (
-                        <Tooltip title={state.isRunning ? null : 'Run this node'}>
-                            <LemonButton
-                                size="xsmall"
-                                type="secondary"
-                                onClick={stop(callbacks.onMaterialize)}
-                                disabledReason={state.isRunning && 'This node is already running...'}
-                                icon={state.isRunning ? <Spinner textColored /> : <IconPlay className="w-3 h-3" />}
-                            />
-                        </Tooltip>
-                    )}
-                </div>
+                {showMetadata && <MetadataBar node={node} />}
             </div>
-            {showMetadata && <MetadataBar node={node} />}
-        </div>
+        </Tooltip>
     )
 }
 


### PR DESCRIPTION
## Problem

People who filter a large Modeling graph still see nodes spaced according to the full graph, which leaves relevant nodes far apart.

Long node names can also be difficult to inspect on the graph.

## Changes

- Filtered nodes receive a fresh layout based only on visible nodes and connecting edges.
- The graph fits the compact layout after the search layout finishes.
- Hovering a lineage node shows its full name after a 500 ms delay.

![lineage-node-tooltip](https://raw.githubusercontent.com/PostHog/pr-assets/66671e3ce094fd7c8779b29103db26ecc9da3b6d/2026/08/946659a2-0910-4a25-9eec-d087f22d0cc5.png)

## How did you test this code?

- Added a Jest logic test that catches filtered nodes retaining their original distant positions.
- Verified the lineage node tooltip in the existing Storybook story with headless Chromium.
- Ran frontend formatting, lint fixes, scoped type generation, and `hogli ci:preflight --fix`.
- The full TypeScript check exceeded this environment's memory limit after the required workspace packages built.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This changes graph layout and hover behavior without changing the documented workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi used OpenAI GPT-5.6 with read, edit, shell, browser, and signed commit tools. No public session link is available.

I invoked `/writing-ui-components`, `/writing-user-facing-copy`, `/writing-kea-logics`, `/writing-tests`, `/writing-code-comments`, and `/writing-pr-descriptions`. The test fixture is synthetic.