### PR TITLE
feat(hogli): flag depot shadow drift in ci:preflight

### DIFF
--- a/tools/hogli-commands/hogli_commands/ci_preflight.py
+++ b/tools/hogli-commands/hogli_commands/ci_preflight.py
@@ -5,7 +5,8 @@ you what's broken on master, preflight stops you from being the one who breaks
 it. It scopes a curated set of checks to the files your branch actually touched,
 each mapped to a CI failure class we've seen take master down, plus an always-on
 branch-freshness check that flags concrete merge risks (textual conflicts,
-migration collisions, generated-file drift, CI changes on master).
+migration collisions, generated-file drift, CI changes on master), plus
+companion-file checks that fail when a mirrored file moves without its pair.
 
     hogli ci:preflight            # report what your diff could break in CI
     hogli ci:preflight --fix      # auto-remediate what's safe, report the rest
@@ -203,6 +204,36 @@ DIFF_CHECKS: list[DiffCheck] = [
 ]
 
 
+@dataclass(frozen=True)
+class CompanionCheck:
+    """Two files a CI gate requires to move together. Unlike a ``DiffCheck`` there is
+    nothing to run: the diff itself is the evidence, so this costs no subprocess."""
+
+    key: str
+    label: str
+    source: str
+    companion: str
+    guidance: str
+
+
+# Mirrors .github/workflows/ci-backend-shadow-drift.yml, which fails a PR that touches
+# canonical without the depot shadow. The pair is declared here as well so the failure
+# lands pre-push instead of a CI round-trip; ``test_shadow_drift_pair_matches_workflow``
+# binds the two declarations so they cannot drift apart.
+COMPANION_CHECKS: list[CompanionCheck] = [
+    CompanionCheck(
+        key="shadow-drift",
+        label="depot shadow drift (.depot mirror of ci-backend.yml)",
+        source=".github/workflows/ci-backend.yml",
+        companion=".depot/workflows/ci-backend.yml",
+        guidance=(
+            "mirror the change into {companion} — or, if it is one of the intentional "
+            "deltas, document it in that file's header"
+        ),
+    ),
+]
+
+
 def _has_node_modules() -> bool:
     return (REPO_ROOT / "node_modules" / ".pnpm").exists()
 
@@ -328,6 +359,12 @@ def _run_diff_check(chk: DiffCheck, do_fix: bool) -> tuple[Status, str]:
         return "pass", "fixed" if do_fix else "ok"
     lines = (result.stdout or result.stderr).strip().splitlines()
     return "fail", " · ".join(lines[:3]) if lines else f"exit {result.returncode}"
+
+
+def _run_companion_check(chk: CompanionCheck, files: list[str]) -> tuple[Status, str]:
+    if chk.companion in files:
+        return "pass", "both files updated"
+    return "fail", chk.guidance.format(companion=chk.companion)
 
 
 # Branch-freshness backstop thresholds. The risk signals in ``_staleness_risks``
@@ -555,6 +592,7 @@ def ci_preflight(do_fix: bool, strict: bool, against: str | None, as_json: bool)
         chk.matched = [f for f in files if matches_globs(f, chk.triggers)]
         if chk.matched:
             triggered.append(chk)
+    triggered_companions = [c for c in COMPANION_CHECKS if c.source in files]
 
     results: list[dict[str, Any]] = []
     failures = 0
@@ -571,6 +609,15 @@ def ci_preflight(do_fix: bool, strict: bool, against: str | None, as_json: bool)
         click.secho(f"   {_ICON[stale_status]} [staleness] branch freshness vs master", fg=_COLOR[stale_status])
         click.echo(f"       {stale_detail}")
 
+    # Free (set logic over the diff), so it runs before the subprocess-backed checks.
+    for companion in triggered_companions:
+        status, detail = _run_companion_check(companion, files)
+        failures += status == "fail"
+        results.append({"check": companion.key, "status": status, "files": 1, "detail": detail})
+        if not as_json:
+            click.secho(f"   {_ICON[status]} [{companion.key}] {companion.label}", fg=_COLOR[status])
+            click.echo(f"       {detail}")
+
     for chk in triggered:
         status, detail = _run_diff_check(chk, do_fix)
         failures += status == "fail"
