### PR TITLE
feat(signals): measure how people find out about self-driving PRs

### DIFF
--- a/posthog/models/user.py
+++ b/posthog/models/user.py
@@ -14,6 +14,7 @@ from rest_framework.exceptions import ValidationError
 
 from posthog.cloud_utils import get_cached_instance_license, is_cloud
 from posthog.constants import AvailableFeature
+from posthog.dataclasses import frozen
 from posthog.exceptions_capture import capture_exception
 from posthog.helpers.email_utils import STRIPPED_EMAIL_EXPRESSION, EmailLookupHandler, EmailNormalizer
 from posthog.models.activity_logging.model_activity import ModelActivityMixin
@@ -227,6 +228,18 @@ class OnboardingSkippedReason(models.TextChoices):
     LATER = "later", "Skipped for later"
     OTHER = "other", "Other"
     PROVISIONED = "provisioned", "Account provisioned by a partner"
+
+
+class GitHubIdentitySource(models.TextChoices):
+    PERSONAL_INTEGRATION = "personal_integration", "Personal GitHub integration"
+    SSO = "sso", "GitHub SSO login"
+    TEAM_INTEGRATION = "team_integration", "Team GitHub integration"
+
+
+@frozen
+class GitHubLoginResolution:
+    login: str
+    source: str
 
 
 class User(AbstractUser, UUIDTClassicModel, ModelActivityMixin):  # type: ignore[django-manager-missing]
@@ -478,7 +491,12 @@ class User(AbstractUser, UUIDTClassicModel, ModelActivityMixin):  # type: ignore
         return self.current_team
 
     def get_github_login(self) -> str | None:
-        """Resolve this user's GitHub login.
+        """Resolve this user's GitHub login. See `get_github_login_with_source` for the precedence."""
+        resolution = self.get_github_login_with_source()
+        return resolution.login if resolution is not None else None
+
+    def get_github_login_with_source(self) -> GitHubLoginResolution | None:
+        """Resolve this user's GitHub login, and which linkage produced it.
 
         Precedence:
         1. `UserIntegration` (kind=github) — user's own GitHub integration
@@ -486,6 +504,9 @@ class User(AbstractUser, UUIDTClassicModel, ModelActivityMixin):  # type: ignore
         3. Team-level `Integration` (kind=github) `connecting_user_github_login` — identity stored on the
            team's GitHub integration (e.g. captured at install). Still a supported integration path,
            lowest precedence as an identity fallback when (1)/(2) do not yield a GitHub username.
+
+        The source rides along so analytics can tell which linkage is missing for the GitHub actors
+        we fail to resolve, rather than only how many of them there are.
         """
         from posthog.models.user_integration import UserGitHubIntegration
 
@@ -498,18 +519,18 @@ class User(AbstractUser, UUIDTClassicModel, ModelActivityMixin):  # type: ignore
         for user_integration in user_integrations:
             login = UserGitHubIntegration(user_integration).github_login
             if login:
-                return login
+                return GitHubLoginResolution(login=login, source=GitHubIdentitySource.PERSONAL_INTEGRATION)
 
         for sa in self.social_auth.all():
             if sa.provider != "github":
                 continue
             login_val = getattr(sa, "_prefetched_github_login", None)
             if login_val:
-                return str(login_val)
+                return GitHubLoginResolution(login=str(login_val), source=GitHubIdentitySource.SSO)
             if isinstance(sa.extra_data, dict):
                 login = sa.extra_data.get("login")
                 if login:
-                    return str(login)
+                    return GitHubLoginResolution(login=str(login), source=GitHubIdentitySource.SSO)
 
         # Team-level GitHub integration: connecting_user_github_login from install / configuration.
         prefetched_integrations = getattr(self, "_prefetched_github_integrations", None)
@@ -517,7 +538,7 @@ class User(AbstractUser, UUIDTClassicModel, ModelActivityMixin):  # type: ignore
             for integration in prefetched_integrations:
                 login = (integration.config or {}).get("connecting_user_github_login")
                 if login:
