### PR TITLE
fix(data-table): honor -- label on properties-prefixed columns

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -6129,9 +6129,9 @@ snapshots:
     scenes-app-events--event-explorer--light:
         hash: v1.k794b7964.12b19a0b4d9792d72a19cc4006fad38d14f173c22c7b529dee3b3158f6199186.bhj09fVfxwO0BXAWVinZUpKaM3CGxF_oFpDfWLJoq4Y
     scenes-app-events-mcp-tool-calls--mcp-tool-calls--dark:
-        hash: v1.k794b7964.44d7d72610e6b825237b2a257b5651183af49d3a42e571628ded66b4b2dc3087.JEJcRFUTqaNIS9SebXDd5NFkr7cga9xrVRKn2A2CNiE
+        hash: v1.k794b7964.f556bb39a4acac2ba03a734739fe0a19b6aaa135b9aa50a4c45f0cda07005c32.AFd4VvCxhkVCB5HVysHoKvyqq56in_Owrl4n_dOlyMU
     scenes-app-events-mcp-tool-calls--mcp-tool-calls--light:
-        hash: v1.k794b7964.423e2228f2e2d55107e73c53678f5076d5e7003ac6e9e2c3b420ba1d5bdc9f5d.6MHkzMWpkO6Q8IRSf3BDISXo3179ssSFM_Th3qBJ0Xs
+        hash: v1.k794b7964.a70db27155e0ba6979890a1d3b328a91d7f2cae9e89d37cb7346fa2d79aaec6d.ybMAg6DfJ6iwBrtLWjqVo9qC-a412ihqd6H6KiAYkgc
     scenes-app-experiments--draft-experiment--dark:
         hash: v1.k794b7964.862ae6da1335a0cec5825234d2a6baf1d5e4eb5c1dec6650924d62d0e117e56b.9_kP5gSMifRjF9JZKyTMqKI2rD78F8UYSBa8ENH_GXU
     scenes-app-experiments--draft-experiment--light:

