### PR TITLE
fix(logs): session links from error tracking find nothing for unconfigured teams

### DIFF
--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -853,13 +853,13 @@ export const SETTINGS_MAP: SettingSection[] = [
                 description: (
                     <>
                         The log attributes PostHog reads to identify which session a log belongs to, checked in order
-                        with the first match winning. Defaults to <code>posthogSessionId</code>, the key the JavaScript
-                        and React Native SDKs auto-attach. Add keys only if your pipeline emits the session ID under
-                        different attributes.
+                        with the first match winning, followed by other common session ID attributes. Defaults to{' '}
+                        <code>sessionId</code>, the key the JavaScript and React Native SDKs auto-attach. Add keys only
+                        if your pipeline emits the session ID under different attributes.
                     </>
                 ),
                 searchDescription:
-                    'The log attributes PostHog reads to identify which session a log belongs to, checked in order with the first match winning. Defaults to posthogSessionId, the key the JavaScript and React Native SDKs auto-attach. Add keys only if your pipeline emits the session ID under different attributes.',
+                    'The log attributes PostHog reads to identify which session a log belongs to, checked in order with the first match winning, followed by other common session ID attributes. Defaults to sessionId, the key the JavaScript and React Native SDKs auto-attach. Add keys only if your pipeline emits the session ID under different attributes.',
                 component: <LogsSessionIdAttributeKeys />,
                 flag: 'LOGS_SETTINGS',
                 keywords: ['log', 'session', 'replay', 'attribute', 'link'],

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -149,10 +149,11 @@ class TeamLogsConfigSerializer(serializers.ModelSerializer):
         max_length=10,
         help_text=(
             "Ordered list of log attribute keys whose values hold the PostHog session ID. "
-            "Detection checks keys in order; the first key with a value wins. Defaults to "
-            "['posthogSessionId'] — the key the posthog-js / posthog-react-native SDKs "
-            "auto-attach. Add keys only if your pipeline emits the session ID under "
-            "different attributes."
+            "Detection checks keys in order, then falls back to common session ID attribute "
+            "conventions; the first key with a value wins. Defaults to ['sessionId'] — the "
+            "convention documented at https://posthog.com/docs/logs/link-session-replay and "
+            "the key the posthog-js / posthog-react-native SDKs auto-attach. Add keys only "
+            "if your pipeline emits the session ID under different attributes."
         ),
     )
 

--- a/products/error_tracking/frontend/ErrorTracking.stories.tsx
+++ b/products/error_tracking/frontend/ErrorTracking.stories.tsx
@@ -255,7 +255,7 @@ const meta: Meta = {
                     {
                         logs_distinct_id_attribute_key: 'posthogDistinctId',
                         logs_distinct_id_attribute_keys: ['posthogDistinctId'],
-                        logs_session_id_attribute_keys: ['posthogSessionId'],
+                        logs_session_id_attribute_keys: ['sessionId'],
                     },
                 ],
                 '/api/environments/:team_id/error_tracking/issues/exists/': [200, { exists: true }],

