### PR TITLE
fix(tracing): find spans by name in the property picker value search

### DIFF
--- a/products/tracing/backend/logic.py
+++ b/products/tracing/backend/logic.py
@@ -894,6 +894,58 @@ def run_attribute_names_query(
     return results, count
 
 
+# Keys whose name matches the search.
+_ATTRIBUTE_KEY_MATCH_BRANCH = """
+    SELECT
+        attribute_key,
+        'key' AS match_type,
+        '' AS sample_value,
+        sum(attribute_count) AS total_count
+    FROM posthog.trace_attributes
+    WHERE time_bucket >= {date_from_start_of_interval}
+    AND time_bucket <= {date_to_start_of_interval} + {one_interval_period}
+    AND attribute_type = {attributeType}
+    AND attribute_key ILIKE {search}
+    GROUP BY team_id, attribute_key
+"""
+
+# Keys whose values match the search but whose name does NOT — the NOT-ILIKE dedupes
+# against the key branch, so a key never appears twice.
+_ATTRIBUTE_VALUE_MATCH_BRANCH = """
+    SELECT
+        attribute_key,
+        'value' AS match_type,
+        argMax(attribute_value, attribute_count) AS sample_value,
+        sum(attribute_count) AS total_count
+    FROM posthog.trace_attributes
+    WHERE time_bucket >= {date_from_start_of_interval}
+    AND time_bucket <= {date_to_start_of_interval} + {one_interval_period}
+    AND attribute_type = {attributeType}
+    AND attribute_value ILIKE {search}
+    AND attribute_key NOT ILIKE {search}
+    GROUP BY team_id, attribute_key
+"""
+
+# Built-in span columns (currently only `name`) whose values match the search. Span names
+# are a column on the span rather than an entry in the attribute maps, so they're aggregated
+# under attribute_type='span' and are invisible to the branches above — which leaves the one
+# identifier people paste in when hunting for a specific trace unsearchable.
+_SPAN_COLUMN_VALUE_MATCH_BRANCH = """
+    SELECT
+        attribute_key,
+        'span' AS match_type,
+        argMax(attribute_value, attribute_count) AS sample_value,
+        sum(attribute_count) AS total_count
+    FROM posthog.trace_attributes
+    WHERE time_bucket >= {date_from_start_of_interval}
+    AND time_bucket <= {date_to_start_of_interval} + {one_interval_period}
+    AND attribute_type = {spanAttributeType}
+    AND attribute_value ILIKE {search}
+    AND attribute_key NOT ILIKE {search}
+    GROUP BY team_id, attribute_key
+"""
+
+
 def _run_attribute_names_value_search(
     team: "Team",
     date_range: DateRange,
@@ -902,11 +954,8 @@ def _run_attribute_names_value_search(
     limit: int,
     offset: int,
 ) -> tuple[list[dict], int]:
-    # UNION ALL of two branches:
-    #   (1) keys whose name matches the search
-    #   (2) keys whose values match the search but whose name does NOT match
-    # The NOT-ILIKE on the value branch dedupes — a key never appears twice.
-    # match_type lets the outer ORDER BY put key matches above value matches.
+    # match_type lets the outer ORDER BY rank key matches first, then span-column matches,
+    # then the remaining attribute value matches.
     query_date_range = QueryDateRange(
         date_range=date_range,
         team=team,
@@ -920,53 +969,39 @@ def _run_attribute_names_value_search(
         attribute_type if attribute_type in ("span_attribute", "span_resource_attribute") else "span_attribute"
     )
 
+    # Only the span-attribute search carries branch (3), so a matching span name is offered
+    # once rather than once per attribute tab.
+    include_span_columns = attribute_type == "span_attribute"
+    branches = [_ATTRIBUTE_KEY_MATCH_BRANCH, _ATTRIBUTE_VALUE_MATCH_BRANCH]
+    if include_span_columns:
+        branches.append(_SPAN_COLUMN_VALUE_MATCH_BRANCH)
+
     query = parse_select(
-        """
+        f"""
         SELECT
             attribute_key,
             match_type,
             sample_value,
             total_count
-        FROM (
-            SELECT
-                attribute_key,
-                'key' AS match_type,
-                '' AS sample_value,
-                sum(attribute_count) AS total_count
-            FROM posthog.trace_attributes
-            WHERE time_bucket >= {date_from_start_of_interval}
-            AND time_bucket <= {date_to_start_of_interval} + {one_interval_period}
-            AND attribute_type = {attributeType}
-            AND attribute_key ILIKE {search}
-            GROUP BY team_id, attribute_key
-
-            UNION ALL
-
-            SELECT
-                attribute_key,
-                'value' AS match_type,
-                argMax(attribute_value, attribute_count) AS sample_value,
-                sum(attribute_count) AS total_count
-            FROM posthog.trace_attributes
-            WHERE time_bucket >= {date_from_start_of_interval}
-            AND time_bucket <= {date_to_start_of_interval} + {one_interval_period}
-            AND attribute_type = {attributeType}
-            AND attribute_value ILIKE {search}
-            AND attribute_key NOT ILIKE {search}
-            GROUP BY team_id, attribute_key
-        )
+        FROM ({" UNION ALL ".join(branches)})
         ORDER BY
             match_type = 'key' DESC,
+            match_type = 'span' DESC,
             total_count DESC,
             attribute_key ASC
-        LIMIT {limit}
-        OFFSET {offset}
+        LIMIT {{limit}}
+        OFFSET {{offset}}
         """,
         placeholders={
             "search": ast.Constant(value=_ilike_pattern(search)),
             "attributeType": ast.Constant(value=attribute_type),
             "limit": ast.Constant(value=limit),
             "offset": ast.Constant(value=offset),
+            **(
+                {"spanAttributeType": ast.Constant(value=SpanPropertyFilterType.SPAN.value)}
+                if include_span_columns
+                else {}
+            ),
             **query_date_range.to_placeholders(),
         },
     )
@@ -992,7 +1027,11 @@ def _run_attribute_names_value_search(
             results.append(
                 {
                     "name": attribute_key,
-                    "propertyFilterType": property_filter_type,
+                    # A span-column match filters on the span itself, not on an attribute map,
+                    # so it has to carry the `span` filter type rather than the searched one.
+                    "propertyFilterType": (
+                        SpanPropertyFilterType.SPAN.value if match_type == "span" else property_filter_type
+                    ),
                     "matchedOn": "key" if matched_on_key else "value",
                     "matchedValue": None if matched_on_key else (sample_value or None),
                 }

--- a/products/tracing/backend/presentation/views.py
+++ b/products/tracing/backend/presentation/views.py
@@ -346,7 +346,7 @@ class _TracingAttributesQuerySerializer(serializers.Serializer):
 class _TracingAttributeEntrySerializer(serializers.Serializer):
     name = serializers.CharField(help_text="Attribute key name.")
     propertyFilterType = serializers.CharField(
-        help_text='Property filter type: "span_attribute" or "span_resource_attribute". Use this as the `type` field when filtering.',
+        help_text='Property filter type: "span_attribute", "span_resource_attribute", or "span" for a built-in span field such as name. Use this as the `type` field when filtering.',
     )
     matchedOn = serializers.ChoiceField(
         choices=["key", "value"],

--- a/products/tracing/backend/tests/test_attribute_value_search.py
+++ b/products/tracing/backend/tests/test_attribute_value_search.py
@@ -42,6 +42,11 @@ class TestTracingAttributeValueSearch(ClickhouseTestMixin, APIBaseTest):
             # ILIKE-escaping fixtures: "50%off" must not wildcard-match "50ABCoff".
             ("promo.code", "50%off", 4, "span_attribute"),
             ("promo.alt", "50ABCoff", 4, "span_attribute"),
+            # Span names are aggregated under attribute_type='span' with a fixed 'name' key.
+            # The attribute below shares the searched substring and is far more common, so
+            # ranking rather than raw counts is what has to put the span name first.
+            ("name", "GET /api/projects/list", 6, "span"),
+            ("http.route", "/api/projects/list", 90, "span_attribute"),
         ]
         values_sql = ",".join(
             f"({cls.team.id}, '{bucket}', '{expiry_bucket}', 'svc', 0, '{k}', '{v}', {c}, '{t}')" for k, v, c, t in rows
@@ -124,6 +129,27 @@ class TestTracingAttributeValueSearch(ClickhouseTestMixin, APIBaseTest):
         self.assertIn("http.target", names)
         self.assertIn("http.method", names)
         self.assertTrue(all(r["matchedOn"] == "key" for r in results))
+
+    def test_search_values_finds_a_span_name_and_ranks_it_above_attribute_values(self):
+        results = self._attributes(
+            {"attribute_type": "span_attribute", "search": "projects/list", "search_values": "true"}
+        )
+        by_name = {r["name"]: r for r in results}
+        self.assertIn("name", by_name)
+        # `span`, not `span_attribute` — the filter has to land on the span column.
+        self.assertEqual(by_name["name"]["propertyFilterType"], "span")
+        self.assertEqual(by_name["name"]["matchedOn"], "value")
+        self.assertEqual(by_name["name"]["matchedValue"], "GET /api/projects/list")
+
+        order = [r["name"] for r in results]
+        self.assertLess(order.index("name"), order.index("http.route"))
+
+    def test_span_name_is_not_offered_by_the_resource_attribute_search(self):
+        # Otherwise the same span name is offered once per attribute tab.
+        results = self._attributes(
+            {"attribute_type": "span_resource_attribute", "search": "projects/list", "search_values": "true"}
+        )
+        self.assertNotIn("name", {r["name"] for r in results})
 
     def test_key_search_case_insensitive_with_value_search(self):
         # The value-search path matches keys case-insensitively too: "TRACE" matches the

--- a/products/tracing/frontend/generated/api.schemas.ts
+++ b/products/tracing/frontend/generated/api.schemas.ts
@@ -258,7 +258,7 @@ export const MatchedOnEnumApi = {
 export interface _TracingAttributeEntryApi {
     /** Attribute key name. */
     name: string
-    /** Property filter type: "span_attribute" or "span_resource_attribute". Use this as the `type` field when filtering. */
+    /** Property filter type: "span_attribute", "span_resource_attribute", or "span" for a built-in span field such as name. Use this as the `type` field when filtering. */
     propertyFilterType: string
     /** How the search query matched this row: "key" if the attribute key matched, "value" if a value matched.
      *

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -81475,7 +81475,7 @@ export namespace Schemas {
     export interface _TracingAttributeEntry {
       /** Attribute key name. */
       name: string;
-      /** Property filter type: "span_attribute" or "span_resource_attribute". Use this as the `type` field when filtering. */
+      /** Property filter type: "span_attribute", "span_resource_attribute", or "span" for a built-in span field such as name. Use this as the `type` field when filtering. */
       propertyFilterType: string;
       /** How the search query matched this row: "key" if the attribute key matched, "value" if a value matched.
        *


### PR DESCRIPTION
## Problem

Someone hunting a specific trace pastes its span name into the tracing filter search and gets nothing back, so they fall back to scrolling the span list.

- The picker's value search matches span attributes and resource attributes, but never span properties.
- Span names are a column on the span, not an entry in the attribute maps. They are aggregated into `trace_attributes` under `attribute_type='span'`, which the search never reads.
- The same span name is already available as value autocomplete once you pick the `name` field by hand, so the data is there.

## Changes

- A span name that matches the search now appears in the Span attributes list, with the matched value shown on the row. Selecting it filters on `name`.
- `_run_attribute_names_value_search` gains a third UNION branch over the `attribute_type='span'` rows.
- The row carries the `span` filter type rather than `span_attribute`, so the filter lands on the span column instead of a non-existent attribute.
- Span-column matches rank above the remaining attribute value matches. A span name beats an attribute that happens to share the substring, even when the attribute is far more common.
- Only the span-attribute search carries the branch. Otherwise the same span name is offered once per attribute tab.

I (actually Claude) kept the row in the existing value-search response rather than giving the Spans tab its own endpoint. A tab is either local options or remote results, never both, so an endpoint there would drop `kind`, `duration`, `trace_id`, `span_id` and `status_code` from browsing.

The alternative of writing the span name into the attributes map at ingestion was rejected: it pays storage on every span and surfaces a synthetic `name` attribute to users, for data the aggregate table already holds.

> [!NOTE]
> This changes result ordering for the span-attribute search only. Key matches still come first.

No visual change beyond the new row, which reuses the existing matched-on-value row and badge.

## How did you test this code?

Two cases added to `products/tracing/backend/tests/test_attribute_value_search.py`:

- A span name is returned for a value-only search, typed `span`, carrying the matched value, and ranked above a higher-count attribute that shares the substring. Catches the branch being dropped, the row being mis-tagged as `span_attribute` (which would build a filter on an attribute that does not exist), and the ranking regressing.
- The resource-attribute search does not offer it. Catches the gate coming off, which would duplicate the row across tabs.

I ran the file against a local ClickHouse and Postgres, and it passes. I also checked the first case fails without the fix: with the span branch disabled, a search for `projects/list` returns only `http.route`, and `name` is absent.

`ruff check` and `ruff format --check` pass. Both query shapes parse under HogQL.

Not tested manually: I did not drive the tracing UI.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude in a PostHog Slack thread, prompted by survey feedback that searching a trace by name was hard.

Skills invoked: `/modifying-taxonomic-filter`, `/writing-tests`, `/writing-pr-descriptions`.

My first attempt was a frontend-only change: a "Search span name for X" free-text row in the Spans tab, following the pattern the Logs group already uses. The human rejected it and named the two options worth taking, so this is the backend query change instead.

Generated files were regenerated with `hogli build:openapi` and `bin/hogli build:openapi-mcp-types` after the serializer help text change. Each moved one line.

Public artifact: nothing here carries material from the session that is not already public. The test fixture span name and attribute values are invented.