--- a/frontend/src/queries/nodes/DataTable/renderColumnMeta.test.tsx
+++ b/frontend/src/queries/nodes/DataTable/renderColumnMeta.test.tsx
@@ -16,8 +16,6 @@ function headerText(key: string): string {
 }
 
 describe('renderColumnMeta', () => {
-    // A trailing `-- label` is the column's display name, and the header is the only place it is
-    // resolved, so it has to win over the `properties.` and `person.properties.` branches.
     it.each([
         ["properties.plan_tier ? 'paid' : 'free' -- Plan", 'Plan'],
         ["properties.$browser IN ('Chrome', 'Firefox') ? 'yes' : 'no' -- Major browser", 'Major browser'],
@@ -28,8 +26,6 @@ describe('renderColumnMeta', () => {
         expect(headerText(key)).toBe(expected)
     })
 
-    // Without a label the property branches still own the header, so a bare property renders its
-    // taxonomy name rather than the raw `properties.` expression the fallback would produce.
     it.each([
         ['properties.plan_tier', 'plan_tier'],
         ['person.properties.signup_source', 'signup_source'],

--- a/frontend/src/queries/nodes/DataTable/renderColumnMeta.test.tsx
+++ b/frontend/src/queries/nodes/DataTable/renderColumnMeta.test.tsx
@@ -1,0 +1,39 @@
+import { render } from '@testing-library/react'
+
+import { DataTableNode, NodeKind } from '~/queries/schema/schema-general'
+import { setLatestVersionsOnQuery } from '~/queries/utils'
+
+import { renderColumnMeta } from './renderColumnMeta'
+
+const personsTable = setLatestVersionsOnQuery({
+    kind: NodeKind.DataTableNode,
+    source: { kind: NodeKind.ActorsQuery, select: [] },
+}) as DataTableNode
+
+function headerText(key: string): string {
+    const { title } = renderColumnMeta(key, personsTable)
+    return render(<>{title}</>).container.textContent ?? ''
+}
+
+describe('renderColumnMeta', () => {
+    // A trailing `-- label` is the column's display name, and the header is the only place it is
+    // resolved, so it has to win over the `properties.` and `person.properties.` branches.
+    it.each([
+        ["properties.plan_tier ? 'paid' : 'free' -- Plan", 'Plan'],
+        ["properties.$browser IN ('Chrome', 'Firefox') ? 'yes' : 'no' -- Major browser", 'Major browser'],
+        ['person.properties.signup_source -- Acquisition', 'Acquisition'],
+        ["concat(properties.first_name, ' ', properties.last_name) -- Full name", 'Full name'],
+        ['person_display_name -- Person', 'Person'],
+    ])('shows the trailing comment as the header for %s', (key: string, expected: string): void => {
+        expect(headerText(key)).toBe(expected)
+    })
+
+    // Without a label the property branches still own the header, so a bare property renders its
+    // taxonomy name rather than the raw `properties.` expression the fallback would produce.
+    it.each([
+        ['properties.plan_tier', 'plan_tier'],
+        ['person.properties.signup_source', 'signup_source'],
+    ])('shows the property name for %s', (key: string, expected: string): void => {
+        expect(headerText(key)).toBe(expected)
+    })
+})

--- a/frontend/src/queries/nodes/DataTable/renderColumnMeta.tsx
+++ b/frontend/src/queries/nodes/DataTable/renderColumnMeta.tsx
@@ -58,8 +58,6 @@ export function renderColumnMeta<T extends DataVisualizationNode | DataTableNode
         const splitPropertyName = propertyName.split('--')
         title = splitPropertyName.length > 1 ? splitPropertyName[1].trim() : propertyName
     } else if (queryFeatures.has(QueryFeature.selectAndOrderByColumns) && key.includes('--')) {
-        // A trailing `-- comment` is a display name the user typed, so it has to outrank the
-        // property-name branches below, which strip it and show the bare expression instead.
         title = extractExpressionComment(key)
     } else if (key === 'timestamp') {
         title = 'Time'

--- a/frontend/src/queries/nodes/DataTable/renderColumnMeta.tsx
+++ b/frontend/src/queries/nodes/DataTable/renderColumnMeta.tsx
@@ -57,6 +57,10 @@ export function renderColumnMeta<T extends DataVisualizationNode | DataTableNode
     } else if (propertyName && isGroupsQuery(query.source)) {
         const splitPropertyName = propertyName.split('--')
         title = splitPropertyName.length > 1 ? splitPropertyName[1].trim() : propertyName
+    } else if (queryFeatures.has(QueryFeature.selectAndOrderByColumns) && key.includes('--')) {
+        // A trailing `-- comment` is a display name the user typed, so it has to outrank the
+        // property-name branches below, which strip it and show the bare expression instead.
+        title = extractExpressionComment(key)
     } else if (key === 'timestamp') {
         title = 'Time'
     } else if (key === 'created_at') {


### PR DESCRIPTION
## Problem

A person who adds a SQL expression column on the Persons page and names it with a trailing `-- label` sees the raw expression in the header, not the name they typed.

- The label survives storage and the column's own dropdown. Only the header drops it.
- `renderColumnMeta` resolves the header through an if/else chain. The `properties.` and `person.properties.` branches match those keys first, so the branch that reads the label never runs.
- The `person.properties.` branch strips nothing, so the raw ` -- label` text leaks into the header.

## Changes

- Move the label check above the property-name branches. A display name the user typed now wins over the taxonomy name.
- Columns without a `-- label` are unchanged. They still render the taxonomy name through `PropertyKeyInfo`.
- The new branch is gated on `QueryFeature.selectAndOrderByColumns`, the same feature the existing fallback uses. No query kind starts honoring comments that did not before.
- The `GroupsQuery` branch keeps its own comment handling, because it sits above the new branch.

I considered patching the two property branches in place. One branch above them fixes both and states the rule once.

Screenshot: none. The change alters header text only, and I could not run the app here (no dev stack). The new test asserts the rendered header text instead.

## How did you test this code?

- Added `renderColumnMeta.test.tsx`. Nothing covered `renderColumnMeta` before, so no test caught a reordering of its branch chain.
- The regression it catches: a column keyed on `properties.` or `person.properties.` silently losing its `-- label` header.
- I reverted the one-file fix and re-ran the new test. 3 of the 7 cases failed, each rendering the bare expression instead of the label. All 7 pass with the fix.
- Not checked: the running app, and `typescript:check`. That command fails in this sandbox on pre-existing errors from the unbuilt `@posthog/quill` and `@posthog/hogvm` workspaces. None of them are in the files this PR touches.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.
