### PR TITLE
fix(mysql): stop retrying a MySQL server out-of-memory error

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
@@ -341,6 +341,13 @@ class MySQLSource(SQLSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatabase
             # customer's server running out of space.
             "OS errno 28 -": "Your MySQL/MariaDB server ran out of disk space while writing a temporary file for this sync ('No space left on device'). Syncing a large table can spill a big sort to the server's temporary directory. Free up disk space on your database server, add an index on this table's incremental field so the sync avoids the large sort, or switch the table to a full re-sync, then resync.",
             "Errcode: 28": "Your MySQL/MariaDB server ran out of disk space while writing a temporary file for this sync ('No space left on device'). Syncing a large table can spill a big sort to the server's temporary directory. Free up disk space on your database server, add an index on this table's incremental field so the sync avoids the large sort, or switch the table to a full re-sync, then resync.",
+            # MySQL/MariaDB error 1041 (ER_OUT_OF_RESOURCES): mysqld itself couldn't allocate memory
+            # for the connection/query — the host's available memory (or its configured swap) is
+            # exhausted, whether by mysqld or another process on the same host. Static server-side
+            # resource state, so every retry hits the same wall — the Postgres source treats its
+            # equivalent (SQLSTATE 53200 "out of memory") the same way. Match the locale-independent
+            # error code (the trailing "ulimit"/swap guidance is MySQL's own, not translated).
+            "(1041,": "Your MySQL/MariaDB server ran out of memory (error 1041). This usually means mysqld or another process on the host is using all available memory, or the host needs more swap space. Free up memory on your database server, raise mysqld's memory limit (for example via 'ulimit'), or add swap space, then resync.",
             # pymysql encodes the handshake fields (host, user, password, database) as latin-1;
             # a value carrying a non-latin-1 character — most often an invisible zero-width space
             # (U+200B) pasted in from another app — raises UnicodeEncodeError before any packet is

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -2143,6 +2143,28 @@ class TestMySQLSourceNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
+            # Raw pymysql str(error) form (single-quoted tuple repr).
+            str(
+                pymysql.err.OperationalError(
+                    1041,
+                    "Out of memory; check if mysqld or some other process uses all available memory; if not, "
+                    "you may have to use 'ulimit' to allow mysqld to use more memory or you can add more swap space",
+                )
+            ),
+            # Temporal-wrapped form (double-quoted).
+            'OperationalError: (1041, "Out of memory; check if mysqld or some other process uses all available '
+            "memory; if not, you may have to use 'ulimit' to allow mysqld to use more memory or you can add more "
+            'swap space")',
+        ],
+    )
+    def test_out_of_memory_is_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"Out-of-memory error should be non-retryable: {error_msg}"
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
             # MariaDB / RDS rendering seen in the wild (error 3, EE_WRITE).
             str(
                 pymysql.err.InternalError(


### PR DESCRIPTION
## Problem

A MySQL source sync keeps retrying when the customer's database server runs out of memory, spending the full activity retry budget against a condition that only their database admin can resolve, and surfacing as noisy error tracking (spotted via an OperationalError issue, code 1041).

## Changes

- Classify pymysql error 1041 (`ER_OUT_OF_RESOURCES`, "Out of memory") as non-retryable in `MySQLSource.get_non_retryable_errors`, matching on the stable `(1041,` code prefix.
- The friendly message points at freeing host memory, raising mysqld's `ulimit`, or adding swap — the same guidance the server itself gives.
- Mirrors the Postgres source, which already treats its equivalent SQLSTATE 53200 "out of memory" the same way.

## How did you test this code?

Added `test_out_of_memory_is_non_retryable` to `TestMySQLSourceNonRetryableErrors`, parameterized over the raw pymysql string form and the Temporal-wrapped form — catches a regression where error 1041 stops being classified as non-retryable, since the classification relies on substring matching. Ran the full `test_mysql.py` suite (284 passed) and `mypy` on the changed file (clean).

Not run: an end-to-end sync against a real out-of-memory MySQL server — no such environment available.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal error-classification change, no documented behavior changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog error tracking (issue matching a live `OperationalError` for the MySQL warehouse source), confirmed the stack trace originates in `mysql.py`/`source.py`, then read the module's existing transient-vs-non-retryable error taxonomy and the sibling Postgres source's "out of memory" handling to size the fix consistently. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.