### PR TITLE
chore(slack_app): retire drained Temporal patches and user_id shims

### DIFF
--- a/posthog/temporal/ai/slack_app/__init__.py
+++ b/posthog/temporal/ai/slack_app/__init__.py
@@ -32,7 +32,6 @@ from posthog.temporal.ai.slack_app.activities import (
     post_posthog_code_repo_picker_activity,
     request_untagged_followup_confirmation_activity,
     resolve_posthog_code_slack_command_user_activity,
-    resolve_posthog_code_slack_user_activity,
     run_posthog_slack_inbox_onboarding_activity,
 )
 from posthog.temporal.ai.slack_app.types import (
@@ -54,7 +53,6 @@ from posthog.temporal.ai.slack_app.types import (
 SLACK_APP_ACTIVITIES = [
     classify_untagged_followup_activity,
     request_untagged_followup_confirmation_activity,
-    resolve_posthog_code_slack_user_activity,
     resolve_posthog_code_slack_command_user_activity,
     collect_posthog_code_thread_messages_activity,
     cascade_posthog_code_repository_activity,
@@ -118,6 +116,5 @@ __all__ = [
     "post_posthog_code_repo_picker_activity",
     "request_untagged_followup_confirmation_activity",
     "resolve_posthog_code_slack_command_user_activity",
-    "resolve_posthog_code_slack_user_activity",
     "run_posthog_slack_inbox_onboarding_activity",
 ]

--- a/posthog/temporal/ai/slack_app/activities/__init__.py
+++ b/posthog/temporal/ai/slack_app/activities/__init__.py
@@ -39,10 +39,7 @@ from posthog.temporal.ai.slack_app.activities.task_creation import (
     forward_posthog_code_followup_activity,
 )
 from posthog.temporal.ai.slack_app.activities.thread import collect_posthog_code_thread_messages_activity
-from posthog.temporal.ai.slack_app.activities.user_resolution import (
-    resolve_posthog_code_slack_command_user_activity,
-    resolve_posthog_code_slack_user_activity,
-)
+from posthog.temporal.ai.slack_app.activities.user_resolution import resolve_posthog_code_slack_command_user_activity
 
 __all__ = [
     "CLASSIFIER_THREAD_HISTORY_MESSAGES",
@@ -73,7 +70,6 @@ __all__ = [
     "post_posthog_code_repo_picker_activity",
     "request_untagged_followup_confirmation_activity",
     "resolve_posthog_code_slack_command_user_activity",
-    "resolve_posthog_code_slack_user_activity",
     "run_posthog_slack_inbox_onboarding",
     "run_posthog_slack_inbox_onboarding_activity",
 ]

--- a/posthog/temporal/ai/slack_app/activities/messaging.py
+++ b/posthog/temporal/ai/slack_app/activities/messaging.py
@@ -61,26 +61,10 @@ def post_posthog_code_repo_picker_activity(
     workflow_id: str,
     guidance: str,
     allow_no_repo: bool,
-    user_id: int | None = None,
+    user_id: int,
 ) -> None:
-    """Post the repository picker block in the Slack thread.
-
-    ``user_id`` is appended last and defaults to ``None`` so a worker draining an
-    activity task scheduled by a pre-2026-06 workflow (recorded with 8 positional
-    args) still binds: the eight legacy slots align by position and ``user_id``
-    falls through to the default. The body short-circuits in that case rather than
-    posting a picker with a missing ``mentioning_user_id``, which would break the
-    downstream external-select handler. New workflows go through the patched call
-    site at the workflow body and pass ``user_id`` as the final positional arg.
-    """
+    """Post the repository picker block in the Slack thread."""
     inputs = coerce_mention_workflow_inputs(inputs)
-    if user_id is None:
-        logger.warning(
-            "posthog_code_picker_legacy_call_skipped",
-            integration_id=inputs.integration_id,
-            slack_team_id=inputs.slack_team_id,
-        )
-        return
 
     from products.slack_app.backend.api import _post_repo_picker_message
 

--- a/posthog/temporal/ai/slack_app/activities/repo_selection.py
+++ b/posthog/temporal/ai/slack_app/activities/repo_selection.py
@@ -21,7 +21,7 @@ logger = structlog.get_logger(__name__)
 def cascade_posthog_code_repository_activity(
     inputs: PostHogCodeSlackMentionWorkflowInputs,
     event_text: str,
-    user_id: int | None = None,
+    user_id: int,
 ) -> PostHogCodeRepoCascadeOutcome:
     """Synchronous fast-path before the discovery agent.
 
@@ -29,21 +29,8 @@ def cascade_posthog_code_repository_activity(
     personal install, exactly one connected, or an explicit `org/repo` mentioned in the
     message — without paying for the sandbox-backed agent. Anything else returns
     `mode='agent_needed'` and the workflow takes over.
-
-    ``user_id`` defaults to ``None`` for backwards compatibility with the pre-2026-06
-    call shape: if a worker drains an activity task that was scheduled by an older
-    workflow (recorded with two positional args), the call still binds, and an
-    unidentifiable mentioner resolves no repos anyway.
     """
     from posthog.models.integration import Integration
-
-    if user_id is None:
-        logger.warning(
-            "posthog_code_cascade_legacy_call",
-            integration_id=inputs.integration_id,
-            slack_team_id=inputs.slack_team_id,
-        )
-        return PostHogCodeRepoCascadeOutcome(mode="no_repo", repository=None, reason="legacy_no_user_id")
 
     from products.slack_app.backend.api import _extract_explicit_repo, _get_full_repo_names
 

--- a/posthog/temporal/ai/slack_app/activities/user_resolution.py
+++ b/posthog/temporal/ai/slack_app/activities/user_resolution.py
@@ -1,32 +1,7 @@
 from temporalio import activity
 
-from posthog.temporal.ai.slack_app.types import (
-    PostHogCodeSlackMentionCommandWorkflowInputs,
-    PostHogCodeSlackMentionWorkflowInputs,
-)
+from posthog.temporal.ai.slack_app.types import PostHogCodeSlackMentionCommandWorkflowInputs
 from posthog.temporal.common.utils import close_db_connections
-
-
-@activity.defn
-@close_db_connections
-def resolve_posthog_code_slack_user_activity(
-    inputs: PostHogCodeSlackMentionWorkflowInputs,
-    channel: str,
-    thread_ts: str,
-    slack_user_id: str,
-) -> int | None:
-    from posthog.models.integration import Integration, SlackIntegration
-
-    from products.slack_app.backend.api import resolve_slack_user
-
-    integration = Integration.objects.select_related("team", "team__organization").get(
-        id=inputs.integration_id,
-        kind="slack",
-        integration_id=inputs.slack_team_id,
-    )
-    slack = SlackIntegration(integration)
-    user_context = resolve_slack_user(slack, integration, slack_user_id, channel, thread_ts)
-    return user_context.user.id if user_context else None
 
 
 @activity.defn

--- a/posthog/temporal/ai/slack_app/posthog_code_slack_mention.py
+++ b/posthog/temporal/ai/slack_app/posthog_code_slack_mention.py
@@ -29,13 +29,15 @@ from posthog.temporal.common.base import PostHogWorkflow
 POSTHOG_CODE_SLACK_MENTION_TIMEOUT_SECONDS = 10 * 60
 POSTHOG_CODE_SLACK_PICKER_TIMEOUT_MINUTES = 15
 
-# Temporal patch IDs — arbitrary strings recorded in workflow history. Every
-# pre-patch history has drained: this workflow's longest wait is the 15-minute
-# repo picker, and it is bounded at an hour as a child of the queue workflow. So
-# the gates are gone and only `deprecate_patch` remains, keeping the recorded
-# marker compatible for executions in flight across the deploy that removes
-# them. Standard two-step Temporal patch lifecycle: these calls come out once
-# the histories that recorded a plain marker have drained in turn.
+# Temporal patch IDs — arbitrary strings recorded in workflow history. The
+# pre-patch histories behind the first three have drained: this workflow's
+# longest wait is the 15-minute repo picker, and it is bounded at an hour as a
+# child of the queue workflow. Their gates are gone and only `deprecate_patch`
+# remains, keeping the recorded marker compatible for executions in flight
+# across the deploy that removes them. Standard two-step Temporal patch
+# lifecycle: those calls come out once the histories that recorded a plain
+# marker have drained in turn. The confirmation patch is younger and still
+# gated, so it stays a full `workflow.patched` branch until it drains too.
 _PATCH_ID_FILE_ONLY_FOLLOWUP_BYPASS = "slack-file-only-followup-bypass-v1"
 _PATCH_ID_MODEL_CLASSIFIER = "slack-app-model-classifier-v1"
 _PATCH_ID_NO_PERSONAL_GITHUB_GATE = "slack-no-personal-github-gate-v1"
@@ -103,25 +105,22 @@ class PostHogCodeSlackMentionWorkflow(PostHogWorkflow):
             event_files = event.get("files")
             event_has_files = isinstance(event_files, list) and len(event_files) > 0
             file_only_followup = event_has_files and not (event.get("text") or "").strip()
-            if (
-                inputs.untagged_followup
-                and not inputs.untagged_followup_confirmed
-                and file_only_followup
-            ):
-                # The gate this replaces was short-circuited behind both flags, so
-                # only these histories carry the marker.
-                workflow.deprecate_patch(_PATCH_ID_FILE_ONLY_FOLLOWUP_BYPASS)
-            elif inputs.untagged_followup:
-                should_forward = await _execute_posthog_code_activity(
-                    classify_untagged_followup_activity,
-                    inputs,
-                    channel,
-                    thread_ts,
-                    slack_user_id,
-                    event.get("text", ""),
-                )
-                if not should_forward:
-                    return
+            if inputs.untagged_followup and not inputs.untagged_followup_confirmed:
+                if file_only_followup:
+                    # The gate this replaces was only ever reached behind both
+                    # flags, so only these histories carry the marker.
+                    workflow.deprecate_patch(_PATCH_ID_FILE_ONLY_FOLLOWUP_BYPASS)
+                else:
+                    should_forward = await _execute_posthog_code_activity(
+                        classify_untagged_followup_activity,
+                        inputs,
+                        channel,
+                        thread_ts,
+                        slack_user_id,
+                        event.get("text", ""),
+                    )
+                    if not should_forward:
+                        return
 
             # The reply is agent-directed. If the thread creator asked to be consulted
             # about other people's replies, this is the moment to ask: the prompt now

--- a/posthog/temporal/ai/slack_app/posthog_code_slack_mention.py
+++ b/posthog/temporal/ai/slack_app/posthog_code_slack_mention.py
@@ -10,7 +10,6 @@ from posthog.temporal.ai.slack_app import (
     POSTHOG_CODE_SLACK_MENTION_PICKER_GUIDANCE,
     PostHogCodeSlackMentionWorkflowInputs,
     SlackAppModelOverrideInput,
-    block_posthog_code_task_if_no_personal_github_activity,
     cascade_posthog_code_repository_activity,
     classify_posthog_code_task_needs_repo_activity,
     classify_slack_app_model_override_activity,
@@ -24,14 +23,19 @@ from posthog.temporal.ai.slack_app import (
     post_posthog_code_picker_timeout_activity,
     post_posthog_code_repo_picker_activity,
     request_untagged_followup_confirmation_activity,
-    resolve_posthog_code_slack_user_activity,
 )
 from posthog.temporal.common.base import PostHogWorkflow
 
 POSTHOG_CODE_SLACK_MENTION_TIMEOUT_SECONDS = 10 * 60
 POSTHOG_CODE_SLACK_PICKER_TIMEOUT_MINUTES = 15
 
-# Temporal patch IDs — arbitrary strings recorded in workflow history.
+# Temporal patch IDs — arbitrary strings recorded in workflow history. Every
+# pre-patch history has drained: this workflow's longest wait is the 15-minute
+# repo picker, and it is bounded at an hour as a child of the queue workflow. So
+# the gates are gone and only `deprecate_patch` remains, keeping the recorded
+# marker compatible for executions in flight across the deploy that removes
+# them. Standard two-step Temporal patch lifecycle: these calls come out once
+# the histories that recorded a plain marker have drained in turn.
 _PATCH_ID_FILE_ONLY_FOLLOWUP_BYPASS = "slack-file-only-followup-bypass-v1"
 _PATCH_ID_MODEL_CLASSIFIER = "slack-app-model-classifier-v1"
 _PATCH_ID_NO_PERSONAL_GITHUB_GATE = "slack-no-personal-github-gate-v1"
@@ -96,18 +100,18 @@ class PostHogCodeSlackMentionWorkflow(PostHogWorkflow):
             # classify, and default-deny would silently drop the attachment.
             # Replies with text still face it even when files are attached, so
             # chitchat with a screenshot doesn't wake the agent.
-            # workflow.patched() returns False for executions started before
-            # this deploy so replay still schedules the classifier for
-            # file-only replies. Delete the gate once history retention
-            # exceeds our longest possible run.
             event_files = event.get("files")
             event_has_files = isinstance(event_files, list) and len(event_files) > 0
             file_only_followup = event_has_files and not (event.get("text") or "").strip()
             if (
                 inputs.untagged_followup
                 and not inputs.untagged_followup_confirmed
-                and not (file_only_followup and workflow.patched(_PATCH_ID_FILE_ONLY_FOLLOWUP_BYPASS))
+                and file_only_followup
             ):
+                # The gate this replaces was short-circuited behind both flags, so
+                # only these histories carry the marker.
+                workflow.deprecate_patch(_PATCH_ID_FILE_ONLY_FOLLOWUP_BYPASS)
+            elif inputs.untagged_followup:
                 should_forward = await _execute_posthog_code_activity(
                     classify_untagged_followup_activity,
                     inputs,
@@ -157,20 +161,7 @@ class PostHogCodeSlackMentionWorkflow(PostHogWorkflow):
             if inputs.untagged_followup:
                 return
 
-            # New starts carry ``user_id`` from routing-time resolution and skip
-            # the activity. Legacy histories started before the field existed
-            # deserialize with ``user_id=None`` and replay through the activity so
-            # the recorded command stream still matches. Drop this fallback (and
-            # make ``user_id`` required on inputs) once the workflow history
-            # retention window has elapsed.
-            if inputs.user_id is not None:
-                user_id = inputs.user_id
-            else:
-                user_id = await _execute_posthog_code_activity(
-                    resolve_posthog_code_slack_user_activity, inputs, channel, thread_ts, slack_user_id
-                )
-                if not user_id:
-                    return
+            user_id = inputs.user_id
 
             thread_messages = await _execute_posthog_code_activity(
                 collect_posthog_code_thread_messages_activity,
@@ -203,23 +194,7 @@ class PostHogCodeSlackMentionWorkflow(PostHogWorkflow):
                 # that here meant a single false positive from the needs-repo classifier
                 # walled a plain analytics question behind a Connect button.
                 repository = None
-                if not workflow.patched(_PATCH_ID_NO_PERSONAL_GITHUB_GATE):
-                    # Replay-only, for executions that recorded the classify-then-block pair.
-                    needs_repo = await _execute_posthog_code_activity(
-                        classify_posthog_code_task_needs_repo_activity,
-                        event.get("text", ""),
-                        thread_messages,
-                    )
-                    if needs_repo:
-                        blocked = await _execute_posthog_code_activity(
-                            block_posthog_code_task_if_no_personal_github_activity,
-                            inputs,
-                            channel,
-                            thread_ts,
-                            user_id,
-                        )
-                        if blocked:
-                            return
+                workflow.deprecate_patch(_PATCH_ID_NO_PERSONAL_GITHUB_GATE)
             else:
                 # Multiple candidates and no explicit mention. Cheap Haiku
                 # check first to skip the agent entirely for analytics/config
@@ -279,16 +254,15 @@ class PostHogCodeSlackMentionWorkflow(PostHogWorkflow):
             # mention, so the reply announcing the model only ever describes a task
             # that gets created. The feature flag is checked inside the activity —
             # branching the workflow on a flag would be non-deterministic on replay.
-            model_override = None
-            if workflow.patched(_PATCH_ID_MODEL_CLASSIFIER):
-                model_override = await _execute_posthog_code_activity(
-                    classify_slack_app_model_override_activity,
-                    SlackAppModelOverrideInput(
-                        integration_id=inputs.integration_id,
-                        slack_team_id=inputs.slack_team_id,
-                        event_text=event.get("text", ""),
-                    ),
-                )
+            workflow.deprecate_patch(_PATCH_ID_MODEL_CLASSIFIER)
+            model_override = await _execute_posthog_code_activity(
+                classify_slack_app_model_override_activity,
+                SlackAppModelOverrideInput(
+                    integration_id=inputs.integration_id,
+                    slack_team_id=inputs.slack_team_id,
+                    event_text=event.get("text", ""),
+                ),
+            )
 
             await _execute_posthog_code_activity(
                 create_posthog_code_task_for_repo_activity,

--- a/posthog/temporal/ai/slack_app/posthog_code_slack_mention_command.py
+++ b/posthog/temporal/ai/slack_app/posthog_code_slack_mention_command.py
@@ -52,12 +52,9 @@ class PostHogCodeSlackMentionCommandWorkflow(PostHogWorkflow):
 
     @workflow.run
     async def run(self, inputs: PostHogCodeSlackMentionCommandWorkflowInputs) -> None:
-        # New starts carry ``user_id`` from routing-time resolution and skip the
-        # activity. Legacy histories started before the field existed deserialize
-        # with ``user_id=None`` and replay through the activity so the recorded
-        # command stream still matches. Drop this fallback (and make ``user_id``
-        # required on inputs) once the workflow history retention window has
-        # elapsed.
+        # The mention surface resolves the user at routing time and passes it in.
+        # The slash surface passes ``None`` on purpose so its webhook ack stays
+        # inside Slack's 3s budget, and resolution happens here instead.
         user_id = inputs.user_id
         if user_id is None:
             user_id = await workflow.execute_activity(
@@ -94,14 +91,15 @@ class PostHogCodeSlackMentionCommandWorkflow(PostHogWorkflow):
         # shape, but today they only read ``integration_id`` / ``slack_team_id``
         # / ``event`` from it. Synthesise a compatible record for the resolved
         # target so we can reuse the existing picker plumbing without
-        # duplicating it. Forward ``user_id`` so any future activity that reads
-        # it (e.g. for attribution) stays consistent with the surrounding
-        # command workflow's resolved user.
+        # duplicating it. Forward the resolved ``user_id`` so any activity that
+        # reads it (e.g. for attribution) sees the same actor as the surrounding
+        # command workflow — on the slash surface ``inputs.user_id`` is still None
+        # here, since that surface defers resolution to the activity above.
         picker_inputs = PostHogCodeSlackMentionWorkflowInputs(
             event=inputs.event,
             integration_id=target_integration_id,
             slack_team_id=inputs.slack_team_id,
-            user_id=inputs.user_id,
+            user_id=user_id,
         )
 
         blocked = await workflow.execute_activity(

--- a/posthog/temporal/ai/slack_app/slack_app_mention.py
+++ b/posthog/temporal/ai/slack_app/slack_app_mention.py
@@ -27,11 +27,12 @@ SLACK_APP_MENTION_IDLE_TIMEOUT_SECONDS = 30
 SLACK_APP_MENTION_MAX_PROCESSED_KEYS = 200
 # Temporal runs buffered signal handlers before run() starts, so dedup state seeded in
 # run() arrived too late: a redelivered Slack event signalled into the first workflow task
-# missed the dedup keys and started a duplicate child workflow. Seeding moved to __init__,
-# which runs first. That changes which child workflows an execution starts, so executions
-# that already recorded the old order keep replaying it through this patch. The patch can
-# be deleted once no pre-patch executions remain, which takes minutes because these
-# workflows complete after a 30 second idle timeout.
+# missed the dedup keys and started a duplicate child workflow. Seeding happens in
+# __init__, which runs first. Pre-patch histories drained long ago — these workflows
+# complete after a 30 second idle timeout — so only `deprecate_patch` remains, keeping the
+# recorded marker compatible for executions in flight across the deploy that removes the
+# gate. Standard two-step Temporal patch lifecycle: the call comes out once the histories
+# that recorded a plain marker have drained in turn.
 SLACK_APP_MENTION_SEED_IN_INIT_PATCH = "slack-app-mention-seed-in-init"
 
 # The queue awaits each child serially, so a child that never completes stalls every
@@ -40,8 +41,10 @@ SLACK_APP_MENTION_SEED_IN_INIT_PATCH = "slack-app-mention-seed-in-init"
 # (15 minutes for the repo picker) plus its 10-minute activity timeouts stay well
 # inside an hour.
 SLACK_APP_MENTION_CHILD_EXECUTION_TIMEOUT = timedelta(hours=1)
-# Bounding the child and telling the user when it dies both add workflow commands, so
-# executions started before this shipped keep replaying the unbounded, silent path.
+# Bounding the child and telling the user when it dies both add workflow commands. The
+# executions that replayed the unbounded, silent path are long gone; `deprecate_patch`
+# only keeps their marker compatible across the deploy that removes the gate, and comes
+# out on the same lifecycle as the seeding patch above.
 SLACK_APP_MENTION_CHILD_TIMEOUT_PATCH = "slack-app-mention-child-timeout"
 
 
@@ -95,8 +98,8 @@ class SlackAppMentionWorkflow(PostHogWorkflow):
         # iteration order stays deterministic for the continue_as_new carry-over.
         self._seen_keys: dict[str, None] = {}
         self._queue: list[PostHogCodeSlackMentionWorkflowInputs] = []
-        if workflow.patched(SLACK_APP_MENTION_SEED_IN_INIT_PATCH):
-            self._seed(inputs)
+        workflow.deprecate_patch(SLACK_APP_MENTION_SEED_IN_INIT_PATCH)
+        self._seed(inputs)
 
     def _seed(self, inputs: SlackAppMentionWorkflowInputs) -> None:
         for key in inputs.processed_event_keys:
@@ -185,7 +188,7 @@ class SlackAppMentionWorkflow(PostHogWorkflow):
         ALLOW_DUPLICATE mirrors the standalone dispatch's reuse policy for
         retries that outlive this instance's dedup keys.
         """
-        bounded = workflow.patched(SLACK_APP_MENTION_CHILD_TIMEOUT_PATCH)
+        workflow.deprecate_patch(SLACK_APP_MENTION_CHILD_TIMEOUT_PATCH)
         try:
             # The default parent close policy (terminate) is deliberate: an
             # operator killing this queue means "stop this conversation", so
@@ -197,7 +200,7 @@ class SlackAppMentionWorkflow(PostHogWorkflow):
                 message,
                 id=derive_mention_workflow_id(message),
                 id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
-                execution_timeout=SLACK_APP_MENTION_CHILD_EXECUTION_TIMEOUT if bounded else None,
+                execution_timeout=SLACK_APP_MENTION_CHILD_EXECUTION_TIMEOUT,
             )
         except exceptions.WorkflowAlreadyStartedError:
             # A standalone execution for this exact message is already
@@ -209,15 +212,11 @@ class SlackAppMentionWorkflow(PostHogWorkflow):
             # expected to fail; this backstop keeps one poisoned message from
             # wedging the conversation's queue.
             workflow.logger.exception("slack_app_mention_child_failed")
-            if bounded:
-                await self._notify_child_failed(message)
+            await self._notify_child_failed(message)
 
     @workflow.run
     async def run(self, inputs: SlackAppMentionWorkflowInputs) -> None:
-        # Executions that predate the patch recorded their seeding here, so they keep it.
-        if not workflow.patched(SLACK_APP_MENTION_SEED_IN_INIT_PATCH):
-            self._seed(inputs)
-
+        # Seeding happens in __init__ — see _seed's call site for why.
         while True:
             try:
                 await workflow.wait_condition(

--- a/posthog/temporal/ai/slack_app/types.py
+++ b/posthog/temporal/ai/slack_app/types.py
@@ -10,13 +10,15 @@ from typing import Any, Literal
 
 from pydantic import BaseModel
 
+from posthog.dataclasses import frozen
+
 
 @dataclass
 class PostHogSlackInboxOnboardingInputs:
     integration_id: int
 
 
-@dataclass(frozen=True)
+@frozen
 class PostHogCodeSlackMentionWorkflowInputs:
     event: dict[str, Any]
     integration_id: int
@@ -147,7 +149,7 @@ class PostHogCodeSlackMentionCommandWorkflowInputs:
     command_prefix: str = "@PostHog"
 
 
-@dataclass
+@frozen
 class PostHogCodeRepoCascadeOutcome:
     """Synchronous fast-path repo resolution before the discovery agent runs.
 

--- a/posthog/temporal/ai/slack_app/types.py
+++ b/posthog/temporal/ai/slack_app/types.py
@@ -21,13 +21,11 @@ class PostHogCodeSlackMentionWorkflowInputs:
     event: dict[str, Any]
     integration_id: int
     slack_team_id: str
+    # Resolved at routing time: dispatch never reaches this workflow without a
+    # PostHog user, on either the ``app_mention`` or the untagged-reply path.
+    user_id: int
     # Event that dispatched the workflow
     slack_event_id: str | None = None
-    # Resolved at routing time. ``None`` only on in-flight workflow histories
-    # started before this field existed; those fall back to the in-workflow
-    # resolve activity below. Remove the fallback (and this field's optionality)
-    # once the workflow history retention window has elapsed.
-    user_id: int | None = None
     # True when the workflow was started for an untagged thread reply (event type
     # ``message``) rather than an explicit ``app_mention``. The routing layer
     # already verified a ``SlackThreadTaskMapping`` exists before dispatch, but
@@ -156,11 +154,10 @@ class PostHogCodeRepoCascadeOutcome:
     `auto` → use `repository` directly. `no_repo` → the mentioning user resolves no
     repos, so the mention becomes a repo-less task and the agent decides whether the
     ask needs code. `agent_needed` → there are multiple candidates and no explicit
-    mention. `needs_user_github` is neither emitted nor handled any more; the value
-    stays in the `Literal` only so an old payload still parses.
+    mention.
     """
 
-    mode: Literal["auto", "no_repo", "agent_needed", "needs_user_github"]
+    mode: Literal["auto", "no_repo", "agent_needed"]
     repository: str | None
     reason: str
 

--- a/posthog/temporal/tests/ai/slack_app/activities/test_task_creation.py
+++ b/posthog/temporal/tests/ai/slack_app/activities/test_task_creation.py
@@ -475,6 +475,7 @@ class TestDeriveMentionWorkflowId:
             "integration_id": 1,
             "slack_team_id": "T_SLACK",
             "slack_event_id": "Ev123",
+            "user_id": 1,
             **overrides,
         }
         return PostHogCodeSlackMentionWorkflowInputs(**fields)

--- a/posthog/temporal/tests/ai/slack_app/test_slack_app_mention_workflow.py
+++ b/posthog/temporal/tests/ai/slack_app/test_slack_app_mention_workflow.py
@@ -64,7 +64,7 @@ class _Recorder:
         # a deleted trigger message reads as.
         self.thread_messages: dict[str, list[dict[str, str]]] = {}
         # ts -> cascade mode; missing means "auto" with a fixed repository.
-        self.cascade_modes: dict[str, Literal["auto", "no_repo", "agent_needed", "needs_user_github"]] = {}
+        self.cascade_modes: dict[str, Literal["auto", "no_repo", "agent_needed"]] = {}
         # ts per personal-GitHub gate call, in execution order.
         self.github_gate_calls: list[str] = []
         # event text per needs-repo classifier call, in execution order.
@@ -212,12 +212,6 @@ def _fake_activities(rec: _Recorder) -> list:
     async def internal_error(inputs: PostHogCodeSlackMentionWorkflowInputs, channel: str, thread_ts: str) -> None:
         rec.internal_errors.append(inputs.event["ts"])
 
-    @activity.defn(name="resolve_posthog_code_slack_user_activity")
-    async def resolve_user(
-        inputs: PostHogCodeSlackMentionWorkflowInputs, channel: str, thread_ts: str, slack_user_id: str
-    ) -> int | None:
-        return 42
-
     @activity.defn(name="mark_slack_app_message_processing_activity")
     async def mark_processing(input: SlackAppMessageReactionInput) -> None:
         rec.processing_marked.append(input.message_ts)
@@ -243,7 +237,6 @@ def _fake_activities(rec: _Recorder) -> list:
         create_task,
         picker_timeout,
         internal_error,
-        resolve_user,
     ]
 
 

--- a/posthog/temporal/tests/ai/slack_app/test_types.py
+++ b/posthog/temporal/tests/ai/slack_app/test_types.py
@@ -4,7 +4,9 @@ from posthog.temporal.ai.slack_app.types import PostHogCodeSlackMentionWorkflowI
 
 
 def test_coerce_returns_dataclass_unchanged():
-    inputs = PostHogCodeSlackMentionWorkflowInputs(event={"ts": "1.2"}, integration_id=7, slack_team_id="T1")
+    inputs = PostHogCodeSlackMentionWorkflowInputs(
+        event={"ts": "1.2"}, integration_id=7, slack_team_id="T1", user_id=42
+    )
     assert coerce_mention_workflow_inputs(inputs) is inputs
 
 
@@ -23,7 +25,7 @@ def test_coerce_rebuilds_dataclass_from_dict():
 def test_coerce_drops_unknown_keys_from_dict():
     # A newer sender's extra field must not blow up an older activity mid-deploy.
     coerced = coerce_mention_workflow_inputs(
-        {"event": {}, "integration_id": 1, "slack_team_id": "T1", "some_future_field": "x"}
+        {"event": {}, "integration_id": 1, "slack_team_id": "T1", "user_id": 42, "some_future_field": "x"}
     )
     assert coerced.integration_id == 1
 

--- a/posthog/temporal/tests/ai/test_block_missing_user_github.py
+++ b/posthog/temporal/tests/ai/test_block_missing_user_github.py
@@ -13,11 +13,14 @@ from posthog.temporal.ai.slack_app import (
 )
 
 
-def _make_inputs(integration_id: int, slack_team_id: str = "T_SLACK") -> PostHogCodeSlackMentionWorkflowInputs:
+def _make_inputs(
+    integration_id: int, user_id: int, slack_team_id: str = "T_SLACK"
+) -> PostHogCodeSlackMentionWorkflowInputs:
     return PostHogCodeSlackMentionWorkflowInputs(
         event={"channel": "C123", "ts": "1234.5678", "user": "U_ALICE", "text": "<@BOT> do something"},
         integration_id=integration_id,
         slack_team_id=slack_team_id,
+        user_id=user_id,
     )
 
 
@@ -34,7 +37,7 @@ class TestBlockPostHogCodeTaskIfNoPersonalGitHub(TestCase):
         mock_slack_cls.return_value = mock_slack
 
         blocked = block_posthog_code_task_if_no_personal_github_activity(
-            _make_inputs(self.integration.id), "C123", "1234.5678", self.user.id
+            _make_inputs(self.integration.id, self.user.id), "C123", "1234.5678", self.user.id
         )
 
         assert blocked is True
@@ -70,7 +73,7 @@ class TestBlockPostHogCodeTaskIfNoPersonalGitHub(TestCase):
         mock_slack_cls.return_value = mock_slack
 
         blocked = block_posthog_code_task_if_no_personal_github_activity(
-            _make_inputs(self.integration.id), "C123", "1234.5678", self.user.id
+            _make_inputs(self.integration.id, self.user.id), "C123", "1234.5678", self.user.id
         )
 
         assert blocked is False
@@ -83,7 +86,7 @@ class TestBlockPostHogCodeTaskIfNoPersonalGitHub(TestCase):
         mock_slack_cls.return_value = mock_slack
 
         blocked = block_posthog_code_task_if_no_personal_github_activity(
-            _make_inputs(self.integration.id), "C123", "1234.5678", self.user.id
+            _make_inputs(self.integration.id, self.user.id), "C123", "1234.5678", self.user.id
         )
 
         assert blocked is True
@@ -105,7 +108,7 @@ class TestBlockPostHogCodeTaskIfNoPersonalGitHub(TestCase):
         mock_slack_cls.return_value = mock_slack
 
         blocked = block_posthog_code_task_if_no_personal_github_activity(
-            _make_inputs(self.integration.id), "C123", "1234.5678", self.user.id
+            _make_inputs(self.integration.id, self.user.id), "C123", "1234.5678", self.user.id
         )
 
         assert blocked is True
@@ -125,7 +128,7 @@ class TestBlockPostHogCodeTaskIfNoPersonalGitHub(TestCase):
         mock_slack_cls.return_value = mock_slack
 
         blocked = block_posthog_code_task_if_no_personal_github_activity(
-            _make_inputs(self.integration.id), "C123", "1234.5678", self.user.id
+            _make_inputs(self.integration.id, self.user.id), "C123", "1234.5678", self.user.id
         )
 
         assert blocked is True

--- a/posthog/temporal/tests/ai/test_cascade_team_install.py
+++ b/posthog/temporal/tests/ai/test_cascade_team_install.py
@@ -15,11 +15,14 @@ from posthog.temporal.ai.slack_app import (
 )
 
 
-def _make_inputs(integration_id: int, slack_team_id: str = "T_SLACK") -> PostHogCodeSlackMentionWorkflowInputs:
+def _make_inputs(
+    integration_id: int, user_id: int, slack_team_id: str = "T_SLACK"
+) -> PostHogCodeSlackMentionWorkflowInputs:
     return PostHogCodeSlackMentionWorkflowInputs(
         event={"channel": "C123", "ts": "1234.5678", "user": "U_ALICE", "text": "<@BOT> fix the thing"},
         integration_id=integration_id,
         slack_team_id=slack_team_id,
+        user_id=user_id,
     )
 
 
@@ -52,7 +55,7 @@ class TestCascadeTeamInstall(TestCase):
             )
 
         outcome = cascade_posthog_code_repository_activity(
-            _make_inputs(self.slack_integration.id), "fix the thing", self.user.id
+            _make_inputs(self.slack_integration.id, self.user.id), "fix the thing", self.user.id
         )
 
         assert outcome.mode == "no_repo"
@@ -75,7 +78,7 @@ class TestCascadeTeamInstall(TestCase):
         mock_user_github_class.return_value = mock_user_github
 
         outcome = cascade_posthog_code_repository_activity(
-            _make_inputs(self.slack_integration.id), "fix the thing", self.user.id
+            _make_inputs(self.slack_integration.id, self.user.id), "fix the thing", self.user.id
         )
 
         assert outcome.mode == "auto"

--- a/posthog/temporal/tests/ai/test_classify_untagged_followup_activity.py
+++ b/posthog/temporal/tests/ai/test_classify_untagged_followup_activity.py
@@ -52,6 +52,7 @@ class TestClassifyUntaggedFollowupActivity(TestCase):
             event={},
             integration_id=self.integration.id,
             slack_team_id="T_SLACK",
+            user_id=self.user.id,
             untagged_followup=True,
         )
 

--- a/posthog/temporal/tests/ai/test_posthog_code_slack_mention_workflow.py
+++ b/posthog/temporal/tests/ai/test_posthog_code_slack_mention_workflow.py
@@ -7,15 +7,19 @@ from posthog.temporal.ai.slack_app.types import PostHogCodeSlackMentionWorkflowI
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "text,expect_classifier",
+    "text,patched,expect_classifier",
     [
         # File-only replies skip the classifier so the attachment isn't dropped.
-        ("", False),
+        ("", True, False),
         # Replies with text still face the classifier even when files are attached.
-        ("nice weather today", True),
+        ("nice weather today", True, True),
+        # Replays of histories recorded before the confirmation patch skip the prompt.
+        ("", False, False),
     ],
 )
-async def test_untagged_followup_with_files_classifier_gating(text: str, expect_classifier: bool) -> None:
+async def test_untagged_followup_with_files_classifier_gating(
+    text: str, patched: bool, expect_classifier: bool
+) -> None:
     workflow = posthog_code_slack_mention.PostHogCodeSlackMentionWorkflow()
     calls: list[str] = []
     inputs = PostHogCodeSlackMentionWorkflowInputs(
@@ -46,6 +50,7 @@ async def test_untagged_followup_with_files_classifier_gating(text: str, expect_
         raise AssertionError(f"unexpected activity: {activity_fn.__name__}")
 
     with (
+        patch.object(posthog_code_slack_mention.workflow, "patched", return_value=patched),
         # Runs outside a workflow context, where the real marker call would raise.
         patch.object(posthog_code_slack_mention.workflow, "deprecate_patch"),
         patch.object(posthog_code_slack_mention, "_execute_posthog_code_activity", side_effect=fake_execute_activity),

--- a/posthog/temporal/tests/ai/test_posthog_code_slack_mention_workflow.py
+++ b/posthog/temporal/tests/ai/test_posthog_code_slack_mention_workflow.py
@@ -7,19 +7,15 @@ from posthog.temporal.ai.slack_app.types import PostHogCodeSlackMentionWorkflowI
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "text,patched,expect_classifier",
+    "text,expect_classifier",
     [
         # File-only replies skip the classifier so the attachment isn't dropped.
-        ("", True, False),
+        ("", False),
         # Replies with text still face the classifier even when files are attached.
-        ("nice weather today", True, True),
-        # Replays of histories recorded before the patch keep the old always-classify sequence.
-        ("", False, True),
+        ("nice weather today", True),
     ],
 )
-async def test_untagged_followup_with_files_classifier_gating(
-    text: str, patched: bool, expect_classifier: bool
-) -> None:
+async def test_untagged_followup_with_files_classifier_gating(text: str, expect_classifier: bool) -> None:
     workflow = posthog_code_slack_mention.PostHogCodeSlackMentionWorkflow()
     calls: list[str] = []
     inputs = PostHogCodeSlackMentionWorkflowInputs(
@@ -50,7 +46,8 @@ async def test_untagged_followup_with_files_classifier_gating(
         raise AssertionError(f"unexpected activity: {activity_fn.__name__}")
 
     with (
-        patch.object(posthog_code_slack_mention.workflow, "patched", return_value=patched),
+        # Runs outside a workflow context, where the real marker call would raise.
+        patch.object(posthog_code_slack_mention.workflow, "deprecate_patch"),
         patch.object(posthog_code_slack_mention, "_execute_posthog_code_activity", side_effect=fake_execute_activity),
     ):
         await workflow.run(inputs)

--- a/posthog/temporal/tests/ai/test_request_untagged_followup_confirmation_activity.py
+++ b/posthog/temporal/tests/ai/test_request_untagged_followup_confirmation_activity.py
@@ -55,6 +55,7 @@ class TestRequestUntaggedFollowupConfirmationActivity(TestCase):
             event={"channel": "C001", "user": "U_BOB", "ts": "1001.0000", "thread_ts": "1000.0000", "text": "and this"},
             integration_id=self.integration.id,
             slack_team_id="T_SLACK",
+            user_id=self.user.id,
             untagged_followup=True,
         )
 

--- a/posthog/test/dataclass_frozen_baseline.txt
+++ b/posthog/test/dataclass_frozen_baseline.txt
@@ -1602,6 +1602,7 @@
 6 posthog/hogql/base.py
 6 posthog/hogql/scripts/build_grammar_strategies.py
 6 posthog/local_bootstrap/config.py
+6 posthog/temporal/ai/slack_app/types.py
 6 posthog/temporal/ai/sync_vectors.py
 6 posthog/temporal/salesforce_enrichment/stripe_workflow.py
 6 products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
@@ -1620,7 +1621,6 @@
 7 products/web_analytics/backend/temporal/digest_notification/types.py
 7 products/web_analytics/backend/temporal/weekly_digest/types.py
 8 ee/vercel/integration.py
-8 posthog/temporal/ai/slack_app/types.py
 8 posthog/temporal/ai_observability/evaluation_clustering/activities.py
 8 posthog/temporal/delete_teams/types.py
 8 products/signals/backend/temporal/signal_queries.py

--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -3193,7 +3193,7 @@ def _start_mention_workflow(
     slack_team_id: str,
     event_id: str | None,
     *,
-    posthog_user: User | None,
+    posthog_user: User,
     untagged_followup: bool = False,
     untagged_followup_confirmed: bool = False,
     is_ext_shared_channel: bool = False,
@@ -3208,13 +3208,8 @@ def _start_mention_workflow(
     is also threaded into the workflow inputs so the workflow runs the
     classifier activity at the top of its body and short-circuits if the
     mapping is gone by the time the followup activity runs.
-
-    ``posthog_user`` is optional only to keep the door open for the legacy
-    in-workflow resolution path; in practice both event types resolve the
-    user at routing time and pass it in.
     """
     if not untagged_followup:
-        assert posthog_user is not None, "app_mention path must always resolve a user before dispatch"
         _report_slack_mention_received(event, integration, slack_team_id, posthog_user=posthog_user)
         if _resolve_pending_repo_picker_from_followup(event, integration):
             return ROUTE_HANDLED_LOCALLY
@@ -3223,7 +3218,7 @@ def _start_mention_workflow(
         integration_id=integration.id,
         slack_team_id=slack_team_id,
         slack_event_id=event_id,
-        user_id=posthog_user.id if posthog_user else None,
+        user_id=posthog_user.id,
         untagged_followup=untagged_followup,
         untagged_followup_confirmed=untagged_followup_confirmed,
         is_ext_shared_channel=is_ext_shared_channel,

--- a/products/slack_app/backend/tests/test_followup_forwarding.py
+++ b/products/slack_app/backend/tests/test_followup_forwarding.py
@@ -1034,7 +1034,7 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
         self._create_mapping()
         mock_slack_cls.return_value = MagicMock()
 
-        inputs = _make_inputs(self.integration.id)
+        inputs = _make_inputs(self.integration.id, self.user.id)
         result = forward_posthog_code_followup_activity(
             inputs, "C123", "1234.5678", "U_ALICE", "<@BOT> fix the tests", "1234.5679"
         )

--- a/products/slack_app/backend/tests/test_followup_forwarding.py
+++ b/products/slack_app/backend/tests/test_followup_forwarding.py
@@ -28,11 +28,14 @@ from products.slack_app.backend.models import SlackThreadTaskMapping
 from products.slack_app.backend.services.run_preferences import SLACK_DEFAULT_MODEL
 
 
-def _make_inputs(integration_id: int, slack_team_id: str = "T_SLACK") -> PostHogCodeSlackMentionWorkflowInputs:
+def _make_inputs(
+    integration_id: int, user_id: int, slack_team_id: str = "T_SLACK"
+) -> PostHogCodeSlackMentionWorkflowInputs:
     return PostHogCodeSlackMentionWorkflowInputs(
         event={"channel": "C123", "ts": "1234.5678", "user": "U_ALICE", "text": "<@BOT> do something"},
         integration_id=integration_id,
         slack_team_id=slack_team_id,
+        user_id=user_id,
     )
 
 
@@ -204,7 +207,7 @@ class TestCreatePostHogCodeTaskForRepoActivity(TestCase):
         }
         mock_slack_cls.return_value = mock_slack_instance
 
-        inputs = _make_inputs(self.integration.id)
+        inputs = _make_inputs(self.integration.id, self.user.id)
         create_posthog_code_task_for_repo_activity(
             inputs,
             "C123",
@@ -263,6 +266,7 @@ class TestCreatePostHogCodeTaskForRepoActivity(TestCase):
             event=event,
             integration_id=self.integration.id,
             slack_team_id="T_SLACK",
+            user_id=self.user.id,
         )
 
         with (
@@ -324,7 +328,7 @@ class TestCreatePostHogCodeTaskForRepoActivity(TestCase):
             mentioning_slack_user_id="U_ALICE",
         )
 
-        inputs = _make_inputs(self.integration.id)
+        inputs = _make_inputs(self.integration.id, self.user.id)
         create_posthog_code_task_for_repo_activity(
             inputs,
             "C123",
@@ -359,6 +363,7 @@ class TestCreatePostHogCodeTaskForRepoActivity(TestCase):
             integration_id=self.integration.id,
             slack_team_id="T_SLACK",
             slack_event_id="Ev01234567",
+            user_id=self.user.id,
         )
         create_posthog_code_task_for_repo_activity(
             inputs,
@@ -384,7 +389,7 @@ class TestCreatePostHogCodeTaskForRepoActivity(TestCase):
         }
         mock_slack_cls.return_value = mock_slack_instance
 
-        inputs = _make_inputs(self.integration.id)
+        inputs = _make_inputs(self.integration.id, self.user.id)
         create_posthog_code_task_for_repo_activity(
             inputs,
             "C123",
@@ -415,7 +420,7 @@ class TestCreatePostHogCodeTaskForRepoActivity(TestCase):
         }
         mock_slack_cls.return_value = mock_slack_instance
 
-        inputs = _make_inputs(self.integration.id)
+        inputs = _make_inputs(self.integration.id, self.user.id)
         create_posthog_code_task_for_repo_activity(
             inputs,
             "C123",
@@ -442,7 +447,7 @@ class TestCreatePostHogCodeTaskForRepoActivity(TestCase):
         }
         mock_slack_cls.return_value = mock_slack_instance
 
-        inputs = _make_inputs(self.integration.id)
+        inputs = _make_inputs(self.integration.id, self.user.id)
         create_posthog_code_task_for_repo_activity(
             inputs,
             "C123",
@@ -481,7 +486,7 @@ class TestCreatePostHogCodeTaskForRepoActivity(TestCase):
         }
         mock_slack_cls.return_value = mock_slack_instance
 
-        inputs = _make_inputs(self.integration.id)
+        inputs = _make_inputs(self.integration.id, self.user.id)
         create_posthog_code_task_for_repo_activity(
             inputs,
             "C123",
@@ -517,7 +522,7 @@ class TestCreatePostHogCodeTaskForRepoActivity(TestCase):
         }
         mock_slack_cls.return_value = mock_slack_instance
 
-        inputs = _make_inputs(self.integration.id)
+        inputs = _make_inputs(self.integration.id, self.user.id)
         create_posthog_code_task_for_repo_activity(
             inputs,
             "C123",
@@ -555,7 +560,7 @@ class TestCreatePostHogCodeTaskForRepoActivity(TestCase):
         }
         mock_slack_cls.return_value = mock_slack_instance
 
-        inputs = _make_inputs(self.integration.id)
+        inputs = _make_inputs(self.integration.id, self.user.id)
         create_posthog_code_task_for_repo_activity(
             inputs,
             "C123",
@@ -587,7 +592,7 @@ class TestCreatePostHogCodeTaskForRepoActivity(TestCase):
         mock_slack_instance = MagicMock()
         mock_slack_cls.return_value = mock_slack_instance
 
-        inputs = _make_inputs(self.integration.id)
+        inputs = _make_inputs(self.integration.id, self.user.id)
         create_posthog_code_task_for_repo_activity(
             inputs,
             "C123",
@@ -651,7 +656,7 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
         )
 
     def test_no_mapping_returns_false(self):
-        inputs = _make_inputs(self.integration.id)
+        inputs = _make_inputs(self.integration.id, self.user.id)
         result = forward_posthog_code_followup_activity(
             inputs, "C123", "1234.5678", "U_ALICE", "do something", "1234.5679"
         )
@@ -668,7 +673,7 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
         mock_slack_instance = MagicMock()
         mock_slack_cls.return_value = mock_slack_instance
 
-        inputs = _make_inputs(self.integration.id)
+        inputs = _make_inputs(self.integration.id, self.user.id)
         result = forward_posthog_code_followup_activity(
             inputs, "C123", "1234.5678", "U_ALICE", "do something", "1234.5679"
         )
@@ -687,7 +692,7 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
         mock_slack_instance = MagicMock()
         mock_slack_cls.return_value = mock_slack_instance
 
-        inputs = _make_inputs(self.integration.id)
+        inputs = _make_inputs(self.integration.id, self.user.id)
         result = forward_posthog_code_followup_activity(
             inputs, "C123", "1234.5678", "U_ALICE", "<@BOT> do something", "1234.5679"
         )
@@ -743,6 +748,7 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
             event=event,
             integration_id=self.integration.id,
             slack_team_id="T_SLACK",
+            user_id=self.user.id,
         )
 
         with (
@@ -778,7 +784,7 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
         self._create_mapping()
         mock_slack_cls.return_value = MagicMock()
 
-        inputs = _make_inputs(self.integration.id)
+        inputs = _make_inputs(self.integration.id, self.user.id)
         result = forward_posthog_code_followup_activity(
             inputs, "C123", "1234.5678", "U_ALICE", "<@BOT> clone org/repo and open PR", "1234.5679"
         )
@@ -796,7 +802,7 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
         self._create_mapping()
         mock_slack_cls.return_value = MagicMock()
 
-        inputs = _make_inputs(self.integration.id)
+        inputs = _make_inputs(self.integration.id, self.user.id)
         forward_posthog_code_followup_activity(
             inputs, "C123", "1234.5678", "U_ALICE", "<@BOT> fix the tests", "1234.5679"
         )
@@ -824,7 +830,7 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
         self._create_mapping()
         mock_slack_cls.return_value = MagicMock()
 
-        inputs = _make_inputs(self.integration.id)
+        inputs = _make_inputs(self.integration.id, self.user.id)
         result = forward_posthog_code_followup_activity(
             inputs, "C123", "1234.5678", "U_ALICE", "<@BOT> I connected GitHub, try again", "1234.5679"
         )
@@ -851,7 +857,7 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
         mock_slack_instance = MagicMock()
         mock_slack_cls.return_value = mock_slack_instance
 
-        inputs = _make_inputs(self.integration.id)
+        inputs = _make_inputs(self.integration.id, self.user.id)
         result = forward_posthog_code_followup_activity(
             inputs, "C123", "1234.5678", "U_BOB", "<@BOT> do something", "1234.5679"
         )
@@ -870,7 +876,7 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
         mock_slack_instance = MagicMock()
         mock_slack_cls.return_value = mock_slack_instance
 
-        inputs = _make_inputs(self.integration.id)
+        inputs = _make_inputs(self.integration.id, self.user.id)
         result = forward_posthog_code_followup_activity(
             inputs, "C123", "1234.5678", "U_ALICE", "<@BOT> do something", "1234.5679"
         )
@@ -888,7 +894,7 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
         mock_slack_instance = MagicMock()
         mock_slack_cls.return_value = mock_slack_instance
 
-        inputs = _make_inputs(self.integration.id)
+        inputs = _make_inputs(self.integration.id, self.user.id)
         result = forward_posthog_code_followup_activity(
             inputs, "C123", "1234.5678", "U_ALICE", "<@BOT> do something", "1234.5679"
         )
@@ -909,7 +915,7 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
         mock_slack_instance = MagicMock()
         mock_slack_cls.return_value = mock_slack_instance
 
-        inputs = _make_inputs(self.integration.id)
+        inputs = _make_inputs(self.integration.id, self.user.id)
         result = forward_posthog_code_followup_activity(
             inputs, "C123", "1234.5678", "U_BOB", "do something", "1234.5679"
         )
@@ -930,7 +936,7 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
         mock_slack_cls.return_value = mock_slack_instance
         mock_resolve.return_value = SlackUserContext(user=bob, slack_email="bob@test.com")
 
-        inputs = _make_inputs(self.integration.id)
+        inputs = _make_inputs(self.integration.id, self.user.id)
         result = forward_posthog_code_followup_activity(
             inputs, "C123", "1234.5678", "U_BOB", "<@BOT> please retry the build", "1234.5679"
         )
@@ -959,7 +965,7 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
         mock_slack_cls.return_value = MagicMock()
         mock_resolve.return_value = SlackUserContext(user=bob, slack_email="bob@test.com")
 
-        inputs = _make_inputs(self.integration.id)
+        inputs = _make_inputs(self.integration.id, self.user.id)
         forward_posthog_code_followup_activity(inputs, "C123", "1234.5678", "U_BOB", "<@BOT> ping", "1234.5679")
 
         mock_signal.assert_called_once()
@@ -978,7 +984,7 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
         mock_slack_instance = MagicMock()
         mock_slack_cls.return_value = mock_slack_instance
 
-        inputs = _make_inputs(self.integration.id)
+        inputs = _make_inputs(self.integration.id, self.user.id)
         result = forward_posthog_code_followup_activity(
             inputs, "C123", "1234.5678", "U_BOB", "<@BOT> sneak in", "1234.5679"
         )
@@ -1003,7 +1009,7 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
         mock_slack_cls.return_value = MagicMock()
         mock_resolve.return_value = SlackUserContext(user=bob, slack_email="bob@test.com")
 
-        inputs = _make_inputs(self.integration.id)
+        inputs = _make_inputs(self.integration.id, self.user.id)
         result = forward_posthog_code_followup_activity(
             inputs, "C123", "1234.5678", "U_BOB", "<@BOT> fix the tests", "1234.5679"
         )
@@ -1046,7 +1052,7 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
         mock_slack_instance = MagicMock()
         mock_slack_cls.return_value = mock_slack_instance
 
-        inputs = _make_inputs(self.integration.id)
+        inputs = _make_inputs(self.integration.id, self.user.id)
         result = forward_posthog_code_followup_activity(
             inputs, "C123", "1234.5678", "U_ALICE", "do something", "1234.5679"
         )
@@ -1061,7 +1067,7 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
         mock_slack_instance = MagicMock()
         mock_slack_cls.return_value = mock_slack_instance
 
-        inputs = _make_inputs(self.integration.id)
+        inputs = _make_inputs(self.integration.id, self.user.id)
         result = forward_posthog_code_followup_activity(
             inputs, "C123", "1234.5678", "U_ALICE", "<@BOT> do something", "1234.5679"
         )
@@ -1104,6 +1110,7 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
             event=event,
             integration_id=self.integration.id,
             slack_team_id="T_SLACK",
+            user_id=self.user.id,
         )
 
         with (
@@ -1167,6 +1174,7 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
             event=event,
             integration_id=self.integration.id,
             slack_team_id="T_SLACK",
+            user_id=self.user.id,
         )
 
         with (
@@ -1197,7 +1205,7 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
         mock_slack_instance = MagicMock()
         mock_slack_cls.return_value = mock_slack_instance
 
-        inputs = _make_inputs(self.integration.id)
+        inputs = _make_inputs(self.integration.id, self.user.id)
         result = forward_posthog_code_followup_activity(
             inputs, "C123", "1234.5678", "U_ALICE", "<@BOT> do something", "1234.5679"
         )
@@ -1220,6 +1228,7 @@ class TestEnforcePostHogCodeBillingQuotaActivity(TestCase):
     def setUp(self):
         self.org = Organization.objects.create(name="TestOrg")
         self.team = Team.objects.create(organization=self.org, name="TestTeam")
+        self.user = User.objects.create(email="alice@test.com")
         self.integration = Integration.objects.create(team=self.team, kind="slack", integration_id="T_SLACK", config={})
 
     @patch("posthog.models.integration.SlackIntegration")
@@ -1228,7 +1237,7 @@ class TestEnforcePostHogCodeBillingQuotaActivity(TestCase):
         mock_slack_instance = MagicMock()
         mock_slack_cls.return_value = mock_slack_instance
 
-        inputs = _make_inputs(self.integration.id)
+        inputs = _make_inputs(self.integration.id, self.user.id)
         blocked = enforce_posthog_code_billing_quota_activity(
             inputs,
             "C123",
@@ -1245,7 +1254,7 @@ class TestEnforcePostHogCodeBillingQuotaActivity(TestCase):
         mock_slack_instance = MagicMock()
         mock_slack_cls.return_value = mock_slack_instance
 
-        inputs = _make_inputs(self.integration.id)
+        inputs = _make_inputs(self.integration.id, self.user.id)
         blocked = enforce_posthog_code_billing_quota_activity(
             inputs,
             "C123",

--- a/products/slack_app/backend/tests/test_guess_repository.py
+++ b/products/slack_app/backend/tests/test_guess_repository.py
@@ -451,6 +451,7 @@ class TestHandleRulesCommandActivity:
             event={"text": text, "channel": self.channel, "thread_ts": self.thread_ts, "user": self.slack_user_id},
             integration_id=self.integration.id,
             slack_team_id="T12345",
+            user_id=self.user.id,
         )
 
     @patch("posthog.models.integration.SlackIntegration")


### PR DESCRIPTION
## Problem

Five Temporal version gates in the Slack app's mention and queue workflows guard replay paths that can no longer run, so anyone reading these workflows reasons about dead branches.

- The gates are 7 to 39 days old.
- Both workflows finish inside an hour, so every pre-patch history drained the day each gate shipped.
- Alongside them sits back-compat for a call shape retired in June 2026, which makes `user_id` optional on the mention workflow's inputs.

## Changes

- Each gate becomes `workflow.deprecate_patch(...)` in the same call position, and only the live path remains.
- `user_id` is now required on `PostHogCodeSlackMentionWorkflowInputs`, since routing resolves the user before dispatch on every path that reaches this workflow.
- The in-workflow resolve fallback goes, and with it `resolve_posthog_code_slack_user_activity`. The command surface twin stays, because the slash path defers resolution on purpose.
- The cascade and picker activities drop the pre-2026-06 positional call shape.
- The command workflow built its picker inputs from the unresolved `inputs.user_id`, which is `None` on the slash surface. It now forwards the resolved user.
- I did not delete the markers outright. Deployed code still writes plain ones, so in-flight histories carry them across this rollout whatever the gate's age. Step two of the lifecycle in `.claude/rules/temporal-workflow-versioning.md` is a follow-up.

| Patch | Shipped | Gated behavior, now unconditional |
| --- | --- | --- |
| `slack-file-only-followup-bypass-v1` | #66834 | File-only replies skip the chitchat classifier |
| `slack-app-mention-seed-in-init` | #73547 | Dedup state seeds in `__init__` |
| `slack-app-mention-child-timeout` | #74673 | Child bounded at one hour, failure reported to the thread |
| `slack-app-model-classifier-v1` | #77250 | Model-override classifier runs |
| `slack-no-personal-github-gate-v1` | #80074 | No GitHub gate on a repo-less mention |

## How did you test this code?

I (actually Claude) ran the automated suites and did no manual Slack testing.

`test_slack_app_mention_workflow.py` drives a real time-skipping Temporal worker, so all five `deprecate_patch` calls execute against a real server, including the one inside `@workflow.init`. Its existing cases already cover each newly unconditional path.

Test edits follow the code: `test_untagged_followup_with_files_classifier_gating` loses the case asserting the replay-only sequence, and other edits add the required `user_id` to fixtures.

Not checked: the database-backed suites did not re-run after I merged master, because the shared test database is stale here and cannot be recreated while other worktrees hold connections. Both affected files passed before the merge, and the merged commits touch no Slack app code.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior, API, or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) did the work. Skills invoked: `/writing-tests` and `/writing-pr-descriptions`.

The session started scoped to the gates. Reading them surfaced the adjacent `user_id` back-compat, which carries the same "drop once histories drain" instruction, and Vojta chose to fold it in. The dead activity and the unresolved-`user_id` bug both fell out of making the field required.

Public artifact: this PR draws on no customer conversation, ticket, or log.
