### PR TITLE
feat(aio): serve only the AI lane on capture-ai

### DIFF
--- a/rust/capture/src/api.rs
+++ b/rust/capture/src/api.rs
@@ -85,6 +85,9 @@ pub enum CaptureError {
     #[error("payload empty after filtering invalid event types")]
     EmptyPayloadFiltered,
 
+    #[error("event {0} is not an AI event; send it to the analytics endpoint")]
+    NonAiEventOnAiLane(String),
+
     #[error("service unavailable: {0}")]
     ServiceUnavailable(String),
 
@@ -127,6 +130,7 @@ impl CaptureError {
             CaptureError::RateLimited => "rate_limited",
             CaptureError::GlobalRateLimitExceeded() => "global_rate_limit",
             CaptureError::EmptyPayloadFiltered => "empty_filtered_payload",
+            CaptureError::NonAiEventOnAiLane(_) => "non_ai_event_on_ai_lane",
             CaptureError::ServiceUnavailable(_) => "service_unavailable",
             CaptureError::BodyReadTimeout => "body_read_timeout",
             CaptureError::InternalError(_) => "internal_error",
@@ -151,6 +155,7 @@ impl IntoResponse for CaptureError {
             | CaptureError::MissingWindowId
             | CaptureError::InvalidSessionId
             | CaptureError::EmptyPayloadFiltered
+            | CaptureError::NonAiEventOnAiLane(_)
             | CaptureError::MissingSnapshotData => (StatusCode::BAD_REQUEST, self.to_string()),
 
             CaptureError::EventTooBig(_) => (StatusCode::PAYLOAD_TOO_LARGE, self.to_string()),

--- a/rust/capture/src/event_restrictions/types.rs
+++ b/rust/capture/src/event_restrictions/types.rs
@@ -54,10 +54,15 @@ impl Pipeline {
     /// slice, which returns an empty `RestrictionSet` — silently unrestricted.
     pub fn for_capture_mode(mode: CaptureMode) -> Vec<Pipeline> {
         match mode {
-            CaptureMode::Events | CaptureMode::Import | CaptureMode::Ai => {
+            CaptureMode::Events | CaptureMode::Import => {
                 vec![Self::Analytics, Self::ErrorTracking, Self::Ai]
             }
             CaptureMode::Recordings => vec![Self::SessionRecordings],
+            // capture-ai registers only the AI routes, and `process_events`
+            // rejects a batch carrying anything off the AI lane, so no event
+            // there ever resolves to another pipeline. Loading the analytics
+            // and error-tracking slices would only cost memory.
+            CaptureMode::Ai => vec![Self::Ai],
         }
     }
 }
@@ -400,12 +405,13 @@ mod tests {
             Pipeline::for_capture_mode(CaptureMode::Recordings),
             vec![Pipeline::SessionRecordings]
         );
-        // Ai serves the same set: its batch route accepts any event name, so a
-        // non-$ai_* event lands on the analytics lane there and must be
-        // governed rather than matching an unloaded, always-empty slice.
+        // Ai serves only the AI lane: its routes are AI-only and its batch path
+        // rejects anything off the allowlist, so every event it processes
+        // resolves to Pipeline::Ai. Widening this would load slices nothing
+        // looks up; narrowing it below is only safe while both of those hold.
         assert_eq!(
             Pipeline::for_capture_mode(CaptureMode::Ai),
-            Pipeline::for_capture_mode(CaptureMode::Events)
+            vec![Pipeline::Ai]
         );
     }
 

--- a/rust/capture/src/events/analytics.rs
+++ b/rust/capture/src/events/analytics.rs
@@ -360,6 +360,28 @@ async fn process_events_inner(
 
     debug_or_info!(chatty_debug_enabled, context=?context, event_count=?events.len(), "created ProcessedEvents batch");
 
+    // capture-ai serves only the AI paths and loads only AI restrictions (see
+    // `Pipeline::for_capture_mode`), so an event on any other lane would run
+    // ungoverned there. Reject the batch rather than dropping the offender: a
+    // client sending non-AI events to an AI endpoint is misconfigured, and a
+    // silent drop would hide that until someone went looking for the data. The
+    // abort path emits an `invalid_ai_event` ingestion warning alongside the
+    // 400, so the project owner sees it too.
+    //
+    // Lane membership is the `AI_EVENT_NAMES` allowlist, not an `$ai_` prefix,
+    // so a prefixed-but-unlisted name is rejected here too — the Node AI
+    // pipeline would DLQ it anyway.
+    if context.capture_mode == crate::config::CaptureMode::Ai {
+        if let Some(offender) = events
+            .iter()
+            .find(|e| e.metadata.data_type != DataType::AiEvents)
+        {
+            return Err(CaptureError::NonAiEventOnAiLane(
+                offender.metadata.event_name.clone(),
+            ));
+        }
+    }
+
     events.retain(|e| {
         if dropper.should_drop(&e.event.token, &e.event.distinct_id) {
             report_dropped_events("token_dropper", 1);
@@ -1423,6 +1445,114 @@ mod tests {
         assert_eq!(
             records[0].topic, ai_topic,
             "the surviving record must be on the AI lane"
+        );
+    }
+
+    /// capture-ai loads only AI restrictions, so anything off the AI lane must
+    /// not reach the pipeline there. Each case sends a two-event batch whose
+    /// second event is the one under test.
+    struct AiLaneGateCase {
+        second_event: &'static str,
+        rejected: bool,
+    }
+
+    #[rstest]
+    #[case::analytics_event_is_rejected(AiLaneGateCase {
+        second_event: "$pageview",
+        rejected: true,
+    })]
+    // Lane membership is the AI_EVENT_NAMES allowlist, not an `$ai_` prefix.
+    // A prefixed-but-unlisted name resolves to AnalyticsMain, so it must be
+    // rejected too -- the Node AI pipeline would DLQ it downstream anyway.
+    #[case::prefixed_but_unlisted_name_is_rejected(AiLaneGateCase {
+        second_event: "$ai_call",
+        rejected: true,
+    })]
+    #[case::exception_is_rejected(AiLaneGateCase {
+        second_event: "$exception",
+        rejected: true,
+    })]
+    #[case::second_allowlisted_event_passes(AiLaneGateCase {
+        second_event: "$ai_span",
+        rejected: false,
+    })]
+    #[tokio::test]
+    async fn ai_mode_rejects_a_batch_carrying_anything_off_the_ai_lane(
+        #[case] case: AiLaneGateCase,
+    ) {
+        let now = DateTime::parse_from_rfc3339("2023-01-01T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let mut context = create_test_context(now, None);
+        context.capture_mode = crate::config::CaptureMode::Ai;
+
+        let events = vec![
+            create_test_event_with_name("$ai_generation", None, None, None),
+            create_test_event_with_name(case.second_event, None, None, None),
+        ];
+
+        let sink = Arc::new(MockSink::new());
+        let collector = Arc::new(CollectingEmitter::new());
+        let result = run_pipeline(
+            sink.clone(),
+            events,
+            &context,
+            PipelineOptions {
+                ingestion_warning_emitter: Some(collector.clone()),
+                ..Default::default()
+            },
+        )
+        .await;
+
+        if !case.rejected {
+            result.expect("an all-AI batch must be accepted");
+            assert_eq!(sink.get_events().len(), 2);
+            assert!(collector.emitted().is_empty());
+            return;
+        }
+
+        let err = result.expect_err("the batch must be rejected");
+        assert!(
+            matches!(&err, CaptureError::NonAiEventOnAiLane(name) if name == case.second_event),
+            "the error must name the offending event, got {err:?}"
+        );
+        // Rejecting the request means the whole batch is refused, including the
+        // valid AI event ahead of the offender.
+        assert!(sink.get_events().is_empty());
+
+        // The 400 reaches the caller; the warning reaches the project owner.
+        let emitted = collector.emitted();
+        assert_eq!(emitted.len(), 1);
+        assert_eq!(emitted[0].warning, WarningType::InvalidAiEvent);
+    }
+
+    /// The gate is scoped to capture-ai. On capture-analytics the same mixed
+    /// batch is ordinary traffic: both events are accepted, each on its lane.
+    #[tokio::test]
+    async fn events_mode_accepts_a_batch_the_ai_lane_would_reject() {
+        let now = DateTime::parse_from_rfc3339("2023-01-01T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let context = create_test_context(now, None);
+
+        let events = vec![
+            create_test_event_with_name("$ai_generation", None, None, None),
+            create_test_event_with_name("$pageview", None, None, None),
+        ];
+
+        let sink = Arc::new(MockSink::new());
+        run_pipeline(sink.clone(), events, &context, PipelineOptions::default())
+            .await
+            .expect("capture-analytics must accept a mixed batch");
+
+        let captured = sink.get_events();
+        assert_eq!(captured.len(), 2);
+        assert_eq!(
+            captured
+                .iter()
+                .filter(|e| e.metadata.data_type == DataType::AiEvents)
+                .count(),
+            1
         );
     }
 

--- a/rust/capture/src/ingestion_warnings/legacy.rs
+++ b/rust/capture/src/ingestion_warnings/legacy.rs
@@ -94,6 +94,11 @@ pub fn warning_for_capture_error(err: &CaptureError) -> Option<WarningType> {
         | CaptureError::ServiceUnavailable(_)
         | CaptureError::BodyReadTimeout
         | CaptureError::InternalError(_) => None,
+
+        // A non-AI event sent to an AI endpoint. The 400 tells whoever made the
+        // call; the warning tells whoever owns the project, who is usually not
+        // the same person and cannot see the response.
+        CaptureError::NonAiEventOnAiLane(_) => Some(WarningType::InvalidAiEvent),
     }
 }
 

--- a/rust/capture/src/ingestion_warnings/otel.rs
+++ b/rust/capture/src/ingestion_warnings/otel.rs
@@ -56,7 +56,10 @@ pub fn warning_for_otel_parse_error(err: &CaptureError) -> Option<WarningType> {
 
         // Reachable only if `parse_request` grows a new failure mode: decide
         // warn-or-not there rather than defaulting to silence here.
-        CaptureError::RequestHydrationError(_)
+        // `NonAiEventOnAiLane` joins them as structurally unreachable: only
+        // `process_events` raises it, and this handler does not call it.
+        CaptureError::NonAiEventOnAiLane(_)
+        | CaptureError::RequestHydrationError(_)
         | CaptureError::EmptyBatch
         | CaptureError::EmptyPayload
         | CaptureError::EmptyPayloadFiltered

--- a/rust/capture/src/ingestion_warnings/replay.rs
+++ b/rust/capture/src/ingestion_warnings/replay.rs
@@ -181,6 +181,7 @@ pub fn warning_for_capture_error(err: &CaptureError) -> Option<WarningType> {
         CaptureError::InvalidCookielessMode
         | CaptureError::InvalidTimestamp
         | CaptureError::MissingWindowId
+        | CaptureError::NonAiEventOnAiLane(_)
         | CaptureError::MissingEventName => None,
 
         // Quota, rate, and ops-imposed drops are surfaced through billing and

--- a/rust/capture/src/router.rs
+++ b/rust/capture/src/router.rs
@@ -250,8 +250,15 @@ pub fn router<TZ: TimeSource + Send + Sync + 'static, R: Client + Send + Sync + 
                 .get(v0_endpoint::event)
                 .options(v0_endpoint::options),
         )
-        // `$ai_*` events: same batch handler, dedicated path so the ingress can route
-        // them to the capture-ai deployment and keep AI/analytics workloads isolated.
+        .layer(DefaultBodyLimit::max(BATCH_BODY_SIZE)); // Have to use this, rather than RequestBodyLimitLayer, because we use `Bytes` in the handler (this limit applies specifically to Bytes body types)
+
+    // AI events: the same batch handler as `/batch`, on a dedicated path so the
+    // ingress can route them to the capture-ai deployment and keep AI and
+    // analytics workloads isolated. Its own router rather than a member of
+    // `batch_router` so capture-ai can serve this path without also serving the
+    // analytics batch and event routes, and rather than a member of `ai_router`
+    // so it keeps the batch body limit instead of the larger multipart one.
+    let ai_batch_router = Router::new()
         .route(
             "/i/v0/ai/batch",
             post(v0_endpoint::event)
@@ -264,7 +271,7 @@ pub fn router<TZ: TimeSource + Send + Sync + 'static, R: Client + Send + Sync + 
                 .get(v0_endpoint::event)
                 .options(v0_endpoint::options),
         )
-        .layer(DefaultBodyLimit::max(BATCH_BODY_SIZE)); // Have to use this, rather than RequestBodyLimitLayer, because we use `Bytes` in the handler (this limit applies specifically to Bytes body types)
+        .layer(DefaultBodyLimit::max(BATCH_BODY_SIZE));
 
     let event_router = Router::new()
         .route(
@@ -387,22 +394,34 @@ pub fn router<TZ: TimeSource + Send + Sync + 'static, R: Client + Send + Sync + 
         .layer(DefaultBodyLimit::max(otel::OTEL_BODY_SIZE));
 
     let mut router = match capture_mode {
-        CaptureMode::Events | CaptureMode::Ai => Router::new()
+        CaptureMode::Events => Router::new()
             .merge(batch_router)
             .merge(event_router)
             .merge(test_router)
+            .merge(ai_batch_router)
+            .merge(ai_router)
+            .merge(otel_router),
+        // Ai serves only the AI paths. The analytics batch and event routes are
+        // never reached there -- the ingress routes only `/i/v0/ai*` to this
+        // deployment -- and registering them would accept analytics traffic that
+        // `Pipeline::for_capture_mode(Ai)` no longer loads restrictions for.
+        // `process_events` rejects a non-AI event name on the batch path, so the
+        // only events this deployment produces are `DataType::AiEvents`.
+        CaptureMode::Ai => Router::new()
+            .merge(ai_batch_router)
             .merge(ai_router)
             .merge(otel_router),
         // Import must not register ai_router/otel_router: those handlers build
         // their own ProcessingContext with historical_migration: false, so they
         // sidestep both Import gates (historical-only drop and GRL bypass) and
         // would return a false 200 for events this deployment silently discards.
-        // The /i/v0/ai/batch path stays reachable via batch_router, which
+        // The /i/v0/ai/batch path stays reachable via ai_batch_router, which
         // dispatches to the gated v0_endpoint::event handler.
         CaptureMode::Import => Router::new()
             .merge(batch_router)
             .merge(event_router)
-            .merge(test_router),
+            .merge(test_router)
+            .merge(ai_batch_router),
         CaptureMode::Recordings => Router::new().merge(recordings_router),
     };
 
@@ -431,8 +450,11 @@ pub fn router<TZ: TimeSource + Send + Sync + 'static, R: Client + Send + Sync + 
     // mode must declare whether it serves the v1 analytics endpoint instead of
     // silently defaulting to "no v1 routes" and 404ing its traffic.
     let serves_v1_analytics = match capture_mode {
-        CaptureMode::Events | CaptureMode::Ai | CaptureMode::Import => true,
-        CaptureMode::Recordings => false,
+        CaptureMode::Events | CaptureMode::Import => true,
+        // `/i/v1/analytics/events` is an analytics endpoint: it accepts any
+        // event name and its traffic is governed by analytics restrictions,
+        // which capture-ai no longer loads.
+        CaptureMode::Ai | CaptureMode::Recordings => false,
     };
     if serves_v1_analytics && state.v1_sink_router.is_some() {
         router = router.merge(crate::v1::router::router(crate::v1::router::RouterConfig {

--- a/rust/capture/tests/integration_ai_route_surface.rs
+++ b/rust/capture/tests/integration_ai_route_surface.rs
@@ -1,0 +1,168 @@
+//! Which paths each capture mode registers.
+//!
+//! capture-ai loads only the `ai` restriction slice
+//! (`Pipeline::for_capture_mode`), so any analytics route registered there
+//! would accept traffic no restriction ever governs. The ingress only sends
+//! `/i/v0/ai*` to that deployment today, but the router is the thing that has
+//! to hold if the ingress is ever changed, so it is asserted directly here.
+//!
+//! The pipeline-level gate in `events::analytics` covers the other half: an
+//! event name off the AI allowlist arriving on a path that IS registered.
+
+#[path = "common/integration_utils.rs"]
+mod integration_utils;
+
+use axum::http::StatusCode;
+use axum::Router;
+use axum_test_helper::TestClient;
+use capture::config::CaptureMode;
+use capture::quota_limiters::CaptureQuotaLimiter;
+use capture::router::router;
+use capture::sinks::print::PrintSink;
+use capture::time::TimeSource;
+use chrono::{DateTime, Utc};
+use common_redis::MockRedisClient;
+use integration_utils::{test_lifecycle_handlers, DEFAULT_CONFIG, DEFAULT_TEST_TIME};
+use limiters::token_dropper::TokenDropper;
+use rstest::rstest;
+use serde_json::json;
+use std::sync::Arc;
+use std::time::Duration;
+
+struct FixedTime {
+    time: DateTime<Utc>,
+}
+
+impl TimeSource for FixedTime {
+    fn current_time(&self) -> DateTime<Utc> {
+        self.time
+    }
+}
+
+fn setup_router_for_mode(capture_mode: CaptureMode) -> Router {
+    let (readiness, liveness, _monitor) = test_lifecycle_handlers();
+    let redis = Arc::new(MockRedisClient::new());
+    let mut cfg = DEFAULT_CONFIG.clone();
+    cfg.capture_mode = capture_mode;
+    let quota_limiter =
+        CaptureQuotaLimiter::new(&cfg, redis.clone(), Duration::from_secs(60 * 60 * 24 * 7));
+
+    router(
+        FixedTime {
+            time: DateTime::parse_from_rfc3339(DEFAULT_TEST_TIME)
+                .expect("invalid fixed time")
+                .with_timezone(&Utc),
+        },
+        readiness,
+        liveness,
+        Arc::new(PrintSink {}),
+        redis,
+        None, // global_rate_limiter_token_distinctid
+        quota_limiter,
+        TokenDropper::default(),
+        None, // event_restriction_service
+        None, // recorder_handle
+        capture_mode,
+        None,
+        25 * 1024 * 1024,
+        false,
+        1_i64,
+        false,
+        0.0_f32,
+        26_214_400,
+        None,
+        256,              // body_read_chunk_size_kb
+        10 * 1024 * 1024, // capture_v1_max_compressed_body_bytes
+        50 * 1024 * 1024, // capture_v1_max_decompressed_body_bytes
+        None,             // overflow_limiter
+        None,             // ai_events_overflow_limiter
+        None,             // ai_byte_rate_limiter
+        None,             // replay_overflow_limiter
+        None,             // v1_sink_router
+        8,                // capture_v1_scatter_gather_min_batch
+        None,             // ai_gateway_signing_secret
+        false,            // ai_events_overflow_enabled
+        None,             // ingestion_warning_emitter
+    )
+}
+
+/// A single `$ai_generation`, valid on any path that accepts a batch.
+fn ai_batch_payload() -> String {
+    json!({
+        "api_key": "phc_route_surface_token",
+        "batch": [{
+            "event": "$ai_generation",
+            "distinct_id": "test_user",
+            "properties": {},
+        }],
+    })
+    .to_string()
+}
+
+/// A route is "registered" when the router does not 404 it. The handler may
+/// still reject the payload for its own reasons, which is not what this file
+/// is about, so any non-404 counts as registered.
+async fn is_registered(router: Router, path: &str) -> bool {
+    let res = TestClient::new(router)
+        .post(path)
+        .body(ai_batch_payload())
+        .header("Content-Type", "application/json")
+        .send()
+        .await;
+    res.status() != StatusCode::NOT_FOUND
+}
+
+/// capture-ai must serve the AI batch path and nothing analytics-shaped.
+#[rstest]
+#[case::ai_batch("/i/v0/ai/batch", true)]
+#[case::ai_batch_trailing_slash("/i/v0/ai/batch/", true)]
+#[case::ai_multipart("/i/v0/ai", true)]
+#[case::ai_otel("/i/v0/ai/otel", true)]
+#[case::analytics_batch("/batch", false)]
+#[case::analytics_event("/e", false)]
+#[case::analytics_capture("/capture", false)]
+#[case::analytics_track("/track", false)]
+#[case::analytics_engage("/engage", false)]
+#[case::analytics_v1("/i/v1/analytics/events", false)]
+#[tokio::test]
+async fn ai_mode_registers_only_the_ai_paths(#[case] path: &str, #[case] expected: bool) {
+    assert_eq!(
+        is_registered(setup_router_for_mode(CaptureMode::Ai), path).await,
+        expected,
+        "capture-ai registration for {path} should be {expected}"
+    );
+}
+
+/// The analytics deployment keeps every path it had, including the AI ones it
+/// serves for teams whose traffic is not split out to capture-ai.
+#[rstest]
+#[case::analytics_batch("/batch")]
+#[case::analytics_event("/e")]
+#[case::analytics_capture("/capture")]
+#[case::ai_batch("/i/v0/ai/batch")]
+#[case::ai_multipart("/i/v0/ai")]
+#[case::ai_otel("/i/v0/ai/otel")]
+#[tokio::test]
+async fn events_mode_still_registers_every_path(#[case] path: &str) {
+    assert!(
+        is_registered(setup_router_for_mode(CaptureMode::Events), path).await,
+        "capture-analytics must keep serving {path}"
+    );
+}
+
+/// Import keeps the AI batch path (it dispatches to the gated batch handler)
+/// and must keep refusing the two AI handlers that build their own context
+/// with `historical_migration: false`, which would sidestep the import gates.
+#[rstest]
+#[case::analytics_batch("/batch", true)]
+#[case::ai_batch("/i/v0/ai/batch", true)]
+#[case::ai_multipart("/i/v0/ai", false)]
+#[case::ai_otel("/i/v0/ai/otel", false)]
+#[tokio::test]
+async fn import_mode_keeps_the_batch_paths_only(#[case] path: &str, #[case] expected: bool) {
+    assert_eq!(
+        is_registered(setup_router_for_mode(CaptureMode::Import), path).await,
+        expected,
+        "capture-import registration for {path} should be {expected}"
+    );
+}


### PR DESCRIPTION
## Problem

A `$pageview` posted to capture-ai is accepted, ingested, and governed by no event restriction at all. capture-ai registers the analytics batch, event, and v1 routes, so the event classifies as `AnalyticsMain` and looks up the `analytics` restriction slice — which that deployment does not load. An operator's `DropEvent` for that project silently does nothing there.

Nothing exploits this today. The ingress routes only `/i/v0/ai*` to capture-ai, and over 7 days in prod-us, prod-eu, and dev the deployment served zero requests on `/batch`, `/capture`, `/e`, `/track`, `/engage`, or `/i/v1/analytics/events`. But the router is what has to hold if the ingress ever changes, and #83680 narrows the restriction slice capture-ai loads, which turns a latent gap into a real one.

Stacked on #83680, which this depends on for `DataType::AiEvents` meaning AI traffic on every deployment.

## Changes

The lane is closed at two levels, because either one alone leaves a hole.

**Routes.** capture-ai registers the AI batch, multipart, and OTEL paths and nothing else, and no longer serves `/i/v1/analytics/events`. capture-analytics and capture-import keep every path they had.

**Event names.** Routes alone are not enough: `/i/v0/ai/batch` dispatches to the generic batch handler, which accepts any event name. `process_events` now rejects a batch carrying anything off `DataType::AiEvents` with a 400 naming the offending event.

With both in place, every event capture-ai processes resolves to `Pipeline::Ai`, so `for_capture_mode(Ai)` drops from `[Analytics, ErrorTracking, Ai]` to `[Ai]`.

### Rejecting, not dropping

A client sending non-AI events to an AI endpoint is misconfigured. A silent drop hides that until someone goes looking for the data, so the whole batch is refused — including any valid AI events ahead of the offender.

The 400 reaches whoever made the call. An `invalid_ai_event` ingestion warning goes out alongside it, because the person who owns the project usually is not the person reading HTTP responses.

### The allowlist is not a prefix

Lane membership is the `AI_EVENT_NAMES` allowlist, not an `$ai_` prefix. A prefixed-but-unlisted name like `$ai_call` resolves to `AnalyticsMain` and is rejected here too. That matches `AI_EVENT_TYPES` in the Node AI pipeline, which DLQs anything it receives off the list, so admitting it would only move the failure downstream.

### `/i/v0/ai/batch` moves out of `batch_router`

It shared a router with `/batch`, so capture-ai could not serve one without the other. It gets its own router, keeping the 20 MB batch body limit rather than inheriting `ai_router`'s 27.5 MB multipart limit.

> [!NOTE]
> capture-import still serves `/i/v0/ai/batch` and still refuses `/i/v0/ai` and `/i/v0/ai/otel`. Those two handlers build their own context with `historical_migration: false` and would sidestep the import gates.

### Companion change

[PostHog/charts#14371](https://github.com/PostHog/charts/pull/14371) points `ingestion-ai`'s `CAPTURE_INTERNAL_URL` at capture-analytics. It targets capture-ai's `/capture` today, which this PR removes. That route is unused — `internal_capture_events` fires only from the `cdp-*` namespaces — so there is no ordering requirement, but the charts PR should land first to be safe.

## How did you test this code?

Automated, plus read-only queries against prod and dev metrics. No manual testing and no deploy.

`integration_ai_route_surface.rs` is new and asserts the route surface per capture mode: 20 cases covering which paths each of `Ai`, `Events`, and `Import` registers. No existing test built a router per mode, so nothing caught a route being added to or removed from the wrong arm.

The gate is covered in `events::analytics`, parameterized over what the second event in the batch is:

- `$pageview` and `$exception` are rejected — the ordinary misroute.
- `$ai_call` is rejected — the allowlist-not-prefix case. This is the one a future reader is most likely to "fix" into a prefix match.
- `$ai_span` passes — an all-AI batch is not affected.
- The same mixed batch is accepted under `Events` mode, pinning the gate to capture-ai.

Each rejection case also asserts the sink received nothing, and that exactly one `invalid_ai_event` warning was emitted.

Traffic evidence for the "nothing reaches these routes" claim, `http_requests_total{capture_mode="ai"}` over 7 days:

| Path | prod-us | prod-eu | dev |
| --- | --- | --- | --- |
| `/i/v0/ai/otel` | 18.5M | 3.6M | 0 |
| `/i/v0/ai/batch/` | 9.6M | 2.0M | 0 |
| `/i/v0/ai` | 3.6M | 1.7M | 40 |
| every analytics path | 0 | 0 | 0 |

`capture_kafka_produce_bytes_total{capture_mode="ai"}` shows one topic per region and no exceptions or heatmaps topic, so `Pipeline::ErrorTracking` was already unreachable there.

Not run locally: the Redis-backed suites in `capture` fail in this sandbox with `Connection refused` at `localhost:6379`, on this branch and on master alike.

## Automatic notifications

- [ ] Publish to changelog? (No. Internal routing change on an endpoint whose only documented use is the AI SDKs.)

## Docs update

None. No documented workflow changes: the AI SDKs already post AI events to the AI endpoints.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Opus 5 in Claude Code, directed by me. Skills invoked: `/writing-pr-descriptions`.

This came out of reviewing #83680. `Pipeline::for_capture_mode(Ai)` had been widened there to load the analytics and error-tracking slices, because capture-ai's routes accept analytics traffic. I asked why, and the better answer turned out to be closing the routes instead of loading slices for traffic that should never arrive.

Two decisions were mine to make and I took them: reject the batch rather than dropping the offending event, and narrow `for_capture_mode` in this PR rather than shipping the gate first and observing. The second is safe because the gate makes the narrowing correct by construction, not by observation.

I checked charts and Grafana before writing any of it, to confirm nothing real depends on the routes being open. That turned up the `ingestion-ai` config above.

Public artifact: the diff, tests, and this description come from this repository and from metric names in it. The traffic table is aggregate request counts by path with no customer, token, or project identifiers.