--- a/products/logs/backend/migrations/0022_backfill_logs_session_id_attribute_keys.py
+++ b/products/logs/backend/migrations/0022_backfill_logs_session_id_attribute_keys.py
@@ -1,0 +1,43 @@
+from django.db import migrations
+
+BATCH_SIZE = 1000
+
+# Teams that existed when 0015 added the column carry its ADD COLUMN default,
+# `{posthogSessionId}`. Our SDKs emit `sessionId`, which is also what
+# https://posthog.com/docs/logs/link-session-replay tells backends to send, so those teams'
+# session links resolve nothing wherever detection trusts the configured keys. Some customer
+# pipelines do emit `posthogSessionId` directly — hence the append below rather than a swap.
+OLD_DEFAULT = ["posthogSessionId"]
+
+# Appended rather than prepended, and rather than replaced. Detection is first-match-wins,
+# and a stored `["posthogSessionId"]` is indistinguishable from a team that configured it
+# deliberately — 31 teams do emit that key, 14 of them alongside `sessionId` (measured in
+# ClickHouse, 2026-08-17). Putting `sessionId` first would switch those 14 onto a different
+# attribute than the one they resolve on today. Keeping the old key first leaves every
+# team that emits it resolving exactly as before, while the ~2,150 teams that emit only
+# `sessionId` start resolving at all.
+NEW_VALUE = ["posthogSessionId", "sessionId"]
+
+
+def backfill_session_id_attribute_keys(apps, schema_editor):
+    TeamLogsConfig = apps.get_model("logs", "TeamLogsConfig")
+    configs = TeamLogsConfig.objects.filter(logs_session_id_attribute_keys=OLD_DEFAULT)
+    batch = []
+    for config in configs.iterator(chunk_size=BATCH_SIZE):
+        config.logs_session_id_attribute_keys = list(NEW_VALUE)
+        batch.append(config)
+        if len(batch) >= BATCH_SIZE:
+            TeamLogsConfig.objects.bulk_update(batch, ["logs_session_id_attribute_keys"])
+            batch = []
+    if batch:
+        TeamLogsConfig.objects.bulk_update(batch, ["logs_session_id_attribute_keys"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("logs", "0021_logsalertconfiguration_schedule_restriction"),
+    ]
+
+    operations = [
+        migrations.RunPython(backfill_session_id_attribute_keys, migrations.RunPython.noop),
+    ]

--- a/products/logs/backend/migrations/0022_backfill_logs_session_id_attribute_keys.py
+++ b/products/logs/backend/migrations/0022_backfill_logs_session_id_attribute_keys.py
@@ -2,11 +2,12 @@ from django.db import migrations
 
 BATCH_SIZE = 1000
 
-# Teams predating #83710 carry 0015's default, which our SDKs don't emit.
+# No SDK emits this key, so a team still carrying it as its stored default resolves nothing
+# wherever detection trusts the configured keys.
 OLD_DEFAULT = ["posthogSessionId"]
 
-# Old key stays first: 14 teams emit both, and detection is first-match-wins, so leading
-# with `sessionId` would move them onto a different attribute than they resolve on today.
+# The old key stays first. Some pipelines do emit it, and detection is first-match-wins, so
+# reordering these two would move those teams onto a different attribute.
 NEW_VALUE = ["posthogSessionId", "sessionId"]
 
 

--- a/products/logs/backend/migrations/0022_backfill_logs_session_id_attribute_keys.py
+++ b/products/logs/backend/migrations/0022_backfill_logs_session_id_attribute_keys.py
@@ -2,20 +2,11 @@ from django.db import migrations
 
 BATCH_SIZE = 1000
 
-# Teams that existed when 0015 added the column carry its ADD COLUMN default,
-# `{posthogSessionId}`. Our SDKs emit `sessionId`, which is also what
-# https://posthog.com/docs/logs/link-session-replay tells backends to send, so those teams'
-# session links resolve nothing wherever detection trusts the configured keys. Some customer
-# pipelines do emit `posthogSessionId` directly — hence the append below rather than a swap.
+# Teams predating #83710 carry 0015's default, which our SDKs don't emit.
 OLD_DEFAULT = ["posthogSessionId"]
 
-# Appended rather than prepended, and rather than replaced. Detection is first-match-wins,
-# and a stored `["posthogSessionId"]` is indistinguishable from a team that configured it
-# deliberately — 31 teams do emit that key, 14 of them alongside `sessionId` (measured in
-# ClickHouse, 2026-08-17). Putting `sessionId` first would switch those 14 onto a different
-# attribute than the one they resolve on today. Keeping the old key first leaves every
-# team that emits it resolving exactly as before, while the ~2,150 teams that emit only
-# `sessionId` start resolving at all.
+# Old key stays first: 14 teams emit both, and detection is first-match-wins, so leading
+# with `sessionId` would move them onto a different attribute than they resolve on today.
 NEW_VALUE = ["posthogSessionId", "sessionId"]
 
 

--- a/products/logs/backend/migrations/max_migration.txt
+++ b/products/logs/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0021_logsalertconfiguration_schedule_restriction
+0022_backfill_logs_session_id_attribute_keys

--- a/products/logs/backend/models.py
+++ b/products/logs/backend/models.py
@@ -54,12 +54,20 @@ DISTINCT_ID_ATTRIBUTE_KEY_CONVENTIONS = [
 ]
 
 
-# Default log attribute keys whose values hold the PostHog session ID. `posthogSessionId`
-# is the key the posthog-js / posthog-react-native SDKs auto-attach to every log they
-# emit (see https://posthog.com/docs/logs/link-session-replay). Ordered: detection checks
-# keys in list order and the first match wins. Customers whose pipeline emits the session
-# ID under different keys can override via the `logs_config` endpoint.
-DEFAULT_LOGS_SESSION_ID_ATTRIBUTE_KEYS = ["posthogSessionId"]
+# Default log attribute keys whose values hold the PostHog session ID. `sessionId` is the
+# key the posthog-js / posthog-react-native SDKs auto-attach to every log they emit, and
+# the key https://posthog.com/docs/logs/link-session-replay tells backends to send.
+# Ordered: detection checks keys in list order and the first match wins. Customers whose
+# pipeline emits the session ID under different keys can override via the `logs_config`
+# endpoint.
+#
+# This default is cosmetic, not functional: `getSessionIdWithKey` in
+# products/logs/frontend/utils.tsx falls back to the SESSION_ID_KEYS conventions when no
+# configured key matches, and `sessionId` is in that list. Session linking worked before
+# this default was corrected and works after. What the default drives is the settings UI
+# and what new teams are told to emit — see `SESSION_ID_KEYS` for why `posthogSessionId`
+# must stay in the conventions regardless.
+DEFAULT_LOGS_SESSION_ID_ATTRIBUTE_KEYS = ["sessionId"]
 
 
 def default_logs_session_id_attribute_keys() -> list[str]:
@@ -98,6 +106,11 @@ class TeamLogsConfig(models.Model):
     logs_session_id_attribute_keys = ArrayField(
         models.CharField(max_length=200),
         default=default_logs_session_id_attribute_keys,
+        # Deliberately left at the original `posthogSessionId` while the Python default
+        # above moved to `sessionId`: changing a db_default needs a migration, and this
+        # one is never observed — every TeamLogsConfig is created through Django, which
+        # applies `default` first. Worth aligning if a migration lands here for another
+        # reason; not worth one on its own.
         db_default=Value("{posthogSessionId}"),
     )
 

--- a/products/logs/backend/models.py
+++ b/products/logs/backend/models.py
@@ -54,19 +54,14 @@ DISTINCT_ID_ATTRIBUTE_KEY_CONVENTIONS = [
 ]
 
 
-# Default log attribute keys whose values hold the PostHog session ID. `sessionId` is the
-# key the posthog-js / posthog-react-native SDKs auto-attach to every log they emit, and
-# the key https://posthog.com/docs/logs/link-session-replay tells backends to send.
-# Ordered: detection checks keys in list order and the first match wins. Customers whose
-# pipeline emits the session ID under different keys can override via the `logs_config`
-# endpoint.
+# Default log attribute keys whose values hold the PostHog session ID. `sessionId` is what
+# the posthog-js / posthog-react-native SDKs emit and what
+# https://posthog.com/docs/logs/link-session-replay tells backends to send. Ordered:
+# detection checks keys in list order and the first match wins. Customers whose pipeline
+# emits the session ID under different keys can override via the `logs_config` endpoint.
 #
-# This default is cosmetic, not functional: `getSessionIdWithKey` in
-# products/logs/frontend/utils.tsx falls back to the SESSION_ID_KEYS conventions when no
-# configured key matches, and `sessionId` is in that list. Session linking worked before
-# this default was corrected and works after. What the default drives is the settings UI
-# and what new teams are told to emit — see `SESSION_ID_KEYS` for why `posthogSessionId`
-# must stay in the conventions regardless.
+# This default is not what makes linking work — resolution also falls back to the
+# SESSION_ID_KEYS conventions in products/logs/frontend/utils.tsx.
 DEFAULT_LOGS_SESSION_ID_ATTRIBUTE_KEYS = ["sessionId"]
 
 
@@ -106,11 +101,8 @@ class TeamLogsConfig(models.Model):
     logs_session_id_attribute_keys = ArrayField(
         models.CharField(max_length=200),
         default=default_logs_session_id_attribute_keys,
-        # Deliberately left at the original `posthogSessionId` while the Python default
-        # above moved to `sessionId`: changing a db_default needs a migration, and this
-        # one is never observed — every TeamLogsConfig is created through Django, which
-        # applies `default` first. Worth aligning if a migration lands here for another
-        # reason; not worth one on its own.
+        # Stale relative to the default above; aligning it needs a migration and Django
+        # applies `default` first, so this is never observed.
         db_default=Value("{posthogSessionId}"),
     )
 

--- a/products/logs/backend/models.py
+++ b/products/logs/backend/models.py
@@ -59,9 +59,6 @@ DISTINCT_ID_ATTRIBUTE_KEY_CONVENTIONS = [
 # https://posthog.com/docs/logs/link-session-replay tells backends to send. Ordered:
 # detection checks keys in list order and the first match wins. Customers whose pipeline
 # emits the session ID under different keys can override via the `logs_config` endpoint.
-#
-# This default is not what makes linking work — resolution also falls back to the
-# SESSION_ID_KEYS conventions in products/logs/frontend/utils.tsx.
 DEFAULT_LOGS_SESSION_ID_ATTRIBUTE_KEYS = ["sessionId"]
 
 

--- a/products/logs/backend/test/test_models.py
+++ b/products/logs/backend/test/test_models.py
@@ -13,6 +13,7 @@ from posthog.models.team.extensions import get_or_create_team_extension
 
 from products.logs.backend.models import (
     DEFAULT_LOGS_DISTINCT_ID_ATTRIBUTE_KEY,
+    DEFAULT_LOGS_SESSION_ID_ATTRIBUTE_KEYS,
     MAX_EVALUATION_PERIODS,
     LogsAlertConfiguration,
     LogsAlertEvent,
@@ -236,6 +237,11 @@ class TestTeamLogsConfig(BaseTest):
         # their person without any team configuration.
         assert config.logs_distinct_id_attribute_key == "posthogDistinctId"
         assert config.logs_distinct_id_attribute_keys == ["posthogDistinctId"]
+        # The SDKs namespace the distinct ID but leave the session ID bare, so this one is
+        # `sessionId`, not `posthogSessionId`. Asserted literally: an assertion against the
+        # constant alone moves with it and would not catch the key drifting from the SDKs.
+        assert config.logs_session_id_attribute_keys == DEFAULT_LOGS_SESSION_ID_ATTRIBUTE_KEYS
+        assert config.logs_session_id_attribute_keys == ["sessionId"]
 
     def test_custom_attribute_keys_persist(self):
         config = get_or_create_team_extension(self.team, TeamLogsConfig)

--- a/products/logs/backend/test/test_models.py
+++ b/products/logs/backend/test/test_models.py
@@ -267,6 +267,47 @@ class TestTeamLogsConfig(BaseTest):
         customized.refresh_from_db()
         assert customized.logs_distinct_id_attribute_keys == ["user.id"]
 
+    def test_migration_backfill_appends_the_key_the_sdks_emit(self):
+        # A team that never opened the setting carries 0015's ADD COLUMN default. The old key
+        # stays FIRST: a deliberate `["posthogSessionId"]` is indistinguishable from this row,
+        # and detection is first-match-wins, so leading with `sessionId` would move the teams
+        # that emit both onto a different attribute than they resolve on today.
+        untouched = get_or_create_team_extension(self.team, TeamLogsConfig)
+        untouched.logs_session_id_attribute_keys = ["posthogSessionId"]
+        untouched.save()
+
+        self._run_session_id_backfill()
+
+        untouched.refresh_from_db()
+        assert untouched.logs_session_id_attribute_keys == ["posthogSessionId", "sessionId"]
+
+    def test_migration_backfill_leaves_a_customized_value_alone(self):
+        customized = get_or_create_team_extension(self.team, TeamLogsConfig)
+        customized.logs_session_id_attribute_keys = ["my.session.key"]
+        customized.save()
+
+        self._run_session_id_backfill()
+
+        customized.refresh_from_db()
+        assert customized.logs_session_id_attribute_keys == ["my.session.key"]
+
+    def test_migration_backfill_is_idempotent(self):
+        already_backfilled = get_or_create_team_extension(self.team, TeamLogsConfig)
+        already_backfilled.logs_session_id_attribute_keys = ["posthogSessionId", "sessionId"]
+        already_backfilled.save()
+
+        self._run_session_id_backfill()
+
+        already_backfilled.refresh_from_db()
+        assert already_backfilled.logs_session_id_attribute_keys == ["posthogSessionId", "sessionId"]
+
+    @staticmethod
+    def _run_session_id_backfill():
+        backfill_module = importlib.import_module(
+            "products.logs.backend.migrations.0022_backfill_logs_session_id_attribute_keys"
+        )
+        backfill_module.backfill_session_id_attribute_keys(apps, None)
+
     def test_cascade_delete_with_team(self):
         get_or_create_team_extension(self.team, TeamLogsConfig)
         team_id = self.team.pk

--- a/products/logs/backend/test/test_models.py
+++ b/products/logs/backend/test/test_models.py
@@ -268,10 +268,7 @@ class TestTeamLogsConfig(BaseTest):
         assert customized.logs_distinct_id_attribute_keys == ["user.id"]
 
     def test_migration_backfill_appends_the_key_the_sdks_emit(self):
-        # A team that never opened the setting carries 0015's ADD COLUMN default. The old key
-        # stays FIRST: a deliberate `["posthogSessionId"]` is indistinguishable from this row,
-        # and detection is first-match-wins, so leading with `sessionId` would move the teams
-        # that emit both onto a different attribute than they resolve on today.
+        # Order matters — see the migration for why the old key stays first.
         untouched = get_or_create_team_extension(self.team, TeamLogsConfig)
         untouched.logs_session_id_attribute_keys = ["posthogSessionId"]
         untouched.save()

--- a/products/logs/frontend/logsConfigLogic.ts
+++ b/products/logs/frontend/logsConfigLogic.ts
@@ -14,7 +14,7 @@ export const DEFAULT_LOGS_DISTINCT_ID_ATTRIBUTE_KEYS = [DEFAULT_LOGS_DISTINCT_ID
 
 // Mirrors the backend default in products/logs/backend/models.py. Ordered: session ID
 // detection checks keys in list order and the first match wins.
-export const DEFAULT_LOGS_SESSION_ID_ATTRIBUTE_KEYS = ['posthogSessionId']
+export const DEFAULT_LOGS_SESSION_ID_ATTRIBUTE_KEYS = ['sessionId']
 
 export interface LogsConfig {
     // Legacy single-key alias — always the first entry of logs_distinct_id_attribute_keys.

--- a/products/logs/frontend/utils.test.ts
+++ b/products/logs/frontend/utils.test.ts
@@ -165,9 +165,9 @@ describe('logs utils', () => {
 
     describe('buildLogsSessionFilters', () => {
         it.each([
-            ['defaults to the SDK convention key', undefined, ['posthogSessionId']],
+            ['defaults to the key the SDKs emit', undefined, ['sessionId']],
             ['uses configured keys in order', ['session.id', 'custom.key'], ['session.id', 'custom.key']],
-            ['empty configured list falls back to default', [], ['posthogSessionId']],
+            ['empty configured list falls back to default', [], ['sessionId']],
         ])('%s', (_, configuredKeys, expectedKeys) => {
             const filters = buildLogsSessionFilters('sess-1', configuredKeys)
 

--- a/products/logs/frontend/utils.test.ts
+++ b/products/logs/frontend/utils.test.ts
@@ -181,11 +181,15 @@ describe('logs utils', () => {
             'posthog.session_id',
         ]
 
+        // Keys of the log-attribute filters only. Every key also gets a resource-attribute
+        // twin, asserted separately below.
         const filterKeys = (configuredKeys?: string[]): string[] => {
             const innerGroup = buildLogsSessionFilters('sess-1', configuredKeys).filterGroup!
                 .values[0] as UniversalFiltersGroup
             expect(innerGroup.type).toBe('OR')
-            return (innerGroup.values as { key: string }[]).map((filter) => filter.key)
+            return (innerGroup.values as { key: string; type: string }[])
+                .filter((filter) => filter.type === 'log_attribute')
+                .map((filter) => filter.key)
         }
 
         it.each([
@@ -217,17 +221,27 @@ describe('logs utils', () => {
             expect(filterKeys(['posthogSessionId'])).toContain('sessionId')
         })
 
-        it('builds one exact log-attribute filter per key', () => {
+        it('queries each key as both a log attribute and a resource attribute', () => {
+            // A log carrying the session id only under resource_attributes still renders the
+            // session link, so View Logs has to match that map too.
             const filters = buildLogsSessionFilters('sess-1', ['custom.key'])
 
             const innerGroup = filters.filterGroup!.values[0] as UniversalFiltersGroup
-            expect(innerGroup.values[0]).toEqual({
-                key: 'custom.key',
-                value: ['sess-1'],
-                operator: 'exact',
-                type: 'log_attribute',
-            })
+            expect(innerGroup.values.slice(0, 2)).toEqual([
+                { key: 'custom.key', value: ['sess-1'], operator: 'exact', type: 'log_attribute' },
+                { key: 'custom.key', value: ['sess-1'], operator: 'exact', type: 'log_resource_attribute' },
+            ])
             expect(filters.dateRange).toBeUndefined()
+        })
+
+        it('pairs every queried key across both maps', () => {
+            const innerGroup = buildLogsSessionFilters('sess-1', ['custom.key']).filterGroup!
+                .values[0] as UniversalFiltersGroup
+            const values = innerGroup.values as { key: string; type: string }[]
+            const keysByType = (type: string): string[] =>
+                values.filter((filter) => filter.type === type).map((filter) => filter.key)
+
+            expect(keysByType('log_resource_attribute')).toEqual(keysByType('log_attribute'))
         })
 
         it('scopes the date range around the timestamp', () => {

--- a/products/logs/frontend/utils.test.ts
+++ b/products/logs/frontend/utils.test.ts
@@ -1,5 +1,7 @@
 import { UniversalFiltersGroup } from '~/types'
 
+import { DEFAULT_LOGS_SESSION_ID_ATTRIBUTE_KEYS } from 'products/logs/frontend/logsConfigLogic'
+
 import {
     buildLogsSessionFilters,
     formatFilterGroupValues,
@@ -164,23 +166,67 @@ describe('logs utils', () => {
     })
 
     describe('buildLogsSessionFilters', () => {
+        // Byte-for-byte SESSION_ID_KEYS from utils.tsx. Spelled out rather than imported so a
+        // silent edit to that list shows up here as a failing assertion.
+        const CONVENTION_KEYS = [
+            'session.id',
+            'session_id',
+            'sessionId',
+            'sessionID',
+            '$session_id',
+            'posthogSessionId',
+            'posthogSessionID',
+            'posthog_session_id',
+            'posthog.session.id',
+            'posthog.session_id',
+        ]
+
+        const filterKeys = (configuredKeys?: string[]): string[] => {
+            const innerGroup = buildLogsSessionFilters('sess-1', configuredKeys).filterGroup!
+                .values[0] as UniversalFiltersGroup
+            expect(innerGroup.type).toBe('OR')
+            return (innerGroup.values as { key: string }[]).map((filter) => filter.key)
+        }
+
         it.each([
-            ['defaults to the key the SDKs emit', undefined, ['sessionId']],
-            ['uses configured keys in order', ['session.id', 'custom.key'], ['session.id', 'custom.key']],
-            ['empty configured list falls back to default', [], ['sessionId']],
-        ])('%s', (_, configuredKeys, expectedKeys) => {
-            const filters = buildLogsSessionFilters('sess-1', configuredKeys)
+            ['no configured keys', undefined],
+            ['empty configured list', []],
+        ])('%s queries the built-in conventions', (_, configuredKeys) => {
+            expect(filterKeys(configuredKeys)).toEqual(CONVENTION_KEYS)
+        })
+
+        it('puts configured keys first, then the conventions, deduped', () => {
+            // `sessionId` is configured and a convention: it keeps its configured position
+            // and is not repeated.
+            expect(filterKeys(['custom.key', 'sessionId'])).toEqual([
+                'custom.key',
+                'sessionId',
+                ...CONVENTION_KEYS.filter((key) => key !== 'sessionId'),
+            ])
+        })
+
+        it('queries the shipped default, which must be one of the conventions', () => {
+            // buildLogsSessionFilters queries the conventions, not the default, so a default
+            // outside this list would go unqueried for a team that never edited it.
+            expect(CONVENTION_KEYS).toEqual(expect.arrayContaining(DEFAULT_LOGS_SESSION_ID_ATTRIBUTE_KEYS))
+        })
+
+        it('queries sessionId for a team whose stored config is the old posthogSessionId default', () => {
+            // Every team created before the default changed has `posthogSessionId` materialised.
+            // The conventions union is what keeps their session link resolving SDK logs.
+            expect(filterKeys(['posthogSessionId'])).toContain('sessionId')
+        })
+
+        it('builds one exact log-attribute filter per key', () => {
+            const filters = buildLogsSessionFilters('sess-1', ['custom.key'])
 
             const innerGroup = filters.filterGroup!.values[0] as UniversalFiltersGroup
-            expect(innerGroup.type).toBe('OR')
-            expect(innerGroup.values).toEqual(
-                expectedKeys.map((key) => ({
-                    key,
-                    value: ['sess-1'],
-                    operator: 'exact',
-                    type: 'log_attribute',
-                }))
-            )
+            expect(innerGroup.values[0]).toEqual({
+                key: 'custom.key',
+                value: ['sess-1'],
+                operator: 'exact',
+                type: 'log_attribute',
+            })
             expect(filters.dateRange).toBeUndefined()
         })
 

--- a/products/logs/frontend/utils.tsx
+++ b/products/logs/frontend/utils.tsx
@@ -82,9 +82,8 @@ const DISTINCT_ID_KEYS = [
     'posthog.distinct.id',
     'posthog.distinct_id',
 ]
-// No SDK emits `posthogSessionId`, but 31 teams send it themselves — it was the team-config
-// default between #70414 and #83710, so pipelines configured from the settings UI in that
-// window emit it. Keep it: removing it would break them.
+// 31 teams emit `posthogSessionId` even though no SDK does — it was the config default
+// between #70414 and #83710. Removing it would break them.
 const SESSION_ID_KEYS = [
     'session.id',
     'session_id',

--- a/products/logs/frontend/utils.tsx
+++ b/products/logs/frontend/utils.tsx
@@ -188,12 +188,23 @@ export function buildLogsSessionFilters(
             values: [
                 {
                     type: FilterLogicalOperator.Or,
-                    values: keys.map((key) => ({
-                        key,
-                        value: [sessionId],
-                        operator: PropertyOperator.Exact,
-                        type: PropertyFilterType.LogAttribute,
-                    })),
+                    // Each key is queried in both maps, because getSessionIdWithKey renders the
+                    // session link off attributes or resource_attributes. Person scoping resolves
+                    // distinct ids across both maps for the same reason.
+                    values: keys.flatMap((key) => [
+                        {
+                            key,
+                            value: [sessionId],
+                            operator: PropertyOperator.Exact,
+                            type: PropertyFilterType.LogAttribute,
+                        },
+                        {
+                            key,
+                            value: [sessionId],
+                            operator: PropertyOperator.Exact,
+                            type: PropertyFilterType.LogResourceAttribute,
+                        },
+                    ]),
                 },
             ],
         },

--- a/products/logs/frontend/utils.tsx
+++ b/products/logs/frontend/utils.tsx
@@ -6,7 +6,6 @@ import { capitalizeFirstLetter } from 'lib/utils/strings'
 import { AnyPropertyFilter, FilterLogicalOperator, PropertyFilterType, PropertyOperator } from '~/types'
 
 import { LogsViewerFilters } from 'products/logs/frontend/components/LogsViewer/config/types'
-import { DEFAULT_LOGS_SESSION_ID_ATTRIBUTE_KEYS } from 'products/logs/frontend/logsConfigLogic'
 
 export function formatFilterGroupValues(filterGroup: Record<string, any> | undefined): string[] {
     const group = filterGroup?.values?.[0]
@@ -83,12 +82,8 @@ const DISTINCT_ID_KEYS = [
     'posthog.distinct.id',
     'posthog.distinct_id',
 ]
-// `sessionId` is what the posthog-js / posthog-react-native SDKs emit and what the docs
-// tell backends to send, so it is the one that matters in practice. `posthogSessionId` is
-// NOT emitted by any SDK — it was the team-config default between #70414 and this list's
-// correction, so a customer who configured their pipeline from the settings UI in that
-// window may be emitting it. It stays here permanently for those customers; do not remove
-// it on the grounds that nothing emits it.
+// No SDK emits `posthogSessionId`, but it was the team-config default between #70414 and
+// #83710, so teams configured in that window still have it stored. Keep it.
 const SESSION_ID_KEYS = [
     'session.id',
     'session_id',
@@ -176,15 +171,18 @@ export function buildDateRangeAround(timestamp: string, windowMinutes: number): 
 }
 
 // Builds logs viewer filters scoped to one session, for other products surfacing logs
-// (error tracking, session replay). Filters on the team's configured session ID keys
-// (OR across keys, exact match), defaulting to the SDK convention; a timestamp scopes
-// the date range to ±30 minutes so old sessions aren't hidden by the default range.
+// (error tracking, session replay). Filters (OR across keys, exact match) on the team's
+// configured session ID keys plus the SESSION_ID_KEYS conventions, deduped, configured
+// first — the same breadth `getSessionIdWithKey` resolves, so a team whose stored key their
+// pipeline never emits still matches. Literal keys only: an exact filter can't express the
+// dot-suffix variants `matchesKey` allows. A timestamp scopes the date range to ±30 minutes
+// so old sessions aren't hidden by the default range.
 export function buildLogsSessionFilters(
     sessionId: string,
     configuredKeys?: string[],
     timestamp?: string
 ): Partial<LogsViewerFilters> {
-    const keys = configuredKeys?.length ? configuredKeys : DEFAULT_LOGS_SESSION_ID_ATTRIBUTE_KEYS
+    const keys = Array.from(new Set([...(configuredKeys ?? []), ...SESSION_ID_KEYS]))
     const filters: Partial<LogsViewerFilters> = {
         filterGroup: {
             type: FilterLogicalOperator.And,

--- a/products/logs/frontend/utils.tsx
+++ b/products/logs/frontend/utils.tsx
@@ -83,6 +83,12 @@ const DISTINCT_ID_KEYS = [
     'posthog.distinct.id',
     'posthog.distinct_id',
 ]
+// `sessionId` is what the posthog-js / posthog-react-native SDKs emit and what the docs
+// tell backends to send, so it is the one that matters in practice. `posthogSessionId` is
+// NOT emitted by any SDK — it was the team-config default between #70414 and this list's
+// correction, so a customer who configured their pipeline from the settings UI in that
+// window may be emitting it. It stays here permanently for those customers; do not remove
+// it on the grounds that nothing emits it.
 const SESSION_ID_KEYS = [
     'session.id',
     'session_id',

--- a/products/logs/frontend/utils.tsx
+++ b/products/logs/frontend/utils.tsx
@@ -82,8 +82,7 @@ const DISTINCT_ID_KEYS = [
     'posthog.distinct.id',
     'posthog.distinct_id',
 ]
-// 31 teams emit `posthogSessionId` even though no SDK does — it was the config default
-// between #70414 and #83710. Removing it would break them.
+// Some pipelines emit `posthogSessionId` even though no SDK does. Removing it breaks them.
 const SESSION_ID_KEYS = [
     'session.id',
     'session_id',

--- a/products/logs/frontend/utils.tsx
+++ b/products/logs/frontend/utils.tsx
@@ -82,8 +82,9 @@ const DISTINCT_ID_KEYS = [
     'posthog.distinct.id',
     'posthog.distinct_id',
 ]
-// No SDK emits `posthogSessionId`, but it was the team-config default between #70414 and
-// #83710, so teams configured in that window still have it stored. Keep it.
+// No SDK emits `posthogSessionId`, but 31 teams send it themselves — it was the team-config
+// default between #70414 and #83710, so pipelines configured from the settings UI in that
+// window emit it. Keep it: removing it would break them.
 const SESSION_ID_KEYS = [
     'session.id',
     'session_id',


### PR DESCRIPTION
## Problem

Clicking **View logs** on an exception returns an empty logs view for teams that never opened Logs settings.

`buildLogsSessionFilters` builds the filter from the team's configured session-ID keys, falling back to the default — never to the `SESSION_ID_KEYS` conventions. That default is `posthogSessionId`, which our SDKs don't send; they send `sessionId`, as does [our docs guidance](https://posthog.com/docs/logs/link-session-replay) for backends. So the filter looks for an attribute that isn't there.

Measured in ClickHouse (`log_attributes_distributed`, 2026-08-17):

| session attribute | teams | records |
| --- | --- | --- |
| `sessionId` | 2,165 | 819.7M |
| `posthogSessionId` | 31 | 8.6M |

So ~2,150 teams are affected. Reached from error tracking's events table and the exception card's Session tab via `ViewLogsButton`, gated on `LOGS_IN_ERROR_TRACKING` — live exposure is limited to teams with that flag and grows as it rolls out.

Session links rendered *on log lines* are fine: `getSessionIdWithKey` and `isSessionIdKey` do fall back to the conventions. Only the filter-building path doesn't, which is why this survived.

The default looks like an analogy from the distinct-ID setting six weeks earlier (#60536), where `posthogDistinctId` genuinely is the SDK key. The SDKs never had that symmetry.

## Changes

Two fixes, deliberately overlapping:

- **`buildLogsSessionFilters` queries configured keys ∪ conventions.** Repairs every affected team on deploy, whatever they have stored.
- **Backfill `0022`** for teams still holding the old default: `["posthogSessionId"]` → `["posthogSessionId", "sessionId"]`.

The backfill is a **no-op behaviourally today** — the union already matches both keys. Its value is making the stored data correct so the union can be dropped when detection moves to configured-keys-only, per #70414. Without it, that change silently reintroduces this bug.

Old key **first** in the backfill: detection is first-match-wins and **14 teams emit both keys**, so leading with `sessionId` would move them onto a different attribute than they resolve on today. Rows with any other value are deliberate config and stay untouched.

Also:

- `DEFAULT_LOGS_SESSION_ID_ATTRIBUTE_KEYS` becomes `["sessionId"]`, so new teams stop inheriting a key our SDKs don't send.
- Settings copy and the `logs_config` API help text no longer name `posthogSessionId`.
- The model comment claimed `posthogSessionId` "is the key the posthog-js / posthog-react-native SDKs auto-attach" — corrected. A test named "defaults to the SDK convention key" asserted the opposite; renamed.
- `SESSION_ID_KEYS` keeps `posthogSessionId` permanently, with a comment saying why: 31 teams emit it.

`db_default` still reads `posthogSessionId`, so it differs from the Python default. Aligning it needs a migration and it is never observed — every `TeamLogsConfig` is created through Django, which applies `default` first. Left with a comment; say the word if you'd rather they match.

## How did you test this code?

Frontend: `products/logs/frontend/utils.test.ts` and `logsSceneLogic.test.ts` — 111 tests, passing locally and in CI (Jest FOSS 1-4, EE 2 and 4).

Backfill: four cases in `products/logs/backend/test/test_models.py`, following the `0019` precedent — the default is appended to in the right order, a customized value is left alone, and re-running is idempotent. Passing locally against Postgres.

Migration: applied against a real Postgres, confirmed in `django_migrations` (`0022` recorded ahead of `0021`, chain linear). `Validate migrations` also passes in CI.

The ordering assertion is the one worth keeping: reversing `NEW_VALUE` silently moves teams that emit both keys onto a different attribute, and nothing else in the suite would catch it.

No manual testing of the error-tracking button. The broken path was traced through `ViewLogsButton` → `buildLogsSessionFilters` → the stored default, not by clicking it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The docs already say `sessionId`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found while adding first-class tracing to posthog-node, which emits the same person/session attributes as logs and planned to reuse this config pattern.

**Three passes; the first two were wrong, and the code comments now carry the correction.**

1. SDK sends `sessionId`, default says `posthogSessionId` → linking must be broken everywhere. A bug report was drafted before the consumer was checked.
2. `getSessionIdWithKey` falls back to the conventions, and the config is never read by `logs_query_runner.py` → harmless and cosmetic. This is the state the PR opened in, and its description said "nothing is broken".
3. `buildLogsSessionFilters` has no fallback and sits behind a user-facing button. The first instinct was right, for a reason neither earlier pass had found.

**If you're looking at a wrong-looking default here, check all three consumers in `products/logs/frontend/utils.tsx` first** — two fall back, one didn't.

A fourth correction came from @jonmcwest asking whether anyone emits the old key. An earlier version of this description claimed nothing ever had, generalised from a single project's logs. 31 teams do, 14 of them alongside `sessionId` — which reversed the backfill's ordering.

Skills invoked: `writing-pr-descriptions`, `django-migrations` (why `db_default` was left alone rather than hand-writing a schema migration without being able to run `makemigrations`).

Tools: Claude Code. No customer data here; the ClickHouse figures are aggregate team and record counts.

