### PR TITLE
fix(data-imports): stop surfacing a cancelled run as a bare "Cancelled" error

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/external_data_job.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/external_data_job.py
@@ -163,6 +163,11 @@ Any_Source_Errors: dict[str, str | None] = {
 
 UNEXPECTED_ERROR_MESSAGE = "An unexpected error has occurred"
 
+CANCELLED_RUN_MESSAGE = (
+    "This sync run was cancelled before it finished. This usually happens when a newer run replaces "
+    "it or the source is paused. It will run again on its next schedule."
+)
+
 
 def _customer_facing_error(cause: BaseException | None) -> str:
     """`latest_error` text a customer reads, without the leaked internal exception class name.
@@ -179,6 +184,11 @@ def _customer_facing_error(cause: BaseException | None) -> str:
     # A wrapped ActivityError can carry no cause; `str(None)` would show the customer "None".
     if cause is None:
         return UNEXPECTED_ERROR_MESSAGE
+    # A cancelled activity surfaces as a Temporal `CancelledError` whose `message` is the bare word
+    # "Cancelled" — meaningless to a customer, and not a failure they caused (a newer run superseded
+    # this one, the source was paused, or a worker was rolled). Give them something readable.
+    if isinstance(cause, exceptions.CancelledError):
+        return CANCELLED_RUN_MESSAGE
     message = getattr(cause, "message", None)
     return message or str(cause)
 

--- a/products/warehouse_sources/backend/temporal/data_imports/tests/test_external_data_job_activities.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/tests/test_external_data_job_activities.py
@@ -6,7 +6,7 @@ from unittest import mock
 from django.test import SimpleTestCase
 
 from parameterized import parameterized
-from temporalio.exceptions import ApplicationError
+from temporalio.exceptions import ApplicationError, CancelledError
 from temporalio.testing import ActivityEnvironment
 
 from posthog.temporal.utils import ExternalDataWorkflowInputs
@@ -15,6 +15,7 @@ from products.warehouse_sources.backend.models.external_data_job import External
 from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
 from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
 from products.warehouse_sources.backend.temporal.data_imports.external_data_job import (
+    CANCELLED_RUN_MESSAGE,
     UNEXPECTED_ERROR_MESSAGE,
     UpdateExternalDataJobStatusInputs,
     _customer_facing_error,
@@ -38,6 +39,13 @@ class TestCustomerFacingError(SimpleTestCase):
 
     def test_falls_back_to_str_when_cause_has_no_message(self) -> None:
         assert _customer_facing_error(ValueError("connection reset")) == "connection reset"
+
+    def test_cancelled_run_does_not_surface_the_bare_cancelled_word(self) -> None:
+        # A superseded/paused run cancels the activity; its cause is a CancelledError whose message
+        # is the bare word "Cancelled". The customer must get a readable message instead.
+        result = _customer_facing_error(CancelledError())
+        assert result == CANCELLED_RUN_MESSAGE
+        assert result != "Cancelled"
 
     def test_missing_cause_does_not_show_the_customer_none(self) -> None:
         assert _customer_facing_error(None) == UNEXPECTED_ERROR_MESSAGE


### PR DESCRIPTION
## Problem

- A data warehouse sync run that gets cancelled shows the customer the bare word "Cancelled" as its error, which reads as an unexplained failure.
- A run is cancelled when a newer run replaces it, the source is paused, or a worker is rolled. None of these is a fault the customer can act on.
- Temporal surfaces a cancelled activity as a `CancelledError` whose `message` is the literal string "Cancelled". `_customer_facing_error` stored that verbatim as the job's `latest_error`.

## Changes

- `_customer_facing_error` now maps a Temporal `CancelledError` to a readable message instead of its bare "Cancelled" text.
- The message states the run was cancelled, gives the usual reasons, and notes it will run again on the next schedule.
- The change is in the pure helper, not the workflow command sequence, so it does not affect in-flight workflow replay determinism.

## How did you test this code?

- Added one case to `TestCustomerFacingError`: a `CancelledError` cause yields the readable message, not "Cancelled". Catches a regression where the mapping is dropped and the raw word returns. No existing case covered a cancellation cause.
- Ran the `TestCustomerFacingError` suite locally.
- Not run: the database-backed warehouse suites.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (actually Claude, via Claude Code) triaged a batch of data-warehouse sync failure classes and found that cancelled runs across sources (Convex was the most affected) recorded a bare "Cancelled" as their customer-facing error. Traced it to a Temporal `CancelledError` whose default message is "Cancelled" flowing through `_customer_facing_error`. Chose to fix it in that pure helper rather than the workflow body to keep it determinism-safe and unit-testable. Skills invoked: `/writing-user-facing-copy`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

Nothing in this PR carries non-public material; the failure-class inputs were internal, and the committed message text and test fixture are invented.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
