### PR TITLE
fix(postgres): stop retrying a session parameter the database doesn't define

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -515,6 +515,21 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
                 '(PostgreSQL reported "permission denied"). Grant the connecting role SELECT on those tables '
                 "(for example: GRANT SELECT ON <table> TO <role>), then re-enable the sync."
             ),
+            # A custom "app.*" session GUC the connecting role doesn't set — raised (SQLSTATE 42704)
+            # by a row-level security policy, view, or connection pooler that reads a per-session
+            # setting the application is expected to set (e.g. `current_setting('app.client_id')`).
+            # PostHog only ever sets standard parameters (client_encoding, statement_timeout,
+            # DateStyle, idle_in_transaction_session_timeout), so an unrecognized `app.*` parameter is
+            # always the customer's own setup and is permanent until they change it — retrying just
+            # re-hits it. Match the stable "app." namespace prefix; the parameter name after it varies.
+            'unrecognized configuration parameter "app.': (
+                "Your database expects a session setting that PostHog doesn't provide (PostgreSQL "
+                'reported "unrecognized configuration parameter"). This usually comes from a row-level '
+                "security policy, view, or connection pooler that reads a custom setting (for example "
+                "app.current_tenant). Make that setting optional in your database (for example with "
+                "current_setting('setting_name', true)), or remove the affected tables from this sync, "
+                "then re-enable the sync."
+            ),
             # A row-level security policy on this table (or another table its policy queries) is
             # self-referential, so Postgres can't evaluate it and raises SQLSTATE 42P17 on every
             # read attempt. The raw psycopg message ("infinite recursion detected in policy for

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -418,12 +418,30 @@ class TestPostgresSourceNonRetryableErrors:
             # Newlines are normalized to spaces upstream, so the FATAL/DETAIL pair arrives on one line.
             # Permanent until the replica's config changes or it's promoted — must not keep retrying.
             'connection failed: connection to server at "10.0.0.1", port 5432 failed: FATAL:  the database system is not accepting connections DETAIL:  Hot standby mode is disabled.',
+            # A custom app.* session GUC the connecting role doesn't set (SQLSTATE 42704), read by a
+            # customer RLS policy, view, or pooler. Permanent until the customer changes it — must not
+            # keep retrying. Parameter name is invented, not a real customer value.
+            'unrecognized configuration parameter "app.current_tenant"',
         ],
     )
     def test_permanent_connection_errors_are_non_retryable(self, source, error_msg):
         non_retryable = source.get_non_retryable_errors()
         is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
         assert is_non_retryable, f"Permanent error should be non-retryable: {error_msg}"
+
+    def test_unrecognized_session_parameter_surfaces_actionable_message(self, source):
+        # A missing custom app.* session setting must stop retrying and explain the pooler/RLS/view
+        # source, rather than storing the raw driver text. Mirror the finalizer's first-match
+        # selection so a future reorder that shadows it with an earlier None-valued key is caught.
+        error_msg = 'unrecognized configuration parameter "app.current_tenant"'
+        matches = [
+            friendly
+            for pattern, friendly in source.get_non_retryable_errors().items()
+            if error_message_matches(error_msg, [pattern])
+        ]
+        assert matches, "unrecognized session parameter must be classified non-retryable"
+        assert matches[0] is not None, "unrecognized session parameter must surface an actionable message"
+        assert "session setting" in matches[0].lower()
 
     def test_connect_timeout_surfaces_actionable_message(self, source):
         # A persistently timing-out connect stays non-retryable, but must surface firewall/reachability


### PR DESCRIPTION
## Problem

- A Postgres source whose database reads a custom `app.*` session setting fails every run and shows the customer the raw driver text `unrecognized configuration parameter "app.<name>"`, with no next step.
- The failure is deterministic, so PostHog retried it on every scheduled run, burning jobs and adding error-tracking noise without ever disabling the sync.
- PostgreSQL raises this (SQLSTATE 42704) when a row-level security policy, view, or connection pooler reads a per-session setting the application is expected to set, for example `current_setting('app.client_id')`. PostHog only sets standard parameters (`client_encoding`, `statement_timeout`, `DateStyle`, `idle_in_transaction_session_timeout`), so an unrecognized `app.*` parameter is always the customer's own setup.

## Changes

- `PostgresSource.get_non_retryable_errors` now classifies `unrecognized configuration parameter "app.` as non-retryable and returns an actionable message.
- The message names the likely source (policy, view, or pooler) and gives two fixes: make the setting optional with `current_setting('name', true)`, or remove the affected tables.
- Supabase inherits this through `PostgresSource`.
- The match uses the stable `app.` namespace prefix; the parameter name after it varies per customer.

## How did you test this code?

- Added a case to `test_permanent_connection_errors_are_non_retryable` (classification) and `test_unrecognized_session_parameter_surfaces_actionable_message` (message). Together they catch a regression where the mapping is dropped, so the error retries again and stores raw driver text. No existing case covered a session-parameter rejection.
- Ran the Postgres classification suite locally.
- Not run: the database-backed warehouse suites.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (actually Claude, via Claude Code) triaged a batch of data-warehouse sync failure classes. One class was a single team whose Postgres syncs failed repeatedly with an unrecognized `app.*` session parameter. I confirmed PostHog never sets a custom `app.*` GUC (only standard parameters), so the rejection is always customer-side and permanent until they change it, which makes retrying pointless. I scoped the match to the `app.` prefix so it can never shadow a standard parameter PostHog sets. Skills invoked: `/writing-user-facing-copy`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

Nothing in this PR carries non-public material; the failure-class input was internal, and the committed message text and test fixture use an invented parameter name.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
