### PR TITLE
refactor(tasks): remove filesystem resume snapshots

### DIFF
--- a/products/tasks/backend/constants.py
+++ b/products/tasks/backend/constants.py
@@ -146,7 +146,6 @@ MAX_CUSTOM_IMAGES_PER_USER = 10
 TASK_SESSION_MAX_SIZE_BYTES = 10 * 1024 * 1024
 TASK_SESSION_UPLOAD_FORM_OVERHEAD_BYTES = 64 * 1024
 
-MODAL_DIRECTORY_RESUME_SNAPSHOTS_FEATURE_FLAG = "tasks-modal-directory-resume-snapshots"
 STREAM_VIA_PROXY_FEATURE_FLAG = "tasks-stream-via-proxy"
 OVERLAP_CLONE_BOOT_FEATURE_FLAG = "tasks-overlap-clone-boot"
 # Kill switch: rtk command-output compression is on by default in cloud sandboxes;

--- a/products/tasks/backend/temporal/execute_sandbox/workflow.py
+++ b/products/tasks/backend/temporal/execute_sandbox/workflow.py
@@ -1448,7 +1448,6 @@ class ExecuteSandboxWorkflow(PostHogWorkflow):
             CreateResumeSnapshotInput(
                 sandbox_id=sandbox_id,
                 run_id=self.context.run_id,
-                use_directory_snapshot=self.context.use_modal_directory_resume_snapshots,
             ),
             start_to_close_timeout=timedelta(minutes=5),
             retry_policy=RetryPolicy(maximum_attempts=3),

