### PR TITLE
fix(replay-vision): show the scanner description limit before save

### DIFF
--- a/products/replay_vision/frontend/replay_scanners/ScannerEditorScene.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ScannerEditorScene.tsx
@@ -54,7 +54,7 @@ import {
     scannerStepUrlWithParams,
 } from './scannerEditorSceneLogic'
 import { ScannerEditorStepper, STEP_LABELS } from './ScannerEditorStepper'
-import { SCANNER_TYPE_OPTIONS, getModelOptions, modelNamingVariant } from './types'
+import { MAX_DESCRIPTION_LENGTH, SCANNER_TYPE_OPTIONS, getModelOptions, modelNamingVariant } from './types'
 
 const HedgehogConstruction2 = pngHoggie(construction2Png)
 const HedgehogImTheDriver = pngHoggie(imTheDriverPng)
@@ -244,7 +244,11 @@ function DetailsStep(): JSX.Element {
                 label="Description (optional)"
                 help="The scanning agent doesn't see this field. It's for you and your team to keep scanners organized."
             >
-                <LemonTextArea placeholder="What this scanner looks for and why." minRows={2} />
+                <LemonTextArea
+                    placeholder="What this scanner looks for and why."
+                    minRows={2}
+                    maxLength={MAX_DESCRIPTION_LENGTH}
+                />
             </LemonField>
 
             <LemonField

--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.test.ts
@@ -376,13 +376,33 @@ describe('replayScannerLogic', () => {
                     attr: 'description',
                 },
             ])
-            router.actions.push('/replay-vision/new/budget')
+            router.actions.push(`${urls.replayVisionScannerBudget('new')}?template=session_outcome`)
             scannerEditorSceneLogic.actions.setStep('budget')
             logic.actions.setScannerValues({ name: 'Test scanner', scanner_config: { prompt: 'Q?' } })
             await expectLogic(logic, () => logic.actions.submitScanner()).toFinishAllListeners()
             // Description is a details-step field, so a toast on the budget step names nothing the user can see.
             expect(router.values.location.pathname).toContain('/replay-vision/new/details')
             expect(logic.values.scannerErrors.description).toBe('Ensure this field has no more than 1000 characters.')