-                    return str(login)
+                    return GitHubLoginResolution(login=str(login), source=GitHubIdentitySource.TEAM_INTEGRATION)
         else:
             team_github_integration = (
                 self.integration_set.filter(kind="github")
@@ -528,7 +549,7 @@ class User(AbstractUser, UUIDTClassicModel, ModelActivityMixin):  # type: ignore
             if team_github_integration and isinstance(team_github_integration.config, dict):
                 login_val = team_github_integration.config.get("connecting_user_github_login")
                 if login_val:
-                    return str(login_val)
+                    return GitHubLoginResolution(login=str(login_val), source=GitHubIdentitySource.TEAM_INTEGRATION)
 
         return None
 

--- a/posthog/notification_links.py
+++ b/posthog/notification_links.py
@@ -1,0 +1,44 @@
+"""Channel tagging for links we send people outside the app.
+
+An arrival in the app carries no usable trace of the link that produced it: Slack's desktop app
+and most link hops report no referrer, so referrer sniffing cannot separate Slack from GitHub
+from a pasted link. Tagging the link where it is built is what makes the channel readable.
+"""
+
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+
+NOTIFICATION_UTM_MEDIUM = "notification"
+NOTIFICATION_UTM_CAMPAIGN = "self-driving-report"
+
+# Query parameter carrying the id of the send that produced a link, joining an arrival back to
+# its `signals_notification_sent` / `pr_notification_sent` event.
+NOTIFICATION_ID_PARAM = "nid"
+
+
+def tag_notification_url(url: str, *, source: str, surface: str, notification_id: str | None = None) -> str:
+    """Add campaign parameters naming the channel and surface that carried this link.
+
+    `utm_*` rather than private parameter names: posthog-js already captures campaign parameters,
+    so the channel reaches analytics with no client-side change, and `utm_medium=notification` is
+    the one key that keeps these internal links out of marketing acquisition reporting.
+
+    `source` is where the person was when they clicked (`slack`, `github`), `surface` is which
+    card or body held the link. Pass `notification_id` when the link belongs to a single send, so
+    click-through can be measured per send; omit it for a link embedded once and read many times,
+    such as the report link in a PR description.
+
+    Existing query parameters on `url` are preserved.
+    """
+    parsed = urlparse(url)
+    params = dict(parse_qsl(parsed.query, keep_blank_values=True))
+    params.update(
+        {
+            "utm_source": source,
+            "utm_medium": NOTIFICATION_UTM_MEDIUM,
+            "utm_campaign": NOTIFICATION_UTM_CAMPAIGN,
+            "utm_content": surface,
+        }
+    )
+    if notification_id:
+        params[NOTIFICATION_ID_PARAM] = notification_id
+    return urlunparse(parsed._replace(query=urlencode(params)))

--- a/posthog/test/test_notification_links.py
+++ b/posthog/test/test_notification_links.py
@@ -1,0 +1,38 @@
+from urllib.parse import parse_qs, urlparse
+
+from django.test import SimpleTestCase
+
+from parameterized import parameterized
+
+from posthog.notification_links import tag_notification_url
+
+
+class TestTagNotificationUrl(SimpleTestCase):
+    @parameterized.expand(
+        [
+            ("no_query", "https://app.posthog.com/project/2/inbox/reports/abc"),
+            ("existing_query", "https://app.posthog.com/project/2/inbox/reports/abc?tab=pulls"),
+        ]
+    )
+    def test_tagging_preserves_the_original_link(self, _name, url):
+        tagged = tag_notification_url(url, source="slack", surface="inbox_card_team", notification_id="n-1")
+
+        original = urlparse(url)
+        parsed = urlparse(tagged)
+        self.assertEqual((parsed.scheme, parsed.netloc, parsed.path), (original.scheme, original.netloc, original.path))
+        params = parse_qs(parsed.query)
+        self.assertEqual(params["utm_source"], ["slack"])
+        self.assertEqual(params["utm_medium"], ["notification"])
+        self.assertEqual(params["utm_content"], ["inbox_card_team"])
+        self.assertEqual(params["nid"], ["n-1"])
+        for key, value in parse_qs(original.query).items():
+            self.assertEqual(params[key], value)
+
+    def test_link_without_a_send_carries_no_notification_id(self):
+        # The PR footer link is written once and read by whoever opens the PR, so a send id on it
+        # would attribute every later click to one imaginary send.
+        tagged = tag_notification_url("https://app.posthog.com/x", source="github", surface="pr_footer")
+
+        params = parse_qs(urlparse(tagged).query)
+        self.assertNotIn("nid", params)
+        self.assertEqual(params["utm_source"], ["github"])

--- a/products/signals/backend/auto_start.py
+++ b/products/signals/backend/auto_start.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel, ValidationError
 from posthog.event_usage import groups
 from posthog.models import Team, User
 from posthog.models.organization import OrganizationMembership
+from posthog.notification_links import tag_notification_url
 from posthog.sync import database_sync_to_async
 
 from products.signals.backend.agent_runtime import STEP_IMPLEMENTATION, resolve_agent_runtime
@@ -212,7 +213,14 @@ def _build_autostart_task_description(
     source_references: list[SignalSourceReference] | None = None,
 ) -> str:
     priority_line = f"Priority: {priority.priority.value}\nReason: {priority.explanation}\n\n" if priority else ""
-    report_link = f"{settings.SITE_URL}/project/{team_id}/inbox/reports/{report_id}"
+    # Tagged as a GitHub arrival: this link lives in the PR description, so a click means the
+    # person found the work on GitHub rather than in Slack or the inbox. It carries no notification
+    # id, because the description is written once and read by whoever opens the PR, not sent.
+    report_link = tag_notification_url(
+        f"{settings.SITE_URL}/project/{team_id}/inbox/reports/{report_id}",
+        source="github",
+        surface="pr_footer",
+    )
     source_links = ", ".join(f"[{ref.label}]({ref.url})" for ref in source_references or [])
     source_issues_line = f"Source issues: {source_links}\n\n" if source_links else ""
     source_reference_instruction = (

--- a/products/signals/backend/report_generation/resolve_reviewers.py
+++ b/products/signals/backend/report_generation/resolve_reviewers.py
@@ -16,6 +16,7 @@ from django.utils import timezone
 
 from social_django.models import UserSocialAuth
 
+from posthog.dataclasses import frozen
 from posthog.egress.github.transport import GitHubRateLimitError
 from posthog.models.integration import GitHubIntegration, Integration
 from posthog.models.organization import OrganizationMembership
@@ -578,8 +579,21 @@ def list_project_members(
     ]
 
 
+@frozen
+class GitHubIdentityMatch:
+    """An org member matched to a GitHub login, and the linkage that produced the match."""
+
+    user: User
+    source: str
+
+
 def resolve_org_github_login_to_users(team_id: int, github_logins: Iterable[str]) -> dict[str, User]:
-    """Map normalized GitHub login -> org member ``User`` (same identity rules as ``User.get_github_login()``).
+    """Map normalized GitHub login -> org member ``User`` (same identity rules as ``User.get_github_login()``)."""
+    return {login: match.user for login, match in resolve_org_github_logins_with_source(team_id, github_logins).items()}
+
+
+def resolve_org_github_logins_with_source(team_id: int, github_logins: Iterable[str]) -> dict[str, GitHubIdentityMatch]:
+    """Map normalized GitHub login -> matched org member and the linkage that resolved them.
 
     Restricts DB work to users that plausibly match the requested logins.
     """
@@ -598,15 +612,15 @@ def resolve_org_github_login_to_users(team_id: int, github_logins: Iterable[str]
 
     users = User.objects.filter(id__in=candidate_ids).prefetch_related(*_github_identity_prefetches()).order_by("id")
 
-    login_to_user: dict[str, User] = {}
+    login_to_match: dict[str, GitHubIdentityMatch] = {}
     for user in users:
-        gl = user.get_github_login()
-        if not gl:
+        resolution = user.get_github_login_with_source()
+        if resolution is None:
             continue
-        k = gl.lower()
+        k = resolution.login.lower()
         if k in logins_normalized:
-            login_to_user[k] = user
-    return login_to_user
+            login_to_match[k] = GitHubIdentityMatch(user=user, source=resolution.source)
+    return login_to_match
 
 
 def _candidate_user_ids_for_organization(org_id: str) -> set[int]:

--- a/products/signals/backend/scout_harness/slack_delivery.py
+++ b/products/signals/backend/scout_harness/slack_delivery.py
@@ -9,7 +9,10 @@ from django.conf import settings
 import structlog
 from slack_sdk.errors import SlackApiError
 
+from posthog.event_usage import groups
 from posthog.models.integration import Integration, SlackIntegration
+from posthog.notification_links import tag_notification_url
+from posthog.ph_client import ph_background_capture
 
 from products.signals.backend.models import SignalReport, SignalScoutEmission, SignalScoutRun
 from products.signals.backend.slack_formatting import (
@@ -241,8 +244,13 @@ def _report_header(report: SignalReport) -> str:
     return title if len(title) <= 150 else title[:147].rstrip() + "..."
 
 
-def _report_link_block(report: SignalReport) -> dict:
-    report_url = f"{settings.SITE_URL.rstrip('/')}/project/{report.team_id}/inbox/reports/{report.id}"
+def _report_link_block(report: SignalReport, *, notification_id: str | None = None) -> dict:
+    report_url = tag_notification_url(
+        f"{settings.SITE_URL.rstrip('/')}/project/{report.team_id}/inbox/reports/{report.id}",
+        source="slack",
+        surface="scout_delivery",
+        notification_id=notification_id,
+    )
     return {
         "type": "actions",
         "elements": [
@@ -255,7 +263,9 @@ def _report_link_block(report: SignalReport) -> dict:
     }
 
 
-def build_scout_report_slack_message(report: SignalReport, run: SignalScoutRun) -> tuple[list[dict], str]:
+def build_scout_report_slack_message(
+    report: SignalReport, run: SignalScoutRun, *, notification_id: str | None = None
+) -> tuple[list[dict], str]:
     scout_name = _prettify_scout_name(run.skill_name)
     header = _report_header(report)
     blocks: list[dict] = [
@@ -271,13 +281,13 @@ def build_scout_report_slack_message(report: SignalReport, run: SignalScoutRun) 
     if rendered_summary:
         blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": rendered_summary}})
 
-    blocks.append(_report_link_block(report))
+    blocks.append(_report_link_block(report, notification_id=notification_id))
     fallback = f"Scout · {escape_slack_mrkdwn(scout_name)}: {escape_slack_mrkdwn(header[:200])}"
     return blocks, fallback
 
 
 def build_scout_report_note_slack_message(
-    report: SignalReport, run: SignalScoutRun, note: str
+    report: SignalReport, run: SignalScoutRun, note: str, *, notification_id: str | None = None
 ) -> tuple[list[dict], str]:
     """Render a note-only report edit as the note itself, framed as an update.
 
@@ -304,7 +314,7 @@ def build_scout_report_note_slack_message(
     if rendered_note:
         blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": rendered_note}})
 
-    blocks.append(_report_link_block(report))
+    blocks.append(_report_link_block(report, notification_id=notification_id))
     fallback = f"Scout · {escape_slack_mrkdwn(scout_name)} added a note to: {escape_slack_mrkdwn(header[:200])}"
     return blocks, fallback
 
@@ -329,10 +339,13 @@ def post_scout_report_to_slack(
         project_id=report.team.project_id,
     )
     channel_id = _slack_channel_id(channel)
+    # The delivery id is already unique per send and is what the retrying worker dedupes on, so it
+    # keys the notification too, so a retried delivery cannot read as a second notification.
+    notification_id = delivery_id
     blocks, fallback = (
-        build_scout_report_note_slack_message(report, run, edit_note)
+        build_scout_report_note_slack_message(report, run, edit_note, notification_id=notification_id)
         if edit_note is not None
-        else build_scout_report_slack_message(report, run)
+        else build_scout_report_slack_message(report, run, notification_id=notification_id)
     )
     client = SlackIntegration(integration).client
     try:
@@ -353,6 +366,8 @@ def post_scout_report_to_slack(
             ) from exc
         raise
 
+    _capture_scout_report_notification_sent(report, run, notification_id=notification_id)
+
     _post_scout_slack_reply(
         client,
         channel_id=channel_id,
@@ -360,3 +375,34 @@ def post_scout_report_to_slack(
         scout_team_id=run.team_id,
         integration_team_id=integration.team_id,
     )
+
+
+def _capture_scout_report_notification_sent(report: SignalReport, run: SignalScoutRun, *, notification_id: str) -> None:
+    """Record a scout report reaching a Slack channel, so its arrivals have a denominator.
+
+    A configured scout channel is a broadcast with no single recipient, so it attributes to the
+    team rather than to a person.
+    """
+    try:
+        ph_background_capture()(
+            distinct_id=str(report.team.uuid),
+            event="signals_notification_sent",
+            properties={
+                "notification_id": notification_id,
+                "report_id": str(report.id),
+                "team_id": report.team_id,
+                "channel": "slack",
+                "destination": "team",
+                "recipient_attribution": "group",
+                "mentioned_user_count": 0,
+                "dispatch_reason": "scout_report",
+                "skill_name": run.skill_name,
+            },
+            groups=groups(report.team.organization, report.team),
+        )
+    except Exception:
+        logger.exception(
+            "scout_report_notification_capture_failed",
+            report_id=str(report.id),
+            team_id=report.team_id,
+        )

--- a/products/signals/backend/slack_inbox_notifications.py
+++ b/products/signals/backend/slack_inbox_notifications.py
@@ -14,6 +14,7 @@ All sends are best-effort.
 from __future__ import annotations
 
 import json
+import uuid
 import logging
 from collections.abc import Iterable
 
@@ -21,8 +22,11 @@ from django.conf import settings
 
 from slack_sdk.errors import SlackApiError
 
+from posthog.event_usage import groups
 from posthog.models import User
 from posthog.models.integration import Integration, SlackIntegration
+from posthog.notification_links import tag_notification_url
+from posthog.ph_client import ph_background_capture
 
 from products.signals.backend.enums import SIGNAL_SOURCE_PRODUCT_LABELS
 from products.signals.backend.models import (
@@ -326,6 +330,7 @@ def _build_message_blocks(
     priority: str | None,
     source_products: list[str],
     reviewer_mentions: list[str],
+    report_url: str,
     repository: str | None = None,
 ) -> tuple[list[dict], str]:
     title_line = report.title or "New report"
@@ -378,7 +383,7 @@ def _build_message_blocks(
         {
             "type": "button",
             "text": {"type": "plain_text", "text": "Review in PostHog", "emoji": True},
-            "url": f"{settings.SITE_URL}/project/{report.team_id}/inbox/reports/{report.id}",
+            "url": report_url,
         }
     ]
     blocks.append({"type": "actions", "elements": action_elements})
@@ -604,6 +609,7 @@ def _deliver_route_notification(
     priority: str | None,
     source_products: list[str],
     repository: str | None,
+    dispatch_reason: str,
     signals: list[dict] | None = None,
 ) -> bool:
     """Post one report notification to a route's channel (with optional evidence thread).
@@ -612,12 +618,14 @@ def _deliver_route_notification(
     message was sent. Best-effort: Slack errors are logged, not raised.
     """
     channel_id = _channel_id_from_target(route.channel)
+    destination = "team" if route.is_team_channel else "user"
     log_context = {
         "report_id": str(report.id),
         "team_id": report.team_id,
         "channel": _channel_display_name(route.channel),
-        "destination": "team" if route.is_team_channel else "user",
+        "destination": destination,
     }
+    notification_id = str(uuid.uuid4())
     try:
         slack = SlackIntegration(route.integration)
         mentions = _resolve_reviewer_mentions(slack, route.users)
@@ -626,16 +634,88 @@ def _deliver_route_notification(
             priority=priority,
             source_products=source_products,
             reviewer_mentions=mentions,
+            report_url=tag_notification_url(
+                _inbox_report_url(report.team_id, str(report.id)),
+                source="slack",
+                surface=f"inbox_card_{destination}",
+                notification_id=notification_id,
+            ),
             repository=repository,
         )
         response = slack.client.chat_postMessage(channel=channel_id, blocks=blocks, text=text)
         thread_ts = response.get("ts") if hasattr(response, "get") else None
         if signals and thread_ts:
             _post_signal_evidence_thread(slack, channel_id, str(thread_ts), signals)
-        return True
     except Exception:
         logger.exception("Failed to deliver signals inbox-item Slack notification", extra=log_context)
         return False
+
+    _capture_notification_sent(
+        report,
+        route,
+        notification_id=notification_id,
+        destination=destination,
+        priority=priority,
+        source_products=source_products,
+        repository=repository,
+        dispatch_reason=dispatch_reason,
+        had_evidence_thread=bool(signals),
+    )
+    return True
+
+
+def _inbox_report_url(team_id: int, report_id: str) -> str:
+    return f"{settings.SITE_URL}/project/{team_id}/inbox/reports/{report_id}"
+
+
+def _capture_notification_sent(
+    report: SignalReport,
+    route: _ChannelRoute,
+    *,
+    notification_id: str,
+    destination: str,
+    priority: str | None,
+    source_products: list[str],
+    repository: str | None,
+    dispatch_reason: str,
+    had_evidence_thread: bool,
+) -> None:
+    """Record that a report notification went out, so arrivals have a denominator.
+
+    Without this, only the people who came back are visible, and silence, which is the response we
+    most need to measure, is indistinguishable from never having been told. Fired only after a
+    successful post, so a failed send can never read as one nobody answered.
+
+    A personal channel has exactly one recipient and attributes to them; a team channel is a
+    broadcast with no single recipient, so it attributes to the team and carries its reach in
+    `mentioned_user_count`.
+    """
+    recipient = route.users[0] if len(route.users) == 1 and not route.is_team_channel else None
+    try:
+        ph_background_capture()(
+            distinct_id=str(recipient.distinct_id) if recipient else str(report.team.uuid),
+            event="signals_notification_sent",
+            properties={
+                "notification_id": notification_id,
+                "report_id": str(report.id),
+                "team_id": report.team_id,
+                "channel": "slack",
+                "destination": destination,
+                "recipient_attribution": "person" if recipient else "group",
+                "mentioned_user_count": len(route.users),
+                "dispatch_reason": dispatch_reason,
+                "priority": priority,
+                "source_products": source_products,
+                "repository": repository,
+                "had_evidence_thread": had_evidence_thread,
+            },
+            groups=groups(report.team.organization, report.team),
+        )
+    except Exception:
+        logger.exception(
+            "Failed to capture signals_notification_sent",
+            extra={"report_id": str(report.id), "team_id": report.team_id},
+        )
 
 
 def dispatch_inbox_item_notifications(
@@ -710,6 +790,7 @@ def dispatch_inbox_item_notifications(
             priority=priority,
             source_products=sources,
             repository=repository,
+            dispatch_reason="report_ready",
             signals=signals,
         ):
             sent += 1
@@ -812,6 +893,7 @@ def dispatch_reviewer_added_notifications(
             priority=priority,
             source_products=sources,
             repository=repository,
+            dispatch_reason="reviewer_added",
         ):
             sent += 1
     logger.info(

--- a/products/signals/backend/test/test_auto_start.py
+++ b/products/signals/backend/test/test_auto_start.py
@@ -597,7 +597,8 @@ def test_autostart_description_lists_source_issues_only_when_references_exist(so
     if not expect_references:
         assert "Source issues" not in description
         assert "addressing" not in description
-        assert "inbox/reports/0198c0de-0000-7000-8000-000000000001).' -" in description
+        assert "inbox/reports/0198c0de-0000-7000-8000-000000000001?" in description
+        assert "utm_content=pr_footer).' -" in description
 
 
 @pytest.mark.parametrize(

--- a/products/signals/backend/test/test_scout_slack_delivery.py
+++ b/products/signals/backend/test/test_scout_slack_delivery.py
@@ -126,9 +126,10 @@ class TestScoutSlackDelivery(BaseTest):
         assert "<!channel>" not in section
         assert "&lt;!channel&gt;" in section
         assert "<https://example.com/trace|trace>" in section
-        assert call["blocks"][-1]["elements"][0]["url"] == (
-            f"{settings.SITE_URL}/project/{self.team.id}/inbox/reports/{report.id}"
-        )
+        button_url = call["blocks"][-1]["elements"][0]["url"]
+        assert button_url.startswith(f"{settings.SITE_URL}/project/{self.team.id}/inbox/reports/{report.id}?")
+        assert "utm_source=slack" in button_url
+        assert f"nid={delivery_id}" in button_url
         reply = fake_client.chat_postMessage.call_args_list[1].kwargs
         assert reply["thread_ts"] == "1785418710.000200"
         assert reply["blocks"][0]["type"] == "context"
@@ -171,9 +172,9 @@ class TestScoutSlackDelivery(BaseTest):
         assert "<!channel>" not in section
         assert "&lt;!channel&gt;" in section
         assert "failed for many users" not in section
-        assert call["blocks"][-1]["elements"][0]["url"] == (
-            f"{settings.SITE_URL}/project/{self.team.id}/inbox/reports/{report.id}"
-        )
+        note_url = call["blocks"][-1]["elements"][0]["url"]
+        assert note_url.startswith(f"{settings.SITE_URL}/project/{self.team.id}/inbox/reports/{report.id}?")
+        assert f"nid={delivery_id}" in note_url
 
     def test_enqueue_omits_edit_note_kwarg_when_unset(self) -> None:
         # A worker still running the previous task signature rejects an unknown kwarg, so every

--- a/products/signals/backend/test/test_slack_inbox_notifications.py
+++ b/products/signals/backend/test/test_slack_inbox_notifications.py
@@ -98,6 +98,7 @@ def test_build_message_blocks_includes_recipient_and_open_in_posthog_button() ->
         priority="P1",
         source_products=["error_tracking"],
         reviewer_mentions=["<@U123>"],
+        report_url=f"{settings.SITE_URL}/project/42/inbox/reports/report-uuid?utm_source=slack",
     )
 
     assert blocks[0]["text"]["text"] == "Checkout errors spiked"
@@ -114,7 +115,7 @@ def test_build_message_blocks_includes_recipient_and_open_in_posthog_button() ->
     buttons = blocks[3]["elements"]
     assert len(buttons) == 1
     assert buttons[0]["text"]["text"] == "Review in PostHog"
-    assert buttons[0]["url"] == f"{settings.SITE_URL}/project/42/inbox/reports/report-uuid"
+    assert buttons[0]["url"] == f"{settings.SITE_URL}/project/42/inbox/reports/report-uuid?utm_source=slack"
     assert text == "Report (P1): Checkout errors spiked"
 
 
@@ -125,6 +126,7 @@ def test_build_message_blocks_mentions_every_routed_reviewer() -> None:
         priority="P2",
         source_products=[],
         reviewer_mentions=["<@U1>", "<@U2>"],
+        report_url="https://app.example.com/inbox",
     )
 
     assert blocks[1]["text"]["text"] == "*🟠 P2*"
@@ -138,6 +140,7 @@ def test_build_message_blocks_includes_repository_in_metadata_line() -> None:
         priority="P2",
         source_products=["error_tracking"],
         reviewer_mentions=[],
+        report_url="https://app.example.com/inbox",
         repository="PostHog/posthog",
     )
 
@@ -157,6 +160,7 @@ def test_build_message_blocks_escapes_mrkdwn_in_llm_derived_fields() -> None:
         priority="P2",
         source_products=[],
         reviewer_mentions=[],
+        report_url="https://app.example.com/inbox",
         repository="<!channel>/repo",
     )
 
@@ -185,6 +189,7 @@ def test_build_message_blocks_prefixes_priority_with_emoji(priority: str, expect
         priority=priority,
         source_products=[],
         reviewer_mentions=["<@U123>"],
+        report_url="https://app.example.com/inbox",
     )
 
     assert blocks[1]["text"]["text"] == f"*{expected_priority_label}*"
@@ -336,7 +341,10 @@ def test_dispatch_sends_to_configured_reviewer(org_and_team):
     assert blocks[1]["text"]["text"].startswith("*❗ P1 · Error tracking*")
     assert "👤 Suggested reviewers: <@U_REVIEWER>" in blocks[2]["elements"][0]["text"]
     assert all("<@" not in t for t in _plain_text_block_texts(blocks))
-    assert blocks[3]["elements"][0]["url"] == f"{settings.SITE_URL}/project/{team.id}/inbox/reports/{report.id}"
+    button_url = blocks[3]["elements"][0]["url"]
+    assert button_url.startswith(f"{settings.SITE_URL}/project/{team.id}/inbox/reports/{report.id}?")
+    assert "utm_source=slack" in button_url
+    assert "utm_content=inbox_card_user" in button_url
 
 
 @pytest.mark.django_db
@@ -715,6 +723,94 @@ def test_dispatch_continues_after_per_user_failure(org_and_team):
 
     assert sent == 1
     assert fake_client.chat_postMessage.call_count == 2
+
+
+@pytest.mark.django_db
+def test_notification_sent_event_records_a_personal_delivery(org_and_team):
+    org, team = org_and_team
+    user = _make_reviewer_user(org, "recorded@example.com", "recorded-login")
+    integration = _make_slack_integration(team, user)
+    SignalUserAutonomyConfig.objects.create(
+        user=user,
+        slack_notification_integration=integration,
+        slack_notification_channel="C1|#personal",
+    )
+    report = _make_ready_report(team, priority=AutonomyPriority.P1, suggested_logins=["recorded-login"])
+
+    fake_client = MagicMock()
+    with (
+        patch("products.signals.backend.slack_inbox_notifications.SlackIntegration") as slack_cls,
+        patch("products.signals.backend.slack_inbox_notifications.lookup_slack_user_id_by_email", return_value=None),
+        patch("products.signals.backend.slack_inbox_notifications.ph_background_capture") as mock_capture_client,
+    ):
+        slack_cls.return_value.client = fake_client
+        capture = mock_capture_client.return_value
+        dispatch_inbox_item_notifications(str(report.id), team.id)
+
+    capture.assert_called_once()
+    kwargs = capture.call_args.kwargs
+    assert kwargs["event"] == "signals_notification_sent"
+    assert kwargs["distinct_id"] == str(user.distinct_id)
+    assert kwargs["properties"]["destination"] == "user"
+    assert kwargs["properties"]["recipient_attribution"] == "person"
+    assert kwargs["properties"]["dispatch_reason"] == "report_ready"
+    assert kwargs["properties"]["report_id"] == str(report.id)
+    # The id on the event is the one the link carries, or the two can never be joined.
+    assert (
+        kwargs["properties"]["notification_id"]
+        in fake_client.chat_postMessage.call_args.kwargs["blocks"][-1]["elements"][0]["url"]
+    )
+
+
+@pytest.mark.django_db
+def test_notification_sent_event_attributes_a_team_channel_to_the_group(org_and_team):
+    org, team = org_and_team
+    reviewer = _make_reviewer_user(org, "broadcast@example.com", "broadcast-login")
+    _make_slack_integration(team, reviewer)
+    _set_team_channel(team, "CTEAM|#posthog-signals")
+    report = _make_ready_report(team, priority=AutonomyPriority.P2, suggested_logins=["broadcast-login"])
+
+    with (
+        patch("products.signals.backend.slack_inbox_notifications.SlackIntegration") as slack_cls,
+        patch("products.signals.backend.slack_inbox_notifications.lookup_slack_user_id_by_email", return_value=None),
+        patch("products.signals.backend.slack_inbox_notifications.ph_background_capture") as mock_capture_client,
+    ):
+        slack_cls.return_value.client = MagicMock()
+        capture = mock_capture_client.return_value
+        dispatch_inbox_item_notifications(str(report.id), team.id)
+
+    kwargs = capture.call_args.kwargs
+    # A broadcast has no single recipient, so it counts for the team rather than for whoever
+    # happened to be mentioned in it.
+    assert kwargs["distinct_id"] == str(team.uuid)
+    assert kwargs["properties"]["destination"] == "team"
+    assert kwargs["properties"]["recipient_attribution"] == "group"
+    assert kwargs["groups"]["organization"] == str(org.id)
+
+
+@pytest.mark.django_db
+def test_failed_delivery_records_no_notification_sent(org_and_team):
+    # A failed send counted as a send would read as a notification nobody answered, which is the
+    # exact signal this event exists to measure.
+    org, team = org_and_team
+    reviewer = _make_reviewer_user(org, "failing@example.com", "failing-login")
+    _make_slack_integration(team, reviewer)
+    _set_team_channel(team, "CTEAM|#posthog-signals")
+    report = _make_ready_report(team, priority=AutonomyPriority.P1, suggested_logins=["failing-login"])
+
+    fake_client = MagicMock()
+    fake_client.chat_postMessage.side_effect = Exception("slack down")
+    with (
+        patch("products.signals.backend.slack_inbox_notifications.SlackIntegration") as slack_cls,
+        patch("products.signals.backend.slack_inbox_notifications.lookup_slack_user_id_by_email", return_value=None),
+        patch("products.signals.backend.slack_inbox_notifications.ph_background_capture") as mock_capture_client,
+    ):
+        slack_cls.return_value.client = fake_client
+        capture = mock_capture_client.return_value
+        sent = dispatch_inbox_item_notifications(str(report.id), team.id)
+
+    assert sent == 0
+    capture.assert_not_called()
 
 
 @pytest.mark.django_db

--- a/products/signals/docs/NOTIFICATIONS.md
+++ b/products/signals/docs/NOTIFICATIONS.md
@@ -1,0 +1,77 @@
+# How people find out about self-driving PRs
+
+Three paths bring a human to a self-driving PR. This document says what each one sends, what it records, and how an arrival in the app is tied back to the notification that produced it.
+
+## The three paths
+
+**GitHub.** The agent opens the PR, and the repository's own conventions decide who hears about it: CODEOWNERS, watch settings, or a person tagging a colleague. PostHog does not request reviewers itself. The PR description footer carries a link back to the inbox report (`auto_start.py`), tagged `utm_source=github`.
+
+**Slack.** Two different products post two different cards.
+
+| Sender                                         | Card                                             | Link                                         |
+| ---------------------------------------------- | ------------------------------------------------ | -------------------------------------------- |
+| `slack_inbox_notifications.py`                 | Report ready, and reviewer-added pings           | "Review in PostHog" only, never a PR link    |
+| `scout_harness/slack_delivery.py`              | A scout's report, to the configured channel      | "View report in PostHog"                     |
+| `tasks/.../post_slack_update.py` + `slack_app` | "Pull request opened", in the originating thread | "View PR" (github.com) and "Open in PostHog" |
+
+The inbox card fires when a report becomes ready and actionable, which is before any PR exists, so it never carries one.
+
+**In-app.** The person opens the inbox and finds the report themselves.
+
+## Send events
+
+Every successful send records one event, so non-response is measurable. Without them only arrivals are visible, and silence is indistinguishable from never having been told.
+
+### `signals_notification_sent`
+
+Emitted by `_deliver_route_notification` (report ready and reviewer added) and by the scout Slack delivery.
+
+| Property                | Type        | Description                                                                   |
+| ----------------------- | ----------- | ----------------------------------------------------------------------------- |
+| `notification_id`       | `str`       | Also the `nid` on the link in the message, which is how an arrival joins back |
+| `report_id`             | `str`       | The report the message is about                                               |
+| `channel`               | `str`       | `slack`                                                                       |
+| `destination`           | `str`       | `team` for a shared channel, `user` for a reviewer's own channel              |
+| `recipient_attribution` | `str`       | `person` when the destination has exactly one recipient, else `group`         |
+| `mentioned_user_count`  | `int`       | How many reviewers the message @-mentions                                     |
+| `dispatch_reason`       | `str`       | `report_ready`, `reviewer_added`, or `scout_report`                           |
+| `priority`              | `str`       | Report priority at send time                                                  |
+| `source_products`       | `list[str]` | Which products the report's signals came from                                 |
+| `repository`            | `str`       | Repository the report selected, when it has one                               |
+| `skill_name`            | `str`       | Scout deliveries only                                                         |
+
+A team channel is a broadcast with no single recipient, so it attributes to the team and carries its reach in `mentioned_user_count`. A personal channel attributes to that person.
+
+Only a successful `chat_postMessage` records an event. Counting a failed send would produce a notification that reads as ignored.
+
+`pr_notification_sent` covers the Slack-app PR card and is documented in [tasks instrumentation](../../tasks/docs/INSTRUMENTATION.md#pr_notification_sent).
+
+## Link tagging
+
+Every notification link is built through `tag_notification_url` (`posthog/notification_links.py`).
+
+| Parameter      | Value                                                                                     |
+| -------------- | ----------------------------------------------------------------------------------------- |
+| `utm_source`   | `slack` or `github`                                                                       |
+| `utm_medium`   | `notification`                                                                            |
+| `utm_campaign` | `self-driving-report`                                                                     |
+| `utm_content`  | `inbox_card_team`, `inbox_card_user`, `scout_delivery`, `pr_footer`, `pr_card`            |
+| `nid`          | The send's `notification_id`. Omitted on the PR footer link, which belongs to no one send |
+
+Campaign parameters rather than private names, because posthog-js already captures `utm_*` from the URL: the channel reaches analytics with no client-side change, and it survives a dropped send event.
+
+**`utm_medium=notification` is the exclusion key.** These are internal product links, not acquisition. Any marketing or web-analytics report that breaks traffic down by source should exclude it.
+
+## Arrivals
+
+`inboxSceneLogic` reads the parameters when a report URL is opened, hands them to `setInboxArrival`, and every report-level inbox event then carries `notification_id`, `notification_channel`, and `notification_surface` for the rest of the session. That is what makes act-rate by channel measurable, not just open-rate.
+
+`nid` is stripped from the URL after it is read, so a refresh cannot count as a second click on the same send. The `utm_*` parameters stay, because posthog-js reads them off the live URL.
+
+`open_method` on `Inbox report opened` is older and answers a different question: `deeplink` means the person landed straight on a report without visiting the list, whatever brought them there.
+
+## Known gaps
+
+- The "View PR" button on the Slack PR card leaves posthog.com, so its clicks are invisible. Measuring them needs a redirect shim.
+- A GitHub notification we did not send (a watcher, a CODEOWNERS rule firing before the PR reached us) has no send event. `pr_review_requested` records the tag itself, which is the closest available substitute.
+- Reviewer assignment inside PostHog still emits no event, so the set of people a report intended to reach is only reconstructable from its `suggested_reviewers` artefact.

--- a/products/signals/frontend/inbox/inboxAnalytics.test.ts
+++ b/products/signals/frontend/inbox/inboxAnalytics.test.ts
@@ -11,6 +11,7 @@ import {
     captureScoutConfigChanged,
     captureSignalSourceConnected,
     INBOX_EVENTS,
+    setInboxArrival,
 } from './inboxAnalytics'
 import { SignalReport, SignalReportStatus } from './types'
 
@@ -43,6 +44,26 @@ function makeReport(overrides: Partial<SignalReport> = {}): SignalReport {
 describe('inboxAnalytics', () => {
     beforeEach(() => {
         ;(posthog.capture as jest.Mock).mockClear()
+        setInboxArrival(null)
+    })
+
+    it('carries the notification that produced the visit onto later report actions', () => {
+        // The action is what makes a channel worth keeping, and it fires long after the arrival,
+        // so without this only the open would carry the channel.
+        setInboxArrival({ notificationId: 'n-1', channel: 'slack', surface: 'inbox_card_team' })
+
+        captureInboxReportAction({ report: makeReport(), actionType: 'open_pr', surface: 'detail_pane' })
+
+        const properties = lastCapture(INBOX_EVENTS.REPORT_ACTION)
+        expect(properties?.notification_id).toBe('n-1')
+        expect(properties?.notification_channel).toBe('slack')
+        expect(properties?.notification_surface).toBe('inbox_card_team')
+    })
+
+    it('leaves report events unmarked when the visit came from no notification', () => {
+        captureInboxReportAction({ report: makeReport(), actionType: 'open_pr', surface: 'detail_pane' })
+
+        expect(lastCapture(INBOX_EVENTS.REPORT_ACTION)).not.toHaveProperty('notification_channel')
     })
 
     it('stamps every event with the cloud client discriminator', () => {

--- a/products/signals/frontend/inbox/inboxAnalytics.ts
+++ b/products/signals/frontend/inbox/inboxAnalytics.ts
@@ -123,8 +123,50 @@ export type ScoutActionType =
 /** What a scout chat CTA was asking for. Matches the desktop values. */
 export type ScoutChatType = 'author_scout' | 'fleet_overview' | 'recent_signals'
 
+/** Which notification carried the person here. `channel` mirrors the link's `utm_source`. */
+export interface InboxArrival {
+    notificationId: string | null
+    channel: string | null
+    surface: string | null
+}
+
+/**
+ * The notification this session arrived from, if any.
+ *
+ * Held here rather than threaded through every capture call: the arrival is a property of the
+ * session, and the report actions that matter most (opening the PR, asking for one) fire from a
+ * dozen components. Without it we could measure open-rate by channel but not act-rate by channel,
+ * which is the more useful half. `inboxSceneLogic` owns deciding what the arrival is; this module
+ * only carries it onto the report events.
+ */
+let currentArrival: InboxArrival | null = null
+
+export function setInboxArrival(arrival: InboxArrival | null): void {
+    currentArrival = arrival
+}
+
+function arrivalProperties(): Record<string, unknown> {
+    if (!currentArrival) {
+        return {}
+    }
+    return {
+        notification_id: currentArrival.notificationId,
+        notification_channel: currentArrival.channel,
+        notification_surface: currentArrival.surface,
+    }
+}
+
 function captureInboxEvent(event: InboxEvent, properties: Record<string, unknown>, options?: CaptureOptions): void {
     posthog.capture(event, { inbox_client: INBOX_CLIENT, ...properties }, options)
+}
+
+/** As {@link captureInboxEvent}, plus the notification that brought the person to this report. */
+function captureInboxReportEvent(
+    event: InboxEvent,
+    properties: Record<string, unknown>,
+    options?: CaptureOptions
+): void {
+    captureInboxEvent(event, { ...arrivalProperties(), ...properties }, options)
 }
 
 /** Whole hours since the report was created, rounded to one decimal. Mirrors desktop `report_age_hours`. */
@@ -290,7 +332,7 @@ export function captureInboxReportOpened(params: {
     rank: number | null
     listSize: number | null
 }): void {
-    captureInboxEvent(INBOX_EVENTS.REPORT_OPENED, {
+    captureInboxReportEvent(INBOX_EVENTS.REPORT_OPENED, {
         ...baseReportProperties(params.report),
         status: params.report.status ?? null,
         source_products: params.report.source_products ?? [],
@@ -310,7 +352,7 @@ export function captureInboxReportClosed(
     /** The unload flush passes `{ send_instantly: true }` so the event leaves before the page goes. */
     options?: CaptureOptions
 ): void {
-    captureInboxEvent(
+    captureInboxReportEvent(
         INBOX_EVENTS.REPORT_CLOSED,
         {
             ...baseReportProperties(params.report),
@@ -333,7 +375,7 @@ export function captureInboxReportScrolled(params: {
     listSize: number | null
     timeSinceOpenMs: number
 }): void {
-    captureInboxEvent(INBOX_EVENTS.REPORT_SCROLLED, {
+    captureInboxReportEvent(INBOX_EVENTS.REPORT_SCROLLED, {
         ...baseReportProperties(params.report),
         rank: params.rank,
         list_size: params.listSize,
@@ -353,7 +395,7 @@ export function captureInboxReportAction(params: {
     const base = params.report
         ? baseReportProperties(params.report)
         : { report_id: null, report_age_hours: 0, priority: null, actionability: null }
-    captureInboxEvent(INBOX_EVENTS.REPORT_ACTION, {
+    captureInboxReportEvent(INBOX_EVENTS.REPORT_ACTION, {
         ...base,
         action_type: params.actionType,
         surface: params.surface,
@@ -375,7 +417,7 @@ export function captureInboxReportFeedback(params: {
     note?: string
     surface: InboxReportActionSurface
 }): void {
-    captureInboxEvent(INBOX_EVENTS.REPORT_FEEDBACK, {
+    captureInboxReportEvent(INBOX_EVENTS.REPORT_FEEDBACK, {
         ...baseReportProperties(params.report),
         sentiment: params.sentiment,
         has_pr: !!params.report.implementation_pr_url,
@@ -396,7 +438,7 @@ export function captureInboxReportFeedbackNote(params: {
     note: string
     surface: InboxReportActionSurface
 }): void {
-    captureInboxEvent(INBOX_EVENTS.REPORT_FEEDBACK_NOTE, {
+    captureInboxReportEvent(INBOX_EVENTS.REPORT_FEEDBACK_NOTE, {
         ...baseReportProperties(params.report),
         sentiment: params.sentiment,
         has_pr: !!params.report.implementation_pr_url,
@@ -469,7 +511,7 @@ export function captureInboxReportActionCompleted(params: {
     /** Only set for `blocked`, and only ever our own consent copy — never a server error body. */
     blockedReason?: string | null
 }): void {
-    captureInboxEvent(INBOX_EVENTS.REPORT_ACTION_COMPLETED, {
+    captureInboxReportEvent(INBOX_EVENTS.REPORT_ACTION_COMPLETED, {
         ...baseReportProperties(params.report),
         action_type: params.actionType,
         outcome: params.outcome,

--- a/products/signals/frontend/inbox/inboxSceneLogic.test.ts
+++ b/products/signals/frontend/inbox/inboxSceneLogic.test.ts
@@ -1,8 +1,24 @@
+import { router } from 'kea-router'
+
 import { OriginProduct, Task, TaskRun, TaskRunStatus } from 'products/posthog_ai/frontend/types/taskTypes'
 import { RuntimeEnumApi } from 'products/tasks/frontend/generated/api.schemas'
 
-import { mergeSignalRuns } from './inboxSceneLogic'
+import { setInboxArrival } from './inboxAnalytics'
+import { consumeArrivalParams, mergeSignalRuns } from './inboxSceneLogic'
 import { SignalScoutRunSummary } from './types'
+
+jest.mock('./inboxAnalytics', () => ({
+    ...jest.requireActual('./inboxAnalytics'),
+    setInboxArrival: jest.fn(),
+}))
+
+jest.mock('kea-router', () => ({
+    ...jest.requireActual('kea-router'),
+    router: {
+        actions: { replace: jest.fn() },
+        values: { location: { pathname: '/project/2/inbox/reports/r1' }, hashParams: {} },
+    },
+}))
 
 function scoutRun(overrides: Partial<SignalScoutRunSummary> = {}): SignalScoutRunSummary {
     return {
@@ -91,5 +107,38 @@ describe('mergeSignalRuns', () => {
         // The `TaskRunStatus` enum is bridged to the equivalent `SignalScoutRunStatus` string the row
         // field holds (here 'in_progress'), and the run's own timestamp wins over the task's.
         expect(row).toMatchObject({ status: 'in_progress', created_at: '2026-06-11T12:00:00Z' })
+    })
+})
+
+describe('consumeArrivalParams', () => {
+    beforeEach(() => {
+        ;(setInboxArrival as jest.Mock).mockClear()
+        ;(router.actions.replace as jest.Mock).mockClear()
+    })
+
+    it('records the channel and send from a tagged notification link', () => {
+        consumeArrivalParams({ nid: 'n-1', utm_source: 'slack', utm_content: 'inbox_card_team', tab: 'pulls' })
+
+        expect(setInboxArrival).toHaveBeenCalledWith({
+            notificationId: 'n-1',
+            channel: 'slack',
+            surface: 'inbox_card_team',
+        })
+    })
+
+    it('strips the send id but keeps the campaign parameters', () => {
+        // The send id has to go, or a refresh reads as a second click on the same notification.
+        // The utm parameters have to stay: posthog-js reads them off the live URL.
+        consumeArrivalParams({ nid: 'n-1', utm_source: 'slack', utm_medium: 'notification', tab: 'pulls' })
+
+        const [, searchParams] = (router.actions.replace as jest.Mock).mock.calls[0]
+        expect(searchParams).toEqual({ utm_source: 'slack', utm_medium: 'notification', tab: 'pulls' })
+    })
+
+    it('leaves an untagged visit alone', () => {
+        consumeArrivalParams({ tab: 'pulls' })
+
+        expect(setInboxArrival).not.toHaveBeenCalled()
+        expect(router.actions.replace).not.toHaveBeenCalled()
     })
 })

--- a/products/signals/frontend/inbox/inboxSceneLogic.ts
+++ b/products/signals/frontend/inbox/inboxSceneLogic.ts
@@ -25,6 +25,7 @@ import {
     captureInboxReportScrolled,
     InboxReportCloseMethod,
     InboxReportOpenMethod,
+    setInboxArrival,
 } from './inboxAnalytics'
 import { inboxFiltersLogic } from './logics/inboxFiltersLogic'
 import { INBOX_FLAT_TAB_LIST_PARAMS, reportListLogic } from './logics/reportListLogic'
@@ -49,6 +50,31 @@ const SCOUT_RUNS_LIMIT = 100
 // Signal-pipeline tasks to pull. Bounded symmetrically with the scout side (the tasks endpoint caps
 // at 100); passed explicitly so the cap is visible rather than relying on the server default.
 const SIGNAL_TASKS_LIMIT = 100
+
+/**
+ * Records which notification carried this session, from the parameters the send side tagged its
+ * link with (`utm_source` / `utm_content` name the channel and surface, `nid` identifies the send).
+ *
+ * Only `nid` is stripped afterwards, so a refresh can't count as a second click on the same send.
+ * The `utm_*` parameters stay: posthog-js reads campaign parameters off the live URL, so removing
+ * them would defeat the automatic capture that makes the channel readable on every event.
+ */
+export function consumeArrivalParams(searchParams: Record<string, any> | undefined): void {
+    const notificationId = searchParams?.['nid']
+    const channel = searchParams?.['utm_source']
+    if (notificationId === undefined && channel === undefined) {
+        return
+    }
+    setInboxArrival({
+        notificationId: notificationId === undefined ? null : String(notificationId),
+        channel: channel === undefined ? null : String(channel),
+        surface: searchParams?.['utm_content'] === undefined ? null : String(searchParams['utm_content']),
+    })
+    if (notificationId !== undefined) {
+        const { nid: _consumed, ...remainingSearchParams } = searchParams ?? {}
+        router.actions.replace(router.values.location.pathname, remainingSearchParams, router.values.hashParams)
+    }
+}
 
 /** Strips `#createScout=` from the URL so a refresh can't re-trigger it, then opens the modal. */
 function consumeScoutTemplateHash(
@@ -821,11 +847,15 @@ export const inboxSceneLogic = kea<inboxSceneLogicType>([
                 actions.setSelectedScoutSkillName(name, finding)
             }
         },
-        [urls.inboxReport(':tab', ':reportId')]: ({ tab, reportId }: { tab?: string; reportId?: string }) => {
+        [urls.inboxReport(':tab', ':reportId')]: (
+            { tab, reportId }: { tab?: string; reportId?: string },
+            searchParams: Record<string, any>
+        ) => {
             // This pattern also matches `/inbox/scouts/<skillName>`; the scout handler owns that path.
             if (tab === 'scouts') {
                 return
             }
+            consumeArrivalParams(searchParams)
             if (isStaffOnlyTab(tab) && userLogic.values.user != null && !values.isStaff) {
                 actions.setActiveTab('pulls')
                 return

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -428,7 +428,7 @@ class Task(DeletedMetaFields, models.Model):
                 distinct_id=distinct_id,
                 event=event,
                 properties=all_properties,
-                groups=groups(team=self.team),
+                groups=groups(self.team.organization, self.team),
                 send_feature_flags=True,
             )
         except Exception as e:
@@ -2348,8 +2348,9 @@ class TaskRun(models.Model):
         distinct_id_override: str | None = None,
     ) -> None:
         try:
-            # The override lets the PR webhook attribute pr_merged to the GitHub user who
-            # actually merged, rather than the task's assigned user.
+            # The override lets the PR webhook attribute an event to the GitHub user who actually
+            # acted, rather than the task's assigned user, or to the team when that user cannot be
+            # named, which is why the webhook passes a team uuid instead of leaving it unset.
             distinct_id = distinct_id_override or (
                 str(self.task.created_by.distinct_id)
                 if self.task.created_by_id and self.task.created_by
@@ -2382,7 +2383,10 @@ class TaskRun(models.Model):
                 "distinct_id": distinct_id,
                 "event": event,
                 "properties": all_properties,
-                "groups": groups(team=self.team),
+                # Passing the organization adds the customer group, which `groups(team=...)` alone
+                # cannot resolve. Most GitHub actor events attribute to the team rather than to a
+                # person, so group grain is what carries the analysis for them.
+                "groups": groups(self.team.organization, self.team),
                 "send_feature_flags": True,
             }
             if event_uuid:

--- a/products/tasks/backend/temporal/process_task/activities/post_slack_update.py
+++ b/products/tasks/backend/temporal/process_task/activities/post_slack_update.py
@@ -1,8 +1,10 @@
+import uuid
 from dataclasses import dataclass
 from typing import Any
 
 from temporalio import activity
 
+from posthog.notification_links import tag_notification_url
 from posthog.temporal.common.logger import get_logger
 from posthog.temporal.common.utils import close_db_connections
 
@@ -209,9 +211,30 @@ def _post_pr_opened_notification_once(
         mapping = SlackThreadTaskMapping.objects.filter(task_run=task_run).first()
         reply_target_slack_user_id = mapping.mentioning_slack_user_id if mapping else None
 
-    handler.post_pr_opened(pr_url, task_url, reply_target_slack_user_id=reply_target_slack_user_id)
+    # The card is the moment someone is told a PR exists, so its PostHog-bound button carries the
+    # channel. The github.com button can't: that click leaves our domain entirely.
+    notification_id = str(uuid.uuid4())
+    tagged_task_url = (
+        tag_notification_url(task_url, source="slack", surface="pr_card", notification_id=notification_id)
+        if task_url
+        else None
+    )
+
+    handler.post_pr_opened(pr_url, tagged_task_url, reply_target_slack_user_id=reply_target_slack_user_id)
 
     task_run.task.mark_slack_pr_notified(pr_url)
+
+    task_run.capture_event(
+        "pr_notification_sent",
+        {
+            "notification_id": notification_id,
+            "channel": "slack",
+            "surface": "pr_card",
+            "pr_url": pr_url,
+            "mentioned_slack_user": bool(reply_target_slack_user_id),
+            "recipient_attribution": "person" if task_run.task.created_by_id else "group",
+        },
+    )
 
 
 def _is_terminal_notified(task_run: Any, status: str, error: str | None = None) -> bool:

--- a/products/tasks/backend/tests/test_post_slack_update.py
+++ b/products/tasks/backend/tests/test_post_slack_update.py
@@ -16,6 +16,17 @@ PostSlackUpdateInput = _post_slack_update_module.PostSlackUpdateInput
 post_slack_update = _post_slack_update_module.post_slack_update
 
 
+def _assert_pr_card_posted(mock_post_pr_opened, *, pr_url: str, reply_target_slack_user_id: str | None) -> None:
+    """The card's PostHog link is tagged per send, so its notification id can't be asserted literally."""
+    mock_post_pr_opened.assert_called_once()
+    posted_pr_url, task_url = mock_post_pr_opened.call_args.args
+    assert posted_pr_url == pr_url
+    assert task_url.startswith("http://localhost:8000/project/1/tasks/10?runId=run-1&")
+    assert "utm_source=slack" in task_url
+    assert "utm_content=pr_card" in task_url
+    assert mock_post_pr_opened.call_args.kwargs["reply_target_slack_user_id"] == reply_target_slack_user_id
+
+
 @override_settings(SITE_URL="http://localhost:8000")
 class TestPostSlackUpdate(TestCase):
     def setUp(self):
@@ -226,9 +237,9 @@ class TestPostSlackUpdate(TestCase):
             )
         )
 
-        mock_post_pr_opened.assert_called_once_with(
-            "https://github.com/org/repo/pull/1",
-            "http://localhost:8000/project/1/tasks/10?runId=run-1",
+        _assert_pr_card_posted(
+            mock_post_pr_opened,
+            pr_url="https://github.com/org/repo/pull/1",
             reply_target_slack_user_id=expected_target,
         )
         mock_update_reaction.assert_called_once_with("eyes")
@@ -373,9 +384,9 @@ class TestPostSlackUpdate(TestCase):
         )
 
         mock_update_reaction.assert_called_once_with("hedgehog")
-        mock_post_pr_opened.assert_called_once_with(
-            "https://github.com/org/repo/pull/1",
-            "http://localhost:8000/project/1/tasks/10?runId=run-1",
+        _assert_pr_card_posted(
+            mock_post_pr_opened,
+            pr_url="https://github.com/org/repo/pull/1",
             reply_target_slack_user_id=None,
         )
 
@@ -469,9 +480,9 @@ class TestPostSlackUpdate(TestCase):
 
         post_slack_update(PostSlackUpdateInput(run_id="run-1", slack_thread_context=self.slack_thread_context))
 
-        mock_post_pr_opened.assert_called_once_with(
-            "https://github.com/org/repo/pull/2",
-            "http://localhost:8000/project/1/tasks/10?runId=run-1",
+        _assert_pr_card_posted(
+            mock_post_pr_opened,
+            pr_url="https://github.com/org/repo/pull/2",
             reply_target_slack_user_id=None,
         )
         mock_run.task.mark_slack_pr_notified.assert_called_once_with("https://github.com/org/repo/pull/2")
@@ -573,9 +584,9 @@ class TestPostSlackUpdate(TestCase):
         )
 
         mock_update_reaction.assert_called_once_with("hedgehog")
-        mock_post_pr_opened.assert_called_once_with(
-            "https://github.com/org/repo/pull/2",
-            "http://localhost:8000/project/1/tasks/10?runId=run-1",
+        _assert_pr_card_posted(
+            mock_post_pr_opened,
+            pr_url="https://github.com/org/repo/pull/2",
             reply_target_slack_user_id=None,
         )
 
@@ -695,8 +706,8 @@ class TestPostSlackUpdate(TestCase):
         )
 
         mock_update_reaction.assert_called_once_with("hedgehog")
-        mock_post_pr_opened.assert_called_once_with(
-            "https://github.com/org/repo/pull/2",
-            "http://localhost:8000/project/1/tasks/10?runId=run-1",
+        _assert_pr_card_posted(
+            mock_post_pr_opened,
+            pr_url="https://github.com/org/repo/pull/2",
             reply_target_slack_user_id=None,
         )

--- a/products/tasks/backend/tests/test_webhooks.py
+++ b/products/tasks/backend/tests/test_webhooks.py
@@ -126,15 +126,13 @@ class TestGitHubPRWebhook(TestCase):
 
     @parameterized.expand(
         [
-            ("resolvable_login", "Octocat", "merger-456", "merger-456"),
-            ("unresolvable_login", "stranger", None, "user-123"),
+            ("resolvable_login", "Octocat", True),
+            ("unresolvable_login", "stranger", False),
         ]
     )
     @patch("products.tasks.backend.facade.webhooks.get_github_webhook_secret")
     @patch("products.tasks.backend.models.posthoganalytics.capture")
-    def test_pr_merged_attributes_to_merger(
-        self, _name, merged_by_login, expected_property, expected_distinct_id, mock_capture, mock_get_secret
-    ):
+    def test_pr_merged_attributes_to_merger(self, _name, merged_by_login, resolvable, mock_capture, mock_get_secret):
         mock_get_secret.return_value = self.webhook_secret
         merger = User.objects.create(email="merger@example.com", distinct_id="merger-456")
         OrganizationMembership.objects.create(organization=self.organization, user=merger)
@@ -153,12 +151,24 @@ class TestGitHubPRWebhook(TestCase):
 
         self.assertEqual(response.status_code, 200)
         call_kwargs = mock_capture.call_args[1]
-        self.assertEqual(call_kwargs["distinct_id"], expected_distinct_id)
-        self.assertEqual(call_kwargs["properties"]["pr_merged_by_login"], merged_by_login)
-        self.assertEqual(call_kwargs["properties"]["pr_merged_by_id"], 583231)
-        self.assertEqual(call_kwargs["properties"].get("pr_merged_by_distinct_id"), expected_property)
+        properties = call_kwargs["properties"]
+        self.assertEqual(properties["pr_merged_by_login"], merged_by_login)
+        self.assertEqual(properties["pr_merged_by_id"], 583231)
+        if resolvable:
+            self.assertEqual(call_kwargs["distinct_id"], "merger-456")
+            self.assertEqual(properties["pr_merged_by_distinct_id"], "merger-456")
+            self.assertEqual(properties["actor_attribution"], "person")
+            self.assertEqual(properties["github_identity_source"], "sso")
+        else:
+            # An unknown merger counts against the team, never against the task's assignee, who
+            # did not merge anything.
+            self.assertEqual(call_kwargs["distinct_id"], str(self.team.uuid))
+            self.assertNotIn("pr_merged_by_distinct_id", properties)
+            self.assertEqual(properties["actor_attribution"], "group")
+            self.assertEqual(call_kwargs["groups"]["organization"], str(self.organization.id))
+            self.assertEqual(call_kwargs["groups"]["project"], str(self.team.uuid))
 
-    @patch("products.tasks.backend.webhooks.resolve_org_github_login_to_users", side_effect=RuntimeError("boom"))
+    @patch("products.tasks.backend.webhooks.resolve_org_github_logins_with_source", side_effect=RuntimeError("boom"))
     @patch("products.tasks.backend.facade.webhooks.get_github_webhook_secret")
     @patch("products.tasks.backend.models.posthoganalytics.capture")
     def test_pr_merged_by_resolution_failure_keeps_webhook_successful(
@@ -179,7 +189,7 @@ class TestGitHubPRWebhook(TestCase):
 
         self.assertEqual(response.status_code, 200)
         call_kwargs = mock_capture.call_args[1]
-        self.assertEqual(call_kwargs["distinct_id"], "user-123")
+        self.assertEqual(call_kwargs["distinct_id"], str(self.team.uuid))
         self.assertEqual(call_kwargs["properties"]["pr_merged_by_login"], "octocat")
         self.assertNotIn("pr_merged_by_distinct_id", call_kwargs["properties"])
 
@@ -476,6 +486,7 @@ class TestGitHubPRWebhook(TestCase):
             "pull_request": {
                 "html_url": "https://github.com/posthog/posthog/pull/123",
                 "merged": False,
+                "requested_reviewers": [{"login": "octocat", "id": 583231}, {"login": "hedgehog", "id": 7}],
             },
         }
 
@@ -486,6 +497,10 @@ class TestGitHubPRWebhook(TestCase):
         mock_capture.assert_called_once()
         call_kwargs = mock_capture.call_args[1]
         self.assertEqual(call_kwargs["event"], "pr_created")
+        # Whether anyone was tagged at open time answers "did GitHub notify a human about this PR"
+        # without joining to the review-request events.
+        self.assertEqual(call_kwargs["properties"]["pr_requested_reviewer_count"], 2)
+        self.assertEqual(call_kwargs["properties"]["pr_requested_reviewer_logins"], ["octocat", "hedgehog"])
 
     @patch("products.tasks.backend.facade.webhooks.get_github_webhook_secret")
     @patch("products.tasks.backend.models.posthoganalytics.capture")
@@ -818,14 +833,14 @@ class TestGitHubPRReviewWebhook(TestCase):
 
     @parameterized.expand(
         [
-            ("resolvable_login", "Octocat", "reviewer-456", "reviewer-456"),
-            ("unresolvable_login", "stranger", None, "user-123"),
+            ("resolvable_login", "Octocat", True),
+            ("unresolvable_login", "stranger", False),
         ]
     )
     @patch("products.tasks.backend.facade.webhooks.get_github_webhook_secret")
     @patch("products.tasks.backend.models.posthoganalytics.capture")
     def test_review_submission_attributes_to_reviewer(
-        self, _name, reviewer_login, expected_property, expected_distinct_id, mock_capture, mock_get_secret
+        self, _name, reviewer_login, resolvable, mock_capture, mock_get_secret
     ):
         mock_get_secret.return_value = self.webhook_secret
         reviewer = User.objects.create(email="reviewer@example.com", distinct_id="reviewer-456")
@@ -839,13 +854,21 @@ class TestGitHubPRReviewWebhook(TestCase):
 
         self.assertEqual(response.status_code, 200)
         call_kwargs = mock_capture.call_args[1]
+        properties = call_kwargs["properties"]
         self.assertEqual(call_kwargs["event"], "pr_reviewed")
-        self.assertEqual(call_kwargs["distinct_id"], expected_distinct_id)
-        self.assertEqual(call_kwargs["properties"]["pr_review_state"], "changes_requested")
-        self.assertEqual(call_kwargs["properties"]["pr_reviewed_by_login"], reviewer_login)
-        self.assertEqual(call_kwargs["properties"]["pr_reviewed_by_id"], 583231)
-        self.assertEqual(call_kwargs["properties"].get("pr_reviewed_by_distinct_id"), expected_property)
-        self.assertEqual(call_kwargs["properties"]["pr_source"], "task")
+        self.assertEqual(properties["pr_review_state"], "changes_requested")
+        self.assertEqual(properties["pr_reviewed_by_login"], reviewer_login)
+        self.assertEqual(properties["pr_reviewed_by_id"], 583231)
+        self.assertEqual(properties["pr_source"], "task")
+        if resolvable:
+            self.assertEqual(call_kwargs["distinct_id"], "reviewer-456")
+            self.assertEqual(properties["pr_reviewed_by_distinct_id"], "reviewer-456")
+            self.assertEqual(properties["actor_attribution"], "person")
+        else:
+            # An unknown reviewer counts against the team, never against the task's assignee.
+            self.assertEqual(call_kwargs["distinct_id"], str(self.team.uuid))
+            self.assertNotIn("pr_reviewed_by_distinct_id", properties)
+            self.assertEqual(properties["actor_attribution"], "group")
 
     @parameterized.expand(
         [
@@ -859,6 +882,137 @@ class TestGitHubPRReviewWebhook(TestCase):
         mock_get_secret.return_value = self.webhook_secret
 
         response = self._make_review_webhook_request(self._review_payload(reviewer, action=action))
+
+        self.assertEqual(response.status_code, 200)
+        mock_capture.assert_not_called()
+
+
+class TestGitHubPRReviewRequestWebhook(TestCase):
+    organization: ClassVar[Organization]
+    team: ClassVar[Team]
+    user: ClassVar[User]
+    task: ClassVar[Task]
+    task_run: ClassVar[TaskRun]
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.organization = Organization.objects.create(name="Test Org")
+        cls.team = Team.objects.create(organization=cls.organization, name="Test Team")
+        cls.user = User.objects.create(email="assignee@example.com", distinct_id="user-123")
+        cls.task = Task.objects.create(
+            team=cls.team,
+            created_by=cls.user,
+            title="Test Task",
+            description="Test description",
+            origin_product=Task.OriginProduct.USER_CREATED,
+            repository="posthog/posthog",
+        )
+        cls.task_run = TaskRun.objects.create(
+            task=cls.task,
+            team=cls.team,
+            status=TaskRun.Status.COMPLETED,
+            state={"verified_pr_urls": ["https://github.com/posthog/posthog/pull/123"]},
+            output={"pr_url": "https://github.com/posthog/posthog/pull/123"},
+        )
+
+    def setUp(self):
+        self.client = APIClient()
+        self.webhook_secret = "test-webhook-secret"
+
+    def _make_webhook_request(self, payload: dict):
+        payload_bytes = json.dumps(payload).encode("utf-8")
+        signature = generate_github_signature(payload_bytes, self.webhook_secret)
+        return self.client.post(
+            "/webhooks/github/pr/",
+            data=payload_bytes,
+            content_type="application/json",
+            headers={"x-hub-signature-256": signature, "x-github-event": "pull_request"},
+        )
+
+    def _request_payload(
+        self,
+        *,
+        action: str = "review_requested",
+        requested_reviewer: dict | None = None,
+        requested_team: dict | None = None,
+        pr_url: str = "https://github.com/posthog/posthog/pull/123",
+    ) -> dict:
+        payload: dict = {
+            "action": action,
+            "pull_request": {"html_url": pr_url, "updated_at": "2026-08-17T10:00:00Z"},
+            "sender": {"login": "author-person", "id": 42},
+        }
+        if requested_reviewer is not None:
+            payload["requested_reviewer"] = requested_reviewer
+        if requested_team is not None:
+            payload["requested_team"] = requested_team
+        return payload
+
+    @parameterized.expand(
+        [
+            ("resolvable", "review_requested", "Octocat", True, "pr_review_requested"),
+            ("unresolvable", "review_requested", "stranger", False, "pr_review_requested"),
+            ("removal", "review_request_removed", "Octocat", True, "pr_review_request_removed"),
+        ]
+    )
+    @patch("products.tasks.backend.facade.webhooks.get_github_webhook_secret")
+    @patch("products.tasks.backend.models.posthoganalytics.capture")
+    def test_review_request_records_who_was_tagged(
+        self, _name, action, reviewer_login, resolvable, expected_event, mock_capture, mock_get_secret
+    ):
+        mock_get_secret.return_value = self.webhook_secret
+        reviewer = User.objects.create(email="reviewer@example.com", distinct_id="reviewer-456")
+        OrganizationMembership.objects.create(organization=self.organization, user=reviewer)
+        UserSocialAuth.objects.create(user=reviewer, provider="github", uid="583231", extra_data={"login": "octocat"})
+
+        response = self._make_webhook_request(
+            self._request_payload(action=action, requested_reviewer={"login": reviewer_login, "id": 583231})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        call_kwargs = mock_capture.call_args[1]
+        properties = call_kwargs["properties"]
+        self.assertEqual(call_kwargs["event"], expected_event)
+        self.assertEqual(properties["pr_requested_reviewer_login"], reviewer_login)
+        self.assertEqual(properties["pr_requested_reviewer_id"], 583231)
+        self.assertEqual(properties["pr_review_requested_by_login"], "author-person")
+        self.assertEqual(properties["pr_source"], "task")
+        if resolvable:
+            self.assertEqual(call_kwargs["distinct_id"], "reviewer-456")
+            self.assertEqual(properties["pr_requested_reviewer_distinct_id"], "reviewer-456")
+            self.assertEqual(properties["actor_attribution"], "person")
+            self.assertEqual(properties["github_identity_source"], "sso")
+        else:
+            self.assertEqual(call_kwargs["distinct_id"], str(self.team.uuid))
+            self.assertNotIn("pr_requested_reviewer_distinct_id", properties)
+            self.assertEqual(properties["actor_attribution"], "group")
+
+    @patch("products.tasks.backend.facade.webhooks.get_github_webhook_secret")
+    @patch("products.tasks.backend.models.posthoganalytics.capture")
+    def test_team_review_request_is_recorded_without_a_reviewer(self, mock_capture, mock_get_secret):
+        mock_get_secret.return_value = self.webhook_secret
+
+        response = self._make_webhook_request(self._request_payload(requested_team={"slug": "platform-team", "id": 7}))
+
+        self.assertEqual(response.status_code, 200)
+        properties = mock_capture.call_args[1]["properties"]
+        self.assertEqual(properties["pr_requested_team_slug"], "platform-team")
+        self.assertNotIn("pr_requested_reviewer_login", properties)
+        self.assertEqual(properties["actor_attribution"], "group")
+
+    @patch("products.tasks.backend.facade.webhooks.get_github_webhook_secret")
+    @patch("products.tasks.backend.models.posthoganalytics.capture")
+    def test_review_request_on_an_unrelated_pr_is_not_captured(self, mock_capture, mock_get_secret):
+        # Every PR in an installed repo delivers here; capturing tags on PRs we did not open would
+        # bury the self-driving signal in ~90x its own volume.
+        mock_get_secret.return_value = self.webhook_secret
+
+        response = self._make_webhook_request(
+            self._request_payload(
+                requested_reviewer={"login": "octocat", "id": 583231},
+                pr_url="https://github.com/posthog/posthog/pull/999999",
+            )
+        )
 
         self.assertEqual(response.status_code, 200)
         mock_capture.assert_not_called()

--- a/products/tasks/backend/webhooks.py
+++ b/products/tasks/backend/webhooks.py
@@ -9,13 +9,14 @@ from django.http import HttpResponse
 import structlog
 import posthoganalytics
 
+from posthog.dataclasses import frozen
 from posthog.event_usage import groups
 from posthog.models.instance_setting import get_instance_setting
 from posthog.models.integration import Integration
 from posthog.models.team.team import Team
 
 from products.signals.backend.models import InvalidStatusTransition, SignalReport
-from products.signals.backend.report_generation.resolve_reviewers import resolve_org_github_login_to_users
+from products.signals.backend.report_generation.resolve_reviewers import resolve_org_github_logins_with_source
 from products.tasks.backend.facade.api import post_pr_created_thread_update, signal_workflow_completion
 from products.tasks.backend.facade.cancellation import cancel_task_run
 from products.tasks.backend.models import TaskRun
@@ -24,7 +25,7 @@ from products.tasks.backend.prompts import WIZARD_HEAD_BRANCH_PREFIX
 
 logger = structlog.get_logger(__name__)
 
-TASK_RUN_SELECT_RELATED = ("task", "task__created_by", "team")
+TASK_RUN_SELECT_RELATED = ("task", "task__created_by", "team", "team__organization")
 
 _TERMINAL_RUN_STATUSES = (TaskRun.Status.COMPLETED, TaskRun.Status.FAILED, TaskRun.Status.CANCELLED)
 
@@ -167,6 +168,9 @@ def handle_pull_request_event(payload: dict) -> HttpResponse:
         logger.warning("github_pr_webhook_no_pr_url", action=action)
         return HttpResponse(status=200)
 
+    if action in ("review_requested", "review_request_removed"):
+        return _handle_review_request_action(payload, action)
+
     if action == "opened":
         event_action = "created"
         analytics_event = "pr_created"
@@ -241,6 +245,66 @@ def handle_pull_request_event(payload: dict) -> HttpResponse:
             task_run.task_id, pr_url, SignalReport.Status.SUPPRESSED, "github_pr_webhook_signal_report_archived"
         )
 
+    return HttpResponse(status=200)
+
+
+def _handle_review_request_action(payload: dict, action: str) -> HttpResponse:
+    """Capture who GitHub tagged for review on one of our PRs.
+
+    PostHog never requests reviewers itself, so a tag comes from the repo's own CODEOWNERS, the
+    PR author, or a teammate, and it is the only record of the GitHub notification path, which
+    carries most self-driving PRs to a human.
+
+    Scoped to task-linked PRs on purpose: these webhooks arrive for every PR in an installed
+    repository, the vast majority of which PostHog did not open, and a tag on someone else's PR
+    says nothing about whether our notifications work.
+    """
+    pull_request = payload.get("pull_request") or {}
+    pr_url = pull_request.get("html_url")
+    task_run = find_task_run(
+        pr_url=pr_url,
+        branch=(pull_request.get("head") or {}).get("ref"),
+        repository=(payload.get("repository") or {}).get("full_name"),
+    )
+    if task_run is None:
+        logger.debug("github_pr_review_request_webhook_external_pr_skipped", pr_url=pr_url, action=action)
+        return HttpResponse(status=200)
+
+    requested_team_slug = (payload.get("requested_team") or {}).get("slug")
+    reviewer = _resolve_github_actor(payload.get("requested_reviewer") or {}, task_run.team_id)
+    requester = _resolve_github_actor(payload.get("sender") or {}, task_run.team_id)
+    analytics_event = "pr_review_requested" if action == "review_requested" else "pr_review_request_removed"
+
+    # A reviewer can legitimately be re-requested after they review, so the tagged identity alone
+    # would collapse those into one event; `updated_at` moves on each request.
+    event_uuid = str(
+        uuid.uuid5(
+            uuid.NAMESPACE_URL,
+            f"{pr_url}:{analytics_event}:{reviewer.login or requested_team_slug}:{pull_request.get('updated_at')}",
+        )
+    )
+
+    task_run.capture_event(
+        analytics_event,
+        {
+            **_pr_payload_properties(payload),
+            **_actor_identity_properties(reviewer, prefix="pr_requested_reviewer"),
+            **_attribution_properties(reviewer),
+            **_actor_identity_properties(requester, prefix="pr_review_requested_by"),
+            "pr_requested_team_slug": requested_team_slug,
+            "pr_source": "task",
+        },
+        event_uuid=event_uuid,
+        distinct_id_override=_group_or_person_distinct_id(reviewer, task_run.team),
+    )
+
+    logger.info(
+        "github_pr_review_request_webhook_processed",
+        action=action,
+        pr_url=pr_url,
+        run_id=str(task_run.id),
+        reviewer_resolved=reviewer.distinct_id is not None,
+    )
     return HttpResponse(status=200)
 
 
@@ -476,6 +540,10 @@ def _account_type(payload: dict) -> str | None:
 
 def _pr_payload_properties(payload: dict) -> dict:
     pull_request = payload.get("pull_request") or {}
+    # GitHub drops a reviewer from `requested_reviewers` once they submit a review, so this is
+    # who is still pending at event time, not everyone ever tagged. `pr_review_requested` carries
+    # the full history.
+    requested_reviewers = pull_request.get("requested_reviewers") or []
     return {
         "pr_url": pull_request.get("html_url"),
         "pr_number": pull_request.get("number"),
@@ -488,75 +556,110 @@ def _pr_payload_properties(payload: dict) -> dict:
         "pr_commits": pull_request.get("commits"),
         "account_type": _account_type(payload),
         "repo_owner_type": ((payload.get("repository") or {}).get("owner") or {}).get("type"),
+        "pr_requested_reviewer_count": len(requested_reviewers),
+        "pr_requested_reviewer_logins": [r.get("login") for r in requested_reviewers if r.get("login")],
     }
 
 
-def _resolve_github_login_distinct_id(login: str | None, team_id: int) -> str | None:
-    """Distinct id of the org member matching a GitHub login, or None when unresolvable."""
+@frozen
+class _GitHubActor:
+    """A GitHub user who acted on a PR: merged it, reviewed it, or was tagged to review it.
+
+    ``distinct_id`` is None for most actors, because a GitHub login only resolves when the person
+    linked that account to PostHog. Events for the rest attribute to the team's group rather than
+    to a stand-in person, so the act is still counted at org grain without being credited to
+    someone who did not perform it.
+    """
+
+    login: str | None
+    github_id: int | None
+    distinct_id: str | None
+    identity_source: str | None
+
+
+def _resolve_github_actor(github_user: dict, team_id: int) -> _GitHubActor:
+    """Map a GitHub user block from a webhook payload onto an org member where one matches."""
+    login = github_user.get("login")
+    github_id = github_user.get("id")
+    unresolved = _GitHubActor(login=login, github_id=github_id, distinct_id=None, identity_source=None)
     if not login:
-        return None
+        return unresolved
     try:
-        resolved = resolve_org_github_login_to_users(team_id, [login]).get(str(login).strip().lower())
+        match = resolve_org_github_logins_with_source(team_id, [login]).get(str(login).strip().lower())
     except Exception as e:
         logger.warning("github_webhook_login_resolution_failed", login=login, team_id=team_id, error=str(e))
-        return None
-    return str(resolved.distinct_id) if resolved is not None else None
+        return unresolved
+    if match is None:
+        return unresolved
+    return _GitHubActor(
+        login=login,
+        github_id=github_id,
+        distinct_id=str(match.user.distinct_id),
+        identity_source=match.source,
+    )
 
 
-def _merged_by_attribution(payload: dict, team_id: int) -> tuple[dict, str | None]:
-    """Identity of the GitHub user who merged the PR, resolved to a PostHog user when possible.
+def _actor_identity_properties(actor: _GitHubActor, *, prefix: str) -> dict:
+    """The ``<prefix>_login`` / ``_id`` / ``_distinct_id`` trio describing one actor on the event."""
+    if not actor.login:
+        return {}
+    properties: dict = {f"{prefix}_login": actor.login, f"{prefix}_id": actor.github_id}
+    if actor.distinct_id is not None:
+        properties[f"{prefix}_distinct_id"] = actor.distinct_id
+    return properties
 
-    Merging is the one unambiguous personal act in the loop, so when the merger's GitHub
-    login maps to an org member the pr_merged event attributes to them. Without a match the
-    event keeps the task's assigned user (an auto-resolved reviewer or fallback for
-    auto-started reports), so a consumer tells the two apart by the presence of
-    pr_merged_by_distinct_id.
+
+def _attribution_properties(actor: _GitHubActor) -> dict:
+    """Which grain the event is attributed at, and which identity linkage got us there.
+
+    ``actor_attribution`` saves every consumer from inferring the grain out of the shape of a
+    distinct id, and ``github_identity_source`` turns the unresolved majority into a diagnosis of
+    which linkage (personal integration, SSO, team integration) is missing.
     """
-    merged_by = (payload.get("pull_request") or {}).get("merged_by") or {}
-    login = merged_by.get("login")
-    if not login:
-        return {}, None
-    properties: dict = {"pr_merged_by_login": login, "pr_merged_by_id": merged_by.get("id")}
-    distinct_id = _resolve_github_login_distinct_id(login, team_id)
-    if distinct_id is not None:
-        properties["pr_merged_by_distinct_id"] = distinct_id
-    return properties, distinct_id
+    if actor.distinct_id is None:
+        return {"actor_attribution": "group"}
+    return {"actor_attribution": "person", "github_identity_source": actor.identity_source}
+
+
+def _group_or_person_distinct_id(actor: _GitHubActor, team: Team) -> str:
+    """The actor when we can name them, else the team, but never a stand-in person."""
+    return actor.distinct_id or str(team.uuid)
 
 
 def _capture_pr_review_event(payload: dict, task_run: TaskRun | None, event_uuid: str) -> None:
     review = payload.get("review") or {}
-    reviewer = review.get("user") or {}
-    login = reviewer.get("login")
-    review_properties: dict = {
-        "pr_review_state": review.get("state"),
-        "pr_reviewed_by_login": login,
-        "pr_reviewed_by_id": reviewer.get("id"),
-    }
-    pr_properties = {**_pr_payload_properties(payload), **review_properties}
+    review_state_properties: dict = {"pr_review_state": review.get("state")}
 
     if task_run is not None:
-        reviewer_distinct_id = _resolve_github_login_distinct_id(login, task_run.team_id)
-        if reviewer_distinct_id is not None:
-            pr_properties["pr_reviewed_by_distinct_id"] = reviewer_distinct_id
+        reviewer = _resolve_github_actor(review.get("user") or {}, task_run.team_id)
         task_run.capture_event(
             "pr_reviewed",
-            {**pr_properties, "pr_source": "task"},
+            {
+                **_pr_payload_properties(payload),
+                **review_state_properties,
+                **_actor_identity_properties(reviewer, prefix="pr_reviewed_by"),
+                **_attribution_properties(reviewer),
+                "pr_source": "task",
+            },
             event_uuid=event_uuid,
-            distinct_id_override=reviewer_distinct_id,
+            distinct_id_override=_group_or_person_distinct_id(reviewer, task_run.team),
         )
         return
 
     team = _resolve_external_team(payload)
     if team is None:
-        logger.debug("github_pr_review_webhook_unresolved_installation", pr_url=pr_properties.get("pr_url"))
+        logger.debug(
+            "github_pr_review_webhook_unresolved_installation",
+            pr_url=(payload.get("pull_request") or {}).get("html_url"),
+        )
         return
 
-    reviewer_distinct_id = _resolve_github_login_distinct_id(login, team.id)
-    if reviewer_distinct_id is not None:
-        pr_properties["pr_reviewed_by_distinct_id"] = reviewer_distinct_id
-
+    reviewer = _resolve_github_actor(review.get("user") or {}, team.id)
     properties: dict = {
-        **pr_properties,
+        **_pr_payload_properties(payload),
+        **review_state_properties,
+        **_actor_identity_properties(reviewer, prefix="pr_reviewed_by"),
+        **_attribution_properties(reviewer),
         "repository": ((payload.get("repository") or {}).get("full_name") or "").strip().lower() or None,
         "pr_source": "external",
         "team_id": team.id,
@@ -566,10 +669,10 @@ def _capture_pr_review_event(payload: dict, task_run: TaskRun | None, event_uuid
 
     try:
         posthoganalytics.capture(
-            distinct_id=reviewer_distinct_id or str(team.uuid),
+            distinct_id=_group_or_person_distinct_id(reviewer, team),
             event="pr_reviewed",
             properties=properties,
-            groups=groups(team=team),
+            groups=groups(team.organization, team),
             uuid=event_uuid,
         )
     except Exception as e:
@@ -578,17 +681,25 @@ def _capture_pr_review_event(payload: dict, task_run: TaskRun | None, event_uuid
 
 def _capture_pr_event(payload: dict, task_run: TaskRun | None, analytics_event: str, event_uuid: str) -> None:
     pr_properties = _pr_payload_properties(payload)
+    merged_by = (payload.get("pull_request") or {}).get("merged_by") or {}
 
     if task_run is not None:
-        merger_distinct_id: str | None = None
+        distinct_id_override: str | None = None
         if analytics_event == "pr_merged":
-            merged_by_properties, merger_distinct_id = _merged_by_attribution(payload, task_run.team_id)
-            pr_properties = {**pr_properties, **merged_by_properties}
+            # Merging is the one unambiguous personal act in the loop, so the event follows the
+            # merger rather than the task's assignee, who often had nothing to do with it.
+            merger = _resolve_github_actor(merged_by, task_run.team_id)
+            pr_properties = {
+                **pr_properties,
+                **_actor_identity_properties(merger, prefix="pr_merged_by"),
+                **_attribution_properties(merger),
+            }
+            distinct_id_override = _group_or_person_distinct_id(merger, task_run.team)
         task_run.capture_event(
             analytics_event,
             {**pr_properties, "pr_source": "task"},
             event_uuid=event_uuid,
-            distinct_id_override=merger_distinct_id,
+            distinct_id_override=distinct_id_override,
         )
         return
 
@@ -599,9 +710,13 @@ def _capture_pr_event(payload: dict, task_run: TaskRun | None, analytics_event: 
 
     external_distinct_id = str(team.uuid)
     if analytics_event == "pr_merged":
-        merged_by_properties, merger_distinct_id = _merged_by_attribution(payload, team.id)
-        pr_properties = {**pr_properties, **merged_by_properties}
-        external_distinct_id = merger_distinct_id or external_distinct_id
+        merger = _resolve_github_actor(merged_by, team.id)
+        pr_properties = {
+            **pr_properties,
+            **_actor_identity_properties(merger, prefix="pr_merged_by"),
+            **_attribution_properties(merger),
+        }
+        external_distinct_id = _group_or_person_distinct_id(merger, team)
 
     properties: dict = {
         **pr_properties,
@@ -617,7 +732,7 @@ def _capture_pr_event(payload: dict, task_run: TaskRun | None, analytics_event: 
             distinct_id=external_distinct_id,
             event=analytics_event,
             properties=properties,
-            groups=groups(team=team),
+            groups=groups(team.organization, team),
             uuid=event_uuid,
         )
     except Exception as e:
@@ -632,7 +747,7 @@ def _resolve_external_team(payload: dict) -> Team | None:
     # One installation can map to multiple teams; order_by makes attribution deterministic.
     integration = (
         Integration.objects.filter(kind="github", integration_id=str(installation_id))
-        .select_related("team")
+        .select_related("team", "team__organization")
         .order_by("team_id")
         .first()
     )

--- a/products/tasks/docs/INSTRUMENTATION.md
+++ b/products/tasks/docs/INSTRUMENTATION.md
@@ -184,22 +184,91 @@ The workflow emission feeds the `posthog_tasks_task_run_failed_total` Prometheus
 Source: `products/tasks/backend/webhooks.py`
 
 These events use `TaskRun.capture_event()` so include all [TaskRun standard properties](#taskrun-events).
+PRs that no task run claims (`pr_source = external`) are captured against the installation's team instead, with the task-attribution properties nulled.
+
+### Person vs group attribution
+
+Every event describing a **human act on GitHub** (`pr_merged`, `pr_reviewed`, `pr_review_requested`, `pr_review_request_removed`) follows one rule:
+
+- The GitHub login resolves to an org member: the event's `distinct_id` is that person, `actor_attribution` is `person`, and `github_identity_source` says which linkage matched (`personal_integration`, `sso`, `team_integration`).
+- It does not resolve: the event's `distinct_id` is the **team uuid** and `actor_attribution` is `group`. It is never attributed to the task's assignee, who did not perform the act.
+
+Most GitHub actors do not resolve, so read these events at organization or project grain (`uniq($group_0)`), not person grain.
+
+### Shared PR properties
+
+Every `pr_*` event carries the PR snapshot from the payload:
+
+| Property                       | Type        | Description                                                                              |
+| ------------------------------ | ----------- | ---------------------------------------------------------------------------------------- |
+| `pr_url`                       | `str`       | GitHub PR URL                                                                            |
+| `pr_number`                    | `int`       | PR number                                                                                |
+| `pr_author`                    | `str`       | Login of whoever opened the PR                                                           |
+| `pr_base_ref` / `pr_head_ref`  | `str`       | Base and head branches                                                                   |
+| `pr_requested_reviewer_count`  | `int`       | Reviewers still awaiting review at event time; GitHub drops a reviewer once they respond |
+| `pr_requested_reviewer_logins` | `list[str]` | Those reviewers' logins                                                                  |
+| `pr_source`                    | `str`       | `task` when a task run claims the PR, else `external`                                    |
 
 ### `pr_created`
 
-Tracked when a GitHub `pull_request.opened` webhook is received. Additional properties:
-
-| Property | Type  | Description   |
-| -------- | ----- | ------------- |
-| `pr_url` | `str` | GitHub PR URL |
+Tracked when a GitHub `pull_request.opened` webhook is received.
 
 ### `pr_merged`
 
-Tracked when a GitHub `pull_request.closed` webhook is received with `merged=true`. Same additional properties as `pr_created`.
+Tracked when a GitHub `pull_request.closed` webhook is received with `merged=true`. Additional properties:
+
+| Property                   | Type  | Description                                             |
+| -------------------------- | ----- | ------------------------------------------------------- |
+| `pr_merged_by_login`       | `str` | GitHub login of the merger                              |
+| `pr_merged_by_id`          | `int` | GitHub user id of the merger                            |
+| `pr_merged_by_distinct_id` | `str` | Present only when the merger resolved to a PostHog user |
 
 ### `pr_closed`
 
-Tracked when a GitHub `pull_request.closed` webhook is received with `merged=false`. Same additional properties as `pr_created`.
+Tracked when a GitHub `pull_request.closed` webhook is received with `merged=false`.
+
+### `pr_reviewed`
+
+Tracked when a GitHub `pull_request_review` webhook is received with `action=submitted`. Bot reviews (StampHog, ReviewHog, CI apps) are skipped so the human review signal stays readable. Additional properties:
+
+| Property                     | Type  | Description                                               |
+| ---------------------------- | ----- | --------------------------------------------------------- |
+| `pr_review_state`            | `str` | `approved`, `changes_requested`, or `commented`           |
+| `pr_reviewed_by_login`       | `str` | GitHub login of the reviewer                              |
+| `pr_reviewed_by_id`          | `int` | GitHub user id of the reviewer                            |
+| `pr_reviewed_by_distinct_id` | `str` | Present only when the reviewer resolved to a PostHog user |
+
+### `pr_review_requested` / `pr_review_request_removed`
+
+Tracked when a GitHub `pull_request` webhook is received with `action=review_requested` / `review_request_removed`.
+
+PostHog never requests reviewers itself, so this records who the repository's own CODEOWNERS, the PR author, or a teammate tagged. It is the only evidence that GitHub notified a person about a self-driving PR.
+
+**Task-linked PRs only.** These webhooks arrive for every PR in an installed repository, the vast majority of which PostHog did not open. A tag on someone else's PR says nothing about whether our notifications work, so it is dropped.
+
+| Property                             | Type  | Description                                                        |
+| ------------------------------------ | ----- | ------------------------------------------------------------------ |
+| `pr_requested_reviewer_login`        | `str` | GitHub login of the person tagged                                  |
+| `pr_requested_reviewer_id`           | `int` | GitHub user id of the person tagged                                |
+| `pr_requested_reviewer_distinct_id`  | `str` | Present only when that person resolved to a PostHog user           |
+| `pr_requested_team_slug`             | `str` | Set instead of the reviewer trio when a GitHub **team** was tagged |
+| `pr_review_requested_by_login`       | `str` | Who did the tagging (the webhook's `sender`)                       |
+| `pr_review_requested_by_distinct_id` | `str` | Present only when the requester resolved to a PostHog user         |
+
+### `pr_notification_sent`
+
+Source: `products/tasks/backend/temporal/process_task/activities/post_slack_update.py`
+
+Tracked when the "Pull request opened" card is posted to a Slack thread. The send side of the Slack path, so arrivals in the app have a denominator. See [signals notifications](../../signals/docs/NOTIFICATIONS.md) for the other senders and the link-tagging scheme.
+
+| Property                | Type   | Description                                                       |
+| ----------------------- | ------ | ----------------------------------------------------------------- |
+| `notification_id`       | `str`  | Matches the `nid` on the card's "Open in PostHog" link            |
+| `channel`               | `str`  | `slack`                                                           |
+| `surface`               | `str`  | `pr_card`                                                         |
+| `pr_url`                | `str`  | GitHub PR URL                                                     |
+| `mentioned_slack_user`  | `bool` | Whether the card @-mentioned someone                              |
+| `recipient_attribution` | `str`  | `person` when the run has a creator to attribute to, else `group` |
 
 ## API Events
 


### PR DESCRIPTION
## Problem

- A person merges a self-driving PR, and we cannot say what brought them to it.
- Three paths reach them: a GitHub review request, a Slack card, or the PostHog inbox.
- Over 30 days, 2,778 of 3,799 merged reports (73%) were never opened in the inbox, so most merges came from a channel nothing records.
- Every Slack sender is uninstrumented, so silence and never-being-told look identical.
- `open_method` on `Inbox report opened` says `deeplink` or `click`, never which channel. Referrer cannot fill the gap: `$direct` covers 10.4k of 15k opens against 75 for Slack.
- Only 26% of merges resolve the merger's GitHub login to a PostHog user, which caps every person-level question about the GitHub path.

## Changes

- Every notification link now carries its channel as campaign parameters, so an arrival names the send that produced it.
- `signals_notification_sent` records each successful Slack send (inbox card, reviewer-added ping, scout delivery); `pr_notification_sent` records the Slack PR card.
- The cloud inbox reads those parameters on arrival and carries `notification_id`, `notification_channel`, and `notification_surface` onto every report event for the session, so act-rate by channel is measurable and not just open-rate.
- `pr_review_requested` and `pr_review_request_removed` record who GitHub tagged for review, who tagged them, and whether either resolves to a PostHog user.
- `pr_created` carries the pending reviewer count and logins, so "was anyone tagged" needs no join.
- `github_identity_source` names the linkage that resolved a person (personal integration, SSO, team integration), turning the unresolved majority into a diagnosis rather than a number.

Campaign parameters (`utm_source=slack|github`, `utm_medium=notification`, `utm_content=<surface>`) rather than private names, because posthog-js already captures them: the channel reaches analytics with no client change and survives a dropped send event. `utm_medium=notification` is the key marketing reports exclude on. The opaque `nid` rides alongside for the per-send join, and is stripped from the URL after it is read so a refresh cannot count twice.

> [!WARNING]
> Attribution change. When a GitHub login does not resolve to an org member, `pr_merged`, `pr_reviewed`, and `pr_review_requested` now attribute to the team uuid with `actor_attribution: "group"`, instead of falling back to the task's assignee. Person-level counts on these events drop to the resolvable subset, about a quarter of merges. Organization and project counts are unchanged, and `groups()` now also carries the customer group. Read these events with `uniq($group_0)`. This is the second attribution shift on `pr_merged` after #78162.

Review requests are captured only for task-linked PRs. These webhooks arrive for every PR in an installed repository, the vast majority of which PostHog did not open.

Documented in `products/signals/docs/NOTIFICATIONS.md` (new) and `products/tasks/docs/INSTRUMENTATION.md`, which was already stale for `pr_reviewed`.

## How did you test this code?

I (actually Claude) ran these; nothing was exercised against GitHub, Slack, or a browser by hand.

- `products/tasks/backend/tests/`, the signals Slack, auto-start and reviewer-resolution suites, and the new link-helper test: 280 tests over the affected files on this branch, plus the full 2,269-test tasks suite on the pre-rebase tree.
- Repo-wide `mypy --cache-fine-grained .`: clean, apart from two pre-existing errors in `common/ingestion/acceptance_tests/api_client.py` caused by my local posthoganalytics being 7.38.3 where master pins 7.39.1.
- `hogli ci:preflight`: 0 failures.
- Jest (`inboxAnalytics`, `inboxSceneLogic`) and a scoped `tsc` passed, but jest ran on the pre-rebase tree because this branch's worktree has no `node_modules`. The type check did run against master's versions of both files, and master's edits to them sit in unrelated regions.

New tests and the regression each catches:

- Group attribution on an unresolved actor for merge, review, and review-request: the assignee fallback is the behavior being removed, and nothing else pinned it.
- Review request with a resolvable and an unresolvable login: the new branch being dropped, and attribution regressions.
- A `requested_team` payload: a crash on the team-request shape, which carries no `requested_reviewer`.
- A review request on an unrelated PR: the volume guard being removed.
- One `signals_notification_sent` per destination with the right attribution, and **none** when Slack raises: a failed send inflating the denominator.
- Link helper against a URL that already has a query string: double-`?` bugs across five call sites.
- Arrival parameters consumed and `nid` stripped: a refresh re-attributing a second open to the same send.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`products/signals/docs/NOTIFICATIONS.md` and `products/tasks/docs/INSTRUMENTATION.md`, both in this PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Opus 5 in Claude Code wrote this, directed by Georgiy after an analysis of how customers reach self-driving PRs. Dashboard: [Self-driving: how people find out about PRs](https://us.posthog.com/project/2/dashboard/2003240).
- Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`, `/querying-posthog-data`.
- The plan started with requesting reviewers on GitHub ourselves. Georgiy scoped it to measurement, and asked that unidentified actors count at group grain rather than against a stand-in person, which is where the attribution rule comes from.
- Two deviations from the plan, both found while implementing. `ph_background_capture` replaced `ph_scoped_capture`, whose per-call client setup and synchronous flush cost seconds on a long-lived worker. And only `nid` is stripped from the URL, because removing the `utm_*` parameters would defeat the automatic capture that motivated using them.
- `scout_harness/tools/report.py` was on the plan's list of links to tag and is not tagged: its URL feeds an analytics property, not a message anyone clicks.
- Nothing here came from a customer conversation, ticket, or log. The numbers in Problem are aggregate counts from PostHog's own analytics project, with PostHog's internal project excluded.
