### PR TITLE
feat(experiments): cache the replay exposure distinct-id expansion

### DIFF
--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -474,8 +474,11 @@ class QueryTags(BaseModel):
     experiment_execution_path: Optional[str] = None  # "direct_scan" or "precomputed"
     experiment_exposures_path: Optional[str] = None  # "direct_scan" or "precomputed"
     experiment_metric_events_path: Optional[str] = None  # "direct_scan", "precomputed", or "not_applicable"
-    experiment_query_surface: Optional[str] = None  # "metric", "exposures_timeseries", "actors", "precompute_build"
+    # "metric", "exposures_timeseries", "actors", "precompute_build", "replay_population_cache"
+    experiment_query_surface: Optional[str] = None
     experiment_precompute_table: Optional[str] = None  # on precompute_build rows: "exposures" or "metric_events"
+    # How replay's exposed-population read was served: "cache_hit", "cache_warmed", "cache_failed"
+    experiment_replay_population: Optional[str] = None
     # Why precompute was not used (set on the metric read). One of "override_direct", "team_disabled",
     # "min_runtime", "data_warehouse"; None/absent when precompute was attempted (so a direct path then
     # means the build failed or wasn't ready — derivable from the precompute_build sub-queries).

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -87,6 +87,7 @@ from posthog.hogql.database.schema.experiment_exposures_preaggregated import Exp
 from posthog.hogql.database.schema.experiment_metric_events_preaggregated import (
     ExperimentMetricEventsPreaggregatedTable,
 )
+from posthog.hogql.database.schema.experiment_replay_exposed_distinct_ids import ExperimentReplayExposedDistinctIdsTable
 from posthog.hogql.database.schema.groups import GroupsTable, RawGroupsTable
 from posthog.hogql.database.schema.groups_revenue_analytics import GroupsRevenueAnalyticsTable
 from posthog.hogql.database.schema.heatmaps import HeatmapsTable
@@ -307,6 +308,9 @@ ROOT_TABLES__DO_NOT_ADD_ANY_MORE: dict[str, TableNode] = {
     ),
     "experiment_metric_events_preaggregated": TableNode(
         name="experiment_metric_events_preaggregated", table=ExperimentMetricEventsPreaggregatedTable()
+    ),
+    "experiment_replay_exposed_distinct_ids": TableNode(
+        name="experiment_replay_exposed_distinct_ids", table=ExperimentReplayExposedDistinctIdsTable()
     ),
     # Revenue analytics tables
     "persons_revenue_analytics": TableNode(name="persons_revenue_analytics", table=PersonsRevenueAnalyticsTable()),

--- a/posthog/hogql/database/schema/experiment_replay_exposed_distinct_ids.py
+++ b/posthog/hogql/database/schema/experiment_replay_exposed_distinct_ids.py
@@ -1,0 +1,46 @@
+from pydantic import Field
+
+from posthog.hogql.constants import HogQLQuerySettings
+from posthog.hogql.database.models import (
+    DateTimeDatabaseField,
+    FieldOrTable,
+    IntegerDatabaseField,
+    StringDatabaseField,
+    Table,
+)
+
+from posthog.clickhouse.preaggregation.experiment_replay_exposed_distinct_ids_sql import (
+    DISTRIBUTED_EXPERIMENT_REPLAY_EXPOSED_DISTINCT_IDS_TABLE,
+)
+
+
+class ExperimentReplayExposedDistinctIdsTable(Table):
+    description: str = (
+        "Internal cache of an experiment's exposed population expanded to distinct ids, one row per distinct id "
+        "per computed generation, carrying the owning person's first exposure time."
+    )
+    top_level_settings: HogQLQuerySettings | None = Field(
+        default_factory=lambda: HogQLQuerySettings(load_balancing="in_order")
+    )
+
+    fields: dict[str, FieldOrTable] = {
+        "team_id": IntegerDatabaseField(name="team_id"),
+        "cache_key": StringDatabaseField(
+            name="cache_key",
+            description="Opaque key naming one computed generation of one experiment's exposed population.",
+        ),
+        "distinct_id": StringDatabaseField(
+            name="distinct_id",
+            description="A distinct id belonging to an exposed person; join to recordings' distinct_id.",
+        ),
+        "first_exposure_time": DateTimeDatabaseField(
+            name="first_exposure_time",
+            description="Timestamp of the owning person's first exposure to the experiment (UTC).",
+        ),
+    }
+
+    def to_printed_clickhouse(self, context):
+        return DISTRIBUTED_EXPERIMENT_REPLAY_EXPOSED_DISTINCT_IDS_TABLE()
+
+    def to_printed_hogql(self):
+        return "experiment_replay_exposed_distinct_ids"