+            // The hop back has to keep ?template, or a templated scanner loses its type on the way.
+            expect(router.values.searchParams.template).toEqual('session_outcome')
+        })
+
+        it('routes a nested field rejection to the step owning its parent', async () => {
+            // exceptions-hog joins nested serializer keys with __, so the root is what maps to a step.
+            createSpy.mockImplementation(() => [
+                400,
+                {
+                    type: 'validation_error',
+                    code: 'max_length',
+                    detail: 'Ensure this field has no more than 400 characters.',
+                    attr: 'experiment_targeting__variant_keys',
+                },
+            ])
+            router.actions.push('/replay-vision/new/budget')
+            scannerEditorSceneLogic.actions.setStep('budget')
+            logic.actions.setScannerValues({ name: 'Test scanner', scanner_config: { prompt: 'Q?' } })
+            await expectLogic(logic, () => logic.actions.submitScanner()).toFinishAllListeners()
+            expect(router.values.location.pathname).toContain('/replay-vision/new/triggers')
         })
 
         it('submitting the final step creates the scanner, lands on it, and announces the first scan', async () => {

--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.test.ts
@@ -366,6 +366,25 @@ describe('replayScannerLogic', () => {
             expect(router.values.location.pathname).toContain('/replay-vision/new/configure')
         })
 
+        it('routes a field the API rejects back to the step rendering it, with the reason attached', async () => {
+            createSpy.mockImplementation(() => [
+                400,
+                {
+                    type: 'validation_error',
+                    code: 'max_length',
+                    detail: 'Ensure this field has no more than 1000 characters.',
+                    attr: 'description',
+                },
+            ])
+            router.actions.push('/replay-vision/new/budget')
+            scannerEditorSceneLogic.actions.setStep('budget')
+            logic.actions.setScannerValues({ name: 'Test scanner', scanner_config: { prompt: 'Q?' } })
+            await expectLogic(logic, () => logic.actions.submitScanner()).toFinishAllListeners()
+            // Description is a details-step field, so a toast on the budget step names nothing the user can see.
+            expect(router.values.location.pathname).toContain('/replay-vision/new/details')
+            expect(logic.values.scannerErrors.description).toBe('Ensure this field has no more than 1000 characters.')
+        })
+
         it('submitting the final step creates the scanner, lands on it, and announces the first scan', async () => {
             const success = jest.spyOn(lemonToast, 'success')
             router.actions.push('/replay-vision/new/budget')

--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
@@ -878,13 +878,18 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
                 } catch (error: any) {
                     // The API names the field it rejected, but the save button sits on the last step, so
                     // route back to the step rendering that field instead of leaving an unattributed toast.
-                    const erroredStep = error.attr && error.detail ? scannerStepForField(error.attr) : null
-                    if (erroredStep) {
-                        // scanner_config's form error is an object its sub-fields render, so it only routes.
-                        if (error.attr !== 'scanner_config') {
-                            actions.setScannerManualErrors({ [error.attr]: error.detail })
+                    // A nested serializer error arrives as `parent__child`, so the root picks the step.
+                    const attr: string | null = typeof error.attr === 'string' ? error.attr : null
+                    const attrRoot = attr ? attr.split('__')[0] : null
+                    const erroredStep = attrRoot && error.detail ? scannerStepForField(attrRoot) : null
+                    if (attrRoot && erroredStep) {
+                        // Only a flat field can display the API's string. scanner_config's form error is an
+                        // object its own sub-fields render, and a nested attr has no single field to hang on.
+                        if (attr === attrRoot && attrRoot !== 'scanner_config') {
+                            actions.setScannerManualErrors({ [attrRoot]: error.detail })
                         }
-                        router.actions.push(scannerStepUrl(erroredStep, props.id))
+                        // ?template drives the type selector, so the hop back has to keep it like every other.
+                        router.actions.push(scannerStepUrlWithParams(erroredStep, props.id, router.values.searchParams))
                         lemonToast.error(error.detail)
                         throw error
                     }

--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
@@ -77,6 +77,7 @@ import {
     SCANNER_EDITOR_STEPS,
     firstErroredScannerStep,
     scannerEditorSceneLogic,
+    scannerStepForField,
     scannerStepUrl,
     scannerStepUrlWithParams,
     UNVALIDATED_SCANNER_STEPS,
@@ -875,10 +876,15 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
                         router.actions.push(urls.replayVision(props.id))
                     }
                 } catch (error: any) {
-                    // A duplicate name is the one field error the details step can fix, so route back to it.
-                    if (error.attr === 'name' && error.detail) {
-                        actions.setScannerManualErrors({ name: error.detail })
-                        router.actions.push(urls.replayVisionScannerDetails(props.id))
+                    // The API names the field it rejected, but the save button sits on the last step, so
+                    // route back to the step rendering that field instead of leaving an unattributed toast.
+                    const erroredStep = error.attr && error.detail ? scannerStepForField(error.attr) : null
+                    if (erroredStep) {
+                        // scanner_config's form error is an object its sub-fields render, so it only routes.
+                        if (error.attr !== 'scanner_config') {
+                            actions.setScannerManualErrors({ [error.attr]: error.detail })
+                        }
+                        router.actions.push(scannerStepUrl(erroredStep, props.id))
                         lemonToast.error(error.detail)
                         throw error
                     }

--- a/products/replay_vision/frontend/replay_scanners/scannerEditorSceneLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/scannerEditorSceneLogic.ts
@@ -50,6 +50,29 @@ export function firstErroredScannerStep(errors: ScannerFieldErrors): ScannerEdit
 }
 
 /**
+ * Which step renders each field the API can reject on save. The save button lives on the last step,
+ * so without this a rejected field two steps back surfaces as a toast naming no field at all.
+ */
+const SCANNER_FIELD_STEPS: Record<string, ScannerEditorStep> = {
+    name: 'details',
+    description: 'details',
+    tags: 'details',
+    scanner_type: 'configure',
+    scanner_config: 'configure',
+    model: 'configure',
+    query: 'triggers',
+    duration: 'triggers',
+    sampling_rate: 'budget',
+    sampling_mode: 'budget',
+    credit_limit: 'budget',
+}
+
+/** Step owning the field the API rejected, or null for a field the editor doesn't render. */
+export function scannerStepForField(field: string): ScannerEditorStep | null {
+    return SCANNER_FIELD_STEPS[field] ?? null
+}
+
+/**
  * Step URL carrying the current query string. ?template drives the type selector and the reload
  * prefill, so every hop between steps has to preserve it, backwards as well as forwards.
  */

--- a/products/replay_vision/frontend/replay_scanners/scannerEditorSceneLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/scannerEditorSceneLogic.ts
@@ -6,6 +6,8 @@ import { urls } from 'scenes/urls'
 import { tagsModel } from '~/models/tagsModel'
 import { Breadcrumb } from '~/types'
 
+import type { ScannerFormValues } from './types'
+
 export type ScannerEditorStep = 'template' | 'details' | 'configure' | 'triggers' | 'budget'
 export const SCANNER_EDITOR_STEPS: readonly ScannerEditorStep[] = [
     'template',
@@ -52,16 +54,18 @@ export function firstErroredScannerStep(errors: ScannerFieldErrors): ScannerEdit
 /**
  * Which step renders each field the API can reject on save. The save button lives on the last step,
  * so without this a rejected field two steps back surfaces as a toast naming no field at all.
+ * Keyed on the form values so a renamed or dropped API field fails typecheck here.
  */
-const SCANNER_FIELD_STEPS: Record<string, ScannerEditorStep> = {
+const SCANNER_FIELD_STEPS: Partial<Record<keyof ScannerFormValues, ScannerEditorStep>> = {
     name: 'details',
     description: 'details',
     tags: 'details',
     scanner_type: 'configure',
     scanner_config: 'configure',
     model: 'configure',
+    emits_signals: 'configure',
     query: 'triggers',
-    duration: 'triggers',
+    experiment_targeting: 'triggers',
     sampling_rate: 'budget',
     sampling_mode: 'budget',
     credit_limit: 'budget',
@@ -69,7 +73,7 @@ const SCANNER_FIELD_STEPS: Record<string, ScannerEditorStep> = {
 
 /** Step owning the field the API rejected, or null for a field the editor doesn't render. */
 export function scannerStepForField(field: string): ScannerEditorStep | null {
-    return SCANNER_FIELD_STEPS[field] ?? null
+    return SCANNER_FIELD_STEPS[field as keyof ScannerFormValues] ?? null
 }
 
 /**

--- a/products/replay_vision/frontend/replay_scanners/types.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/types.test.ts
@@ -1,5 +1,8 @@
+import { visionScannersCreateBodyCreditLimitMax, visionScannersCreateBodyDescriptionMax } from '../generated/api.zod'
 import {
     type FailureKind,
+    MAX_CREDIT_LIMIT,
+    MAX_DESCRIPTION_LENGTH,
     type ModelNamingVariant,
     failureRetryGuidance,
     getModelOptions,
@@ -111,6 +114,18 @@ describe('scanner type helpers', () => {
         it('falls back to the raw id for retired models frozen in old observation snapshots', () => {
             expect(modelLabel('gemini-1.5-retired', 'test')).toBe('gemini-1.5-retired')
             expect(modelLabel('gemini-1.5-retired', null)).toBe('gemini-1.5-retired')
+        })
+    })
+
+    describe('API bounds', () => {
+        // Hand-mirrored rather than imported so the zod module stays out of the bundle, which leaves
+        // them free to drift. A stale cap is the bug the description counter exists to prevent: the
+        // field would stop short of, or run past, what the API actually accepts.
+        it.each([
+            ['MAX_DESCRIPTION_LENGTH', MAX_DESCRIPTION_LENGTH, visionScannersCreateBodyDescriptionMax],
+            ['MAX_CREDIT_LIMIT', MAX_CREDIT_LIMIT, visionScannersCreateBodyCreditLimitMax],
+        ])('%s still matches the generated schema', (_name, mirrored, generated) => {
+            expect(mirrored).toBe(generated)
         })
     })
 })

--- a/products/replay_vision/frontend/replay_scanners/types.ts
+++ b/products/replay_vision/frontend/replay_scanners/types.ts
@@ -447,6 +447,9 @@ export type ScannerFormValues = ReplayScanner & { credit_limit_enabled?: boolean
 // Mirrors the API's int4 bound on credit_limit (visionScannersCreateBodyCreditLimitMax in generated/api.zod.ts).
 export const MAX_CREDIT_LIMIT = 2147483647
 
+// Mirrors the API's cap on description (visionScannersCreateBodyDescriptionMax in generated/api.zod.ts).
+export const MAX_DESCRIPTION_LENGTH = 1000
+
 /** Narrow a snapshot's untyped scanner_config at one boundary; pair with the snapshot's scanner_type to pick the variant. */
 export function configFromSnapshot(snapshot: { scanner_config?: unknown } | null | undefined): ScannerConfig | null {
     const config = snapshot?.scanner_config


### PR DESCRIPTION
## Problem

Someone who writes a long description for a Replay Vision scanner cannot save it.
The wizard accepts the text, then the save on the final step fails with "Failed to save scanner: Ensure this field has no more than 1000 characters."

- The API caps the scanner description at 1000 characters.
- The details step rendered the field with no counter and no limit, so nothing showed the cap while typing.
- The save button sits on the budget step, three steps after details.
- The toast names no field, so the message points at nothing the user can see.

## Changes

- The description field shows a live character counter and stops at the cap.
- A field the API rejects routes back to the step that renders it, with the message attached to that field. Only a duplicate name did this before.
- `MAX_DESCRIPTION_LENGTH` mirrors the generated `visionScannersCreateBodyDescriptionMax`, following the existing `MAX_CREDIT_LIMIT` in the same file.

The description field at the cap:

![vision-desc-counter](https://raw.githubusercontent.com/PostHog/pr-assets/115f833e81b9f117949f2fd9b75bcb4ae4216b59/2026/08/63701b8a-8a54-4e1b-8c9f-9301ffb41d99.png)

## How did you test this code?

- I added one Jest case: a 400 naming `description` routes the wizard to the details step and attaches the message to the field.
- I confirmed that case fails without the fix, where the wizard stays on the budget step.
- No existing test covered an API field rejection. The nearest case covers client-side validation only.
- I checked the rendered field in Storybook. A 1400-character paste caps at 1000, and the counter turns red.
- Not run: backend suites. The change is frontend only.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude, via PostHog Desktop) investigated a report that saving a Replay Vision scanner failed, working from a screenshot of the error toast.
The message comes from the scanner editor's save path, and the description is the only field in that path with a 1000-character cap, so I identified the field by elimination rather than from logs.

I considered raising or removing the cap.
The column is an unbounded `TextField` and the cap is serializer-only, but the limit is a product decision, so I surfaced it rather than changing it.
I also generalized the error routing, because the same opaque toast would appear for any other field the API rejects.

Skills invoked: `/writing-ui-components`, `/writing-user-facing-copy`, `/writing-tests`, `/writing-pr-descriptions`.

Public artifact: the diff, the test, and the screenshot use only the repo's own Storybook demo fixtures. Nothing from the originating report reached this PR.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
