### PR TITLE
fix(mysql): stop retrying a MySQL server that's out of memory

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
@@ -312,6 +312,14 @@ class MySQLSource(SQLSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatabase
             # locale-independent error code (the trailing message text is translated on non-English
             # servers) so it catches both the raw pymysql string and the wrapped `(1038, ...)` form.
             "(1038,": "Your MySQL/MariaDB server ran out of sort buffer memory while ordering this table by its incremental field (error 1038). We try to avoid the sort by forcing the incremental field's index, but this table has no usable index on that field. Add an index on the incremental field, raise the server's 'sort_buffer_size', or switch this table to a full re-sync, then resync.",
+            # MySQL/MariaDB error 1041 (ER_OUT_OF_RESOURCES): the server (mysqld) or another process
+            # on its host has used up all available memory. Seen escaping the in-activity FORCE INDEX
+            # fallback (see `_is_bad_plan_error`) when the server is already so memory-starved from an
+            # unindexed filesort that it can't even open the probe connection used to look up an index.
+            # The host's available memory is static customer-side state, so every retry hits the same
+            # wall. Match the locale-independent error code (the trailing message text is translated on
+            # non-English servers).
+            "(1041,": "Your MySQL/MariaDB server ran out of memory (error 1041). This can happen when a large, unindexed sync query pushes the server (or another process on its host) to use all available memory. Add an index on this table's incremental field to avoid the large sort, free up memory or add swap space on your database server, or switch this table to a full re-sync, then resync.",
             # MySQL/MariaDB error 3024 (ER_QUERY_TIMEOUT): the server's own `max_execution_time`
             # cap killed the `ORDER BY <incremental_field>` query before the filesort could
             # finish. We already try to dodge the sort with the in-activity FORCE INDEX fallback

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -2128,6 +2128,28 @@ class TestMySQLSourceNonRetryableErrors:
             # Raw pymysql str(error) form (single-quoted tuple repr).
             str(
                 pymysql.err.OperationalError(
+                    1041,
+                    "Out of memory; check if mysqld or some other process uses all available memory; if not, you "
+                    "may have to use 'ulimit' to allow mysqld to use more memory or you can add more swap space",
+                )
+            ),
+            # Temporal-wrapped form (double-quoted).
+            'OperationalError: (1041, "Out of memory; check if mysqld or some other process uses all available '
+            "memory; if not, you may have to use 'ulimit' to allow mysqld to use more memory or you can add more "
+            'swap space")',
+        ],
+    )
+    def test_out_of_memory_is_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"Out-of-memory error should be non-retryable: {error_msg}"
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
+            # Raw pymysql str(error) form (single-quoted tuple repr).
+            str(
+                pymysql.err.OperationalError(
                     3024, "Query execution was interrupted, maximum statement execution time exceeded"
                 )
             ),


### PR DESCRIPTION
## Problem

A MySQL data-warehouse sync keeps retrying when the customer's database server runs out of memory, instead of stopping with an actionable message. This surfaced in error tracking as an `OperationalError` (MySQL error 1041) with no matching non-retryable rule.

## Changes

- Add MySQL error 1041 ("Out of memory; check if mysqld or some other process uses all available memory...") to `MySQLSource.get_non_retryable_errors`, matching on the stable `(1041,` code prefix.
- The available memory on the customer's server is static state, so every retry hits the same wall — the same reasoning already applied to the sibling entries for error 1038 (out of sort memory), 3024 (execution time exceeded), and disk-full errors.
- In the observed case, this error escaped an in-activity `FORCE INDEX` fallback: the server was already memory-starved from an unindexed filesort (1038) when the fallback tried to open a probe connection to look up an index, and that probe connection failed with 1041.

## How did you test this code?

- Added `test_out_of_memory_is_non_retryable`, parameterized over the raw pymysql and Temporal-wrapped message forms — mirrors the existing 1038 coverage. Catches a regression where this error keeps retrying instead of stopping with guidance.
- Ran the full MySQL source test suite: 284 passed.
- Ran `ruff check` and `ruff format` on the changed files — clean.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing config or workflow changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a live error-tracking issue for the MySQL warehouse source. Confirmed the error genuinely originates in `products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py` via the full stack trace, read the `get_rows`/`_stream_with_optional_force_index`/FORCE-INDEX-fallback code path, and classified this as a customer/upstream server-resource condition rather than a code bug, consistent with how sibling errors (1038, 3024, disk-full) are already handled. Searched open PRs (human-authored and the automation bot) for a duplicate fix; found none.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.