--- a/posthog/session_recordings/queries/test/listing_recordings/test_session_recordings_list_by_experiment_exposure.py
+++ b/posthog/session_recordings/queries/test/listing_recordings/test_session_recordings_list_by_experiment_exposure.py
@@ -1,4 +1,5 @@
 import json
+import uuid
 from datetime import UTC, datetime, timedelta
 from typing import cast
 
@@ -21,6 +22,7 @@ from posthog.models import User
 from posthog.models.personal_api_key import PersonalAPIKey
 from posthog.models.team.extensions import get_or_create_team_extension
 from posthog.models.utils import generate_random_token_personal, hash_key_value
+from posthog.redis import get_client as get_redis_client
 from posthog.session_recordings.models.session_recording import SessionRecording
 from posthog.session_recordings.models.session_recording_playlist import SessionRecordingPlaylist
 from posthog.session_recordings.queries.recordings_query_runner import RecordingsQueryRunner
@@ -861,3 +863,158 @@ class TestSessionRecordingsListByExperimentExposure(ClickhouseTestMixin, APIBase
         )
 
         assert response.status_code == expected_status, response.content
+
+    def _insert_preaggregated_exposure(
+        self, job_id: uuid.UUID, person_uuid: object, variant: str, exposure_time: datetime
+    ) -> None:
+        # expires_at deliberately keeps its server-clock default: an explicit value would come
+        # from the frozen 2021 test clock, making the row already past TTL on arrival.
+        sync_execute(
+            "INSERT INTO experiment_exposures_preaggregated "
+            "(team_id, job_id, entity_id, variant, first_exposure_time, last_exposure_time, "
+            "exposure_event_uuid, exposure_session_id, breakdown_value) VALUES",
+            [
+                {
+                    "team_id": self.team.pk,
+                    "job_id": job_id,
+                    "entity_id": str(person_uuid),
+                    "variant": variant,
+                    "first_exposure_time": exposure_time,
+                    "last_exposure_time": exposure_time,
+                    "exposure_event_uuid": uuid.uuid4(),
+                    "exposure_session_id": "",
+                    "breakdown_value": [],
+                }
+            ],
+        )
+
+    def _patch_precomputed_jobs(self, job_id: uuid.UUID):
+        return patch(
+            "products.experiments.backend.replay_linkage.ensure_precomputed",
+            return_value=LazyComputationResult(ready=True, job_ids=[job_id]),
+        )
+
+    def test_cached_population_serves_reads_until_refreshed(self) -> None:
+        # Precomputing teams serve the distinct-id expansion from a cached generation. A
+        # population change that only the expansion can see — a new distinct id on an
+        # already-exposed person, the preaggregated exposure rows unchanged — must not
+        # appear while the generation is fresh, and must appear once it refreshes.
+        self._enable_precomputation()
+        experiment = self._create_experiment()
+        person = create_person(team=self.team, distinct_ids=["exposed-user"])
+        flush_persons_and_events()
+        exposure_time = BASE_TIME + timedelta(hours=2)
+        job_id = uuid.uuid4()
+        self._insert_preaggregated_exposure(job_id, person.uuid, "test", exposure_time)
+        session_start = exposure_time + timedelta(hours=1)
+        self._produce_recording(
+            "exposed-user", "session-of-exposed", session_start, session_start + timedelta(minutes=10)
+        )
+
+        with self._patch_precomputed_jobs(job_id):
+            self._assert_query_matches_session_ids(
+                {"experiment_exposure": {"experiment_id": experiment.id}},
+                ["session-of-exposed"],
+            )
+
+            add_distinct_id(person=person, distinct_id="second-device")
+            flush_persons_and_events()
+            self._produce_recording(
+                "second-device", "session-on-second-device", session_start, session_start + timedelta(minutes=10)
+            )
+
+            self._assert_query_matches_session_ids(
+                {"experiment_exposure": {"experiment_id": experiment.id}},
+                ["session-of-exposed"],
+            )
+
+            # The freshness marker expiring is what triggers a recompute; flushing redis stands
+            # in for the TTL elapsing.
+            get_redis_client().flushdb()
+            self._assert_query_matches_session_ids(
+                {"experiment_exposure": {"experiment_id": experiment.id}},
+                ["session-of-exposed", "session-on-second-device"],
+            )
+
+    def test_cached_population_read_keeps_one_row_per_distinct_id(self) -> None:
+        # Writers racing on a cold window append a generation's rows more than once. The read
+        # must collapse them: duplicate exposure rows multiply the listing's join rows, which
+        # doubles the per-session aggregates it sums.
+        self._enable_precomputation()
+        experiment = self._create_experiment()
+        person = create_person(team=self.team, distinct_ids=["exposed-user"])
+        flush_persons_and_events()
+        exposure_time = BASE_TIME + timedelta(hours=2)
+        job_id = uuid.uuid4()
+        self._insert_preaggregated_exposure(job_id, person.uuid, "test", exposure_time)
+        session_start = exposure_time + timedelta(hours=1)
+        produce_replay_summary(
+            team_id=self.team.id,
+            session_id="session-of-exposed",
+            distinct_id="exposed-user",
+            first_timestamp=session_start,
+            last_timestamp=session_start + timedelta(minutes=10),
+            click_count=3,
+        )
+
+        with self._patch_precomputed_jobs(job_id):
+            (recordings, _, _, _) = filter_recordings_by(
+                team=self.team,
+                recordings_filter={"experiment_exposure": {"experiment_id": experiment.id}},
+                user=self.user,
+            )
+            assert [recording["session_id"] for recording in recordings] == ["session-of-exposed"]
+            assert recordings[0]["click_count"] == 3
+
+            generations = sync_execute(
+                "SELECT DISTINCT cache_key FROM experiment_replay_exposed_distinct_ids WHERE team_id = %(team_id)s",
+                {"team_id": self.team.pk},
+            )
+            assert len(generations) == 1
+            sync_execute(
+                "INSERT INTO experiment_replay_exposed_distinct_ids "
+                "(team_id, cache_key, distinct_id, first_exposure_time) VALUES",
+                [
+                    {
+                        "team_id": self.team.pk,
+                        "cache_key": generations[0][0],
+                        "distinct_id": "exposed-user",
+                        "first_exposure_time": exposure_time,
+                    }
+                ],
+            )
+
+            (recordings, _, _, _) = filter_recordings_by(
+                team=self.team,
+                recordings_filter={"experiment_exposure": {"experiment_id": experiment.id}},
+                user=self.user,
+            )
+            assert [recording["session_id"] for recording in recordings] == ["session-of-exposed"]
+            assert recordings[0]["click_count"] == 3
+
+    def test_population_cache_failure_falls_back_to_inline_expansion(self) -> None:
+        # The cache is an optimization: a Redis outage must leave the listing working on the
+        # inline expansion, not fail it.
+        self._enable_precomputation()
+        experiment = self._create_experiment()
+        person = create_person(team=self.team, distinct_ids=["exposed-user"])
+        flush_persons_and_events()
+        exposure_time = BASE_TIME + timedelta(hours=2)
+        job_id = uuid.uuid4()
+        self._insert_preaggregated_exposure(job_id, person.uuid, "test", exposure_time)
+        session_start = exposure_time + timedelta(hours=1)
+        self._produce_recording(
+            "exposed-user", "session-of-exposed", session_start, session_start + timedelta(minutes=10)
+        )
+
+        with (
+            self._patch_precomputed_jobs(job_id),
+            patch(
+                "products.experiments.backend.replay_linkage.get_client",
+                side_effect=ConnectionError("redis unavailable"),
+            ),
+        ):
+            self._assert_query_matches_session_ids(
+                {"experiment_exposure": {"experiment_id": experiment.id}},
+                ["session-of-exposed"],
+            )

