### PR TITLE
fix(desktop): clarify deferred steering

### DIFF
--- a/products/desktop/packages/ui/src/features/pi-sessions/PiSessionControls.tsx
+++ b/products/desktop/packages/ui/src/features/pi-sessions/PiSessionControls.tsx
@@ -308,7 +308,7 @@ export function PiMessagingModeSelector({
           onValueChange={(value) => onModeChange(value as MessagingMode)}
         >
           <DropdownMenuRadioItem value="steer">
-            Steer at the next tool boundary
+            Steer after the current tool finishes
           </DropdownMenuRadioItem>
           <DropdownMenuRadioItem value="queue">
             Queue for the next turn

--- a/products/desktop/packages/ui/src/features/pi-sessions/PiSessionView.tsx
+++ b/products/desktop/packages/ui/src/features/pi-sessions/PiSessionView.tsx
@@ -329,7 +329,15 @@ function usePiSubmit(
       );
       void controller
         .submit(taskId, message, isStreaming, messagingMode, pendingConfig)
-        .then(() => onSuccess(action))
+        .then((result) => {
+          if (result === "steer") {
+            toast.info("Steering waits for a safe boundary", {
+              description:
+                "Pi will apply it at the next safe boundary. The run stays active until then.",
+            });
+          }
+          onSuccess(action);
+        })
         .catch((error) => {
           handleControllerError(
             error,

--- a/products/desktop/packages/ui/src/features/sessions/components/SteerQueueToggle.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/SteerQueueToggle.test.tsx
@@ -63,8 +63,9 @@ describe("steer tooltip copy follows the session's native-steer capability", () 
       const tooltip = steerQueueTooltip(true, result.current, "Cmd+S");
       if (expectNative) {
         expect(tooltip).toContain(
-          "injects your message mid-turn at the next tool boundary",
+          "applies your message at the next safe boundary",
         );
+        expect(tooltip).toContain("current command may keep running");
       } else {
         expect(tooltip).toContain(
           "interrupts the current turn and resends with your message",

--- a/products/desktop/packages/ui/src/features/sessions/components/SteerQueueToggle.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/SteerQueueToggle.tsx
@@ -25,7 +25,7 @@ export function steerQueueTooltip(
     return `Queue: holds messages until the current turn ends. ${shortcut} to switch to Steer.`;
   }
   return supportsNativeSteer
-    ? `Steer: injects your message mid-turn at the next tool boundary. ${shortcut} to switch to Queue.`
+    ? `Steer: applies your message at the next safe boundary. The current command may keep running until then. ${shortcut} to switch to Queue.`
     : `Steer: interrupts the current turn and resends with your message. ${shortcut} to switch to Queue.`;
 }
 

--- a/products/desktop/packages/ui/src/features/sessions/hooks/useSessionCallbacks.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/hooks/useSessionCallbacks.test.tsx
@@ -1,3 +1,4 @@
+import type { AgentSession } from "@posthog/shared";
 import type { Task } from "@posthog/shared/domain-types";
 import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -42,8 +43,9 @@ vi.mock("@posthog/ui/features/sidebar/useTaskViewed", () => ({
   useTaskViewed: () => taskViewed,
 }));
 
+const messagingMode = vi.hoisted(() => ({ value: "queue" }));
 vi.mock("@posthog/ui/features/sessions/hooks/useMessagingMode", () => ({
-  useMessagingMode: () => "queue",
+  useMessagingMode: () => messagingMode.value,
 }));
 
 // No code command / skill rewrite; the raw text is used as the prompt.
@@ -56,6 +58,11 @@ vi.mock("@posthog/ui/features/message-editor/commands", () => ({
 const sessionState = vi.hoisted(() => ({
   editingQueuedId: "q-1" as string | undefined,
   messageQueue: [] as Array<{ id: string; content: string; queuedAt: number }>,
+  isPromptPending: true,
+  isCompacting: false,
+  adapter: "claude" as const,
+  isCloud: false,
+  steering: "native",
 }));
 const dequeueMessages = vi.hoisted(() =>
   vi.fn(() => [] as Array<{ id: string; content: string; queuedAt: number }>),
@@ -71,9 +78,12 @@ vi.mock("@posthog/ui/router/useAppView", () => ({
   getAppViewSnapshot: () => null,
 }));
 
-const toastError = vi.hoisted(() => vi.fn());
+const { toastError, toastInfo } = vi.hoisted(() => ({
+  toastError: vi.fn(),
+  toastInfo: vi.fn(),
+}));
 vi.mock("@posthog/ui/primitives/toast", () => ({
-  toast: { error: toastError },
+  toast: { error: toastError, info: toastInfo },
 }));
 
 import { useDraftStore } from "@posthog/ui/features/message-editor/draftStore";
@@ -82,12 +92,12 @@ import { useSessionCallbacks } from "./useSessionCallbacks";
 const TASK = "task-1";
 const task = { id: TASK, latest_run: null } as unknown as Task;
 
-function renderCallbacks() {
+function renderCallbacks(session?: AgentSession) {
   return renderHook(() =>
     useSessionCallbacks({
       taskId: TASK,
       task,
-      session: undefined,
+      session,
       repoPath: "/repo",
     }),
   );
@@ -166,8 +176,11 @@ describe("useSessionCallbacks.handleSendPrompt while editing a queued message", 
 describe("useSessionCallbacks.handleSendPrompt", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    messagingMode.value = "queue";
     sessionState.editingQueuedId = undefined;
     sessionState.messageQueue = [];
+    sessionState.isPromptPending = true;
+    sessionState.isCompacting = false;
   });
 
   it("reports a failed send so the composer keeps its content", async () => {
@@ -178,6 +191,18 @@ describe("useSessionCallbacks.handleSendPrompt", () => {
 
     expect(sent).toBe(false);
     expect(toastError).toHaveBeenCalledWith("fetch failed");
+  });
+
+  it("uses the post-send compaction state for the steering notice", async () => {
+    messagingMode.value = "steer";
+    sessionService.sendPrompt.mockImplementation(async () => {
+      sessionState.isCompacting = true;
+    });
+
+    const { result } = renderCallbacks(sessionState as unknown as AgentSession);
+    await result.current.handleSendPrompt("change direction");
+
+    expect(toastInfo).not.toHaveBeenCalled();
   });
 });
 

--- a/products/desktop/packages/ui/src/features/sessions/hooks/useSessionCallbacks.ts
+++ b/products/desktop/packages/ui/src/features/sessions/hooks/useSessionCallbacks.ts
@@ -13,6 +13,7 @@ import {
 } from "@posthog/core/sessions/sessionService";
 import { useService } from "@posthog/di/react";
 import { useHostTRPCClient } from "@posthog/host-router/react";
+import { sessionSupportsNativeSteer } from "@posthog/shared";
 import type { Task } from "@posthog/shared/domain-types";
 import {
   resolveLocalSkillPrompt,
@@ -137,6 +138,20 @@ export function useSessionCallbacks({
         await sessionService.sendPrompt(taskId, promptText ?? text, {
           steer: messagingMode === "steer",
         });
+
+        const sentSession = sessionStoreSetters.getSessionByTaskId(taskId);
+        if (
+          messagingMode === "steer" &&
+          sentSession?.isPromptPending &&
+          !sentSession.isCompacting &&
+          sentSession.adapter === "claude" &&
+          sessionSupportsNativeSteer(sentSession)
+        ) {
+          toast.info("Steering waits for a safe boundary", {
+            description:
+              "It will apply at the next safe boundary. The current command may keep running until then.",
+          });
+        }
 
         const view = getAppViewSnapshot();
         const isViewingTask =


### PR DESCRIPTION
## Problem

Steering can appear to stop a run while a long-running tool continues, leaving people unsure whether their message was received.

## Changes

- Explain that native steering applies at a safe boundary and may not stop the current command.
- Show immediate notices when Claude or Pi defers a steering message.