@@ -584,7 +631,7 @@ def ci_preflight(do_fix: bool, strict: bool, against: str | None, as_json: bool)
 
     summary = {
         "changed_files": len(files),
-        "triggered": [c.key for c in triggered],
+        "triggered": [c.key for c in triggered_companions] + [c.key for c in triggered],
         "failures": failures,
         "advisories": advisories,
         "mode": "fix" if do_fix else ("strict" if strict else "advisory"),
@@ -594,7 +641,7 @@ def ci_preflight(do_fix: bool, strict: bool, against: str | None, as_json: bool)
     if as_json:
         click.echo(json.dumps(summary))
     else:
-        if not triggered:
+        if not triggered and not triggered_companions:
             click.secho("   ✓ Nothing in this diff maps to a known CI failure class.", fg="green")
         click.echo()
         click.echo(

--- a/tools/hogli-commands/hogli_commands/ci_preflight.py
+++ b/tools/hogli-commands/hogli_commands/ci_preflight.py
@@ -204,8 +204,6 @@ DIFF_CHECKS: list[DiffCheck] = [
 ]
 
 
-# Mirrors the house `@frozen` defaults; hogli can't import posthog.dataclasses, since
-# it has to run on a bare checkout. kw_only earns its place here — every field is a str.
 @dataclass(frozen=True, kw_only=True, slots=True)
 class CompanionCheck:
     """Two files a CI gate requires to move together. Unlike a ``DiffCheck`` there is
@@ -218,10 +216,8 @@ class CompanionCheck:
     guidance: str
 
 
-# Mirrors .github/workflows/ci-backend-shadow-drift.yml, which fails a PR that touches
-# canonical without the depot shadow. The pair is declared here as well so the failure
-# lands pre-push instead of a CI round-trip; ``test_shadow_drift_pair_matches_workflow``
-# binds the two declarations so they cannot drift apart.
+# Duplicated from .github/workflows/ci-backend-shadow-drift.yml so the failure lands
+# pre-push instead of a CI round-trip. A test binds the two so they cannot drift.
 COMPANION_CHECKS: list[CompanionCheck] = [
     CompanionCheck(
         key="shadow-drift",

--- a/tools/hogli-commands/hogli_commands/ci_preflight.py
+++ b/tools/hogli-commands/hogli_commands/ci_preflight.py
@@ -204,7 +204,9 @@ DIFF_CHECKS: list[DiffCheck] = [
 ]
 
 
-@dataclass(frozen=True)
+# Mirrors the house `@frozen` defaults; hogli can't import posthog.dataclasses, since
+# it has to run on a bare checkout. kw_only earns its place here — every field is a str.
+@dataclass(frozen=True, kw_only=True, slots=True)
 class CompanionCheck:
     """Two files a CI gate requires to move together. Unlike a ``DiffCheck`` there is
     nothing to run: the diff itself is the evidence, so this costs no subprocess."""

--- a/tools/hogli-commands/hogli_commands/ci_preflight.py
+++ b/tools/hogli-commands/hogli_commands/ci_preflight.py
@@ -206,14 +206,14 @@ DIFF_CHECKS: list[DiffCheck] = [
 
 @dataclass(frozen=True, kw_only=True, slots=True)
 class CompanionCheck:
-    """Two files a CI gate requires to move together. Unlike a ``DiffCheck`` there is
-    nothing to run: the diff itself is the evidence, so this costs no subprocess."""
+    """Two files a CI gate requires to move together. The diff is the evidence, so
+    unlike a ``DiffCheck`` there is nothing to run."""
 
     key: str
     label: str
     source: str
     companion: str
-    guidance: str
+    escape_hatch: str  # what to do when the change is deliberately one-sided
 
 
 # Duplicated from .github/workflows/ci-backend-shadow-drift.yml so the failure lands
@@ -224,10 +224,7 @@ COMPANION_CHECKS: list[CompanionCheck] = [
         label="depot shadow drift (.depot mirror of ci-backend.yml)",
         source=".github/workflows/ci-backend.yml",
         companion=".depot/workflows/ci-backend.yml",
-        guidance=(
-            "mirror the change into {companion} — or, if it is one of the intentional "
-            "deltas, document it in that file's header"
-        ),
+        escape_hatch="document it as an intentional delta in that file's header",
     ),
 ]
 
@@ -362,7 +359,7 @@ def _run_diff_check(chk: DiffCheck, do_fix: bool) -> tuple[Status, str]:
 def _run_companion_check(chk: CompanionCheck, files: list[str]) -> tuple[Status, str]:
     if chk.companion in files:
         return "pass", "both files updated"
-    return "fail", chk.guidance.format(companion=chk.companion)
+    return "fail", f"mirror the change into {chk.companion}, or {chk.escape_hatch}"
 
 
 # Branch-freshness backstop thresholds. The risk signals in ``_staleness_risks``
@@ -607,7 +604,6 @@ def ci_preflight(do_fix: bool, strict: bool, against: str | None, as_json: bool)
         click.secho(f"   {_ICON[stale_status]} [staleness] branch freshness vs master", fg=_COLOR[stale_status])
         click.echo(f"       {stale_detail}")
 
-    # Free (set logic over the diff), so it runs before the subprocess-backed checks.
     for companion in triggered_companions:
         status, detail = _run_companion_check(companion, files)
         failures += status == "fail"

--- a/tools/hogli-commands/hogli_commands/tests/test_ci_preflight.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_ci_preflight.py
@@ -7,7 +7,13 @@ from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
 from hogli.cli import cli
-from hogli_commands.ci_preflight import DIFF_CHECKS, _pnpm_workspace_root, _run_workspace_scoped, _staleness_risks
+from hogli_commands.ci_preflight import (
+    COMPANION_CHECKS,
+    DIFF_CHECKS,
+    _pnpm_workspace_root,
+    _run_workspace_scoped,
+    _staleness_risks,
+)
 
 runner = CliRunner()
 
@@ -207,3 +213,53 @@ class TestWorkspaceScopedLockfile:
 
         assert status == "skipped"
         assert "products/desktop: needs node" in detail
+
+
+class TestShadowDriftCompanion:
+    """The depot shadow gate is a CI hard-fail that costs a full round-trip to learn about.
+    Preflight has to reach the same verdict from the diff alone."""
+
+    @pytest.mark.parametrize(
+        "changed,expected_exit,expected_fragment",
+        [
+            ([".github/workflows/ci-backend.yml"], 1, "mirror the change into .depot/workflows/ci-backend.yml"),
+            ([".github/workflows/ci-backend.yml", ".depot/workflows/ci-backend.yml"], 0, "both files updated"),
+            # Depot-only is a notice in CI, never a failure — blocking it would false-block depot tuning.
+            ([".depot/workflows/ci-backend.yml"], 0, ""),
+        ],
+    )
+    @patch("hogli_commands.ci_preflight._emit_telemetry")
+    @patch("hogli_commands.ci_preflight._staleness", return_value=("pass", "even with master", {}))
+    @patch("hogli_commands.ci_preflight._fetch_master")
+    @patch("hogli_commands.ci_preflight.shutil.which", return_value=None)
+    def test_verdict_matches_ci(
+        self,
+        mock_which: MagicMock,
+        mock_fetch: MagicMock,
+        mock_stale: MagicMock,
+        mock_emit: MagicMock,
+        changed: list[str],
+        expected_exit: int,
+        expected_fragment: str,
+    ) -> None:
+        with patch("hogli_commands.ci_preflight.changed_files", return_value=changed):
+            result = runner.invoke(cli, ["ci:preflight", "--strict"])
+
+        assert result.exit_code == expected_exit
+        if expected_fragment:
+            assert expected_fragment in result.output
+        else:
+            assert "shadow-drift" not in result.output
+
+    def test_pair_matches_workflow(self) -> None:
+        """The pair is declared here and in the workflow. If they drift, the local gate
+        silently stops matching CI — which is the failure this whole check exists to stop."""
+        import yaml
+        from hogli.manifest import REPO_ROOT
+
+        workflow = yaml.safe_load((REPO_ROOT / ".github" / "workflows" / "ci-backend-shadow-drift.yml").read_text())
+        # `on` parses as the boolean True in YAML 1.1.
+        watched = set(workflow[True]["pull_request"]["paths"])
+        shadow = next(chk for chk in COMPANION_CHECKS if chk.key == "shadow-drift")
+
+        assert watched == {shadow.source, shadow.companion}

--- a/tools/hogli-commands/hogli_commands/tests/test_ci_preflight.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_ci_preflight.py
@@ -221,7 +221,7 @@ class TestShadowDriftCompanion:
         [
             ([".github/workflows/ci-backend.yml"], 1, "mirror the change into .depot/workflows/ci-backend.yml"),
             ([".github/workflows/ci-backend.yml", ".depot/workflows/ci-backend.yml"], 0, "both files updated"),
-            # Depot-only is a notice in CI, never a failure — blocking it would false-block depot tuning.
+            # Depot-only is a notice in CI, never a failure. Blocking it would false-block depot tuning.
             ([".depot/workflows/ci-backend.yml"], 0, ""),
         ],
     )

--- a/tools/hogli-commands/hogli_commands/tests/test_ci_preflight.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_ci_preflight.py
@@ -216,9 +216,6 @@ class TestWorkspaceScopedLockfile:
 
 
 class TestShadowDriftCompanion:
-    """The depot shadow gate is a CI hard-fail that costs a full round-trip to learn about.
-    Preflight has to reach the same verdict from the diff alone."""
-
     @pytest.mark.parametrize(
         "changed,expected_exit,expected_fragment",
         [
@@ -252,8 +249,6 @@ class TestShadowDriftCompanion:
             assert "shadow-drift" not in result.output
 
     def test_pair_matches_workflow(self) -> None:
-        """The pair is declared here and in the workflow. If they drift, the local gate
-        silently stops matching CI — which is the failure this whole check exists to stop."""
         import yaml
         from hogli.manifest import REPO_ROOT
 


### PR DESCRIPTION
## Problem

Editing `.github/workflows/ci-backend.yml` without its `.depot/` mirror fails a required CI check, and you only find out after pushing.
The gate is [ci-backend-shadow-drift.yml](https://github.com/PostHog/posthog/blob/master/.github/workflows/ci-backend-shadow-drift.yml), and it costs a full round-trip to learn about.

- I hit it this week on [my own curl-retry PR](https://github.com/PostHog/posthog/pull/83712) ([failing check](https://github.com/PostHog/posthog/actions/runs/32026976161/job/95378331496)).
- `ci:preflight` already intercepts lint, lockfile and migration failures pre-push. It did not know about this one.

## Changes

`ci:preflight` now reaches the same verdict as the CI gate, from the diff alone.

- A `CompanionCheck` declares two files that must move together. It is a separate shape from `DiffCheck`, which runs a subprocess; this is set logic over the diff preflight already computed, so it adds no work and runs before the subprocess-backed checks.
- The result counts as a `fail`, so `--strict` blocks the push exactly where CI would block the PR.
- No `--fix`. Nothing can decide for you whether a change is one of the depot-exempt deltas, so guessing would be worse than failing.
- A depot-only change stays a pass, matching CI, which treats it as a notice.

```text
✗ [shadow-drift] depot shadow drift (.depot mirror of ci-backend.yml)
    mirror the change into .depot/workflows/ci-backend.yml — or, if it is one of
    the intentional deltas, document it in that file's header
```

The file pair is now declared in two places, here and in the workflow.
Preflight cannot derive it: the workflow's `paths:` lists both files with no marker for which one is the mirror.
So `test_pair_matches_workflow` parses the workflow and asserts the two agree, and the local gate cannot silently stop matching CI.

> [!NOTE]
> `CompanionCheck` uses `@dataclass(frozen=True, kw_only=True, slots=True)` rather than `@frozen` from `posthog.dataclasses`. `hogli_commands` imports nothing from `posthog`, because preflight has to run on a bare checkout. The decorator mirrors the house defaults by hand.

## How did you test this code?

I drove the real command against the real repo, not only the mocked CLI:

<details>
<summary>Throwaway commit touching canonical alone, then mirrored</summary>

```text
# canonical only
✗ [shadow-drift] depot shadow drift (.depot mirror of ci-backend.yml)
summary {"failures": 1, "mode": "strict"}
exit=1

# after mirroring into .depot/
✓ [shadow-drift] depot shadow drift (.depot mirror of ci-backend.yml)
       both files updated
summary {"failures": 0, "mode": "strict"}
exit=0
```

</details>

Four tests added to `test_ci_preflight.py`:

- One parameterized case per diff shape. Catches a preflight that goes green while CI is red, and an inverted condition that would false-block every `ci-backend.yml` edit.
- `test_pair_matches_workflow`. Catches the two declarations drifting apart, which is the exact failure the check exists to prevent.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude) wrote this after hitting the gate on an unrelated PR.

- Skills invoked: `/writing-tests`, `/writing-dataclasses`, `/writing-pr-descriptions`, `/writing-code-comments`.
- I first considered extending `DiffCheck` with a companion field. That would have mixed two modes into one dataclass and forced a special case into `_run_diff_check`, so the second shape stayed separate.
- Considered and rejected: having preflight parse the workflow at runtime for a single source of truth. The `paths:` list cannot express which file is the mirror, and it would add YAML parsing to a hot path. A test binds the two declarations instead.
- This is deliberately not stacked on the curl PR. The two share no files and neither depends on the other.