--- a/products/experiments/backend/replay_linkage.py
+++ b/products/experiments/backend/replay_linkage.py
@@ -27,9 +27,17 @@ long-running experiments), activation-mode exposures always resolve with a live 
 they have no preaggregated form (carrying an explicit memory budget on precomputing teams),
 and where neither the preaggregated read nor an affordable live scan is available the query
 is refused with a ValidationError rather than left to time out.
+
+On those same precomputing teams, the expansion of exposed persons to distinct ids — a full
+scan of the team's person mapping — is served from a short-lived cached generation in
+``experiment_replay_exposed_distinct_ids``, computed at resolution time once per freshness
+window instead of inside every recordings-list query. The cache is an optimization only:
+when it can't be read or written, the expansion runs inline as before.
 """
 
-from dataclasses import dataclass
+import json
+import hashlib
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 
 from django.contrib.auth.models import AnonymousUser
@@ -40,19 +48,29 @@ from rest_framework.exceptions import ValidationError
 from posthog.schema import IntervalType
 
 from posthog.hogql import ast
+from posthog.hogql.constants import get_default_hogql_global_settings
+from posthog.hogql.context import HogQLContext
+from posthog.hogql.modifiers import create_default_modifiers_for_team
 from posthog.hogql.parser import parse_select
+from posthog.hogql.printer import prepare_and_print_ast
 
+from posthog.clickhouse.client import sync_execute
+from posthog.clickhouse.preaggregation.experiment_replay_exposed_distinct_ids_sql import (
+    DISTRIBUTED_EXPERIMENT_REPLAY_EXPOSED_DISTINCT_IDS_TABLE,
+)
 from posthog.clickhouse.query_tagging import tag_queries, tags_context
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
 from posthog.models.team.extensions import get_or_create_team_extension
 from posthog.models.team.team import Team
 from posthog.models.user import User
+from posthog.redis import get_client
 from posthog.synthetic_user import SyntheticUser
 
 from products.access_control.backend.facade.user_access_control import UserAccessControl, UserAccessControlError
 from products.analytics_platform.backend.lazy_computation.lazy_computation_executor import (
     LazyComputationTable,
     ensure_precomputed,
+    is_memory_limit_error,
 )
 from products.experiments.backend.hogql_queries.base_query_utils import experiment_window, experiment_window_end
 from products.experiments.backend.hogql_queries.cuped_config import CupedQueryConfig
@@ -82,6 +100,12 @@ COHORT_NOT_CALCULATED_MESSAGE = (
 # default per-query limit, so the kill renders as the standard memory-limit error before the
 # scan becomes cluster-level pressure.
 ACTIVATION_LIVE_SCAN_MAX_MEMORY_BYTES = 4 * 1024**3
+# How long one computed generation of the exposed distinct-id population serves reads before
+# resolution computes a fresh one. Bounds how stale the tab's population can be to newly
+# exposed persons and to person merges, and caps the expansion's cost at one run per
+# experiment-variant per window rather than one per list, poll, and pagination page.
+EXPOSED_DISTINCT_IDS_CACHE_TTL_SECONDS = 600
+_EXPOSED_DISTINCT_IDS_CACHE_REDIS_PREFIX = "@posthog/experiment-replay-exposed-distinct-ids"
 
 
 def validate_experiment_exposure_access(
@@ -141,6 +165,9 @@ class ExperimentExposureLinkage:
     # population is already test-filtered at the person level. Queries that restrict their rows
     # to this population can skip re-applying the same filters to their own rows.
     population_filters_test_accounts: bool = False
+    # Names the computed generation of the expanded distinct-id population to read from
+    # experiment_replay_exposed_distinct_ids. None = expand inline in the embedding query.
+    cached_population_key: str | None = None
 
 
 def resolve_exposure_linkage(team: Team, *, experiment_id: int, variant: str | None) -> ExperimentExposureLinkage:
@@ -207,19 +234,29 @@ def resolve_exposure_linkage(team: Team, *, experiment_id: int, variant: str | N
         activation_config=exposure_params.activation_config,
     )
     read = _resolve_exposure_read(team, experiment, context)
-    return ExperimentExposureLinkage(
+    linkage = ExperimentExposureLinkage(
         context=context,
         requested_variants=requested_variants,
         preaggregation_job_ids=read.preaggregation_job_ids,
         live_scan_max_memory_bytes=read.live_scan_max_memory_bytes,
         population_filters_test_accounts=exposure_params.filter_test_accounts,
     )
+    if read.population_cache_eligible:
+        cached_population_key = _ensure_population_cached(team, experiment, linkage)
+        if cached_population_key is not None:
+            linkage = replace(linkage, cached_population_key=cached_population_key)
+    return linkage
 
 
 @dataclass(frozen=True, kw_only=True)
 class _ExposureRead:
     preaggregation_job_ids: list[str] | None
     live_scan_max_memory_bytes: int | None
+    # Whether resolution may serve the distinct-id expansion from the population cache. Only
+    # set on precomputing teams: they are the teams where the expansion's full scan of the
+    # person mapping is a real per-request cost, and keeping everyone else on the inline path
+    # is the smallest blast radius for the cache.
+    population_cache_eligible: bool
 
 
 def _resolve_exposure_read(team: Team, experiment: Experiment, context: ExperimentQueryContext) -> _ExposureRead:
@@ -245,7 +282,9 @@ def _resolve_exposure_read(team: Team, experiment: Experiment, context: Experime
         experiment.start_date, experiment.end_date
     ):
         tag_queries(experiment_exposures_path="direct_scan")
-        return _ExposureRead(preaggregation_job_ids=None, live_scan_max_memory_bytes=None)
+        return _ExposureRead(
+            preaggregation_job_ids=None, live_scan_max_memory_bytes=None, population_cache_eligible=False
+        )
 
     if has_uncalculated_cohorts(team, experiment.exposure_criteria):
         # Both reads below see the cohort's partially-inserted membership: a precompute build
@@ -265,6 +304,7 @@ def _resolve_exposure_read(team: Team, experiment: Experiment, context: Experime
         return _ExposureRead(
             preaggregation_job_ids=None,
             live_scan_max_memory_bytes=ACTIVATION_LIVE_SCAN_MAX_MEMORY_BYTES,
+            population_cache_eligible=True,
         )
 
     query_string, placeholders = ExposureQueryBuilder(context=context).precomputation_query()
@@ -295,15 +335,135 @@ def _resolve_exposure_read(team: Team, experiment: Experiment, context: Experime
     return _ExposureRead(
         preaggregation_job_ids=[str(job_id) for job_id in result.job_ids],
         live_scan_max_memory_bytes=None,
+        population_cache_eligible=True,
     )
+
+
+def _population_cache_digest(experiment: Experiment, linkage: ExperimentExposureLinkage) -> str:
+    """Identity of the population this linkage would compute, hashed for cache keying.
+
+    Job ids cover the precomputed read (they rotate as new exposure windows are built), and
+    the updated_at stamps cover live reads whose definition changed (edited exposure
+    criteria, redefined flag variants). Over-invalidation on unrelated edits is fine: a miss
+    costs one expansion run.
+    """
+    flag = experiment.feature_flag
+    return hashlib.sha256(
+        json.dumps(
+            [
+                experiment.pk,
+                sorted(linkage.requested_variants),
+                sorted(linkage.preaggregation_job_ids or []),
+                experiment.updated_at,
+                flag.updated_at if flag is not None else None,
+            ],
+            default=str,
+        ).encode()
+    ).hexdigest()
+
+
+def _ensure_population_cached(team: Team, experiment: Experiment, linkage: ExperimentExposureLinkage) -> str | None:
+    """Serve the expanded distinct-id population from cache, computing it when needed.
+
+    Returns the generation key to read, or None to expand inline: the cache is an
+    optimization, so an unreachable Redis or a failed insert falls back rather than failing
+    the listing. Memory-limit kills are the exception and propagate, because the inline
+    expansion would exhaust the same budget after paying the scan a second time, and the
+    kill must render as the platform's standard memory-limit error either way.
+
+    Racing requests on a cold window each compute the generation (there is deliberately no
+    lock: a reader must never be pointed at a generation before its rows are written, so the
+    marker is only set after a completed insert). Their duplicate rows are collapsed by the
+    read's GROUP BY and eventually by the ReplacingMergeTree merge.
+    """
+    digest = _population_cache_digest(experiment, linkage)
+    redis_key = f"{_EXPOSED_DISTINCT_IDS_CACHE_REDIS_PREFIX}/{team.pk}/{digest}"
+    try:
+        redis_client = get_client()
+        current_generation = redis_client.get(redis_key)
+        if current_generation is not None:
+            tag_queries(experiment_replay_population="cache_hit")
+            return current_generation.decode()
+        generation = f"{digest[:32]}:{datetime.now(UTC).strftime('%Y%m%d%H%M')}"
+        insert_sql, values = _population_insert_sql(team, linkage, generation)
+        settings = get_default_hogql_global_settings(team_id=team.pk).model_dump(exclude_none=True)
+        settings.pop("readonly", None)  # INSERTs need write access
+        if linkage.live_scan_max_memory_bytes is not None:
+            settings["max_memory_usage"] = linkage.live_scan_max_memory_bytes
+        with tags_context(experiment_query_surface="replay_population_cache"):
+            sync_execute(insert_sql, values, settings=settings)
+        redis_client.setex(redis_key, EXPOSED_DISTINCT_IDS_CACHE_TTL_SECONDS, generation)
+        tag_queries(experiment_replay_population="cache_warmed")
+        return generation
+    except Exception as error:
+        if is_memory_limit_error(error):
+            raise
+        logger.exception("experiment_replay_population_cache_failed", experiment_id=experiment.pk, team_id=team.pk)
+        tag_queries(experiment_replay_population="cache_failed")
+        return None
+
+
+def _population_insert_sql(team: Team, linkage: ExperimentExposureLinkage, cache_key: str) -> tuple[str, dict]:
+    """INSERT writing one generation of the expanded population, plus its bound values."""
+    population = _live_population_select(linkage)
+    insert_select = ast.SelectQuery(
+        select=[
+            ast.Alias(alias="team_id", expr=ast.Constant(value=team.pk)),
+            ast.Alias(alias="cache_key", expr=ast.Constant(value=cache_key)),
+            ast.Alias(alias="distinct_id", expr=ast.Field(chain=["population", "distinct_id"])),
+            ast.Alias(alias="first_exposure_time", expr=ast.Field(chain=["population", "first_exposure_time"])),
+        ],
+        select_from=ast.JoinExpr(table=population, alias="population"),
+    )
+    context = HogQLContext(
+        team_id=team.pk,
+        team=team,
+        enable_select_queries=True,
+        limit_top_select=False,
+        modifiers=create_default_modifiers_for_team(team),
+    )
+    select_sql, _ = prepare_and_print_ast(insert_select, context=context, dialect="clickhouse")
+    table = DISTRIBUTED_EXPERIMENT_REPLAY_EXPOSED_DISTINCT_IDS_TABLE()
+    return f"INSERT INTO {table} (team_id, cache_key, distinct_id, first_exposure_time)\n{select_sql}", context.values
 
 
 def exposed_distinct_ids_select(linkage: ExperimentExposureLinkage) -> ast.SelectQuery:
     """One row per exposed distinct id: (distinct_id, first_exposure_time).
 