--- a/products/tasks/backend/temporal/process_task/activities/create_resume_snapshot.py
+++ b/products/tasks/backend/temporal/process_task/activities/create_resume_snapshot.py
@@ -9,7 +9,6 @@ from posthog.temporal.common.utils import asyncify
 from products.tasks.backend.constants import (
     DEFAULT_DIRECTORY_RESUME_SNAPSHOT_MOUNT_PATH,
     SNAPSHOT_KIND_DIRECTORY,
-    SNAPSHOT_KIND_FILESYSTEM,
     SnapshotKind,
 )
 from products.tasks.backend.exceptions import (
@@ -24,12 +23,6 @@ from products.tasks.backend.temporal.observability import emit_agent_log
 
 logger = structlog.get_logger(__name__)
 
-# Both callers (process_task and execute_sandbox workflows) give this activity a
-# 5-minute start_to_close budget; the Modal-side snapshot timeout must be tighter so
-# a slow snapshot surfaces as the classified SnapshotTimeoutError instead of Temporal
-# killing the attempt first.
-RESUME_SNAPSHOT_TIMEOUT_SECONDS = 4 * 60
-
 PENDING_USER_STATE_KEYS = [
     "pending_user_message",
     "pending_user_artifact_ids",
@@ -38,11 +31,12 @@ PENDING_USER_STATE_KEYS = [
 ]
 
 
-@dataclass
+@dataclass(frozen=True)
 class CreateResumeSnapshotInput:
     sandbox_id: str
     run_id: str
-    use_directory_snapshot: bool = False
+    # Retained for Temporal payload compatibility while existing workflows drain.
+    use_directory_snapshot: bool = True
     snapshot_mount_path: str = DEFAULT_DIRECTORY_RESUME_SNAPSHOT_MOUNT_PATH
     reason: str = "teardown"
     allow_pruning: bool = True
@@ -66,7 +60,7 @@ def create_resume_snapshot(input: CreateResumeSnapshotInput) -> CreateResumeSnap
     API can look it up when resuming.
     """
     SandboxClass = get_sandbox_class()
-    snapshot_kind: SnapshotKind = SNAPSHOT_KIND_DIRECTORY if input.use_directory_snapshot else SNAPSHOT_KIND_FILESYSTEM
+    snapshot_kind: SnapshotKind = SNAPSHOT_KIND_DIRECTORY
     snapshot_mount_path = input.snapshot_mount_path or DEFAULT_DIRECTORY_RESUME_SNAPSHOT_MOUNT_PATH
 
     logger.info(
@@ -125,15 +119,9 @@ def create_resume_snapshot(input: CreateResumeSnapshotInput) -> CreateResumeSnap
 
     outcome = "created"
     try:
-        if snapshot_kind == SNAPSHOT_KIND_DIRECTORY:
-            external_id = sandbox.create_directory_snapshot(snapshot_mount_path)
-        else:
-            external_id = sandbox.create_snapshot(timeout_seconds=RESUME_SNAPSHOT_TIMEOUT_SECONDS)
+        external_id = sandbox.create_directory_snapshot(snapshot_mount_path)
     except SnapshotFileLimitExceededError as e:
-        # Modal caps snapshots at 1M files and a directory snapshot of the workspace can exceed it
-        # once install trees and caches pile up. Only the directory snapshot has a mount path to
-        # shrink; a full filesystem snapshot does not, so it degrades to a fresh start.
-        if snapshot_kind != SNAPSHOT_KIND_DIRECTORY or not input.allow_pruning:
+        if not input.allow_pruning:
             outcome = "file_limit_exceeded"
             duration_ms = int((time.perf_counter() - started_at) * 1000)
             logger.warning(
@@ -246,13 +234,9 @@ def create_resume_snapshot(input: CreateResumeSnapshotInput) -> CreateResumeSnap
         updates = {
             "snapshot_external_id": external_id,
             "snapshot_kind": snapshot_kind,
+            "snapshot_mount_path": snapshot_mount_path,
         }
-        remove_keys: list[str] = [*PENDING_USER_STATE_KEYS]
-        if snapshot_kind == SNAPSHOT_KIND_DIRECTORY:
-            updates["snapshot_mount_path"] = snapshot_mount_path
-        else:
-            remove_keys.append("snapshot_mount_path")
-        TaskRun.update_state_atomic(input.run_id, updates=updates, remove_keys=remove_keys)
+        TaskRun.update_state_atomic(input.run_id, updates=updates, remove_keys=PENDING_USER_STATE_KEYS)
     except Exception as e:
         outcome = "persist_failed"
         duration_ms = int((time.perf_counter() - started_at) * 1000)
@@ -287,13 +271,13 @@ def create_resume_snapshot(input: CreateResumeSnapshotInput) -> CreateResumeSnap
         reason=input.reason,
         snapshot_kind=snapshot_kind,
         snapshot_external_id=external_id,
-        snapshot_mount_path=snapshot_mount_path if snapshot_kind == SNAPSHOT_KIND_DIRECTORY else None,
+        snapshot_mount_path=snapshot_mount_path,
         duration_ms=duration_ms,
     )
     emit_agent_log(input.run_id, "debug", f"Resume snapshot created ({input.reason}): {external_id}")
     return CreateResumeSnapshotOutput(
         external_id=external_id,
         snapshot_kind=snapshot_kind,
-        snapshot_mount_path=snapshot_mount_path if snapshot_kind == SNAPSHOT_KIND_DIRECTORY else None,
+        snapshot_mount_path=snapshot_mount_path,
         duration_ms=duration_ms,
     )

--- a/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
@@ -14,7 +14,6 @@ from products.tasks.backend.constants import (
     AGENT_OTEL_TELEMETRY_STATE_KEY,
     AGENT_PROXY_KEEP_STREAM_OPEN_FEATURE_FLAG,
     CONTINUE_AS_NEW_FEATURE_FLAG,
-    MODAL_DIRECTORY_RESUME_SNAPSHOTS_FEATURE_FLAG,
     MODAL_NETWORK_ALLOWLIST_FEATURE_FLAG,
     OVERLAP_CLONE_BOOT_FEATURE_FLAG,
     RTK_DISABLED_FEATURE_FLAG,
@@ -98,7 +97,7 @@ class TaskProcessingContext:
     # activity retries. This means "create any Modal resume snapshot"; filesystem
     # snapshots are guarded by the legacy setting, directory snapshots by feature flag.
     use_modal_resume_snapshots: bool = True
-    use_modal_directory_resume_snapshots: bool = False
+    use_modal_directory_resume_snapshots: bool = True  # Temporal payload compatibility
     # Captured at workflow start so the sandbox event transport branch is
     # deterministic for the full run.
     sandbox_event_ingest_enabled: bool = False
@@ -667,35 +666,6 @@ def _compile_effective_network_policy(allowed_domains: list[str]) -> EffectiveNe
     )
 
 
-def _is_modal_directory_resume_snapshots_enabled(
-    *,
-    distinct_id: str,
-    organization_id: str,
-    run_id: str,
-) -> bool:
-    try:
-        enabled = bool(
-            posthoganalytics.feature_enabled(
-                MODAL_DIRECTORY_RESUME_SNAPSHOTS_FEATURE_FLAG,
-                distinct_id=distinct_id,
-                groups={"organization": organization_id},
-                group_properties={"organization": {"id": organization_id}},
-                only_evaluate_locally=False,
-                send_feature_flag_events=False,
-            )
-        )
-    except Exception as e:
-        log_with_activity_context("modal_directory_resume_snapshots_flag_check_failed", run_id=run_id, error=str(e))
-        return False
-
-    log_with_activity_context(
-        "modal_directory_resume_snapshots_flag_checked",
-        run_id=run_id,
-        use_modal_directory_resume_snapshots=enabled,
-    )
-    return enabled
-
-
 def _loop_pr_follow_up_enabled(task: Task, state: dict) -> bool:
     """Loop runs opt into the CI/review-comment follow-up loop when the loop's
     snapshotted behaviors ask for it (see products/tasks/docs/LOOPS.md "Behaviors":
@@ -996,16 +966,6 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
         "debug",
         f"overlap_clone_boot_enabled: {overlap_clone_boot_enabled} for this task run",
     )
-    use_modal_directory_resume_snapshots = _is_modal_directory_resume_snapshots_enabled(
-        distinct_id=distinct_id,
-        organization_id=organization_id,
-        run_id=run_id,
-    )
-    emit_agent_log(
-        run_id,
-        "debug",
-        f"use_modal_directory_resume_snapshots: {use_modal_directory_resume_snapshots} for this task run",
-    )
     agent_proxy_keep_stream_open = _is_agent_proxy_keep_stream_open_enabled(
         distinct_id=distinct_id,
         organization_id=organization_id,
@@ -1072,8 +1032,8 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
         ),
         json_schema=task.json_schema,
         ci_prompt=task.ci_prompt,
-        use_modal_resume_snapshots=settings.TASKS_USE_MODAL_RESUME_SNAPSHOTS or use_modal_directory_resume_snapshots,
-        use_modal_directory_resume_snapshots=use_modal_directory_resume_snapshots,
+        use_modal_resume_snapshots=True,
+        use_modal_directory_resume_snapshots=True,
         sandbox_event_ingest_enabled=sandbox_event_ingest_enabled,
         agent_otel_telemetry_enabled=agent_otel_telemetry_enabled,
         use_modal_vm_sandbox=use_modal_vm_sandbox,

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_create_resume_snapshot.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_create_resume_snapshot.py
@@ -143,34 +143,3 @@ def test_directory_file_limit_prunes_and_retries_via_temporal(activity_environme
 
     sandbox.prune_snapshot_heavy_dirs.assert_called_once_with(DEFAULT_DIRECTORY_RESUME_SNAPSHOT_MOUNT_PATH)
     update_state.assert_not_called()
-
-
-@pytest.mark.django_db
-def test_filesystem_file_limit_degrades_to_fresh_start(activity_environment, mocker) -> None:
-    # A full filesystem snapshot has no mount path to prune, so it degrades gracefully rather than
-    # crashing or looping retries.
-    sandbox = mocker.Mock()
-    sandbox.is_running.return_value = True
-    sandbox.create_snapshot.side_effect = SnapshotFileLimitExceededError(
-        "Filesystem snapshot exceeds Modal's file-count cap",
-        {"sandbox_id": "sandbox-1"},
-        cause=RuntimeError("filesystem snapshot contains more than 1000000 files"),
-    )
-    SandboxClass = mocker.Mock()
-    SandboxClass.get_by_id.return_value = sandbox
-
-    mocker.patch(
-        "products.tasks.backend.temporal.process_task.activities.create_resume_snapshot.get_sandbox_class",
-        return_value=SandboxClass,
-    )
-    update_state = mocker.patch.object(TaskRun, "update_state_atomic")
-
-    output = async_to_sync(activity_environment.run)(
-        create_resume_snapshot,
-        CreateResumeSnapshotInput(sandbox_id="sandbox-1", run_id="run-1", use_directory_snapshot=False),
-    )
-
-    assert output.external_id is None
-    assert output.error is not None
-    sandbox.prune_snapshot_heavy_dirs.assert_not_called()
-    update_state.assert_not_called()

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
@@ -12,7 +12,6 @@ from posthog.models.user_integration import UserIntegration
 from products.tasks.backend.constants import (
     AGENT_PROXY_KEEP_STREAM_OPEN_FEATURE_FLAG,
     CONTINUE_AS_NEW_FEATURE_FLAG,
-    MODAL_DIRECTORY_RESUME_SNAPSHOTS_FEATURE_FLAG,
     MODAL_VM_SANDBOX_FEATURE_FLAG,
     RTK_DISABLED_FEATURE_FLAG,
     SANDBOX_EVENT_INGEST_FEATURE_FLAG,
@@ -1163,44 +1162,18 @@ class TestGetTaskProcessingContextActivity:
         assert result.sandbox_event_ingest_enabled is True
 
     @pytest.mark.django_db(transaction=True)
-    @pytest.mark.parametrize(
-        "legacy_resume_snapshots, directory_resume_snapshots, run_state, expected_resume_snapshots",
-        [
-            (True, False, {}, True),
-            (False, True, {}, True),
-            (False, False, {}, False),
-            (False, False, {"use_modal_directory_resume_snapshots": True}, False),
-            (False, True, {"use_modal_directory_resume_snapshots": False}, True),
-        ],
-    )
-    def test_get_task_processing_context_combines_legacy_and_directory_resume_snapshot_flags(
-        self,
-        activity_environment,
-        test_task,
-        legacy_resume_snapshots,
-        directory_resume_snapshots,
-        run_state,
-        expected_resume_snapshots,
-    ):
-        task_run = test_task.create_run(extra_state=run_state)
+    def test_get_task_processing_context_enables_directory_resume_snapshots(self, activity_environment, test_task):
+        task_run = test_task.create_run()
         input_data = GetTaskProcessingContextInput(run_id=str(task_run.id))
 
-        def feature_enabled(flag_key, *args, **kwargs):
-            if flag_key == MODAL_DIRECTORY_RESUME_SNAPSHOTS_FEATURE_FLAG:
-                return directory_resume_snapshots
-            return False
-
-        with (
-            override_settings(TASKS_USE_MODAL_RESUME_SNAPSHOTS=legacy_resume_snapshots),
-            patch(
-                "products.tasks.backend.temporal.process_task.activities.get_task_processing_context.posthoganalytics.feature_enabled",
-                side_effect=feature_enabled,
-            ),
+        with patch(
+            "products.tasks.backend.temporal.process_task.activities.get_task_processing_context.posthoganalytics.feature_enabled",
+            return_value=False,
         ):
             result = async_to_sync(activity_environment.run)(get_task_processing_context, input_data)
 
-        assert result.use_modal_resume_snapshots is expected_resume_snapshots
-        assert result.use_modal_directory_resume_snapshots is directory_resume_snapshots
+        assert result.use_modal_resume_snapshots is True
+        assert result.use_modal_directory_resume_snapshots is True
 
     @pytest.mark.django_db(transaction=True)
     def test_get_task_processing_context_applies_org_default_custom_image(self, activity_environment, test_task):

--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -2218,7 +2218,6 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                 CreateResumeSnapshotInput(
                     sandbox_id=sandbox_id,
                     run_id=self.context.run_id,
-                    use_directory_snapshot=self.context.use_modal_directory_resume_snapshots,
                     reason=reason,
                     allow_pruning=allow_pruning,
                 ),


### PR DESCRIPTION
## Problem

Directory resume snapshots are fully rolled out, leaving the feature-flag check and filesystem resume creation path unreachable.

## Changes

- Always create directory resume snapshots.
- Remove the rollout flag and filesystem creation fallback.
- Retain restore and Temporal payload compatibility for existing runs.