-    Pure AST construction; :func:`resolve_exposure_linkage` carries the validation and the
-    precompute decision, so callers can build query ASTs without side effects.
+    Pure AST construction; :func:`resolve_exposure_linkage` carries the validation, the
+    precompute decision, and the population-cache warm, so callers can build query ASTs
+    without side effects.
     """
+    if linkage.cached_population_key is not None:
+        return _cached_population_select(linkage)
+    return _live_population_select(linkage)
+
+
+def _cached_population_select(linkage: ExperimentExposureLinkage) -> ast.SelectQuery:
+    # GROUP BY re-establishes one row per distinct id: writers racing on a cold window append
+    # the same generation's rows more than once, and the callers' join contract (no session-row
+    # duplication, min() over a single exposure row) assumes uniqueness rather than waiting on
+    # the ReplacingMergeTree merge to enforce it.
+    query = parse_select(
+        """
+        SELECT
+            distinct_id AS distinct_id,
+            min(first_exposure_time) AS first_exposure_time
+        FROM experiment_replay_exposed_distinct_ids
+        WHERE team_id = {team_id} AND cache_key = {cache_key}
+        GROUP BY distinct_id
+        """,
+        placeholders={
+            "team_id": ast.Constant(value=linkage.context.team.pk),
+            "cache_key": ast.Constant(value=linkage.cached_population_key),
+        },
+    )
+    assert isinstance(query, ast.SelectQuery)
+    return query
+
+
+def _live_population_select(linkage: ExperimentExposureLinkage) -> ast.SelectQuery:
+    """The population expanded inline: the exposure source joined through the person mapping."""
     exposure_select = ExposureQueryBuilder(
         context=linkage.context,
         preaggregation_job_ids=linkage.preaggregation_job_ids,


### PR DESCRIPTION
## Problem

The experiments recordings tab stays slow on large projects even with the redundant test-account scan removed (#83555): every list request — each load, poll, and pagination page — re-expands the experiment's exposed persons to distinct ids, which double-scans the team's whole person-mapping table. The expansion's result changes on the order of minutes; the tab recomputes it on the order of seconds.

## Changes

- On precomputing teams, linkage resolution now serves the expansion from a cached generation in `experiment_replay_exposed_distinct_ids` (the table from #83704), computed synchronously once per ten-minute freshness window. The listing subquery becomes a keyed read that scales with the exposed population instead of the mapping table.
- A Redis marker names the current generation and is set only after a completed insert, so a reader is never pointed at rows that don't exist yet; racing cold-window writers produce duplicate rows that the read's `GROUP BY` collapses.
- The generation key hashes the experiment, requested variants, preaggregation job ids, and the experiment/flag `updated_at` stamps — so new precompute windows and edited exposure criteria invalidate immediately; new exposures and person merges appear within the window TTL.
- Cache failures (Redis down, insert error) fall back to the inline expansion; memory-limit kills propagate so they keep the platform's standard rendering (#83514 semantics). Non-precomputing teams keep the inline path untouched.
- New `experiment_replay_population` query tag (`cache_hit`/`cache_warmed`/`cache_failed`) for query-log attribution.

Known accepted edge, mirrored from the preaggregated-exposures path: a replica-lagged read directly after a warm can briefly miss rows; it self-heals on the next request.

## How did you test this code?

Recordings listing exposure suite green locally against real ClickHouse (38 passed, repeated runs), including three new tests:

- cached generations serve reads until refreshed: a new distinct id on an already-exposed person stays invisible while the generation is fresh and appears after the marker expires — catches a broken cache read, key mismatch, or lost refresh;
- the cached read keeps one row per distinct id even with duplicate generation rows — catches losing the `GROUP BY` and silently doubling per-session aggregates;
- Redis failure falls back to the inline expansion — catches losing the fail-open.

The new tests fake `ensure_precomputed` (the suite's existing pattern) and seed preaggregated rows keeping the server-clock `expires_at` default. While testing this I found the real-pipeline fixtures write rows whose frozen-clock `expires_at` is already past TTL; that only bites when ClickHouse's TTL merges are active (not within `merge_with_ttl_timeout` of a fresh CI instance) and predates this PR — left as-is.

Not run locally: repo-wide mypy (file-scoped mypy on the changed backend files is clean) and `hogli ci:preflight` (sandbox node toolchain can't build `lz4`); CI covers both.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing behavior change beyond latency; population semantics of the tab are unchanged up to the documented freshness window.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude in a PostHog Desktop cloud task, directed by a PostHog engineer, as item 2 of a ranked optimization list from a query-log investigation (item 1 was #83555). Skills consulted: /writing-tests, /writing-code-comments, /writing-pr-descriptions, /clickhouse-migrations, /stacking-prs.
Decisions along the way: gated to precomputation-enabled teams (where the mapping-table scan is a real cost) instead of all teams; warm placed in linkage resolution — the phase documented as allowed to run inserts — keeping `exposed_distinct_ids_select` pure AST construction; no cold-window lock, preferring duplicate work over the empty-read race a lock invites; per-variant cache keys rather than a variant-column artifact, trading one extra warm per variant flip for a much smaller change.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
