### PR TITLE
feat(insights): inline behavioral (performed event) property filter

### DIFF
--- a/bin/patch-schema-property-filter-discriminator.py
+++ b/bin/patch-schema-property-filter-discriminator.py
@@ -59,6 +59,7 @@ MEMBER_TAGS: dict[str, str] = {
     "RevenueAnalyticsPropertyFilter": "revenue_analytics",
     "AccountCustomPropertyFilter": "account_custom_property",
     "WorkflowVariablePropertyFilter": "workflow_variable",
+    "BehavioralPropertyFilter": "behavioral",
 }
 
 # How many union sites each rewrite must hit. A mismatch means the schema changed

--- a/frontend/src/lib/components/PropertyFilters/utils.ts
+++ b/frontend/src/lib/components/PropertyFilters/utils.ts
@@ -123,7 +123,6 @@ export const PROPERTY_FILTER_TYPE_TO_TAXONOMIC_FILTER_GROUP_TYPE: Record<Propert
         [PropertyFilterType.PersonMetadata]: TaxonomicFilterGroupType.PersonMetadata,
         [PropertyFilterType.Feature]: TaxonomicFilterGroupType.EventFeatureFlags,
         [PropertyFilterType.Cohort]: TaxonomicFilterGroupType.Cohorts,
-        // Behavioral filters reference an event (or action) rather than a property
         [PropertyFilterType.Behavioral]: TaxonomicFilterGroupType.Events,
         [PropertyFilterType.Element]: TaxonomicFilterGroupType.Elements,
         [PropertyFilterType.Session]: TaxonomicFilterGroupType.SessionProperties,

--- a/frontend/src/lib/components/PropertyFilters/utils.ts
+++ b/frontend/src/lib/components/PropertyFilters/utils.ts
@@ -123,6 +123,8 @@ export const PROPERTY_FILTER_TYPE_TO_TAXONOMIC_FILTER_GROUP_TYPE: Record<Propert
         [PropertyFilterType.PersonMetadata]: TaxonomicFilterGroupType.PersonMetadata,
         [PropertyFilterType.Feature]: TaxonomicFilterGroupType.EventFeatureFlags,
         [PropertyFilterType.Cohort]: TaxonomicFilterGroupType.Cohorts,
+        // Behavioral filters reference an event (or action) rather than a property
+        [PropertyFilterType.Behavioral]: TaxonomicFilterGroupType.Events,
         [PropertyFilterType.Element]: TaxonomicFilterGroupType.Elements,
         [PropertyFilterType.Session]: TaxonomicFilterGroupType.SessionProperties,
         [PropertyFilterType.HogQL]: TaxonomicFilterGroupType.HogQLExpression,

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -5900,7 +5900,7 @@
         },
         "BehavioralPropertyFilter": {
             "additionalProperties": false,
-            "description": "Filters persons on whether they performed an event (optionally a number of times) within a time window, without needing a saved cohort. Shares the cohort criteria vocabulary (`BehavioralEventType`), but only the \"performed event\" family is supported inline — sequences and lifecycle criteria still require a cohort. Event scope only: person scope needs `id IN (SELECT person_id FROM events ...)`, which HogQL cannot yet resolve under a `persons` FROM. Filter the underlying insight instead, or use a cohort.",
+            "description": "Filters persons on whether they performed an event in a time window, without a saved cohort. Event scope only.",
             "properties": {
                 "event_filters": {
                     "description": "Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral/cohort filters and groups",

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -1832,6 +1832,9 @@
                 },
                 {
                     "$ref": "#/definitions/EmptyPropertyFilter"
+                },
+                {
+                    "$ref": "#/definitions/BehavioralPropertyFilter"
                 }
             ],
             "description": "Any filter type supported by `property_to_expr(scope=\"person\", ...)`."
@@ -1906,6 +1909,9 @@
                 },
                 {
                     "$ref": "#/definitions/WorkflowVariablePropertyFilter"
+                },
+                {
+                    "$ref": "#/definitions/BehavioralPropertyFilter"
                 }
             ]
         },
@@ -5889,6 +5895,86 @@
                 "first_matching_event_for_user"
             ],
             "type": "string"
+        },
+        "BehavioralEventSource": {
+            "description": "Whether a behavioral filter's `key` refers to an event name or an action id",
+            "enum": ["events", "actions"],
+            "type": "string"
+        },
+        "BehavioralPropertyFilter": {
+            "additionalProperties": false,
+            "description": "Filters persons on whether they performed an event (optionally a number of times) within a time window, without needing a saved cohort. Shares the cohort criteria vocabulary (`BehavioralEventType`), but only the \"performed event\" family is supported inline — sequences and lifecycle criteria still require a cohort.",
+            "properties": {
+                "event_filters": {
+                    "description": "Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral/cohort filters and groups",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/EventPropertyFilter"
+                            },
+                            {
+                                "$ref": "#/definitions/PersonPropertyFilter"
+                            },
+                            {
+                                "$ref": "#/definitions/ElementPropertyFilter"
+                            },
+                            {
+                                "$ref": "#/definitions/FeaturePropertyFilter"
+                            },
+                            {
+                                "$ref": "#/definitions/HogQLPropertyFilter"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "event_type": {
+                    "$ref": "#/definitions/BehavioralEventSource"
+                },
+                "explicit_datetime": {
+                    "description": "Absolute or relative (e.g. -30d) lower date bound — alternative to time_value/time_interval",
+                    "type": "string"
+                },
+                "explicit_datetime_to": {
+                    "type": "string"
+                },
+                "key": {
+                    "description": "Event name, or action id when event_type is 'actions'",
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "negation": {
+                    "description": "Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators",
+                    "type": "boolean"
+                },
+                "operator": {
+                    "$ref": "#/definitions/PropertyOperator",
+                    "description": "Count comparison for performed_event_multiple, defaults to exact"
+                },
+                "operator_value": {
+                    "description": "Count threshold for performed_event_multiple",
+                    "type": "integer"
+                },
+                "time_interval": {
+                    "$ref": "#/definitions/TimeUnitType"
+                },
+                "time_value": {
+                    "description": "Relative time window size, paired with time_interval",
+                    "type": "integer"
+                },
+                "type": {
+                    "const": "behavioral",
+                    "description": "Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP",
+                    "type": "string"
+                },
+                "value": {
+                    "$ref": "#/definitions/InlineBehavioralType"
+                }
+            },
+            "required": ["event_type", "key", "type", "value"],
+            "type": "object"
         },
         "BiasRisk": {
             "additionalProperties": false,
@@ -28935,6 +29021,11 @@
             "enum": [999999, -999999],
             "type": "number"
         },
+        "InlineBehavioralType": {
+            "description": "The subset of cohort behavioral criteria supported by the inline `BehavioralPropertyFilter`",
+            "enum": ["performed_event", "performed_event_multiple"],
+            "type": "string"
+        },
         "InsightActorsQuery": {
             "additionalProperties": false,
             "properties": {
@@ -38520,6 +38611,7 @@
                 "feature",
                 "session",
                 "cohort",
+                "behavioral",
                 "recording",
                 "log_entry",
                 "group",
@@ -51794,6 +51886,10 @@
                 }
             },
             "type": "object"
+        },
+        "TimeUnitType": {
+            "enum": ["day", "week", "month", "year"],
+            "type": "string"
         },
         "TimelineEntry": {
             "additionalProperties": false,

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -1832,9 +1832,6 @@
                 },
                 {
                     "$ref": "#/definitions/EmptyPropertyFilter"
-                },
-                {
-                    "$ref": "#/definitions/BehavioralPropertyFilter"
                 }
             ],
             "description": "Any filter type supported by `property_to_expr(scope=\"person\", ...)`."
@@ -5903,7 +5900,7 @@
         },
         "BehavioralPropertyFilter": {
             "additionalProperties": false,
-            "description": "Filters persons on whether they performed an event (optionally a number of times) within a time window, without needing a saved cohort. Shares the cohort criteria vocabulary (`BehavioralEventType`), but only the \"performed event\" family is supported inline — sequences and lifecycle criteria still require a cohort.",
+            "description": "Filters persons on whether they performed an event (optionally a number of times) within a time window, without needing a saved cohort. Shares the cohort criteria vocabulary (`BehavioralEventType`), but only the \"performed event\" family is supported inline — sequences and lifecycle criteria still require a cohort. Event scope only: person scope needs `id IN (SELECT person_id FROM events ...)`, which HogQL cannot yet resolve under a `persons` FROM. Filter the underlying insight instead, or use a cohort.",
             "properties": {
                 "event_filters": {
                     "description": "Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral/cohort filters and groups",

--- a/frontend/src/queries/validators.js
+++ b/frontend/src/queries/validators.js
@@ -5705,7 +5705,7 @@ function validate72(data, { instancePath = '', parentData, parentDataProperty, r
 const schema62 = {
     additionalProperties: false,
     description:
-        'Filters persons on whether they performed an event (optionally a number of times) within a time window, without needing a saved cohort. Shares the cohort criteria vocabulary (`BehavioralEventType`), but only the "performed event" family is supported inline — sequences and lifecycle criteria still require a cohort.',
+        'Filters persons on whether they performed an event (optionally a number of times) within a time window, without needing a saved cohort. Shares the cohort criteria vocabulary (`BehavioralEventType`), but only the "performed event" family is supported inline — sequences and lifecycle criteria still require a cohort. Event scope only: person scope needs `id IN (SELECT person_id FROM events ...)`, which HogQL cannot yet resolve under a `persons` FROM. Filter the underlying insight instead, or use a cohort.',
     properties: {
         event_filters: {
             description:

--- a/frontend/src/queries/validators.js
+++ b/frontend/src/queries/validators.js
@@ -11996,6 +11996,15 @@ function validate93(data, { instancePath = '', parentData, parentDataProperty, r
 const schema106 = {
     additionalProperties: false,
     properties: {
+        breakdownAttributionType: {
+            $ref: '#/definitions/BreakdownAttributionType',
+            default: 'first_touch',
+            description: 'How to attribute the breakdown value across funnel steps.',
+        },
+        breakdownAttributionValue: {
+            description: 'When breakdownAttributionType is `step`, the 0-indexed step to attribute from.',
+            type: 'integer',
+        },
         breakdownFilter: { $ref: '#/definitions/BreakdownFilter' },
         conversion_window: { $ref: '#/definitions/integer' },
         conversion_window_unit: { $ref: '#/definitions/FunnelConversionWindowTimeUnit' },
@@ -12015,8 +12024,9 @@ const schema106 = {
     required: ['kind', 'metric_type', 'series'],
     type: 'object',
 }
-const schema109 = { enum: ['strict', 'unordered', 'ordered'], type: 'string' }
-const schema111 = {
+const schema107 = { enum: ['first_touch', 'last_touch', 'all_events', 'step'], type: 'string' }
+const schema110 = { enum: ['strict', 'unordered', 'ordered'], type: 'string' }
+const schema112 = {
     discriminator: { propertyName: 'kind' },
     oneOf: [
         { $ref: '#/definitions/EventsNode' },
@@ -12168,32 +12178,53 @@ function validate121(data, { instancePath = '', parentData, parentDataProperty, 
                     }
                 }
                 if (_errs1 === errors) {
-                    if (data.breakdownFilter !== undefined) {
+                    if (data.breakdownAttributionType !== undefined) {
+                        let data0 = data.breakdownAttributionType
                         const _errs2 = errors
+                        if (typeof data0 !== 'string') {
+                            validate121.errors = [
+                                {
+                                    instancePath: instancePath + '/breakdownAttributionType',
+                                    schemaPath: '#/definitions/BreakdownAttributionType/type',
+                                    keyword: 'type',
+                                    params: { type: 'string' },
+                                    message: 'must be string',
+                                },
+                            ]
+                            return false
+                        }
                         if (
-                            !validate94(data.breakdownFilter, {
-                                instancePath: instancePath + '/breakdownFilter',
-                                parentData: data,
-                                parentDataProperty: 'breakdownFilter',
-                                rootData,
-                            })
+                            !(
+                                data0 === 'first_touch' ||
+                                data0 === 'last_touch' ||
+                                data0 === 'all_events' ||
+                                data0 === 'step'
+                            )
                         ) {
-                            vErrors = vErrors === null ? validate94.errors : vErrors.concat(validate94.errors)
-                            errors = vErrors.length
+                            validate121.errors = [
+                                {
+                                    instancePath: instancePath + '/breakdownAttributionType',
+                                    schemaPath: '#/definitions/BreakdownAttributionType/enum',
+                                    keyword: 'enum',
+                                    params: { allowedValues: schema107.enum },
+                                    message: 'must be equal to one of the allowed values',
+                                },
+                            ]
+                            return false
                         }
                         var valid0 = _errs2 === errors
                     } else {
                         var valid0 = true
                     }
                     if (valid0) {
-                        if (data.conversion_window !== undefined) {
-                            let data1 = data.conversion_window
-                            const _errs3 = errors
+                        if (data.breakdownAttributionValue !== undefined) {
+                            let data1 = data.breakdownAttributionValue
+                            const _errs5 = errors
                             if (!(typeof data1 == 'number' && !(data1 % 1) && !isNaN(data1) && isFinite(data1))) {
                                 validate121.errors = [
                                     {
-                                        instancePath: instancePath + '/conversion_window',
-                                        schemaPath: '#/definitions/integer/type',
+                                        instancePath: instancePath + '/breakdownAttributionValue',
+                                        schemaPath: '#/properties/breakdownAttributionValue/type',
                                         keyword: 'type',
                                         params: { type: 'integer' },
                                         message: 'must be integer',
@@ -12201,79 +12232,59 @@ function validate121(data, { instancePath = '', parentData, parentDataProperty, 
                                 ]
                                 return false
                             }
-                            var valid0 = _errs3 === errors
+                            var valid0 = _errs5 === errors
                         } else {
                             var valid0 = true
                         }
                         if (valid0) {
-                            if (data.conversion_window_unit !== undefined) {
-                                let data2 = data.conversion_window_unit
-                                const _errs6 = errors
-                                if (typeof data2 !== 'string') {
-                                    validate121.errors = [
-                                        {
-                                            instancePath: instancePath + '/conversion_window_unit',
-                                            schemaPath: '#/definitions/FunnelConversionWindowTimeUnit/type',
-                                            keyword: 'type',
-                                            params: { type: 'string' },
-                                            message: 'must be string',
-                                        },
-                                    ]
-                                    return false
-                                }
+                            if (data.breakdownFilter !== undefined) {
+                                const _errs7 = errors
                                 if (
-                                    !(
-                                        data2 === 'second' ||
-                                        data2 === 'minute' ||
-                                        data2 === 'hour' ||
-                                        data2 === 'day' ||
-                                        data2 === 'week' ||
-                                        data2 === 'month'
-                                    )
+                                    !validate94(data.breakdownFilter, {
+                                        instancePath: instancePath + '/breakdownFilter',
+                                        parentData: data,
+                                        parentDataProperty: 'breakdownFilter',
+                                        rootData,
+                                    })
                                 ) {
-                                    validate121.errors = [
-                                        {
-                                            instancePath: instancePath + '/conversion_window_unit',
-                                            schemaPath: '#/definitions/FunnelConversionWindowTimeUnit/enum',
-                                            keyword: 'enum',
-                                            params: { allowedValues: schema87.enum },
-                                            message: 'must be equal to one of the allowed values',
-                                        },
-                                    ]
-                                    return false
+                                    vErrors = vErrors === null ? validate94.errors : vErrors.concat(validate94.errors)
+                                    errors = vErrors.length
                                 }
-                                var valid0 = _errs6 === errors
+                                var valid0 = _errs7 === errors
                             } else {
                                 var valid0 = true
                             }
                             if (valid0) {
-                                if (data.fingerprint !== undefined) {
-                                    const _errs9 = errors
-                                    if (typeof data.fingerprint !== 'string') {
+                                if (data.conversion_window !== undefined) {
+                                    let data3 = data.conversion_window
+                                    const _errs8 = errors
+                                    if (
+                                        !(typeof data3 == 'number' && !(data3 % 1) && !isNaN(data3) && isFinite(data3))
+                                    ) {
                                         validate121.errors = [
                                             {
-                                                instancePath: instancePath + '/fingerprint',
-                                                schemaPath: '#/properties/fingerprint/type',
+                                                instancePath: instancePath + '/conversion_window',
+                                                schemaPath: '#/definitions/integer/type',
                                                 keyword: 'type',
-                                                params: { type: 'string' },
-                                                message: 'must be string',
+                                                params: { type: 'integer' },
+                                                message: 'must be integer',
                                             },
                                         ]
                                         return false
                                     }
-                                    var valid0 = _errs9 === errors
+                                    var valid0 = _errs8 === errors
                                 } else {
                                     var valid0 = true
                                 }
                                 if (valid0) {
-                                    if (data.funnel_order_type !== undefined) {
-                                        let data4 = data.funnel_order_type
+                                    if (data.conversion_window_unit !== undefined) {
+                                        let data4 = data.conversion_window_unit
                                         const _errs11 = errors
                                         if (typeof data4 !== 'string') {
                                             validate121.errors = [
                                                 {
-                                                    instancePath: instancePath + '/funnel_order_type',
-                                                    schemaPath: '#/definitions/StepOrderValue/type',
+                                                    instancePath: instancePath + '/conversion_window_unit',
+                                                    schemaPath: '#/definitions/FunnelConversionWindowTimeUnit/type',
                                                     keyword: 'type',
                                                     params: { type: 'string' },
                                                     message: 'must be string',
@@ -12281,13 +12292,22 @@ function validate121(data, { instancePath = '', parentData, parentDataProperty, 
                                             ]
                                             return false
                                         }
-                                        if (!(data4 === 'strict' || data4 === 'unordered' || data4 === 'ordered')) {
+                                        if (
+                                            !(
+                                                data4 === 'second' ||
+                                                data4 === 'minute' ||
+                                                data4 === 'hour' ||
+                                                data4 === 'day' ||
+                                                data4 === 'week' ||
+                                                data4 === 'month'
+                                            )
+                                        ) {
                                             validate121.errors = [
                                                 {
-                                                    instancePath: instancePath + '/funnel_order_type',
-                                                    schemaPath: '#/definitions/StepOrderValue/enum',
+                                                    instancePath: instancePath + '/conversion_window_unit',
+                                                    schemaPath: '#/definitions/FunnelConversionWindowTimeUnit/enum',
                                                     keyword: 'enum',
-                                                    params: { allowedValues: schema109.enum },
+                                                    params: { allowedValues: schema87.enum },
                                                     message: 'must be equal to one of the allowed values',
                                                 },
                                             ]
@@ -12298,29 +12318,16 @@ function validate121(data, { instancePath = '', parentData, parentDataProperty, 
                                         var valid0 = true
                                     }
                                     if (valid0) {
-                                        if (data.goal !== undefined) {
-                                            let data5 = data.goal
+                                        if (data.fingerprint !== undefined) {
                                             const _errs14 = errors
-                                            if (typeof data5 !== 'string') {
+                                            if (typeof data.fingerprint !== 'string') {
                                                 validate121.errors = [
                                                     {
-                                                        instancePath: instancePath + '/goal',
-                                                        schemaPath: '#/definitions/ExperimentMetricGoal/type',
+                                                        instancePath: instancePath + '/fingerprint',
+                                                        schemaPath: '#/properties/fingerprint/type',
                                                         keyword: 'type',
                                                         params: { type: 'string' },
                                                         message: 'must be string',
-                                                    },
-                                                ]
-                                                return false
-                                            }
-                                            if (!(data5 === 'increase' || data5 === 'decrease')) {
-                                                validate121.errors = [
-                                                    {
-                                                        instancePath: instancePath + '/goal',
-                                                        schemaPath: '#/definitions/ExperimentMetricGoal/enum',
-                                                        keyword: 'enum',
-                                                        params: { allowedValues: schema88.enum },
-                                                        message: 'must be equal to one of the allowed values',
                                                     },
                                                 ]
                                                 return false
@@ -12330,33 +12337,52 @@ function validate121(data, { instancePath = '', parentData, parentDataProperty, 
                                             var valid0 = true
                                         }
                                         if (valid0) {
-                                            if (data.isSharedMetric !== undefined) {
-                                                const _errs17 = errors
-                                                if (typeof data.isSharedMetric !== 'boolean') {
+                                            if (data.funnel_order_type !== undefined) {
+                                                let data6 = data.funnel_order_type
+                                                const _errs16 = errors
+                                                if (typeof data6 !== 'string') {
                                                     validate121.errors = [
                                                         {
-                                                            instancePath: instancePath + '/isSharedMetric',
-                                                            schemaPath: '#/properties/isSharedMetric/type',
+                                                            instancePath: instancePath + '/funnel_order_type',
+                                                            schemaPath: '#/definitions/StepOrderValue/type',
                                                             keyword: 'type',
-                                                            params: { type: 'boolean' },
-                                                            message: 'must be boolean',
+                                                            params: { type: 'string' },
+                                                            message: 'must be string',
                                                         },
                                                     ]
                                                     return false
                                                 }
-                                                var valid0 = _errs17 === errors
+                                                if (
+                                                    !(
+                                                        data6 === 'strict' ||
+                                                        data6 === 'unordered' ||
+                                                        data6 === 'ordered'
+                                                    )
+                                                ) {
+                                                    validate121.errors = [
+                                                        {
+                                                            instancePath: instancePath + '/funnel_order_type',
+                                                            schemaPath: '#/definitions/StepOrderValue/enum',
+                                                            keyword: 'enum',
+                                                            params: { allowedValues: schema110.enum },
+                                                            message: 'must be equal to one of the allowed values',
+                                                        },
+                                                    ]
+                                                    return false
+                                                }
+                                                var valid0 = _errs16 === errors
                                             } else {
                                                 var valid0 = true
                                             }
                                             if (valid0) {
-                                                if (data.kind !== undefined) {
-                                                    let data7 = data.kind
+                                                if (data.goal !== undefined) {
+                                                    let data7 = data.goal
                                                     const _errs19 = errors
                                                     if (typeof data7 !== 'string') {
                                                         validate121.errors = [
                                                             {
-                                                                instancePath: instancePath + '/kind',
-                                                                schemaPath: '#/properties/kind/type',
+                                                                instancePath: instancePath + '/goal',
+                                                                schemaPath: '#/definitions/ExperimentMetricGoal/type',
                                                                 keyword: 'type',
                                                                 params: { type: 'string' },
                                                                 message: 'must be string',
@@ -12364,14 +12390,14 @@ function validate121(data, { instancePath = '', parentData, parentDataProperty, 
                                                         ]
                                                         return false
                                                     }
-                                                    if ('ExperimentMetric' !== data7) {
+                                                    if (!(data7 === 'increase' || data7 === 'decrease')) {
                                                         validate121.errors = [
                                                             {
-                                                                instancePath: instancePath + '/kind',
-                                                                schemaPath: '#/properties/kind/const',
-                                                                keyword: 'const',
-                                                                params: { allowedValue: 'ExperimentMetric' },
-                                                                message: 'must be equal to constant',
+                                                                instancePath: instancePath + '/goal',
+                                                                schemaPath: '#/definitions/ExperimentMetricGoal/enum',
+                                                                keyword: 'enum',
+                                                                params: { allowedValues: schema88.enum },
+                                                                message: 'must be equal to one of the allowed values',
                                                             },
                                                         ]
                                                         return false
@@ -12381,45 +12407,33 @@ function validate121(data, { instancePath = '', parentData, parentDataProperty, 
                                                     var valid0 = true
                                                 }
                                                 if (valid0) {
-                                                    if (data.metric_type !== undefined) {
-                                                        let data8 = data.metric_type
-                                                        const _errs21 = errors
-                                                        if (typeof data8 !== 'string') {
+                                                    if (data.isSharedMetric !== undefined) {
+                                                        const _errs22 = errors
+                                                        if (typeof data.isSharedMetric !== 'boolean') {
                                                             validate121.errors = [
                                                                 {
-                                                                    instancePath: instancePath + '/metric_type',
-                                                                    schemaPath: '#/properties/metric_type/type',
+                                                                    instancePath: instancePath + '/isSharedMetric',
+                                                                    schemaPath: '#/properties/isSharedMetric/type',
                                                                     keyword: 'type',
-                                                                    params: { type: 'string' },
-                                                                    message: 'must be string',
+                                                                    params: { type: 'boolean' },
+                                                                    message: 'must be boolean',
                                                                 },
                                                             ]
                                                             return false
                                                         }
-                                                        if ('funnel' !== data8) {
-                                                            validate121.errors = [
-                                                                {
-                                                                    instancePath: instancePath + '/metric_type',
-                                                                    schemaPath: '#/properties/metric_type/const',
-                                                                    keyword: 'const',
-                                                                    params: { allowedValue: 'funnel' },
-                                                                    message: 'must be equal to constant',
-                                                                },
-                                                            ]
-                                                            return false
-                                                        }
-                                                        var valid0 = _errs21 === errors
+                                                        var valid0 = _errs22 === errors
                                                     } else {
                                                         var valid0 = true
                                                     }
                                                     if (valid0) {
-                                                        if (data.name !== undefined) {
-                                                            const _errs23 = errors
-                                                            if (typeof data.name !== 'string') {
+                                                        if (data.kind !== undefined) {
+                                                            let data9 = data.kind
+                                                            const _errs24 = errors
+                                                            if (typeof data9 !== 'string') {
                                                                 validate121.errors = [
                                                                     {
-                                                                        instancePath: instancePath + '/name',
-                                                                        schemaPath: '#/properties/name/type',
+                                                                        instancePath: instancePath + '/kind',
+                                                                        schemaPath: '#/properties/kind/type',
                                                                         keyword: 'type',
                                                                         params: { type: 'string' },
                                                                         message: 'must be string',
@@ -12427,109 +12441,94 @@ function validate121(data, { instancePath = '', parentData, parentDataProperty, 
                                                                 ]
                                                                 return false
                                                             }
-                                                            var valid0 = _errs23 === errors
+                                                            if ('ExperimentMetric' !== data9) {
+                                                                validate121.errors = [
+                                                                    {
+                                                                        instancePath: instancePath + '/kind',
+                                                                        schemaPath: '#/properties/kind/const',
+                                                                        keyword: 'const',
+                                                                        params: { allowedValue: 'ExperimentMetric' },
+                                                                        message: 'must be equal to constant',
+                                                                    },
+                                                                ]
+                                                                return false
+                                                            }
+                                                            var valid0 = _errs24 === errors
                                                         } else {
                                                             var valid0 = true
                                                         }
                                                         if (valid0) {
-                                                            if (data.response !== undefined) {
-                                                                let data10 = data.response
-                                                                const _errs25 = errors
-                                                                if (
-                                                                    !(
-                                                                        data10 &&
-                                                                        typeof data10 == 'object' &&
-                                                                        !Array.isArray(data10)
-                                                                    )
-                                                                ) {
+                                                            if (data.metric_type !== undefined) {
+                                                                let data10 = data.metric_type
+                                                                const _errs26 = errors
+                                                                if (typeof data10 !== 'string') {
                                                                     validate121.errors = [
                                                                         {
-                                                                            instancePath: instancePath + '/response',
-                                                                            schemaPath: '#/properties/response/type',
+                                                                            instancePath: instancePath + '/metric_type',
+                                                                            schemaPath: '#/properties/metric_type/type',
                                                                             keyword: 'type',
-                                                                            params: { type: 'object' },
-                                                                            message: 'must be object',
+                                                                            params: { type: 'string' },
+                                                                            message: 'must be string',
                                                                         },
                                                                     ]
                                                                     return false
                                                                 }
-                                                                var valid0 = _errs25 === errors
+                                                                if ('funnel' !== data10) {
+                                                                    validate121.errors = [
+                                                                        {
+                                                                            instancePath: instancePath + '/metric_type',
+                                                                            schemaPath:
+                                                                                '#/properties/metric_type/const',
+                                                                            keyword: 'const',
+                                                                            params: { allowedValue: 'funnel' },
+                                                                            message: 'must be equal to constant',
+                                                                        },
+                                                                    ]
+                                                                    return false
+                                                                }
+                                                                var valid0 = _errs26 === errors
                                                             } else {
                                                                 var valid0 = true
                                                             }
                                                             if (valid0) {
-                                                                if (data.series !== undefined) {
-                                                                    let data11 = data.series
-                                                                    const _errs27 = errors
-                                                                    if (errors === _errs27) {
-                                                                        if (Array.isArray(data11)) {
-                                                                            var valid5 = true
-                                                                            const len0 = data11.length
-                                                                            for (let i0 = 0; i0 < len0; i0++) {
-                                                                                const _errs29 = errors
-                                                                                if (
-                                                                                    !validate123(data11[i0], {
-                                                                                        instancePath:
-                                                                                            instancePath +
-                                                                                            '/series/' +
-                                                                                            i0,
-                                                                                        parentData: data11,
-                                                                                        parentDataProperty: i0,
-                                                                                        rootData,
-                                                                                    })
-                                                                                ) {
-                                                                                    vErrors =
-                                                                                        vErrors === null
-                                                                                            ? validate123.errors
-                                                                                            : vErrors.concat(
-                                                                                                  validate123.errors
-                                                                                              )
-                                                                                    errors = vErrors.length
-                                                                                }
-                                                                                var valid5 = _errs29 === errors
-                                                                                if (!valid5) {
-                                                                                    break
-                                                                                }
-                                                                            }
-                                                                        } else {
-                                                                            validate121.errors = [
-                                                                                {
-                                                                                    instancePath:
-                                                                                        instancePath + '/series',
-                                                                                    schemaPath:
-                                                                                        '#/properties/series/type',
-                                                                                    keyword: 'type',
-                                                                                    params: { type: 'array' },
-                                                                                    message: 'must be array',
-                                                                                },
-                                                                            ]
-                                                                            return false
-                                                                        }
+                                                                if (data.name !== undefined) {
+                                                                    const _errs28 = errors
+                                                                    if (typeof data.name !== 'string') {
+                                                                        validate121.errors = [
+                                                                            {
+                                                                                instancePath: instancePath + '/name',
+                                                                                schemaPath: '#/properties/name/type',
+                                                                                keyword: 'type',
+                                                                                params: { type: 'string' },
+                                                                                message: 'must be string',
+                                                                            },
+                                                                        ]
+                                                                        return false
                                                                     }
-                                                                    var valid0 = _errs27 === errors
+                                                                    var valid0 = _errs28 === errors
                                                                 } else {
                                                                     var valid0 = true
                                                                 }
                                                                 if (valid0) {
-                                                                    if (data.sharedMetricId !== undefined) {
-                                                                        let data13 = data.sharedMetricId
+                                                                    if (data.response !== undefined) {
+                                                                        let data12 = data.response
                                                                         const _errs30 = errors
                                                                         if (
                                                                             !(
-                                                                                typeof data13 == 'number' &&
-                                                                                isFinite(data13)
+                                                                                data12 &&
+                                                                                typeof data12 == 'object' &&
+                                                                                !Array.isArray(data12)
                                                                             )
                                                                         ) {
                                                                             validate121.errors = [
                                                                                 {
                                                                                     instancePath:
-                                                                                        instancePath +
-                                                                                        '/sharedMetricId',
+                                                                                        instancePath + '/response',
                                                                                     schemaPath:
-                                                                                        '#/properties/sharedMetricId/type',
+                                                                                        '#/properties/response/type',
                                                                                     keyword: 'type',
-                                                                                    params: { type: 'number' },
-                                                                                    message: 'must be number',
+                                                                                    params: { type: 'object' },
+                                                                                    message: 'must be object',
                                                                                 },
                                                                             ]
                                                                             return false
@@ -12539,30 +12538,63 @@ function validate121(data, { instancePath = '', parentData, parentDataProperty, 
                                                                         var valid0 = true
                                                                     }
                                                                     if (valid0) {
-                                                                        if (data.uuid !== undefined) {
+                                                                        if (data.series !== undefined) {
+                                                                            let data13 = data.series
                                                                             const _errs32 = errors
-                                                                            if (typeof data.uuid !== 'string') {
-                                                                                validate121.errors = [
-                                                                                    {
-                                                                                        instancePath:
-                                                                                            instancePath + '/uuid',
-                                                                                        schemaPath:
-                                                                                            '#/properties/uuid/type',
-                                                                                        keyword: 'type',
-                                                                                        params: { type: 'string' },
-                                                                                        message: 'must be string',
-                                                                                    },
-                                                                                ]
-                                                                                return false
+                                                                            if (errors === _errs32) {
+                                                                                if (Array.isArray(data13)) {
+                                                                                    var valid6 = true
+                                                                                    const len0 = data13.length
+                                                                                    for (let i0 = 0; i0 < len0; i0++) {
+                                                                                        const _errs34 = errors
+                                                                                        if (
+                                                                                            !validate123(data13[i0], {
+                                                                                                instancePath:
+                                                                                                    instancePath +
+                                                                                                    '/series/' +
+                                                                                                    i0,
+                                                                                                parentData: data13,
+                                                                                                parentDataProperty: i0,
+                                                                                                rootData,
+                                                                                            })
+                                                                                        ) {
+                                                                                            vErrors =
+                                                                                                vErrors === null
+                                                                                                    ? validate123.errors
+                                                                                                    : vErrors.concat(
+                                                                                                          validate123.errors
+                                                                                                      )
+                                                                                            errors = vErrors.length
+                                                                                        }
+                                                                                        var valid6 = _errs34 === errors
+                                                                                        if (!valid6) {
+                                                                                            break
+                                                                                        }
+                                                                                    }
+                                                                                } else {
+                                                                                    validate121.errors = [
+                                                                                        {
+                                                                                            instancePath:
+                                                                                                instancePath +
+                                                                                                '/series',
+                                                                                            schemaPath:
+                                                                                                '#/properties/series/type',
+                                                                                            keyword: 'type',
+                                                                                            params: { type: 'array' },
+                                                                                            message: 'must be array',
+                                                                                        },
+                                                                                    ]
+                                                                                    return false
+                                                                                }
                                                                             }
                                                                             var valid0 = _errs32 === errors
                                                                         } else {
                                                                             var valid0 = true
                                                                         }
                                                                         if (valid0) {
-                                                                            if (data.version !== undefined) {
-                                                                                let data15 = data.version
-                                                                                const _errs34 = errors
+                                                                            if (data.sharedMetricId !== undefined) {
+                                                                                let data15 = data.sharedMetricId
+                                                                                const _errs35 = errors
                                                                                 if (
                                                                                     !(
                                                                                         typeof data15 == 'number' &&
@@ -12573,9 +12605,9 @@ function validate121(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                         {
                                                                                             instancePath:
                                                                                                 instancePath +
-                                                                                                '/version',
+                                                                                                '/sharedMetricId',
                                                                                             schemaPath:
-                                                                                                '#/properties/version/type',
+                                                                                                '#/properties/sharedMetricId/type',
                                                                                             keyword: 'type',
                                                                                             params: { type: 'number' },
                                                                                             message: 'must be number',
@@ -12583,9 +12615,68 @@ function validate121(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                     ]
                                                                                     return false
                                                                                 }
-                                                                                var valid0 = _errs34 === errors
+                                                                                var valid0 = _errs35 === errors
                                                                             } else {
                                                                                 var valid0 = true
+                                                                            }
+                                                                            if (valid0) {
+                                                                                if (data.uuid !== undefined) {
+                                                                                    const _errs37 = errors
+                                                                                    if (typeof data.uuid !== 'string') {
+                                                                                        validate121.errors = [
+                                                                                            {
+                                                                                                instancePath:
+                                                                                                    instancePath +
+                                                                                                    '/uuid',
+                                                                                                schemaPath:
+                                                                                                    '#/properties/uuid/type',
+                                                                                                keyword: 'type',
+                                                                                                params: {
+                                                                                                    type: 'string',
+                                                                                                },
+                                                                                                message:
+                                                                                                    'must be string',
+                                                                                            },
+                                                                                        ]
+                                                                                        return false
+                                                                                    }
+                                                                                    var valid0 = _errs37 === errors
+                                                                                } else {
+                                                                                    var valid0 = true
+                                                                                }
+                                                                                if (valid0) {
+                                                                                    if (data.version !== undefined) {
+                                                                                        let data17 = data.version
+                                                                                        const _errs39 = errors
+                                                                                        if (
+                                                                                            !(
+                                                                                                typeof data17 ==
+                                                                                                    'number' &&
+                                                                                                isFinite(data17)
+                                                                                            )
+                                                                                        ) {
+                                                                                            validate121.errors = [
+                                                                                                {
+                                                                                                    instancePath:
+                                                                                                        instancePath +
+                                                                                                        '/version',
+                                                                                                    schemaPath:
+                                                                                                        '#/properties/version/type',
+                                                                                                    keyword: 'type',
+                                                                                                    params: {
+                                                                                                        type: 'number',
+                                                                                                    },
+                                                                                                    message:
+                                                                                                        'must be number',
+                                                                                                },
+                                                                                            ]
+                                                                                            return false
+                                                                                        }
+                                                                                        var valid0 = _errs39 === errors
+                                                                                    } else {
+                                                                                        var valid0 = true
+                                                                                    }
+                                                                                }
                                                                             }
                                                                         }
                                                                     }
@@ -12619,7 +12710,7 @@ function validate121(data, { instancePath = '', parentData, parentDataProperty, 
     validate121.errors = vErrors
     return errors === 0
 }
-const schema112 = {
+const schema113 = {
     additionalProperties: false,
     properties: {
         breakdownFilter: { $ref: '#/definitions/BreakdownFilter' },
@@ -12643,7 +12734,7 @@ const schema112 = {
     required: ['denominator', 'kind', 'metric_type', 'numerator'],
     type: 'object',
 }
-const schema115 = {
+const schema116 = {
     additionalProperties: false,
     properties: {
         ignore_zeros: { type: 'boolean' },
@@ -12689,7 +12780,7 @@ function validate129(data, { instancePath = '', parentData, parentDataProperty, 
             } else {
                 const _errs1 = errors
                 for (const key0 in data) {
-                    if (!func2.call(schema112.properties, key0)) {
+                    if (!func2.call(schema113.properties, key0)) {
                         validate129.errors = [
                             {
                                 instancePath,
@@ -13609,7 +13700,7 @@ function validate129(data, { instancePath = '', parentData, parentDataProperty, 
     validate129.errors = vErrors
     return errors === 0
 }
-const schema118 = {
+const schema119 = {
     additionalProperties: false,
     properties: {
         breakdownFilter: { $ref: '#/definitions/BreakdownFilter' },
@@ -13673,7 +13764,7 @@ function validate134(data, { instancePath = '', parentData, parentDataProperty, 
             } else {
                 const _errs1 = errors
                 for (const key0 in data) {
-                    if (!func2.call(schema118.properties, key0)) {
+                    if (!func2.call(schema119.properties, key0)) {
                         validate134.errors = [
                             {
                                 instancePath,
@@ -14172,7 +14263,7 @@ function validate134(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                                     keyword: 'enum',
                                                                                                     params: {
                                                                                                         allowedValues:
-                                                                                                            schema118
+                                                                                                            schema119
                                                                                                                 .properties
                                                                                                                 .start_handling
                                                                                                                 .enum,

--- a/frontend/src/queries/validators.js
+++ b/frontend/src/queries/validators.js
@@ -5705,7 +5705,7 @@ function validate72(data, { instancePath = '', parentData, parentDataProperty, r
 const schema62 = {
     additionalProperties: false,
     description:
-        'Filters persons on whether they performed an event (optionally a number of times) within a time window, without needing a saved cohort. Shares the cohort criteria vocabulary (`BehavioralEventType`), but only the "performed event" family is supported inline — sequences and lifecycle criteria still require a cohort. Event scope only: person scope needs `id IN (SELECT person_id FROM events ...)`, which HogQL cannot yet resolve under a `persons` FROM. Filter the underlying insight instead, or use a cohort.',
+        'Filters persons on whether they performed an event in a time window, without a saved cohort. Event scope only.',
     properties: {
         event_filters: {
             description:

--- a/frontend/src/queries/validators.js
+++ b/frontend/src/queries/validators.js
@@ -26,6 +26,7 @@ const schema12 = {
         { $ref: '#/definitions/RevenueAnalyticsPropertyFilter' },
         { $ref: '#/definitions/AccountCustomPropertyFilter' },
         { $ref: '#/definitions/WorkflowVariablePropertyFilter' },
+        { $ref: '#/definitions/BehavioralPropertyFilter' },
     ],
 }
 const schema39 = {
@@ -5701,6 +5702,657 @@ function validate72(data, { instancePath = '', parentData, parentDataProperty, r
     validate72.errors = vErrors
     return errors === 0
 }
+const schema62 = {
+    additionalProperties: false,
+    description:
+        'Filters persons on whether they performed an event (optionally a number of times) within a time window, without needing a saved cohort. Shares the cohort criteria vocabulary (`BehavioralEventType`), but only the "performed event" family is supported inline — sequences and lifecycle criteria still require a cohort.',
+    properties: {
+        event_filters: {
+            description:
+                'Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral/cohort filters and groups',
+            items: {
+                anyOf: [
+                    { $ref: '#/definitions/EventPropertyFilter' },
+                    { $ref: '#/definitions/PersonPropertyFilter' },
+                    { $ref: '#/definitions/ElementPropertyFilter' },
+                    { $ref: '#/definitions/FeaturePropertyFilter' },
+                    { $ref: '#/definitions/HogQLPropertyFilter' },
+                ],
+            },
+            type: 'array',
+        },
+        event_type: { $ref: '#/definitions/BehavioralEventSource' },
+        explicit_datetime: {
+            description: 'Absolute or relative (e.g. -30d) lower date bound — alternative to time_value/time_interval',
+            type: 'string',
+        },
+        explicit_datetime_to: { type: 'string' },
+        key: { description: "Event name, or action id when event_type is 'actions'", type: 'string' },
+        label: { type: 'string' },
+        negation: {
+            description:
+                'Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators',
+            type: 'boolean',
+        },
+        operator: {
+            $ref: '#/definitions/PropertyOperator',
+            description: 'Count comparison for performed_event_multiple, defaults to exact',
+        },
+        operator_value: { description: 'Count threshold for performed_event_multiple', type: 'integer' },
+        time_interval: { $ref: '#/definitions/TimeUnitType' },
+        time_value: { description: 'Relative time window size, paired with time_interval', type: 'integer' },
+        type: {
+            const: 'behavioral',
+            description:
+                "Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP",
+            type: 'string',
+        },
+        value: { $ref: '#/definitions/InlineBehavioralType' },
+    },
+    required: ['event_type', 'key', 'type', 'value'],
+    type: 'object',
+}
+const schema63 = {
+    description: "Whether a behavioral filter's `key` refers to an event name or an action id",
+    enum: ['events', 'actions'],
+    type: 'string',
+}
+const schema65 = { enum: ['day', 'week', 'month', 'year'], type: 'string' }
+const schema66 = {
+    description: 'The subset of cohort behavioral criteria supported by the inline `BehavioralPropertyFilter`',
+    enum: ['performed_event', 'performed_event_multiple'],
+    type: 'string',
+}
+const func2 = Object.prototype.hasOwnProperty
+function validate75(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
+    let vErrors = null
+    let errors = 0
+    if (errors === 0) {
+        if (data && typeof data == 'object' && !Array.isArray(data)) {
+            let missing0
+            if (
+                (data.event_type === undefined && (missing0 = 'event_type')) ||
+                (data.key === undefined && (missing0 = 'key')) ||
+                (data.type === undefined && (missing0 = 'type')) ||
+                (data.value === undefined && (missing0 = 'value'))
+            ) {
+                validate75.errors = [
+                    {
+                        instancePath,
+                        schemaPath: '#/required',
+                        keyword: 'required',
+                        params: { missingProperty: missing0 },
+                        message: "must have required property '" + missing0 + "'",
+                    },
+                ]
+                return false
+            } else {
+                const _errs1 = errors
+                for (const key0 in data) {
+                    if (!func2.call(schema62.properties, key0)) {
+                        validate75.errors = [
+                            {
+                                instancePath,
+                                schemaPath: '#/additionalProperties',
+                                keyword: 'additionalProperties',
+                                params: { additionalProperty: key0 },
+                                message: 'must NOT have additional properties',
+                            },
+                        ]
+                        return false
+                        break
+                    }
+                }
+                if (_errs1 === errors) {
+                    if (data.event_filters !== undefined) {
+                        let data0 = data.event_filters
+                        const _errs2 = errors
+                        if (errors === _errs2) {
+                            if (Array.isArray(data0)) {
+                                var valid1 = true
+                                const len0 = data0.length
+                                for (let i0 = 0; i0 < len0; i0++) {
+                                    let data1 = data0[i0]
+                                    const _errs4 = errors
+                                    const _errs5 = errors
+                                    let valid2 = false
+                                    const _errs6 = errors
+                                    if (
+                                        !validate12(data1, {
+                                            instancePath: instancePath + '/event_filters/' + i0,
+                                            parentData: data0,
+                                            parentDataProperty: i0,
+                                            rootData,
+                                        })
+                                    ) {
+                                        vErrors =
+                                            vErrors === null ? validate12.errors : vErrors.concat(validate12.errors)
+                                        errors = vErrors.length
+                                    }
+                                    var _valid0 = _errs6 === errors
+                                    valid2 = valid2 || _valid0
+                                    if (!valid2) {
+                                        const _errs7 = errors
+                                        if (
+                                            !validate16(data1, {
+                                                instancePath: instancePath + '/event_filters/' + i0,
+                                                parentData: data0,
+                                                parentDataProperty: i0,
+                                                rootData,
+                                            })
+                                        ) {
+                                            vErrors =
+                                                vErrors === null ? validate16.errors : vErrors.concat(validate16.errors)
+                                            errors = vErrors.length
+                                        }
+                                        var _valid0 = _errs7 === errors
+                                        valid2 = valid2 || _valid0
+                                        if (!valid2) {
+                                            const _errs8 = errors
+                                            if (
+                                                !validate22(data1, {
+                                                    instancePath: instancePath + '/event_filters/' + i0,
+                                                    parentData: data0,
+                                                    parentDataProperty: i0,
+                                                    rootData,
+                                                })
+                                            ) {
+                                                vErrors =
+                                                    vErrors === null
+                                                        ? validate22.errors
+                                                        : vErrors.concat(validate22.errors)
+                                                errors = vErrors.length
+                                            }
+                                            var _valid0 = _errs8 === errors
+                                            valid2 = valid2 || _valid0
+                                            if (!valid2) {
+                                                const _errs9 = errors
+                                                if (
+                                                    !validate42(data1, {
+                                                        instancePath: instancePath + '/event_filters/' + i0,
+                                                        parentData: data0,
+                                                        parentDataProperty: i0,
+                                                        rootData,
+                                                    })
+                                                ) {
+                                                    vErrors =
+                                                        vErrors === null
+                                                            ? validate42.errors
+                                                            : vErrors.concat(validate42.errors)
+                                                    errors = vErrors.length
+                                                }
+                                                var _valid0 = _errs9 === errors
+                                                valid2 = valid2 || _valid0
+                                                if (!valid2) {
+                                                    const _errs10 = errors
+                                                    if (
+                                                        !validate45(data1, {
+                                                            instancePath: instancePath + '/event_filters/' + i0,
+                                                            parentData: data0,
+                                                            parentDataProperty: i0,
+                                                            rootData,
+                                                        })
+                                                    ) {
+                                                        vErrors =
+                                                            vErrors === null
+                                                                ? validate45.errors
+                                                                : vErrors.concat(validate45.errors)
+                                                        errors = vErrors.length
+                                                    }
+                                                    var _valid0 = _errs10 === errors
+                                                    valid2 = valid2 || _valid0
+                                                }
+                                            }
+                                        }
+                                    }
+                                    if (!valid2) {
+                                        const err0 = {
+                                            instancePath: instancePath + '/event_filters/' + i0,
+                                            schemaPath: '#/properties/event_filters/items/anyOf',
+                                            keyword: 'anyOf',
+                                            params: {},
+                                            message: 'must match a schema in anyOf',
+                                        }
+                                        if (vErrors === null) {
+                                            vErrors = [err0]
+                                        } else {
+                                            vErrors.push(err0)
+                                        }
+                                        errors++
+                                        validate75.errors = vErrors
+                                        return false
+                                    } else {
+                                        errors = _errs5
+                                        if (vErrors !== null) {
+                                            if (_errs5) {
+                                                vErrors.length = _errs5
+                                            } else {
+                                                vErrors = null
+                                            }
+                                        }
+                                    }
+                                    var valid1 = _errs4 === errors
+                                    if (!valid1) {
+                                        break
+                                    }
+                                }
+                            } else {
+                                validate75.errors = [
+                                    {
+                                        instancePath: instancePath + '/event_filters',
+                                        schemaPath: '#/properties/event_filters/type',
+                                        keyword: 'type',
+                                        params: { type: 'array' },
+                                        message: 'must be array',
+                                    },
+                                ]
+                                return false
+                            }
+                        }
+                        var valid0 = _errs2 === errors
+                    } else {
+                        var valid0 = true
+                    }
+                    if (valid0) {
+                        if (data.event_type !== undefined) {
+                            let data2 = data.event_type
+                            const _errs11 = errors
+                            if (typeof data2 !== 'string') {
+                                validate75.errors = [
+                                    {
+                                        instancePath: instancePath + '/event_type',
+                                        schemaPath: '#/definitions/BehavioralEventSource/type',
+                                        keyword: 'type',
+                                        params: { type: 'string' },
+                                        message: 'must be string',
+                                    },
+                                ]
+                                return false
+                            }
+                            if (!(data2 === 'events' || data2 === 'actions')) {
+                                validate75.errors = [
+                                    {
+                                        instancePath: instancePath + '/event_type',
+                                        schemaPath: '#/definitions/BehavioralEventSource/enum',
+                                        keyword: 'enum',
+                                        params: { allowedValues: schema63.enum },
+                                        message: 'must be equal to one of the allowed values',
+                                    },
+                                ]
+                                return false
+                            }
+                            var valid0 = _errs11 === errors
+                        } else {
+                            var valid0 = true
+                        }
+                        if (valid0) {
+                            if (data.explicit_datetime !== undefined) {
+                                const _errs14 = errors
+                                if (typeof data.explicit_datetime !== 'string') {
+                                    validate75.errors = [
+                                        {
+                                            instancePath: instancePath + '/explicit_datetime',
+                                            schemaPath: '#/properties/explicit_datetime/type',
+                                            keyword: 'type',
+                                            params: { type: 'string' },
+                                            message: 'must be string',
+                                        },
+                                    ]
+                                    return false
+                                }
+                                var valid0 = _errs14 === errors
+                            } else {
+                                var valid0 = true
+                            }
+                            if (valid0) {
+                                if (data.explicit_datetime_to !== undefined) {
+                                    const _errs16 = errors
+                                    if (typeof data.explicit_datetime_to !== 'string') {
+                                        validate75.errors = [
+                                            {
+                                                instancePath: instancePath + '/explicit_datetime_to',
+                                                schemaPath: '#/properties/explicit_datetime_to/type',
+                                                keyword: 'type',
+                                                params: { type: 'string' },
+                                                message: 'must be string',
+                                            },
+                                        ]
+                                        return false
+                                    }
+                                    var valid0 = _errs16 === errors
+                                } else {
+                                    var valid0 = true
+                                }
+                                if (valid0) {
+                                    if (data.key !== undefined) {
+                                        const _errs18 = errors
+                                        if (typeof data.key !== 'string') {
+                                            validate75.errors = [
+                                                {
+                                                    instancePath: instancePath + '/key',
+                                                    schemaPath: '#/properties/key/type',
+                                                    keyword: 'type',
+                                                    params: { type: 'string' },
+                                                    message: 'must be string',
+                                                },
+                                            ]
+                                            return false
+                                        }
+                                        var valid0 = _errs18 === errors
+                                    } else {
+                                        var valid0 = true
+                                    }
+                                    if (valid0) {
+                                        if (data.label !== undefined) {
+                                            const _errs20 = errors
+                                            if (typeof data.label !== 'string') {
+                                                validate75.errors = [
+                                                    {
+                                                        instancePath: instancePath + '/label',
+                                                        schemaPath: '#/properties/label/type',
+                                                        keyword: 'type',
+                                                        params: { type: 'string' },
+                                                        message: 'must be string',
+                                                    },
+                                                ]
+                                                return false
+                                            }
+                                            var valid0 = _errs20 === errors
+                                        } else {
+                                            var valid0 = true
+                                        }
+                                        if (valid0) {
+                                            if (data.negation !== undefined) {
+                                                const _errs22 = errors
+                                                if (typeof data.negation !== 'boolean') {
+                                                    validate75.errors = [
+                                                        {
+                                                            instancePath: instancePath + '/negation',
+                                                            schemaPath: '#/properties/negation/type',
+                                                            keyword: 'type',
+                                                            params: { type: 'boolean' },
+                                                            message: 'must be boolean',
+                                                        },
+                                                    ]
+                                                    return false
+                                                }
+                                                var valid0 = _errs22 === errors
+                                            } else {
+                                                var valid0 = true
+                                            }
+                                            if (valid0) {
+                                                if (data.operator !== undefined) {
+                                                    let data8 = data.operator
+                                                    const _errs24 = errors
+                                                    if (typeof data8 !== 'string') {
+                                                        validate75.errors = [
+                                                            {
+                                                                instancePath: instancePath + '/operator',
+                                                                schemaPath: '#/definitions/PropertyOperator/type',
+                                                                keyword: 'type',
+                                                                params: { type: 'string' },
+                                                                message: 'must be string',
+                                                            },
+                                                        ]
+                                                        return false
+                                                    }
+                                                    if (
+                                                        !(
+                                                            data8 === 'exact' ||
+                                                            data8 === 'is_not' ||
+                                                            data8 === 'icontains' ||
+                                                            data8 === 'not_icontains' ||
+                                                            data8 === 'starts_with' ||
+                                                            data8 === 'not_starts_with' ||
+                                                            data8 === 'ends_with' ||
+                                                            data8 === 'not_ends_with' ||
+                                                            data8 === 'regex' ||
+                                                            data8 === 'not_regex' ||
+                                                            data8 === 'gt' ||
+                                                            data8 === 'gte' ||
+                                                            data8 === 'lt' ||
+                                                            data8 === 'lte' ||
+                                                            data8 === 'is_set' ||
+                                                            data8 === 'is_not_set' ||
+                                                            data8 === 'is_date_exact' ||
+                                                            data8 === 'is_date_before' ||
+                                                            data8 === 'is_date_after' ||
+                                                            data8 === 'between' ||
+                                                            data8 === 'not_between' ||
+                                                            data8 === 'min' ||
+                                                            data8 === 'max' ||
+                                                            data8 === 'in' ||
+                                                            data8 === 'not_in' ||
+                                                            data8 === 'is_cleaned_path_exact' ||
+                                                            data8 === 'flag_evaluates_to' ||
+                                                            data8 === 'semver_eq' ||
+                                                            data8 === 'semver_neq' ||
+                                                            data8 === 'semver_gt' ||
+                                                            data8 === 'semver_gte' ||
+                                                            data8 === 'semver_lt' ||
+                                                            data8 === 'semver_lte' ||
+                                                            data8 === 'semver_tilde' ||
+                                                            data8 === 'semver_caret' ||
+                                                            data8 === 'semver_wildcard' ||
+                                                            data8 === 'icontains_multi' ||
+                                                            data8 === 'not_icontains_multi'
+                                                        )
+                                                    ) {
+                                                        validate75.errors = [
+                                                            {
+                                                                instancePath: instancePath + '/operator',
+                                                                schemaPath: '#/definitions/PropertyOperator/enum',
+                                                                keyword: 'enum',
+                                                                params: { allowedValues: schema14.enum },
+                                                                message: 'must be equal to one of the allowed values',
+                                                            },
+                                                        ]
+                                                        return false
+                                                    }
+                                                    var valid0 = _errs24 === errors
+                                                } else {
+                                                    var valid0 = true
+                                                }
+                                                if (valid0) {
+                                                    if (data.operator_value !== undefined) {
+                                                        let data9 = data.operator_value
+                                                        const _errs27 = errors
+                                                        if (
+                                                            !(
+                                                                typeof data9 == 'number' &&
+                                                                !(data9 % 1) &&
+                                                                !isNaN(data9) &&
+                                                                isFinite(data9)
+                                                            )
+                                                        ) {
+                                                            validate75.errors = [
+                                                                {
+                                                                    instancePath: instancePath + '/operator_value',
+                                                                    schemaPath: '#/properties/operator_value/type',
+                                                                    keyword: 'type',
+                                                                    params: { type: 'integer' },
+                                                                    message: 'must be integer',
+                                                                },
+                                                            ]
+                                                            return false
+                                                        }
+                                                        var valid0 = _errs27 === errors
+                                                    } else {
+                                                        var valid0 = true
+                                                    }
+                                                    if (valid0) {
+                                                        if (data.time_interval !== undefined) {
+                                                            let data10 = data.time_interval
+                                                            const _errs29 = errors
+                                                            if (typeof data10 !== 'string') {
+                                                                validate75.errors = [
+                                                                    {
+                                                                        instancePath: instancePath + '/time_interval',
+                                                                        schemaPath: '#/definitions/TimeUnitType/type',
+                                                                        keyword: 'type',
+                                                                        params: { type: 'string' },
+                                                                        message: 'must be string',
+                                                                    },
+                                                                ]
+                                                                return false
+                                                            }
+                                                            if (
+                                                                !(
+                                                                    data10 === 'day' ||
+                                                                    data10 === 'week' ||
+                                                                    data10 === 'month' ||
+                                                                    data10 === 'year'
+                                                                )
+                                                            ) {
+                                                                validate75.errors = [
+                                                                    {
+                                                                        instancePath: instancePath + '/time_interval',
+                                                                        schemaPath: '#/definitions/TimeUnitType/enum',
+                                                                        keyword: 'enum',
+                                                                        params: { allowedValues: schema65.enum },
+                                                                        message:
+                                                                            'must be equal to one of the allowed values',
+                                                                    },
+                                                                ]
+                                                                return false
+                                                            }
+                                                            var valid0 = _errs29 === errors
+                                                        } else {
+                                                            var valid0 = true
+                                                        }
+                                                        if (valid0) {
+                                                            if (data.time_value !== undefined) {
+                                                                let data11 = data.time_value
+                                                                const _errs32 = errors
+                                                                if (
+                                                                    !(
+                                                                        typeof data11 == 'number' &&
+                                                                        !(data11 % 1) &&
+                                                                        !isNaN(data11) &&
+                                                                        isFinite(data11)
+                                                                    )
+                                                                ) {
+                                                                    validate75.errors = [
+                                                                        {
+                                                                            instancePath: instancePath + '/time_value',
+                                                                            schemaPath: '#/properties/time_value/type',
+                                                                            keyword: 'type',
+                                                                            params: { type: 'integer' },
+                                                                            message: 'must be integer',
+                                                                        },
+                                                                    ]
+                                                                    return false
+                                                                }
+                                                                var valid0 = _errs32 === errors
+                                                            } else {
+                                                                var valid0 = true
+                                                            }
+                                                            if (valid0) {
+                                                                if (data.type !== undefined) {
+                                                                    let data12 = data.type
+                                                                    const _errs34 = errors
+                                                                    if (typeof data12 !== 'string') {
+                                                                        validate75.errors = [
+                                                                            {
+                                                                                instancePath: instancePath + '/type',
+                                                                                schemaPath: '#/properties/type/type',
+                                                                                keyword: 'type',
+                                                                                params: { type: 'string' },
+                                                                                message: 'must be string',
+                                                                            },
+                                                                        ]
+                                                                        return false
+                                                                    }
+                                                                    if ('behavioral' !== data12) {
+                                                                        validate75.errors = [
+                                                                            {
+                                                                                instancePath: instancePath + '/type',
+                                                                                schemaPath: '#/properties/type/const',
+                                                                                keyword: 'const',
+                                                                                params: { allowedValue: 'behavioral' },
+                                                                                message: 'must be equal to constant',
+                                                                            },
+                                                                        ]
+                                                                        return false
+                                                                    }
+                                                                    var valid0 = _errs34 === errors
+                                                                } else {
+                                                                    var valid0 = true
+                                                                }
+                                                                if (valid0) {
+                                                                    if (data.value !== undefined) {
+                                                                        let data13 = data.value
+                                                                        const _errs36 = errors
+                                                                        if (typeof data13 !== 'string') {
+                                                                            validate75.errors = [
+                                                                                {
+                                                                                    instancePath:
+                                                                                        instancePath + '/value',
+                                                                                    schemaPath:
+                                                                                        '#/definitions/InlineBehavioralType/type',
+                                                                                    keyword: 'type',
+                                                                                    params: { type: 'string' },
+                                                                                    message: 'must be string',
+                                                                                },
+                                                                            ]
+                                                                            return false
+                                                                        }
+                                                                        if (
+                                                                            !(
+                                                                                data13 === 'performed_event' ||
+                                                                                data13 === 'performed_event_multiple'
+                                                                            )
+                                                                        ) {
+                                                                            validate75.errors = [
+                                                                                {
+                                                                                    instancePath:
+                                                                                        instancePath + '/value',
+                                                                                    schemaPath:
+                                                                                        '#/definitions/InlineBehavioralType/enum',
+                                                                                    keyword: 'enum',
+                                                                                    params: {
+                                                                                        allowedValues: schema66.enum,
+                                                                                    },
+                                                                                    message:
+                                                                                        'must be equal to one of the allowed values',
+                                                                                },
+                                                                            ]
+                                                                            return false
+                                                                        }
+                                                                        var valid0 = _errs36 === errors
+                                                                    } else {
+                                                                        var valid0 = true
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        } else {
+            validate75.errors = [
+                {
+                    instancePath,
+                    schemaPath: '#/type',
+                    keyword: 'type',
+                    params: { type: 'object' },
+                    message: 'must be object',
+                },
+            ]
+            return false
+        }
+    }
+    validate75.errors = vErrors
+    return errors === 0
+}
 function validate11(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
     let vErrors = null
     let errors = 0
@@ -6338,6 +6990,30 @@ function validate11(data, { instancePath = '', parentData, parentDataProperty, r
                                                                                             var _valid0 =
                                                                                                 _errs41 === errors
                                                                                             valid0 = valid0 || _valid0
+                                                                                            if (!valid0) {
+                                                                                                const _errs42 = errors
+                                                                                                if (
+                                                                                                    !validate75(data, {
+                                                                                                        instancePath,
+                                                                                                        parentData,
+                                                                                                        parentDataProperty,
+                                                                                                        rootData,
+                                                                                                    })
+                                                                                                ) {
+                                                                                                    vErrors =
+                                                                                                        vErrors === null
+                                                                                                            ? validate75.errors
+                                                                                                            : vErrors.concat(
+                                                                                                                  validate75.errors
+                                                                                                              )
+                                                                                                    errors =
+                                                                                                        vErrors.length
+                                                                                                }
+                                                                                                var _valid0 =
+                                                                                                    _errs42 === errors
+                                                                                                valid0 =
+                                                                                                    valid0 || _valid0
+                                                                                            }
                                                                                         }
                                                                                     }
                                                                                 }
@@ -6389,9 +7065,9 @@ function validate11(data, { instancePath = '', parentData, parentDataProperty, r
     validate11.errors = vErrors
     return errors === 0
 }
-export const WebAnalyticsPropertyFilters = validate75
-const schema62 = { items: { $ref: '#/definitions/WebAnalyticsPropertyFilter' }, type: 'array' }
-const schema63 = {
+export const WebAnalyticsPropertyFilters = validate82
+const schema67 = { items: { $ref: '#/definitions/WebAnalyticsPropertyFilter' }, type: 'array' }
+const schema68 = {
     anyOf: [
         { $ref: '#/definitions/EventPropertyFilter' },
         { $ref: '#/definitions/PersonPropertyFilter' },
@@ -6399,7 +7075,7 @@ const schema63 = {
         { $ref: '#/definitions/CohortPropertyFilter' },
     ],
 }
-function validate76(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
+function validate83(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
     let vErrors = null
     let errors = 0
     const _errs0 = errors
@@ -6452,7 +7128,7 @@ function validate76(data, { instancePath = '', parentData, parentDataProperty, r
             vErrors.push(err0)
         }
         errors++
-        validate76.errors = vErrors
+        validate83.errors = vErrors
         return false
     } else {
         errors = _errs0
@@ -6464,10 +7140,10 @@ function validate76(data, { instancePath = '', parentData, parentDataProperty, r
             }
         }
     }
-    validate76.errors = vErrors
+    validate83.errors = vErrors
     return errors === 0
 }
-function validate75(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
+function validate82(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
     let vErrors = null
     let errors = 0
     if (errors === 0) {
@@ -6477,14 +7153,14 @@ function validate75(data, { instancePath = '', parentData, parentDataProperty, r
             for (let i0 = 0; i0 < len0; i0++) {
                 const _errs1 = errors
                 if (
-                    !validate76(data[i0], {
+                    !validate83(data[i0], {
                         instancePath: instancePath + '/' + i0,
                         parentData: data,
                         parentDataProperty: i0,
                         rootData,
                     })
                 ) {
-                    vErrors = vErrors === null ? validate76.errors : vErrors.concat(validate76.errors)
+                    vErrors = vErrors === null ? validate83.errors : vErrors.concat(validate83.errors)
                     errors = vErrors.length
                 }
                 var valid0 = _errs1 === errors
@@ -6493,7 +7169,7 @@ function validate75(data, { instancePath = '', parentData, parentDataProperty, r
                 }
             }
         } else {
-            validate75.errors = [
+            validate82.errors = [
                 {
                     instancePath,
                     schemaPath: '#/type',
@@ -6505,11 +7181,11 @@ function validate75(data, { instancePath = '', parentData, parentDataProperty, r
             return false
         }
     }
-    validate75.errors = vErrors
+    validate82.errors = vErrors
     return errors === 0
 }
-export const SessionPropertyFilter = validate82
-function validate82(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
+export const SessionPropertyFilter = validate89
+function validate89(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
     let vErrors = null
     let errors = 0
     if (errors === 0) {
@@ -6520,7 +7196,7 @@ function validate82(data, { instancePath = '', parentData, parentDataProperty, r
                 (data.operator === undefined && (missing0 = 'operator')) ||
                 (data.type === undefined && (missing0 = 'type'))
             ) {
-                validate82.errors = [
+                validate89.errors = [
                     {
                         instancePath,
                         schemaPath: '#/required',
@@ -6542,7 +7218,7 @@ function validate82(data, { instancePath = '', parentData, parentDataProperty, r
                             key0 === 'value'
                         )
                     ) {
-                        validate82.errors = [
+                        validate89.errors = [
                             {
                                 instancePath,
                                 schemaPath: '#/additionalProperties',
@@ -6559,7 +7235,7 @@ function validate82(data, { instancePath = '', parentData, parentDataProperty, r
                     if (data.key !== undefined) {
                         const _errs2 = errors
                         if (typeof data.key !== 'string') {
-                            validate82.errors = [
+                            validate89.errors = [
                                 {
                                     instancePath: instancePath + '/key',
                                     schemaPath: '#/properties/key/type',
@@ -6578,7 +7254,7 @@ function validate82(data, { instancePath = '', parentData, parentDataProperty, r
                         if (data.label !== undefined) {
                             const _errs4 = errors
                             if (typeof data.label !== 'string') {
-                                validate82.errors = [
+                                validate89.errors = [
                                     {
                                         instancePath: instancePath + '/label',
                                         schemaPath: '#/properties/label/type',
@@ -6598,7 +7274,7 @@ function validate82(data, { instancePath = '', parentData, parentDataProperty, r
                                 let data2 = data.operator
                                 const _errs6 = errors
                                 if (typeof data2 !== 'string') {
-                                    validate82.errors = [
+                                    validate89.errors = [
                                         {
                                             instancePath: instancePath + '/operator',
                                             schemaPath: '#/definitions/PropertyOperator/type',
@@ -6651,7 +7327,7 @@ function validate82(data, { instancePath = '', parentData, parentDataProperty, r
                                         data2 === 'not_icontains_multi'
                                     )
                                 ) {
-                                    validate82.errors = [
+                                    validate89.errors = [
                                         {
                                             instancePath: instancePath + '/operator',
                                             schemaPath: '#/definitions/PropertyOperator/enum',
@@ -6671,7 +7347,7 @@ function validate82(data, { instancePath = '', parentData, parentDataProperty, r
                                     let data3 = data.type
                                     const _errs9 = errors
                                     if (typeof data3 !== 'string') {
-                                        validate82.errors = [
+                                        validate89.errors = [
                                             {
                                                 instancePath: instancePath + '/type',
                                                 schemaPath: '#/properties/type/type',
@@ -6683,7 +7359,7 @@ function validate82(data, { instancePath = '', parentData, parentDataProperty, r
                                         return false
                                     }
                                     if ('session' !== data3) {
-                                        validate82.errors = [
+                                        validate89.errors = [
                                             {
                                                 instancePath: instancePath + '/type',
                                                 schemaPath: '#/properties/type/const',
@@ -6724,7 +7400,7 @@ function validate82(data, { instancePath = '', parentData, parentDataProperty, r
                 }
             }
         } else {
-            validate82.errors = [
+            validate89.errors = [
                 {
                     instancePath,
                     schemaPath: '#/type',
@@ -6736,11 +7412,11 @@ function validate82(data, { instancePath = '', parentData, parentDataProperty, r
             return false
         }
     }
-    validate82.errors = vErrors
+    validate89.errors = vErrors
     return errors === 0
 }
-export const CompareFilter = validate84
-const schema66 = {
+export const CompareFilter = validate91
+const schema71 = {
     additionalProperties: false,
     properties: {
         compare: {
@@ -6756,7 +7432,7 @@ const schema66 = {
     },
     type: 'object',
 }
-function validate84(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
+function validate91(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
     let vErrors = null
     let errors = 0
     if (errors === 0) {
@@ -6764,7 +7440,7 @@ function validate84(data, { instancePath = '', parentData, parentDataProperty, r
             const _errs1 = errors
             for (const key0 in data) {
                 if (!(key0 === 'compare' || key0 === 'compare_to')) {
-                    validate84.errors = [
+                    validate91.errors = [
                         {
                             instancePath,
                             schemaPath: '#/additionalProperties',
@@ -6781,7 +7457,7 @@ function validate84(data, { instancePath = '', parentData, parentDataProperty, r
                 if (data.compare !== undefined) {
                     const _errs2 = errors
                     if (typeof data.compare !== 'boolean') {
-                        validate84.errors = [
+                        validate91.errors = [
                             {
                                 instancePath: instancePath + '/compare',
                                 schemaPath: '#/properties/compare/type',
@@ -6800,7 +7476,7 @@ function validate84(data, { instancePath = '', parentData, parentDataProperty, r
                     if (data.compare_to !== undefined) {
                         const _errs4 = errors
                         if (typeof data.compare_to !== 'string') {
-                            validate84.errors = [
+                            validate91.errors = [
                                 {
                                     instancePath: instancePath + '/compare_to',
                                     schemaPath: '#/properties/compare_to/type',
@@ -6818,7 +7494,7 @@ function validate84(data, { instancePath = '', parentData, parentDataProperty, r
                 }
             }
         } else {
-            validate84.errors = [
+            validate91.errors = [
                 {
                     instancePath,
                     schemaPath: '#/type',
@@ -6830,11 +7506,11 @@ function validate84(data, { instancePath = '', parentData, parentDataProperty, r
             return false
         }
     }
-    validate84.errors = vErrors
+    validate91.errors = vErrors
     return errors === 0
 }
-export const ExperimentMetric = validate85
-const schema67 = {
+export const ExperimentMetric = validate92
+const schema72 = {
     discriminator: { propertyName: 'metric_type' },
     oneOf: [
         { $ref: '#/definitions/ExperimentMeanMetric' },
@@ -6845,7 +7521,7 @@ const schema67 = {
     required: ['metric_type'],
     type: 'object',
 }
-const schema68 = {
+const schema73 = {
     additionalProperties: false,
     properties: {
         breakdownFilter: { $ref: '#/definitions/BreakdownFilter' },
@@ -6886,11 +7562,10 @@ const schema68 = {
     required: ['kind', 'metric_type', 'source'],
     type: 'object',
 }
-const schema70 = { type: 'integer' }
-const schema82 = { enum: ['second', 'minute', 'hour', 'day', 'week', 'month'], type: 'string' }
-const schema83 = { enum: ['increase', 'decrease'], type: 'string' }
-const func2 = Object.prototype.hasOwnProperty
-const schema69 = {
+const schema75 = { type: 'integer' }
+const schema87 = { enum: ['second', 'minute', 'hour', 'day', 'week', 'month'], type: 'string' }
+const schema88 = { enum: ['increase', 'decrease'], type: 'string' }
+const schema74 = {
     additionalProperties: false,
     properties: {
         breakdown: {
@@ -6912,7 +7587,7 @@ const schema69 = {
     },
     type: 'object',
 }
-const schema75 = {
+const schema80 = {
     enum: [
         'cohort',
         'person',
@@ -6927,7 +7602,7 @@ const schema75 = {
     ],
     type: 'string',
 }
-const schema76 = {
+const schema81 = {
     additionalProperties: false,
     properties: {
         group_type_index: { anyOf: [{ $ref: '#/definitions/integer' }, { type: 'null' }] },
@@ -6939,7 +7614,7 @@ const schema76 = {
     required: ['property'],
     type: 'object',
 }
-const schema80 = {
+const schema85 = {
     enum: [
         'person',
         'event',
@@ -6954,14 +7629,14 @@ const schema80 = {
     ],
     type: 'string',
 }
-function validate88(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
+function validate95(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
     let vErrors = null
     let errors = 0
     if (errors === 0) {
         if (data && typeof data == 'object' && !Array.isArray(data)) {
             let missing0
             if (data.property === undefined && (missing0 = 'property')) {
-                validate88.errors = [
+                validate95.errors = [
                     {
                         instancePath,
                         schemaPath: '#/required',
@@ -6983,7 +7658,7 @@ function validate88(data, { instancePath = '', parentData, parentDataProperty, r
                             key0 === 'type'
                         )
                     ) {
-                        validate88.errors = [
+                        validate95.errors = [
                             {
                                 instancePath,
                                 schemaPath: '#/additionalProperties',
@@ -7054,7 +7729,7 @@ function validate88(data, { instancePath = '', parentData, parentDataProperty, r
                                 vErrors.push(err2)
                             }
                             errors++
-                            validate88.errors = vErrors
+                            validate95.errors = vErrors
                             return false
                         } else {
                             errors = _errs3
@@ -7075,7 +7750,7 @@ function validate88(data, { instancePath = '', parentData, parentDataProperty, r
                             let data1 = data.histogram_bin_count
                             const _errs9 = errors
                             if (!(typeof data1 == 'number' && !(data1 % 1) && !isNaN(data1) && isFinite(data1))) {
-                                validate88.errors = [
+                                validate95.errors = [
                                     {
                                         instancePath: instancePath + '/histogram_bin_count',
                                         schemaPath: '#/definitions/integer/type',
@@ -7094,7 +7769,7 @@ function validate88(data, { instancePath = '', parentData, parentDataProperty, r
                             if (data.normalize_url !== undefined) {
                                 const _errs12 = errors
                                 if (typeof data.normalize_url !== 'boolean') {
-                                    validate88.errors = [
+                                    validate95.errors = [
                                         {
                                             instancePath: instancePath + '/normalize_url',
                                             schemaPath: '#/properties/normalize_url/type',
@@ -7174,7 +7849,7 @@ function validate88(data, { instancePath = '', parentData, parentDataProperty, r
                                             vErrors.push(err5)
                                         }
                                         errors++
-                                        validate88.errors = vErrors
+                                        validate95.errors = vErrors
                                         return false
                                     } else {
                                         errors = _errs15
@@ -7230,7 +7905,7 @@ function validate88(data, { instancePath = '', parentData, parentDataProperty, r
                                                 instancePath: instancePath + '/type',
                                                 schemaPath: '#/definitions/MultipleBreakdownType/enum',
                                                 keyword: 'enum',
-                                                params: { allowedValues: schema80.enum },
+                                                params: { allowedValues: schema85.enum },
                                                 message: 'must be equal to one of the allowed values',
                                             }
                                             if (vErrors === null) {
@@ -7276,7 +7951,7 @@ function validate88(data, { instancePath = '', parentData, parentDataProperty, r
                                                 vErrors.push(err9)
                                             }
                                             errors++
-                                            validate88.errors = vErrors
+                                            validate95.errors = vErrors
                                             return false
                                         } else {
                                             errors = _errs22
@@ -7299,7 +7974,7 @@ function validate88(data, { instancePath = '', parentData, parentDataProperty, r
                 }
             }
         } else {
-            validate88.errors = [
+            validate95.errors = [
                 {
                     instancePath,
                     schemaPath: '#/type',
@@ -7311,18 +7986,18 @@ function validate88(data, { instancePath = '', parentData, parentDataProperty, r
             return false
         }
     }
-    validate88.errors = vErrors
+    validate95.errors = vErrors
     return errors === 0
 }
-function validate87(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
+function validate94(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
     let vErrors = null
     let errors = 0
     if (errors === 0) {
         if (data && typeof data == 'object' && !Array.isArray(data)) {
             const _errs1 = errors
             for (const key0 in data) {
-                if (!func2.call(schema69.properties, key0)) {
-                    validate87.errors = [
+                if (!func2.call(schema74.properties, key0)) {
+                    validate94.errors = [
                         {
                             instancePath,
                             schemaPath: '#/additionalProperties',
@@ -7517,7 +8192,7 @@ function validate87(data, { instancePath = '', parentData, parentDataProperty, r
                             vErrors.push(err7)
                         }
                         errors++
-                        validate87.errors = vErrors
+                        validate94.errors = vErrors
                         return false
                     } else {
                         errors = _errs3
@@ -7591,7 +8266,7 @@ function validate87(data, { instancePath = '', parentData, parentDataProperty, r
                                 vErrors.push(err10)
                             }
                             errors++
-                            validate87.errors = vErrors
+                            validate94.errors = vErrors
                             return false
                         } else {
                             errors = _errs21
@@ -7612,12 +8287,12 @@ function validate87(data, { instancePath = '', parentData, parentDataProperty, r
                             let data3 = data.breakdown_hide_other_aggregation
                             const _errs27 = errors
                             if (typeof data3 !== 'boolean' && data3 !== null) {
-                                validate87.errors = [
+                                validate94.errors = [
                                     {
                                         instancePath: instancePath + '/breakdown_hide_other_aggregation',
                                         schemaPath: '#/properties/breakdown_hide_other_aggregation/type',
                                         keyword: 'type',
-                                        params: { type: schema69.properties.breakdown_hide_other_aggregation.type },
+                                        params: { type: schema74.properties.breakdown_hide_other_aggregation.type },
                                         message: 'must be boolean,null',
                                     },
                                 ]
@@ -7632,7 +8307,7 @@ function validate87(data, { instancePath = '', parentData, parentDataProperty, r
                                 let data4 = data.breakdown_histogram_bin_count
                                 const _errs29 = errors
                                 if (!(typeof data4 == 'number' && !(data4 % 1) && !isNaN(data4) && isFinite(data4))) {
-                                    validate87.errors = [
+                                    validate94.errors = [
                                         {
                                             instancePath: instancePath + '/breakdown_histogram_bin_count',
                                             schemaPath: '#/definitions/integer/type',
@@ -7654,7 +8329,7 @@ function validate87(data, { instancePath = '', parentData, parentDataProperty, r
                                     if (
                                         !(typeof data5 == 'number' && !(data5 % 1) && !isNaN(data5) && isFinite(data5))
                                     ) {
-                                        validate87.errors = [
+                                        validate94.errors = [
                                             {
                                                 instancePath: instancePath + '/breakdown_limit',
                                                 schemaPath: '#/definitions/integer/type',
@@ -7673,7 +8348,7 @@ function validate87(data, { instancePath = '', parentData, parentDataProperty, r
                                     if (data.breakdown_normalize_url !== undefined) {
                                         const _errs35 = errors
                                         if (typeof data.breakdown_normalize_url !== 'boolean') {
-                                            validate87.errors = [
+                                            validate94.errors = [
                                                 {
                                                     instancePath: instancePath + '/breakdown_normalize_url',
                                                     schemaPath: '#/properties/breakdown_normalize_url/type',
@@ -7692,7 +8367,7 @@ function validate87(data, { instancePath = '', parentData, parentDataProperty, r
                                         if (data.breakdown_path_cleaning !== undefined) {
                                             const _errs37 = errors
                                             if (typeof data.breakdown_path_cleaning !== 'boolean') {
-                                                validate87.errors = [
+                                                validate94.errors = [
                                                     {
                                                         instancePath: instancePath + '/breakdown_path_cleaning',
                                                         schemaPath: '#/properties/breakdown_path_cleaning/type',
@@ -7747,7 +8422,7 @@ function validate87(data, { instancePath = '', parentData, parentDataProperty, r
                                                         instancePath: instancePath + '/breakdown_type',
                                                         schemaPath: '#/definitions/BreakdownType/enum',
                                                         keyword: 'enum',
-                                                        params: { allowedValues: schema75.enum },
+                                                        params: { allowedValues: schema80.enum },
                                                         message: 'must be equal to one of the allowed values',
                                                     }
                                                     if (vErrors === null) {
@@ -7793,7 +8468,7 @@ function validate87(data, { instancePath = '', parentData, parentDataProperty, r
                                                         vErrors.push(err14)
                                                     }
                                                     errors++
-                                                    validate87.errors = vErrors
+                                                    validate94.errors = vErrors
                                                     return false
                                                 } else {
                                                     errors = _errs40
@@ -7816,7 +8491,7 @@ function validate87(data, { instancePath = '', parentData, parentDataProperty, r
                                                     if (errors === _errs46) {
                                                         if (Array.isArray(data9)) {
                                                             if (data9.length > 3) {
-                                                                validate87.errors = [
+                                                                validate94.errors = [
                                                                     {
                                                                         instancePath: instancePath + '/breakdowns',
                                                                         schemaPath: '#/properties/breakdowns/maxItems',
@@ -7832,7 +8507,7 @@ function validate87(data, { instancePath = '', parentData, parentDataProperty, r
                                                                 for (let i1 = 0; i1 < len1; i1++) {
                                                                     const _errs48 = errors
                                                                     if (
-                                                                        !validate88(data9[i1], {
+                                                                        !validate95(data9[i1], {
                                                                             instancePath:
                                                                                 instancePath + '/breakdowns/' + i1,
                                                                             parentData: data9,
@@ -7842,8 +8517,8 @@ function validate87(data, { instancePath = '', parentData, parentDataProperty, r
                                                                     ) {
                                                                         vErrors =
                                                                             vErrors === null
-                                                                                ? validate88.errors
-                                                                                : vErrors.concat(validate88.errors)
+                                                                                ? validate95.errors
+                                                                                : vErrors.concat(validate95.errors)
                                                                         errors = vErrors.length
                                                                     }
                                                                     var valid12 = _errs48 === errors
@@ -7853,7 +8528,7 @@ function validate87(data, { instancePath = '', parentData, parentDataProperty, r
                                                                 }
                                                             }
                                                         } else {
-                                                            validate87.errors = [
+                                                            validate94.errors = [
                                                                 {
                                                                     instancePath: instancePath + '/breakdowns',
                                                                     schemaPath: '#/properties/breakdowns/type',
@@ -7879,7 +8554,7 @@ function validate87(data, { instancePath = '', parentData, parentDataProperty, r
                 }
             }
         } else {
-            validate87.errors = [
+            validate94.errors = [
                 {
                     instancePath,
                     schemaPath: '#/type',
@@ -7891,10 +8566,10 @@ function validate87(data, { instancePath = '', parentData, parentDataProperty, r
             return false
         }
     }
-    validate87.errors = vErrors
+    validate94.errors = vErrors
     return errors === 0
 }
-const schema84 = {
+const schema89 = {
     discriminator: { propertyName: 'kind' },
     oneOf: [
         { $ref: '#/definitions/EventsNode' },
@@ -7904,7 +8579,7 @@ const schema84 = {
     required: ['kind'],
     type: 'object',
 }
-const schema85 = {
+const schema90 = {
     additionalProperties: false,
     properties: {
         custom_name: { type: 'string' },
@@ -7938,7 +8613,7 @@ const schema85 = {
     required: ['kind'],
     type: 'object',
 }
-const schema87 = {
+const schema92 = {
     anyOf: [
         { $ref: '#/definitions/BaseMathType' },
         { $ref: '#/definitions/FunnelMathType' },
@@ -7950,7 +8625,7 @@ const schema87 = {
         { $ref: '#/definitions/CalendarHeatmapMathType' },
     ],
 }
-const schema88 = {
+const schema93 = {
     enum: [
         'total',
         'dau',
@@ -7962,9 +8637,9 @@ const schema88 = {
     ],
     type: 'string',
 }
-const schema89 = { enum: ['total', 'first_time_for_user', 'first_time_for_user_with_filters'], type: 'string' }
-const schema90 = { enum: ['avg', 'sum', 'min', 'max', 'median', 'p75', 'p90', 'p95', 'p99'], type: 'string' }
-const schema91 = {
+const schema94 = { enum: ['total', 'first_time_for_user', 'first_time_for_user_with_filters'], type: 'string' }
+const schema95 = { enum: ['avg', 'sum', 'min', 'max', 'median', 'p75', 'p90', 'p95', 'p99'], type: 'string' }
+const schema96 = {
     enum: [
         'avg_count_per_actor',
         'min_count_per_actor',
@@ -7977,14 +8652,14 @@ const schema91 = {
     ],
     type: 'string',
 }
-const schema92 = { enum: ['unique_group', 'first_time_for_group', 'first_matching_event_for_group'], type: 'string' }
-const schema93 = { const: 'hogql', type: 'string' }
-const schema94 = {
+const schema97 = { enum: ['unique_group', 'first_time_for_group', 'first_matching_event_for_group'], type: 'string' }
+const schema98 = { const: 'hogql', type: 'string' }
+const schema99 = {
     enum: ['total', 'sum', 'unique_session', 'min', 'max', 'avg', 'dau', 'unique_group', 'hogql'],
     type: 'string',
 }
-const schema95 = { enum: ['total', 'dau'], type: 'string' }
-function validate94(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
+const schema100 = { enum: ['total', 'dau'], type: 'string' }
+function validate101(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
     let vErrors = null
     let errors = 0
     const _errs0 = errors
@@ -8020,7 +8695,7 @@ function validate94(data, { instancePath = '', parentData, parentDataProperty, r
             instancePath,
             schemaPath: '#/definitions/BaseMathType/enum',
             keyword: 'enum',
-            params: { allowedValues: schema88.enum },
+            params: { allowedValues: schema93.enum },
             message: 'must be equal to one of the allowed values',
         }
         if (vErrors === null) {
@@ -8054,7 +8729,7 @@ function validate94(data, { instancePath = '', parentData, parentDataProperty, r
                 instancePath,
                 schemaPath: '#/definitions/FunnelMathType/enum',
                 keyword: 'enum',
-                params: { allowedValues: schema89.enum },
+                params: { allowedValues: schema94.enum },
                 message: 'must be equal to one of the allowed values',
             }
             if (vErrors === null) {
@@ -8100,7 +8775,7 @@ function validate94(data, { instancePath = '', parentData, parentDataProperty, r
                     instancePath,
                     schemaPath: '#/definitions/PropertyMathType/enum',
                     keyword: 'enum',
-                    params: { allowedValues: schema90.enum },
+                    params: { allowedValues: schema95.enum },
                     message: 'must be equal to one of the allowed values',
                 }
                 if (vErrors === null) {
@@ -8145,7 +8820,7 @@ function validate94(data, { instancePath = '', parentData, parentDataProperty, r
                         instancePath,
                         schemaPath: '#/definitions/CountPerActorMathType/enum',
                         keyword: 'enum',
-                        params: { allowedValues: schema91.enum },
+                        params: { allowedValues: schema96.enum },
                         message: 'must be equal to one of the allowed values',
                     }
                     if (vErrors === null) {
@@ -8185,7 +8860,7 @@ function validate94(data, { instancePath = '', parentData, parentDataProperty, r
                             instancePath,
                             schemaPath: '#/definitions/GroupMathType/enum',
                             keyword: 'enum',
-                            params: { allowedValues: schema92.enum },
+                            params: { allowedValues: schema97.enum },
                             message: 'must be equal to one of the allowed values',
                         }
                         if (vErrors === null) {
@@ -8265,7 +8940,7 @@ function validate94(data, { instancePath = '', parentData, parentDataProperty, r
                                     instancePath,
                                     schemaPath: '#/definitions/ExperimentMetricMathType/enum',
                                     keyword: 'enum',
-                                    params: { allowedValues: schema94.enum },
+                                    params: { allowedValues: schema99.enum },
                                     message: 'must be equal to one of the allowed values',
                                 }
                                 if (vErrors === null) {
@@ -8299,7 +8974,7 @@ function validate94(data, { instancePath = '', parentData, parentDataProperty, r
                                         instancePath,
                                         schemaPath: '#/definitions/CalendarHeatmapMathType/enum',
                                         keyword: 'enum',
-                                        params: { allowedValues: schema95.enum },
+                                        params: { allowedValues: schema100.enum },
                                         message: 'must be equal to one of the allowed values',
                                     }
                                     if (vErrors === null) {
@@ -8332,7 +9007,7 @@ function validate94(data, { instancePath = '', parentData, parentDataProperty, r
             vErrors.push(err16)
         }
         errors++
-        validate94.errors = vErrors
+        validate101.errors = vErrors
         return false
     } else {
         errors = _errs0
@@ -8344,15 +9019,15 @@ function validate94(data, { instancePath = '', parentData, parentDataProperty, r
             }
         }
     }
-    validate94.errors = vErrors
+    validate101.errors = vErrors
     return errors === 0
 }
-const schema96 = {
+const schema101 = {
     additionalProperties: false,
     properties: { property: { type: 'string' }, static: { $ref: '#/definitions/CurrencyCode' } },
     type: 'object',
 }
-const schema97 = {
+const schema102 = {
     enum: [
         'AED',
         'AFN',
@@ -8509,7 +9184,7 @@ const schema97 = {
     ],
     type: 'string',
 }
-function validate96(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
+function validate103(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
     let vErrors = null
     let errors = 0
     if (errors === 0) {
@@ -8517,7 +9192,7 @@ function validate96(data, { instancePath = '', parentData, parentDataProperty, r
             const _errs1 = errors
             for (const key0 in data) {
                 if (!(key0 === 'property' || key0 === 'static')) {
-                    validate96.errors = [
+                    validate103.errors = [
                         {
                             instancePath,
                             schemaPath: '#/additionalProperties',
@@ -8534,7 +9209,7 @@ function validate96(data, { instancePath = '', parentData, parentDataProperty, r
                 if (data.property !== undefined) {
                     const _errs2 = errors
                     if (typeof data.property !== 'string') {
-                        validate96.errors = [
+                        validate103.errors = [
                             {
                                 instancePath: instancePath + '/property',
                                 schemaPath: '#/properties/property/type',
@@ -8554,7 +9229,7 @@ function validate96(data, { instancePath = '', parentData, parentDataProperty, r
                         let data1 = data.static
                         const _errs4 = errors
                         if (typeof data1 !== 'string') {
-                            validate96.errors = [
+                            validate103.errors = [
                                 {
                                     instancePath: instancePath + '/static',
                                     schemaPath: '#/definitions/CurrencyCode/type',
@@ -8721,12 +9396,12 @@ function validate96(data, { instancePath = '', parentData, parentDataProperty, r
                                 data1 === 'ZMW'
                             )
                         ) {
-                            validate96.errors = [
+                            validate103.errors = [
                                 {
                                     instancePath: instancePath + '/static',
                                     schemaPath: '#/definitions/CurrencyCode/enum',
                                     keyword: 'enum',
-                                    params: { allowedValues: schema97.enum },
+                                    params: { allowedValues: schema102.enum },
                                     message: 'must be equal to one of the allowed values',
                                 },
                             ]
@@ -8739,7 +9414,7 @@ function validate96(data, { instancePath = '', parentData, parentDataProperty, r
                 }
             }
         } else {
-            validate96.errors = [
+            validate103.errors = [
                 {
                     instancePath,
                     schemaPath: '#/type',
@@ -8751,17 +9426,17 @@ function validate96(data, { instancePath = '', parentData, parentDataProperty, r
             return false
         }
     }
-    validate96.errors = vErrors
+    validate103.errors = vErrors
     return errors === 0
 }
-function validate92(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
+function validate99(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
     let vErrors = null
     let errors = 0
     if (errors === 0) {
         if (data && typeof data == 'object' && !Array.isArray(data)) {
             let missing0
             if (data.kind === undefined && (missing0 = 'kind')) {
-                validate92.errors = [
+                validate99.errors = [
                     {
                         instancePath,
                         schemaPath: '#/required',
@@ -8774,8 +9449,8 @@ function validate92(data, { instancePath = '', parentData, parentDataProperty, r
             } else {
                 const _errs1 = errors
                 for (const key0 in data) {
-                    if (!func2.call(schema85.properties, key0)) {
-                        validate92.errors = [
+                    if (!func2.call(schema90.properties, key0)) {
+                        validate99.errors = [
                             {
                                 instancePath,
                                 schemaPath: '#/additionalProperties',
@@ -8792,7 +9467,7 @@ function validate92(data, { instancePath = '', parentData, parentDataProperty, r
                     if (data.custom_name !== undefined) {
                         const _errs2 = errors
                         if (typeof data.custom_name !== 'string') {
-                            validate92.errors = [
+                            validate99.errors = [
                                 {
                                     instancePath: instancePath + '/custom_name',
                                     schemaPath: '#/properties/custom_name/type',
@@ -8812,12 +9487,12 @@ function validate92(data, { instancePath = '', parentData, parentDataProperty, r
                             let data1 = data.event
                             const _errs4 = errors
                             if (typeof data1 !== 'string' && data1 !== null) {
-                                validate92.errors = [
+                                validate99.errors = [
                                     {
                                         instancePath: instancePath + '/event',
                                         schemaPath: '#/properties/event/type',
                                         keyword: 'type',
-                                        params: { type: schema85.properties.event.type },
+                                        params: { type: schema90.properties.event.type },
                                         message: 'must be string,null',
                                     },
                                 ]
@@ -8857,7 +9532,7 @@ function validate92(data, { instancePath = '', parentData, parentDataProperty, r
                                             }
                                         }
                                     } else {
-                                        validate92.errors = [
+                                        validate99.errors = [
                                             {
                                                 instancePath: instancePath + '/fixedProperties',
                                                 schemaPath: '#/properties/fixedProperties/type',
@@ -8878,7 +9553,7 @@ function validate92(data, { instancePath = '', parentData, parentDataProperty, r
                                     let data4 = data.kind
                                     const _errs9 = errors
                                     if (typeof data4 !== 'string') {
-                                        validate92.errors = [
+                                        validate99.errors = [
                                             {
                                                 instancePath: instancePath + '/kind',
                                                 schemaPath: '#/properties/kind/type',
@@ -8890,7 +9565,7 @@ function validate92(data, { instancePath = '', parentData, parentDataProperty, r
                                         return false
                                     }
                                     if ('EventsNode' !== data4) {
-                                        validate92.errors = [
+                                        validate99.errors = [
                                             {
                                                 instancePath: instancePath + '/kind',
                                                 schemaPath: '#/properties/kind/const',
@@ -8917,7 +9592,7 @@ function validate92(data, { instancePath = '', parentData, parentDataProperty, r
                                                 isFinite(data5)
                                             )
                                         ) {
-                                            validate92.errors = [
+                                            validate99.errors = [
                                                 {
                                                     instancePath: instancePath + '/limit',
                                                     schemaPath: '#/definitions/integer/type',
@@ -8936,7 +9611,7 @@ function validate92(data, { instancePath = '', parentData, parentDataProperty, r
                                         if (data.math !== undefined) {
                                             const _errs14 = errors
                                             if (
-                                                !validate94(data.math, {
+                                                !validate101(data.math, {
                                                     instancePath: instancePath + '/math',
                                                     parentData: data,
                                                     parentDataProperty: 'math',
@@ -8945,8 +9620,8 @@ function validate92(data, { instancePath = '', parentData, parentDataProperty, r
                                             ) {
                                                 vErrors =
                                                     vErrors === null
-                                                        ? validate94.errors
-                                                        : vErrors.concat(validate94.errors)
+                                                        ? validate101.errors
+                                                        : vErrors.concat(validate101.errors)
                                                 errors = vErrors.length
                                             }
                                             var valid0 = _errs14 === errors
@@ -8958,7 +9633,7 @@ function validate92(data, { instancePath = '', parentData, parentDataProperty, r
                                                 let data7 = data.math_group_type_index
                                                 const _errs15 = errors
                                                 if (!(typeof data7 == 'number' && isFinite(data7))) {
-                                                    validate92.errors = [
+                                                    validate99.errors = [
                                                         {
                                                             instancePath: instancePath + '/math_group_type_index',
                                                             schemaPath: '#/properties/math_group_type_index/type',
@@ -8978,14 +9653,14 @@ function validate92(data, { instancePath = '', parentData, parentDataProperty, r
                                                         data7 === 4
                                                     )
                                                 ) {
-                                                    validate92.errors = [
+                                                    validate99.errors = [
                                                         {
                                                             instancePath: instancePath + '/math_group_type_index',
                                                             schemaPath: '#/properties/math_group_type_index/enum',
                                                             keyword: 'enum',
                                                             params: {
                                                                 allowedValues:
-                                                                    schema85.properties.math_group_type_index.enum,
+                                                                    schema90.properties.math_group_type_index.enum,
                                                             },
                                                             message: 'must be equal to one of the allowed values',
                                                         },
@@ -9000,7 +9675,7 @@ function validate92(data, { instancePath = '', parentData, parentDataProperty, r
                                                 if (data.math_hogql !== undefined) {
                                                     const _errs17 = errors
                                                     if (typeof data.math_hogql !== 'string') {
-                                                        validate92.errors = [
+                                                        validate99.errors = [
                                                             {
                                                                 instancePath: instancePath + '/math_hogql',
                                                                 schemaPath: '#/properties/math_hogql/type',
@@ -9020,7 +9695,7 @@ function validate92(data, { instancePath = '', parentData, parentDataProperty, r
                                                         let data9 = data.math_multiplier
                                                         const _errs19 = errors
                                                         if (!(typeof data9 == 'number' && isFinite(data9))) {
-                                                            validate92.errors = [
+                                                            validate99.errors = [
                                                                 {
                                                                     instancePath: instancePath + '/math_multiplier',
                                                                     schemaPath: '#/properties/math_multiplier/type',
@@ -9039,7 +9714,7 @@ function validate92(data, { instancePath = '', parentData, parentDataProperty, r
                                                         if (data.math_property !== undefined) {
                                                             const _errs21 = errors
                                                             if (typeof data.math_property !== 'string') {
-                                                                validate92.errors = [
+                                                                validate99.errors = [
                                                                     {
                                                                         instancePath: instancePath + '/math_property',
                                                                         schemaPath: '#/properties/math_property/type',
@@ -9058,7 +9733,7 @@ function validate92(data, { instancePath = '', parentData, parentDataProperty, r
                                                             if (data.math_property_revenue_currency !== undefined) {
                                                                 const _errs23 = errors
                                                                 if (
-                                                                    !validate96(data.math_property_revenue_currency, {
+                                                                    !validate103(data.math_property_revenue_currency, {
                                                                         instancePath:
                                                                             instancePath +
                                                                             '/math_property_revenue_currency',
@@ -9070,8 +9745,8 @@ function validate92(data, { instancePath = '', parentData, parentDataProperty, r
                                                                 ) {
                                                                     vErrors =
                                                                         vErrors === null
-                                                                            ? validate96.errors
-                                                                            : vErrors.concat(validate96.errors)
+                                                                            ? validate103.errors
+                                                                            : vErrors.concat(validate103.errors)
                                                                     errors = vErrors.length
                                                                 }
                                                                 var valid0 = _errs23 === errors
@@ -9082,7 +9757,7 @@ function validate92(data, { instancePath = '', parentData, parentDataProperty, r
                                                                 if (data.math_property_type !== undefined) {
                                                                     const _errs24 = errors
                                                                     if (typeof data.math_property_type !== 'string') {
-                                                                        validate92.errors = [
+                                                                        validate99.errors = [
                                                                             {
                                                                                 instancePath:
                                                                                     instancePath +
@@ -9104,7 +9779,7 @@ function validate92(data, { instancePath = '', parentData, parentDataProperty, r
                                                                     if (data.name !== undefined) {
                                                                         const _errs26 = errors
                                                                         if (typeof data.name !== 'string') {
-                                                                            validate92.errors = [
+                                                                            validate99.errors = [
                                                                                 {
                                                                                     instancePath:
                                                                                         instancePath + '/name',
@@ -9128,7 +9803,7 @@ function validate92(data, { instancePath = '', parentData, parentDataProperty, r
                                                                                 typeof data.optionalInFunnel !==
                                                                                 'boolean'
                                                                             ) {
-                                                                                validate92.errors = [
+                                                                                validate99.errors = [
                                                                                     {
                                                                                         instancePath:
                                                                                             instancePath +
@@ -9164,7 +9839,7 @@ function validate92(data, { instancePath = '', parentData, parentDataProperty, r
                                                                                                 typeof data15[i1] !==
                                                                                                 'string'
                                                                                             ) {
-                                                                                                validate92.errors = [
+                                                                                                validate99.errors = [
                                                                                                     {
                                                                                                         instancePath:
                                                                                                             instancePath +
@@ -9189,7 +9864,7 @@ function validate92(data, { instancePath = '', parentData, parentDataProperty, r
                                                                                             }
                                                                                         }
                                                                                     } else {
-                                                                                        validate92.errors = [
+                                                                                        validate99.errors = [
                                                                                             {
                                                                                                 instancePath:
                                                                                                     instancePath +
@@ -9257,7 +9932,7 @@ function validate92(data, { instancePath = '', parentData, parentDataProperty, r
                                                                                                 }
                                                                                             }
                                                                                         } else {
-                                                                                            validate92.errors = [
+                                                                                            validate99.errors = [
                                                                                                 {
                                                                                                     instancePath:
                                                                                                         instancePath +
@@ -9291,7 +9966,7 @@ function validate92(data, { instancePath = '', parentData, parentDataProperty, r
                                                                                                 !Array.isArray(data19)
                                                                                             )
                                                                                         ) {
-                                                                                            validate92.errors = [
+                                                                                            validate99.errors = [
                                                                                                 {
                                                                                                     instancePath:
                                                                                                         instancePath +
@@ -9325,7 +10000,7 @@ function validate92(data, { instancePath = '', parentData, parentDataProperty, r
                                                                                                     isFinite(data20)
                                                                                                 )
                                                                                             ) {
-                                                                                                validate92.errors = [
+                                                                                                validate99.errors = [
                                                                                                     {
                                                                                                         instancePath:
                                                                                                             instancePath +
@@ -9367,7 +10042,7 @@ function validate92(data, { instancePath = '', parentData, parentDataProperty, r
                 }
             }
         } else {
-            validate92.errors = [
+            validate99.errors = [
                 {
                     instancePath,
                     schemaPath: '#/type',
@@ -9379,10 +10054,10 @@ function validate92(data, { instancePath = '', parentData, parentDataProperty, r
             return false
         }
     }
-    validate92.errors = vErrors
+    validate99.errors = vErrors
     return errors === 0
 }
-const schema98 = {
+const schema103 = {
     additionalProperties: false,
     properties: {
         custom_name: { type: 'string' },
@@ -9414,14 +10089,14 @@ const schema98 = {
     required: ['id', 'kind'],
     type: 'object',
 }
-function validate100(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
+function validate107(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
     let vErrors = null
     let errors = 0
     if (errors === 0) {
         if (data && typeof data == 'object' && !Array.isArray(data)) {
             let missing0
             if ((data.id === undefined && (missing0 = 'id')) || (data.kind === undefined && (missing0 = 'kind'))) {
-                validate100.errors = [
+                validate107.errors = [
                     {
                         instancePath,
                         schemaPath: '#/required',
@@ -9434,8 +10109,8 @@ function validate100(data, { instancePath = '', parentData, parentDataProperty, 
             } else {
                 const _errs1 = errors
                 for (const key0 in data) {
-                    if (!func2.call(schema98.properties, key0)) {
-                        validate100.errors = [
+                    if (!func2.call(schema103.properties, key0)) {
+                        validate107.errors = [
                             {
                                 instancePath,
                                 schemaPath: '#/additionalProperties',
@@ -9452,7 +10127,7 @@ function validate100(data, { instancePath = '', parentData, parentDataProperty, 
                     if (data.custom_name !== undefined) {
                         const _errs2 = errors
                         if (typeof data.custom_name !== 'string') {
-                            validate100.errors = [
+                            validate107.errors = [
                                 {
                                     instancePath: instancePath + '/custom_name',
                                     schemaPath: '#/properties/custom_name/type',
@@ -9495,7 +10170,7 @@ function validate100(data, { instancePath = '', parentData, parentDataProperty, 
                                         }
                                     }
                                 } else {
-                                    validate100.errors = [
+                                    validate107.errors = [
                                         {
                                             instancePath: instancePath + '/fixedProperties',
                                             schemaPath: '#/properties/fixedProperties/type',
@@ -9516,7 +10191,7 @@ function validate100(data, { instancePath = '', parentData, parentDataProperty, 
                                 let data3 = data.id
                                 const _errs7 = errors
                                 if (!(typeof data3 == 'number' && !(data3 % 1) && !isNaN(data3) && isFinite(data3))) {
-                                    validate100.errors = [
+                                    validate107.errors = [
                                         {
                                             instancePath: instancePath + '/id',
                                             schemaPath: '#/definitions/integer/type',
@@ -9536,7 +10211,7 @@ function validate100(data, { instancePath = '', parentData, parentDataProperty, 
                                     let data4 = data.kind
                                     const _errs10 = errors
                                     if (typeof data4 !== 'string') {
-                                        validate100.errors = [
+                                        validate107.errors = [
                                             {
                                                 instancePath: instancePath + '/kind',
                                                 schemaPath: '#/properties/kind/type',
@@ -9548,7 +10223,7 @@ function validate100(data, { instancePath = '', parentData, parentDataProperty, 
                                         return false
                                     }
                                     if ('ActionsNode' !== data4) {
-                                        validate100.errors = [
+                                        validate107.errors = [
                                             {
                                                 instancePath: instancePath + '/kind',
                                                 schemaPath: '#/properties/kind/const',
@@ -9567,7 +10242,7 @@ function validate100(data, { instancePath = '', parentData, parentDataProperty, 
                                     if (data.math !== undefined) {
                                         const _errs12 = errors
                                         if (
-                                            !validate94(data.math, {
+                                            !validate101(data.math, {
                                                 instancePath: instancePath + '/math',
                                                 parentData: data,
                                                 parentDataProperty: 'math',
@@ -9575,7 +10250,9 @@ function validate100(data, { instancePath = '', parentData, parentDataProperty, 
                                             })
                                         ) {
                                             vErrors =
-                                                vErrors === null ? validate94.errors : vErrors.concat(validate94.errors)
+                                                vErrors === null
+                                                    ? validate101.errors
+                                                    : vErrors.concat(validate101.errors)
                                             errors = vErrors.length
                                         }
                                         var valid0 = _errs12 === errors
@@ -9587,7 +10264,7 @@ function validate100(data, { instancePath = '', parentData, parentDataProperty, 
                                             let data6 = data.math_group_type_index
                                             const _errs13 = errors
                                             if (!(typeof data6 == 'number' && isFinite(data6))) {
-                                                validate100.errors = [
+                                                validate107.errors = [
                                                     {
                                                         instancePath: instancePath + '/math_group_type_index',
                                                         schemaPath: '#/properties/math_group_type_index/type',
@@ -9607,14 +10284,14 @@ function validate100(data, { instancePath = '', parentData, parentDataProperty, 
                                                     data6 === 4
                                                 )
                                             ) {
-                                                validate100.errors = [
+                                                validate107.errors = [
                                                     {
                                                         instancePath: instancePath + '/math_group_type_index',
                                                         schemaPath: '#/properties/math_group_type_index/enum',
                                                         keyword: 'enum',
                                                         params: {
                                                             allowedValues:
-                                                                schema98.properties.math_group_type_index.enum,
+                                                                schema103.properties.math_group_type_index.enum,
                                                         },
                                                         message: 'must be equal to one of the allowed values',
                                                     },
@@ -9629,7 +10306,7 @@ function validate100(data, { instancePath = '', parentData, parentDataProperty, 
                                             if (data.math_hogql !== undefined) {
                                                 const _errs15 = errors
                                                 if (typeof data.math_hogql !== 'string') {
-                                                    validate100.errors = [
+                                                    validate107.errors = [
                                                         {
                                                             instancePath: instancePath + '/math_hogql',
                                                             schemaPath: '#/properties/math_hogql/type',
@@ -9649,7 +10326,7 @@ function validate100(data, { instancePath = '', parentData, parentDataProperty, 
                                                     let data8 = data.math_multiplier
                                                     const _errs17 = errors
                                                     if (!(typeof data8 == 'number' && isFinite(data8))) {
-                                                        validate100.errors = [
+                                                        validate107.errors = [
                                                             {
                                                                 instancePath: instancePath + '/math_multiplier',
                                                                 schemaPath: '#/properties/math_multiplier/type',
@@ -9668,7 +10345,7 @@ function validate100(data, { instancePath = '', parentData, parentDataProperty, 
                                                     if (data.math_property !== undefined) {
                                                         const _errs19 = errors
                                                         if (typeof data.math_property !== 'string') {
-                                                            validate100.errors = [
+                                                            validate107.errors = [
                                                                 {
                                                                     instancePath: instancePath + '/math_property',
                                                                     schemaPath: '#/properties/math_property/type',
@@ -9687,7 +10364,7 @@ function validate100(data, { instancePath = '', parentData, parentDataProperty, 
                                                         if (data.math_property_revenue_currency !== undefined) {
                                                             const _errs21 = errors
                                                             if (
-                                                                !validate96(data.math_property_revenue_currency, {
+                                                                !validate103(data.math_property_revenue_currency, {
                                                                     instancePath:
                                                                         instancePath +
                                                                         '/math_property_revenue_currency',
@@ -9699,8 +10376,8 @@ function validate100(data, { instancePath = '', parentData, parentDataProperty, 
                                                             ) {
                                                                 vErrors =
                                                                     vErrors === null
-                                                                        ? validate96.errors
-                                                                        : vErrors.concat(validate96.errors)
+                                                                        ? validate103.errors
+                                                                        : vErrors.concat(validate103.errors)
                                                                 errors = vErrors.length
                                                             }
                                                             var valid0 = _errs21 === errors
@@ -9711,7 +10388,7 @@ function validate100(data, { instancePath = '', parentData, parentDataProperty, 
                                                             if (data.math_property_type !== undefined) {
                                                                 const _errs22 = errors
                                                                 if (typeof data.math_property_type !== 'string') {
-                                                                    validate100.errors = [
+                                                                    validate107.errors = [
                                                                         {
                                                                             instancePath:
                                                                                 instancePath + '/math_property_type',
@@ -9732,7 +10409,7 @@ function validate100(data, { instancePath = '', parentData, parentDataProperty, 
                                                                 if (data.name !== undefined) {
                                                                     const _errs24 = errors
                                                                     if (typeof data.name !== 'string') {
-                                                                        validate100.errors = [
+                                                                        validate107.errors = [
                                                                             {
                                                                                 instancePath: instancePath + '/name',
                                                                                 schemaPath: '#/properties/name/type',
@@ -9753,7 +10430,7 @@ function validate100(data, { instancePath = '', parentData, parentDataProperty, 
                                                                         if (
                                                                             typeof data.optionalInFunnel !== 'boolean'
                                                                         ) {
-                                                                            validate100.errors = [
+                                                                            validate107.errors = [
                                                                                 {
                                                                                     instancePath:
                                                                                         instancePath +
@@ -9806,7 +10483,7 @@ function validate100(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                         }
                                                                                     }
                                                                                 } else {
-                                                                                    validate100.errors = [
+                                                                                    validate107.errors = [
                                                                                         {
                                                                                             instancePath:
                                                                                                 instancePath +
@@ -9836,7 +10513,7 @@ function validate100(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                         !Array.isArray(data16)
                                                                                     )
                                                                                 ) {
-                                                                                    validate100.errors = [
+                                                                                    validate107.errors = [
                                                                                         {
                                                                                             instancePath:
                                                                                                 instancePath +
@@ -9864,7 +10541,7 @@ function validate100(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                             isFinite(data17)
                                                                                         )
                                                                                     ) {
-                                                                                        validate100.errors = [
+                                                                                        validate107.errors = [
                                                                                             {
                                                                                                 instancePath:
                                                                                                     instancePath +
@@ -9903,7 +10580,7 @@ function validate100(data, { instancePath = '', parentData, parentDataProperty, 
                 }
             }
         } else {
-            validate100.errors = [
+            validate107.errors = [
                 {
                     instancePath,
                     schemaPath: '#/type',
@@ -9915,10 +10592,10 @@ function validate100(data, { instancePath = '', parentData, parentDataProperty, 
             return false
         }
     }
-    validate100.errors = vErrors
+    validate107.errors = vErrors
     return errors === 0
 }
-const schema100 = {
+const schema105 = {
     additionalProperties: false,
     properties: {
         custom_name: { type: 'string' },
@@ -9953,7 +10630,7 @@ const schema100 = {
     required: ['data_warehouse_join_key', 'events_join_key', 'kind', 'table_name', 'timestamp_field'],
     type: 'object',
 }
-function validate106(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
+function validate113(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
     let vErrors = null
     let errors = 0
     if (errors === 0) {
@@ -9966,7 +10643,7 @@ function validate106(data, { instancePath = '', parentData, parentDataProperty, 
                 (data.table_name === undefined && (missing0 = 'table_name')) ||
                 (data.timestamp_field === undefined && (missing0 = 'timestamp_field'))
             ) {
-                validate106.errors = [
+                validate113.errors = [
                     {
                         instancePath,
                         schemaPath: '#/required',
@@ -9979,8 +10656,8 @@ function validate106(data, { instancePath = '', parentData, parentDataProperty, 
             } else {
                 const _errs1 = errors
                 for (const key0 in data) {
-                    if (!func2.call(schema100.properties, key0)) {
-                        validate106.errors = [
+                    if (!func2.call(schema105.properties, key0)) {
+                        validate113.errors = [
                             {
                                 instancePath,
                                 schemaPath: '#/additionalProperties',
@@ -9997,7 +10674,7 @@ function validate106(data, { instancePath = '', parentData, parentDataProperty, 
                     if (data.custom_name !== undefined) {
                         const _errs2 = errors
                         if (typeof data.custom_name !== 'string') {
-                            validate106.errors = [
+                            validate113.errors = [
                                 {
                                     instancePath: instancePath + '/custom_name',
                                     schemaPath: '#/properties/custom_name/type',
@@ -10016,7 +10693,7 @@ function validate106(data, { instancePath = '', parentData, parentDataProperty, 
                         if (data.data_warehouse_join_key !== undefined) {
                             const _errs4 = errors
                             if (typeof data.data_warehouse_join_key !== 'string') {
-                                validate106.errors = [
+                                validate113.errors = [
                                     {
                                         instancePath: instancePath + '/data_warehouse_join_key',
                                         schemaPath: '#/properties/data_warehouse_join_key/type',
@@ -10035,7 +10712,7 @@ function validate106(data, { instancePath = '', parentData, parentDataProperty, 
                             if (data.events_join_key !== undefined) {
                                 const _errs6 = errors
                                 if (typeof data.events_join_key !== 'string') {
-                                    validate106.errors = [
+                                    validate113.errors = [
                                         {
                                             instancePath: instancePath + '/events_join_key',
                                             schemaPath: '#/properties/events_join_key/type',
@@ -10080,7 +10757,7 @@ function validate106(data, { instancePath = '', parentData, parentDataProperty, 
                                                 }
                                             }
                                         } else {
-                                            validate106.errors = [
+                                            validate113.errors = [
                                                 {
                                                     instancePath: instancePath + '/fixedProperties',
                                                     schemaPath: '#/properties/fixedProperties/type',
@@ -10101,7 +10778,7 @@ function validate106(data, { instancePath = '', parentData, parentDataProperty, 
                                         let data5 = data.kind
                                         const _errs11 = errors
                                         if (typeof data5 !== 'string') {
-                                            validate106.errors = [
+                                            validate113.errors = [
                                                 {
                                                     instancePath: instancePath + '/kind',
                                                     schemaPath: '#/properties/kind/type',
@@ -10113,7 +10790,7 @@ function validate106(data, { instancePath = '', parentData, parentDataProperty, 
                                             return false
                                         }
                                         if ('ExperimentDataWarehouseNode' !== data5) {
-                                            validate106.errors = [
+                                            validate113.errors = [
                                                 {
                                                     instancePath: instancePath + '/kind',
                                                     schemaPath: '#/properties/kind/const',
@@ -10132,7 +10809,7 @@ function validate106(data, { instancePath = '', parentData, parentDataProperty, 
                                         if (data.math !== undefined) {
                                             const _errs13 = errors
                                             if (
-                                                !validate94(data.math, {
+                                                !validate101(data.math, {
                                                     instancePath: instancePath + '/math',
                                                     parentData: data,
                                                     parentDataProperty: 'math',
@@ -10141,8 +10818,8 @@ function validate106(data, { instancePath = '', parentData, parentDataProperty, 
                                             ) {
                                                 vErrors =
                                                     vErrors === null
-                                                        ? validate94.errors
-                                                        : vErrors.concat(validate94.errors)
+                                                        ? validate101.errors
+                                                        : vErrors.concat(validate101.errors)
                                                 errors = vErrors.length
                                             }
                                             var valid0 = _errs13 === errors
@@ -10154,7 +10831,7 @@ function validate106(data, { instancePath = '', parentData, parentDataProperty, 
                                                 let data7 = data.math_group_type_index
                                                 const _errs14 = errors
                                                 if (!(typeof data7 == 'number' && isFinite(data7))) {
-                                                    validate106.errors = [
+                                                    validate113.errors = [
                                                         {
                                                             instancePath: instancePath + '/math_group_type_index',
                                                             schemaPath: '#/properties/math_group_type_index/type',
@@ -10174,14 +10851,14 @@ function validate106(data, { instancePath = '', parentData, parentDataProperty, 
                                                         data7 === 4
                                                     )
                                                 ) {
-                                                    validate106.errors = [
+                                                    validate113.errors = [
                                                         {
                                                             instancePath: instancePath + '/math_group_type_index',
                                                             schemaPath: '#/properties/math_group_type_index/enum',
                                                             keyword: 'enum',
                                                             params: {
                                                                 allowedValues:
-                                                                    schema100.properties.math_group_type_index.enum,
+                                                                    schema105.properties.math_group_type_index.enum,
                                                             },
                                                             message: 'must be equal to one of the allowed values',
                                                         },
@@ -10196,7 +10873,7 @@ function validate106(data, { instancePath = '', parentData, parentDataProperty, 
                                                 if (data.math_hogql !== undefined) {
                                                     const _errs16 = errors
                                                     if (typeof data.math_hogql !== 'string') {
-                                                        validate106.errors = [
+                                                        validate113.errors = [
                                                             {
                                                                 instancePath: instancePath + '/math_hogql',
                                                                 schemaPath: '#/properties/math_hogql/type',
@@ -10216,7 +10893,7 @@ function validate106(data, { instancePath = '', parentData, parentDataProperty, 
                                                         let data9 = data.math_multiplier
                                                         const _errs18 = errors
                                                         if (!(typeof data9 == 'number' && isFinite(data9))) {
-                                                            validate106.errors = [
+                                                            validate113.errors = [
                                                                 {
                                                                     instancePath: instancePath + '/math_multiplier',
                                                                     schemaPath: '#/properties/math_multiplier/type',
@@ -10235,7 +10912,7 @@ function validate106(data, { instancePath = '', parentData, parentDataProperty, 
                                                         if (data.math_property !== undefined) {
                                                             const _errs20 = errors
                                                             if (typeof data.math_property !== 'string') {
-                                                                validate106.errors = [
+                                                                validate113.errors = [
                                                                     {
                                                                         instancePath: instancePath + '/math_property',
                                                                         schemaPath: '#/properties/math_property/type',
@@ -10254,7 +10931,7 @@ function validate106(data, { instancePath = '', parentData, parentDataProperty, 
                                                             if (data.math_property_revenue_currency !== undefined) {
                                                                 const _errs22 = errors
                                                                 if (
-                                                                    !validate96(data.math_property_revenue_currency, {
+                                                                    !validate103(data.math_property_revenue_currency, {
                                                                         instancePath:
                                                                             instancePath +
                                                                             '/math_property_revenue_currency',
@@ -10266,8 +10943,8 @@ function validate106(data, { instancePath = '', parentData, parentDataProperty, 
                                                                 ) {
                                                                     vErrors =
                                                                         vErrors === null
-                                                                            ? validate96.errors
-                                                                            : vErrors.concat(validate96.errors)
+                                                                            ? validate103.errors
+                                                                            : vErrors.concat(validate103.errors)
                                                                     errors = vErrors.length
                                                                 }
                                                                 var valid0 = _errs22 === errors
@@ -10278,7 +10955,7 @@ function validate106(data, { instancePath = '', parentData, parentDataProperty, 
                                                                 if (data.math_property_type !== undefined) {
                                                                     const _errs23 = errors
                                                                     if (typeof data.math_property_type !== 'string') {
-                                                                        validate106.errors = [
+                                                                        validate113.errors = [
                                                                             {
                                                                                 instancePath:
                                                                                     instancePath +
@@ -10300,7 +10977,7 @@ function validate106(data, { instancePath = '', parentData, parentDataProperty, 
                                                                     if (data.name !== undefined) {
                                                                         const _errs25 = errors
                                                                         if (typeof data.name !== 'string') {
-                                                                            validate106.errors = [
+                                                                            validate113.errors = [
                                                                                 {
                                                                                     instancePath:
                                                                                         instancePath + '/name',
@@ -10324,7 +11001,7 @@ function validate106(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                 typeof data.optionalInFunnel !==
                                                                                 'boolean'
                                                                             ) {
-                                                                                validate106.errors = [
+                                                                                validate113.errors = [
                                                                                     {
                                                                                         instancePath:
                                                                                             instancePath +
@@ -10387,7 +11064,7 @@ function validate106(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                             }
                                                                                         }
                                                                                     } else {
-                                                                                        validate106.errors = [
+                                                                                        validate113.errors = [
                                                                                             {
                                                                                                 instancePath:
                                                                                                     instancePath +
@@ -10420,7 +11097,7 @@ function validate106(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                             !Array.isArray(data17)
                                                                                         )
                                                                                     ) {
-                                                                                        validate106.errors = [
+                                                                                        validate113.errors = [
                                                                                             {
                                                                                                 instancePath:
                                                                                                     instancePath +
@@ -10448,7 +11125,7 @@ function validate106(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                             typeof data.table_name !==
                                                                                             'string'
                                                                                         ) {
-                                                                                            validate106.errors = [
+                                                                                            validate113.errors = [
                                                                                                 {
                                                                                                     instancePath:
                                                                                                         instancePath +
@@ -10479,7 +11156,7 @@ function validate106(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                                 typeof data.timestamp_field !==
                                                                                                 'string'
                                                                                             ) {
-                                                                                                validate106.errors = [
+                                                                                                validate113.errors = [
                                                                                                     {
                                                                                                         instancePath:
                                                                                                             instancePath +
@@ -10516,7 +11193,7 @@ function validate106(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                                         isFinite(data20)
                                                                                                     )
                                                                                                 ) {
-                                                                                                    validate106.errors =
+                                                                                                    validate113.errors =
                                                                                                         [
                                                                                                             {
                                                                                                                 instancePath:
@@ -10561,7 +11238,7 @@ function validate106(data, { instancePath = '', parentData, parentDataProperty, 
                 }
             }
         } else {
-            validate106.errors = [
+            validate113.errors = [
                 {
                     instancePath,
                     schemaPath: '#/type',
@@ -10573,18 +11250,18 @@ function validate106(data, { instancePath = '', parentData, parentDataProperty, 
             return false
         }
     }
-    validate106.errors = vErrors
+    validate113.errors = vErrors
     return errors === 0
 }
-function validate91(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
+function validate98(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
     let vErrors = null
     let errors = 0
     const _errs1 = errors
     let valid0 = false
     let passing0 = null
     const _errs2 = errors
-    if (!validate92(data, { instancePath, parentData, parentDataProperty, rootData })) {
-        vErrors = vErrors === null ? validate92.errors : vErrors.concat(validate92.errors)
+    if (!validate99(data, { instancePath, parentData, parentDataProperty, rootData })) {
+        vErrors = vErrors === null ? validate99.errors : vErrors.concat(validate99.errors)
         errors = vErrors.length
     }
     var _valid0 = _errs2 === errors
@@ -10593,8 +11270,8 @@ function validate91(data, { instancePath = '', parentData, parentDataProperty, r
         passing0 = 0
     }
     const _errs3 = errors
-    if (!validate100(data, { instancePath, parentData, parentDataProperty, rootData })) {
-        vErrors = vErrors === null ? validate100.errors : vErrors.concat(validate100.errors)
+    if (!validate107(data, { instancePath, parentData, parentDataProperty, rootData })) {
+        vErrors = vErrors === null ? validate107.errors : vErrors.concat(validate107.errors)
         errors = vErrors.length
     }
     var _valid0 = _errs3 === errors
@@ -10607,8 +11284,8 @@ function validate91(data, { instancePath = '', parentData, parentDataProperty, r
             passing0 = 1
         }
         const _errs4 = errors
-        if (!validate106(data, { instancePath, parentData, parentDataProperty, rootData })) {
-            vErrors = vErrors === null ? validate106.errors : vErrors.concat(validate106.errors)
+        if (!validate113(data, { instancePath, parentData, parentDataProperty, rootData })) {
+            vErrors = vErrors === null ? validate113.errors : vErrors.concat(validate113.errors)
             errors = vErrors.length
         }
         var _valid0 = _errs4 === errors
@@ -10636,7 +11313,7 @@ function validate91(data, { instancePath = '', parentData, parentDataProperty, r
             vErrors.push(err0)
         }
         errors++
-        validate91.errors = vErrors
+        validate98.errors = vErrors
         return false
     } else {
         errors = _errs1
@@ -10652,7 +11329,7 @@ function validate91(data, { instancePath = '', parentData, parentDataProperty, r
         if (data && typeof data == 'object' && !Array.isArray(data)) {
             let missing0
             if (data.kind === undefined && (missing0 = 'kind')) {
-                validate91.errors = [
+                validate98.errors = [
                     {
                         instancePath,
                         schemaPath: '#/required',
@@ -10664,7 +11341,7 @@ function validate91(data, { instancePath = '', parentData, parentDataProperty, r
                 return false
             }
         } else {
-            validate91.errors = [
+            validate98.errors = [
                 {
                     instancePath,
                     schemaPath: '#/type',
@@ -10676,10 +11353,10 @@ function validate91(data, { instancePath = '', parentData, parentDataProperty, r
             return false
         }
     }
-    validate91.errors = vErrors
+    validate98.errors = vErrors
     return errors === 0
 }
-function validate86(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
+function validate93(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
     let vErrors = null
     let errors = 0
     if (errors === 0) {
@@ -10690,7 +11367,7 @@ function validate86(data, { instancePath = '', parentData, parentDataProperty, r
                 (data.metric_type === undefined && (missing0 = 'metric_type')) ||
                 (data.source === undefined && (missing0 = 'source'))
             ) {
-                validate86.errors = [
+                validate93.errors = [
                     {
                         instancePath,
                         schemaPath: '#/required',
@@ -10703,8 +11380,8 @@ function validate86(data, { instancePath = '', parentData, parentDataProperty, r
             } else {
                 const _errs1 = errors
                 for (const key0 in data) {
-                    if (!func2.call(schema68.properties, key0)) {
-                        validate86.errors = [
+                    if (!func2.call(schema73.properties, key0)) {
+                        validate93.errors = [
                             {
                                 instancePath,
                                 schemaPath: '#/additionalProperties',
@@ -10721,14 +11398,14 @@ function validate86(data, { instancePath = '', parentData, parentDataProperty, r
                     if (data.breakdownFilter !== undefined) {
                         const _errs2 = errors
                         if (
-                            !validate87(data.breakdownFilter, {
+                            !validate94(data.breakdownFilter, {
                                 instancePath: instancePath + '/breakdownFilter',
                                 parentData: data,
                                 parentDataProperty: 'breakdownFilter',
                                 rootData,
                             })
                         ) {
-                            vErrors = vErrors === null ? validate87.errors : vErrors.concat(validate87.errors)
+                            vErrors = vErrors === null ? validate94.errors : vErrors.concat(validate94.errors)
                             errors = vErrors.length
                         }
                         var valid0 = _errs2 === errors
@@ -10740,7 +11417,7 @@ function validate86(data, { instancePath = '', parentData, parentDataProperty, r
                             let data1 = data.conversion_window
                             const _errs3 = errors
                             if (!(typeof data1 == 'number' && !(data1 % 1) && !isNaN(data1) && isFinite(data1))) {
-                                validate86.errors = [
+                                validate93.errors = [
                                     {
                                         instancePath: instancePath + '/conversion_window',
                                         schemaPath: '#/definitions/integer/type',
@@ -10760,7 +11437,7 @@ function validate86(data, { instancePath = '', parentData, parentDataProperty, r
                                 let data2 = data.conversion_window_unit
                                 const _errs6 = errors
                                 if (typeof data2 !== 'string') {
-                                    validate86.errors = [
+                                    validate93.errors = [
                                         {
                                             instancePath: instancePath + '/conversion_window_unit',
                                             schemaPath: '#/definitions/FunnelConversionWindowTimeUnit/type',
@@ -10781,12 +11458,12 @@ function validate86(data, { instancePath = '', parentData, parentDataProperty, r
                                         data2 === 'month'
                                     )
                                 ) {
-                                    validate86.errors = [
+                                    validate93.errors = [
                                         {
                                             instancePath: instancePath + '/conversion_window_unit',
                                             schemaPath: '#/definitions/FunnelConversionWindowTimeUnit/enum',
                                             keyword: 'enum',
-                                            params: { allowedValues: schema82.enum },
+                                            params: { allowedValues: schema87.enum },
                                             message: 'must be equal to one of the allowed values',
                                         },
                                     ]
@@ -10800,7 +11477,7 @@ function validate86(data, { instancePath = '', parentData, parentDataProperty, r
                                 if (data.fingerprint !== undefined) {
                                     const _errs9 = errors
                                     if (typeof data.fingerprint !== 'string') {
-                                        validate86.errors = [
+                                        validate93.errors = [
                                             {
                                                 instancePath: instancePath + '/fingerprint',
                                                 schemaPath: '#/properties/fingerprint/type',
@@ -10820,7 +11497,7 @@ function validate86(data, { instancePath = '', parentData, parentDataProperty, r
                                         let data4 = data.goal
                                         const _errs11 = errors
                                         if (typeof data4 !== 'string') {
-                                            validate86.errors = [
+                                            validate93.errors = [
                                                 {
                                                     instancePath: instancePath + '/goal',
                                                     schemaPath: '#/definitions/ExperimentMetricGoal/type',
@@ -10832,12 +11509,12 @@ function validate86(data, { instancePath = '', parentData, parentDataProperty, r
                                             return false
                                         }
                                         if (!(data4 === 'increase' || data4 === 'decrease')) {
-                                            validate86.errors = [
+                                            validate93.errors = [
                                                 {
                                                     instancePath: instancePath + '/goal',
                                                     schemaPath: '#/definitions/ExperimentMetricGoal/enum',
                                                     keyword: 'enum',
-                                                    params: { allowedValues: schema83.enum },
+                                                    params: { allowedValues: schema88.enum },
                                                     message: 'must be equal to one of the allowed values',
                                                 },
                                             ]
@@ -10851,7 +11528,7 @@ function validate86(data, { instancePath = '', parentData, parentDataProperty, r
                                         if (data.ignore_zeros !== undefined) {
                                             const _errs14 = errors
                                             if (typeof data.ignore_zeros !== 'boolean') {
-                                                validate86.errors = [
+                                                validate93.errors = [
                                                     {
                                                         instancePath: instancePath + '/ignore_zeros',
                                                         schemaPath: '#/properties/ignore_zeros/type',
@@ -10870,7 +11547,7 @@ function validate86(data, { instancePath = '', parentData, parentDataProperty, r
                                             if (data.isSharedMetric !== undefined) {
                                                 const _errs16 = errors
                                                 if (typeof data.isSharedMetric !== 'boolean') {
-                                                    validate86.errors = [
+                                                    validate93.errors = [
                                                         {
                                                             instancePath: instancePath + '/isSharedMetric',
                                                             schemaPath: '#/properties/isSharedMetric/type',
@@ -10890,7 +11567,7 @@ function validate86(data, { instancePath = '', parentData, parentDataProperty, r
                                                     let data7 = data.kind
                                                     const _errs18 = errors
                                                     if (typeof data7 !== 'string') {
-                                                        validate86.errors = [
+                                                        validate93.errors = [
                                                             {
                                                                 instancePath: instancePath + '/kind',
                                                                 schemaPath: '#/properties/kind/type',
@@ -10902,7 +11579,7 @@ function validate86(data, { instancePath = '', parentData, parentDataProperty, r
                                                         return false
                                                     }
                                                     if ('ExperimentMetric' !== data7) {
-                                                        validate86.errors = [
+                                                        validate93.errors = [
                                                             {
                                                                 instancePath: instancePath + '/kind',
                                                                 schemaPath: '#/properties/kind/const',
@@ -10924,7 +11601,7 @@ function validate86(data, { instancePath = '', parentData, parentDataProperty, r
                                                         if (errors === _errs20) {
                                                             if (typeof data8 == 'number' && isFinite(data8)) {
                                                                 if (data8 > 1 || isNaN(data8)) {
-                                                                    validate86.errors = [
+                                                                    validate93.errors = [
                                                                         {
                                                                             instancePath:
                                                                                 instancePath +
@@ -10939,7 +11616,7 @@ function validate86(data, { instancePath = '', parentData, parentDataProperty, r
                                                                     return false
                                                                 } else {
                                                                     if (data8 < 0 || isNaN(data8)) {
-                                                                        validate86.errors = [
+                                                                        validate93.errors = [
                                                                             {
                                                                                 instancePath:
                                                                                     instancePath +
@@ -10955,7 +11632,7 @@ function validate86(data, { instancePath = '', parentData, parentDataProperty, r
                                                                     }
                                                                 }
                                                             } else {
-                                                                validate86.errors = [
+                                                                validate93.errors = [
                                                                     {
                                                                         instancePath:
                                                                             instancePath + '/lower_bound_percentile',
@@ -10978,7 +11655,7 @@ function validate86(data, { instancePath = '', parentData, parentDataProperty, r
                                                             let data9 = data.metric_type
                                                             const _errs22 = errors
                                                             if (typeof data9 !== 'string') {
-                                                                validate86.errors = [
+                                                                validate93.errors = [
                                                                     {
                                                                         instancePath: instancePath + '/metric_type',
                                                                         schemaPath: '#/properties/metric_type/type',
@@ -10990,7 +11667,7 @@ function validate86(data, { instancePath = '', parentData, parentDataProperty, r
                                                                 return false
                                                             }
                                                             if ('mean' !== data9) {
-                                                                validate86.errors = [
+                                                                validate93.errors = [
                                                                     {
                                                                         instancePath: instancePath + '/metric_type',
                                                                         schemaPath: '#/properties/metric_type/const',
@@ -11009,7 +11686,7 @@ function validate86(data, { instancePath = '', parentData, parentDataProperty, r
                                                             if (data.name !== undefined) {
                                                                 const _errs24 = errors
                                                                 if (typeof data.name !== 'string') {
-                                                                    validate86.errors = [
+                                                                    validate93.errors = [
                                                                         {
                                                                             instancePath: instancePath + '/name',
                                                                             schemaPath: '#/properties/name/type',
@@ -11035,7 +11712,7 @@ function validate86(data, { instancePath = '', parentData, parentDataProperty, r
                                                                             !Array.isArray(data11)
                                                                         )
                                                                     ) {
-                                                                        validate86.errors = [
+                                                                        validate93.errors = [
                                                                             {
                                                                                 instancePath:
                                                                                     instancePath + '/response',
@@ -11062,7 +11739,7 @@ function validate86(data, { instancePath = '', parentData, parentDataProperty, r
                                                                                 isFinite(data12)
                                                                             )
                                                                         ) {
-                                                                            validate86.errors = [
+                                                                            validate93.errors = [
                                                                                 {
                                                                                     instancePath:
                                                                                         instancePath +
@@ -11084,7 +11761,7 @@ function validate86(data, { instancePath = '', parentData, parentDataProperty, r
                                                                         if (data.source !== undefined) {
                                                                             const _errs30 = errors
                                                                             if (
-                                                                                !validate91(data.source, {
+                                                                                !validate98(data.source, {
                                                                                     instancePath:
                                                                                         instancePath + '/source',
                                                                                     parentData: data,
@@ -11094,9 +11771,9 @@ function validate86(data, { instancePath = '', parentData, parentDataProperty, r
                                                                             ) {
                                                                                 vErrors =
                                                                                     vErrors === null
-                                                                                        ? validate91.errors
+                                                                                        ? validate98.errors
                                                                                         : vErrors.concat(
-                                                                                              validate91.errors
+                                                                                              validate98.errors
                                                                                           )
                                                                                 errors = vErrors.length
                                                                             }
@@ -11114,7 +11791,7 @@ function validate86(data, { instancePath = '', parentData, parentDataProperty, r
                                                                                         isFinite(data14)
                                                                                     )
                                                                                 ) {
-                                                                                    validate86.errors = [
+                                                                                    validate93.errors = [
                                                                                         {
                                                                                             instancePath:
                                                                                                 instancePath +
@@ -11149,7 +11826,7 @@ function validate86(data, { instancePath = '', parentData, parentDataProperty, r
                                                                                                 data15 > 1 ||
                                                                                                 isNaN(data15)
                                                                                             ) {
-                                                                                                validate86.errors = [
+                                                                                                validate93.errors = [
                                                                                                     {
                                                                                                         instancePath:
                                                                                                             instancePath +
@@ -11173,7 +11850,7 @@ function validate86(data, { instancePath = '', parentData, parentDataProperty, r
                                                                                                     data15 < 0 ||
                                                                                                     isNaN(data15)
                                                                                                 ) {
-                                                                                                    validate86.errors =
+                                                                                                    validate93.errors =
                                                                                                         [
                                                                                                             {
                                                                                                                 instancePath:
@@ -11196,7 +11873,7 @@ function validate86(data, { instancePath = '', parentData, parentDataProperty, r
                                                                                                 }
                                                                                             }
                                                                                         } else {
-                                                                                            validate86.errors = [
+                                                                                            validate93.errors = [
                                                                                                 {
                                                                                                     instancePath:
                                                                                                         instancePath +
@@ -11225,7 +11902,7 @@ function validate86(data, { instancePath = '', parentData, parentDataProperty, r
                                                                                             typeof data.uuid !==
                                                                                             'string'
                                                                                         ) {
-                                                                                            validate86.errors = [
+                                                                                            validate93.errors = [
                                                                                                 {
                                                                                                     instancePath:
                                                                                                         instancePath +
@@ -11259,7 +11936,7 @@ function validate86(data, { instancePath = '', parentData, parentDataProperty, r
                                                                                                     isFinite(data17)
                                                                                                 )
                                                                                             ) {
-                                                                                                validate86.errors = [
+                                                                                                validate93.errors = [
                                                                                                     {
                                                                                                         instancePath:
                                                                                                             instancePath +
@@ -11301,7 +11978,7 @@ function validate86(data, { instancePath = '', parentData, parentDataProperty, r
                 }
             }
         } else {
-            validate86.errors = [
+            validate93.errors = [
                 {
                     instancePath,
                     schemaPath: '#/type',
@@ -11313,21 +11990,12 @@ function validate86(data, { instancePath = '', parentData, parentDataProperty, r
             return false
         }
     }
-    validate86.errors = vErrors
+    validate93.errors = vErrors
     return errors === 0
 }
-const schema101 = {
+const schema106 = {
     additionalProperties: false,
     properties: {
-        breakdownAttributionType: {
-            $ref: '#/definitions/BreakdownAttributionType',
-            default: 'first_touch',
-            description: 'How to attribute the breakdown value across funnel steps.',
-        },
-        breakdownAttributionValue: {
-            description: 'When breakdownAttributionType is `step`, the 0-indexed step to attribute from.',
-            type: 'integer',
-        },
         breakdownFilter: { $ref: '#/definitions/BreakdownFilter' },
         conversion_window: { $ref: '#/definitions/integer' },
         conversion_window_unit: { $ref: '#/definitions/FunnelConversionWindowTimeUnit' },
@@ -11347,9 +12015,8 @@ const schema101 = {
     required: ['kind', 'metric_type', 'series'],
     type: 'object',
 }
-const schema102 = { enum: ['first_touch', 'last_touch', 'all_events', 'step'], type: 'string' }
-const schema105 = { enum: ['strict', 'unordered', 'ordered'], type: 'string' }
-const schema107 = {
+const schema109 = { enum: ['strict', 'unordered', 'ordered'], type: 'string' }
+const schema111 = {
     discriminator: { propertyName: 'kind' },
     oneOf: [
         { $ref: '#/definitions/EventsNode' },
@@ -11359,15 +12026,15 @@ const schema107 = {
     required: ['kind'],
     type: 'object',
 }
-function validate116(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
+function validate123(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
     let vErrors = null
     let errors = 0
     const _errs1 = errors
     let valid0 = false
     let passing0 = null
     const _errs2 = errors
-    if (!validate92(data, { instancePath, parentData, parentDataProperty, rootData })) {
-        vErrors = vErrors === null ? validate92.errors : vErrors.concat(validate92.errors)
+    if (!validate99(data, { instancePath, parentData, parentDataProperty, rootData })) {
+        vErrors = vErrors === null ? validate99.errors : vErrors.concat(validate99.errors)
         errors = vErrors.length
     }
     var _valid0 = _errs2 === errors
@@ -11376,8 +12043,8 @@ function validate116(data, { instancePath = '', parentData, parentDataProperty, 
         passing0 = 0
     }
     const _errs3 = errors
-    if (!validate100(data, { instancePath, parentData, parentDataProperty, rootData })) {
-        vErrors = vErrors === null ? validate100.errors : vErrors.concat(validate100.errors)
+    if (!validate107(data, { instancePath, parentData, parentDataProperty, rootData })) {
+        vErrors = vErrors === null ? validate107.errors : vErrors.concat(validate107.errors)
         errors = vErrors.length
     }
     var _valid0 = _errs3 === errors
@@ -11390,8 +12057,8 @@ function validate116(data, { instancePath = '', parentData, parentDataProperty, 
             passing0 = 1
         }
         const _errs4 = errors
-        if (!validate106(data, { instancePath, parentData, parentDataProperty, rootData })) {
-            vErrors = vErrors === null ? validate106.errors : vErrors.concat(validate106.errors)
+        if (!validate113(data, { instancePath, parentData, parentDataProperty, rootData })) {
+            vErrors = vErrors === null ? validate113.errors : vErrors.concat(validate113.errors)
             errors = vErrors.length
         }
         var _valid0 = _errs4 === errors
@@ -11419,7 +12086,7 @@ function validate116(data, { instancePath = '', parentData, parentDataProperty, 
             vErrors.push(err0)
         }
         errors++
-        validate116.errors = vErrors
+        validate123.errors = vErrors
         return false
     } else {
         errors = _errs1
@@ -11435,7 +12102,7 @@ function validate116(data, { instancePath = '', parentData, parentDataProperty, 
         if (data && typeof data == 'object' && !Array.isArray(data)) {
             let missing0
             if (data.kind === undefined && (missing0 = 'kind')) {
-                validate116.errors = [
+                validate123.errors = [
                     {
                         instancePath,
                         schemaPath: '#/required',
@@ -11447,7 +12114,7 @@ function validate116(data, { instancePath = '', parentData, parentDataProperty, 
                 return false
             }
         } else {
-            validate116.errors = [
+            validate123.errors = [
                 {
                     instancePath,
                     schemaPath: '#/type',
@@ -11459,10 +12126,10 @@ function validate116(data, { instancePath = '', parentData, parentDataProperty, 
             return false
         }
     }
-    validate116.errors = vErrors
+    validate123.errors = vErrors
     return errors === 0
 }
-function validate114(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
+function validate121(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
     let vErrors = null
     let errors = 0
     if (errors === 0) {
@@ -11473,7 +12140,7 @@ function validate114(data, { instancePath = '', parentData, parentDataProperty, 
                 (data.metric_type === undefined && (missing0 = 'metric_type')) ||
                 (data.series === undefined && (missing0 = 'series'))
             ) {
-                validate114.errors = [
+                validate121.errors = [
                     {
                         instancePath,
                         schemaPath: '#/required',
@@ -11486,8 +12153,8 @@ function validate114(data, { instancePath = '', parentData, parentDataProperty, 
             } else {
                 const _errs1 = errors
                 for (const key0 in data) {
-                    if (!func2.call(schema101.properties, key0)) {
-                        validate114.errors = [
+                    if (!func2.call(schema106.properties, key0)) {
+                        validate121.errors = [
                             {
                                 instancePath,
                                 schemaPath: '#/additionalProperties',
@@ -11501,53 +12168,32 @@ function validate114(data, { instancePath = '', parentData, parentDataProperty, 
                     }
                 }
                 if (_errs1 === errors) {
-                    if (data.breakdownAttributionType !== undefined) {
-                        let data0 = data.breakdownAttributionType
+                    if (data.breakdownFilter !== undefined) {
                         const _errs2 = errors
-                        if (typeof data0 !== 'string') {
-                            validate114.errors = [
-                                {
-                                    instancePath: instancePath + '/breakdownAttributionType',
-                                    schemaPath: '#/definitions/BreakdownAttributionType/type',
-                                    keyword: 'type',
-                                    params: { type: 'string' },
-                                    message: 'must be string',
-                                },
-                            ]
-                            return false
-                        }
                         if (
-                            !(
-                                data0 === 'first_touch' ||
-                                data0 === 'last_touch' ||
-                                data0 === 'all_events' ||
-                                data0 === 'step'
-                            )
+                            !validate94(data.breakdownFilter, {
+                                instancePath: instancePath + '/breakdownFilter',
+                                parentData: data,
+                                parentDataProperty: 'breakdownFilter',
+                                rootData,
+                            })
                         ) {
-                            validate114.errors = [
-                                {
-                                    instancePath: instancePath + '/breakdownAttributionType',
-                                    schemaPath: '#/definitions/BreakdownAttributionType/enum',
-                                    keyword: 'enum',
-                                    params: { allowedValues: schema102.enum },
-                                    message: 'must be equal to one of the allowed values',
-                                },
-                            ]
-                            return false
+                            vErrors = vErrors === null ? validate94.errors : vErrors.concat(validate94.errors)
+                            errors = vErrors.length
                         }
                         var valid0 = _errs2 === errors
                     } else {
                         var valid0 = true
                     }
                     if (valid0) {
-                        if (data.breakdownAttributionValue !== undefined) {
-                            let data1 = data.breakdownAttributionValue
-                            const _errs5 = errors
+                        if (data.conversion_window !== undefined) {
+                            let data1 = data.conversion_window
+                            const _errs3 = errors
                             if (!(typeof data1 == 'number' && !(data1 % 1) && !isNaN(data1) && isFinite(data1))) {
-                                validate114.errors = [
+                                validate121.errors = [
                                     {
-                                        instancePath: instancePath + '/breakdownAttributionValue',
-                                        schemaPath: '#/properties/breakdownAttributionValue/type',
+                                        instancePath: instancePath + '/conversion_window',
+                                        schemaPath: '#/definitions/integer/type',
                                         keyword: 'type',
                                         params: { type: 'integer' },
                                         message: 'must be integer',
@@ -11555,59 +12201,79 @@ function validate114(data, { instancePath = '', parentData, parentDataProperty, 
                                 ]
                                 return false
                             }
-                            var valid0 = _errs5 === errors
+                            var valid0 = _errs3 === errors
                         } else {
                             var valid0 = true
                         }
                         if (valid0) {
-                            if (data.breakdownFilter !== undefined) {
-                                const _errs7 = errors
-                                if (
-                                    !validate87(data.breakdownFilter, {
-                                        instancePath: instancePath + '/breakdownFilter',
-                                        parentData: data,
-                                        parentDataProperty: 'breakdownFilter',
-                                        rootData,
-                                    })
-                                ) {
-                                    vErrors = vErrors === null ? validate87.errors : vErrors.concat(validate87.errors)
-                                    errors = vErrors.length
+                            if (data.conversion_window_unit !== undefined) {
+                                let data2 = data.conversion_window_unit
+                                const _errs6 = errors
+                                if (typeof data2 !== 'string') {
+                                    validate121.errors = [
+                                        {
+                                            instancePath: instancePath + '/conversion_window_unit',
+                                            schemaPath: '#/definitions/FunnelConversionWindowTimeUnit/type',
+                                            keyword: 'type',
+                                            params: { type: 'string' },
+                                            message: 'must be string',
+                                        },
+                                    ]
+                                    return false
                                 }
-                                var valid0 = _errs7 === errors
+                                if (
+                                    !(
+                                        data2 === 'second' ||
+                                        data2 === 'minute' ||
+                                        data2 === 'hour' ||
+                                        data2 === 'day' ||
+                                        data2 === 'week' ||
+                                        data2 === 'month'
+                                    )
+                                ) {
+                                    validate121.errors = [
+                                        {
+                                            instancePath: instancePath + '/conversion_window_unit',
+                                            schemaPath: '#/definitions/FunnelConversionWindowTimeUnit/enum',
+                                            keyword: 'enum',
+                                            params: { allowedValues: schema87.enum },
+                                            message: 'must be equal to one of the allowed values',
+                                        },
+                                    ]
+                                    return false
+                                }
+                                var valid0 = _errs6 === errors
                             } else {
                                 var valid0 = true
                             }
                             if (valid0) {
-                                if (data.conversion_window !== undefined) {
-                                    let data3 = data.conversion_window
-                                    const _errs8 = errors
-                                    if (
-                                        !(typeof data3 == 'number' && !(data3 % 1) && !isNaN(data3) && isFinite(data3))
-                                    ) {
-                                        validate114.errors = [
+                                if (data.fingerprint !== undefined) {
+                                    const _errs9 = errors
+                                    if (typeof data.fingerprint !== 'string') {
+                                        validate121.errors = [
                                             {
-                                                instancePath: instancePath + '/conversion_window',
-                                                schemaPath: '#/definitions/integer/type',
+                                                instancePath: instancePath + '/fingerprint',
+                                                schemaPath: '#/properties/fingerprint/type',
                                                 keyword: 'type',
-                                                params: { type: 'integer' },
-                                                message: 'must be integer',
+                                                params: { type: 'string' },
+                                                message: 'must be string',
                                             },
                                         ]
                                         return false
                                     }
-                                    var valid0 = _errs8 === errors
+                                    var valid0 = _errs9 === errors
                                 } else {
                                     var valid0 = true
                                 }
                                 if (valid0) {
-                                    if (data.conversion_window_unit !== undefined) {
-                                        let data4 = data.conversion_window_unit
+                                    if (data.funnel_order_type !== undefined) {
+                                        let data4 = data.funnel_order_type
                                         const _errs11 = errors
                                         if (typeof data4 !== 'string') {
-                                            validate114.errors = [
+                                            validate121.errors = [
                                                 {
-                                                    instancePath: instancePath + '/conversion_window_unit',
-                                                    schemaPath: '#/definitions/FunnelConversionWindowTimeUnit/type',
+                                                    instancePath: instancePath + '/funnel_order_type',
+                                                    schemaPath: '#/definitions/StepOrderValue/type',
                                                     keyword: 'type',
                                                     params: { type: 'string' },
                                                     message: 'must be string',
@@ -11615,22 +12281,13 @@ function validate114(data, { instancePath = '', parentData, parentDataProperty, 
                                             ]
                                             return false
                                         }
-                                        if (
-                                            !(
-                                                data4 === 'second' ||
-                                                data4 === 'minute' ||
-                                                data4 === 'hour' ||
-                                                data4 === 'day' ||
-                                                data4 === 'week' ||
-                                                data4 === 'month'
-                                            )
-                                        ) {
-                                            validate114.errors = [
+                                        if (!(data4 === 'strict' || data4 === 'unordered' || data4 === 'ordered')) {
+                                            validate121.errors = [
                                                 {
-                                                    instancePath: instancePath + '/conversion_window_unit',
-                                                    schemaPath: '#/definitions/FunnelConversionWindowTimeUnit/enum',
+                                                    instancePath: instancePath + '/funnel_order_type',
+                                                    schemaPath: '#/definitions/StepOrderValue/enum',
                                                     keyword: 'enum',
-                                                    params: { allowedValues: schema82.enum },
+                                                    params: { allowedValues: schema109.enum },
                                                     message: 'must be equal to one of the allowed values',
                                                 },
                                             ]
@@ -11641,16 +12298,29 @@ function validate114(data, { instancePath = '', parentData, parentDataProperty, 
                                         var valid0 = true
                                     }
                                     if (valid0) {
-                                        if (data.fingerprint !== undefined) {
+                                        if (data.goal !== undefined) {
+                                            let data5 = data.goal
                                             const _errs14 = errors
-                                            if (typeof data.fingerprint !== 'string') {
-                                                validate114.errors = [
+                                            if (typeof data5 !== 'string') {
+                                                validate121.errors = [
                                                     {
-                                                        instancePath: instancePath + '/fingerprint',
-                                                        schemaPath: '#/properties/fingerprint/type',
+                                                        instancePath: instancePath + '/goal',
+                                                        schemaPath: '#/definitions/ExperimentMetricGoal/type',
                                                         keyword: 'type',
                                                         params: { type: 'string' },
                                                         message: 'must be string',
+                                                    },
+                                                ]
+                                                return false
+                                            }
+                                            if (!(data5 === 'increase' || data5 === 'decrease')) {
+                                                validate121.errors = [
+                                                    {
+                                                        instancePath: instancePath + '/goal',
+                                                        schemaPath: '#/definitions/ExperimentMetricGoal/enum',
+                                                        keyword: 'enum',
+                                                        params: { allowedValues: schema88.enum },
+                                                        message: 'must be equal to one of the allowed values',
                                                     },
                                                 ]
                                                 return false
@@ -11660,52 +12330,33 @@ function validate114(data, { instancePath = '', parentData, parentDataProperty, 
                                             var valid0 = true
                                         }
                                         if (valid0) {
-                                            if (data.funnel_order_type !== undefined) {
-                                                let data6 = data.funnel_order_type
-                                                const _errs16 = errors
-                                                if (typeof data6 !== 'string') {
-                                                    validate114.errors = [
+                                            if (data.isSharedMetric !== undefined) {
+                                                const _errs17 = errors
+                                                if (typeof data.isSharedMetric !== 'boolean') {
+                                                    validate121.errors = [
                                                         {
-                                                            instancePath: instancePath + '/funnel_order_type',
-                                                            schemaPath: '#/definitions/StepOrderValue/type',
+                                                            instancePath: instancePath + '/isSharedMetric',
+                                                            schemaPath: '#/properties/isSharedMetric/type',
                                                             keyword: 'type',
-                                                            params: { type: 'string' },
-                                                            message: 'must be string',
+                                                            params: { type: 'boolean' },
+                                                            message: 'must be boolean',
                                                         },
                                                     ]
                                                     return false
                                                 }
-                                                if (
-                                                    !(
-                                                        data6 === 'strict' ||
-                                                        data6 === 'unordered' ||
-                                                        data6 === 'ordered'
-                                                    )
-                                                ) {
-                                                    validate114.errors = [
-                                                        {
-                                                            instancePath: instancePath + '/funnel_order_type',
-                                                            schemaPath: '#/definitions/StepOrderValue/enum',
-                                                            keyword: 'enum',
-                                                            params: { allowedValues: schema105.enum },
-                                                            message: 'must be equal to one of the allowed values',
-                                                        },
-                                                    ]
-                                                    return false
-                                                }
-                                                var valid0 = _errs16 === errors
+                                                var valid0 = _errs17 === errors
                                             } else {
                                                 var valid0 = true
                                             }
                                             if (valid0) {
-                                                if (data.goal !== undefined) {
-                                                    let data7 = data.goal
+                                                if (data.kind !== undefined) {
+                                                    let data7 = data.kind
                                                     const _errs19 = errors
                                                     if (typeof data7 !== 'string') {
-                                                        validate114.errors = [
+                                                        validate121.errors = [
                                                             {
-                                                                instancePath: instancePath + '/goal',
-                                                                schemaPath: '#/definitions/ExperimentMetricGoal/type',
+                                                                instancePath: instancePath + '/kind',
+                                                                schemaPath: '#/properties/kind/type',
                                                                 keyword: 'type',
                                                                 params: { type: 'string' },
                                                                 message: 'must be string',
@@ -11713,14 +12364,14 @@ function validate114(data, { instancePath = '', parentData, parentDataProperty, 
                                                         ]
                                                         return false
                                                     }
-                                                    if (!(data7 === 'increase' || data7 === 'decrease')) {
-                                                        validate114.errors = [
+                                                    if ('ExperimentMetric' !== data7) {
+                                                        validate121.errors = [
                                                             {
-                                                                instancePath: instancePath + '/goal',
-                                                                schemaPath: '#/definitions/ExperimentMetricGoal/enum',
-                                                                keyword: 'enum',
-                                                                params: { allowedValues: schema83.enum },
-                                                                message: 'must be equal to one of the allowed values',
+                                                                instancePath: instancePath + '/kind',
+                                                                schemaPath: '#/properties/kind/const',
+                                                                keyword: 'const',
+                                                                params: { allowedValue: 'ExperimentMetric' },
+                                                                message: 'must be equal to constant',
                                                             },
                                                         ]
                                                         return false
@@ -11730,33 +12381,45 @@ function validate114(data, { instancePath = '', parentData, parentDataProperty, 
                                                     var valid0 = true
                                                 }
                                                 if (valid0) {
-                                                    if (data.isSharedMetric !== undefined) {
-                                                        const _errs22 = errors
-                                                        if (typeof data.isSharedMetric !== 'boolean') {
-                                                            validate114.errors = [
+                                                    if (data.metric_type !== undefined) {
+                                                        let data8 = data.metric_type
+                                                        const _errs21 = errors
+                                                        if (typeof data8 !== 'string') {
+                                                            validate121.errors = [
                                                                 {
-                                                                    instancePath: instancePath + '/isSharedMetric',
-                                                                    schemaPath: '#/properties/isSharedMetric/type',
+                                                                    instancePath: instancePath + '/metric_type',
+                                                                    schemaPath: '#/properties/metric_type/type',
                                                                     keyword: 'type',
-                                                                    params: { type: 'boolean' },
-                                                                    message: 'must be boolean',
+                                                                    params: { type: 'string' },
+                                                                    message: 'must be string',
                                                                 },
                                                             ]
                                                             return false
                                                         }
-                                                        var valid0 = _errs22 === errors
+                                                        if ('funnel' !== data8) {
+                                                            validate121.errors = [
+                                                                {
+                                                                    instancePath: instancePath + '/metric_type',
+                                                                    schemaPath: '#/properties/metric_type/const',
+                                                                    keyword: 'const',
+                                                                    params: { allowedValue: 'funnel' },
+                                                                    message: 'must be equal to constant',
+                                                                },
+                                                            ]
+                                                            return false
+                                                        }
+                                                        var valid0 = _errs21 === errors
                                                     } else {
                                                         var valid0 = true
                                                     }
                                                     if (valid0) {
-                                                        if (data.kind !== undefined) {
-                                                            let data9 = data.kind
-                                                            const _errs24 = errors
-                                                            if (typeof data9 !== 'string') {
-                                                                validate114.errors = [
+                                                        if (data.name !== undefined) {
+                                                            const _errs23 = errors
+                                                            if (typeof data.name !== 'string') {
+                                                                validate121.errors = [
                                                                     {
-                                                                        instancePath: instancePath + '/kind',
-                                                                        schemaPath: '#/properties/kind/type',
+                                                                        instancePath: instancePath + '/name',
+                                                                        schemaPath: '#/properties/name/type',
                                                                         keyword: 'type',
                                                                         params: { type: 'string' },
                                                                         message: 'must be string',
@@ -11764,94 +12427,109 @@ function validate114(data, { instancePath = '', parentData, parentDataProperty, 
                                                                 ]
                                                                 return false
                                                             }
-                                                            if ('ExperimentMetric' !== data9) {
-                                                                validate114.errors = [
-                                                                    {
-                                                                        instancePath: instancePath + '/kind',
-                                                                        schemaPath: '#/properties/kind/const',
-                                                                        keyword: 'const',
-                                                                        params: { allowedValue: 'ExperimentMetric' },
-                                                                        message: 'must be equal to constant',
-                                                                    },
-                                                                ]
-                                                                return false
-                                                            }
-                                                            var valid0 = _errs24 === errors
+                                                            var valid0 = _errs23 === errors
                                                         } else {
                                                             var valid0 = true
                                                         }
                                                         if (valid0) {
-                                                            if (data.metric_type !== undefined) {
-                                                                let data10 = data.metric_type
-                                                                const _errs26 = errors
-                                                                if (typeof data10 !== 'string') {
-                                                                    validate114.errors = [
+                                                            if (data.response !== undefined) {
+                                                                let data10 = data.response
+                                                                const _errs25 = errors
+                                                                if (
+                                                                    !(
+                                                                        data10 &&
+                                                                        typeof data10 == 'object' &&
+                                                                        !Array.isArray(data10)
+                                                                    )
+                                                                ) {
+                                                                    validate121.errors = [
                                                                         {
-                                                                            instancePath: instancePath + '/metric_type',
-                                                                            schemaPath: '#/properties/metric_type/type',
+                                                                            instancePath: instancePath + '/response',
+                                                                            schemaPath: '#/properties/response/type',
                                                                             keyword: 'type',
-                                                                            params: { type: 'string' },
-                                                                            message: 'must be string',
+                                                                            params: { type: 'object' },
+                                                                            message: 'must be object',
                                                                         },
                                                                     ]
                                                                     return false
                                                                 }
-                                                                if ('funnel' !== data10) {
-                                                                    validate114.errors = [
-                                                                        {
-                                                                            instancePath: instancePath + '/metric_type',
-                                                                            schemaPath:
-                                                                                '#/properties/metric_type/const',
-                                                                            keyword: 'const',
-                                                                            params: { allowedValue: 'funnel' },
-                                                                            message: 'must be equal to constant',
-                                                                        },
-                                                                    ]
-                                                                    return false
-                                                                }
-                                                                var valid0 = _errs26 === errors
+                                                                var valid0 = _errs25 === errors
                                                             } else {
                                                                 var valid0 = true
                                                             }
                                                             if (valid0) {
-                                                                if (data.name !== undefined) {
-                                                                    const _errs28 = errors
-                                                                    if (typeof data.name !== 'string') {
-                                                                        validate114.errors = [
-                                                                            {
-                                                                                instancePath: instancePath + '/name',
-                                                                                schemaPath: '#/properties/name/type',
-                                                                                keyword: 'type',
-                                                                                params: { type: 'string' },
-                                                                                message: 'must be string',
-                                                                            },
-                                                                        ]
-                                                                        return false
+                                                                if (data.series !== undefined) {
+                                                                    let data11 = data.series
+                                                                    const _errs27 = errors
+                                                                    if (errors === _errs27) {
+                                                                        if (Array.isArray(data11)) {
+                                                                            var valid5 = true
+                                                                            const len0 = data11.length
+                                                                            for (let i0 = 0; i0 < len0; i0++) {
+                                                                                const _errs29 = errors
+                                                                                if (
+                                                                                    !validate123(data11[i0], {
+                                                                                        instancePath:
+                                                                                            instancePath +
+                                                                                            '/series/' +
+                                                                                            i0,
+                                                                                        parentData: data11,
+                                                                                        parentDataProperty: i0,
+                                                                                        rootData,
+                                                                                    })
+                                                                                ) {
+                                                                                    vErrors =
+                                                                                        vErrors === null
+                                                                                            ? validate123.errors
+                                                                                            : vErrors.concat(
+                                                                                                  validate123.errors
+                                                                                              )
+                                                                                    errors = vErrors.length
+                                                                                }
+                                                                                var valid5 = _errs29 === errors
+                                                                                if (!valid5) {
+                                                                                    break
+                                                                                }
+                                                                            }
+                                                                        } else {
+                                                                            validate121.errors = [
+                                                                                {
+                                                                                    instancePath:
+                                                                                        instancePath + '/series',
+                                                                                    schemaPath:
+                                                                                        '#/properties/series/type',
+                                                                                    keyword: 'type',
+                                                                                    params: { type: 'array' },
+                                                                                    message: 'must be array',
+                                                                                },
+                                                                            ]
+                                                                            return false
+                                                                        }
                                                                     }
-                                                                    var valid0 = _errs28 === errors
+                                                                    var valid0 = _errs27 === errors
                                                                 } else {
                                                                     var valid0 = true
                                                                 }
                                                                 if (valid0) {
-                                                                    if (data.response !== undefined) {
-                                                                        let data12 = data.response
+                                                                    if (data.sharedMetricId !== undefined) {
+                                                                        let data13 = data.sharedMetricId
                                                                         const _errs30 = errors
                                                                         if (
                                                                             !(
-                                                                                data12 &&
-                                                                                typeof data12 == 'object' &&
-                                                                                !Array.isArray(data12)
+                                                                                typeof data13 == 'number' &&
+                                                                                isFinite(data13)
                                                                             )
                                                                         ) {
-                                                                            validate114.errors = [
+                                                                            validate121.errors = [
                                                                                 {
                                                                                     instancePath:
-                                                                                        instancePath + '/response',
+                                                                                        instancePath +
+                                                                                        '/sharedMetricId',
                                                                                     schemaPath:
-                                                                                        '#/properties/response/type',
+                                                                                        '#/properties/sharedMetricId/type',
                                                                                     keyword: 'type',
-                                                                                    params: { type: 'object' },
-                                                                                    message: 'must be object',
+                                                                                    params: { type: 'number' },
+                                                                                    message: 'must be number',
                                                                                 },
                                                                             ]
                                                                             return false
@@ -11861,76 +12539,43 @@ function validate114(data, { instancePath = '', parentData, parentDataProperty, 
                                                                         var valid0 = true
                                                                     }
                                                                     if (valid0) {
-                                                                        if (data.series !== undefined) {
-                                                                            let data13 = data.series
+                                                                        if (data.uuid !== undefined) {
                                                                             const _errs32 = errors
-                                                                            if (errors === _errs32) {
-                                                                                if (Array.isArray(data13)) {
-                                                                                    var valid6 = true
-                                                                                    const len0 = data13.length
-                                                                                    for (let i0 = 0; i0 < len0; i0++) {
-                                                                                        const _errs34 = errors
-                                                                                        if (
-                                                                                            !validate116(data13[i0], {
-                                                                                                instancePath:
-                                                                                                    instancePath +
-                                                                                                    '/series/' +
-                                                                                                    i0,
-                                                                                                parentData: data13,
-                                                                                                parentDataProperty: i0,
-                                                                                                rootData,
-                                                                                            })
-                                                                                        ) {
-                                                                                            vErrors =
-                                                                                                vErrors === null
-                                                                                                    ? validate116.errors
-                                                                                                    : vErrors.concat(
-                                                                                                          validate116.errors
-                                                                                                      )
-                                                                                            errors = vErrors.length
-                                                                                        }
-                                                                                        var valid6 = _errs34 === errors
-                                                                                        if (!valid6) {
-                                                                                            break
-                                                                                        }
-                                                                                    }
-                                                                                } else {
-                                                                                    validate114.errors = [
-                                                                                        {
-                                                                                            instancePath:
-                                                                                                instancePath +
-                                                                                                '/series',
-                                                                                            schemaPath:
-                                                                                                '#/properties/series/type',
-                                                                                            keyword: 'type',
-                                                                                            params: { type: 'array' },
-                                                                                            message: 'must be array',
-                                                                                        },
-                                                                                    ]
-                                                                                    return false
-                                                                                }
+                                                                            if (typeof data.uuid !== 'string') {
+                                                                                validate121.errors = [
+                                                                                    {
+                                                                                        instancePath:
+                                                                                            instancePath + '/uuid',
+                                                                                        schemaPath:
+                                                                                            '#/properties/uuid/type',
+                                                                                        keyword: 'type',
+                                                                                        params: { type: 'string' },
+                                                                                        message: 'must be string',
+                                                                                    },
+                                                                                ]
+                                                                                return false
                                                                             }
                                                                             var valid0 = _errs32 === errors
                                                                         } else {
                                                                             var valid0 = true
                                                                         }
                                                                         if (valid0) {
-                                                                            if (data.sharedMetricId !== undefined) {
-                                                                                let data15 = data.sharedMetricId
-                                                                                const _errs35 = errors
+                                                                            if (data.version !== undefined) {
+                                                                                let data15 = data.version
+                                                                                const _errs34 = errors
                                                                                 if (
                                                                                     !(
                                                                                         typeof data15 == 'number' &&
                                                                                         isFinite(data15)
                                                                                     )
                                                                                 ) {
-                                                                                    validate114.errors = [
+                                                                                    validate121.errors = [
                                                                                         {
                                                                                             instancePath:
                                                                                                 instancePath +
-                                                                                                '/sharedMetricId',
+                                                                                                '/version',
                                                                                             schemaPath:
-                                                                                                '#/properties/sharedMetricId/type',
+                                                                                                '#/properties/version/type',
                                                                                             keyword: 'type',
                                                                                             params: { type: 'number' },
                                                                                             message: 'must be number',
@@ -11938,68 +12583,9 @@ function validate114(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                     ]
                                                                                     return false
                                                                                 }
-                                                                                var valid0 = _errs35 === errors
+                                                                                var valid0 = _errs34 === errors
                                                                             } else {
                                                                                 var valid0 = true
-                                                                            }
-                                                                            if (valid0) {
-                                                                                if (data.uuid !== undefined) {
-                                                                                    const _errs37 = errors
-                                                                                    if (typeof data.uuid !== 'string') {
-                                                                                        validate114.errors = [
-                                                                                            {
-                                                                                                instancePath:
-                                                                                                    instancePath +
-                                                                                                    '/uuid',
-                                                                                                schemaPath:
-                                                                                                    '#/properties/uuid/type',
-                                                                                                keyword: 'type',
-                                                                                                params: {
-                                                                                                    type: 'string',
-                                                                                                },
-                                                                                                message:
-                                                                                                    'must be string',
-                                                                                            },
-                                                                                        ]
-                                                                                        return false
-                                                                                    }
-                                                                                    var valid0 = _errs37 === errors
-                                                                                } else {
-                                                                                    var valid0 = true
-                                                                                }
-                                                                                if (valid0) {
-                                                                                    if (data.version !== undefined) {
-                                                                                        let data17 = data.version
-                                                                                        const _errs39 = errors
-                                                                                        if (
-                                                                                            !(
-                                                                                                typeof data17 ==
-                                                                                                    'number' &&
-                                                                                                isFinite(data17)
-                                                                                            )
-                                                                                        ) {
-                                                                                            validate114.errors = [
-                                                                                                {
-                                                                                                    instancePath:
-                                                                                                        instancePath +
-                                                                                                        '/version',
-                                                                                                    schemaPath:
-                                                                                                        '#/properties/version/type',
-                                                                                                    keyword: 'type',
-                                                                                                    params: {
-                                                                                                        type: 'number',
-                                                                                                    },
-                                                                                                    message:
-                                                                                                        'must be number',
-                                                                                                },
-                                                                                            ]
-                                                                                            return false
-                                                                                        }
-                                                                                        var valid0 = _errs39 === errors
-                                                                                    } else {
-                                                                                        var valid0 = true
-                                                                                    }
-                                                                                }
                                                                             }
                                                                         }
                                                                     }
@@ -12018,7 +12604,7 @@ function validate114(data, { instancePath = '', parentData, parentDataProperty, 
                 }
             }
         } else {
-            validate114.errors = [
+            validate121.errors = [
                 {
                     instancePath,
                     schemaPath: '#/type',
@@ -12030,10 +12616,10 @@ function validate114(data, { instancePath = '', parentData, parentDataProperty, 
             return false
         }
     }
-    validate114.errors = vErrors
+    validate121.errors = vErrors
     return errors === 0
 }
-const schema108 = {
+const schema112 = {
     additionalProperties: false,
     properties: {
         breakdownFilter: { $ref: '#/definitions/BreakdownFilter' },
@@ -12057,7 +12643,7 @@ const schema108 = {
     required: ['denominator', 'kind', 'metric_type', 'numerator'],
     type: 'object',
 }
-const schema111 = {
+const schema115 = {
     additionalProperties: false,
     properties: {
         ignore_zeros: { type: 'boolean' },
@@ -12078,7 +12664,7 @@ const schema111 = {
     },
     type: 'object',
 }
-function validate122(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
+function validate129(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
     let vErrors = null
     let errors = 0
     if (errors === 0) {
@@ -12090,7 +12676,7 @@ function validate122(data, { instancePath = '', parentData, parentDataProperty, 
                 (data.metric_type === undefined && (missing0 = 'metric_type')) ||
                 (data.numerator === undefined && (missing0 = 'numerator'))
             ) {
-                validate122.errors = [
+                validate129.errors = [
                     {
                         instancePath,
                         schemaPath: '#/required',
@@ -12103,8 +12689,8 @@ function validate122(data, { instancePath = '', parentData, parentDataProperty, 
             } else {
                 const _errs1 = errors
                 for (const key0 in data) {
-                    if (!func2.call(schema108.properties, key0)) {
-                        validate122.errors = [
+                    if (!func2.call(schema112.properties, key0)) {
+                        validate129.errors = [
                             {
                                 instancePath,
                                 schemaPath: '#/additionalProperties',
@@ -12121,14 +12707,14 @@ function validate122(data, { instancePath = '', parentData, parentDataProperty, 
                     if (data.breakdownFilter !== undefined) {
                         const _errs2 = errors
                         if (
-                            !validate87(data.breakdownFilter, {
+                            !validate94(data.breakdownFilter, {
                                 instancePath: instancePath + '/breakdownFilter',
                                 parentData: data,
                                 parentDataProperty: 'breakdownFilter',
                                 rootData,
                             })
                         ) {
-                            vErrors = vErrors === null ? validate87.errors : vErrors.concat(validate87.errors)
+                            vErrors = vErrors === null ? validate94.errors : vErrors.concat(validate94.errors)
                             errors = vErrors.length
                         }
                         var valid0 = _errs2 === errors
@@ -12140,7 +12726,7 @@ function validate122(data, { instancePath = '', parentData, parentDataProperty, 
                             let data1 = data.conversion_window
                             const _errs3 = errors
                             if (!(typeof data1 == 'number' && !(data1 % 1) && !isNaN(data1) && isFinite(data1))) {
-                                validate122.errors = [
+                                validate129.errors = [
                                     {
                                         instancePath: instancePath + '/conversion_window',
                                         schemaPath: '#/definitions/integer/type',
@@ -12160,7 +12746,7 @@ function validate122(data, { instancePath = '', parentData, parentDataProperty, 
                                 let data2 = data.conversion_window_unit
                                 const _errs6 = errors
                                 if (typeof data2 !== 'string') {
-                                    validate122.errors = [
+                                    validate129.errors = [
                                         {
                                             instancePath: instancePath + '/conversion_window_unit',
                                             schemaPath: '#/definitions/FunnelConversionWindowTimeUnit/type',
@@ -12181,12 +12767,12 @@ function validate122(data, { instancePath = '', parentData, parentDataProperty, 
                                         data2 === 'month'
                                     )
                                 ) {
-                                    validate122.errors = [
+                                    validate129.errors = [
                                         {
                                             instancePath: instancePath + '/conversion_window_unit',
                                             schemaPath: '#/definitions/FunnelConversionWindowTimeUnit/enum',
                                             keyword: 'enum',
-                                            params: { allowedValues: schema82.enum },
+                                            params: { allowedValues: schema87.enum },
                                             message: 'must be equal to one of the allowed values',
                                         },
                                     ]
@@ -12200,7 +12786,7 @@ function validate122(data, { instancePath = '', parentData, parentDataProperty, 
                                 if (data.denominator !== undefined) {
                                     const _errs9 = errors
                                     if (
-                                        !validate91(data.denominator, {
+                                        !validate98(data.denominator, {
                                             instancePath: instancePath + '/denominator',
                                             parentData: data,
                                             parentDataProperty: 'denominator',
@@ -12208,7 +12794,7 @@ function validate122(data, { instancePath = '', parentData, parentDataProperty, 
                                         })
                                     ) {
                                         vErrors =
-                                            vErrors === null ? validate91.errors : vErrors.concat(validate91.errors)
+                                            vErrors === null ? validate98.errors : vErrors.concat(validate98.errors)
                                         errors = vErrors.length
                                     }
                                     var valid0 = _errs9 === errors
@@ -12231,7 +12817,7 @@ function validate122(data, { instancePath = '', parentData, parentDataProperty, 
                                                             key1 === 'upper_bound_percentile'
                                                         )
                                                     ) {
-                                                        validate122.errors = [
+                                                        validate129.errors = [
                                                             {
                                                                 instancePath:
                                                                     instancePath + '/denominator_outlier_handling',
@@ -12250,7 +12836,7 @@ function validate122(data, { instancePath = '', parentData, parentDataProperty, 
                                                     if (data4.ignore_zeros !== undefined) {
                                                         const _errs14 = errors
                                                         if (typeof data4.ignore_zeros !== 'boolean') {
-                                                            validate122.errors = [
+                                                            validate129.errors = [
                                                                 {
                                                                     instancePath:
                                                                         instancePath +
@@ -12275,7 +12861,7 @@ function validate122(data, { instancePath = '', parentData, parentDataProperty, 
                                                             if (errors === _errs16) {
                                                                 if (typeof data6 == 'number' && isFinite(data6)) {
                                                                     if (data6 > 1 || isNaN(data6)) {
-                                                                        validate122.errors = [
+                                                                        validate129.errors = [
                                                                             {
                                                                                 instancePath:
                                                                                     instancePath +
@@ -12290,7 +12876,7 @@ function validate122(data, { instancePath = '', parentData, parentDataProperty, 
                                                                         return false
                                                                     } else {
                                                                         if (data6 < 0 || isNaN(data6)) {
-                                                                            validate122.errors = [
+                                                                            validate129.errors = [
                                                                                 {
                                                                                     instancePath:
                                                                                         instancePath +
@@ -12309,7 +12895,7 @@ function validate122(data, { instancePath = '', parentData, parentDataProperty, 
                                                                         }
                                                                     }
                                                                 } else {
-                                                                    validate122.errors = [
+                                                                    validate129.errors = [
                                                                         {
                                                                             instancePath:
                                                                                 instancePath +
@@ -12335,7 +12921,7 @@ function validate122(data, { instancePath = '', parentData, parentDataProperty, 
                                                                 if (errors === _errs18) {
                                                                     if (typeof data7 == 'number' && isFinite(data7)) {
                                                                         if (data7 > 1 || isNaN(data7)) {
-                                                                            validate122.errors = [
+                                                                            validate129.errors = [
                                                                                 {
                                                                                     instancePath:
                                                                                         instancePath +
@@ -12353,7 +12939,7 @@ function validate122(data, { instancePath = '', parentData, parentDataProperty, 
                                                                             return false
                                                                         } else {
                                                                             if (data7 < 0 || isNaN(data7)) {
-                                                                                validate122.errors = [
+                                                                                validate129.errors = [
                                                                                     {
                                                                                         instancePath:
                                                                                             instancePath +
@@ -12372,7 +12958,7 @@ function validate122(data, { instancePath = '', parentData, parentDataProperty, 
                                                                             }
                                                                         }
                                                                     } else {
-                                                                        validate122.errors = [
+                                                                        validate129.errors = [
                                                                             {
                                                                                 instancePath:
                                                                                     instancePath +
@@ -12395,7 +12981,7 @@ function validate122(data, { instancePath = '', parentData, parentDataProperty, 
                                                     }
                                                 }
                                             } else {
-                                                validate122.errors = [
+                                                validate129.errors = [
                                                     {
                                                         instancePath: instancePath + '/denominator_outlier_handling',
                                                         schemaPath:
@@ -12416,7 +13002,7 @@ function validate122(data, { instancePath = '', parentData, parentDataProperty, 
                                         if (data.fingerprint !== undefined) {
                                             const _errs20 = errors
                                             if (typeof data.fingerprint !== 'string') {
-                                                validate122.errors = [
+                                                validate129.errors = [
                                                     {
                                                         instancePath: instancePath + '/fingerprint',
                                                         schemaPath: '#/properties/fingerprint/type',
@@ -12436,7 +13022,7 @@ function validate122(data, { instancePath = '', parentData, parentDataProperty, 
                                                 let data9 = data.goal
                                                 const _errs22 = errors
                                                 if (typeof data9 !== 'string') {
-                                                    validate122.errors = [
+                                                    validate129.errors = [
                                                         {
                                                             instancePath: instancePath + '/goal',
                                                             schemaPath: '#/definitions/ExperimentMetricGoal/type',
@@ -12448,12 +13034,12 @@ function validate122(data, { instancePath = '', parentData, parentDataProperty, 
                                                     return false
                                                 }
                                                 if (!(data9 === 'increase' || data9 === 'decrease')) {
-                                                    validate122.errors = [
+                                                    validate129.errors = [
                                                         {
                                                             instancePath: instancePath + '/goal',
                                                             schemaPath: '#/definitions/ExperimentMetricGoal/enum',
                                                             keyword: 'enum',
-                                                            params: { allowedValues: schema83.enum },
+                                                            params: { allowedValues: schema88.enum },
                                                             message: 'must be equal to one of the allowed values',
                                                         },
                                                     ]
@@ -12467,7 +13053,7 @@ function validate122(data, { instancePath = '', parentData, parentDataProperty, 
                                                 if (data.isSharedMetric !== undefined) {
                                                     const _errs25 = errors
                                                     if (typeof data.isSharedMetric !== 'boolean') {
-                                                        validate122.errors = [
+                                                        validate129.errors = [
                                                             {
                                                                 instancePath: instancePath + '/isSharedMetric',
                                                                 schemaPath: '#/properties/isSharedMetric/type',
@@ -12487,7 +13073,7 @@ function validate122(data, { instancePath = '', parentData, parentDataProperty, 
                                                         let data11 = data.kind
                                                         const _errs27 = errors
                                                         if (typeof data11 !== 'string') {
-                                                            validate122.errors = [
+                                                            validate129.errors = [
                                                                 {
                                                                     instancePath: instancePath + '/kind',
                                                                     schemaPath: '#/properties/kind/type',
@@ -12499,7 +13085,7 @@ function validate122(data, { instancePath = '', parentData, parentDataProperty, 
                                                             return false
                                                         }
                                                         if ('ExperimentMetric' !== data11) {
-                                                            validate122.errors = [
+                                                            validate129.errors = [
                                                                 {
                                                                     instancePath: instancePath + '/kind',
                                                                     schemaPath: '#/properties/kind/const',
@@ -12519,7 +13105,7 @@ function validate122(data, { instancePath = '', parentData, parentDataProperty, 
                                                             let data12 = data.metric_type
                                                             const _errs29 = errors
                                                             if (typeof data12 !== 'string') {
-                                                                validate122.errors = [
+                                                                validate129.errors = [
                                                                     {
                                                                         instancePath: instancePath + '/metric_type',
                                                                         schemaPath: '#/properties/metric_type/type',
@@ -12531,7 +13117,7 @@ function validate122(data, { instancePath = '', parentData, parentDataProperty, 
                                                                 return false
                                                             }
                                                             if ('ratio' !== data12) {
-                                                                validate122.errors = [
+                                                                validate129.errors = [
                                                                     {
                                                                         instancePath: instancePath + '/metric_type',
                                                                         schemaPath: '#/properties/metric_type/const',
@@ -12550,7 +13136,7 @@ function validate122(data, { instancePath = '', parentData, parentDataProperty, 
                                                             if (data.name !== undefined) {
                                                                 const _errs31 = errors
                                                                 if (typeof data.name !== 'string') {
-                                                                    validate122.errors = [
+                                                                    validate129.errors = [
                                                                         {
                                                                             instancePath: instancePath + '/name',
                                                                             schemaPath: '#/properties/name/type',
@@ -12569,7 +13155,7 @@ function validate122(data, { instancePath = '', parentData, parentDataProperty, 
                                                                 if (data.numerator !== undefined) {
                                                                     const _errs33 = errors
                                                                     if (
-                                                                        !validate91(data.numerator, {
+                                                                        !validate98(data.numerator, {
                                                                             instancePath: instancePath + '/numerator',
                                                                             parentData: data,
                                                                             parentDataProperty: 'numerator',
@@ -12578,8 +13164,8 @@ function validate122(data, { instancePath = '', parentData, parentDataProperty, 
                                                                     ) {
                                                                         vErrors =
                                                                             vErrors === null
-                                                                                ? validate91.errors
-                                                                                : vErrors.concat(validate91.errors)
+                                                                                ? validate98.errors
+                                                                                : vErrors.concat(validate98.errors)
                                                                         errors = vErrors.length
                                                                     }
                                                                     var valid0 = _errs33 === errors
@@ -12608,7 +13194,7 @@ function validate122(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                                 'upper_bound_percentile'
                                                                                         )
                                                                                     ) {
-                                                                                        validate122.errors = [
+                                                                                        validate129.errors = [
                                                                                             {
                                                                                                 instancePath:
                                                                                                     instancePath +
@@ -12639,7 +13225,7 @@ function validate122(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                             typeof data15.ignore_zeros !==
                                                                                             'boolean'
                                                                                         ) {
-                                                                                            validate122.errors = [
+                                                                                            validate129.errors = [
                                                                                                 {
                                                                                                     instancePath:
                                                                                                         instancePath +
@@ -12678,7 +13264,7 @@ function validate122(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                                         data17 > 1 ||
                                                                                                         isNaN(data17)
                                                                                                     ) {
-                                                                                                        validate122.errors =
+                                                                                                        validate129.errors =
                                                                                                             [
                                                                                                                 {
                                                                                                                     instancePath:
@@ -12706,7 +13292,7 @@ function validate122(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                                                 data17
                                                                                                             )
                                                                                                         ) {
-                                                                                                            validate122.errors =
+                                                                                                            validate129.errors =
                                                                                                                 [
                                                                                                                     {
                                                                                                                         instancePath:
@@ -12729,7 +13315,7 @@ function validate122(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                                         }
                                                                                                     }
                                                                                                 } else {
-                                                                                                    validate122.errors =
+                                                                                                    validate129.errors =
                                                                                                         [
                                                                                                             {
                                                                                                                 instancePath:
@@ -12777,7 +13363,7 @@ function validate122(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                                                 data18
                                                                                                             )
                                                                                                         ) {
-                                                                                                            validate122.errors =
+                                                                                                            validate129.errors =
                                                                                                                 [
                                                                                                                     {
                                                                                                                         instancePath:
@@ -12805,7 +13391,7 @@ function validate122(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                                                     data18
                                                                                                                 )
                                                                                                             ) {
-                                                                                                                validate122.errors =
+                                                                                                                validate129.errors =
                                                                                                                     [
                                                                                                                         {
                                                                                                                             instancePath:
@@ -12828,7 +13414,7 @@ function validate122(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                                             }
                                                                                                         }
                                                                                                     } else {
-                                                                                                        validate122.errors =
+                                                                                                        validate129.errors =
                                                                                                             [
                                                                                                                 {
                                                                                                                     instancePath:
@@ -12857,7 +13443,7 @@ function validate122(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                     }
                                                                                 }
                                                                             } else {
-                                                                                validate122.errors = [
+                                                                                validate129.errors = [
                                                                                     {
                                                                                         instancePath:
                                                                                             instancePath +
@@ -12887,7 +13473,7 @@ function validate122(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                     !Array.isArray(data19)
                                                                                 )
                                                                             ) {
-                                                                                validate122.errors = [
+                                                                                validate129.errors = [
                                                                                     {
                                                                                         instancePath:
                                                                                             instancePath + '/response',
@@ -12914,7 +13500,7 @@ function validate122(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                         isFinite(data20)
                                                                                     )
                                                                                 ) {
-                                                                                    validate122.errors = [
+                                                                                    validate129.errors = [
                                                                                         {
                                                                                             instancePath:
                                                                                                 instancePath +
@@ -12936,7 +13522,7 @@ function validate122(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                 if (data.uuid !== undefined) {
                                                                                     const _errs48 = errors
                                                                                     if (typeof data.uuid !== 'string') {
-                                                                                        validate122.errors = [
+                                                                                        validate129.errors = [
                                                                                             {
                                                                                                 instancePath:
                                                                                                     instancePath +
@@ -12968,7 +13554,7 @@ function validate122(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                                 isFinite(data22)
                                                                                             )
                                                                                         ) {
-                                                                                            validate122.errors = [
+                                                                                            validate129.errors = [
                                                                                                 {
                                                                                                     instancePath:
                                                                                                         instancePath +
@@ -13008,7 +13594,7 @@ function validate122(data, { instancePath = '', parentData, parentDataProperty, 
                 }
             }
         } else {
-            validate122.errors = [
+            validate129.errors = [
                 {
                     instancePath,
                     schemaPath: '#/type',
@@ -13020,10 +13606,10 @@ function validate122(data, { instancePath = '', parentData, parentDataProperty, 
             return false
         }
     }
-    validate122.errors = vErrors
+    validate129.errors = vErrors
     return errors === 0
 }
-const schema114 = {
+const schema118 = {
     additionalProperties: false,
     properties: {
         breakdownFilter: { $ref: '#/definitions/BreakdownFilter' },
@@ -13058,7 +13644,7 @@ const schema114 = {
     ],
     type: 'object',
 }
-function validate127(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
+function validate134(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
     let vErrors = null
     let errors = 0
     if (errors === 0) {
@@ -13074,7 +13660,7 @@ function validate127(data, { instancePath = '', parentData, parentDataProperty, 
                 (data.start_event === undefined && (missing0 = 'start_event')) ||
                 (data.start_handling === undefined && (missing0 = 'start_handling'))
             ) {
-                validate127.errors = [
+                validate134.errors = [
                     {
                         instancePath,
                         schemaPath: '#/required',
@@ -13087,8 +13673,8 @@ function validate127(data, { instancePath = '', parentData, parentDataProperty, 
             } else {
                 const _errs1 = errors
                 for (const key0 in data) {
-                    if (!func2.call(schema114.properties, key0)) {
-                        validate127.errors = [
+                    if (!func2.call(schema118.properties, key0)) {
+                        validate134.errors = [
                             {
                                 instancePath,
                                 schemaPath: '#/additionalProperties',
@@ -13105,14 +13691,14 @@ function validate127(data, { instancePath = '', parentData, parentDataProperty, 
                     if (data.breakdownFilter !== undefined) {
                         const _errs2 = errors
                         if (
-                            !validate87(data.breakdownFilter, {
+                            !validate94(data.breakdownFilter, {
                                 instancePath: instancePath + '/breakdownFilter',
                                 parentData: data,
                                 parentDataProperty: 'breakdownFilter',
                                 rootData,
                             })
                         ) {
-                            vErrors = vErrors === null ? validate87.errors : vErrors.concat(validate87.errors)
+                            vErrors = vErrors === null ? validate94.errors : vErrors.concat(validate94.errors)
                             errors = vErrors.length
                         }
                         var valid0 = _errs2 === errors
@@ -13123,14 +13709,14 @@ function validate127(data, { instancePath = '', parentData, parentDataProperty, 
                         if (data.completion_event !== undefined) {
                             const _errs3 = errors
                             if (
-                                !validate91(data.completion_event, {
+                                !validate98(data.completion_event, {
                                     instancePath: instancePath + '/completion_event',
                                     parentData: data,
                                     parentDataProperty: 'completion_event',
                                     rootData,
                                 })
                             ) {
-                                vErrors = vErrors === null ? validate91.errors : vErrors.concat(validate91.errors)
+                                vErrors = vErrors === null ? validate98.errors : vErrors.concat(validate98.errors)
                                 errors = vErrors.length
                             }
                             var valid0 = _errs3 === errors
@@ -13142,7 +13728,7 @@ function validate127(data, { instancePath = '', parentData, parentDataProperty, 
                                 let data2 = data.conversion_window
                                 const _errs4 = errors
                                 if (!(typeof data2 == 'number' && !(data2 % 1) && !isNaN(data2) && isFinite(data2))) {
-                                    validate127.errors = [
+                                    validate134.errors = [
                                         {
                                             instancePath: instancePath + '/conversion_window',
                                             schemaPath: '#/definitions/integer/type',
@@ -13162,7 +13748,7 @@ function validate127(data, { instancePath = '', parentData, parentDataProperty, 
                                     let data3 = data.conversion_window_unit
                                     const _errs7 = errors
                                     if (typeof data3 !== 'string') {
-                                        validate127.errors = [
+                                        validate134.errors = [
                                             {
                                                 instancePath: instancePath + '/conversion_window_unit',
                                                 schemaPath: '#/definitions/FunnelConversionWindowTimeUnit/type',
@@ -13183,12 +13769,12 @@ function validate127(data, { instancePath = '', parentData, parentDataProperty, 
                                             data3 === 'month'
                                         )
                                     ) {
-                                        validate127.errors = [
+                                        validate134.errors = [
                                             {
                                                 instancePath: instancePath + '/conversion_window_unit',
                                                 schemaPath: '#/definitions/FunnelConversionWindowTimeUnit/enum',
                                                 keyword: 'enum',
-                                                params: { allowedValues: schema82.enum },
+                                                params: { allowedValues: schema87.enum },
                                                 message: 'must be equal to one of the allowed values',
                                             },
                                         ]
@@ -13202,7 +13788,7 @@ function validate127(data, { instancePath = '', parentData, parentDataProperty, 
                                     if (data.fingerprint !== undefined) {
                                         const _errs10 = errors
                                         if (typeof data.fingerprint !== 'string') {
-                                            validate127.errors = [
+                                            validate134.errors = [
                                                 {
                                                     instancePath: instancePath + '/fingerprint',
                                                     schemaPath: '#/properties/fingerprint/type',
@@ -13222,7 +13808,7 @@ function validate127(data, { instancePath = '', parentData, parentDataProperty, 
                                             let data5 = data.goal
                                             const _errs12 = errors
                                             if (typeof data5 !== 'string') {
-                                                validate127.errors = [
+                                                validate134.errors = [
                                                     {
                                                         instancePath: instancePath + '/goal',
                                                         schemaPath: '#/definitions/ExperimentMetricGoal/type',
@@ -13234,12 +13820,12 @@ function validate127(data, { instancePath = '', parentData, parentDataProperty, 
                                                 return false
                                             }
                                             if (!(data5 === 'increase' || data5 === 'decrease')) {
-                                                validate127.errors = [
+                                                validate134.errors = [
                                                     {
                                                         instancePath: instancePath + '/goal',
                                                         schemaPath: '#/definitions/ExperimentMetricGoal/enum',
                                                         keyword: 'enum',
-                                                        params: { allowedValues: schema83.enum },
+                                                        params: { allowedValues: schema88.enum },
                                                         message: 'must be equal to one of the allowed values',
                                                     },
                                                 ]
@@ -13253,7 +13839,7 @@ function validate127(data, { instancePath = '', parentData, parentDataProperty, 
                                             if (data.isSharedMetric !== undefined) {
                                                 const _errs15 = errors
                                                 if (typeof data.isSharedMetric !== 'boolean') {
-                                                    validate127.errors = [
+                                                    validate134.errors = [
                                                         {
                                                             instancePath: instancePath + '/isSharedMetric',
                                                             schemaPath: '#/properties/isSharedMetric/type',
@@ -13273,7 +13859,7 @@ function validate127(data, { instancePath = '', parentData, parentDataProperty, 
                                                     let data7 = data.kind
                                                     const _errs17 = errors
                                                     if (typeof data7 !== 'string') {
-                                                        validate127.errors = [
+                                                        validate134.errors = [
                                                             {
                                                                 instancePath: instancePath + '/kind',
                                                                 schemaPath: '#/properties/kind/type',
@@ -13285,7 +13871,7 @@ function validate127(data, { instancePath = '', parentData, parentDataProperty, 
                                                         return false
                                                     }
                                                     if ('ExperimentMetric' !== data7) {
-                                                        validate127.errors = [
+                                                        validate134.errors = [
                                                             {
                                                                 instancePath: instancePath + '/kind',
                                                                 schemaPath: '#/properties/kind/const',
@@ -13305,7 +13891,7 @@ function validate127(data, { instancePath = '', parentData, parentDataProperty, 
                                                         let data8 = data.metric_type
                                                         const _errs19 = errors
                                                         if (typeof data8 !== 'string') {
-                                                            validate127.errors = [
+                                                            validate134.errors = [
                                                                 {
                                                                     instancePath: instancePath + '/metric_type',
                                                                     schemaPath: '#/properties/metric_type/type',
@@ -13317,7 +13903,7 @@ function validate127(data, { instancePath = '', parentData, parentDataProperty, 
                                                             return false
                                                         }
                                                         if ('retention' !== data8) {
-                                                            validate127.errors = [
+                                                            validate134.errors = [
                                                                 {
                                                                     instancePath: instancePath + '/metric_type',
                                                                     schemaPath: '#/properties/metric_type/const',
@@ -13336,7 +13922,7 @@ function validate127(data, { instancePath = '', parentData, parentDataProperty, 
                                                         if (data.name !== undefined) {
                                                             const _errs21 = errors
                                                             if (typeof data.name !== 'string') {
-                                                                validate127.errors = [
+                                                                validate134.errors = [
                                                                     {
                                                                         instancePath: instancePath + '/name',
                                                                         schemaPath: '#/properties/name/type',
@@ -13362,7 +13948,7 @@ function validate127(data, { instancePath = '', parentData, parentDataProperty, 
                                                                         !Array.isArray(data10)
                                                                     )
                                                                 ) {
-                                                                    validate127.errors = [
+                                                                    validate134.errors = [
                                                                         {
                                                                             instancePath: instancePath + '/response',
                                                                             schemaPath: '#/properties/response/type',
@@ -13389,7 +13975,7 @@ function validate127(data, { instancePath = '', parentData, parentDataProperty, 
                                                                             isFinite(data11)
                                                                         )
                                                                     ) {
-                                                                        validate127.errors = [
+                                                                        validate134.errors = [
                                                                             {
                                                                                 instancePath:
                                                                                     instancePath +
@@ -13419,7 +14005,7 @@ function validate127(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                 isFinite(data12)
                                                                             )
                                                                         ) {
-                                                                            validate127.errors = [
+                                                                            validate134.errors = [
                                                                                 {
                                                                                     instancePath:
                                                                                         instancePath +
@@ -13442,7 +14028,7 @@ function validate127(data, { instancePath = '', parentData, parentDataProperty, 
                                                                             let data13 = data.retention_window_unit
                                                                             const _errs31 = errors
                                                                             if (typeof data13 !== 'string') {
-                                                                                validate127.errors = [
+                                                                                validate134.errors = [
                                                                                     {
                                                                                         instancePath:
                                                                                             instancePath +
@@ -13466,7 +14052,7 @@ function validate127(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                     data13 === 'month'
                                                                                 )
                                                                             ) {
-                                                                                validate127.errors = [
+                                                                                validate134.errors = [
                                                                                     {
                                                                                         instancePath:
                                                                                             instancePath +
@@ -13476,7 +14062,7 @@ function validate127(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                         keyword: 'enum',
                                                                                         params: {
                                                                                             allowedValues:
-                                                                                                schema82.enum,
+                                                                                                schema87.enum,
                                                                                         },
                                                                                         message:
                                                                                             'must be equal to one of the allowed values',
@@ -13498,7 +14084,7 @@ function validate127(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                         isFinite(data14)
                                                                                     )
                                                                                 ) {
-                                                                                    validate127.errors = [
+                                                                                    validate134.errors = [
                                                                                         {
                                                                                             instancePath:
                                                                                                 instancePath +
@@ -13520,7 +14106,7 @@ function validate127(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                 if (data.start_event !== undefined) {
                                                                                     const _errs36 = errors
                                                                                     if (
-                                                                                        !validate91(data.start_event, {
+                                                                                        !validate98(data.start_event, {
                                                                                             instancePath:
                                                                                                 instancePath +
                                                                                                 '/start_event',
@@ -13532,9 +14118,9 @@ function validate127(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                     ) {
                                                                                         vErrors =
                                                                                             vErrors === null
-                                                                                                ? validate91.errors
+                                                                                                ? validate98.errors
                                                                                                 : vErrors.concat(
-                                                                                                      validate91.errors
+                                                                                                      validate98.errors
                                                                                                   )
                                                                                         errors = vErrors.length
                                                                                     }
@@ -13552,7 +14138,7 @@ function validate127(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                         if (
                                                                                             typeof data16 !== 'string'
                                                                                         ) {
-                                                                                            validate127.errors = [
+                                                                                            validate134.errors = [
                                                                                                 {
                                                                                                     instancePath:
                                                                                                         instancePath +
@@ -13576,7 +14162,7 @@ function validate127(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                                 data16 === 'last_seen'
                                                                                             )
                                                                                         ) {
-                                                                                            validate127.errors = [
+                                                                                            validate134.errors = [
                                                                                                 {
                                                                                                     instancePath:
                                                                                                         instancePath +
@@ -13586,7 +14172,7 @@ function validate127(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                                     keyword: 'enum',
                                                                                                     params: {
                                                                                                         allowedValues:
-                                                                                                            schema114
+                                                                                                            schema118
                                                                                                                 .properties
                                                                                                                 .start_handling
                                                                                                                 .enum,
@@ -13608,7 +14194,7 @@ function validate127(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                                 typeof data.uuid !==
                                                                                                 'string'
                                                                                             ) {
-                                                                                                validate127.errors = [
+                                                                                                validate134.errors = [
                                                                                                     {
                                                                                                         instancePath:
                                                                                                             instancePath +
@@ -13645,7 +14231,7 @@ function validate127(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                                         isFinite(data18)
                                                                                                     )
                                                                                                 ) {
-                                                                                                    validate127.errors =
+                                                                                                    validate134.errors =
                                                                                                         [
                                                                                                             {
                                                                                                                 instancePath:
@@ -13690,7 +14276,7 @@ function validate127(data, { instancePath = '', parentData, parentDataProperty, 
                 }
             }
         } else {
-            validate127.errors = [
+            validate134.errors = [
                 {
                     instancePath,
                     schemaPath: '#/type',
@@ -13702,18 +14288,18 @@ function validate127(data, { instancePath = '', parentData, parentDataProperty, 
             return false
         }
     }
-    validate127.errors = vErrors
+    validate134.errors = vErrors
     return errors === 0
 }
-function validate85(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
+function validate92(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
     let vErrors = null
     let errors = 0
     const _errs1 = errors
     let valid0 = false
     let passing0 = null
     const _errs2 = errors
-    if (!validate86(data, { instancePath, parentData, parentDataProperty, rootData })) {
-        vErrors = vErrors === null ? validate86.errors : vErrors.concat(validate86.errors)
+    if (!validate93(data, { instancePath, parentData, parentDataProperty, rootData })) {
+        vErrors = vErrors === null ? validate93.errors : vErrors.concat(validate93.errors)
         errors = vErrors.length
     }
     var _valid0 = _errs2 === errors
@@ -13722,8 +14308,8 @@ function validate85(data, { instancePath = '', parentData, parentDataProperty, r
         passing0 = 0
     }
     const _errs3 = errors
-    if (!validate114(data, { instancePath, parentData, parentDataProperty, rootData })) {
-        vErrors = vErrors === null ? validate114.errors : vErrors.concat(validate114.errors)
+    if (!validate121(data, { instancePath, parentData, parentDataProperty, rootData })) {
+        vErrors = vErrors === null ? validate121.errors : vErrors.concat(validate121.errors)
         errors = vErrors.length
     }
     var _valid0 = _errs3 === errors
@@ -13736,8 +14322,8 @@ function validate85(data, { instancePath = '', parentData, parentDataProperty, r
             passing0 = 1
         }
         const _errs4 = errors
-        if (!validate122(data, { instancePath, parentData, parentDataProperty, rootData })) {
-            vErrors = vErrors === null ? validate122.errors : vErrors.concat(validate122.errors)
+        if (!validate129(data, { instancePath, parentData, parentDataProperty, rootData })) {
+            vErrors = vErrors === null ? validate129.errors : vErrors.concat(validate129.errors)
             errors = vErrors.length
         }
         var _valid0 = _errs4 === errors
@@ -13750,8 +14336,8 @@ function validate85(data, { instancePath = '', parentData, parentDataProperty, r
                 passing0 = 2
             }
             const _errs5 = errors
-            if (!validate127(data, { instancePath, parentData, parentDataProperty, rootData })) {
-                vErrors = vErrors === null ? validate127.errors : vErrors.concat(validate127.errors)
+            if (!validate134(data, { instancePath, parentData, parentDataProperty, rootData })) {
+                vErrors = vErrors === null ? validate134.errors : vErrors.concat(validate134.errors)
                 errors = vErrors.length
             }
             var _valid0 = _errs5 === errors
@@ -13780,7 +14366,7 @@ function validate85(data, { instancePath = '', parentData, parentDataProperty, r
             vErrors.push(err0)
         }
         errors++
-        validate85.errors = vErrors
+        validate92.errors = vErrors
         return false
     } else {
         errors = _errs1
@@ -13796,7 +14382,7 @@ function validate85(data, { instancePath = '', parentData, parentDataProperty, r
         if (data && typeof data == 'object' && !Array.isArray(data)) {
             let missing0
             if (data.metric_type === undefined && (missing0 = 'metric_type')) {
-                validate85.errors = [
+                validate92.errors = [
                     {
                         instancePath,
                         schemaPath: '#/required',
@@ -13808,7 +14394,7 @@ function validate85(data, { instancePath = '', parentData, parentDataProperty, r
                 return false
             }
         } else {
-            validate85.errors = [
+            validate92.errors = [
                 {
                     instancePath,
                     schemaPath: '#/type',
@@ -13820,6 +14406,6 @@ function validate85(data, { instancePath = '', parentData, parentDataProperty, r
             return false
         }
     }
-    validate85.errors = vErrors
+    validate92.errors = vErrors
     return errors === 0
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1288,13 +1288,7 @@ export type InlineBehavioralType = BehavioralEventType.PerformEvent | Behavioral
 /** Whether a behavioral filter's `key` refers to an event name or an action id */
 export type BehavioralEventSource = 'events' | 'actions'
 
-/**
- * Filters persons on whether they performed an event (optionally a number of times) within a time window,
- * without needing a saved cohort. Shares the cohort criteria vocabulary (`BehavioralEventType`), but only
- * the "performed event" family is supported inline — sequences and lifecycle criteria still require a cohort.
- * Event scope only: person scope needs `id IN (SELECT person_id FROM events ...)`, which HogQL cannot yet
- * resolve under a `persons` FROM. Filter the underlying insight instead, or use a cohort.
- */
+/** Filters persons on whether they performed an event in a time window, without a saved cohort. Event scope only. */
 export interface BehavioralPropertyFilter extends BasePropertyFilter {
     type: PropertyFilterType.Behavioral
     value: InlineBehavioralType

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1170,6 +1170,8 @@ export enum PropertyFilterType {
     Feature = 'feature',
     Session = 'session',
     Cohort = 'cohort',
+    /** Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP */
+    Behavioral = 'behavioral',
     Recording = 'recording',
     LogEntry = 'log_entry',
     Group = 'group',
@@ -1280,6 +1282,51 @@ export interface GroupPropertyFilter extends BasePropertyFilter {
     group_key_names?: Record<string, string>
 }
 
+/** The subset of cohort behavioral criteria supported by the inline `BehavioralPropertyFilter` */
+export type InlineBehavioralType = BehavioralEventType.PerformEvent | BehavioralEventType.PerformMultipleEvents
+
+/** Whether a behavioral filter's `key` refers to an event name or an action id */
+export type BehavioralEventSource = 'events' | 'actions'
+
+/**
+ * Filters persons on whether they performed an event (optionally a number of times) within a time window,
+ * without needing a saved cohort. Shares the cohort criteria vocabulary (`BehavioralEventType`), but only
+ * the "performed event" family is supported inline — sequences and lifecycle criteria still require a cohort.
+ */
+export interface BehavioralPropertyFilter extends BasePropertyFilter {
+    type: PropertyFilterType.Behavioral
+    value: InlineBehavioralType
+    /** Event name, or action id when event_type is 'actions' */
+    key: string
+    event_type: BehavioralEventSource
+    /** Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators */
+    negation?: boolean
+    /** Count comparison for performed_event_multiple, defaults to exact */
+    operator?: PropertyOperator
+    /**
+     * Count threshold for performed_event_multiple
+     * @asType integer
+     */
+    operator_value?: number
+    /**
+     * Relative time window size, paired with time_interval
+     * @asType integer
+     */
+    time_value?: number
+    time_interval?: TimeUnitType
+    /** Absolute or relative (e.g. -30d) lower date bound — alternative to time_value/time_interval */
+    explicit_datetime?: string
+    explicit_datetime_to?: string
+    /** Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral/cohort filters and groups */
+    event_filters?: (
+        | EventPropertyFilter
+        | PersonPropertyFilter
+        | ElementPropertyFilter
+        | FeaturePropertyFilter
+        | HogQLPropertyFilter
+    )[]
+}
+
 export type LogPropertyFilterType =
     | PropertyFilterType.Log
     | PropertyFilterType.LogAttribute
@@ -1361,6 +1408,7 @@ export type AnyPropertyFilter =
     | RevenueAnalyticsPropertyFilter
     | AccountCustomPropertyFilter
     | WorkflowVariablePropertyFilter
+    | BehavioralPropertyFilter
 
 /** Any filter type supported by `property_to_expr(scope="person", ...)`. */
 export type AnyPersonScopeFilter =
@@ -1369,6 +1417,7 @@ export type AnyPersonScopeFilter =
     | CohortPropertyFilter
     | HogQLPropertyFilter
     | EmptyPropertyFilter
+    | BehavioralPropertyFilter
 
 export type AnyGroupScopeFilter = GroupPropertyFilter | HogQLPropertyFilter
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1292,6 +1292,8 @@ export type BehavioralEventSource = 'events' | 'actions'
  * Filters persons on whether they performed an event (optionally a number of times) within a time window,
  * without needing a saved cohort. Shares the cohort criteria vocabulary (`BehavioralEventType`), but only
  * the "performed event" family is supported inline — sequences and lifecycle criteria still require a cohort.
+ * Event scope only: person scope needs `id IN (SELECT person_id FROM events ...)`, which HogQL cannot yet
+ * resolve under a `persons` FROM. Filter the underlying insight instead, or use a cohort.
  */
 export interface BehavioralPropertyFilter extends BasePropertyFilter {
     type: PropertyFilterType.Behavioral
@@ -1417,7 +1419,6 @@ export type AnyPersonScopeFilter =
     | CohortPropertyFilter
     | HogQLPropertyFilter
     | EmptyPropertyFilter
-    | BehavioralPropertyFilter
 
 export type AnyGroupScopeFilter = GroupPropertyFilter | HogQLPropertyFilter
 

--- a/posthog/cdp/test/test_validation.py
+++ b/posthog/cdp/test/test_validation.py
@@ -898,6 +898,36 @@ class TestHogFunctionValidation(ClickhouseTestMixin, APIBaseTest, QueryMatchingT
             ],
         }
 
+    # Behavioral filters compile to a ClickHouse subquery over events history, which neither
+    # bytecode (per-event) nor transpiled JS (in-browser) filters can evaluate
+    @parameterized.expand(
+        [
+            ("destination_global_properties", "destination", "properties"),
+            ("site_destination_global_properties", "site_destination", "properties"),
+            ("destination_event_properties", "destination", "event_properties"),
+        ]
+    )
+    def test_validate_filters_rejects_behavioral_properties(self, _name, function_type, placement):
+        behavioral_property = {
+            "type": "behavioral",
+            "value": "performed_event",
+            "key": "$pageview",
+            "event_type": "events",
+            "time_value": 30,
+            "time_interval": "day",
+        }
+        event = {"id": "$pageview", "type": "events", "name": "$pageview", "order": 0}
+        if placement == "properties":
+            filters = {"events": [event], "properties": [behavioral_property]}
+        else:
+            filters = {"events": [{**event, "properties": [behavioral_property]}]}
+
+        serializer = HogFunctionFiltersSerializer(
+            data=filters, context={**self.filters_context, "function_type": function_type}
+        )
+        assert not serializer.is_valid()
+        assert "behavioral" in str(serializer.errors).lower()
+
     def test_validate_filters_person_updates_only_allows_properties(self):
         filters = {
             "source": "person-updates",

--- a/posthog/cdp/validation.py
+++ b/posthog/cdp/validation.py
@@ -832,6 +832,21 @@ class InputsSerializer(serializers.DictField):
 DATA_WAREHOUSE_SOURCES = ("data-warehouse-table", "data-warehouse-view")
 
 
+def _contains_behavioral_property(filters: dict) -> bool:
+    """Behavioral ("performed event") property filters compile to a ClickHouse subquery over events
+    history, which realtime function filters (bytecode per-event, or JS transpiled into the browser)
+    can never evaluate."""
+    entities = (filters.get("events") or []) + (filters.get("actions") or []) + (filters.get("data_warehouse") or [])
+    property_lists = [filters.get("properties") or []] + [
+        entity.get("properties") or [] for entity in entities if isinstance(entity, dict)
+    ]
+    return any(
+        isinstance(prop, dict) and prop.get("type") == "behavioral"
+        for property_list in property_lists
+        for prop in property_list
+    )
+
+
 class HogFunctionFiltersSerializer(serializers.Serializer):
     source = serializers.ChoiceField(
         choices=["events", "person-updates", *DATA_WAREHOUSE_SOURCES], required=False, default="events"
@@ -856,6 +871,12 @@ class HogFunctionFiltersSerializer(serializers.Serializer):
 
         # Ensure data is initialized as an empty dict if it's None
         data = data or {}
+
+        if _contains_behavioral_property(data):
+            raise serializers.ValidationError(
+                "Behavioral (performed event) filters can't be evaluated in realtime functions. "
+                "Use a cohort to filter on past behavior."
+            )
 
         if function_type == "transformation_log":
             # Filter bytecode is compiled against event-shaped globals, which log records

--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -836,12 +836,9 @@ def _behavioral_property_to_expr(property: Property, team: Team, scope: str, str
             count = int(property.operator_value)  # type: ignore[arg-type]
         except (ValueError, TypeError):
             raise QueryError(f"Invalid behavioral filter count: {property.operator_value}")
-        if property.operator is None:
-            count_op = ast.CompareOperationOp.Eq
-        else:
-            count_op = _BEHAVIORAL_COUNT_OPERATORS.get(property.operator)
-            if count_op is None:
-                raise QueryError(f"Invalid behavioral filter count operator: {property.operator}")
+        count_op = _BEHAVIORAL_COUNT_OPERATORS.get(property.operator or "exact")
+        if count_op is None:
+            raise QueryError(f"Invalid behavioral filter count operator: {property.operator}")
         having = ast.CompareOperation(
             op=count_op,
             left=ast.Call(name="count", args=[]),

--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -754,14 +754,12 @@ _BEHAVIORAL_COUNT_OPERATORS = {
 
 
 def _behavioral_property_to_expr(property: Property, team: Team, scope: str, strict: bool = False) -> ast.Expr:
-    """Compile a behavioral ("performed event") filter into `person_id [NOT] IN (SELECT person_id FROM events ...)`.
+    """Compile a behavioral ("performed event") filter into a `person_id IN (...)` subquery.
 
-    Unlike cohort-backed behavioral criteria this runs entirely at query time — no saved cohort,
-    no precalculated cohortpeople. Only the performed-event family is supported; the multi-subquery
-    criteria (sequences, stopped/restarted) still require a cohort.
+    Unlike cohort-backed behavioral criteria this runs at query time, with no saved cohort and no
+    precalculated cohortpeople.
     """
-    # Person scope would emit `id IN (SELECT person_id FROM events ...)`, which HogQL cannot resolve when the
-    # enclosing FROM is `persons` — the lazy person join gets added twice. Event scope only until that is fixed.
+    # Person scope needs `id IN (SELECT person_id FROM events ...)`, which HogQL can't resolve under a `persons` FROM.
     if scope != "event":
         raise QueryError(f"The 'behavioral' property filter does not work in '{scope}' scope")
     if property.value not in (
@@ -817,7 +815,6 @@ def _behavioral_property_to_expr(property: Property, team: Team, scope: str, str
         # An unbounded "ever performed" filter would scan every partition of the events table.
         raise QueryError("Behavioral filters require a time window (time_value/time_interval or explicit_datetime)")
 
-    # Deliberately outside the branch above, so it bounds a relative window too.
     if property.explicit_datetime_to:
         date_to = relative_date_parse(property.explicit_datetime_to, team.timezone_info)
         conditions.append(

--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -817,7 +817,7 @@ def _behavioral_property_to_expr(property: Property, team: Team, scope: str, str
         # An unbounded "ever performed" filter would scan every partition of the events table.
         raise QueryError("Behavioral filters require a time window (time_value/time_interval or explicit_datetime)")
 
-    # Applies to both window styles — pairing it only with explicit_datetime silently drops the upper bound.
+    # Deliberately outside the branch above, so it bounds a relative window too.
     if property.explicit_datetime_to:
         date_to = relative_date_parse(property.explicit_datetime_to, team.timezone_info)
         conditions.append(

--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -12,6 +12,7 @@ from rest_framework.exceptions import ValidationError
 
 from posthog.schema import (
     AccountCustomPropertyFilter,
+    BehavioralPropertyFilter,
     CohortPropertyFilter,
     DataWarehousePersonPropertyFilter,
     DataWarehousePropertyFilter,
@@ -58,9 +59,9 @@ from posthog.dataclasses import frozen
 from posthog.models import Property, PropertyDefinition, Team
 from posthog.models.element import Element
 from posthog.models.event import Selector
-from posthog.models.property import PropertyGroup, ValueT
+from posthog.models.property import BehavioralPropertyType, PropertyGroup, ValueT
 from posthog.models.property.util import build_selector_regex
-from posthog.utils import get_from_dict_or_attr
+from posthog.utils import get_from_dict_or_attr, relative_date_parse
 
 from products.actions.backend.models.action import Action, ActionStepJSON
 from products.cohorts.backend.models.cohort import Cohort
@@ -738,6 +739,129 @@ def apply_path_cleaning(path_expr: ast.Expr, team: Team) -> ast.Expr:
     return path_expr
 
 
+_BEHAVIORAL_INTERVAL_FUNCTIONS = {
+    "day": "toIntervalDay",
+    "week": "toIntervalWeek",
+    "month": "toIntervalMonth",
+    "year": "toIntervalYear",
+}
+
+_BEHAVIORAL_COUNT_OPERATORS = {
+    "gte": ast.CompareOperationOp.GtEq,
+    "lte": ast.CompareOperationOp.LtEq,
+    "gt": ast.CompareOperationOp.Gt,
+    "lt": ast.CompareOperationOp.Lt,
+    "eq": ast.CompareOperationOp.Eq,
+    "exact": ast.CompareOperationOp.Eq,
+}
+
+
+def _behavioral_property_to_expr(property: Property, team: Team, scope: str, strict: bool = False) -> ast.Expr:
+    """Compile a behavioral ("performed event") filter into `person_id [NOT] IN (SELECT person_id FROM events ...)`.
+
+    Unlike cohort-backed behavioral criteria this runs entirely at query time — no saved cohort,
+    no precalculated cohortpeople. Only the performed-event family is supported; the multi-subquery
+    criteria (sequences, stopped/restarted) still require a cohort.
+    """
+    if scope not in ("event", "person"):
+        raise QueryError(f"The 'behavioral' property filter does not work in '{scope}' scope")
+    if property.value not in (
+        BehavioralPropertyType.PERFORMED_EVENT,
+        BehavioralPropertyType.PERFORMED_EVENT_MULTIPLE,
+    ):
+        raise QueryError(f"The behavioral criterion '{property.value}' requires a cohort, it cannot be used inline")
+
+    if property.event_type == "actions":
+        try:
+            action = Action.objects.get(pk=int(property.key), team__project_id=team.project_id)
+        except (Action.DoesNotExist, ValueError, TypeError):
+            raise QueryError(f"Action '{property.key}' in behavioral filter not found")
+        conditions: list[ast.Expr] = [action_to_expr(action)]
+    else:
+        conditions = [
+            ast.CompareOperation(
+                op=ast.CompareOperationOp.Eq,
+                left=ast.Field(chain=["event"]),
+                right=ast.Constant(value=str(property.key)),
+            )
+        ]
+
+    if property.explicit_datetime:
+        date_from = relative_date_parse(property.explicit_datetime, team.timezone_info)
+        conditions.append(
+            ast.CompareOperation(
+                op=ast.CompareOperationOp.Gt, left=ast.Field(chain=["timestamp"]), right=ast.Constant(value=date_from)
+            )
+        )
+        if property.explicit_datetime_to:
+            date_to = relative_date_parse(property.explicit_datetime_to, team.timezone_info)
+            conditions.append(
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.Lt,
+                    left=ast.Field(chain=["timestamp"]),
+                    right=ast.Constant(value=date_to),
+                )
+            )
+    elif property.time_value is not None and property.time_interval is not None:
+        interval_function = _BEHAVIORAL_INTERVAL_FUNCTIONS.get(property.time_interval)
+        if interval_function is None:
+            raise QueryError(f"Invalid behavioral filter time interval: {property.time_interval}")
+        try:
+            time_value = int(property.time_value)
+        except (ValueError, TypeError):
+            raise QueryError(f"Invalid behavioral filter time value: {property.time_value}")
+        if time_value <= 0:
+            raise QueryError(f"Invalid behavioral filter time value: {property.time_value}")
+        conditions.append(
+            ast.CompareOperation(
+                op=ast.CompareOperationOp.Gt,
+                left=ast.Field(chain=["timestamp"]),
+                right=ast.ArithmeticOperation(
+                    op=ast.ArithmeticOperationOp.Sub,
+                    left=ast.Call(name="now", args=[]),
+                    right=ast.Call(name=interval_function, args=[ast.Constant(value=time_value)]),
+                ),
+            )
+        )
+    else:
+        # An unbounded "ever performed" filter would scan every partition of the events table.
+        raise QueryError("Behavioral filters require a time window (time_value/time_interval or explicit_datetime)")
+
+    if property.event_filters:
+        conditions.append(property_to_expr(list(property.event_filters), team, scope="event", strict=strict))
+
+    having: Optional[ast.Expr] = None
+    if property.value == BehavioralPropertyType.PERFORMED_EVENT_MULTIPLE:
+        try:
+            count = int(property.operator_value)  # type: ignore[arg-type]
+        except (ValueError, TypeError):
+            raise QueryError(f"Invalid behavioral filter count: {property.operator_value}")
+        if property.operator is None:
+            count_op = ast.CompareOperationOp.Eq
+        else:
+            count_op = _BEHAVIORAL_COUNT_OPERATORS.get(property.operator)
+            if count_op is None:
+                raise QueryError(f"Invalid behavioral filter count operator: {property.operator}")
+        having = ast.CompareOperation(
+            op=count_op,
+            left=ast.Call(name="count", args=[]),
+            right=ast.Constant(value=count),
+        )
+
+    subquery = ast.SelectQuery(
+        select=[ast.Field(chain=["person_id"])],
+        select_from=ast.JoinExpr(table=ast.Field(chain=["events"])),
+        where=ast.And(exprs=conditions) if len(conditions) > 1 else conditions[0],
+        group_by=[ast.Field(chain=["person_id"])],
+        having=having,
+    )
+    return ast.CompareOperation(
+        left=ast.Field(chain=["id" if scope == "person" else "person_id"]),
+        op=ast.CompareOperationOp.NotIn if property.negation else ast.CompareOperationOp.In,
+        right=subquery,
+    )
+
+
 def property_to_expr(
     property: (
         list
@@ -747,6 +871,7 @@ def property_to_expr(
         | PropertyGroupFilterValue
         | Property
         | ast.Expr
+        | BehavioralPropertyFilter
         | EventPropertyFilter
         | PersonPropertyFilter
         | ElementPropertyFilter
@@ -855,6 +980,10 @@ def property_to_expr(
     elif property.type == "hogql":
         tag_contains_user_hogql()
         return parse_expr(property.key, cache_origin=CacheOrigin.USER)
+    elif property.type == "behavioral":
+        if not team:
+            raise Exception("Can not convert behavioral property to expression without team")
+        return _behavioral_property_to_expr(property, team, scope, strict=strict)
     elif property.type == "event_metadata" and scope == "group" and GROUP_KEY_PATTERN.match(property.key) is not None:
         group_type_index = property.key.split("_")[1]
         operator = cast(Optional[PropertyOperator], property.operator) or PropertyOperator.EXACT
@@ -891,7 +1020,6 @@ def property_to_expr(
         or property.type == "person"
         or property.type == "person_metadata"
         or property.type == "group"
-        or property.type == "behavioral"
         or property.type == "data_warehouse"
         or property.type == "data_warehouse_person_property"
         or property.type == "session"

--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -56,6 +56,7 @@ from posthog.hogql.visitor import CloningVisitor, TraversingVisitor, clone_expr
 from posthog.clickhouse.query_tagging import tag_contains_user_hogql
 from posthog.constants import AUTOCAPTURE_EVENT, TREND_FILTER_TYPE_ACTIONS, PropertyOperatorType
 from posthog.dataclasses import frozen
+from posthog.interval_specs import get_interval_func
 from posthog.models import Property, PropertyDefinition, Team
 from posthog.models.element import Element
 from posthog.models.event import Selector
@@ -739,12 +740,8 @@ def apply_path_cleaning(path_expr: ast.Expr, team: Team) -> ast.Expr:
     return path_expr
 
 
-_BEHAVIORAL_INTERVAL_FUNCTIONS = {
-    "day": "toIntervalDay",
-    "week": "toIntervalWeek",
-    "month": "toIntervalMonth",
-    "year": "toIntervalYear",
-}
+# get_interval_func also resolves minute/hour/quarter; behavioral windows are restricted to calendar intervals.
+_BEHAVIORAL_INTERVALS = frozenset({"day", "week", "month", "year"})
 
 _BEHAVIORAL_COUNT_OPERATORS = {
     "gte": ast.CompareOperationOp.GtEq,
@@ -803,9 +800,9 @@ def _behavioral_property_to_expr(property: Property, team: Team, scope: str, str
                 )
             )
     elif property.time_value is not None and property.time_interval is not None:
-        interval_function = _BEHAVIORAL_INTERVAL_FUNCTIONS.get(property.time_interval)
-        if interval_function is None:
+        if property.time_interval not in _BEHAVIORAL_INTERVALS:
             raise QueryError(f"Invalid behavioral filter time interval: {property.time_interval}")
+        interval_function = get_interval_func(property.time_interval)
         try:
             time_value = int(property.time_value)
         except (ValueError, TypeError):

--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -760,7 +760,9 @@ def _behavioral_property_to_expr(property: Property, team: Team, scope: str, str
     no precalculated cohortpeople. Only the performed-event family is supported; the multi-subquery
     criteria (sequences, stopped/restarted) still require a cohort.
     """
-    if scope not in ("event", "person"):
+    # Person scope would emit `id IN (SELECT person_id FROM events ...)`, which HogQL cannot resolve when the
+    # enclosing FROM is `persons` — the lazy person join gets added twice. Event scope only until that is fixed.
+    if scope != "event":
         raise QueryError(f"The 'behavioral' property filter does not work in '{scope}' scope")
     if property.value not in (
         BehavioralPropertyType.PERFORMED_EVENT,
@@ -790,15 +792,6 @@ def _behavioral_property_to_expr(property: Property, team: Team, scope: str, str
                 op=ast.CompareOperationOp.Gt, left=ast.Field(chain=["timestamp"]), right=ast.Constant(value=date_from)
             )
         )
-        if property.explicit_datetime_to:
-            date_to = relative_date_parse(property.explicit_datetime_to, team.timezone_info)
-            conditions.append(
-                ast.CompareOperation(
-                    op=ast.CompareOperationOp.Lt,
-                    left=ast.Field(chain=["timestamp"]),
-                    right=ast.Constant(value=date_to),
-                )
-            )
     elif property.time_value is not None and property.time_interval is not None:
         if property.time_interval not in _BEHAVIORAL_INTERVALS:
             raise QueryError(f"Invalid behavioral filter time interval: {property.time_interval}")
@@ -824,6 +817,17 @@ def _behavioral_property_to_expr(property: Property, team: Team, scope: str, str
         # An unbounded "ever performed" filter would scan every partition of the events table.
         raise QueryError("Behavioral filters require a time window (time_value/time_interval or explicit_datetime)")
 
+    # Applies to both window styles — pairing it only with explicit_datetime silently drops the upper bound.
+    if property.explicit_datetime_to:
+        date_to = relative_date_parse(property.explicit_datetime_to, team.timezone_info)
+        conditions.append(
+            ast.CompareOperation(
+                op=ast.CompareOperationOp.Lt,
+                left=ast.Field(chain=["timestamp"]),
+                right=ast.Constant(value=date_to),
+            )
+        )
+
     if property.event_filters:
         conditions.append(property_to_expr(list(property.event_filters), team, scope="event", strict=strict))
 
@@ -832,6 +836,9 @@ def _behavioral_property_to_expr(property: Property, team: Team, scope: str, str
         try:
             count = int(property.operator_value)  # type: ignore[arg-type]
         except (ValueError, TypeError):
+            raise QueryError(f"Invalid behavioral filter count: {property.operator_value}")
+        # count() = 0 can never match a grouped row, so a non-positive threshold silently matches nobody.
+        if count <= 0:
             raise QueryError(f"Invalid behavioral filter count: {property.operator_value}")
         count_op = _BEHAVIORAL_COUNT_OPERATORS.get(property.operator or "exact")
         if count_op is None:
@@ -850,7 +857,7 @@ def _behavioral_property_to_expr(property: Property, team: Team, scope: str, str
         having=having,
     )
     return ast.CompareOperation(
-        left=ast.Field(chain=["id" if scope == "person" else "person_id"]),
+        left=ast.Field(chain=["person_id"]),
         op=ast.CompareOperationOp.NotIn if property.negation else ast.CompareOperationOp.In,
         right=subquery,
     )
@@ -897,17 +904,17 @@ def property_to_expr(
     strict: bool = False,
 ) -> ast.Expr:
     if isinstance(property, dict):
+        is_behavioral = property.get("type") == "behavioral"
         try:
             property = Property(**property)
         # The property was saved as an incomplete object. Instead of crashing the entire query, pretend it's not there.
         # TODO: revert this when removing legacy insights?
-        except ValueError:
+        except (ValueError, TypeError) as e:
             if strict:
                 raise
-            return ast.Constant(value=1)
-        except TypeError:
-            if strict:
-                raise
+            # Dropping a behavioral filter would widen the query to every person instead of narrowing it.
+            if is_behavioral:
+                raise QueryError(f"Invalid behavioral property filter: {e}")
             return ast.Constant(value=1)
     elif isinstance(property, list):
         properties = [property_to_expr(p, team, scope, strict=strict) for p in property]
@@ -959,9 +966,12 @@ def property_to_expr(
     elif isinstance(property, BaseModel):
         try:
             property = Property(**property.dict())
-        except ValueError:
+        except ValueError as e:
             if strict:
                 raise
+            # Dropping a behavioral filter would widen the query to every person instead of narrowing it.
+            if isinstance(property, BehavioralPropertyFilter):
+                raise QueryError(f"Invalid behavioral property filter: {e}")
             # The property was saved as an incomplete object. Instead of crashing the entire query, pretend it's not there.
             return ast.Constant(value=1)
     else:

--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -7,6 +7,7 @@ from django.db.models import Q
 from django.db.models.functions.comparison import Coalesce
 
 import re2
+import posthoganalytics
 from pydantic import BaseModel
 from rest_framework.exceptions import ValidationError
 
@@ -753,12 +754,43 @@ _BEHAVIORAL_COUNT_OPERATORS = {
 }
 
 
+# Keep in sync with FEATURE_FLAGS.BEHAVIORAL_PROPERTY_FILTER in frontend/src/lib/constants.tsx.
+BEHAVIORAL_PROPERTY_FILTER_FLAG = "behavioral-property-filter"
+
+
+def _is_behavioral_property_filter_enabled(team: Team) -> bool:
+    # Fails closed: this runs on the query compile path, so an inconclusive local evaluation must
+    # mean "off" rather than an HTTP call, and a flag-service error must not open the gate.
+    try:
+        return bool(
+            posthoganalytics.feature_enabled(
+                BEHAVIORAL_PROPERTY_FILTER_FLAG,
+                str(team.uuid),
+                groups={"organization": str(team.organization_id), "project": str(team.id)},
+                group_properties={
+                    "organization": {"id": str(team.organization_id)},
+                    "project": {"id": str(team.id)},
+                },
+                only_evaluate_locally=True,
+                send_feature_flag_events=False,
+            )
+        )
+    except Exception:
+        return False
+
+
 def _behavioral_property_to_expr(property: Property, team: Team, scope: str, strict: bool = False) -> ast.Expr:
     """Compile a behavioral ("performed event") filter into a `person_id IN (...)` subquery.
 
     Unlike cohort-backed behavioral criteria this runs at query time, with no saved cohort and no
     precalculated cohortpeople.
     """
+    # Gates every entry point, not just the UI: /query, MCP query tools, and saved insights all land here.
+    if not _is_behavioral_property_filter_enabled(team):
+        raise QueryError(
+            "Behavioral (performed event) filters aren't available for this project. "
+            "Use a cohort to filter on past behavior."
+        )
     # Person scope needs `id IN (SELECT person_id FROM events ...)`, which HogQL can't resolve under a `persons` FROM.
     if scope != "event":
         raise QueryError(f"The 'behavioral' property filter does not work in '{scope}' scope")

--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -1614,6 +1614,9 @@ def steps_to_expr(steps: list[ActionStepJSON], team: Team, events_alias: Optiona
             exprs.append(expr)
 
         if step.properties:
+            # An action referencing itself here would re-enter action_to_expr until Python's recursion limit.
+            if any(isinstance(prop, dict) and prop.get("type") == "behavioral" for prop in step.properties):
+                raise QueryError("Action steps can't filter on behavioral properties")
             exprs.append(property_to_expr(step.properties, team))
 
         if len(exprs) == 1:

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -59,7 +59,7 @@ class TestProperty(BaseTest):
 
     def _property_to_expr(
         self,
-        property: Union[PropertyGroup, Property, HogQLPropertyFilter, dict, list],
+        property: Union[PropertyGroup, Property, BehavioralPropertyFilter, HogQLPropertyFilter, dict, list],
         team: Optional[Team] = None,
         scope: Optional[
             Literal["event", "person", "group", "session", "replay", "replay_entity", "revenue_analytics"]

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -27,6 +27,7 @@ from posthog.hogql.modifiers import create_default_modifiers_for_team
 from posthog.hogql.parser import parse_expr
 from posthog.hogql.printer.utils import prepare_and_print_ast
 from posthog.hogql.property import (
+    BEHAVIORAL_PROPERTY_FILTER_FLAG,
     action_to_expr,
     entity_to_expr,
     has_aggregation,
@@ -58,6 +59,15 @@ not_call = lambda x: ast.Call(name="not", args=[x])
 
 class TestProperty(BaseTest):
     maxDiff = None
+
+    def setUp(self):
+        super().setUp()
+        flag_patch = patch(
+            "posthog.hogql.property.posthoganalytics.feature_enabled",
+            side_effect=lambda flag, *args, **kwargs: flag == BEHAVIORAL_PROPERTY_FILTER_FLAG,
+        )
+        flag_patch.start()
+        self.addCleanup(flag_patch.stop)
 
     def _property_to_expr(
         self,
@@ -2021,6 +2031,18 @@ class TestProperty(BaseTest):
             self._behavioral_filter(value="performed_event_multiple", operator="gte", operator_value=2)
         )
         self.assertEqual(has_aggregation(expr), False)
+
+    @parameterized.expand(
+        [
+            ("flag_off", {"return_value": False}),
+            ("flag_service_unavailable", {"side_effect": Exception("flag service unreachable")}),
+        ]
+    )
+    def test_behavioral_filter_requires_the_feature_flag(self, _name: str, flag_mock: dict):
+        # The gate sits in property_to_expr, so it covers the /query API and MCP, not just the UI entry point.
+        with patch("posthog.hogql.property.posthoganalytics.feature_enabled", **flag_mock):
+            with self.assertRaisesMessage(QueryError, "aren't available for this project"):
+                self._property_to_expr(self._behavioral_filter())
 
     def test_behavioral_cohort_only_criteria_raise(self):
         with self.assertRaises(QueryError):

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from parameterized import parameterized
 
 from posthog.schema import (
+    BehavioralPropertyFilter,
     EmptyPropertyFilter,
     FlagPropertyFilter,
     HogQLPropertyFilter,
@@ -39,6 +40,7 @@ from posthog.hogql.visitor import clear_locations
 from posthog.constants import TREND_FILTER_TYPE_ACTIONS, TREND_FILTER_TYPE_EVENTS, PropertyOperatorType
 from posthog.models import Property, PropertyDefinition, Team
 from posthog.models.property import PropertyGroup
+from posthog.utils import relative_date_parse
 
 from products.cohorts.backend.models.cohort import Cohort
 from products.data_tools.backend.models.join import DataWarehouseJoin
@@ -1918,6 +1920,147 @@ class TestProperty(BaseTest):
         self.assertEqual(cast(ast.And, result).exprs[0], ast.Constant(value=1))
         # The person filter must survive as a real comparison, not collapse to neutral too
         self.assertIsInstance(cast(ast.And, result).exprs[1], ast.CompareOperation)
+
+    def _behavioral_filter(self, **overrides: Any) -> dict[str, Any]:
+        filter: dict[str, Any] = {
+            "type": "behavioral",
+            "value": "performed_event",
+            "key": "$pageview",
+            "event_type": "events",
+            "time_value": 30,
+            "time_interval": "day",
+        }
+        filter.update(overrides)
+        return filter
+
+    def test_behavioral_performed_event(self):
+        self.assertEqual(
+            self._property_to_expr(self._behavioral_filter()),
+            self._parse_expr(
+                "person_id IN (SELECT person_id FROM events"
+                " WHERE event = '$pageview' AND timestamp > now() - toIntervalDay(30) GROUP BY person_id)"
+            ),
+        )
+
+    def test_behavioral_performed_event_negation(self):
+        self.assertEqual(
+            self._property_to_expr(self._behavioral_filter(negation=True)),
+            self._parse_expr(
+                "person_id NOT IN (SELECT person_id FROM events"
+                " WHERE event = '$pageview' AND timestamp > now() - toIntervalDay(30) GROUP BY person_id)"
+            ),
+        )
+
+    def test_behavioral_person_scope_compares_person_table_id(self):
+        expr = cast(ast.CompareOperation, self._property_to_expr(self._behavioral_filter(), scope="person"))
+        self.assertEqual(expr.left, ast.Field(chain=["id"]))
+        self.assertEqual(expr.op, ast.CompareOperationOp.In)
+
+    @parameterized.expand(
+        [
+            ("gte", ">="),
+            ("lte", "<="),
+            ("gt", ">"),
+            ("lt", "<"),
+            ("exact", "="),
+            (None, "="),
+        ]
+    )
+    def test_behavioral_performed_event_multiple_count_operators(self, operator: Optional[str], sql_op: str):
+        self.assertEqual(
+            self._property_to_expr(
+                self._behavioral_filter(value="performed_event_multiple", operator=operator, operator_value=5)
+            ),
+            self._parse_expr(
+                "person_id IN (SELECT person_id FROM events"
+                " WHERE event = '$pageview' AND timestamp > now() - toIntervalDay(30)"
+                f" GROUP BY person_id HAVING count() {sql_op} 5)"
+            ),
+        )
+
+    def test_behavioral_event_filters_apply_to_matching_events(self):
+        self.assertEqual(
+            self._property_to_expr(
+                self._behavioral_filter(
+                    event_filters=[{"type": "event", "key": "$browser", "value": "Chrome", "operator": "exact"}]
+                )
+            ),
+            self._parse_expr(
+                "person_id IN (SELECT person_id FROM events"
+                " WHERE event = '$pageview' AND timestamp > now() - toIntervalDay(30)"
+                " AND properties.$browser = 'Chrome' GROUP BY person_id)"
+            ),
+        )
+
+    def test_behavioral_explicit_datetime_bounds(self):
+        with freeze_time("2024-05-15T12:00:00Z"):
+            expected_from = relative_date_parse("-7d", self.team.timezone_info)
+            self.assertEqual(
+                self._property_to_expr(
+                    self._behavioral_filter(time_value=None, time_interval=None, explicit_datetime="-7d")
+                ),
+                self._parse_expr(
+                    "person_id IN (SELECT person_id FROM events"
+                    " WHERE event = '$pageview' AND timestamp > {date_from} GROUP BY person_id)",
+                    {"date_from": ast.Constant(value=expected_from)},
+                ),
+            )
+
+    def test_behavioral_pydantic_filter_matches_dict_compilation(self):
+        pydantic_filter = BehavioralPropertyFilter(**self._behavioral_filter())
+        self.assertEqual(
+            self._property_to_expr(pydantic_filter),
+            self._property_to_expr(self._behavioral_filter()),
+        )
+
+    def test_behavioral_count_aggregation_is_invisible_to_has_aggregation(self):
+        # Trends moves aggregating WHERE clauses into HAVING; the count() inside the behavioral
+        # subquery must not trigger that
+        expr = self._property_to_expr(
+            self._behavioral_filter(value="performed_event_multiple", operator="gte", operator_value=2)
+        )
+        self.assertEqual(has_aggregation(expr), False)
+
+    @parameterized.expand([("performed_event_sequence",), ("stopped_performing_event",)])
+    def test_behavioral_cohort_only_criteria_raise(self, value: str):
+        with self.assertRaises(QueryError):
+            self._property_to_expr(
+                Property(
+                    type="behavioral",
+                    value=value,
+                    key="$pageview",
+                    event_type="events",
+                    time_value=1,
+                    time_interval="week",
+                    seq_event="sign up",
+                    seq_event_type="events",
+                    seq_time_value=30,
+                    seq_time_interval="day",
+                )
+            )
+
+    def test_behavioral_unsupported_scope_raises(self):
+        with self.assertRaises(QueryError):
+            self._property_to_expr(self._behavioral_filter(), scope="session")
+
+    def test_behavioral_missing_time_window_raises(self):
+        # Property-level validation accepts window-less realtime-cohort leaves (bytecode); the
+        # inline filter must still refuse to scan all of events history
+        with self.assertRaises(QueryError):
+            self._property_to_expr(
+                Property(
+                    type="behavioral",
+                    value="performed_event",
+                    key="$pageview",
+                    event_type="events",
+                    conditionHash="x",
+                    bytecode=[],
+                )
+            )
+
+    def test_behavioral_action_not_found_raises(self):
+        with self.assertRaises(QueryError):
+            self._property_to_expr(self._behavioral_filter(event_type="actions", key="999999"))
 
 
 class TestPropertyIsSetIsNotSetWithData(APIBaseTest):

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -27,6 +27,7 @@ from posthog.hogql.modifiers import create_default_modifiers_for_team
 from posthog.hogql.parser import parse_expr
 from posthog.hogql.printer.utils import prepare_and_print_ast
 from posthog.hogql.property import (
+    action_to_expr,
     entity_to_expr,
     has_aggregation,
     map_virtual_properties,
@@ -42,6 +43,7 @@ from posthog.models import Property, PropertyDefinition, Team
 from posthog.models.property import PropertyGroup
 from posthog.utils import relative_date_parse
 
+from products.actions.backend.models.action import Action
 from products.cohorts.backend.models.cohort import Cohort
 from products.data_tools.backend.models.join import DataWarehouseJoin
 from products.event_definitions.backend.models.property_definition import PropertyType
@@ -2061,6 +2063,17 @@ class TestProperty(BaseTest):
     def test_behavioral_action_not_found_raises(self):
         with self.assertRaises(QueryError):
             self._property_to_expr(self._behavioral_filter(event_type="actions", key="999999"))
+
+    def test_behavioral_performed_event_with_action(self):
+        action = Action.objects.create(team=self.team, steps_json=[{"event": "$pageview"}])
+        self.assertEqual(
+            self._property_to_expr(self._behavioral_filter(event_type="actions", key=str(action.pk))),
+            self._parse_expr(
+                "person_id IN (SELECT person_id FROM events WHERE {action}"
+                " AND timestamp > now() - toIntervalDay(30) GROUP BY person_id)",
+                {"action": action_to_expr(action)},
+            ),
+        )
 
 
 class TestPropertyIsSetIsNotSetWithData(APIBaseTest):

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -2122,6 +2122,19 @@ class TestProperty(BaseTest):
             ),
         )
 
+    def test_behavioral_property_in_action_step_raises(self):
+        # Compiling one would re-enter action_to_expr until Python's recursion limit
+        action = Action.objects.create(team=self.team, steps_json=[{"event": "$pageview"}])
+        action.steps_json = [
+            {
+                "event": "$pageview",
+                "properties": [self._behavioral_filter(event_type="actions", key=str(action.pk))],
+            }
+        ]
+        action.save()
+        with self.assertRaises(QueryError):
+            action_to_expr(action)
+
 
 class TestPropertyIsSetIsNotSetWithData(APIBaseTest):
     # Sentinel to indicate a property should not be included in the event

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -1935,28 +1935,19 @@ class TestProperty(BaseTest):
         filter.update(overrides)
         return filter
 
-    def test_behavioral_performed_event(self):
+    @parameterized.expand([(False, "IN"), (True, "NOT IN")])
+    def test_behavioral_performed_event(self, negation: bool, sql_op: str):
         self.assertEqual(
-            self._property_to_expr(self._behavioral_filter()),
+            self._property_to_expr(self._behavioral_filter(negation=negation)),
             self._parse_expr(
-                "person_id IN (SELECT person_id FROM events"
+                f"person_id {sql_op} (SELECT person_id FROM events"
                 " WHERE event = '$pageview' AND timestamp > now() - toIntervalDay(30) GROUP BY person_id)"
             ),
         )
 
-    def test_behavioral_performed_event_negation(self):
-        self.assertEqual(
-            self._property_to_expr(self._behavioral_filter(negation=True)),
-            self._parse_expr(
-                "person_id NOT IN (SELECT person_id FROM events"
-                " WHERE event = '$pageview' AND timestamp > now() - toIntervalDay(30) GROUP BY person_id)"
-            ),
-        )
-
-    @parameterized.expand([("person",), ("session",), ("group",), ("replay",), ("revenue_analytics",)])
-    def test_behavioral_unsupported_scopes_raise(self, scope: str):
+    def test_behavioral_person_scope_raises(self):
         with self.assertRaises(QueryError):
-            self._property_to_expr(self._behavioral_filter(), scope=cast(Any, scope))
+            self._property_to_expr(self._behavioral_filter(), scope="person")
 
     @parameterized.expand([(mode,) for mode in PersonsOnEventsMode])
     def test_behavioral_resolves_under_all_poe_modes(self, mode: PersonsOnEventsMode):
@@ -1971,7 +1962,7 @@ class TestProperty(BaseTest):
             modifiers=create_default_modifiers_for_team(self.team, HogQLQueryModifiers(personsOnEventsMode=mode)),
         )
         sql, _ = prepare_and_print_ast(query, context=context, dialect="clickhouse")
-        self.assertIn("SELECT", sql)
+        self.assertIn("GROUP BY", sql)
 
     @parameterized.expand(
         [
@@ -2023,13 +2014,6 @@ class TestProperty(BaseTest):
                 ),
             )
 
-    def test_behavioral_pydantic_filter_matches_dict_compilation(self):
-        pydantic_filter = BehavioralPropertyFilter(**self._behavioral_filter())
-        self.assertEqual(
-            self._property_to_expr(pydantic_filter),
-            self._property_to_expr(self._behavioral_filter()),
-        )
-
     def test_behavioral_count_aggregation_is_invisible_to_has_aggregation(self):
         # Trends moves aggregating WHERE clauses into HAVING; the count() inside the behavioral
         # subquery must not trigger that
@@ -2038,13 +2022,12 @@ class TestProperty(BaseTest):
         )
         self.assertEqual(has_aggregation(expr), False)
 
-    @parameterized.expand([("performed_event_sequence",), ("stopped_performing_event",)])
-    def test_behavioral_cohort_only_criteria_raise(self, value: str):
+    def test_behavioral_cohort_only_criteria_raise(self):
         with self.assertRaises(QueryError):
             self._property_to_expr(
                 Property(
                     type="behavioral",
-                    value=value,
+                    value="performed_event_sequence",
                     key="$pageview",
                     event_type="events",
                     time_value=1,
@@ -2083,12 +2066,9 @@ class TestProperty(BaseTest):
                 ),
             )
 
-    @parameterized.expand([(0,), (-5,)])
-    def test_behavioral_non_positive_count_raises(self, operator_value: int):
+    def test_behavioral_zero_count_raises(self):
         with self.assertRaises(QueryError):
-            self._property_to_expr(
-                self._behavioral_filter(value="performed_event_multiple", operator_value=operator_value)
-            )
+            self._property_to_expr(self._behavioral_filter(value="performed_event_multiple", operator_value=0))
 
     def test_behavioral_missing_time_window_raises(self):
         # Property-level validation accepts window-less realtime-cohort leaves (bytecode); the

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -1953,10 +1953,25 @@ class TestProperty(BaseTest):
             ),
         )
 
-    def test_behavioral_person_scope_compares_person_table_id(self):
-        expr = cast(ast.CompareOperation, self._property_to_expr(self._behavioral_filter(), scope="person"))
-        self.assertEqual(expr.left, ast.Field(chain=["id"]))
-        self.assertEqual(expr.op, ast.CompareOperationOp.In)
+    @parameterized.expand([("person",), ("session",), ("group",), ("replay",), ("revenue_analytics",)])
+    def test_behavioral_unsupported_scopes_raise(self, scope: str):
+        with self.assertRaises(QueryError):
+            self._property_to_expr(self._behavioral_filter(), scope=cast(Any, scope))
+
+    @parameterized.expand([(mode,) for mode in PersonsOnEventsMode])
+    def test_behavioral_resolves_under_all_poe_modes(self, mode: PersonsOnEventsMode):
+        query = ast.SelectQuery(
+            select=[ast.Constant(value=1)],
+            select_from=ast.JoinExpr(table=ast.Field(chain=["events"])),
+            where=self._property_to_expr(self._behavioral_filter()),
+        )
+        context = HogQLContext(
+            team_id=self.team.pk,
+            enable_select_queries=True,
+            modifiers=create_default_modifiers_for_team(self.team, HogQLQueryModifiers(personsOnEventsMode=mode)),
+        )
+        sql, _ = prepare_and_print_ast(query, context=context, dialect="clickhouse")
+        self.assertIn("SELECT", sql)
 
     @parameterized.expand(
         [
@@ -2041,9 +2056,39 @@ class TestProperty(BaseTest):
                 )
             )
 
-    def test_behavioral_unsupported_scope_raises(self):
+    @parameterized.expand(
+        [
+            ("no_window", {"time_value": None, "time_interval": None}),
+            ("multiple_without_count", {"value": "performed_event_multiple", "operator_value": None}),
+        ]
+    )
+    def test_behavioral_incomplete_filter_raises_instead_of_matching_everyone(self, _name: str, overrides: dict):
+        # Non-strict callers drop incomplete filters to Constant(1); for a behavioral filter that would
+        # widen the query to every person rather than narrowing it.
         with self.assertRaises(QueryError):
-            self._property_to_expr(self._behavioral_filter(), scope="session")
+            self._property_to_expr(
+                BehavioralPropertyFilter(**self._behavioral_filter(**overrides)), strict=False, scope="event"
+            )
+
+    def test_behavioral_explicit_datetime_to_bounds_a_relative_window(self):
+        with freeze_time("2024-05-15T12:00:00Z"):
+            expected_to = relative_date_parse("-1d", self.team.timezone_info)
+            self.assertEqual(
+                self._property_to_expr(self._behavioral_filter(explicit_datetime_to="-1d")),
+                self._parse_expr(
+                    "person_id IN (SELECT person_id FROM events"
+                    " WHERE event = '$pageview' AND timestamp > now() - toIntervalDay(30)"
+                    " AND timestamp < {date_to} GROUP BY person_id)",
+                    {"date_to": ast.Constant(value=expected_to)},
+                ),
+            )
+
+    @parameterized.expand([(0,), (-5,)])
+    def test_behavioral_non_positive_count_raises(self, operator_value: int):
+        with self.assertRaises(QueryError):
+            self._property_to_expr(
+                self._behavioral_filter(value="performed_event_multiple", operator_value=operator_value)
+            )
 
     def test_behavioral_missing_time_window_raises(self):
         # Property-level validation accepts window-less realtime-cohort leaves (bytecode); the

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -14,7 +14,6 @@ from posthog.schema_discriminators import property_filter_discriminator
 from posthog.schema_enums import (
     AccessControlLevel as AccessControlLevel,
     AccountsTableAccountField as AccountsTableAccountField,
-    AccountsTableAccountFieldOperator as AccountsTableAccountFieldOperator,
     AccountsTableAggregation as AccountsTableAggregation,
     AccountsTableCustomPropertyOperator as AccountsTableCustomPropertyOperator,
     AccountsTableSortDirection as AccountsTableSortDirection,
@@ -51,6 +50,7 @@ from posthog.schema_enums import (
     AttributionMode as AttributionMode,
     AutocompleteCompletionItemKind as AutocompleteCompletionItemKind,
     BaseMathType as BaseMathType,
+    BehavioralEventSource as BehavioralEventSource,
     BillingSpendResponseBreakdownType as BillingSpendResponseBreakdownType,
     BillingUsageResponseBreakdownType as BillingUsageResponseBreakdownType,
     BingAdsDefaultSources as BingAdsDefaultSources,
@@ -100,7 +100,6 @@ from posthog.schema_enums import (
     ErrorTrackingIssueAssigneeType as ErrorTrackingIssueAssigneeType,
     ErrorTrackingIssueStatus as ErrorTrackingIssueStatus,
     ErrorTrackingOrderBy as ErrorTrackingOrderBy,
-    ErrorTrackingQueryIssueSeverity as ErrorTrackingQueryIssueSeverity,
     EvaluationRuntime as EvaluationRuntime,
     ExperimentMetricGoal as ExperimentMetricGoal,
     ExperimentMetricMathType as ExperimentMetricMathType,
@@ -136,6 +135,7 @@ from posthog.schema_enums import (
     HrefMatching as HrefMatching,
     InCohortVia as InCohortVia,
     InfinityValue as InfinityValue,
+    InlineBehavioralType as InlineBehavioralType,
     InlineCohortCalculation as InlineCohortCalculation,
     InsightFilterProperty as InsightFilterProperty,
     InsightNodeKind as InsightNodeKind,
@@ -267,6 +267,7 @@ from posthog.schema_enums import (
     TextMatching as TextMatching,
     Theme as Theme,
     TikTokAdsDefaultSources as TikTokAdsDefaultSources,
+    TimeUnitType as TimeUnitType,
     TimeWindowMode as TimeWindowMode,
     TraceOrderColumn as TraceOrderColumn,
     TraceSpanBreakdownOrderBy as TraceSpanBreakdownOrderBy,
@@ -1221,15 +1222,6 @@ class Population(BaseModel):
     success_only: float
 
 
-class ErrorTrackingFingerprintProjectionPoint(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    fingerprint: str
-    x: float
-    y: float
-
-
 class FirstEvent(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -1726,14 +1718,6 @@ class MCPToolCategoryItem(BaseModel):
         extra="forbid",
     )
     category: str
-
-
-class MCPToolCategoryMapItem(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    category: str
-    tool: str
 
 
 class MCPToolDescriptionItem(BaseModel):
@@ -2457,7 +2441,7 @@ class QueryResponseAlternative7(BaseModel):
     stdout: str | None = None
 
 
-class QueryResponseAlternative78(BaseModel):
+class QueryResponseAlternative77(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -3100,16 +3084,6 @@ class AccountCustomPropertyFilter(BaseModel):
     value: list[str | float | bool] | str | float | bool | None = None
 
 
-class AccountsTableAccountFieldFilter(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    field: AccountsTableAccountField
-    kind: Literal["account_field"] = "account_field"
-    operator: AccountsTableAccountFieldOperator
-    values: list[str] | None = None
-
-
 class AccountsTableAggregateMetric(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -3316,8 +3290,7 @@ class AssistantDataVisualizationChartSettings(BaseModel):
         description=(
             "Column that splits a single Y series into multiple colored series — e.g."
             " breaking down a line chart by `country`. Set to `null` or omit to"
-            " disable. A breakdown buckets rows by x value, so it is ignored when"
-            " `display` is `ScatterPlot`."
+            " disable."
         ),
     )
     showLegend: bool | None = Field(default=None, description="Show the chart legend.")
@@ -3336,11 +3309,7 @@ class AssistantDataVisualizationChartSettings(BaseModel):
     )
     xAxis: AssistantDataVisualizationAxis | None = Field(
         default=None,
-        description=(
-            "Column used as the X axis. Typically a time bucket or categorical column,"
-            " but `ScatterPlot` plots two measures against each other, so it needs a"
-            " numeric column here too."
-        ),
+        description=("Column used as the X axis. Typically a time bucket or categorical column."),
     )
     xAxisLabel: str | None = Field(default=None, description="Label rendered under the X axis.")
     yAxis: list[AssistantDataVisualizationAxis] | None = Field(
@@ -4504,14 +4473,6 @@ class AutocompleteCompletionItem(BaseModel):
             " is inserted when selecting this completion."
         ),
     )
-    sortText: str | None = Field(
-        default=None,
-        description=(
-            "Overrides the editor's default ordering for this item. Set when the"
-            " backend can rank a suggestion, for example a function whose return type"
-            " fits the comparison being written."
-        ),
-    )
 
 
 class BoxPlotDatum(BaseModel):
@@ -4811,7 +4772,6 @@ class ErrorTrackingPendingFingerprintIssueStateUpdate(BaseModel):
     issue_description: str | None = None
     issue_id: str
     issue_name: str | None = None
-    issue_severity: ErrorTrackingQueryIssueSeverity | None = None
     issue_status: str
     version: int = Field(
         ...,
@@ -6357,7 +6317,7 @@ class QueryResponseAlternative10(BaseModel):
     )
 
 
-class QueryResponseAlternative20(BaseModel):
+class QueryResponseAlternative19(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -6373,7 +6333,7 @@ class QueryResponseAlternative20(BaseModel):
     )
 
 
-class QueryResponseAlternative29(BaseModel):
+class QueryResponseAlternative28(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -6382,7 +6342,7 @@ class QueryResponseAlternative29(BaseModel):
     status: ExternalQueryStatus
 
 
-class QueryResponseAlternative85(BaseModel):
+class QueryResponseAlternative84(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -7087,37 +7047,6 @@ class SpanPropertyFilter(BaseModel):
     operator: PropertyOperator
     type: SpanPropertyFilterType
     value: list[str | float | bool] | str | float | bool | None = None
-
-
-# Added by bin/patch-schema-property-filter-discriminator.py: tagged AnyPropertyFilter
-# alias so validation routes on `type` instead of trying every member. The callable
-# keeps legacy tolerance — see posthog/schema_discriminators.py.
-AnyPropertyFilterDiscriminated = Annotated[
-    Annotated[EventPropertyFilter, pydantic.Tag("event")]
-    | Annotated[PersonPropertyFilter, pydantic.Tag("person")]
-    | Annotated[PersonMetadataPropertyFilter, pydantic.Tag("person_metadata")]
-    | Annotated[ElementPropertyFilter, pydantic.Tag("element")]
-    | Annotated[EventMetadataPropertyFilter, pydantic.Tag("event_metadata")]
-    | Annotated[SessionPropertyFilter, pydantic.Tag("session")]
-    | Annotated[CohortPropertyFilter, pydantic.Tag("cohort")]
-    | Annotated[RecordingPropertyFilter, pydantic.Tag("recording")]
-    | Annotated[LogEntryPropertyFilter, pydantic.Tag("log_entry")]
-    | Annotated[GroupPropertyFilter, pydantic.Tag("group")]
-    | Annotated[FeaturePropertyFilter, pydantic.Tag("feature")]
-    | Annotated[FlagPropertyFilter, pydantic.Tag("flag")]
-    | Annotated[HogQLPropertyFilter, pydantic.Tag("hogql")]
-    | Annotated[EmptyPropertyFilter, pydantic.Tag("empty")]
-    | Annotated[DataWarehousePropertyFilter, pydantic.Tag("data_warehouse")]
-    | Annotated[DataWarehousePersonPropertyFilter, pydantic.Tag("data_warehouse_person_property")]
-    | Annotated[ErrorTrackingIssueFilter, pydantic.Tag("error_tracking_issue")]
-    | Annotated[LogPropertyFilter, pydantic.Tag("log")]
-    | Annotated[MetricPropertyFilter, pydantic.Tag("metric_attribute")]
-    | Annotated[SpanPropertyFilter, pydantic.Tag("span")]
-    | Annotated[RevenueAnalyticsPropertyFilter, pydantic.Tag("revenue_analytics")]
-    | Annotated[AccountCustomPropertyFilter, pydantic.Tag("account_custom_property")]
-    | Annotated[WorkflowVariablePropertyFilter, pydantic.Tag("workflow_variable")],
-    pydantic.Discriminator(property_filter_discriminator),
-]
 
 
 class SpanTreeNode(BaseModel):
@@ -8999,9 +8928,8 @@ class AssistantDataVisualizationNode(BaseModel):
             " row) → `BoldNumber`.\n- Time series → `ActionsLineGraph` or"
             " `ActionsAreaGraph`.\n- Categorical proportions → `ActionsPie`.\n-"
             " Categorical comparison → `ActionsBar` or `ActionsStackedBar`.\n-"
-            " Two-dimensional aggregation → `TwoDimensionalHeatmap`.\n- Relationship"
-            " between two numeric measures, one point per row → `ScatterPlot`.\n-"
-            " Otherwise → `ActionsTable`."
+            " Two-dimensional aggregation → `TwoDimensionalHeatmap`.\n- Otherwise →"
+            " `ActionsTable`."
         ),
     )
     kind: Literal["DataVisualizationNode"] = "DataVisualizationNode"
@@ -10422,6 +10350,90 @@ class AssistantWebVitalsPathBreakdownQuery(BaseModel):
     )
 
 
+class BehavioralPropertyFilter(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    event_filters: (
+        list[
+            EventPropertyFilter
+            | PersonPropertyFilter
+            | ElementPropertyFilter
+            | FeaturePropertyFilter
+            | HogQLPropertyFilter
+        ]
+        | None
+    ) = Field(
+        default=None,
+        description=(
+            "Extra property filters the matching events must satisfy. Deliberately"
+            " excludes nested behavioral/cohort filters and groups"
+        ),
+    )
+    event_type: BehavioralEventSource
+    explicit_datetime: str | None = Field(
+        default=None,
+        description=("Absolute or relative (e.g. -30d) lower date bound — alternative to time_value/time_interval"),
+    )
+    explicit_datetime_to: str | None = None
+    key: str = Field(..., description="Event name, or action id when event_type is 'actions'")
+    label: str | None = None
+    negation: bool | None = Field(
+        default=None,
+        description=(
+            "Match persons who did NOT satisfy the criterion. Not the same as a low"
+            " count — zero-occurrence persons never match count operators"
+        ),
+    )
+    operator: PropertyOperator | None = Field(
+        default=None,
+        description="Count comparison for performed_event_multiple, defaults to exact",
+    )
+    operator_value: int | None = Field(default=None, description="Count threshold for performed_event_multiple")
+    time_interval: TimeUnitType | None = None
+    time_value: int | None = Field(default=None, description="Relative time window size, paired with time_interval")
+    type: Literal["behavioral"] = Field(
+        default="behavioral",
+        description=(
+            "Person performed (or didn't perform) an event in a time window."
+            " ClickHouse-only — not evaluable by flags or CDP"
+        ),
+    )
+    value: InlineBehavioralType
+
+
+# Added by bin/patch-schema-property-filter-discriminator.py: tagged AnyPropertyFilter
+# alias so validation routes on `type` instead of trying every member. The callable
+# keeps legacy tolerance — see posthog/schema_discriminators.py.
+AnyPropertyFilterDiscriminated = Annotated[
+    Annotated[EventPropertyFilter, pydantic.Tag("event")]
+    | Annotated[PersonPropertyFilter, pydantic.Tag("person")]
+    | Annotated[PersonMetadataPropertyFilter, pydantic.Tag("person_metadata")]
+    | Annotated[ElementPropertyFilter, pydantic.Tag("element")]
+    | Annotated[EventMetadataPropertyFilter, pydantic.Tag("event_metadata")]
+    | Annotated[SessionPropertyFilter, pydantic.Tag("session")]
+    | Annotated[CohortPropertyFilter, pydantic.Tag("cohort")]
+    | Annotated[RecordingPropertyFilter, pydantic.Tag("recording")]
+    | Annotated[LogEntryPropertyFilter, pydantic.Tag("log_entry")]
+    | Annotated[GroupPropertyFilter, pydantic.Tag("group")]
+    | Annotated[FeaturePropertyFilter, pydantic.Tag("feature")]
+    | Annotated[FlagPropertyFilter, pydantic.Tag("flag")]
+    | Annotated[HogQLPropertyFilter, pydantic.Tag("hogql")]
+    | Annotated[EmptyPropertyFilter, pydantic.Tag("empty")]
+    | Annotated[DataWarehousePropertyFilter, pydantic.Tag("data_warehouse")]
+    | Annotated[DataWarehousePersonPropertyFilter, pydantic.Tag("data_warehouse_person_property")]
+    | Annotated[ErrorTrackingIssueFilter, pydantic.Tag("error_tracking_issue")]
+    | Annotated[LogPropertyFilter, pydantic.Tag("log")]
+    | Annotated[MetricPropertyFilter, pydantic.Tag("metric_attribute")]
+    | Annotated[SpanPropertyFilter, pydantic.Tag("span")]
+    | Annotated[RevenueAnalyticsPropertyFilter, pydantic.Tag("revenue_analytics")]
+    | Annotated[AccountCustomPropertyFilter, pydantic.Tag("account_custom_property")]
+    | Annotated[WorkflowVariablePropertyFilter, pydantic.Tag("workflow_variable")]
+    | Annotated[BehavioralPropertyFilter, pydantic.Tag("behavioral")],
+    pydantic.Discriminator(property_filter_discriminator),
+]
+
+
 class BreakdownItem(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -11044,65 +11056,6 @@ class CachedErrorTrackingBreakdownsQueryResponse(BaseModel):
         default=None, description="The date range used for the query"
     )
     results: dict[str, Results]
-    timezone: str
-    timings: list[QueryTiming] | None = Field(
-        default=None,
-        description=("Measured timings for different parts of the query generation process"),
-    )
-    used_data_warehouse_sources: list[DataWarehouseSourceUsage] | None = Field(
-        default=None,
-        description=("Connector-synced data warehouse sources referenced by this query, if any."),
-    )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
-        default=None,
-        description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
-        ),
-    )
-
-
-class CachedErrorTrackingFingerprintProjectionQueryResponse(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    cache_key: str
-    cache_target_age: AwareDatetime | None = None
-    calculation_trigger: str | None = Field(
-        default=None,
-        description=("What triggered the calculation of the query, leave empty if user/immediate"),
-    )
-    error: str | None = Field(
-        default=None,
-        description=(
-            "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise."
-        ),
-    )
-    hasMore: bool | None = None
-    hogql: str | None = Field(default=None, description="Generated HogQL query.")
-    is_cached: bool
-    last_refresh: AwareDatetime
-    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
-    query_metadata: dict[str, Any] | None = None
-    query_status: QueryStatus | None = Field(
-        default=None,
-        description=("Query status indicates whether next to the provided data, a query is still running."),
-    )
-    resolved_compare_date_range: ResolvedDateRangeResponse | None = Field(
-        default=None,
-        description=("The resolved previous/comparison period date range, when comparing against another period"),
-    )
-    resolved_date_range: ResolvedDateRangeResponse | None = Field(
-        default=None, description="The date range used for the query"
-    )
-    results: list[ErrorTrackingFingerprintProjectionPoint]
     timezone: str
     timings: list[QueryTiming] | None = Field(
         default=None,
@@ -11923,64 +11876,6 @@ class CachedMCPToolCategoryCountsQueryResponse(BaseModel):
         default=None, description="The date range used for the query"
     )
     results: list[MCPToolCategoryCountItem]
-    timezone: str
-    timings: list[QueryTiming] | None = Field(
-        default=None,
-        description=("Measured timings for different parts of the query generation process"),
-    )
-    used_data_warehouse_sources: list[DataWarehouseSourceUsage] | None = Field(
-        default=None,
-        description=("Connector-synced data warehouse sources referenced by this query, if any."),
-    )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
-        default=None,
-        description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
-        ),
-    )
-
-
-class CachedMCPToolCategoryMapQueryResponse(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    cache_key: str
-    cache_target_age: AwareDatetime | None = None
-    calculation_trigger: str | None = Field(
-        default=None,
-        description=("What triggered the calculation of the query, leave empty if user/immediate"),
-    )
-    error: str | None = Field(
-        default=None,
-        description=(
-            "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise."
-        ),
-    )
-    hogql: str | None = Field(default=None, description="Generated HogQL query.")
-    is_cached: bool
-    last_refresh: AwareDatetime
-    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
-    query_metadata: dict[str, Any] | None = None
-    query_status: QueryStatus | None = Field(
-        default=None,
-        description=("Query status indicates whether next to the provided data, a query is still running."),
-    )
-    resolved_compare_date_range: ResolvedDateRangeResponse | None = Field(
-        default=None,
-        description=("The resolved previous/comparison period date range, when comparing against another period"),
-    )
-    resolved_date_range: ResolvedDateRangeResponse | None = Field(
-        default=None, description="The date range used for the query"
-    )
-    results: list[MCPToolCategoryMapItem]
     timezone: str
     timings: list[QueryTiming] | None = Field(
         default=None,
@@ -14940,230 +14835,6 @@ class ContextMessage(BaseModel):
     type: Literal["context"] = "context"
 
 
-class ConversionGoalFilter1(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    conversion_goal_id: str
-    conversion_goal_name: str
-    counts_as_customer: bool | None = Field(
-        default=None,
-        description=(
-            "Marks this goal as customer-defining: a conversion here means the person"
-            " became a customer (e.g. a payment or subscription), not an intermediate"
-            " step like a sign up. It gates customer-based metrics such as CAC, whose"
-            " denominator is this goal's conversions — its count, or its unique"
-            " converters under dau math. That equals new customers only for a"
-            " once-per-person moment: a repeatable event such as a monthly payment"
-            " counts every time and understates cost per customer, and dedup under dau"
-            " is per result row, so someone converting under two sources counts twice"
-            " at channel level. Defaults to false."
-        ),
-    )
-    counts_as_revenue: bool | None = Field(
-        default=None,
-        description=(
-            "Marks this goal as revenue-bearing: the value of a conversion is a"
-            " monetary amount, not a count or an arbitrary numeric property. It gates"
-            " revenue metrics such as ROAS and LTV:CAC. The amount itself comes from"
-            " math_property, and its currency from math_property_revenue_currency, the"
-            " same shape Revenue analytics uses for revenue events. Independent of"
-            " counts_as_customer: a purchase is usually both, a trial signup neither."
-            " Defaults to false."
-        ),
-    )
-    custom_name: str | None = None
-    event: str | None = Field(default=None, description="The event or `null` for all events.")
-    fixedProperties: list[AnyPropertyFilterDiscriminated] | None = Field(
-        default=None,
-        description=("Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person)"),
-    )
-    kind: Literal["EventsNode"] = "EventsNode"
-    limit: int | None = None
-    math: (
-        BaseMathType
-        | FunnelMathType
-        | PropertyMathType
-        | CountPerActorMathType
-        | GroupMathType
-        | ExperimentMetricMathType
-        | CalendarHeatmapMathType
-        | Literal["hogql"]
-        | None
-    ) = None
-    math_group_type_index: MathGroupTypeIndex | None = None
-    math_hogql: str | None = None
-    math_multiplier: float | None = None
-    math_property: str | None = None
-    math_property_revenue_currency: RevenueCurrencyPropertyConfig | None = None
-    math_property_type: str | None = None
-    name: str | None = None
-    optionalInFunnel: bool | None = None
-    orderBy: list[str] | None = Field(default=None, description="Columns to order by")
-    properties: list[AnyPropertyFilterDiscriminated] | None = Field(
-        default=None, description="Properties configurable in the interface"
-    )
-    response: dict[str, Any] | None = None
-    schema_map: dict[str, str | Any]
-    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
-
-
-class ConversionGoalFilter2(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    conversion_goal_id: str
-    conversion_goal_name: str
-    counts_as_customer: bool | None = Field(
-        default=None,
-        description=(
-            "Marks this goal as customer-defining: a conversion here means the person"
-            " became a customer (e.g. a payment or subscription), not an intermediate"
-            " step like a sign up. It gates customer-based metrics such as CAC, whose"
-            " denominator is this goal's conversions — its count, or its unique"
-            " converters under dau math. That equals new customers only for a"
-            " once-per-person moment: a repeatable event such as a monthly payment"
-            " counts every time and understates cost per customer, and dedup under dau"
-            " is per result row, so someone converting under two sources counts twice"
-            " at channel level. Defaults to false."
-        ),
-    )
-    counts_as_revenue: bool | None = Field(
-        default=None,
-        description=(
-            "Marks this goal as revenue-bearing: the value of a conversion is a"
-            " monetary amount, not a count or an arbitrary numeric property. It gates"
-            " revenue metrics such as ROAS and LTV:CAC. The amount itself comes from"
-            " math_property, and its currency from math_property_revenue_currency, the"
-            " same shape Revenue analytics uses for revenue events. Independent of"
-            " counts_as_customer: a purchase is usually both, a trial signup neither."
-            " Defaults to false."
-        ),
-    )
-    custom_name: str | None = None
-    fixedProperties: list[AnyPropertyFilterDiscriminated] | None = Field(
-        default=None,
-        description=("Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person)"),
-    )
-    id: int
-    kind: Literal["ActionsNode"] = "ActionsNode"
-    math: (
-        BaseMathType
-        | FunnelMathType
-        | PropertyMathType
-        | CountPerActorMathType
-        | GroupMathType
-        | ExperimentMetricMathType
-        | CalendarHeatmapMathType
-        | Literal["hogql"]
-        | None
-    ) = None
-    math_group_type_index: MathGroupTypeIndex | None = None
-    math_hogql: str | None = None
-    math_multiplier: float | None = None
-    math_property: str | None = None
-    math_property_revenue_currency: RevenueCurrencyPropertyConfig | None = None
-    math_property_type: str | None = None
-    name: str | None = None
-    optionalInFunnel: bool | None = None
-    properties: list[AnyPropertyFilterDiscriminated] | None = Field(
-        default=None, description="Properties configurable in the interface"
-    )
-    response: dict[str, Any] | None = None
-    schema_map: dict[str, str | Any]
-    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
-
-
-class ConversionGoalFilter3(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    conversion_goal_id: str
-    conversion_goal_name: str
-    counts_as_customer: bool | None = Field(
-        default=None,
-        description=(
-            "Marks this goal as customer-defining: a conversion here means the person"
-            " became a customer (e.g. a payment or subscription), not an intermediate"
-            " step like a sign up. It gates customer-based metrics such as CAC, whose"
-            " denominator is this goal's conversions — its count, or its unique"
-            " converters under dau math. That equals new customers only for a"
-            " once-per-person moment: a repeatable event such as a monthly payment"
-            " counts every time and understates cost per customer, and dedup under dau"
-            " is per result row, so someone converting under two sources counts twice"
-            " at channel level. Defaults to false."
-        ),
-    )
-    counts_as_revenue: bool | None = Field(
-        default=None,
-        description=(
-            "Marks this goal as revenue-bearing: the value of a conversion is a"
-            " monetary amount, not a count or an arbitrary numeric property. It gates"
-            " revenue metrics such as ROAS and LTV:CAC. The amount itself comes from"
-            " math_property, and its currency from math_property_revenue_currency, the"
-            " same shape Revenue analytics uses for revenue events. Independent of"
-            " counts_as_customer: a purchase is usually both, a trial signup neither."
-            " Defaults to false."
-        ),
-    )
-    custom_name: str | None = None
-    distinct_id_field: str
-    dw_source_type: str | None = None
-    fixedProperties: list[AnyPropertyFilterDiscriminated] | None = Field(
-        default=None,
-        description=("Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person)"),
-    )
-    id: str
-    id_field: str
-    kind: Literal["DataWarehouseNode"] = "DataWarehouseNode"
-    math: (
-        BaseMathType
-        | FunnelMathType
-        | PropertyMathType
-        | CountPerActorMathType
-        | GroupMathType
-        | ExperimentMetricMathType
-        | CalendarHeatmapMathType
-        | Literal["hogql"]
-        | None
-    ) = None
-    math_group_type_index: MathGroupTypeIndex | None = None
-    math_hogql: str | None = None
-    math_multiplier: float | None = None
-    math_property: str | None = None
-    math_property_revenue_currency: RevenueCurrencyPropertyConfig | None = None
-    math_property_type: str | None = None
-    name: str | None = None
-    optionalInFunnel: bool | None = None
-    properties: list[AnyPropertyFilterDiscriminated] | None = Field(
-        default=None, description="Properties configurable in the interface"
-    )
-    response: dict[str, Any] | None = None
-    schema_map: dict[str, str | Any]
-    table_name: str
-    timestamp_field: str
-    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
-
-
-class DashboardFilter(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    breakdown_filter: BreakdownFilter | None = None
-    date_from: str | None = None
-    date_to: str | None = None
-    explicitDate: bool | None = None
-    filterTestAccounts: bool | None = Field(
-        default=None,
-        description=("Tri-state test-account override. Null/absent = inherit; true = force on; false = force off."),
-    )
-    interval: IntervalType | None = Field(
-        default=None,
-        description=("Time granularity forced onto every insight that supports one. Absent/null = inherit."),
-    )
-    properties: list[AnyPropertyFilterDiscriminated] | None = None
-
-
 class Response(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -16115,48 +15786,6 @@ class Response23(BaseModel):
     )
 
 
-class DataWarehouseNode(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    custom_name: str | None = None
-    distinct_id_field: str
-    dw_source_type: str | None = None
-    fixedProperties: list[AnyPropertyFilterDiscriminated] | None = Field(
-        default=None,
-        description=("Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person)"),
-    )
-    id: str
-    id_field: str
-    kind: Literal["DataWarehouseNode"] = "DataWarehouseNode"
-    math: (
-        BaseMathType
-        | FunnelMathType
-        | PropertyMathType
-        | CountPerActorMathType
-        | GroupMathType
-        | ExperimentMetricMathType
-        | CalendarHeatmapMathType
-        | Literal["hogql"]
-        | None
-    ) = None
-    math_group_type_index: MathGroupTypeIndex | None = None
-    math_hogql: str | None = None
-    math_multiplier: float | None = None
-    math_property: str | None = None
-    math_property_revenue_currency: RevenueCurrencyPropertyConfig | None = None
-    math_property_type: str | None = None
-    name: str | None = None
-    optionalInFunnel: bool | None = None
-    properties: list[AnyPropertyFilterDiscriminated] | None = Field(
-        default=None, description="Properties configurable in the interface"
-    )
-    response: dict[str, Any] | None = None
-    table_name: str
-    timestamp_field: str
-    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
-
-
 class DatabaseSchemaBatchExportTable(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -16297,52 +15926,6 @@ class ECODDetectorConfig(BaseModel):
         description=(
             "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
         ),
-    )
-
-
-class EndpointRunRequest(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    client_query_id: str | None = Field(
-        default=None,
-        description=("Client provided query ID. Can be used to retrieve the status or cancel the query."),
-    )
-    debug: bool | None = Field(
-        default=False,
-        description=("Whether to include debug information (such as the executed HogQL) in the response."),
-    )
-    filters_override: DashboardFilter | None = None
-    limit: int | None = Field(
-        default=None,
-        description=("Maximum number of results to return. If not provided, returns all results."),
-    )
-    offset: int | None = Field(
-        default=None,
-        description=(
-            "Number of results to skip. Must be used together with limit. Only supported for HogQL endpoints."
-        ),
-    )
-    refresh: EndpointRefreshMode | None = EndpointRefreshMode.CACHE
-    variables: dict[str, Any] | None = Field(
-        default=None,
-        description=(
-            "Variables to parameterize the endpoint query. The key is the variable name"
-            " and the value is the variable value.\n\nFor HogQL endpoints:   Keys must"
-            " match a variable `code_name` defined in the query (referenced as"
-            ' `{variables.code_name}`).   Example: `{"event_name": "$pageview"}`\n\nFor'
-            " non-materialized insight endpoints (e.g. TrendsQuery):   - `date_from`"
-            " and `date_to` are built-in variables that filter the date range.    "
-            ' Example: `{"date_from": "2024-01-01", "date_to": "2024-01-31"}`\n\nFor'
-            " materialized insight endpoints:   - Use the breakdown property name as"
-            ' the key to filter by breakdown value.     Example: `{"$browser":'
-            ' "Chrome"}`   - `date_from`/`date_to` are not supported on materialized'
-            " insight endpoints.\n\nUnknown variable names will return a 400 error."
-        ),
-    )
-    version: int | None = Field(
-        default=None,
-        description=("Specific endpoint version to execute. If not provided, the latest version is used."),
     )
 
 
@@ -16492,42 +16075,6 @@ class EndpointsUsageTrendsQueryResponse(BaseModel):
     )
 
 
-class EntityNode(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    custom_name: str | None = None
-    fixedProperties: list[AnyPropertyFilterDiscriminated] | None = Field(
-        default=None,
-        description=("Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person)"),
-    )
-    kind: NodeKind
-    math: (
-        BaseMathType
-        | FunnelMathType
-        | PropertyMathType
-        | CountPerActorMathType
-        | GroupMathType
-        | ExperimentMetricMathType
-        | CalendarHeatmapMathType
-        | Literal["hogql"]
-        | None
-    ) = None
-    math_group_type_index: MathGroupTypeIndex | None = None
-    math_hogql: str | None = None
-    math_multiplier: float | None = None
-    math_property: str | None = None
-    math_property_revenue_currency: RevenueCurrencyPropertyConfig | None = None
-    math_property_type: str | None = None
-    name: str | None = None
-    optionalInFunnel: bool | None = None
-    properties: list[AnyPropertyFilterDiscriminated] | None = Field(
-        default=None, description="Properties configurable in the interface"
-    )
-    response: dict[str, Any] | None = None
-    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
-
-
 class ErrorTrackingBreakdownsQueryResponse(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -16584,54 +16131,6 @@ class ErrorTrackingExternalReference(BaseModel):
     integration: ErrorTrackingExternalReferenceIntegration
 
 
-class ErrorTrackingFingerprintProjectionQueryResponse(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    error: str | None = Field(
-        default=None,
-        description=(
-            "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise."
-        ),
-    )
-    hasMore: bool | None = None
-    hogql: str | None = Field(default=None, description="Generated HogQL query.")
-    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    query_status: QueryStatus | None = Field(
-        default=None,
-        description=("Query status indicates whether next to the provided data, a query is still running."),
-    )
-    resolved_compare_date_range: ResolvedDateRangeResponse | None = Field(
-        default=None,
-        description=("The resolved previous/comparison period date range, when comparing against another period"),
-    )
-    resolved_date_range: ResolvedDateRangeResponse | None = Field(
-        default=None, description="The date range used for the query"
-    )
-    results: list[ErrorTrackingFingerprintProjectionPoint]
-    timings: list[QueryTiming] | None = Field(
-        default=None,
-        description=("Measured timings for different parts of the query generation process"),
-    )
-    used_data_warehouse_sources: list[DataWarehouseSourceUsage] | None = Field(
-        default=None,
-        description=("Connector-synced data warehouse sources referenced by this query, if any."),
-    )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
-        default=None,
-        description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
-        ),
-    )
-
-
 class ErrorTrackingIssue(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -16649,30 +16148,8 @@ class ErrorTrackingIssue(BaseModel):
     last_seen: AwareDatetime
     library: str | None = None
     name: str | None = None
-    severity: ErrorTrackingQueryIssueSeverity | None = None
     source: str | None = None
     status: ErrorTrackingIssueStatus
-
-
-class ErrorTrackingIssueFilteringToolOutput(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    dateRange: DateRange | None = None
-    filterTestAccounts: bool | None = None
-    newFilters: list[AnyPropertyFilterDiscriminated] | None = None
-    orderBy: ErrorTrackingOrderBy = Field(..., description="Field to sort results by.")
-    orderDirection: OrderDirection2 | None = Field(default=None, description="Sort direction.")
-    removedFilterIndexes: list[int] | None = None
-    searchQuery: str | None = Field(
-        default=None,
-        description=("Free-text search across exception type, message, and stack frames."),
-    )
-    status: ErrorTrackingIssueStatus | str | None = Field(
-        default=None,
-        description="Filter by issue status.",
-        title="ErrorTrackingQueryStatus",
-    )
 
 
 class ErrorTrackingQueryResponse(BaseModel):
@@ -16737,7 +16214,6 @@ class ErrorTrackingRelationalIssue(BaseModel):
     first_seen: AwareDatetime
     id: str
     name: str | None = None
-    severity: ErrorTrackingQueryIssueSeverity | None = None
     status: ErrorTrackingIssueStatus
 
 
@@ -16841,61 +16317,6 @@ class EventTaxonomyQueryResponse(BaseModel):
     )
 
 
-class EventsNode(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    custom_name: str | None = None
-    event: str | None = Field(default=None, description="The event or `null` for all events.")
-    fixedProperties: list[AnyPropertyFilterDiscriminated] | None = Field(
-        default=None,
-        description=("Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person)"),
-    )
-    kind: Literal["EventsNode"] = "EventsNode"
-    limit: int | None = None
-    math: (
-        BaseMathType
-        | FunnelMathType
-        | PropertyMathType
-        | CountPerActorMathType
-        | GroupMathType
-        | ExperimentMetricMathType
-        | CalendarHeatmapMathType
-        | Literal["hogql"]
-        | None
-    ) = None
-    math_group_type_index: MathGroupTypeIndex | None = None
-    math_hogql: str | None = None
-    math_multiplier: float | None = None
-    math_property: str | None = None
-    math_property_revenue_currency: RevenueCurrencyPropertyConfig | None = None
-    math_property_type: str | None = None
-    name: str | None = None
-    optionalInFunnel: bool | None = None
-    orderBy: list[str] | None = Field(default=None, description="Columns to order by")
-    properties: list[AnyPropertyFilterDiscriminated] | None = Field(
-        default=None, description="Properties configurable in the interface"
-    )
-    response: dict[str, Any] | None = None
-    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
-
-
-class EventsQueryActionStep(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    event: str | None = None
-    href: str | None = None
-    href_matching: HrefMatching | None = None
-    properties: list[AnyPropertyFilterDiscriminated] | None = None
-    selector: str | None = None
-    tag_name: str | None = None
-    text: str | None = None
-    text_matching: TextMatching | None = None
-    url: str | None = None
-    url_matching: UrlMatching | None = None
-
-
 class EventsQueryResponse(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -16949,54 +16370,6 @@ class EventsQueryResponse(BaseModel):
     )
 
 
-class ExperimentApiExposureConfig(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    event: str | None = Field(
-        default=None,
-        description=("Custom exposure event name. Required when kind is 'ExperimentEventExposureConfig'."),
-    )
-    id: int | None = Field(default=None, description="Action ID. Required when kind is 'ActionsNode'.")
-    kind: Kind1 | None = Field(
-        default=None,
-        description=(
-            "Defaults to 'ExperimentEventExposureConfig' when omitted. Pass 'ActionsNode' for an action-based exposure."
-        ),
-    )
-    properties: list[AnyPropertyFilterDiscriminated] = Field(
-        ...,
-        description=(
-            "Property filters (event, person, and other supported types). Pass an empty array if no filters needed."
-        ),
-    )
-
-
-class ExperimentApiExposureCriteria(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    activation_config: ExperimentApiExposureConfig | None = Field(
-        default=None,
-        description=(
-            "Additional event (or action) an entity must emit at/after their first"
-            " default exposure event before they count as exposed; exposure time"
-            " becomes this event's timestamp. Only valid with the default exposure"
-            " event, not a custom `exposure_config`."
-        ),
-    )
-    exposure_config: ExperimentApiExposureConfig | None = None
-    filterTestAccounts: bool | None = None
-    multiple_variant_handling: MultipleVariantHandling | None = Field(
-        default=None,
-        description=(
-            "How to handle entities exposed to multiple variants. 'exclude' (default)"
-            " drops them from the analysis; 'first_seen' assigns them to the variant"
-            " from their earliest exposure."
-        ),
-    )
-
-
 class ExperimentBreakdownResult(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -17017,80 +16390,6 @@ class ExperimentBreakdownResult(BaseModel):
         ...,
         description=("Test variant results with statistical comparisons for this breakdown"),
     )
-
-
-class ExperimentDataWarehouseNode(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    custom_name: str | None = None
-    data_warehouse_join_key: str
-    events_join_key: str
-    fixedProperties: list[AnyPropertyFilterDiscriminated] | None = Field(
-        default=None,
-        description=("Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person)"),
-    )
-    kind: Literal["ExperimentDataWarehouseNode"] = "ExperimentDataWarehouseNode"
-    math: (
-        BaseMathType
-        | FunnelMathType
-        | PropertyMathType
-        | CountPerActorMathType
-        | GroupMathType
-        | ExperimentMetricMathType
-        | CalendarHeatmapMathType
-        | Literal["hogql"]
-        | None
-    ) = None
-    math_group_type_index: MathGroupTypeIndex | None = None
-    math_hogql: str | None = None
-    math_multiplier: float | None = None
-    math_property: str | None = None
-    math_property_revenue_currency: RevenueCurrencyPropertyConfig | None = None
-    math_property_type: str | None = None
-    name: str | None = None
-    optionalInFunnel: bool | None = None
-    properties: list[AnyPropertyFilterDiscriminated] | None = Field(
-        default=None, description="Properties configurable in the interface"
-    )
-    response: dict[str, Any] | None = None
-    table_name: str
-    timestamp_field: str
-    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
-
-
-class ExperimentEventExposureConfig(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    event: str
-    kind: Literal["ExperimentEventExposureConfig"] = "ExperimentEventExposureConfig"
-    properties: list[AnyPropertyFilterDiscriminated]
-    response: dict[str, Any] | None = None
-    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
-
-
-class FeatureFlagGroupType(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    aggregation_group_type_index: int | None = None
-    description: str | None = None
-    exposure_frozen: bool | None = Field(
-        default=None,
-        description=(
-            "Stamped by the experiment exposure freeze: the group carries a machine-added snapshot-cohort condition."
-        ),
-    )
-    exposure_frozen_cohort: float | None = Field(
-        default=None,
-        description=("Snapshot cohort the exposure freeze AND'd into this group's properties."),
-    )
-    properties: list[AnyPropertyFilterDiscriminated] | None = None
-    rollout_percentage: float | None = None
-    sort_key: str | None = None
-    users_affected: float | None = None
-    variant: str | None = None
 
 
 class FunnelCorrelationResponse(BaseModel):
@@ -17143,128 +16442,6 @@ class FunnelCorrelationResponse(BaseModel):
             " access."
         ),
     )
-
-
-class FunnelExclusionActionsNode(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    custom_name: str | None = None
-    fixedProperties: list[AnyPropertyFilterDiscriminated] | None = Field(
-        default=None,
-        description=("Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person)"),
-    )
-    funnelFromStep: int
-    funnelToStep: int
-    id: int
-    kind: Literal["ActionsNode"] = "ActionsNode"
-    math: (
-        BaseMathType
-        | FunnelMathType
-        | PropertyMathType
-        | CountPerActorMathType
-        | GroupMathType
-        | ExperimentMetricMathType
-        | CalendarHeatmapMathType
-        | Literal["hogql"]
-        | None
-    ) = None
-    math_group_type_index: MathGroupTypeIndex | None = None
-    math_hogql: str | None = None
-    math_multiplier: float | None = None
-    math_property: str | None = None
-    math_property_revenue_currency: RevenueCurrencyPropertyConfig | None = None
-    math_property_type: str | None = None
-    name: str | None = None
-    optionalInFunnel: bool | None = None
-    properties: list[AnyPropertyFilterDiscriminated] | None = Field(
-        default=None, description="Properties configurable in the interface"
-    )
-    response: dict[str, Any] | None = None
-    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
-
-
-class FunnelExclusionEventsNode(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    custom_name: str | None = None
-    event: str | None = Field(default=None, description="The event or `null` for all events.")
-    fixedProperties: list[AnyPropertyFilterDiscriminated] | None = Field(
-        default=None,
-        description=("Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person)"),
-    )
-    funnelFromStep: int
-    funnelToStep: int
-    kind: Literal["EventsNode"] = "EventsNode"
-    limit: int | None = None
-    math: (
-        BaseMathType
-        | FunnelMathType
-        | PropertyMathType
-        | CountPerActorMathType
-        | GroupMathType
-        | ExperimentMetricMathType
-        | CalendarHeatmapMathType
-        | Literal["hogql"]
-        | None
-    ) = None
-    math_group_type_index: MathGroupTypeIndex | None = None
-    math_hogql: str | None = None
-    math_multiplier: float | None = None
-    math_property: str | None = None
-    math_property_revenue_currency: RevenueCurrencyPropertyConfig | None = None
-    math_property_type: str | None = None
-    name: str | None = None
-    optionalInFunnel: bool | None = None
-    orderBy: list[str] | None = Field(default=None, description="Columns to order by")
-    properties: list[AnyPropertyFilterDiscriminated] | None = Field(
-        default=None, description="Properties configurable in the interface"
-    )
-    response: dict[str, Any] | None = None
-    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
-
-
-class FunnelsDataWarehouseNode(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    aggregation_target_field: str
-    custom_name: str | None = None
-    dw_source_type: str | None = None
-    fixedProperties: list[AnyPropertyFilterDiscriminated] | None = Field(
-        default=None,
-        description=("Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person)"),
-    )
-    id: str
-    id_field: str
-    kind: Literal["FunnelsDataWarehouseNode"] = "FunnelsDataWarehouseNode"
-    math: (
-        BaseMathType
-        | FunnelMathType
-        | PropertyMathType
-        | CountPerActorMathType
-        | GroupMathType
-        | ExperimentMetricMathType
-        | CalendarHeatmapMathType
-        | Literal["hogql"]
-        | None
-    ) = None
-    math_group_type_index: MathGroupTypeIndex | None = None
-    math_hogql: str | None = None
-    math_multiplier: float | None = None
-    math_property: str | None = None
-    math_property_revenue_currency: RevenueCurrencyPropertyConfig | None = None
-    math_property_type: str | None = None
-    name: str | None = None
-    optionalInFunnel: bool | None = None
-    properties: list[AnyPropertyFilterDiscriminated] | None = Field(
-        default=None, description="Properties configurable in the interface"
-    )
-    response: dict[str, Any] | None = None
-    table_name: str
-    timestamp_field: str
-    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
 
 class FunnelsQueryResponse(BaseModel):
@@ -17408,31 +16585,6 @@ class HBOSDetectorConfig(BaseModel):
             "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
         ),
     )
-
-
-class HeatMapQuerySource(RootModel[EventsNode]):
-    root: EventsNode
-
-
-class HogQLFilters(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    breakdownFilter: BreakdownFilter | None = Field(
-        default=None,
-        description=(
-            "Breakdown consumed by the {filters.breakdown(...)} placeholder. Set from the dashboard-level breakdown."
-        ),
-    )
-    dateRange: DateRange | None = None
-    filterTestAccounts: bool | None = None
-    interval: IntervalType | None = Field(
-        default=None,
-        description=(
-            "Time granularity consumed by the {filters.interval} placeholder. Set from the dashboard-level interval."
-        ),
-    )
-    properties: list[AnyPropertyFilterDiscriminated] | None = None
 
 
 class HogQLMetadataResponse(BaseModel):
@@ -17592,47 +16744,6 @@ class LOFDetectorConfig(BaseModel):
             "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
         ),
     )
-
-
-class LifecycleDataWarehouseNode(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    aggregation_target_field: str
-    created_at_field: str
-    custom_name: str | None = None
-    fixedProperties: list[AnyPropertyFilterDiscriminated] | None = Field(
-        default=None,
-        description=("Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person)"),
-    )
-    id: str
-    kind: Literal["LifecycleDataWarehouseNode"] = "LifecycleDataWarehouseNode"
-    math: (
-        BaseMathType
-        | FunnelMathType
-        | PropertyMathType
-        | CountPerActorMathType
-        | GroupMathType
-        | ExperimentMetricMathType
-        | CalendarHeatmapMathType
-        | Literal["hogql"]
-        | None
-    ) = None
-    math_group_type_index: MathGroupTypeIndex | None = None
-    math_hogql: str | None = None
-    math_multiplier: float | None = None
-    math_property: str | None = None
-    math_property_revenue_currency: RevenueCurrencyPropertyConfig | None = None
-    math_property_type: str | None = None
-    name: str | None = None
-    optionalInFunnel: bool | None = None
-    properties: list[AnyPropertyFilterDiscriminated] | None = Field(
-        default=None, description="Properties configurable in the interface"
-    )
-    response: dict[str, Any] | None = None
-    table_name: str
-    timestamp_field: str
-    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
 
 class LifecycleQueryResponse(BaseModel):
@@ -18059,53 +17170,6 @@ class MCPToolCategoryCountsQueryResponse(BaseModel):
         default=None, description="The date range used for the query"
     )
     results: list[MCPToolCategoryCountItem]
-    timings: list[QueryTiming] | None = Field(
-        default=None,
-        description=("Measured timings for different parts of the query generation process"),
-    )
-    used_data_warehouse_sources: list[DataWarehouseSourceUsage] | None = Field(
-        default=None,
-        description=("Connector-synced data warehouse sources referenced by this query, if any."),
-    )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
-        default=None,
-        description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
-        ),
-    )
-
-
-class MCPToolCategoryMapQueryResponse(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    error: str | None = Field(
-        default=None,
-        description=(
-            "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise."
-        ),
-    )
-    hogql: str | None = Field(default=None, description="Generated HogQL query.")
-    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    query_status: QueryStatus | None = Field(
-        default=None,
-        description=("Query status indicates whether next to the provided data, a query is still running."),
-    )
-    resolved_compare_date_range: ResolvedDateRangeResponse | None = Field(
-        default=None,
-        description=("The resolved previous/comparison period date range, when comparing against another period"),
-    )
-    resolved_date_range: ResolvedDateRangeResponse | None = Field(
-        default=None, description="The date range used for the query"
-    )
-    results: list[MCPToolCategoryMapItem]
     timings: list[QueryTiming] | None = Field(
         default=None,
         description=("Measured timings for different parts of the query generation process"),
@@ -18784,19 +17848,6 @@ class MarketingAnalyticsAttributionQueryResponse(BaseModel):
     )
 
 
-class MarketingAnalyticsConfig(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    attribution_mode: AttributionMode | None = None
-    attribution_window_days: float | None = None
-    campaign_field_preferences: dict[str, CampaignFieldPreference] | None = None
-    campaign_name_mappings: dict[str, dict[str, list[str]]] | None = None
-    conversion_goals: list[ConversionGoalFilter1 | ConversionGoalFilter2 | ConversionGoalFilter3] | None = None
-    custom_source_mappings: dict[str, list[str]] | None = None
-    sources_map: dict[str, SourceMap] | None = None
-
-
 class MarketingAnalyticsTableQueryResponse(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -19110,29 +18161,6 @@ class PathsV2Results(BaseModel):
     steps: list[PathsV2Step]
 
 
-class PersonsNode(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    cohort: int | None = None
-    distinctId: str | None = None
-    fixedProperties: list[AnyPropertyFilterDiscriminated] | None = Field(
-        default=None,
-        description=("Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person)"),
-    )
-    kind: Literal["PersonsNode"] = "PersonsNode"
-    limit: int | None = None
-    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    offset: int | None = None
-    properties: list[AnyPropertyFilterDiscriminated] | None = Field(
-        default=None, description="Properties configurable in the interface"
-    )
-    response: dict[str, Any] | None = None
-    search: str | None = None
-    tags: QueryLogTags | None = None
-    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
-
-
 class PlanningMessage(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -19141,45 +18169,6 @@ class PlanningMessage(BaseModel):
     parent_tool_call_id: str | None = None
     steps: list[PlanningStep]
     type: Literal["ai/planning"] = "ai/planning"
-
-
-class PropertyGroupFilterValue(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    type: FilterLogicalOperator
-    values: list[AnyPropertyFilterOrGroupDiscriminated]
-
-
-# Variant of AnyPropertyFilterDiscriminated for PropertyGroupFilterValue's recursive `values`
-# field; sits after that class because the union references the class object.
-AnyPropertyFilterOrGroupDiscriminated = Annotated[
-    Annotated[PropertyGroupFilterValue, pydantic.Tag("property_group")]
-    | Annotated[EventPropertyFilter, pydantic.Tag("event")]
-    | Annotated[PersonPropertyFilter, pydantic.Tag("person")]
-    | Annotated[PersonMetadataPropertyFilter, pydantic.Tag("person_metadata")]
-    | Annotated[ElementPropertyFilter, pydantic.Tag("element")]
-    | Annotated[EventMetadataPropertyFilter, pydantic.Tag("event_metadata")]
-    | Annotated[SessionPropertyFilter, pydantic.Tag("session")]
-    | Annotated[CohortPropertyFilter, pydantic.Tag("cohort")]
-    | Annotated[RecordingPropertyFilter, pydantic.Tag("recording")]
-    | Annotated[LogEntryPropertyFilter, pydantic.Tag("log_entry")]
-    | Annotated[GroupPropertyFilter, pydantic.Tag("group")]
-    | Annotated[FeaturePropertyFilter, pydantic.Tag("feature")]
-    | Annotated[FlagPropertyFilter, pydantic.Tag("flag")]
-    | Annotated[HogQLPropertyFilter, pydantic.Tag("hogql")]
-    | Annotated[EmptyPropertyFilter, pydantic.Tag("empty")]
-    | Annotated[DataWarehousePropertyFilter, pydantic.Tag("data_warehouse")]
-    | Annotated[DataWarehousePersonPropertyFilter, pydantic.Tag("data_warehouse_person_property")]
-    | Annotated[ErrorTrackingIssueFilter, pydantic.Tag("error_tracking_issue")]
-    | Annotated[LogPropertyFilter, pydantic.Tag("log")]
-    | Annotated[MetricPropertyFilter, pydantic.Tag("metric_attribute")]
-    | Annotated[SpanPropertyFilter, pydantic.Tag("span")]
-    | Annotated[RevenueAnalyticsPropertyFilter, pydantic.Tag("revenue_analytics")]
-    | Annotated[AccountCustomPropertyFilter, pydantic.Tag("account_custom_property")]
-    | Annotated[WorkflowVariablePropertyFilter, pydantic.Tag("workflow_variable")],
-    pydantic.Discriminator(property_filter_discriminator),
-]
 
 
 class PropertyValuesQueryResponse(BaseModel):
@@ -19721,54 +18710,6 @@ class QueryResponseAlternative14(BaseModel):
             "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise."
         ),
     )
-    hasMore: bool | None = None
-    hogql: str | None = Field(default=None, description="Generated HogQL query.")
-    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    query_status: QueryStatus | None = Field(
-        default=None,
-        description=("Query status indicates whether next to the provided data, a query is still running."),
-    )
-    resolved_compare_date_range: ResolvedDateRangeResponse | None = Field(
-        default=None,
-        description=("The resolved previous/comparison period date range, when comparing against another period"),
-    )
-    resolved_date_range: ResolvedDateRangeResponse | None = Field(
-        default=None, description="The date range used for the query"
-    )
-    results: list[ErrorTrackingFingerprintProjectionPoint]
-    timings: list[QueryTiming] | None = Field(
-        default=None,
-        description=("Measured timings for different parts of the query generation process"),
-    )
-    used_data_warehouse_sources: list[DataWarehouseSourceUsage] | None = Field(
-        default=None,
-        description=("Connector-synced data warehouse sources referenced by this query, if any."),
-    )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
-        default=None,
-        description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
-        ),
-    )
-
-
-class QueryResponseAlternative15(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    error: str | None = Field(
-        default=None,
-        description=(
-            "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise."
-        ),
-    )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
     query_status: QueryStatus | None = Field(
@@ -19806,7 +18747,7 @@ class QueryResponseAlternative15(BaseModel):
     )
 
 
-class QueryResponseAlternative21(BaseModel):
+class QueryResponseAlternative20(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -19856,7 +18797,7 @@ class QueryResponseAlternative21(BaseModel):
     )
 
 
-class QueryResponseAlternative22(BaseModel):
+class QueryResponseAlternative21(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -19907,7 +18848,7 @@ class QueryResponseAlternative22(BaseModel):
     )
 
 
-class QueryResponseAlternative23(BaseModel):
+class QueryResponseAlternative22(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -19931,6 +18872,59 @@ class QueryResponseAlternative23(BaseModel):
         ),
     )
     preComputeStrategy: WebAnalyticsPreComputeStrategy | None = None
+    query_status: QueryStatus | None = Field(
+        default=None,
+        description=("Query status indicates whether next to the provided data, a query is still running."),
+    )
+    resolved_compare_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None,
+        description=("The resolved previous/comparison period date range, when comparing against another period"),
+    )
+    resolved_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None, description="The date range used for the query"
+    )
+    results: list
+    samplingRate: SamplingRate | None = None
+    timings: list[QueryTiming] | None = Field(
+        default=None,
+        description=("Measured timings for different parts of the query generation process"),
+    )
+    types: list | None = None
+    used_data_warehouse_sources: list[DataWarehouseSourceUsage] | None = Field(
+        default=None,
+        description=("Connector-synced data warehouse sources referenced by this query, if any."),
+    )
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+        default=None,
+        description=(
+            "Warnings about data warehouse sources referenced by the query whose"
+            " latest sync failed, is paused, hit a billing limit, or is otherwise"
+            " stale. Results may not reflect current source data. Accumulated"
+            " across every HogQL execution that contributes to this response — so"
+            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
+            " the same warnings as raw HogQL queries. Also carries access control"
+            " warnings when a system-table query filters out objects the user can't"
+            " access."
+        ),
+    )
+
+
+class QueryResponseAlternative23(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    columns: list | None = None
+    error: str | None = Field(
+        default=None,
+        description=(
+            "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise."
+        ),
+    )
+    hasMore: bool | None = None
+    hogql: str | None = Field(default=None, description="Generated HogQL query.")
+    limit: int | None = None
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    offset: int | None = None
     query_status: QueryStatus | None = Field(
         default=None,
         description=("Query status indicates whether next to the provided data, a query is still running."),
@@ -19996,7 +18990,6 @@ class QueryResponseAlternative24(BaseModel):
         default=None, description="The date range used for the query"
     )
     results: list
-    samplingRate: SamplingRate | None = None
     timings: list[QueryTiming] | None = Field(
         default=None,
         description=("Measured timings for different parts of the query generation process"),
@@ -20022,58 +19015,6 @@ class QueryResponseAlternative24(BaseModel):
 
 
 class QueryResponseAlternative25(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    columns: list | None = None
-    error: str | None = Field(
-        default=None,
-        description=(
-            "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise."
-        ),
-    )
-    hasMore: bool | None = None
-    hogql: str | None = Field(default=None, description="Generated HogQL query.")
-    limit: int | None = None
-    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    offset: int | None = None
-    query_status: QueryStatus | None = Field(
-        default=None,
-        description=("Query status indicates whether next to the provided data, a query is still running."),
-    )
-    resolved_compare_date_range: ResolvedDateRangeResponse | None = Field(
-        default=None,
-        description=("The resolved previous/comparison period date range, when comparing against another period"),
-    )
-    resolved_date_range: ResolvedDateRangeResponse | None = Field(
-        default=None, description="The date range used for the query"
-    )
-    results: list
-    timings: list[QueryTiming] | None = Field(
-        default=None,
-        description=("Measured timings for different parts of the query generation process"),
-    )
-    types: list | None = None
-    used_data_warehouse_sources: list[DataWarehouseSourceUsage] | None = Field(
-        default=None,
-        description=("Connector-synced data warehouse sources referenced by this query, if any."),
-    )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
-        default=None,
-        description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
-        ),
-    )
-
-
-class QueryResponseAlternative26(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20127,7 +19068,7 @@ class QueryResponseAlternative26(BaseModel):
     )
 
 
-class QueryResponseAlternative27(BaseModel):
+class QueryResponseAlternative26(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20175,7 +19116,7 @@ class QueryResponseAlternative27(BaseModel):
     )
 
 
-class QueryResponseAlternative28(BaseModel):
+class QueryResponseAlternative27(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20225,7 +19166,7 @@ class QueryResponseAlternative28(BaseModel):
     )
 
 
-class QueryResponseAlternative30(BaseModel):
+class QueryResponseAlternative29(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20274,7 +19215,7 @@ class QueryResponseAlternative30(BaseModel):
     )
 
 
-class QueryResponseAlternative31(BaseModel):
+class QueryResponseAlternative30(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20327,7 +19268,7 @@ class QueryResponseAlternative31(BaseModel):
     )
 
 
-class QueryResponseAlternative32(BaseModel):
+class QueryResponseAlternative31(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20375,7 +19316,7 @@ class QueryResponseAlternative32(BaseModel):
     )
 
 
-class QueryResponseAlternative33(BaseModel):
+class QueryResponseAlternative32(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20445,7 +19386,7 @@ class QueryResponseAlternative33(BaseModel):
     )
 
 
-class QueryResponseAlternative34(BaseModel):
+class QueryResponseAlternative33(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20509,7 +19450,7 @@ class QueryResponseAlternative34(BaseModel):
     )
 
 
-class QueryResponseAlternative35(BaseModel):
+class QueryResponseAlternative34(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20562,7 +19503,7 @@ class QueryResponseAlternative35(BaseModel):
     )
 
 
-class QueryResponseAlternative36(BaseModel):
+class QueryResponseAlternative35(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20615,7 +19556,7 @@ class QueryResponseAlternative36(BaseModel):
     )
 
 
-class QueryResponseAlternative37(BaseModel):
+class QueryResponseAlternative36(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20668,7 +19609,7 @@ class QueryResponseAlternative37(BaseModel):
     )
 
 
-class QueryResponseAlternative38(BaseModel):
+class QueryResponseAlternative37(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20721,7 +19662,7 @@ class QueryResponseAlternative38(BaseModel):
     )
 
 
-class QueryResponseAlternative39(BaseModel):
+class QueryResponseAlternative38(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20774,7 +19715,7 @@ class QueryResponseAlternative39(BaseModel):
     )
 
 
-class QueryResponseAlternative40(BaseModel):
+class QueryResponseAlternative39(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20825,7 +19766,7 @@ class QueryResponseAlternative40(BaseModel):
     )
 
 
-class QueryResponseAlternative41(BaseModel):
+class QueryResponseAlternative40(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20849,6 +19790,59 @@ class QueryResponseAlternative41(BaseModel):
         ),
     )
     preComputeStrategy: WebAnalyticsPreComputeStrategy | None = None
+    query_status: QueryStatus | None = Field(
+        default=None,
+        description=("Query status indicates whether next to the provided data, a query is still running."),
+    )
+    resolved_compare_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None,
+        description=("The resolved previous/comparison period date range, when comparing against another period"),
+    )
+    resolved_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None, description="The date range used for the query"
+    )
+    results: list
+    samplingRate: SamplingRate | None = None
+    timings: list[QueryTiming] | None = Field(
+        default=None,
+        description=("Measured timings for different parts of the query generation process"),
+    )
+    types: list | None = None
+    used_data_warehouse_sources: list[DataWarehouseSourceUsage] | None = Field(
+        default=None,
+        description=("Connector-synced data warehouse sources referenced by this query, if any."),
+    )
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+        default=None,
+        description=(
+            "Warnings about data warehouse sources referenced by the query whose"
+            " latest sync failed, is paused, hit a billing limit, or is otherwise"
+            " stale. Results may not reflect current source data. Accumulated"
+            " across every HogQL execution that contributes to this response — so"
+            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
+            " the same warnings as raw HogQL queries. Also carries access control"
+            " warnings when a system-table query filters out objects the user can't"
+            " access."
+        ),
+    )
+
+
+class QueryResponseAlternative41(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    columns: list | None = None
+    error: str | None = Field(
+        default=None,
+        description=(
+            "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise."
+        ),
+    )
+    hasMore: bool | None = None
+    hogql: str | None = Field(default=None, description="Generated HogQL query.")
+    limit: int | None = None
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    offset: int | None = None
     query_status: QueryStatus | None = Field(
         default=None,
         description=("Query status indicates whether next to the provided data, a query is still running."),
@@ -20914,7 +19908,6 @@ class QueryResponseAlternative42(BaseModel):
         default=None, description="The date range used for the query"
     )
     results: list
-    samplingRate: SamplingRate | None = None
     timings: list[QueryTiming] | None = Field(
         default=None,
         description=("Measured timings for different parts of the query generation process"),
@@ -20940,58 +19933,6 @@ class QueryResponseAlternative42(BaseModel):
 
 
 class QueryResponseAlternative43(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    columns: list | None = None
-    error: str | None = Field(
-        default=None,
-        description=(
-            "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise."
-        ),
-    )
-    hasMore: bool | None = None
-    hogql: str | None = Field(default=None, description="Generated HogQL query.")
-    limit: int | None = None
-    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    offset: int | None = None
-    query_status: QueryStatus | None = Field(
-        default=None,
-        description=("Query status indicates whether next to the provided data, a query is still running."),
-    )
-    resolved_compare_date_range: ResolvedDateRangeResponse | None = Field(
-        default=None,
-        description=("The resolved previous/comparison period date range, when comparing against another period"),
-    )
-    resolved_date_range: ResolvedDateRangeResponse | None = Field(
-        default=None, description="The date range used for the query"
-    )
-    results: list
-    timings: list[QueryTiming] | None = Field(
-        default=None,
-        description=("Measured timings for different parts of the query generation process"),
-    )
-    types: list | None = None
-    used_data_warehouse_sources: list[DataWarehouseSourceUsage] | None = Field(
-        default=None,
-        description=("Connector-synced data warehouse sources referenced by this query, if any."),
-    )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
-        default=None,
-        description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
-        ),
-    )
-
-
-class QueryResponseAlternative44(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -21045,7 +19986,7 @@ class QueryResponseAlternative44(BaseModel):
     )
 
 
-class QueryResponseAlternative45(BaseModel):
+class QueryResponseAlternative44(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -21093,7 +20034,7 @@ class QueryResponseAlternative45(BaseModel):
     )
 
 
-class QueryResponseAlternative46(BaseModel):
+class QueryResponseAlternative45(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -21145,7 +20086,7 @@ class QueryResponseAlternative46(BaseModel):
     )
 
 
-class QueryResponseAlternative47(BaseModel):
+class QueryResponseAlternative46(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -21197,7 +20138,7 @@ class QueryResponseAlternative47(BaseModel):
     )
 
 
-class QueryResponseAlternative48(BaseModel):
+class QueryResponseAlternative47(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -21250,7 +20191,7 @@ class QueryResponseAlternative48(BaseModel):
     )
 
 
-class QueryResponseAlternative49(BaseModel):
+class QueryResponseAlternative48(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -21298,7 +20239,7 @@ class QueryResponseAlternative49(BaseModel):
     )
 
 
-class QueryResponseAlternative50(BaseModel):
+class QueryResponseAlternative49(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -21351,7 +20292,7 @@ class QueryResponseAlternative50(BaseModel):
     )
 
 
-class QueryResponseAlternative51(BaseModel):
+class QueryResponseAlternative50(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -21402,7 +20343,7 @@ class QueryResponseAlternative51(BaseModel):
     )
 
 
-class QueryResponseAlternative55(BaseModel):
+class QueryResponseAlternative54(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -21453,7 +20394,7 @@ class QueryResponseAlternative55(BaseModel):
     )
 
 
-class QueryResponseAlternative57(BaseModel):
+class QueryResponseAlternative56(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -21505,7 +20446,7 @@ class QueryResponseAlternative57(BaseModel):
     )
 
 
-class QueryResponseAlternative58(BaseModel):
+class QueryResponseAlternative57(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -21562,7 +20503,7 @@ class QueryResponseAlternative58(BaseModel):
     )
 
 
-class QueryResponseAlternative59(BaseModel):
+class QueryResponseAlternative58(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -21617,7 +20558,7 @@ class QueryResponseAlternative59(BaseModel):
     )
 
 
-class QueryResponseAlternative60(BaseModel):
+class QueryResponseAlternative59(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -21666,7 +20607,7 @@ class QueryResponseAlternative60(BaseModel):
     )
 
 
-class QueryResponseAlternative61(BaseModel):
+class QueryResponseAlternative60(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -21720,7 +20661,7 @@ class QueryResponseAlternative61(BaseModel):
     )
 
 
-class QueryResponseAlternative62(BaseModel):
+class QueryResponseAlternative61(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -21767,7 +20708,7 @@ class QueryResponseAlternative62(BaseModel):
     )
 
 
-class QueryResponseAlternative63(BaseModel):
+class QueryResponseAlternative62(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -21814,7 +20755,7 @@ class QueryResponseAlternative63(BaseModel):
     )
 
 
-class QueryResponseAlternative64(BaseModel):
+class QueryResponseAlternative63(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -21861,7 +20802,7 @@ class QueryResponseAlternative64(BaseModel):
     )
 
 
-class QueryResponseAlternative65(BaseModel):
+class QueryResponseAlternative64(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -21908,7 +20849,7 @@ class QueryResponseAlternative65(BaseModel):
     )
 
 
-class QueryResponseAlternative67(BaseModel):
+class QueryResponseAlternative66(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -21960,7 +20901,7 @@ class QueryResponseAlternative67(BaseModel):
     )
 
 
-class QueryResponseAlternative69(BaseModel):
+class QueryResponseAlternative68(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -22012,7 +20953,7 @@ class QueryResponseAlternative69(BaseModel):
     )
 
 
-class QueryResponseAlternative70(BaseModel):
+class QueryResponseAlternative69(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -22064,7 +21005,7 @@ class QueryResponseAlternative70(BaseModel):
     )
 
 
-class QueryResponseAlternative71(BaseModel):
+class QueryResponseAlternative70(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -22112,7 +21053,7 @@ class QueryResponseAlternative71(BaseModel):
     )
 
 
-class QueryResponseAlternative72(BaseModel):
+class QueryResponseAlternative71(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -22159,7 +21100,7 @@ class QueryResponseAlternative72(BaseModel):
     )
 
 
-class QueryResponseAlternative73(BaseModel):
+class QueryResponseAlternative72(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -22206,7 +21147,7 @@ class QueryResponseAlternative73(BaseModel):
     )
 
 
-class QueryResponseAlternative74(BaseModel):
+class QueryResponseAlternative73(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -22257,7 +21198,7 @@ class QueryResponseAlternative74(BaseModel):
     )
 
 
-class QueryResponseAlternative75(BaseModel):
+class QueryResponseAlternative74(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -22308,7 +21249,7 @@ class QueryResponseAlternative75(BaseModel):
     )
 
 
-class QueryResponseAlternative76(BaseModel):
+class QueryResponseAlternative75(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -22359,7 +21300,7 @@ class QueryResponseAlternative76(BaseModel):
     )
 
 
-class QueryResponseAlternative77(BaseModel):
+class QueryResponseAlternative76(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -22410,7 +21351,7 @@ class QueryResponseAlternative77(BaseModel):
     )
 
 
-class QueryResponseAlternative79(BaseModel):
+class QueryResponseAlternative78(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -22460,7 +21401,7 @@ class QueryResponseAlternative79(BaseModel):
     )
 
 
-class QueryResponseAlternative80(BaseModel):
+class QueryResponseAlternative79(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -22510,7 +21451,7 @@ class QueryResponseAlternative80(BaseModel):
     )
 
 
-class QueryResponseAlternative81(BaseModel):
+class QueryResponseAlternative80(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -22557,7 +21498,7 @@ class QueryResponseAlternative81(BaseModel):
     )
 
 
-class QueryResponseAlternative82(BaseModel):
+class QueryResponseAlternative81(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -22608,7 +21549,7 @@ class QueryResponseAlternative82(BaseModel):
     )
 
 
-class QueryResponseAlternative86(BaseModel):
+class QueryResponseAlternative85(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -22655,7 +21596,7 @@ class QueryResponseAlternative86(BaseModel):
     )
 
 
-class QueryResponseAlternative87(BaseModel):
+class QueryResponseAlternative86(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -22702,7 +21643,7 @@ class QueryResponseAlternative87(BaseModel):
     )
 
 
-class QueryResponseAlternative88(BaseModel):
+class QueryResponseAlternative87(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -22759,7 +21700,7 @@ class QueryResponseAlternative88(BaseModel):
     )
 
 
-class QueryResponseAlternative89(BaseModel):
+class QueryResponseAlternative88(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -22814,7 +21755,7 @@ class QueryResponseAlternative89(BaseModel):
     )
 
 
-class QueryResponseAlternative90(BaseModel):
+class QueryResponseAlternative89(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -22861,7 +21802,7 @@ class QueryResponseAlternative90(BaseModel):
     )
 
 
-class QueryResponseAlternative91(BaseModel):
+class QueryResponseAlternative90(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -22913,7 +21854,7 @@ class QueryResponseAlternative91(BaseModel):
     )
 
 
-class QueryResponseAlternative92(BaseModel):
+class QueryResponseAlternative91(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -22960,7 +21901,7 @@ class QueryResponseAlternative92(BaseModel):
     )
 
 
-class QueryResponseAlternative93(BaseModel):
+class QueryResponseAlternative92(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -23007,7 +21948,7 @@ class QueryResponseAlternative93(BaseModel):
     )
 
 
-class QueryResponseAlternative94(BaseModel):
+class QueryResponseAlternative93(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -23054,7 +21995,7 @@ class QueryResponseAlternative94(BaseModel):
     )
 
 
-class QueryResponseAlternative95(BaseModel):
+class QueryResponseAlternative94(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -23101,7 +22042,7 @@ class QueryResponseAlternative95(BaseModel):
     )
 
 
-class QueryResponseAlternative96(BaseModel):
+class QueryResponseAlternative95(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -23148,7 +22089,7 @@ class QueryResponseAlternative96(BaseModel):
     )
 
 
-class QueryResponseAlternative97(BaseModel):
+class QueryResponseAlternative96(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -23195,7 +22136,7 @@ class QueryResponseAlternative97(BaseModel):
     )
 
 
-class QueryResponseAlternative98(BaseModel):
+class QueryResponseAlternative97(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -23242,7 +22183,7 @@ class QueryResponseAlternative98(BaseModel):
     )
 
 
-class QueryResponseAlternative99(BaseModel):
+class QueryResponseAlternative98(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -23292,7 +22233,7 @@ class QueryResponseAlternative99(BaseModel):
     )
 
 
-class QueryResponseAlternative100(BaseModel):
+class QueryResponseAlternative99(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -23339,7 +22280,7 @@ class QueryResponseAlternative100(BaseModel):
     )
 
 
-class QueryResponseAlternative101(BaseModel):
+class QueryResponseAlternative100(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -23386,7 +22327,7 @@ class QueryResponseAlternative101(BaseModel):
     )
 
 
-class QueryResponseAlternative102(BaseModel):
+class QueryResponseAlternative101(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -23433,7 +22374,7 @@ class QueryResponseAlternative102(BaseModel):
     )
 
 
-class QueryResponseAlternative103(BaseModel):
+class QueryResponseAlternative102(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -23480,7 +22421,7 @@ class QueryResponseAlternative103(BaseModel):
     )
 
 
-class QueryResponseAlternative104(BaseModel):
+class QueryResponseAlternative103(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -23527,54 +22468,7 @@ class QueryResponseAlternative104(BaseModel):
     )
 
 
-class QueryResponseAlternative105(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    error: str | None = Field(
-        default=None,
-        description=(
-            "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise."
-        ),
-    )
-    hogql: str | None = Field(default=None, description="Generated HogQL query.")
-    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    query_status: QueryStatus | None = Field(
-        default=None,
-        description=("Query status indicates whether next to the provided data, a query is still running."),
-    )
-    resolved_compare_date_range: ResolvedDateRangeResponse | None = Field(
-        default=None,
-        description=("The resolved previous/comparison period date range, when comparing against another period"),
-    )
-    resolved_date_range: ResolvedDateRangeResponse | None = Field(
-        default=None, description="The date range used for the query"
-    )
-    results: list[MCPToolCategoryMapItem]
-    timings: list[QueryTiming] | None = Field(
-        default=None,
-        description=("Measured timings for different parts of the query generation process"),
-    )
-    used_data_warehouse_sources: list[DataWarehouseSourceUsage] | None = Field(
-        default=None,
-        description=("Connector-synced data warehouse sources referenced by this query, if any."),
-    )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
-        default=None,
-        description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
-        ),
-    )
-
-
-class QueryResponseAlternative106(BaseModel):
+class QueryResponseAlternative104(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -23621,7 +22515,7 @@ class QueryResponseAlternative106(BaseModel):
     )
 
 
-class QueryResponseAlternative107(BaseModel):
+class QueryResponseAlternative105(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -23668,7 +22562,7 @@ class QueryResponseAlternative107(BaseModel):
     )
 
 
-class QueryResponseAlternative108(BaseModel):
+class QueryResponseAlternative106(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -23715,7 +22609,7 @@ class QueryResponseAlternative108(BaseModel):
     )
 
 
-class QueryResponseAlternative109(BaseModel):
+class QueryResponseAlternative107(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -23812,103 +22706,6 @@ class RecordingsQueryResponse(BaseModel):
             " access."
         ),
     )
-
-
-class RetentionEntity(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    aggregation_target_field: str | None = Field(
-        default=None, description="Data warehouse field used as the actor identifier"
-    )
-    custom_name: str | None = None
-    id: str | float | None = None
-    kind: RetentionEntityKind | None = None
-    name: str | None = None
-    order: int | None = None
-    properties: list[AnyPropertyFilterDiscriminated] | None = Field(default=None, description="filters on the event")
-    table_name: str | None = Field(default=None, description="Data warehouse table name")
-    timestamp_field: str | None = Field(default=None, description="Data warehouse timestamp field")
-    type: EntityType | None = None
-    uuid: str | None = None
-
-
-class RetentionFilter(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    aggregationProperty: str | None = Field(
-        default=None,
-        description="The property to aggregate when aggregationType is sum or avg",
-    )
-    aggregationPropertyType: AggregationPropertyType | None = Field(
-        default=AggregationPropertyType.EVENT,
-        description=("The type of property to aggregate on (event, person or data_warehouse). Defaults to event."),
-    )
-    aggregationType: AggregationType | None = Field(
-        default=AggregationType.COUNT,
-        description="The aggregation type to use for retention",
-    )
-    chartStyle: ChartStyle | None = Field(default=None, description="Chart rendering style overrides (line shape).")
-    cohortLabelStartIndex: int | None = Field(
-        default=0,
-        description=(
-            "Starting index used when labeling cohort columns (e.g. 0 for D0/D1/D2, 1"
-            " for D1/D2/D3). Display-only — does not affect retention calculations."
-        ),
-    )
-    cumulative: bool | None = None
-    customAggregationTarget: bool | None = Field(
-        default=None,
-        description=(
-            "For data warehouse based retention insights when the aggregation target"
-            " can't be mapped to persons or groups."
-        ),
-    )
-    dashboardDisplay: RetentionDashboardDisplayType | None = None
-    display: ChartDisplayType | None = Field(default=None, description="controls the display of the retention graph")
-    goalLines: list[GoalLine] | None = None
-    meanRetentionCalculation: MeanRetentionCalculation | None = None
-    minimumOccurrences: int | None = None
-    period: RetentionPeriod | None = RetentionPeriod.DAY
-    retentionCustomBrackets: list[float] | None = Field(
-        default=None, description="Custom brackets for retention calculations"
-    )
-    retentionReference: RetentionReference | None = Field(
-        default=None,
-        description=("Whether retention is with regard to initial cohort size, or that of the previous period."),
-    )
-    retentionType: RetentionType | None = None
-    returningEntity: RetentionEntity | None = None
-    selectedInterval: int | None = Field(
-        default=None,
-        description=("The selected interval to display across all cohorts (null = show all intervals for each cohort)"),
-    )
-    showTrendLines: bool | None = None
-    targetEntity: RetentionEntity | None = None
-    timeWindowMode: TimeWindowMode | None = Field(
-        default=None,
-        description="The time window mode to use for retention calculations",
-    )
-    totalIntervals: int | None = 8
-
-
-class RetentionFilterLegacy(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    cumulative: bool | None = None
-    mean_retention_calculation: MeanRetentionCalculation | None = None
-    period: RetentionPeriod | None = None
-    retention_reference: RetentionReference | None = Field(
-        default=None,
-        description=("Whether retention is with regard to initial cohort size, or that of the previous period."),
-    )
-    retention_type: RetentionType | None = None
-    returning_entity: RetentionEntity | None = None
-    show_mean: bool | None = None
-    target_entity: RetentionEntity | None = None
-    total_intervals: int | None = None
 
 
 class RetentionQueryResponse(BaseModel):
@@ -24098,64 +22895,6 @@ class TeamTaxonomyQueryResponse(BaseModel):
     )
 
 
-class TileFilters(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    breakdown_filter: BreakdownFilter | None = None
-    date_from: str | None = None
-    date_to: str | None = None
-    explicitDate: bool | None = None
-    filterTestAccounts: bool | None = None
-    ignoreDashboardFilters: bool | None = Field(
-        default=None,
-        description=(
-            "When true, this tile ignores every dashboard-level filter; the tile's own overrides still apply."
-        ),
-    )
-    interval: IntervalType | None = None
-    properties: list[AnyPropertyFilterDiscriminated] | None = None
-
-
-class TraceNeighborsQuery(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    dateRange: DateRange | None = None
-    filterSupportTraces: bool | None = None
-    filterTestAccounts: bool | None = None
-    kind: Literal["TraceNeighborsQuery"] = "TraceNeighborsQuery"
-    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    properties: list[AnyPropertyFilterDiscriminated] | None = Field(
-        default=None, description="Properties configurable in the interface"
-    )
-    response: TraceNeighborsQueryResponse | None = None
-    tags: QueryLogTags | None = None
-    timestamp: str = Field(..., description="Timestamp of the current trace to find neighbors for")
-    traceId: str = Field(..., description="ID of the current trace to find neighbors for")
-    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
-
-
-class TraceQuery(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    dateRange: DateRange | None = None
-    includeSentiment: bool | None = Field(
-        default=None,
-        description=("Include stored sentiment evaluation results for the trace and its generations."),
-    )
-    kind: Literal["TraceQuery"] = "TraceQuery"
-    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    properties: list[AnyPropertyFilterDiscriminated] | None = Field(
-        default=None, description="Properties configurable in the interface"
-    )
-    response: TraceQueryResponse | None = None
-    tags: QueryLogTags | None = None
-    traceId: str
-    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
-
-
 class TraceSpansSymbolStatsQuery(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -24183,40 +22922,6 @@ class TraceSpansSymbolStatsQuery(BaseModel):
             " single whole-file range for a file-level total."
         ),
     )
-    tags: QueryLogTags | None = None
-    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
-
-
-class TracesQuery(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    dateRange: DateRange | None = None
-    filterSupportTraces: bool | None = None
-    filterTestAccounts: bool | None = None
-    groupKey: str | None = None
-    groupTypeIndex: int | None = None
-    includeSentiment: bool | None = Field(
-        default=None,
-        description=("Include stored sentiment evaluation results for returned traces and direct generation events."),
-    )
-    kind: Literal["TracesQuery"] = "TracesQuery"
-    limit: int | None = None
-    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    offset: int | None = None
-    personId: str | None = Field(default=None, description="Person who performed the event")
-    properties: list[AnyPropertyFilterDiscriminated] | None = Field(
-        default=None, description="Properties configurable in the interface"
-    )
-    randomOrder: bool | None = Field(
-        default=None,
-        description=(
-            "Use random ordering instead of timestamp DESC. Useful for representative sampling to avoid recency bias."
-        ),
-    )
-    response: TracesQueryResponse | None = None
-    searchTerm: str | None = None
-    showColumnConfigurator: bool | None = None
     tags: QueryLogTags | None = None
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
@@ -24742,10 +23447,6 @@ class AccountsQuery(BaseModel):
             " the overview tile click-to-filter affordance."
         ),
     )
-    includeIgnored: bool | None = Field(
-        default=None,
-        description="Include ignored accounts. Ignored accounts are hidden by default.",
-    )
     kind: Literal["AccountsQuery"] = "AccountsQuery"
     limit: int | None = None
     metrics: list[str] | None = Field(
@@ -24793,7 +23494,6 @@ class AccountsTableQuery(BaseModel):
             | AccountsTableAssignedToFilter
             | AccountsTableUnassignedFilter
             | AccountsTableAccountIdFilter
-            | AccountsTableAccountFieldFilter
             | AccountsTableCustomPropertyFilter
         ]
         | None
@@ -24804,10 +23504,6 @@ class AccountsTableQuery(BaseModel):
     includeChurned: bool | None = Field(
         default=None,
         description="Include churned accounts. Churned accounts are hidden by default.",
-    )
-    includeIgnored: bool | None = Field(
-        default=None,
-        description="Include ignored accounts. Ignored accounts are hidden by default.",
     )
     kind: Literal["AccountsTableQuery"] = "AccountsTableQuery"
     limit: conint(ge=1) | None = None
@@ -24825,43 +23521,6 @@ class AccountsTableQuery(BaseModel):
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
 
-class ActionsNode(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    custom_name: str | None = None
-    fixedProperties: list[AnyPropertyFilterDiscriminated] | None = Field(
-        default=None,
-        description=("Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person)"),
-    )
-    id: int
-    kind: Literal["ActionsNode"] = "ActionsNode"
-    math: (
-        BaseMathType
-        | FunnelMathType
-        | PropertyMathType
-        | CountPerActorMathType
-        | GroupMathType
-        | ExperimentMetricMathType
-        | CalendarHeatmapMathType
-        | Literal["hogql"]
-        | None
-    ) = None
-    math_group_type_index: MathGroupTypeIndex | None = None
-    math_hogql: str | None = None
-    math_multiplier: float | None = None
-    math_property: str | None = None
-    math_property_revenue_currency: RevenueCurrencyPropertyConfig | None = None
-    math_property_type: str | None = None
-    name: str | None = None
-    optionalInFunnel: bool | None = None
-    properties: list[AnyPropertyFilterDiscriminated] | None = Field(
-        default=None, description="Properties configurable in the interface"
-    )
-    response: dict[str, Any] | None = None
-    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
-
-
 class ActorsPropertyTaxonomyQuery(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -24874,14 +23533,6 @@ class ActorsPropertyTaxonomyQuery(BaseModel):
     response: ActorsPropertyTaxonomyQueryResponse | None = None
     tags: QueryLogTags | None = None
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
-
-
-class AnyDataWarehouseNode(RootModel[DataWarehouseNode | FunnelsDataWarehouseNode | LifecycleDataWarehouseNode]):
-    root: DataWarehouseNode | FunnelsDataWarehouseNode | LifecycleDataWarehouseNode
-
-
-class AnyEntityNodeDataWarehouseNode(RootModel[EventsNode | ActionsNode | DataWarehouseNode]):
-    root: EventsNode | ActionsNode | DataWarehouseNode
 
 
 class AnyResponseType(
@@ -24989,19 +23640,6 @@ class AssistantFunnelsActorsQuery(BaseModel):
         description="Whether to include matched session recordings for each actor.",
     )
     kind: Literal["FunnelsActorsQuery"] = "FunnelsActorsQuery"
-    limit: int | None = Field(
-        default=100,
-        description=("Maximum number of persons to return in one page, from 1 to 1000. Higher values are clamped."),
-    )
-    offset: int | None = Field(
-        default=0,
-        description=(
-            "Number of persons to skip before the returned page. Use it with `limit` to"
-            " walk the whole result set: the response reports `limit`, `offset`, and"
-            " `hasMore`, so when `hasMore` is true, call again with `offset` raised by"
-            " `limit`."
-        ),
-    )
     source: AssistantFunnelsQuery = Field(
         ...,
         description=("The source funnel insight query whose step (or trends point) we are drilling into."),
@@ -25071,19 +23709,6 @@ class AssistantPathsActorsQuery(BaseModel):
         description="Whether to include matched session recordings for each actor.",
     )
     kind: Literal["InsightActorsQuery"] = "InsightActorsQuery"
-    limit: int | None = Field(
-        default=100,
-        description=("Maximum number of persons to return in one page, from 1 to 1000. Higher values are clamped."),
-    )
-    offset: int | None = Field(
-        default=0,
-        description=(
-            "Number of persons to skip before the returned page. Use it with `limit` to"
-            " walk the whole result set: the response reports `limit`, `offset`, and"
-            " `hasMore`, so when `hasMore` is true, call again with `offset` raised by"
-            " `limit`."
-        ),
-    )
     source: AssistantPathsQuery = Field(..., description="The source paths insight query whose actors we are listing.")
 
 
@@ -25100,19 +23725,6 @@ class AssistantRetentionActorsQuery(BaseModel):
         ),
     )
     kind: Literal["InsightActorsQuery"] = "InsightActorsQuery"
-    limit: int | None = Field(
-        default=100,
-        description=("Maximum number of persons to return in one page, from 1 to 1000. Higher values are clamped."),
-    )
-    offset: int | None = Field(
-        default=0,
-        description=(
-            "Number of persons to skip before the returned page. Use it with `limit` to"
-            " walk the whole cohort: the response reports `limit`, `offset`, and"
-            " `hasMore`, so when `hasMore` is true, call again with `offset` raised by"
-            " `limit`."
-        ),
-    )
     source: AssistantRetentionQuery = Field(
         ...,
         description=("The source retention insight query whose cohort we are drilling into."),
@@ -25137,19 +23749,6 @@ class AssistantStickinessActorsQuery(BaseModel):
         ),
     )
     kind: Literal["InsightActorsQuery"] = "InsightActorsQuery"
-    limit: int | None = Field(
-        default=100,
-        description=("Maximum number of persons to return in one page, from 1 to 1000. Higher values are clamped."),
-    )
-    offset: int | None = Field(
-        default=0,
-        description=(
-            "Number of persons to skip before the returned page. Use it with `limit` to"
-            " walk the whole result set: the response reports `limit`, `offset`, and"
-            " `hasMore`, so when `hasMore` is true, call again with `offset` raised by"
-            " `limit`."
-        ),
-    )
     series: int | None = Field(
         default=None,
         description=("0-based index of the series to drill into when the source has multiple series. Defaults to 0."),
@@ -25185,19 +23784,6 @@ class AssistantTrendsActorsQuery(BaseModel):
         description="Whether to include matched session recordings for each actor.",
     )
     kind: Literal["InsightActorsQuery"] = "InsightActorsQuery"
-    limit: int | None = Field(
-        default=100,
-        description=("Maximum number of persons to return in one page, from 1 to 1000. Higher values are clamped."),
-    )
-    offset: int | None = Field(
-        default=0,
-        description=(
-            "Number of persons to skip before the returned page. Use it with `limit` to"
-            " walk the whole result set: the response reports `limit`, `offset`, and"
-            " `hasMore`, so when `hasMore` is true, call again with `offset` raised by"
-            " `limit`."
-        ),
-    )
     series: int | None = Field(
         default=None,
         description="Series index (0-based) when the source has multiple series.",
@@ -25516,35 +24102,216 @@ class CachedWebVitalsQueryResponse(BaseModel):
     )
 
 
-class CoreEvent(BaseModel):
+class ConversionGoalFilter1(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    category: CoreEventCategory = Field(
-        ...,
-        description="Category (acquisition, activation, retention, referral, revenue)",
-    )
-    description: str | None = Field(default=None, description="Optional description")
-    filter: EventsNode | ActionsNode | DataWarehouseNode = Field(
-        ...,
+    conversion_goal_id: str
+    conversion_goal_name: str
+    counts_as_customer: bool | None = Field(
+        default=None,
         description=(
-            "Filter configuration - event, action, or data warehouse node (includes math support for sum, etc.)"
+            "Marks this goal as customer-defining: a conversion here means the person"
+            " became a customer (e.g. a payment or subscription), not an intermediate"
+            " step like a sign up. It gates customer-based metrics such as CAC and"
+            " LTV:CAC, whose denominator is new customers (counted once per person via"
+            " first_time_for_user) rather than every conversion. Defaults to false."
         ),
     )
-    id: str = Field(..., description="Unique identifier")
-    name: str = Field(..., description="Display name")
+    counts_as_revenue: bool | None = Field(
+        default=None,
+        description=(
+            "Marks this goal as revenue-bearing: the value of a conversion is a"
+            " monetary amount, not a count or an arbitrary numeric property. It gates"
+            " revenue metrics such as ROAS and LTV:CAC. The amount itself comes from"
+            " math_property, and its currency from math_property_revenue_currency, the"
+            " same shape Revenue analytics uses for revenue events. Independent of"
+            " counts_as_customer: a purchase is usually both, a trial signup neither."
+            " Defaults to false."
+        ),
+    )
+    custom_name: str | None = None
+    event: str | None = Field(default=None, description="The event or `null` for all events.")
+    fixedProperties: list[AnyPropertyFilterDiscriminated] | None = Field(
+        default=None,
+        description=("Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person)"),
+    )
+    kind: Literal["EventsNode"] = "EventsNode"
+    limit: int | None = None
+    math: (
+        BaseMathType
+        | FunnelMathType
+        | PropertyMathType
+        | CountPerActorMathType
+        | GroupMathType
+        | ExperimentMetricMathType
+        | CalendarHeatmapMathType
+        | Literal["hogql"]
+        | None
+    ) = None
+    math_group_type_index: MathGroupTypeIndex | None = None
+    math_hogql: str | None = None
+    math_multiplier: float | None = None
+    math_property: str | None = None
+    math_property_revenue_currency: RevenueCurrencyPropertyConfig | None = None
+    math_property_type: str | None = None
+    name: str | None = None
+    optionalInFunnel: bool | None = None
+    orderBy: list[str] | None = Field(default=None, description="Columns to order by")
+    properties: list[AnyPropertyFilterDiscriminated] | None = Field(
+        default=None, description="Properties configurable in the interface"
+    )
+    response: dict[str, Any] | None = None
+    schema_map: dict[str, str | Any]
+    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
 
-class CustomerAnalyticsConfig(BaseModel):
+class ConversionGoalFilter2(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    account_group_type_index: int | None = None
-    activity_event: EventsNode | ActionsNode
-    payment_event: EventsNode | ActionsNode
-    signup_event: EventsNode | ActionsNode
-    signup_pageview_event: EventsNode | ActionsNode
-    subscription_event: EventsNode | ActionsNode
+    conversion_goal_id: str
+    conversion_goal_name: str
+    counts_as_customer: bool | None = Field(
+        default=None,
+        description=(
+            "Marks this goal as customer-defining: a conversion here means the person"
+            " became a customer (e.g. a payment or subscription), not an intermediate"
+            " step like a sign up. It gates customer-based metrics such as CAC and"
+            " LTV:CAC, whose denominator is new customers (counted once per person via"
+            " first_time_for_user) rather than every conversion. Defaults to false."
+        ),
+    )
+    counts_as_revenue: bool | None = Field(
+        default=None,
+        description=(
+            "Marks this goal as revenue-bearing: the value of a conversion is a"
+            " monetary amount, not a count or an arbitrary numeric property. It gates"
+            " revenue metrics such as ROAS and LTV:CAC. The amount itself comes from"
+            " math_property, and its currency from math_property_revenue_currency, the"
+            " same shape Revenue analytics uses for revenue events. Independent of"
+            " counts_as_customer: a purchase is usually both, a trial signup neither."
+            " Defaults to false."
+        ),
+    )
+    custom_name: str | None = None
+    fixedProperties: list[AnyPropertyFilterDiscriminated] | None = Field(
+        default=None,
+        description=("Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person)"),
+    )
+    id: int
+    kind: Literal["ActionsNode"] = "ActionsNode"
+    math: (
+        BaseMathType
+        | FunnelMathType
+        | PropertyMathType
+        | CountPerActorMathType
+        | GroupMathType
+        | ExperimentMetricMathType
+        | CalendarHeatmapMathType
+        | Literal["hogql"]
+        | None
+    ) = None
+    math_group_type_index: MathGroupTypeIndex | None = None
+    math_hogql: str | None = None
+    math_multiplier: float | None = None
+    math_property: str | None = None
+    math_property_revenue_currency: RevenueCurrencyPropertyConfig | None = None
+    math_property_type: str | None = None
+    name: str | None = None
+    optionalInFunnel: bool | None = None
+    properties: list[AnyPropertyFilterDiscriminated] | None = Field(
+        default=None, description="Properties configurable in the interface"
+    )
+    response: dict[str, Any] | None = None
+    schema_map: dict[str, str | Any]
+    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
+
+
+class ConversionGoalFilter3(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    conversion_goal_id: str
+    conversion_goal_name: str
+    counts_as_customer: bool | None = Field(
+        default=None,
+        description=(
+            "Marks this goal as customer-defining: a conversion here means the person"
+            " became a customer (e.g. a payment or subscription), not an intermediate"
+            " step like a sign up. It gates customer-based metrics such as CAC and"
+            " LTV:CAC, whose denominator is new customers (counted once per person via"
+            " first_time_for_user) rather than every conversion. Defaults to false."
+        ),
+    )
+    counts_as_revenue: bool | None = Field(
+        default=None,
+        description=(
+            "Marks this goal as revenue-bearing: the value of a conversion is a"
+            " monetary amount, not a count or an arbitrary numeric property. It gates"
+            " revenue metrics such as ROAS and LTV:CAC. The amount itself comes from"
+            " math_property, and its currency from math_property_revenue_currency, the"
+            " same shape Revenue analytics uses for revenue events. Independent of"
+            " counts_as_customer: a purchase is usually both, a trial signup neither."
+            " Defaults to false."
+        ),
+    )
+    custom_name: str | None = None
+    distinct_id_field: str
+    dw_source_type: str | None = None
+    fixedProperties: list[AnyPropertyFilterDiscriminated] | None = Field(
+        default=None,
+        description=("Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person)"),
+    )
+    id: str
+    id_field: str
+    kind: Literal["DataWarehouseNode"] = "DataWarehouseNode"
+    math: (
+        BaseMathType
+        | FunnelMathType
+        | PropertyMathType
+        | CountPerActorMathType
+        | GroupMathType
+        | ExperimentMetricMathType
+        | CalendarHeatmapMathType
+        | Literal["hogql"]
+        | None
+    ) = None
+    math_group_type_index: MathGroupTypeIndex | None = None
+    math_hogql: str | None = None
+    math_multiplier: float | None = None
+    math_property: str | None = None
+    math_property_revenue_currency: RevenueCurrencyPropertyConfig | None = None
+    math_property_type: str | None = None
+    name: str | None = None
+    optionalInFunnel: bool | None = None
+    properties: list[AnyPropertyFilterDiscriminated] | None = Field(
+        default=None, description="Properties configurable in the interface"
+    )
+    response: dict[str, Any] | None = None
+    schema_map: dict[str, str | Any]
+    table_name: str
+    timestamp_field: str
+    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
+
+
+class DashboardFilter(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    breakdown_filter: BreakdownFilter | None = None
+    date_from: str | None = None
+    date_to: str | None = None
+    explicitDate: bool | None = None
+    filterTestAccounts: bool | None = Field(
+        default=None,
+        description=("Tri-state test-account override. Null/absent = inherit; true = force on; false = force off."),
+    )
+    interval: IntervalType | None = Field(
+        default=None,
+        description=("Time granularity forced onto every insight that supports one. Absent/null = inherit."),
+    )
+    properties: list[AnyPropertyFilterDiscriminated] | None = None
 
 
 class Response3(BaseModel):
@@ -25651,6 +24418,48 @@ class Response15(BaseModel):
     )
 
 
+class DataWarehouseNode(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    custom_name: str | None = None
+    distinct_id_field: str
+    dw_source_type: str | None = None
+    fixedProperties: list[AnyPropertyFilterDiscriminated] | None = Field(
+        default=None,
+        description=("Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person)"),
+    )
+    id: str
+    id_field: str
+    kind: Literal["DataWarehouseNode"] = "DataWarehouseNode"
+    math: (
+        BaseMathType
+        | FunnelMathType
+        | PropertyMathType
+        | CountPerActorMathType
+        | GroupMathType
+        | ExperimentMetricMathType
+        | CalendarHeatmapMathType
+        | Literal["hogql"]
+        | None
+    ) = None
+    math_group_type_index: MathGroupTypeIndex | None = None
+    math_hogql: str | None = None
+    math_multiplier: float | None = None
+    math_property: str | None = None
+    math_property_revenue_currency: RevenueCurrencyPropertyConfig | None = None
+    math_property_type: str | None = None
+    name: str | None = None
+    optionalInFunnel: bool | None = None
+    properties: list[AnyPropertyFilterDiscriminated] | None = Field(
+        default=None, description="Properties configurable in the interface"
+    )
+    response: dict[str, Any] | None = None
+    table_name: str
+    timestamp_field: str
+    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
+
+
 class DocumentSimilarityQuery(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -25672,6 +24481,52 @@ class DocumentSimilarityQuery(BaseModel):
     tags: QueryLogTags | None = None
     threshold: float | None = None
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
+
+
+class EndpointRunRequest(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    client_query_id: str | None = Field(
+        default=None,
+        description=("Client provided query ID. Can be used to retrieve the status or cancel the query."),
+    )
+    debug: bool | None = Field(
+        default=False,
+        description=("Whether to include debug information (such as the executed HogQL) in the response."),
+    )
+    filters_override: DashboardFilter | None = None
+    limit: int | None = Field(
+        default=None,
+        description=("Maximum number of results to return. If not provided, returns all results."),
+    )
+    offset: int | None = Field(
+        default=None,
+        description=(
+            "Number of results to skip. Must be used together with limit. Only supported for HogQL endpoints."
+        ),
+    )
+    refresh: EndpointRefreshMode | None = EndpointRefreshMode.CACHE
+    variables: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Variables to parameterize the endpoint query. The key is the variable name"
+            " and the value is the variable value.\n\nFor HogQL endpoints:   Keys must"
+            " match a variable `code_name` defined in the query (referenced as"
+            ' `{variables.code_name}`).   Example: `{"event_name": "$pageview"}`\n\nFor'
+            " non-materialized insight endpoints (e.g. TrendsQuery):   - `date_from`"
+            " and `date_to` are built-in variables that filter the date range.    "
+            ' Example: `{"date_from": "2024-01-01", "date_to": "2024-01-31"}`\n\nFor'
+            " materialized insight endpoints:   - Use the breakdown property name as"
+            ' the key to filter by breakdown value.     Example: `{"$browser":'
+            ' "Chrome"}`   - `date_from`/`date_to` are not supported on materialized'
+            " insight endpoints.\n\nUnknown variable names will return a 400 error."
+        ),
+    )
+    version: int | None = Field(
+        default=None,
+        description=("Specific endpoint version to execute. If not provided, the latest version is used."),
+    )
 
 
 class EndpointsUsageOverviewQuery(BaseModel):
@@ -25752,6 +24607,58 @@ class EnsembleDetectorConfig(BaseModel):
     type: Literal["ensemble"] = "ensemble"
 
 
+class EntityNode(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    custom_name: str | None = None
+    fixedProperties: list[AnyPropertyFilterDiscriminated] | None = Field(
+        default=None,
+        description=("Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person)"),
+    )
+    kind: NodeKind
+    math: (
+        BaseMathType
+        | FunnelMathType
+        | PropertyMathType
+        | CountPerActorMathType
+        | GroupMathType
+        | ExperimentMetricMathType
+        | CalendarHeatmapMathType
+        | Literal["hogql"]
+        | None
+    ) = None
+    math_group_type_index: MathGroupTypeIndex | None = None
+    math_hogql: str | None = None
+    math_multiplier: float | None = None
+    math_property: str | None = None
+    math_property_revenue_currency: RevenueCurrencyPropertyConfig | None = None
+    math_property_type: str | None = None
+    name: str | None = None
+    optionalInFunnel: bool | None = None
+    properties: list[AnyPropertyFilterDiscriminated] | None = Field(
+        default=None, description="Properties configurable in the interface"
+    )
+    response: dict[str, Any] | None = None
+    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
+
+
+class ErrorTrackingBreakdownsQuery(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    breakdownProperties: list[str]
+    dateRange: DateRange | None = None
+    filterTestAccounts: bool | None = None
+    issueId: str
+    kind: Literal["ErrorTrackingBreakdownsQuery"] = "ErrorTrackingBreakdownsQuery"
+    maxValuesPerProperty: int | None = None
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    response: ErrorTrackingBreakdownsQueryResponse | None = None
+    tags: QueryLogTags | None = None
+    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
+
+
 class ErrorTrackingCorrelatedIssue(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -25768,22 +24675,7 @@ class ErrorTrackingCorrelatedIssue(BaseModel):
     name: str | None = None
     odds_ratio: float
     population: Population
-    severity: ErrorTrackingQueryIssueSeverity | None = None
     status: ErrorTrackingIssueStatus
-
-
-class ErrorTrackingFingerprintProjectionQuery(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    issueId: str
-    kind: Literal["ErrorTrackingFingerprintProjectionQuery"] = "ErrorTrackingFingerprintProjectionQuery"
-    modelName: EmbeddingModelName | None = None
-    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    rendering: str | None = None
-    response: ErrorTrackingFingerprintProjectionQueryResponse | None = None
-    tags: QueryLogTags | None = None
-    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
 
 class ErrorTrackingIssueCorrelationQueryResponse(BaseModel):
@@ -25837,6 +24729,27 @@ class ErrorTrackingIssueCorrelationQueryResponse(BaseModel):
     )
 
 
+class ErrorTrackingIssueFilteringToolOutput(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    dateRange: DateRange | None = None
+    filterTestAccounts: bool | None = None
+    newFilters: list[AnyPropertyFilterDiscriminated] | None = None
+    orderBy: ErrorTrackingOrderBy = Field(..., description="Field to sort results by.")
+    orderDirection: OrderDirection2 | None = Field(default=None, description="Sort direction.")
+    removedFilterIndexes: list[int] | None = None
+    searchQuery: str | None = Field(
+        default=None,
+        description=("Free-text search across exception type, message, and stack frames."),
+    )
+    status: ErrorTrackingIssueStatus | str | None = Field(
+        default=None,
+        description="Filter by issue status.",
+        title="ErrorTrackingQueryStatus",
+    )
+
+
 class ErrorTrackingSimilarIssuesQuery(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -25872,11 +24785,89 @@ class EventTaxonomyQuery(BaseModel):
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
 
-class ExperimentExposureCriteria(BaseModel):
+class EventsNode(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    activation_config: ExperimentEventExposureConfig | ActionsNode | None = Field(
+    custom_name: str | None = None
+    event: str | None = Field(default=None, description="The event or `null` for all events.")
+    fixedProperties: list[AnyPropertyFilterDiscriminated] | None = Field(
+        default=None,
+        description=("Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person)"),
+    )
+    kind: Literal["EventsNode"] = "EventsNode"
+    limit: int | None = None
+    math: (
+        BaseMathType
+        | FunnelMathType
+        | PropertyMathType
+        | CountPerActorMathType
+        | GroupMathType
+        | ExperimentMetricMathType
+        | CalendarHeatmapMathType
+        | Literal["hogql"]
+        | None
+    ) = None
+    math_group_type_index: MathGroupTypeIndex | None = None
+    math_hogql: str | None = None
+    math_multiplier: float | None = None
+    math_property: str | None = None
+    math_property_revenue_currency: RevenueCurrencyPropertyConfig | None = None
+    math_property_type: str | None = None
+    name: str | None = None
+    optionalInFunnel: bool | None = None
+    orderBy: list[str] | None = Field(default=None, description="Columns to order by")
+    properties: list[AnyPropertyFilterDiscriminated] | None = Field(
+        default=None, description="Properties configurable in the interface"
+    )
+    response: dict[str, Any] | None = None
+    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
+
+
+class EventsQueryActionStep(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    event: str | None = None
+    href: str | None = None
+    href_matching: HrefMatching | None = None
+    properties: list[AnyPropertyFilterDiscriminated] | None = None
+    selector: str | None = None
+    tag_name: str | None = None
+    text: str | None = None
+    text_matching: TextMatching | None = None
+    url: str | None = None
+    url_matching: UrlMatching | None = None
+
+
+class ExperimentApiExposureConfig(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    event: str | None = Field(
+        default=None,
+        description=("Custom exposure event name. Required when kind is 'ExperimentEventExposureConfig'."),
+    )
+    id: int | None = Field(default=None, description="Action ID. Required when kind is 'ActionsNode'.")
+    kind: Kind1 | None = Field(
+        default=None,
+        description=(
+            "Defaults to 'ExperimentEventExposureConfig' when omitted. Pass 'ActionsNode' for an action-based exposure."
+        ),
+    )
+    properties: list[AnyPropertyFilterDiscriminated] = Field(
+        ...,
+        description=(
+            "Property filters (event, person, and other supported types). Pass an empty array if no filters needed."
+        ),
+    )
+
+
+class ExperimentApiExposureCriteria(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    activation_config: ExperimentApiExposureConfig | None = Field(
         default=None,
         description=(
             "Additional event (or action) an entity must emit at/after their first"
@@ -25885,100 +24876,212 @@ class ExperimentExposureCriteria(BaseModel):
             " event, not a custom `exposure_config`."
         ),
     )
-    exposure_config: ExperimentEventExposureConfig | ActionsNode | None = None
+    exposure_config: ExperimentApiExposureConfig | None = None
     filterTestAccounts: bool | None = None
-    multiple_variant_handling: MultipleVariantHandling | None = None
+    multiple_variant_handling: MultipleVariantHandling | None = Field(
+        default=None,
+        description=(
+            "How to handle entities exposed to multiple variants. 'exclude' (default)"
+            " drops them from the analysis; 'first_seen' assigns them to the variant"
+            " from their earliest exposure."
+        ),
+    )
 
 
-class ExperimentHoldoutType(BaseModel):
+class ExperimentDataWarehouseNode(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    created_at: str | None = None
-    created_by: UserBasicType | None = None
+    custom_name: str | None = None
+    data_warehouse_join_key: str
+    events_join_key: str
+    fixedProperties: list[AnyPropertyFilterDiscriminated] | None = Field(
+        default=None,
+        description=("Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person)"),
+    )
+    kind: Literal["ExperimentDataWarehouseNode"] = "ExperimentDataWarehouseNode"
+    math: (
+        BaseMathType
+        | FunnelMathType
+        | PropertyMathType
+        | CountPerActorMathType
+        | GroupMathType
+        | ExperimentMetricMathType
+        | CalendarHeatmapMathType
+        | Literal["hogql"]
+        | None
+    ) = None
+    math_group_type_index: MathGroupTypeIndex | None = None
+    math_hogql: str | None = None
+    math_multiplier: float | None = None
+    math_property: str | None = None
+    math_property_revenue_currency: RevenueCurrencyPropertyConfig | None = None
+    math_property_type: str | None = None
+    name: str | None = None
+    optionalInFunnel: bool | None = None
+    properties: list[AnyPropertyFilterDiscriminated] | None = Field(
+        default=None, description="Properties configurable in the interface"
+    )
+    response: dict[str, Any] | None = None
+    table_name: str
+    timestamp_field: str
+    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
+
+
+class ExperimentEventExposureConfig(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    event: str
+    kind: Literal["ExperimentEventExposureConfig"] = "ExperimentEventExposureConfig"
+    properties: list[AnyPropertyFilterDiscriminated]
+    response: dict[str, Any] | None = None
+    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
+
+
+class FeatureFlagGroupType(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    aggregation_group_type_index: int | None = None
     description: str | None = None
-    filters: list[FeatureFlagGroupType]
-    id: int
-    name: str
-    updated_at: str | None = None
-    user_access_level: AccessControlLevel | None = Field(
+    exposure_frozen: bool | None = Field(
         default=None,
-        description=("Read-only, server-computed effective access level; absent on a not-yet-created holdout."),
+        description=(
+            "Stamped by the experiment exposure freeze: the group carries a machine-added snapshot-cohort condition."
+        ),
     )
+    exposure_frozen_cohort: float | None = Field(
+        default=None,
+        description=("Snapshot cohort the exposure freeze AND'd into this group's properties."),
+    )
+    properties: list[AnyPropertyFilterDiscriminated] | None = None
+    rollout_percentage: float | None = None
+    sort_key: str | None = None
+    users_affected: float | None = None
+    variant: str | None = None
 
 
-class FunnelsFilter(BaseModel):
+class FunnelExclusionActionsNode(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    binCount: int | None = None
-    breakdownAttributionType: BreakdownAttributionType | None = BreakdownAttributionType.FIRST_TOUCH
-    breakdownAttributionValue: int | None = None
-    breakdownSorting: str | None = Field(
+    custom_name: str | None = None
+    fixedProperties: list[AnyPropertyFilterDiscriminated] | None = Field(
         default=None,
-        description=("Breakdown table sorting. Format: 'column_key' or '-column_key' (descending)"),
+        description=("Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person)"),
     )
-    chartStyle: ChartStyle | None = Field(
+    funnelFromStep: int
+    funnelToStep: int
+    id: int
+    kind: Literal["ActionsNode"] = "ActionsNode"
+    math: (
+        BaseMathType
+        | FunnelMathType
+        | PropertyMathType
+        | CountPerActorMathType
+        | GroupMathType
+        | ExperimentMetricMathType
+        | CalendarHeatmapMathType
+        | Literal["hogql"]
+        | None
+    ) = None
+    math_group_type_index: MathGroupTypeIndex | None = None
+    math_hogql: str | None = None
+    math_multiplier: float | None = None
+    math_property: str | None = None
+    math_property_revenue_currency: RevenueCurrencyPropertyConfig | None = None
+    math_property_type: str | None = None
+    name: str | None = None
+    optionalInFunnel: bool | None = None
+    properties: list[AnyPropertyFilterDiscriminated] | None = Field(
+        default=None, description="Properties configurable in the interface"
+    )
+    response: dict[str, Any] | None = None
+    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
+
+
+class FunnelExclusionEventsNode(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    custom_name: str | None = None
+    event: str | None = Field(default=None, description="The event or `null` for all events.")
+    fixedProperties: list[AnyPropertyFilterDiscriminated] | None = Field(
         default=None,
-        description=("Chart rendering style overrides (line shape). Only applies to historical-trends funnels."),
+        description=("Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person)"),
     )
-    customAggregationTarget: bool | None = Field(
+    funnelFromStep: int
+    funnelToStep: int
+    kind: Literal["EventsNode"] = "EventsNode"
+    limit: int | None = None
+    math: (
+        BaseMathType
+        | FunnelMathType
+        | PropertyMathType
+        | CountPerActorMathType
+        | GroupMathType
+        | ExperimentMetricMathType
+        | CalendarHeatmapMathType
+        | Literal["hogql"]
+        | None
+    ) = None
+    math_group_type_index: MathGroupTypeIndex | None = None
+    math_hogql: str | None = None
+    math_multiplier: float | None = None
+    math_property: str | None = None
+    math_property_revenue_currency: RevenueCurrencyPropertyConfig | None = None
+    math_property_type: str | None = None
+    name: str | None = None
+    optionalInFunnel: bool | None = None
+    orderBy: list[str] | None = Field(default=None, description="Columns to order by")
+    properties: list[AnyPropertyFilterDiscriminated] | None = Field(
+        default=None, description="Properties configurable in the interface"
+    )
+    response: dict[str, Any] | None = None
+    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
+
+
+class FunnelsDataWarehouseNode(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    aggregation_target_field: str
+    custom_name: str | None = None
+    dw_source_type: str | None = None
+    fixedProperties: list[AnyPropertyFilterDiscriminated] | None = Field(
         default=None,
-        description=(
-            "For data warehouse based funnel insights when the aggregation target can't be mapped to persons or groups."
-        ),
+        description=("Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person)"),
     )
-    exclusions: (
-        list[Annotated[FunnelExclusionEventsNode | FunnelExclusionActionsNode, Field(discriminator="kind")]] | None
-    ) = []
-    funnelAggregateByHogQL: str | None = None
-    funnelFromStep: int | None = None
-    funnelOrderType: StepOrderValue | None = StepOrderValue.ORDERED
-    funnelStepReference: FunnelStepReference | None = FunnelStepReference.TOTAL
-    funnelToStep: int | None = Field(
-        default=None,
-        description=("To select the range of steps for trends & time to convert funnels, 0-indexed"),
+    id: str
+    id_field: str
+    kind: Literal["FunnelsDataWarehouseNode"] = "FunnelsDataWarehouseNode"
+    math: (
+        BaseMathType
+        | FunnelMathType
+        | PropertyMathType
+        | CountPerActorMathType
+        | GroupMathType
+        | ExperimentMetricMathType
+        | CalendarHeatmapMathType
+        | Literal["hogql"]
+        | None
+    ) = None
+    math_group_type_index: MathGroupTypeIndex | None = None
+    math_hogql: str | None = None
+    math_multiplier: float | None = None
+    math_property: str | None = None
+    math_property_revenue_currency: RevenueCurrencyPropertyConfig | None = None
+    math_property_type: str | None = None
+    name: str | None = None
+    optionalInFunnel: bool | None = None
+    properties: list[AnyPropertyFilterDiscriminated] | None = Field(
+        default=None, description="Properties configurable in the interface"
     )
-    funnelVizType: FunnelVizType | None = FunnelVizType.STEPS
-    funnelWindowInterval: int | None = 14
-    funnelWindowIntervalUnit: FunnelConversionWindowTimeUnit | None = FunnelConversionWindowTimeUnit.DAY
-    goalLines: list[GoalLine] | None = Field(default=None, description="Goal Lines")
-    hiddenLegendBreakdowns: list[str] | None = None
-    hideIncompleteConversionWindowPeriods: bool | None = Field(
-        default=False,
-        description=(
-            "Trends only: hide periods whose conversion window has not fully elapsed"
-            " yet, so the recent tail of the trend isn't dragged down by entrants who"
-            " still have time to convert."
-        ),
-    )
-    layout: FunnelLayout | None = FunnelLayout.VERTICAL
-    legendPosition: LegendPosition | None = Field(
-        default=LegendPosition.BOTTOM,
-        description=("Where the in-chart legend sits relative to the plot. Only applies to the in-chart legend."),
-    )
-    resultCustomizations: dict[str, ResultCustomizationByValue] | None = Field(
-        default=None,
-        description="Customizations for the appearance of result datasets.",
-    )
-    showAnnotations: bool | None = Field(
-        default=True,
-        description=("Whether to render annotations on the chart. Only applies to historical-trends funnels."),
-    )
-    showLegend: bool | None = Field(
-        default=False,
-        description=(
-            "Whether to show a legend describing the series. The legend only renders"
-            " when the funnel has multiple series. Only applies to historical-trends"
-            " funnels."
-        ),
-    )
-    showTrendLines: bool | None = Field(
-        default=None,
-        description=("Display linear regression trend lines on the chart (only for historical trends viz)"),
-    )
-    showValuesOnSeries: bool | None = False
-    useUdf: bool | None = None
+    response: dict[str, Any] | None = None
+    table_name: str
+    timestamp_field: str
+    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
 
 class GroupsQuery(BaseModel):
@@ -25997,6 +25100,31 @@ class GroupsQuery(BaseModel):
     select: list[str] | None = None
     tags: QueryLogTags | None = None
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
+
+
+class HeatMapQuerySource(RootModel[EventsNode]):
+    root: EventsNode
+
+
+class HogQLFilters(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    breakdownFilter: BreakdownFilter | None = Field(
+        default=None,
+        description=(
+            "Breakdown consumed by the {filters.breakdown(...)} placeholder. Set from the dashboard-level breakdown."
+        ),
+    )
+    dateRange: DateRange | None = None
+    filterTestAccounts: bool | None = None
+    interval: IntervalType | None = Field(
+        default=None,
+        description=(
+            "Time granularity consumed by the {filters.interval} placeholder. Set from the dashboard-level interval."
+        ),
+    )
+    properties: list[AnyPropertyFilterDiscriminated] | None = None
 
 
 class HogQLQuery(BaseModel):
@@ -26055,30 +25183,45 @@ class InsightActorsQueryOptionsResponse(BaseModel):
     )
 
 
-class InsightFilter(
-    RootModel[
-        TrendsFilter
-        | FunnelsFilter
-        | RetentionFilter
-        | PathsFilter
-        | PathsV2Filter
-        | StickinessFilter
-        | LifecycleFilter
-        | CalendarHeatmapFilter
-        | list[EventPropertyFilter | PersonPropertyFilter | SessionPropertyFilter | CohortPropertyFilter]
-    ]
-):
-    root: (
-        TrendsFilter
-        | FunnelsFilter
-        | RetentionFilter
-        | PathsFilter
-        | PathsV2Filter
-        | StickinessFilter
-        | LifecycleFilter
-        | CalendarHeatmapFilter
-        | list[EventPropertyFilter | PersonPropertyFilter | SessionPropertyFilter | CohortPropertyFilter]
+class LifecycleDataWarehouseNode(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
     )
+    aggregation_target_field: str
+    created_at_field: str
+    custom_name: str | None = None
+    fixedProperties: list[AnyPropertyFilterDiscriminated] | None = Field(
+        default=None,
+        description=("Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person)"),
+    )
+    id: str
+    kind: Literal["LifecycleDataWarehouseNode"] = "LifecycleDataWarehouseNode"
+    math: (
+        BaseMathType
+        | FunnelMathType
+        | PropertyMathType
+        | CountPerActorMathType
+        | GroupMathType
+        | ExperimentMetricMathType
+        | CalendarHeatmapMathType
+        | Literal["hogql"]
+        | None
+    ) = None
+    math_group_type_index: MathGroupTypeIndex | None = None
+    math_hogql: str | None = None
+    math_multiplier: float | None = None
+    math_property: str | None = None
+    math_property_revenue_currency: RevenueCurrencyPropertyConfig | None = None
+    math_property_type: str | None = None
+    name: str | None = None
+    optionalInFunnel: bool | None = None
+    properties: list[AnyPropertyFilterDiscriminated] | None = Field(
+        default=None, description="Properties configurable in the interface"
+    )
+    response: dict[str, Any] | None = None
+    table_name: str
+    timestamp_field: str
+    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
 
 class MCPHarnessBreakdownQuery(BaseModel):
@@ -26155,18 +25298,6 @@ class MCPToolCategoryCountsQuery(BaseModel):
     kind: Literal["MCPToolCategoryCountsQuery"] = "MCPToolCategoryCountsQuery"
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
     response: MCPToolCategoryCountsQueryResponse | None = None
-    tags: QueryLogTags | None = None
-    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
-
-
-class MCPToolCategoryMapQuery(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    dateRange: DateRange | None = None
-    kind: Literal["MCPToolCategoryMapQuery"] = "MCPToolCategoryMapQuery"
-    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    response: MCPToolCategoryMapQueryResponse | None = None
     tags: QueryLogTags | None = None
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
@@ -26558,6 +25689,19 @@ class MarketingAnalyticsAttributionQuery(BaseModel):
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
 
+class MarketingAnalyticsConfig(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    attribution_mode: AttributionMode | None = None
+    attribution_window_days: float | None = None
+    campaign_field_preferences: dict[str, CampaignFieldPreference] | None = None
+    campaign_name_mappings: dict[str, dict[str, list[str]]] | None = None
+    conversion_goals: list[ConversionGoalFilter1 | ConversionGoalFilter2 | ConversionGoalFilter3] | None = None
+    custom_source_mappings: dict[str, list[str]] | None = None
+    sources_map: dict[str, SourceMap] | None = None
+
+
 class MarketingAnalyticsTableQuery(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -26670,14 +25814,6 @@ class MaxRecordingUniversalFilters(BaseModel):
             " indicate descending order to avoid invalidating or migrating all existing"
             " filters we keep DESC as the default or allow specification of an explicit"
             " order direction here"
-        ),
-    )
-    session_ids: list[str] | None = Field(
-        default=None,
-        description=(
-            "Pin the result to specific recordings by their session id, e.g. the ones"
-            " just summarized. `$session_id` is not a session property, so it cannot be"
-            " filtered on in `filter_group`."
         ),
     )
 
@@ -26804,12 +25940,67 @@ class PathsV2QueryResponse(BaseModel):
     )
 
 
-class PropertyGroupFilter(BaseModel):
+class PersonsNode(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    cohort: int | None = None
+    distinctId: str | None = None
+    fixedProperties: list[AnyPropertyFilterDiscriminated] | None = Field(
+        default=None,
+        description=("Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person)"),
+    )
+    kind: Literal["PersonsNode"] = "PersonsNode"
+    limit: int | None = None
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    offset: int | None = None
+    properties: list[AnyPropertyFilterDiscriminated] | None = Field(
+        default=None, description="Properties configurable in the interface"
+    )
+    response: dict[str, Any] | None = None
+    search: str | None = None
+    tags: QueryLogTags | None = None
+    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
+
+
+class PropertyGroupFilterValue(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
     type: FilterLogicalOperator
-    values: list[PropertyGroupFilterValue]
+    values: list[AnyPropertyFilterOrGroupDiscriminated]
+
+
+# Variant of AnyPropertyFilterDiscriminated for PropertyGroupFilterValue's recursive `values`
+# field; sits after that class because the union references the class object.
+AnyPropertyFilterOrGroupDiscriminated = Annotated[
+    Annotated[PropertyGroupFilterValue, pydantic.Tag("property_group")]
+    | Annotated[EventPropertyFilter, pydantic.Tag("event")]
+    | Annotated[PersonPropertyFilter, pydantic.Tag("person")]
+    | Annotated[PersonMetadataPropertyFilter, pydantic.Tag("person_metadata")]
+    | Annotated[ElementPropertyFilter, pydantic.Tag("element")]
+    | Annotated[EventMetadataPropertyFilter, pydantic.Tag("event_metadata")]
+    | Annotated[SessionPropertyFilter, pydantic.Tag("session")]
+    | Annotated[CohortPropertyFilter, pydantic.Tag("cohort")]
+    | Annotated[RecordingPropertyFilter, pydantic.Tag("recording")]
+    | Annotated[LogEntryPropertyFilter, pydantic.Tag("log_entry")]
+    | Annotated[GroupPropertyFilter, pydantic.Tag("group")]
+    | Annotated[FeaturePropertyFilter, pydantic.Tag("feature")]
+    | Annotated[FlagPropertyFilter, pydantic.Tag("flag")]
+    | Annotated[HogQLPropertyFilter, pydantic.Tag("hogql")]
+    | Annotated[EmptyPropertyFilter, pydantic.Tag("empty")]
+    | Annotated[DataWarehousePropertyFilter, pydantic.Tag("data_warehouse")]
+    | Annotated[DataWarehousePersonPropertyFilter, pydantic.Tag("data_warehouse_person_property")]
+    | Annotated[ErrorTrackingIssueFilter, pydantic.Tag("error_tracking_issue")]
+    | Annotated[LogPropertyFilter, pydantic.Tag("log")]
+    | Annotated[MetricPropertyFilter, pydantic.Tag("metric_attribute")]
+    | Annotated[SpanPropertyFilter, pydantic.Tag("span")]
+    | Annotated[RevenueAnalyticsPropertyFilter, pydantic.Tag("revenue_analytics")]
+    | Annotated[AccountCustomPropertyFilter, pydantic.Tag("account_custom_property")]
+    | Annotated[WorkflowVariablePropertyFilter, pydantic.Tag("workflow_variable")]
+    | Annotated[BehavioralPropertyFilter, pydantic.Tag("behavioral")],
+    pydantic.Discriminator(property_filter_discriminator),
+]
 
 
 class PropertyValuesQuery(BaseModel):
@@ -26828,7 +26019,7 @@ class PropertyValuesQuery(BaseModel):
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
 
-class QueryResponseAlternative16(BaseModel):
+class QueryResponseAlternative15(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -26952,28 +26143,101 @@ class RecordingsQuery(BaseModel):
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
 
-class RetentionQuery(BaseModel):
+class RetentionEntity(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    aggregation_group_type_index: int | None = Field(default=None, description="Groups aggregation")
-    breakdownFilter: BreakdownFilter | None = Field(default=None, description="Breakdown of the events and actions")
-    dataColorTheme: float | None = Field(default=None, description="Colors used in the insight's visualization")
-    dateRange: DateRange | None = Field(default=None, description="Date range for the query")
-    filterTestAccounts: bool | None = Field(
-        default=False,
-        description=("Exclude internal and test users by applying the respective filters"),
+    aggregation_target_field: str | None = Field(
+        default=None, description="Data warehouse field used as the actor identifier"
     )
-    kind: Literal["RetentionQuery"] = "RetentionQuery"
-    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    properties: list[AnyPropertyFilterDiscriminated] | PropertyGroupFilter | None = Field(
-        default=[], description="Property filters for all series"
+    custom_name: str | None = None
+    id: str | float | None = None
+    kind: RetentionEntityKind | None = None
+    name: str | None = None
+    order: int | None = None
+    properties: list[AnyPropertyFilterDiscriminated] | None = Field(default=None, description="filters on the event")
+    table_name: str | None = Field(default=None, description="Data warehouse table name")
+    timestamp_field: str | None = Field(default=None, description="Data warehouse timestamp field")
+    type: EntityType | None = None
+    uuid: str | None = None
+
+
+class RetentionFilter(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
     )
-    response: RetentionQueryResponse | None = None
-    retentionFilter: RetentionFilter = Field(..., description="Properties specific to the retention insight")
-    samplingFactor: float | None = Field(default=None, description="Sampling rate")
-    tags: QueryLogTags | None = Field(default=None, description="Tags that will be added to the Query log comment")
-    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
+    aggregationProperty: str | None = Field(
+        default=None,
+        description="The property to aggregate when aggregationType is sum or avg",
+    )
+    aggregationPropertyType: AggregationPropertyType | None = Field(
+        default=AggregationPropertyType.EVENT,
+        description=("The type of property to aggregate on (event, person or data_warehouse). Defaults to event."),
+    )
+    aggregationType: AggregationType | None = Field(
+        default=AggregationType.COUNT,
+        description="The aggregation type to use for retention",
+    )
+    chartStyle: ChartStyle | None = Field(default=None, description="Chart rendering style overrides (line shape).")
+    cohortLabelStartIndex: int | None = Field(
+        default=0,
+        description=(
+            "Starting index used when labeling cohort columns (e.g. 0 for D0/D1/D2, 1"
+            " for D1/D2/D3). Display-only — does not affect retention calculations."
+        ),
+    )
+    cumulative: bool | None = None
+    customAggregationTarget: bool | None = Field(
+        default=None,
+        description=(
+            "For data warehouse based retention insights when the aggregation target"
+            " can't be mapped to persons or groups."
+        ),
+    )
+    dashboardDisplay: RetentionDashboardDisplayType | None = None
+    display: ChartDisplayType | None = Field(default=None, description="controls the display of the retention graph")
+    goalLines: list[GoalLine] | None = None
+    meanRetentionCalculation: MeanRetentionCalculation | None = None
+    minimumOccurrences: int | None = None
+    period: RetentionPeriod | None = RetentionPeriod.DAY
+    retentionCustomBrackets: list[float] | None = Field(
+        default=None, description="Custom brackets for retention calculations"
+    )
+    retentionReference: RetentionReference | None = Field(
+        default=None,
+        description=("Whether retention is with regard to initial cohort size, or that of the previous period."),
+    )
+    retentionType: RetentionType | None = None
+    returningEntity: RetentionEntity | None = None
+    selectedInterval: int | None = Field(
+        default=None,
+        description=("The selected interval to display across all cohorts (null = show all intervals for each cohort)"),
+    )
+    showTrendLines: bool | None = None
+    targetEntity: RetentionEntity | None = None
+    timeWindowMode: TimeWindowMode | None = Field(
+        default=None,
+        description="The time window mode to use for retention calculations",
+    )
+    totalIntervals: int | None = 8
+
+
+class RetentionFilterLegacy(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    cumulative: bool | None = None
+    mean_retention_calculation: MeanRetentionCalculation | None = None
+    period: RetentionPeriod | None = None
+    retention_reference: RetentionReference | None = Field(
+        default=None,
+        description=("Whether retention is with regard to initial cohort size, or that of the previous period."),
+    )
+    retention_type: RetentionType | None = None
+    returning_entity: RetentionEntity | None = None
+    show_mean: bool | None = None
+    target_entity: RetentionEntity | None = None
+    total_intervals: int | None = None
 
 
 class TeamTaxonomyQuery(BaseModel):
@@ -26989,159 +26253,94 @@ class TeamTaxonomyQuery(BaseModel):
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
 
-class TraceSpansAggregationQuery(BaseModel):
+class TileFilters(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    compareFilter: CompareFilter | None = Field(
+    breakdown_filter: BreakdownFilter | None = None
+    date_from: str | None = None
+    date_to: str | None = None
+    explicitDate: bool | None = None
+    filterTestAccounts: bool | None = None
+    ignoreDashboardFilters: bool | None = Field(
         default=None,
         description=(
-            "Optional comparison window — when `compare` is true, the runner returns an extra `compare` result set."
+            "When true, this tile ignores every dashboard-level filter; the tile's own overrides still apply."
         ),
     )
-    dateRange: DateRange
-    filterGroup: PropertyGroupFilter | None = None
-    kind: Literal["TraceSpansAggregationQuery"] = "TraceSpansAggregationQuery"
+    interval: IntervalType | None = None
+    properties: list[AnyPropertyFilterDiscriminated] | None = None
+
+
+class TraceNeighborsQuery(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    dateRange: DateRange | None = None
+    filterSupportTraces: bool | None = None
+    filterTestAccounts: bool | None = None
+    kind: Literal["TraceNeighborsQuery"] = "TraceNeighborsQuery"
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    response: TraceSpansAggregationQueryResponse | None = None
-    serviceNames: list[str] | None = None
+    properties: list[AnyPropertyFilterDiscriminated] | None = Field(
+        default=None, description="Properties configurable in the interface"
+    )
+    response: TraceNeighborsQueryResponse | None = None
     tags: QueryLogTags | None = None
+    timestamp: str = Field(..., description="Timestamp of the current trace to find neighbors for")
+    traceId: str = Field(..., description="ID of the current trace to find neighbors for")
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
 
-class TraceSpansAttributeBreakdownQuery(BaseModel):
+class TraceQuery(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    breakdownKey: str = Field(
-        ...,
-        description=(
-            "Attribute key to group by (e.g. `http.response.status_code`,"
-            " `server.address`). For the `span` breakdown type, must be an allowlisted"
-            " top-level column (`service_name`, `status_code`)."
-        ),
-    )
-    breakdownType: TraceSpanBreakdownType = Field(
-        ...,
-        description=(
-            "Where the key lives: an allowlisted top-level span column, span-level"
-            " attributes, or resource-level attributes."
-        ),
-    )
-    compareFilter: CompareFilter | None = Field(
+    dateRange: DateRange | None = None
+    includeSentiment: bool | None = Field(
         default=None,
-        description=(
-            "Optional comparison window — when `compare` is true, the runner returns an extra `compare` result set."
-        ),
+        description=("Include stored sentiment evaluation results for the trace and its generations."),
     )
-    dateRange: DateRange
-    excludeBreakdownFilter: bool | None = Field(
-        default=None,
-        description=(
-            "Drop filters targeting the breakdown key itself (including `serviceNames`"
-            " for a `service_name` breakdown) so a facet's value list stays complete"
-            " while one of its values is selected."
-        ),
-    )
-    facetSearch: str | None = Field(
-        default=None,
-        description=(
-            "Type-ahead filter over the breakdown field's own values (case-insensitive"
-            " substring match). Lets a facet's value search reach past the row limit."
-        ),
-    )
-    filterGroup: PropertyGroupFilter | None = None
-    kind: Literal["TraceSpansAttributeBreakdownQuery"] = "TraceSpansAttributeBreakdownQuery"
+    kind: Literal["TraceQuery"] = "TraceQuery"
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    orderBy: TraceSpanBreakdownOrderBy | None = Field(
-        default=None,
-        description=("Order rows by span count or error count, descending. Defaults to count."),
+    properties: list[AnyPropertyFilterDiscriminated] | None = Field(
+        default=None, description="Properties configurable in the interface"
     )
-    response: TraceSpansAttributeBreakdownQueryResponse | None = None
-    serviceNames: list[str] | None = None
+    response: TraceQueryResponse | None = None
     tags: QueryLogTags | None = None
+    traceId: str
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
 
-class TraceSpansQuery(BaseModel):
+class TracesQuery(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    after: str | None = Field(default=None, description="Cursor for fetching the next page of results")
-    dateRange: DateRange
-    excludeAttributes: bool | None = Field(
+    dateRange: DateRange | None = None
+    filterSupportTraces: bool | None = None
+    filterTestAccounts: bool | None = None
+    groupKey: str | None = None
+    groupTypeIndex: int | None = None
+    includeSentiment: bool | None = Field(
         default=None,
-        description=("Omit the per-span `attributes` map from results to keep payloads compact"),
+        description=("Include stored sentiment evaluation results for returned traces and direct generation events."),
     )
-    filterGroup: PropertyGroupFilter | None = None
-    flatSpans: bool | None = Field(
-        default=None,
-        description=(
-            "Return the matching spans themselves, one row per span (root and child),"
-            " instead of the whole-trace grouping. Streams the matches under `ORDER BY"
-            " … LIMIT` rather than grouping every matching span by trace, so a filter"
-            " on a hot child attribute (e.g. `code.filepath`) stays bounded. Distinct"
-            " from `rootSpans`, which scopes whole-trace selection. The single-trace"
-            " waterfall never sets this."
-        ),
-    )
-    kind: Literal["TraceSpansQuery"] = "TraceSpansQuery"
+    kind: Literal["TracesQuery"] = "TracesQuery"
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
     offset: int | None = None
-    orderBy: TraceOrderColumn | None = Field(
+    personId: str | None = Field(default=None, description="Person who performed the event")
+    properties: list[AnyPropertyFilterDiscriminated] | None = Field(
+        default=None, description="Properties configurable in the interface"
+    )
+    randomOrder: bool | None = Field(
         default=None,
         description=(
-            "Column to order by. Defaults to timestamp. `timestamp` paginates via"
-            " keyset cursor (`after`); other columns via `offset`."
+            "Use random ordering instead of timestamp DESC. Useful for representative sampling to avoid recency bias."
         ),
     )
-    orderDirection: OrderDirection2 | None = Field(default=None, description="Order direction. Defaults to DESC.")
-    prefetchSpans: int | None = Field(
-        default=None,
-        description=("Prefetch up to this many spans per trace and include them in results"),
-    )
-    response: TraceSpansQueryResponse | None = None
-    rootSpans: bool | None = None
-    serviceNames: list[str] | None = None
-    statusCodes: list[int] | None = None
-    tags: QueryLogTags | None = None
-    traceId: str | None = None
-    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
-
-
-class TraceSpansTreeQuery(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    compareFilter: CompareFilter | None = Field(
-        default=None,
-        description=(
-            "Optional comparison window — when `compare` is true, the runner returns an extra `compare` result set."
-        ),
-    )
-    dateRange: DateRange
-    filterGroup: PropertyGroupFilter | None = None
-    kind: Literal["TraceSpansTreeQuery"] = "TraceSpansTreeQuery"
-    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    response: TraceSpansTreeQueryResponse | None = None
-    serviceName: str = Field(
-        ...,
-        description=(
-            "Service name that scopes the returned tree. Applied to the spans CTE so"
-            " the call-tree only contains spans from this service, even when matched"
-            " traces span multiple services."
-        ),
-    )
-    serviceNames: list[str] | None = None
-    spanName: str = Field(
-        ...,
-        description=(
-            "Span name to scope the matched trace set. Required because the `(trace_id,"
-            " parent_span_id)` self-join is prohibitive without bounding the matched"
-            " traces — at high name cardinality the query becomes unsafe to run."
-        ),
-    )
+    response: TracesQueryResponse | None = None
+    searchTerm: str | None = None
+    showColumnConfigurator: bool | None = None
     tags: QueryLogTags | None = None
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
@@ -27206,6 +26405,51 @@ class WebVitalsPathBreakdownQuery(BaseModel):
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
 
+class ActionsNode(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    custom_name: str | None = None
+    fixedProperties: list[AnyPropertyFilterDiscriminated] | None = Field(
+        default=None,
+        description=("Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person)"),
+    )
+    id: int
+    kind: Literal["ActionsNode"] = "ActionsNode"
+    math: (
+        BaseMathType
+        | FunnelMathType
+        | PropertyMathType
+        | CountPerActorMathType
+        | GroupMathType
+        | ExperimentMetricMathType
+        | CalendarHeatmapMathType
+        | Literal["hogql"]
+        | None
+    ) = None
+    math_group_type_index: MathGroupTypeIndex | None = None
+    math_hogql: str | None = None
+    math_multiplier: float | None = None
+    math_property: str | None = None
+    math_property_revenue_currency: RevenueCurrencyPropertyConfig | None = None
+    math_property_type: str | None = None
+    name: str | None = None
+    optionalInFunnel: bool | None = None
+    properties: list[AnyPropertyFilterDiscriminated] | None = Field(
+        default=None, description="Properties configurable in the interface"
+    )
+    response: dict[str, Any] | None = None
+    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
+
+
+class AnyDataWarehouseNode(RootModel[DataWarehouseNode | FunnelsDataWarehouseNode | LifecycleDataWarehouseNode]):
+    root: DataWarehouseNode | FunnelsDataWarehouseNode | LifecycleDataWarehouseNode
+
+
+class AnyEntityNodeDataWarehouseNode(RootModel[EventsNode | ActionsNode | DataWarehouseNode]):
+    root: EventsNode | ActionsNode | DataWarehouseNode
+
+
 class AssistantLifecycleActorsQuery(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -27215,19 +26459,6 @@ class AssistantLifecycleActorsQuery(BaseModel):
         description=("Bucket date for the data point. Must be an ISO date string (YYYY-MM-DD), e.g. '2024-01-15'."),
     )
     kind: Literal["InsightActorsQuery"] = "InsightActorsQuery"
-    limit: int | None = Field(
-        default=100,
-        description=("Maximum number of persons to return in one page, from 1 to 1000. Higher values are clamped."),
-    )
-    offset: int | None = Field(
-        default=0,
-        description=(
-            "Number of persons to skip before the returned page. Use it with `limit` to"
-            " walk the whole result set: the response reports `limit`, `offset`, and"
-            " `hasMore`, so when `hasMore` is true, call again with `offset` raised by"
-            " `limit`."
-        ),
-    )
     source: AssistantLifecycleQuery = Field(
         ...,
         description=("The source lifecycle insight query whose bucket we are drilling into."),
@@ -27302,6 +26533,37 @@ class CachedErrorTrackingIssueCorrelationQueryResponse(BaseModel):
             " access."
         ),
     )
+
+
+class CoreEvent(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    category: CoreEventCategory = Field(
+        ...,
+        description="Category (acquisition, activation, retention, referral, revenue)",
+    )
+    description: str | None = Field(default=None, description="Optional description")
+    filter: EventsNode | ActionsNode | DataWarehouseNode = Field(
+        ...,
+        description=(
+            "Filter configuration - event, action, or data warehouse node (includes math support for sum, etc.)"
+        ),
+    )
+    id: str = Field(..., description="Unique identifier")
+    name: str = Field(..., description="Display name")
+
+
+class CustomerAnalyticsConfig(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    account_group_type_index: int | None = None
+    activity_event: EventsNode | ActionsNode
+    payment_event: EventsNode | ActionsNode
+    signup_event: EventsNode | ActionsNode
+    signup_pageview_event: EventsNode | ActionsNode
+    subscription_event: EventsNode | ActionsNode
 
 
 class Response16(BaseModel):
@@ -27470,23 +26732,6 @@ class DetectorConfig(
     ) = Field(..., description="Detector configuration types", discriminator="type")
 
 
-class ErrorTrackingBreakdownsQuery(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    breakdownProperties: list[str]
-    dateRange: DateRange | None = None
-    filterGroup: PropertyGroupFilter | None = None
-    filterTestAccounts: bool | None = None
-    issueId: str
-    kind: Literal["ErrorTrackingBreakdownsQuery"] = "ErrorTrackingBreakdownsQuery"
-    maxValuesPerProperty: int | None = None
-    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    response: ErrorTrackingBreakdownsQueryResponse | None = None
-    tags: QueryLogTags | None = None
-    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
-
-
 class ErrorTrackingIssueCorrelationQuery(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -27495,6 +26740,330 @@ class ErrorTrackingIssueCorrelationQuery(BaseModel):
     kind: Literal["ErrorTrackingIssueCorrelationQuery"] = "ErrorTrackingIssueCorrelationQuery"
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
     response: ErrorTrackingIssueCorrelationQueryResponse | None = None
+    tags: QueryLogTags | None = None
+    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
+
+
+class ExperimentExposureCriteria(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    activation_config: ExperimentEventExposureConfig | ActionsNode | None = Field(
+        default=None,
+        description=(
+            "Additional event (or action) an entity must emit at/after their first"
+            " default exposure event before they count as exposed; exposure time"
+            " becomes this event's timestamp. Only valid with the default exposure"
+            " event, not a custom `exposure_config`."
+        ),
+    )
+    exposure_config: ExperimentEventExposureConfig | ActionsNode | None = None
+    filterTestAccounts: bool | None = None
+    multiple_variant_handling: MultipleVariantHandling | None = None
+
+
+class ExperimentHoldoutType(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    created_at: str | None = None
+    created_by: UserBasicType | None = None
+    description: str | None = None
+    filters: list[FeatureFlagGroupType]
+    id: int
+    name: str
+    updated_at: str | None = None
+    user_access_level: AccessControlLevel | None = Field(
+        default=None,
+        description=("Read-only, server-computed effective access level; absent on a not-yet-created holdout."),
+    )
+
+
+class FunnelsFilter(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    binCount: int | None = None
+    breakdownAttributionType: BreakdownAttributionType | None = BreakdownAttributionType.FIRST_TOUCH
+    breakdownAttributionValue: int | None = None
+    breakdownSorting: str | None = Field(
+        default=None,
+        description=("Breakdown table sorting. Format: 'column_key' or '-column_key' (descending)"),
+    )
+    chartStyle: ChartStyle | None = Field(
+        default=None,
+        description=("Chart rendering style overrides (line shape). Only applies to historical-trends funnels."),
+    )
+    customAggregationTarget: bool | None = Field(
+        default=None,
+        description=(
+            "For data warehouse based funnel insights when the aggregation target can't be mapped to persons or groups."
+        ),
+    )
+    exclusions: (
+        list[Annotated[FunnelExclusionEventsNode | FunnelExclusionActionsNode, Field(discriminator="kind")]] | None
+    ) = []
+    funnelAggregateByHogQL: str | None = None
+    funnelFromStep: int | None = None
+    funnelOrderType: StepOrderValue | None = StepOrderValue.ORDERED
+    funnelStepReference: FunnelStepReference | None = FunnelStepReference.TOTAL
+    funnelToStep: int | None = Field(
+        default=None,
+        description=("To select the range of steps for trends & time to convert funnels, 0-indexed"),
+    )
+    funnelVizType: FunnelVizType | None = FunnelVizType.STEPS
+    funnelWindowInterval: int | None = 14
+    funnelWindowIntervalUnit: FunnelConversionWindowTimeUnit | None = FunnelConversionWindowTimeUnit.DAY
+    goalLines: list[GoalLine] | None = Field(default=None, description="Goal Lines")
+    hiddenLegendBreakdowns: list[str] | None = None
+    hideIncompleteConversionWindowPeriods: bool | None = Field(
+        default=False,
+        description=(
+            "Trends only: hide periods whose conversion window has not fully elapsed"
+            " yet, so the recent tail of the trend isn't dragged down by entrants who"
+            " still have time to convert."
+        ),
+    )
+    layout: FunnelLayout | None = FunnelLayout.VERTICAL
+    legendPosition: LegendPosition | None = Field(
+        default=LegendPosition.BOTTOM,
+        description=("Where the in-chart legend sits relative to the plot. Only applies to the in-chart legend."),
+    )
+    resultCustomizations: dict[str, ResultCustomizationByValue] | None = Field(
+        default=None,
+        description="Customizations for the appearance of result datasets.",
+    )
+    showAnnotations: bool | None = Field(
+        default=True,
+        description=("Whether to render annotations on the chart. Only applies to historical-trends funnels."),
+    )
+    showLegend: bool | None = Field(
+        default=False,
+        description=(
+            "Whether to show a legend describing the series. The legend only renders"
+            " when the funnel has multiple series. Only applies to historical-trends"
+            " funnels."
+        ),
+    )
+    showTrendLines: bool | None = Field(
+        default=None,
+        description=("Display linear regression trend lines on the chart (only for historical trends viz)"),
+    )
+    showValuesOnSeries: bool | None = False
+    useUdf: bool | None = None
+
+
+class InsightFilter(
+    RootModel[
+        TrendsFilter
+        | FunnelsFilter
+        | RetentionFilter
+        | PathsFilter
+        | PathsV2Filter
+        | StickinessFilter
+        | LifecycleFilter
+        | CalendarHeatmapFilter
+        | list[EventPropertyFilter | PersonPropertyFilter | SessionPropertyFilter | CohortPropertyFilter]
+    ]
+):
+    root: (
+        TrendsFilter
+        | FunnelsFilter
+        | RetentionFilter
+        | PathsFilter
+        | PathsV2Filter
+        | StickinessFilter
+        | LifecycleFilter
+        | CalendarHeatmapFilter
+        | list[EventPropertyFilter | PersonPropertyFilter | SessionPropertyFilter | CohortPropertyFilter]
+    )
+
+
+class PropertyGroupFilter(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    type: FilterLogicalOperator
+    values: list[PropertyGroupFilterValue]
+
+
+class RetentionQuery(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    aggregation_group_type_index: int | None = Field(default=None, description="Groups aggregation")
+    breakdownFilter: BreakdownFilter | None = Field(default=None, description="Breakdown of the events and actions")
+    dataColorTheme: float | None = Field(default=None, description="Colors used in the insight's visualization")
+    dateRange: DateRange | None = Field(default=None, description="Date range for the query")
+    filterTestAccounts: bool | None = Field(
+        default=False,
+        description=("Exclude internal and test users by applying the respective filters"),
+    )
+    kind: Literal["RetentionQuery"] = "RetentionQuery"
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    properties: list[AnyPropertyFilterDiscriminated] | PropertyGroupFilter | None = Field(
+        default=[], description="Property filters for all series"
+    )
+    response: RetentionQueryResponse | None = None
+    retentionFilter: RetentionFilter = Field(..., description="Properties specific to the retention insight")
+    samplingFactor: float | None = Field(default=None, description="Sampling rate")
+    tags: QueryLogTags | None = Field(default=None, description="Tags that will be added to the Query log comment")
+    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
+
+
+class TraceSpansAggregationQuery(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    compareFilter: CompareFilter | None = Field(
+        default=None,
+        description=(
+            "Optional comparison window — when `compare` is true, the runner returns an extra `compare` result set."
+        ),
+    )
+    dateRange: DateRange
+    filterGroup: PropertyGroupFilter | None = None
+    kind: Literal["TraceSpansAggregationQuery"] = "TraceSpansAggregationQuery"
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    response: TraceSpansAggregationQueryResponse | None = None
+    serviceNames: list[str] | None = None
+    tags: QueryLogTags | None = None
+    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
+
+
+class TraceSpansAttributeBreakdownQuery(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    breakdownKey: str = Field(
+        ...,
+        description=(
+            "Attribute key to group by (e.g. `http.response.status_code`,"
+            " `server.address`). For the `span` breakdown type, must be an allowlisted"
+            " top-level column (`service_name`, `status_code`)."
+        ),
+    )
+    breakdownType: TraceSpanBreakdownType = Field(
+        ...,
+        description=(
+            "Where the key lives: an allowlisted top-level span column, span-level"
+            " attributes, or resource-level attributes."
+        ),
+    )
+    compareFilter: CompareFilter | None = Field(
+        default=None,
+        description=(
+            "Optional comparison window — when `compare` is true, the runner returns an extra `compare` result set."
+        ),
+    )
+    dateRange: DateRange
+    excludeBreakdownFilter: bool | None = Field(
+        default=None,
+        description=(
+            "Drop filters targeting the breakdown key itself (including `serviceNames`"
+            " for a `service_name` breakdown) so a facet's value list stays complete"
+            " while one of its values is selected."
+        ),
+    )
+    facetSearch: str | None = Field(
+        default=None,
+        description=(
+            "Type-ahead filter over the breakdown field's own values (case-insensitive"
+            " substring match). Lets a facet's value search reach past the row limit."
+        ),
+    )
+    filterGroup: PropertyGroupFilter | None = None
+    kind: Literal["TraceSpansAttributeBreakdownQuery"] = "TraceSpansAttributeBreakdownQuery"
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    orderBy: TraceSpanBreakdownOrderBy | None = Field(
+        default=None,
+        description=("Order rows by span count or error count, descending. Defaults to count."),
+    )
+    response: TraceSpansAttributeBreakdownQueryResponse | None = None
+    serviceNames: list[str] | None = None
+    tags: QueryLogTags | None = None
+    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
+
+
+class TraceSpansQuery(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    after: str | None = Field(default=None, description="Cursor for fetching the next page of results")
+    dateRange: DateRange
+    excludeAttributes: bool | None = Field(
+        default=None,
+        description=("Omit the per-span `attributes` map from results to keep payloads compact"),
+    )
+    filterGroup: PropertyGroupFilter | None = None
+    flatSpans: bool | None = Field(
+        default=None,
+        description=(
+            "Return the matching spans themselves, one row per span (root and child),"
+            " instead of the whole-trace grouping. Streams the matches under `ORDER BY"
+            " … LIMIT` rather than grouping every matching span by trace, so a filter"
+            " on a hot child attribute (e.g. `code.filepath`) stays bounded. Distinct"
+            " from `rootSpans`, which scopes whole-trace selection. The single-trace"
+            " waterfall never sets this."
+        ),
+    )
+    kind: Literal["TraceSpansQuery"] = "TraceSpansQuery"
+    limit: int | None = None
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    offset: int | None = None
+    orderBy: TraceOrderColumn | None = Field(
+        default=None,
+        description=(
+            "Column to order by. Defaults to timestamp. `timestamp` paginates via"
+            " keyset cursor (`after`); other columns via `offset`."
+        ),
+    )
+    orderDirection: OrderDirection2 | None = Field(default=None, description="Order direction. Defaults to DESC.")
+    prefetchSpans: int | None = Field(
+        default=None,
+        description=("Prefetch up to this many spans per trace and include them in results"),
+    )
+    response: TraceSpansQueryResponse | None = None
+    rootSpans: bool | None = None
+    serviceNames: list[str] | None = None
+    statusCodes: list[int] | None = None
+    tags: QueryLogTags | None = None
+    traceId: str | None = None
+    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
+
+
+class TraceSpansTreeQuery(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    compareFilter: CompareFilter | None = Field(
+        default=None,
+        description=(
+            "Optional comparison window — when `compare` is true, the runner returns an extra `compare` result set."
+        ),
+    )
+    dateRange: DateRange
+    filterGroup: PropertyGroupFilter | None = None
+    kind: Literal["TraceSpansTreeQuery"] = "TraceSpansTreeQuery"
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    response: TraceSpansTreeQueryResponse | None = None
+    serviceName: str = Field(
+        ...,
+        description=(
+            "Service name that scopes the returned tree. Applied to the spans CTE so"
+            " the call-tree only contains spans from this service, even when matched"
+            " traces span multiple services."
+        ),
+    )
+    serviceNames: list[str] | None = None
+    spanName: str = Field(
+        ...,
+        description=(
+            "Span name to scope the matched trace set. Required because the `(trace_id,"
+            " parent_span_id)` self-join is prohibitive without bounding the matched"
+            " traces — at high name cardinality the query becomes unsafe to run."
+        ),
+    )
     tags: QueryLogTags | None = None
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
@@ -27566,14 +27135,6 @@ class ExperimentExposureQuery(BaseModel):
 class ExperimentFunnelMetricTypeProps(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
-    )
-    breakdownAttributionType: BreakdownAttributionType | None = Field(
-        default=BreakdownAttributionType.FIRST_TOUCH,
-        description="How to attribute the breakdown value across funnel steps.",
-    )
-    breakdownAttributionValue: int | None = Field(
-        default=None,
-        description=("When breakdownAttributionType is `step`, the 0-indexed step to attribute from."),
     )
     funnel_order_type: StepOrderValue | None = None
     metric_type: Literal["funnel"] = "funnel"
@@ -27951,6 +27512,24 @@ class PathsV2Query(BaseModel):
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
 
+class QueryResponseAlternative67(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    joins: list[DataWarehouseViewLink]
+    tables: dict[
+        str,
+        DatabaseSchemaPostHogTable
+        | DatabaseSchemaSystemTable
+        | DatabaseSchemaDataWarehouseTable
+        | DatabaseSchemaViewTable
+        | DatabaseSchemaManagedViewTable
+        | DatabaseSchemaBatchExportTable
+        | DatabaseSchemaMaterializedViewTable
+        | DatabaseSchemaEndpointTable,
+    ]
+
+
 class SessionsQuery(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -28036,17 +27615,27 @@ class CalendarHeatmapQuery(BaseModel):
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
 
-class ExperimentFunnelMetric(BaseModel):
+class DatabaseSchemaQueryResponse(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    breakdownAttributionType: BreakdownAttributionType | None = Field(
-        default=BreakdownAttributionType.FIRST_TOUCH,
-        description="How to attribute the breakdown value across funnel steps.",
-    )
-    breakdownAttributionValue: int | None = Field(
-        default=None,
-        description=("When breakdownAttributionType is `step`, the 0-indexed step to attribute from."),
+    joins: list[DataWarehouseViewLink]
+    tables: dict[
+        str,
+        DatabaseSchemaPostHogTable
+        | DatabaseSchemaSystemTable
+        | DatabaseSchemaDataWarehouseTable
+        | DatabaseSchemaViewTable
+        | DatabaseSchemaManagedViewTable
+        | DatabaseSchemaBatchExportTable
+        | DatabaseSchemaMaterializedViewTable
+        | DatabaseSchemaEndpointTable,
+    ]
+
+
+class ExperimentFunnelMetric(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
     )
     breakdownFilter: BreakdownFilter | None = None
     conversion_window: int | None = None
@@ -28204,24 +27793,6 @@ class PathsV2ActorsQuery(BaseModel):
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
 
-class QueryResponseAlternative68(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    joins: list[DataWarehouseViewLink]
-    tables: dict[
-        str,
-        DatabaseSchemaPostHogTable
-        | DatabaseSchemaSystemTable
-        | DatabaseSchemaDataWarehouseTable
-        | DatabaseSchemaViewTable
-        | DatabaseSchemaManagedViewTable
-        | DatabaseSchemaBatchExportTable
-        | DatabaseSchemaMaterializedViewTable
-        | DatabaseSchemaEndpointTable,
-    ]
-
-
 class StickinessQuery(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -28258,22 +27829,30 @@ class StickinessQuery(BaseModel):
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
 
-class DatabaseSchemaQueryResponse(BaseModel):
+class DatabaseSchemaQuery(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    joins: list[DataWarehouseViewLink]
-    tables: dict[
-        str,
-        DatabaseSchemaPostHogTable
-        | DatabaseSchemaSystemTable
-        | DatabaseSchemaDataWarehouseTable
-        | DatabaseSchemaViewTable
-        | DatabaseSchemaManagedViewTable
-        | DatabaseSchemaBatchExportTable
-        | DatabaseSchemaMaterializedViewTable
-        | DatabaseSchemaEndpointTable,
-    ]
+    connectionId: str | None = Field(
+        default=None,
+        description="Optional direct external data source id for schema introspection",
+    )
+    includeFields: bool | None = Field(
+        default=None,
+        description=("When false, skip serializing each table's fields (`fields` comes back empty). Defaults to true."),
+    )
+    kind: Literal["DatabaseSchemaQuery"] = "DatabaseSchemaQuery"
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    response: DatabaseSchemaQueryResponse | None = None
+    tables: list[str] | None = Field(
+        default=None,
+        description=(
+            "Only serialize these tables (keys as returned in the response, e.g."
+            " `events` or `zendesk.groups`). Omit for all tables."
+        ),
+    )
+    tags: QueryLogTags | None = None
+    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
 
 class ExperimentMetric(
@@ -28342,7 +27921,7 @@ class LegacyExperimentQueryResponse(BaseModel):
     )
 
 
-class QueryResponseAlternative19(BaseModel):
+class QueryResponseAlternative18(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -28609,32 +28188,6 @@ class Response18(BaseModel):
     )
 
 
-class DatabaseSchemaQuery(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    connectionId: str | None = Field(
-        default=None,
-        description="Optional direct external data source id for schema introspection",
-    )
-    includeFields: bool | None = Field(
-        default=None,
-        description=("When false, skip serializing each table's fields (`fields` comes back empty). Defaults to true."),
-    )
-    kind: Literal["DatabaseSchemaQuery"] = "DatabaseSchemaQuery"
-    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    response: DatabaseSchemaQueryResponse | None = None
-    tables: list[str] | None = Field(
-        default=None,
-        description=(
-            "Only serialize these tables (keys as returned in the response, e.g."
-            " `events` or `zendesk.groups`). Omit for all tables."
-        ),
-    )
-    tags: QueryLogTags | None = None
-    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
-
-
 class EndpointRequest(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -28769,7 +28322,7 @@ class FunnelsQuery(BaseModel):
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
 
-class QueryResponseAlternative17(BaseModel):
+class QueryResponseAlternative16(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -28789,7 +28342,7 @@ class QueryResponseAlternative17(BaseModel):
     )
 
 
-class QueryResponseAlternative18(BaseModel):
+class QueryResponseAlternative17(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -28810,7 +28363,7 @@ class QueryResponseAlternative18(BaseModel):
     )
 
 
-class QueryResponseAlternative53(BaseModel):
+class QueryResponseAlternative52(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -28830,7 +28383,7 @@ class QueryResponseAlternative53(BaseModel):
     )
 
 
-class QueryResponseAlternative54(BaseModel):
+class QueryResponseAlternative53(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -28888,8 +28441,8 @@ class QueryResponseAlternative(
         | QueryResponseAlternative32
         | QueryResponseAlternative33
         | QueryResponseAlternative34
-        | QueryResponseAlternative35
         | Any
+        | QueryResponseAlternative35
         | QueryResponseAlternative36
         | QueryResponseAlternative37
         | QueryResponseAlternative38
@@ -28905,10 +28458,10 @@ class QueryResponseAlternative(
         | QueryResponseAlternative48
         | QueryResponseAlternative49
         | QueryResponseAlternative50
-        | QueryResponseAlternative51
+        | QueryResponseAlternative52
         | QueryResponseAlternative53
         | QueryResponseAlternative54
-        | QueryResponseAlternative55
+        | QueryResponseAlternative56
         | QueryResponseAlternative57
         | QueryResponseAlternative58
         | QueryResponseAlternative59
@@ -28917,7 +28470,7 @@ class QueryResponseAlternative(
         | QueryResponseAlternative62
         | QueryResponseAlternative63
         | QueryResponseAlternative64
-        | QueryResponseAlternative65
+        | QueryResponseAlternative66
         | QueryResponseAlternative67
         | QueryResponseAlternative68
         | QueryResponseAlternative69
@@ -28933,7 +28486,7 @@ class QueryResponseAlternative(
         | QueryResponseAlternative79
         | QueryResponseAlternative80
         | QueryResponseAlternative81
-        | QueryResponseAlternative82
+        | QueryResponseAlternative84
         | QueryResponseAlternative85
         | QueryResponseAlternative86
         | QueryResponseAlternative87
@@ -28957,8 +28510,6 @@ class QueryResponseAlternative(
         | QueryResponseAlternative105
         | QueryResponseAlternative106
         | QueryResponseAlternative107
-        | QueryResponseAlternative108
-        | QueryResponseAlternative109
     ]
 ):
     root: (
@@ -28997,8 +28548,8 @@ class QueryResponseAlternative(
         | QueryResponseAlternative32
         | QueryResponseAlternative33
         | QueryResponseAlternative34
-        | QueryResponseAlternative35
         | Any
+        | QueryResponseAlternative35
         | QueryResponseAlternative36
         | QueryResponseAlternative37
         | QueryResponseAlternative38
@@ -29014,10 +28565,10 @@ class QueryResponseAlternative(
         | QueryResponseAlternative48
         | QueryResponseAlternative49
         | QueryResponseAlternative50
-        | QueryResponseAlternative51
+        | QueryResponseAlternative52
         | QueryResponseAlternative53
         | QueryResponseAlternative54
-        | QueryResponseAlternative55
+        | QueryResponseAlternative56
         | QueryResponseAlternative57
         | QueryResponseAlternative58
         | QueryResponseAlternative59
@@ -29026,7 +28577,7 @@ class QueryResponseAlternative(
         | QueryResponseAlternative62
         | QueryResponseAlternative63
         | QueryResponseAlternative64
-        | QueryResponseAlternative65
+        | QueryResponseAlternative66
         | QueryResponseAlternative67
         | QueryResponseAlternative68
         | QueryResponseAlternative69
@@ -29042,7 +28593,7 @@ class QueryResponseAlternative(
         | QueryResponseAlternative79
         | QueryResponseAlternative80
         | QueryResponseAlternative81
-        | QueryResponseAlternative82
+        | QueryResponseAlternative84
         | QueryResponseAlternative85
         | QueryResponseAlternative86
         | QueryResponseAlternative87
@@ -29066,8 +28617,6 @@ class QueryResponseAlternative(
         | QueryResponseAlternative105
         | QueryResponseAlternative106
         | QueryResponseAlternative107
-        | QueryResponseAlternative108
-        | QueryResponseAlternative109
     )
 
 
@@ -29672,6 +29221,7 @@ class ActorsQuery(BaseModel):
             | CohortPropertyFilter
             | HogQLPropertyFilter
             | EmptyPropertyFilter
+            | BehavioralPropertyFilter
         ]
         | None
     ) = Field(
@@ -29693,6 +29243,7 @@ class ActorsQuery(BaseModel):
             | CohortPropertyFilter
             | HogQLPropertyFilter
             | EmptyPropertyFilter
+            | BehavioralPropertyFilter
         ]
         | PropertyGroupFilterValue
         | None
@@ -29999,7 +29550,6 @@ class HogQLAutocomplete(BaseModel):
         | SessionAttributionExplorerQuery
         | ErrorTrackingQuery
         | ErrorTrackingSimilarIssuesQuery
-        | ErrorTrackingFingerprintProjectionQuery
         | ErrorTrackingBreakdownsQuery
         | ErrorTrackingIssueCorrelationQuery
         | LogsQuery
@@ -30037,7 +29587,6 @@ class HogQLAutocomplete(BaseModel):
         | MCPToolQualityDailyStatsQuery
         | MCPToolCategoryCountsQuery
         | MCPToolCategoriesQuery
-        | MCPToolCategoryMapQuery
         | MCPToolDescriptionsQuery
         | MCPToolSampleIntentsQuery
         | MCPToolNeighborsQuery
@@ -30113,7 +29662,6 @@ class HogQLMetadata(BaseModel):
         | SessionAttributionExplorerQuery
         | ErrorTrackingQuery
         | ErrorTrackingSimilarIssuesQuery
-        | ErrorTrackingFingerprintProjectionQuery
         | ErrorTrackingBreakdownsQuery
         | ErrorTrackingIssueCorrelationQuery
         | LogsQuery
@@ -30151,7 +29699,6 @@ class HogQLMetadata(BaseModel):
         | MCPToolQualityDailyStatsQuery
         | MCPToolCategoryCountsQuery
         | MCPToolCategoriesQuery
-        | MCPToolCategoryMapQuery
         | MCPToolDescriptionsQuery
         | MCPToolSampleIntentsQuery
         | MCPToolNeighborsQuery
@@ -30221,7 +29768,6 @@ class MaxInsightContext(BaseModel):
         | SessionAttributionExplorerQuery
         | ErrorTrackingQuery
         | ErrorTrackingSimilarIssuesQuery
-        | ErrorTrackingFingerprintProjectionQuery
         | ErrorTrackingBreakdownsQuery
         | ErrorTrackingIssueCorrelationQuery
         | ExperimentFunnelsQuery
@@ -30293,7 +29839,6 @@ class MaxInsightContext(BaseModel):
         | MCPToolQualityDailyStatsQuery
         | MCPToolCategoryCountsQuery
         | MCPToolCategoriesQuery
-        | MCPToolCategoryMapQuery
         | MCPToolDescriptionsQuery
         | MCPToolSampleIntentsQuery
         | MCPToolNeighborsQuery
@@ -30359,7 +29904,6 @@ class QueryRequest(BaseModel):
         | SessionAttributionExplorerQuery
         | ErrorTrackingQuery
         | ErrorTrackingSimilarIssuesQuery
-        | ErrorTrackingFingerprintProjectionQuery
         | ErrorTrackingBreakdownsQuery
         | ErrorTrackingIssueCorrelationQuery
         | ExperimentFunnelsQuery
@@ -30431,7 +29975,6 @@ class QueryRequest(BaseModel):
         | MCPToolQualityDailyStatsQuery
         | MCPToolCategoryCountsQuery
         | MCPToolCategoriesQuery
-        | MCPToolCategoryMapQuery
         | MCPToolDescriptionsQuery
         | MCPToolSampleIntentsQuery
         | MCPToolNeighborsQuery
@@ -30489,7 +30032,6 @@ class QuerySchemaRoot(
         | SessionAttributionExplorerQuery
         | ErrorTrackingQuery
         | ErrorTrackingSimilarIssuesQuery
-        | ErrorTrackingFingerprintProjectionQuery
         | ErrorTrackingBreakdownsQuery
         | ErrorTrackingIssueCorrelationQuery
         | ExperimentFunnelsQuery
@@ -30561,7 +30103,6 @@ class QuerySchemaRoot(
         | MCPToolQualityDailyStatsQuery
         | MCPToolCategoryCountsQuery
         | MCPToolCategoriesQuery
-        | MCPToolCategoryMapQuery
         | MCPToolDescriptionsQuery
         | MCPToolSampleIntentsQuery
         | MCPToolNeighborsQuery
@@ -30589,7 +30130,6 @@ class QuerySchemaRoot(
         | SessionAttributionExplorerQuery
         | ErrorTrackingQuery
         | ErrorTrackingSimilarIssuesQuery
-        | ErrorTrackingFingerprintProjectionQuery
         | ErrorTrackingBreakdownsQuery
         | ErrorTrackingIssueCorrelationQuery
         | ExperimentFunnelsQuery
@@ -30661,7 +30201,6 @@ class QuerySchemaRoot(
         | MCPToolQualityDailyStatsQuery
         | MCPToolCategoryCountsQuery
         | MCPToolCategoriesQuery
-        | MCPToolCategoryMapQuery
         | MCPToolDescriptionsQuery
         | MCPToolSampleIntentsQuery
         | MCPToolNeighborsQuery
@@ -30694,7 +30233,6 @@ class QueryUpgradeRequest(BaseModel):
         | SessionAttributionExplorerQuery
         | ErrorTrackingQuery
         | ErrorTrackingSimilarIssuesQuery
-        | ErrorTrackingFingerprintProjectionQuery
         | ErrorTrackingBreakdownsQuery
         | ErrorTrackingIssueCorrelationQuery
         | ExperimentFunnelsQuery
@@ -30766,7 +30304,6 @@ class QueryUpgradeRequest(BaseModel):
         | MCPToolQualityDailyStatsQuery
         | MCPToolCategoryCountsQuery
         | MCPToolCategoriesQuery
-        | MCPToolCategoryMapQuery
         | MCPToolDescriptionsQuery
         | MCPToolSampleIntentsQuery
         | MCPToolNeighborsQuery
@@ -30799,7 +30336,6 @@ class QueryUpgradeResponse(BaseModel):
         | SessionAttributionExplorerQuery
         | ErrorTrackingQuery
         | ErrorTrackingSimilarIssuesQuery
-        | ErrorTrackingFingerprintProjectionQuery
         | ErrorTrackingBreakdownsQuery
         | ErrorTrackingIssueCorrelationQuery
         | ExperimentFunnelsQuery
@@ -30871,7 +30407,6 @@ class QueryUpgradeResponse(BaseModel):
         | MCPToolQualityDailyStatsQuery
         | MCPToolCategoryCountsQuery
         | MCPToolCategoriesQuery
-        | MCPToolCategoryMapQuery
         | MCPToolDescriptionsQuery
         | MCPToolSampleIntentsQuery
         | MCPToolNeighborsQuery
@@ -31090,7 +30625,6 @@ class VisualizationArtifactContent(BaseModel):
         | SessionAttributionExplorerQuery
         | ErrorTrackingQuery
         | ErrorTrackingSimilarIssuesQuery
-        | ErrorTrackingFingerprintProjectionQuery
         | ErrorTrackingBreakdownsQuery
         | ErrorTrackingIssueCorrelationQuery
         | ExperimentFunnelsQuery
@@ -31162,7 +30696,6 @@ class VisualizationArtifactContent(BaseModel):
         | MCPToolQualityDailyStatsQuery
         | MCPToolCategoryCountsQuery
         | MCPToolCategoriesQuery
-        | MCPToolCategoryMapQuery
         | MCPToolDescriptionsQuery
         | MCPToolSampleIntentsQuery
         | MCPToolNeighborsQuery

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -14,6 +14,7 @@ from posthog.schema_discriminators import property_filter_discriminator
 from posthog.schema_enums import (
     AccessControlLevel as AccessControlLevel,
     AccountsTableAccountField as AccountsTableAccountField,
+    AccountsTableAccountFieldOperator as AccountsTableAccountFieldOperator,
     AccountsTableAggregation as AccountsTableAggregation,
     AccountsTableCustomPropertyOperator as AccountsTableCustomPropertyOperator,
     AccountsTableSortDirection as AccountsTableSortDirection,
@@ -100,6 +101,7 @@ from posthog.schema_enums import (
     ErrorTrackingIssueAssigneeType as ErrorTrackingIssueAssigneeType,
     ErrorTrackingIssueStatus as ErrorTrackingIssueStatus,
     ErrorTrackingOrderBy as ErrorTrackingOrderBy,
+    ErrorTrackingQueryIssueSeverity as ErrorTrackingQueryIssueSeverity,
     EvaluationRuntime as EvaluationRuntime,
     ExperimentMetricGoal as ExperimentMetricGoal,
     ExperimentMetricMathType as ExperimentMetricMathType,
@@ -1222,6 +1224,15 @@ class Population(BaseModel):
     success_only: float
 
 
+class ErrorTrackingFingerprintProjectionPoint(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    fingerprint: str
+    x: float
+    y: float
+
+
 class FirstEvent(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -1718,6 +1729,14 @@ class MCPToolCategoryItem(BaseModel):
         extra="forbid",
     )
     category: str
+
+
+class MCPToolCategoryMapItem(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    category: str
+    tool: str
 
 
 class MCPToolDescriptionItem(BaseModel):
@@ -2441,7 +2460,7 @@ class QueryResponseAlternative7(BaseModel):
     stdout: str | None = None
 
 
-class QueryResponseAlternative77(BaseModel):
+class QueryResponseAlternative78(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -3084,6 +3103,16 @@ class AccountCustomPropertyFilter(BaseModel):
     value: list[str | float | bool] | str | float | bool | None = None
 
 
+class AccountsTableAccountFieldFilter(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    field: AccountsTableAccountField
+    kind: Literal["account_field"] = "account_field"
+    operator: AccountsTableAccountFieldOperator
+    values: list[str] | None = None
+
+
 class AccountsTableAggregateMetric(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -3290,7 +3319,8 @@ class AssistantDataVisualizationChartSettings(BaseModel):
         description=(
             "Column that splits a single Y series into multiple colored series — e.g."
             " breaking down a line chart by `country`. Set to `null` or omit to"
-            " disable."
+            " disable. A breakdown buckets rows by x value, so it is ignored when"
+            " `display` is `ScatterPlot`."
         ),
     )
     showLegend: bool | None = Field(default=None, description="Show the chart legend.")
@@ -3309,7 +3339,11 @@ class AssistantDataVisualizationChartSettings(BaseModel):
     )
     xAxis: AssistantDataVisualizationAxis | None = Field(
         default=None,
-        description=("Column used as the X axis. Typically a time bucket or categorical column."),
+        description=(
+            "Column used as the X axis. Typically a time bucket or categorical column,"
+            " but `ScatterPlot` plots two measures against each other, so it needs a"
+            " numeric column here too."
+        ),
     )
     xAxisLabel: str | None = Field(default=None, description="Label rendered under the X axis.")
     yAxis: list[AssistantDataVisualizationAxis] | None = Field(
@@ -4473,6 +4507,14 @@ class AutocompleteCompletionItem(BaseModel):
             " is inserted when selecting this completion."
         ),
     )
+    sortText: str | None = Field(
+        default=None,
+        description=(
+            "Overrides the editor's default ordering for this item. Set when the"
+            " backend can rank a suggestion, for example a function whose return type"
+            " fits the comparison being written."
+        ),
+    )
 
 
 class BoxPlotDatum(BaseModel):
@@ -4772,6 +4814,7 @@ class ErrorTrackingPendingFingerprintIssueStateUpdate(BaseModel):
     issue_description: str | None = None
     issue_id: str
     issue_name: str | None = None
+    issue_severity: ErrorTrackingQueryIssueSeverity | None = None
     issue_status: str
     version: int = Field(
         ...,
@@ -6317,7 +6360,7 @@ class QueryResponseAlternative10(BaseModel):
     )
 
 
-class QueryResponseAlternative19(BaseModel):
+class QueryResponseAlternative20(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -6333,7 +6376,7 @@ class QueryResponseAlternative19(BaseModel):
     )
 
 
-class QueryResponseAlternative28(BaseModel):
+class QueryResponseAlternative29(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -6342,7 +6385,7 @@ class QueryResponseAlternative28(BaseModel):
     status: ExternalQueryStatus
 
 
-class QueryResponseAlternative84(BaseModel):
+class QueryResponseAlternative85(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -8928,8 +8971,9 @@ class AssistantDataVisualizationNode(BaseModel):
             " row) → `BoldNumber`.\n- Time series → `ActionsLineGraph` or"
             " `ActionsAreaGraph`.\n- Categorical proportions → `ActionsPie`.\n-"
             " Categorical comparison → `ActionsBar` or `ActionsStackedBar`.\n-"
-            " Two-dimensional aggregation → `TwoDimensionalHeatmap`.\n- Otherwise →"
-            " `ActionsTable`."
+            " Two-dimensional aggregation → `TwoDimensionalHeatmap`.\n- Relationship"
+            " between two numeric measures, one point per row → `ScatterPlot`.\n-"
+            " Otherwise → `ActionsTable`."
         ),
     )
     kind: Literal["DataVisualizationNode"] = "DataVisualizationNode"
@@ -11080,6 +11124,65 @@ class CachedErrorTrackingBreakdownsQueryResponse(BaseModel):
     )
 
 
+class CachedErrorTrackingFingerprintProjectionQueryResponse(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    cache_key: str
+    cache_target_age: AwareDatetime | None = None
+    calculation_trigger: str | None = Field(
+        default=None,
+        description=("What triggered the calculation of the query, leave empty if user/immediate"),
+    )
+    error: str | None = Field(
+        default=None,
+        description=(
+            "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise."
+        ),
+    )
+    hasMore: bool | None = None
+    hogql: str | None = Field(default=None, description="Generated HogQL query.")
+    is_cached: bool
+    last_refresh: AwareDatetime
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    next_allowed_client_refresh: AwareDatetime
+    query_metadata: dict[str, Any] | None = None
+    query_status: QueryStatus | None = Field(
+        default=None,
+        description=("Query status indicates whether next to the provided data, a query is still running."),
+    )
+    resolved_compare_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None,
+        description=("The resolved previous/comparison period date range, when comparing against another period"),
+    )
+    resolved_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None, description="The date range used for the query"
+    )
+    results: list[ErrorTrackingFingerprintProjectionPoint]
+    timezone: str
+    timings: list[QueryTiming] | None = Field(
+        default=None,
+        description=("Measured timings for different parts of the query generation process"),
+    )
+    used_data_warehouse_sources: list[DataWarehouseSourceUsage] | None = Field(
+        default=None,
+        description=("Connector-synced data warehouse sources referenced by this query, if any."),
+    )
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+        default=None,
+        description=(
+            "Warnings about data warehouse sources referenced by the query whose"
+            " latest sync failed, is paused, hit a billing limit, or is otherwise"
+            " stale. Results may not reflect current source data. Accumulated"
+            " across every HogQL execution that contributes to this response — so"
+            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
+            " the same warnings as raw HogQL queries. Also carries access control"
+            " warnings when a system-table query filters out objects the user can't"
+            " access."
+        ),
+    )
+
+
 class CachedErrorTrackingSimilarIssuesQueryResponse(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -11876,6 +11979,64 @@ class CachedMCPToolCategoryCountsQueryResponse(BaseModel):
         default=None, description="The date range used for the query"
     )
     results: list[MCPToolCategoryCountItem]
+    timezone: str
+    timings: list[QueryTiming] | None = Field(
+        default=None,
+        description=("Measured timings for different parts of the query generation process"),
+    )
+    used_data_warehouse_sources: list[DataWarehouseSourceUsage] | None = Field(
+        default=None,
+        description=("Connector-synced data warehouse sources referenced by this query, if any."),
+    )
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+        default=None,
+        description=(
+            "Warnings about data warehouse sources referenced by the query whose"
+            " latest sync failed, is paused, hit a billing limit, or is otherwise"
+            " stale. Results may not reflect current source data. Accumulated"
+            " across every HogQL execution that contributes to this response — so"
+            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
+            " the same warnings as raw HogQL queries. Also carries access control"
+            " warnings when a system-table query filters out objects the user can't"
+            " access."
+        ),
+    )
+
+
+class CachedMCPToolCategoryMapQueryResponse(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    cache_key: str
+    cache_target_age: AwareDatetime | None = None
+    calculation_trigger: str | None = Field(
+        default=None,
+        description=("What triggered the calculation of the query, leave empty if user/immediate"),
+    )
+    error: str | None = Field(
+        default=None,
+        description=(
+            "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise."
+        ),
+    )
+    hogql: str | None = Field(default=None, description="Generated HogQL query.")
+    is_cached: bool
+    last_refresh: AwareDatetime
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    next_allowed_client_refresh: AwareDatetime
+    query_metadata: dict[str, Any] | None = None
+    query_status: QueryStatus | None = Field(
+        default=None,
+        description=("Query status indicates whether next to the provided data, a query is still running."),
+    )
+    resolved_compare_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None,
+        description=("The resolved previous/comparison period date range, when comparing against another period"),
+    )
+    resolved_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None, description="The date range used for the query"
+    )
+    results: list[MCPToolCategoryMapItem]
     timezone: str
     timings: list[QueryTiming] | None = Field(
         default=None,
@@ -16131,6 +16292,54 @@ class ErrorTrackingExternalReference(BaseModel):
     integration: ErrorTrackingExternalReferenceIntegration
 
 
+class ErrorTrackingFingerprintProjectionQueryResponse(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    error: str | None = Field(
+        default=None,
+        description=(
+            "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise."
+        ),
+    )
+    hasMore: bool | None = None
+    hogql: str | None = Field(default=None, description="Generated HogQL query.")
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    query_status: QueryStatus | None = Field(
+        default=None,
+        description=("Query status indicates whether next to the provided data, a query is still running."),
+    )
+    resolved_compare_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None,
+        description=("The resolved previous/comparison period date range, when comparing against another period"),
+    )
+    resolved_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None, description="The date range used for the query"
+    )
+    results: list[ErrorTrackingFingerprintProjectionPoint]
+    timings: list[QueryTiming] | None = Field(
+        default=None,
+        description=("Measured timings for different parts of the query generation process"),
+    )
+    used_data_warehouse_sources: list[DataWarehouseSourceUsage] | None = Field(
+        default=None,
+        description=("Connector-synced data warehouse sources referenced by this query, if any."),
+    )
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+        default=None,
+        description=(
+            "Warnings about data warehouse sources referenced by the query whose"
+            " latest sync failed, is paused, hit a billing limit, or is otherwise"
+            " stale. Results may not reflect current source data. Accumulated"
+            " across every HogQL execution that contributes to this response — so"
+            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
+            " the same warnings as raw HogQL queries. Also carries access control"
+            " warnings when a system-table query filters out objects the user can't"
+            " access."
+        ),
+    )
+
+
 class ErrorTrackingIssue(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -16148,6 +16357,7 @@ class ErrorTrackingIssue(BaseModel):
     last_seen: AwareDatetime
     library: str | None = None
     name: str | None = None
+    severity: ErrorTrackingQueryIssueSeverity | None = None
     source: str | None = None
     status: ErrorTrackingIssueStatus
 
@@ -16214,6 +16424,7 @@ class ErrorTrackingRelationalIssue(BaseModel):
     first_seen: AwareDatetime
     id: str
     name: str | None = None
+    severity: ErrorTrackingQueryIssueSeverity | None = None
     status: ErrorTrackingIssueStatus
 
 
@@ -17170,6 +17381,53 @@ class MCPToolCategoryCountsQueryResponse(BaseModel):
         default=None, description="The date range used for the query"
     )
     results: list[MCPToolCategoryCountItem]
+    timings: list[QueryTiming] | None = Field(
+        default=None,
+        description=("Measured timings for different parts of the query generation process"),
+    )
+    used_data_warehouse_sources: list[DataWarehouseSourceUsage] | None = Field(
+        default=None,
+        description=("Connector-synced data warehouse sources referenced by this query, if any."),
+    )
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+        default=None,
+        description=(
+            "Warnings about data warehouse sources referenced by the query whose"
+            " latest sync failed, is paused, hit a billing limit, or is otherwise"
+            " stale. Results may not reflect current source data. Accumulated"
+            " across every HogQL execution that contributes to this response — so"
+            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
+            " the same warnings as raw HogQL queries. Also carries access control"
+            " warnings when a system-table query filters out objects the user can't"
+            " access."
+        ),
+    )
+
+
+class MCPToolCategoryMapQueryResponse(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    error: str | None = Field(
+        default=None,
+        description=(
+            "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise."
+        ),
+    )
+    hogql: str | None = Field(default=None, description="Generated HogQL query.")
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    query_status: QueryStatus | None = Field(
+        default=None,
+        description=("Query status indicates whether next to the provided data, a query is still running."),
+    )
+    resolved_compare_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None,
+        description=("The resolved previous/comparison period date range, when comparing against another period"),
+    )
+    resolved_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None, description="The date range used for the query"
+    )
+    results: list[MCPToolCategoryMapItem]
     timings: list[QueryTiming] | None = Field(
         default=None,
         description=("Measured timings for different parts of the query generation process"),
@@ -18710,6 +18968,54 @@ class QueryResponseAlternative14(BaseModel):
             "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise."
         ),
     )
+    hasMore: bool | None = None
+    hogql: str | None = Field(default=None, description="Generated HogQL query.")
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    query_status: QueryStatus | None = Field(
+        default=None,
+        description=("Query status indicates whether next to the provided data, a query is still running."),
+    )
+    resolved_compare_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None,
+        description=("The resolved previous/comparison period date range, when comparing against another period"),
+    )
+    resolved_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None, description="The date range used for the query"
+    )
+    results: list[ErrorTrackingFingerprintProjectionPoint]
+    timings: list[QueryTiming] | None = Field(
+        default=None,
+        description=("Measured timings for different parts of the query generation process"),
+    )
+    used_data_warehouse_sources: list[DataWarehouseSourceUsage] | None = Field(
+        default=None,
+        description=("Connector-synced data warehouse sources referenced by this query, if any."),
+    )
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+        default=None,
+        description=(
+            "Warnings about data warehouse sources referenced by the query whose"
+            " latest sync failed, is paused, hit a billing limit, or is otherwise"
+            " stale. Results may not reflect current source data. Accumulated"
+            " across every HogQL execution that contributes to this response — so"
+            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
+            " the same warnings as raw HogQL queries. Also carries access control"
+            " warnings when a system-table query filters out objects the user can't"
+            " access."
+        ),
+    )
+
+
+class QueryResponseAlternative15(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    error: str | None = Field(
+        default=None,
+        description=(
+            "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise."
+        ),
+    )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
     query_status: QueryStatus | None = Field(
@@ -18747,7 +19053,7 @@ class QueryResponseAlternative14(BaseModel):
     )
 
 
-class QueryResponseAlternative20(BaseModel):
+class QueryResponseAlternative21(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -18797,7 +19103,7 @@ class QueryResponseAlternative20(BaseModel):
     )
 
 
-class QueryResponseAlternative21(BaseModel):
+class QueryResponseAlternative22(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -18848,7 +19154,7 @@ class QueryResponseAlternative21(BaseModel):
     )
 
 
-class QueryResponseAlternative22(BaseModel):
+class QueryResponseAlternative23(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -18872,59 +19178,6 @@ class QueryResponseAlternative22(BaseModel):
         ),
     )
     preComputeStrategy: WebAnalyticsPreComputeStrategy | None = None
-    query_status: QueryStatus | None = Field(
-        default=None,
-        description=("Query status indicates whether next to the provided data, a query is still running."),
-    )
-    resolved_compare_date_range: ResolvedDateRangeResponse | None = Field(
-        default=None,
-        description=("The resolved previous/comparison period date range, when comparing against another period"),
-    )
-    resolved_date_range: ResolvedDateRangeResponse | None = Field(
-        default=None, description="The date range used for the query"
-    )
-    results: list
-    samplingRate: SamplingRate | None = None
-    timings: list[QueryTiming] | None = Field(
-        default=None,
-        description=("Measured timings for different parts of the query generation process"),
-    )
-    types: list | None = None
-    used_data_warehouse_sources: list[DataWarehouseSourceUsage] | None = Field(
-        default=None,
-        description=("Connector-synced data warehouse sources referenced by this query, if any."),
-    )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
-        default=None,
-        description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
-        ),
-    )
-
-
-class QueryResponseAlternative23(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    columns: list | None = None
-    error: str | None = Field(
-        default=None,
-        description=(
-            "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise."
-        ),
-    )
-    hasMore: bool | None = None
-    hogql: str | None = Field(default=None, description="Generated HogQL query.")
-    limit: int | None = None
-    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    offset: int | None = None
     query_status: QueryStatus | None = Field(
         default=None,
         description=("Query status indicates whether next to the provided data, a query is still running."),
@@ -18990,6 +19243,7 @@ class QueryResponseAlternative24(BaseModel):
         default=None, description="The date range used for the query"
     )
     results: list
+    samplingRate: SamplingRate | None = None
     timings: list[QueryTiming] | None = Field(
         default=None,
         description=("Measured timings for different parts of the query generation process"),
@@ -19015,6 +19269,58 @@ class QueryResponseAlternative24(BaseModel):
 
 
 class QueryResponseAlternative25(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    columns: list | None = None
+    error: str | None = Field(
+        default=None,
+        description=(
+            "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise."
+        ),
+    )
+    hasMore: bool | None = None
+    hogql: str | None = Field(default=None, description="Generated HogQL query.")
+    limit: int | None = None
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    offset: int | None = None
+    query_status: QueryStatus | None = Field(
+        default=None,
+        description=("Query status indicates whether next to the provided data, a query is still running."),
+    )
+    resolved_compare_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None,
+        description=("The resolved previous/comparison period date range, when comparing against another period"),
+    )
+    resolved_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None, description="The date range used for the query"
+    )
+    results: list
+    timings: list[QueryTiming] | None = Field(
+        default=None,
+        description=("Measured timings for different parts of the query generation process"),
+    )
+    types: list | None = None
+    used_data_warehouse_sources: list[DataWarehouseSourceUsage] | None = Field(
+        default=None,
+        description=("Connector-synced data warehouse sources referenced by this query, if any."),
+    )
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+        default=None,
+        description=(
+            "Warnings about data warehouse sources referenced by the query whose"
+            " latest sync failed, is paused, hit a billing limit, or is otherwise"
+            " stale. Results may not reflect current source data. Accumulated"
+            " across every HogQL execution that contributes to this response — so"
+            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
+            " the same warnings as raw HogQL queries. Also carries access control"
+            " warnings when a system-table query filters out objects the user can't"
+            " access."
+        ),
+    )
+
+
+class QueryResponseAlternative26(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -19068,7 +19374,7 @@ class QueryResponseAlternative25(BaseModel):
     )
 
 
-class QueryResponseAlternative26(BaseModel):
+class QueryResponseAlternative27(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -19116,7 +19422,7 @@ class QueryResponseAlternative26(BaseModel):
     )
 
 
-class QueryResponseAlternative27(BaseModel):
+class QueryResponseAlternative28(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -19166,7 +19472,7 @@ class QueryResponseAlternative27(BaseModel):
     )
 
 
-class QueryResponseAlternative29(BaseModel):
+class QueryResponseAlternative30(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -19215,7 +19521,7 @@ class QueryResponseAlternative29(BaseModel):
     )
 
 
-class QueryResponseAlternative30(BaseModel):
+class QueryResponseAlternative31(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -19268,7 +19574,7 @@ class QueryResponseAlternative30(BaseModel):
     )
 
 
-class QueryResponseAlternative31(BaseModel):
+class QueryResponseAlternative32(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -19316,7 +19622,7 @@ class QueryResponseAlternative31(BaseModel):
     )
 
 
-class QueryResponseAlternative32(BaseModel):
+class QueryResponseAlternative33(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -19386,7 +19692,7 @@ class QueryResponseAlternative32(BaseModel):
     )
 
 
-class QueryResponseAlternative33(BaseModel):
+class QueryResponseAlternative34(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -19450,7 +19756,7 @@ class QueryResponseAlternative33(BaseModel):
     )
 
 
-class QueryResponseAlternative34(BaseModel):
+class QueryResponseAlternative35(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -19503,7 +19809,7 @@ class QueryResponseAlternative34(BaseModel):
     )
 
 
-class QueryResponseAlternative35(BaseModel):
+class QueryResponseAlternative36(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -19556,7 +19862,7 @@ class QueryResponseAlternative35(BaseModel):
     )
 
 
-class QueryResponseAlternative36(BaseModel):
+class QueryResponseAlternative37(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -19609,7 +19915,7 @@ class QueryResponseAlternative36(BaseModel):
     )
 
 
-class QueryResponseAlternative37(BaseModel):
+class QueryResponseAlternative38(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -19662,7 +19968,7 @@ class QueryResponseAlternative37(BaseModel):
     )
 
 
-class QueryResponseAlternative38(BaseModel):
+class QueryResponseAlternative39(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -19715,7 +20021,7 @@ class QueryResponseAlternative38(BaseModel):
     )
 
 
-class QueryResponseAlternative39(BaseModel):
+class QueryResponseAlternative40(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -19766,7 +20072,7 @@ class QueryResponseAlternative39(BaseModel):
     )
 
 
-class QueryResponseAlternative40(BaseModel):
+class QueryResponseAlternative41(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -19790,59 +20096,6 @@ class QueryResponseAlternative40(BaseModel):
         ),
     )
     preComputeStrategy: WebAnalyticsPreComputeStrategy | None = None
-    query_status: QueryStatus | None = Field(
-        default=None,
-        description=("Query status indicates whether next to the provided data, a query is still running."),
-    )
-    resolved_compare_date_range: ResolvedDateRangeResponse | None = Field(
-        default=None,
-        description=("The resolved previous/comparison period date range, when comparing against another period"),
-    )
-    resolved_date_range: ResolvedDateRangeResponse | None = Field(
-        default=None, description="The date range used for the query"
-    )
-    results: list
-    samplingRate: SamplingRate | None = None
-    timings: list[QueryTiming] | None = Field(
-        default=None,
-        description=("Measured timings for different parts of the query generation process"),
-    )
-    types: list | None = None
-    used_data_warehouse_sources: list[DataWarehouseSourceUsage] | None = Field(
-        default=None,
-        description=("Connector-synced data warehouse sources referenced by this query, if any."),
-    )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
-        default=None,
-        description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
-        ),
-    )
-
-
-class QueryResponseAlternative41(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    columns: list | None = None
-    error: str | None = Field(
-        default=None,
-        description=(
-            "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise."
-        ),
-    )
-    hasMore: bool | None = None
-    hogql: str | None = Field(default=None, description="Generated HogQL query.")
-    limit: int | None = None
-    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    offset: int | None = None
     query_status: QueryStatus | None = Field(
         default=None,
         description=("Query status indicates whether next to the provided data, a query is still running."),
@@ -19908,6 +20161,7 @@ class QueryResponseAlternative42(BaseModel):
         default=None, description="The date range used for the query"
     )
     results: list
+    samplingRate: SamplingRate | None = None
     timings: list[QueryTiming] | None = Field(
         default=None,
         description=("Measured timings for different parts of the query generation process"),
@@ -19933,6 +20187,58 @@ class QueryResponseAlternative42(BaseModel):
 
 
 class QueryResponseAlternative43(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    columns: list | None = None
+    error: str | None = Field(
+        default=None,
+        description=(
+            "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise."
+        ),
+    )
+    hasMore: bool | None = None
+    hogql: str | None = Field(default=None, description="Generated HogQL query.")
+    limit: int | None = None
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    offset: int | None = None
+    query_status: QueryStatus | None = Field(
+        default=None,
+        description=("Query status indicates whether next to the provided data, a query is still running."),
+    )
+    resolved_compare_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None,
+        description=("The resolved previous/comparison period date range, when comparing against another period"),
+    )
+    resolved_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None, description="The date range used for the query"
+    )
+    results: list
+    timings: list[QueryTiming] | None = Field(
+        default=None,
+        description=("Measured timings for different parts of the query generation process"),
+    )
+    types: list | None = None
+    used_data_warehouse_sources: list[DataWarehouseSourceUsage] | None = Field(
+        default=None,
+        description=("Connector-synced data warehouse sources referenced by this query, if any."),
+    )
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+        default=None,
+        description=(
+            "Warnings about data warehouse sources referenced by the query whose"
+            " latest sync failed, is paused, hit a billing limit, or is otherwise"
+            " stale. Results may not reflect current source data. Accumulated"
+            " across every HogQL execution that contributes to this response — so"
+            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
+            " the same warnings as raw HogQL queries. Also carries access control"
+            " warnings when a system-table query filters out objects the user can't"
+            " access."
+        ),
+    )
+
+
+class QueryResponseAlternative44(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -19986,7 +20292,7 @@ class QueryResponseAlternative43(BaseModel):
     )
 
 
-class QueryResponseAlternative44(BaseModel):
+class QueryResponseAlternative45(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20034,7 +20340,7 @@ class QueryResponseAlternative44(BaseModel):
     )
 
 
-class QueryResponseAlternative45(BaseModel):
+class QueryResponseAlternative46(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20086,7 +20392,7 @@ class QueryResponseAlternative45(BaseModel):
     )
 
 
-class QueryResponseAlternative46(BaseModel):
+class QueryResponseAlternative47(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20138,7 +20444,7 @@ class QueryResponseAlternative46(BaseModel):
     )
 
 
-class QueryResponseAlternative47(BaseModel):
+class QueryResponseAlternative48(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20191,7 +20497,7 @@ class QueryResponseAlternative47(BaseModel):
     )
 
 
-class QueryResponseAlternative48(BaseModel):
+class QueryResponseAlternative49(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20239,7 +20545,7 @@ class QueryResponseAlternative48(BaseModel):
     )
 
 
-class QueryResponseAlternative49(BaseModel):
+class QueryResponseAlternative50(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20292,7 +20598,7 @@ class QueryResponseAlternative49(BaseModel):
     )
 
 
-class QueryResponseAlternative50(BaseModel):
+class QueryResponseAlternative51(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20343,7 +20649,7 @@ class QueryResponseAlternative50(BaseModel):
     )
 
 
-class QueryResponseAlternative54(BaseModel):
+class QueryResponseAlternative55(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20394,7 +20700,7 @@ class QueryResponseAlternative54(BaseModel):
     )
 
 
-class QueryResponseAlternative56(BaseModel):
+class QueryResponseAlternative57(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20446,7 +20752,7 @@ class QueryResponseAlternative56(BaseModel):
     )
 
 
-class QueryResponseAlternative57(BaseModel):
+class QueryResponseAlternative58(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20503,7 +20809,7 @@ class QueryResponseAlternative57(BaseModel):
     )
 
 
-class QueryResponseAlternative58(BaseModel):
+class QueryResponseAlternative59(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20558,7 +20864,7 @@ class QueryResponseAlternative58(BaseModel):
     )
 
 
-class QueryResponseAlternative59(BaseModel):
+class QueryResponseAlternative60(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20607,7 +20913,7 @@ class QueryResponseAlternative59(BaseModel):
     )
 
 
-class QueryResponseAlternative60(BaseModel):
+class QueryResponseAlternative61(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20661,7 +20967,7 @@ class QueryResponseAlternative60(BaseModel):
     )
 
 
-class QueryResponseAlternative61(BaseModel):
+class QueryResponseAlternative62(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20708,7 +21014,7 @@ class QueryResponseAlternative61(BaseModel):
     )
 
 
-class QueryResponseAlternative62(BaseModel):
+class QueryResponseAlternative63(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20755,7 +21061,7 @@ class QueryResponseAlternative62(BaseModel):
     )
 
 
-class QueryResponseAlternative63(BaseModel):
+class QueryResponseAlternative64(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20802,7 +21108,7 @@ class QueryResponseAlternative63(BaseModel):
     )
 
 
-class QueryResponseAlternative64(BaseModel):
+class QueryResponseAlternative65(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20849,7 +21155,7 @@ class QueryResponseAlternative64(BaseModel):
     )
 
 
-class QueryResponseAlternative66(BaseModel):
+class QueryResponseAlternative67(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20901,7 +21207,7 @@ class QueryResponseAlternative66(BaseModel):
     )
 
 
-class QueryResponseAlternative68(BaseModel):
+class QueryResponseAlternative69(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20953,7 +21259,7 @@ class QueryResponseAlternative68(BaseModel):
     )
 
 
-class QueryResponseAlternative69(BaseModel):
+class QueryResponseAlternative70(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -21005,7 +21311,7 @@ class QueryResponseAlternative69(BaseModel):
     )
 
 
-class QueryResponseAlternative70(BaseModel):
+class QueryResponseAlternative71(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -21053,7 +21359,7 @@ class QueryResponseAlternative70(BaseModel):
     )
 
 
-class QueryResponseAlternative71(BaseModel):
+class QueryResponseAlternative72(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -21100,7 +21406,7 @@ class QueryResponseAlternative71(BaseModel):
     )
 
 
-class QueryResponseAlternative72(BaseModel):
+class QueryResponseAlternative73(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -21147,7 +21453,7 @@ class QueryResponseAlternative72(BaseModel):
     )
 
 
-class QueryResponseAlternative73(BaseModel):
+class QueryResponseAlternative74(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -21198,7 +21504,7 @@ class QueryResponseAlternative73(BaseModel):
     )
 
 
-class QueryResponseAlternative74(BaseModel):
+class QueryResponseAlternative75(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -21249,7 +21555,7 @@ class QueryResponseAlternative74(BaseModel):
     )
 
 
-class QueryResponseAlternative75(BaseModel):
+class QueryResponseAlternative76(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -21300,7 +21606,7 @@ class QueryResponseAlternative75(BaseModel):
     )
 
 
-class QueryResponseAlternative76(BaseModel):
+class QueryResponseAlternative77(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -21351,7 +21657,7 @@ class QueryResponseAlternative76(BaseModel):
     )
 
 
-class QueryResponseAlternative78(BaseModel):
+class QueryResponseAlternative79(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -21401,7 +21707,7 @@ class QueryResponseAlternative78(BaseModel):
     )
 
 
-class QueryResponseAlternative79(BaseModel):
+class QueryResponseAlternative80(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -21451,7 +21757,7 @@ class QueryResponseAlternative79(BaseModel):
     )
 
 
-class QueryResponseAlternative80(BaseModel):
+class QueryResponseAlternative81(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -21498,7 +21804,7 @@ class QueryResponseAlternative80(BaseModel):
     )
 
 
-class QueryResponseAlternative81(BaseModel):
+class QueryResponseAlternative82(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -21549,7 +21855,7 @@ class QueryResponseAlternative81(BaseModel):
     )
 
 
-class QueryResponseAlternative85(BaseModel):
+class QueryResponseAlternative86(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -21596,7 +21902,7 @@ class QueryResponseAlternative85(BaseModel):
     )
 
 
-class QueryResponseAlternative86(BaseModel):
+class QueryResponseAlternative87(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -21643,7 +21949,7 @@ class QueryResponseAlternative86(BaseModel):
     )
 
 
-class QueryResponseAlternative87(BaseModel):
+class QueryResponseAlternative88(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -21700,7 +22006,7 @@ class QueryResponseAlternative87(BaseModel):
     )
 
 
-class QueryResponseAlternative88(BaseModel):
+class QueryResponseAlternative89(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -21755,7 +22061,7 @@ class QueryResponseAlternative88(BaseModel):
     )
 
 
-class QueryResponseAlternative89(BaseModel):
+class QueryResponseAlternative90(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -21802,7 +22108,7 @@ class QueryResponseAlternative89(BaseModel):
     )
 
 
-class QueryResponseAlternative90(BaseModel):
+class QueryResponseAlternative91(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -21854,7 +22160,7 @@ class QueryResponseAlternative90(BaseModel):
     )
 
 
-class QueryResponseAlternative91(BaseModel):
+class QueryResponseAlternative92(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -21901,7 +22207,7 @@ class QueryResponseAlternative91(BaseModel):
     )
 
 
-class QueryResponseAlternative92(BaseModel):
+class QueryResponseAlternative93(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -21948,7 +22254,7 @@ class QueryResponseAlternative92(BaseModel):
     )
 
 
-class QueryResponseAlternative93(BaseModel):
+class QueryResponseAlternative94(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -21995,7 +22301,7 @@ class QueryResponseAlternative93(BaseModel):
     )
 
 
-class QueryResponseAlternative94(BaseModel):
+class QueryResponseAlternative95(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -22042,7 +22348,7 @@ class QueryResponseAlternative94(BaseModel):
     )
 
 
-class QueryResponseAlternative95(BaseModel):
+class QueryResponseAlternative96(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -22089,7 +22395,7 @@ class QueryResponseAlternative95(BaseModel):
     )
 
 
-class QueryResponseAlternative96(BaseModel):
+class QueryResponseAlternative97(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -22136,7 +22442,7 @@ class QueryResponseAlternative96(BaseModel):
     )
 
 
-class QueryResponseAlternative97(BaseModel):
+class QueryResponseAlternative98(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -22183,7 +22489,7 @@ class QueryResponseAlternative97(BaseModel):
     )
 
 
-class QueryResponseAlternative98(BaseModel):
+class QueryResponseAlternative99(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -22233,7 +22539,7 @@ class QueryResponseAlternative98(BaseModel):
     )
 
 
-class QueryResponseAlternative99(BaseModel):
+class QueryResponseAlternative100(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -22280,7 +22586,7 @@ class QueryResponseAlternative99(BaseModel):
     )
 
 
-class QueryResponseAlternative100(BaseModel):
+class QueryResponseAlternative101(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -22327,7 +22633,7 @@ class QueryResponseAlternative100(BaseModel):
     )
 
 
-class QueryResponseAlternative101(BaseModel):
+class QueryResponseAlternative102(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -22374,7 +22680,7 @@ class QueryResponseAlternative101(BaseModel):
     )
 
 
-class QueryResponseAlternative102(BaseModel):
+class QueryResponseAlternative103(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -22421,7 +22727,7 @@ class QueryResponseAlternative102(BaseModel):
     )
 
 
-class QueryResponseAlternative103(BaseModel):
+class QueryResponseAlternative104(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -22468,53 +22774,6 @@ class QueryResponseAlternative103(BaseModel):
     )
 
 
-class QueryResponseAlternative104(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    error: str | None = Field(
-        default=None,
-        description=(
-            "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise."
-        ),
-    )
-    hogql: str | None = Field(default=None, description="Generated HogQL query.")
-    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    query_status: QueryStatus | None = Field(
-        default=None,
-        description=("Query status indicates whether next to the provided data, a query is still running."),
-    )
-    resolved_compare_date_range: ResolvedDateRangeResponse | None = Field(
-        default=None,
-        description=("The resolved previous/comparison period date range, when comparing against another period"),
-    )
-    resolved_date_range: ResolvedDateRangeResponse | None = Field(
-        default=None, description="The date range used for the query"
-    )
-    results: list[MCPToolDescriptionItem]
-    timings: list[QueryTiming] | None = Field(
-        default=None,
-        description=("Measured timings for different parts of the query generation process"),
-    )
-    used_data_warehouse_sources: list[DataWarehouseSourceUsage] | None = Field(
-        default=None,
-        description=("Connector-synced data warehouse sources referenced by this query, if any."),
-    )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
-        default=None,
-        description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
-        ),
-    )
-
-
 class QueryResponseAlternative105(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -22538,7 +22797,7 @@ class QueryResponseAlternative105(BaseModel):
     resolved_date_range: ResolvedDateRangeResponse | None = Field(
         default=None, description="The date range used for the query"
     )
-    results: list[MCPToolSampleIntentItem]
+    results: list[MCPToolCategoryMapItem]
     timings: list[QueryTiming] | None = Field(
         default=None,
         description=("Measured timings for different parts of the query generation process"),
@@ -22585,7 +22844,7 @@ class QueryResponseAlternative106(BaseModel):
     resolved_date_range: ResolvedDateRangeResponse | None = Field(
         default=None, description="The date range used for the query"
     )
-    results: list[MCPToolNeighborItem]
+    results: list[MCPToolDescriptionItem]
     timings: list[QueryTiming] | None = Field(
         default=None,
         description=("Measured timings for different parts of the query generation process"),
@@ -22610,6 +22869,100 @@ class QueryResponseAlternative106(BaseModel):
 
 
 class QueryResponseAlternative107(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    error: str | None = Field(
+        default=None,
+        description=(
+            "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise."
+        ),
+    )
+    hogql: str | None = Field(default=None, description="Generated HogQL query.")
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    query_status: QueryStatus | None = Field(
+        default=None,
+        description=("Query status indicates whether next to the provided data, a query is still running."),
+    )
+    resolved_compare_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None,
+        description=("The resolved previous/comparison period date range, when comparing against another period"),
+    )
+    resolved_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None, description="The date range used for the query"
+    )
+    results: list[MCPToolSampleIntentItem]
+    timings: list[QueryTiming] | None = Field(
+        default=None,
+        description=("Measured timings for different parts of the query generation process"),
+    )
+    used_data_warehouse_sources: list[DataWarehouseSourceUsage] | None = Field(
+        default=None,
+        description=("Connector-synced data warehouse sources referenced by this query, if any."),
+    )
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+        default=None,
+        description=(
+            "Warnings about data warehouse sources referenced by the query whose"
+            " latest sync failed, is paused, hit a billing limit, or is otherwise"
+            " stale. Results may not reflect current source data. Accumulated"
+            " across every HogQL execution that contributes to this response — so"
+            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
+            " the same warnings as raw HogQL queries. Also carries access control"
+            " warnings when a system-table query filters out objects the user can't"
+            " access."
+        ),
+    )
+
+
+class QueryResponseAlternative108(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    error: str | None = Field(
+        default=None,
+        description=(
+            "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise."
+        ),
+    )
+    hogql: str | None = Field(default=None, description="Generated HogQL query.")
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    query_status: QueryStatus | None = Field(
+        default=None,
+        description=("Query status indicates whether next to the provided data, a query is still running."),
+    )
+    resolved_compare_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None,
+        description=("The resolved previous/comparison period date range, when comparing against another period"),
+    )
+    resolved_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None, description="The date range used for the query"
+    )
+    results: list[MCPToolNeighborItem]
+    timings: list[QueryTiming] | None = Field(
+        default=None,
+        description=("Measured timings for different parts of the query generation process"),
+    )
+    used_data_warehouse_sources: list[DataWarehouseSourceUsage] | None = Field(
+        default=None,
+        description=("Connector-synced data warehouse sources referenced by this query, if any."),
+    )
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+        default=None,
+        description=(
+            "Warnings about data warehouse sources referenced by the query whose"
+            " latest sync failed, is paused, hit a billing limit, or is otherwise"
+            " stale. Results may not reflect current source data. Accumulated"
+            " across every HogQL execution that contributes to this response — so"
+            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
+            " the same warnings as raw HogQL queries. Also carries access control"
+            " warnings when a system-table query filters out objects the user can't"
+            " access."
+        ),
+    )
+
+
+class QueryResponseAlternative109(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -23447,6 +23800,10 @@ class AccountsQuery(BaseModel):
             " the overview tile click-to-filter affordance."
         ),
     )
+    includeIgnored: bool | None = Field(
+        default=None,
+        description="Include ignored accounts. Ignored accounts are hidden by default.",
+    )
     kind: Literal["AccountsQuery"] = "AccountsQuery"
     limit: int | None = None
     metrics: list[str] | None = Field(
@@ -23494,6 +23851,7 @@ class AccountsTableQuery(BaseModel):
             | AccountsTableAssignedToFilter
             | AccountsTableUnassignedFilter
             | AccountsTableAccountIdFilter
+            | AccountsTableAccountFieldFilter
             | AccountsTableCustomPropertyFilter
         ]
         | None
@@ -23504,6 +23862,10 @@ class AccountsTableQuery(BaseModel):
     includeChurned: bool | None = Field(
         default=None,
         description="Include churned accounts. Churned accounts are hidden by default.",
+    )
+    includeIgnored: bool | None = Field(
+        default=None,
+        description="Include ignored accounts. Ignored accounts are hidden by default.",
     )
     kind: Literal["AccountsTableQuery"] = "AccountsTableQuery"
     limit: conint(ge=1) | None = None
@@ -23640,6 +24002,19 @@ class AssistantFunnelsActorsQuery(BaseModel):
         description="Whether to include matched session recordings for each actor.",
     )
     kind: Literal["FunnelsActorsQuery"] = "FunnelsActorsQuery"
+    limit: int | None = Field(
+        default=100,
+        description=("Maximum number of persons to return in one page, from 1 to 1000. Higher values are clamped."),
+    )
+    offset: int | None = Field(
+        default=0,
+        description=(
+            "Number of persons to skip before the returned page. Use it with `limit` to"
+            " walk the whole result set: the response reports `limit`, `offset`, and"
+            " `hasMore`, so when `hasMore` is true, call again with `offset` raised by"
+            " `limit`."
+        ),
+    )
     source: AssistantFunnelsQuery = Field(
         ...,
         description=("The source funnel insight query whose step (or trends point) we are drilling into."),
@@ -23709,6 +24084,19 @@ class AssistantPathsActorsQuery(BaseModel):
         description="Whether to include matched session recordings for each actor.",
     )
     kind: Literal["InsightActorsQuery"] = "InsightActorsQuery"
+    limit: int | None = Field(
+        default=100,
+        description=("Maximum number of persons to return in one page, from 1 to 1000. Higher values are clamped."),
+    )
+    offset: int | None = Field(
+        default=0,
+        description=(
+            "Number of persons to skip before the returned page. Use it with `limit` to"
+            " walk the whole result set: the response reports `limit`, `offset`, and"
+            " `hasMore`, so when `hasMore` is true, call again with `offset` raised by"
+            " `limit`."
+        ),
+    )
     source: AssistantPathsQuery = Field(..., description="The source paths insight query whose actors we are listing.")
 
 
@@ -23725,6 +24113,19 @@ class AssistantRetentionActorsQuery(BaseModel):
         ),
     )
     kind: Literal["InsightActorsQuery"] = "InsightActorsQuery"
+    limit: int | None = Field(
+        default=100,
+        description=("Maximum number of persons to return in one page, from 1 to 1000. Higher values are clamped."),
+    )
+    offset: int | None = Field(
+        default=0,
+        description=(
+            "Number of persons to skip before the returned page. Use it with `limit` to"
+            " walk the whole cohort: the response reports `limit`, `offset`, and"
+            " `hasMore`, so when `hasMore` is true, call again with `offset` raised by"
+            " `limit`."
+        ),
+    )
     source: AssistantRetentionQuery = Field(
         ...,
         description=("The source retention insight query whose cohort we are drilling into."),
@@ -23749,6 +24150,19 @@ class AssistantStickinessActorsQuery(BaseModel):
         ),
     )
     kind: Literal["InsightActorsQuery"] = "InsightActorsQuery"
+    limit: int | None = Field(
+        default=100,
+        description=("Maximum number of persons to return in one page, from 1 to 1000. Higher values are clamped."),
+    )
+    offset: int | None = Field(
+        default=0,
+        description=(
+            "Number of persons to skip before the returned page. Use it with `limit` to"
+            " walk the whole result set: the response reports `limit`, `offset`, and"
+            " `hasMore`, so when `hasMore` is true, call again with `offset` raised by"
+            " `limit`."
+        ),
+    )
     series: int | None = Field(
         default=None,
         description=("0-based index of the series to drill into when the source has multiple series. Defaults to 0."),
@@ -23784,6 +24198,19 @@ class AssistantTrendsActorsQuery(BaseModel):
         description="Whether to include matched session recordings for each actor.",
     )
     kind: Literal["InsightActorsQuery"] = "InsightActorsQuery"
+    limit: int | None = Field(
+        default=100,
+        description=("Maximum number of persons to return in one page, from 1 to 1000. Higher values are clamped."),
+    )
+    offset: int | None = Field(
+        default=0,
+        description=(
+            "Number of persons to skip before the returned page. Use it with `limit` to"
+            " walk the whole result set: the response reports `limit`, `offset`, and"
+            " `hasMore`, so when `hasMore` is true, call again with `offset` raised by"
+            " `limit`."
+        ),
+    )
     series: int | None = Field(
         default=None,
         description="Series index (0-based) when the source has multiple series.",
@@ -24113,9 +24540,13 @@ class ConversionGoalFilter1(BaseModel):
         description=(
             "Marks this goal as customer-defining: a conversion here means the person"
             " became a customer (e.g. a payment or subscription), not an intermediate"
-            " step like a sign up. It gates customer-based metrics such as CAC and"
-            " LTV:CAC, whose denominator is new customers (counted once per person via"
-            " first_time_for_user) rather than every conversion. Defaults to false."
+            " step like a sign up. It gates customer-based metrics such as CAC, whose"
+            " denominator is this goal's conversions — its count, or its unique"
+            " converters under dau math. That equals new customers only for a"
+            " once-per-person moment: a repeatable event such as a monthly payment"
+            " counts every time and understates cost per customer, and dedup under dau"
+            " is per result row, so someone converting under two sources counts twice"
+            " at channel level. Defaults to false."
         ),
     )
     counts_as_revenue: bool | None = Field(
@@ -24177,9 +24608,13 @@ class ConversionGoalFilter2(BaseModel):
         description=(
             "Marks this goal as customer-defining: a conversion here means the person"
             " became a customer (e.g. a payment or subscription), not an intermediate"
-            " step like a sign up. It gates customer-based metrics such as CAC and"
-            " LTV:CAC, whose denominator is new customers (counted once per person via"
-            " first_time_for_user) rather than every conversion. Defaults to false."
+            " step like a sign up. It gates customer-based metrics such as CAC, whose"
+            " denominator is this goal's conversions — its count, or its unique"
+            " converters under dau math. That equals new customers only for a"
+            " once-per-person moment: a repeatable event such as a monthly payment"
+            " counts every time and understates cost per customer, and dedup under dau"
+            " is per result row, so someone converting under two sources counts twice"
+            " at channel level. Defaults to false."
         ),
     )
     counts_as_revenue: bool | None = Field(
@@ -24239,9 +24674,13 @@ class ConversionGoalFilter3(BaseModel):
         description=(
             "Marks this goal as customer-defining: a conversion here means the person"
             " became a customer (e.g. a payment or subscription), not an intermediate"
-            " step like a sign up. It gates customer-based metrics such as CAC and"
-            " LTV:CAC, whose denominator is new customers (counted once per person via"
-            " first_time_for_user) rather than every conversion. Defaults to false."
+            " step like a sign up. It gates customer-based metrics such as CAC, whose"
+            " denominator is this goal's conversions — its count, or its unique"
+            " converters under dau math. That equals new customers only for a"
+            " once-per-person moment: a repeatable event such as a monthly payment"
+            " counts every time and understates cost per customer, and dedup under dau"
+            " is per result row, so someone converting under two sources counts twice"
+            " at channel level. Defaults to false."
         ),
     )
     counts_as_revenue: bool | None = Field(
@@ -24643,22 +25082,6 @@ class EntityNode(BaseModel):
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
 
-class ErrorTrackingBreakdownsQuery(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    breakdownProperties: list[str]
-    dateRange: DateRange | None = None
-    filterTestAccounts: bool | None = None
-    issueId: str
-    kind: Literal["ErrorTrackingBreakdownsQuery"] = "ErrorTrackingBreakdownsQuery"
-    maxValuesPerProperty: int | None = None
-    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    response: ErrorTrackingBreakdownsQueryResponse | None = None
-    tags: QueryLogTags | None = None
-    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
-
-
 class ErrorTrackingCorrelatedIssue(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -24675,7 +25098,22 @@ class ErrorTrackingCorrelatedIssue(BaseModel):
     name: str | None = None
     odds_ratio: float
     population: Population
+    severity: ErrorTrackingQueryIssueSeverity | None = None
     status: ErrorTrackingIssueStatus
+
+
+class ErrorTrackingFingerprintProjectionQuery(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    issueId: str
+    kind: Literal["ErrorTrackingFingerprintProjectionQuery"] = "ErrorTrackingFingerprintProjectionQuery"
+    modelName: EmbeddingModelName | None = None
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    rendering: str | None = None
+    response: ErrorTrackingFingerprintProjectionQueryResponse | None = None
+    tags: QueryLogTags | None = None
+    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
 
 class ErrorTrackingIssueCorrelationQueryResponse(BaseModel):
@@ -25302,6 +25740,18 @@ class MCPToolCategoryCountsQuery(BaseModel):
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
 
+class MCPToolCategoryMapQuery(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    dateRange: DateRange | None = None
+    kind: Literal["MCPToolCategoryMapQuery"] = "MCPToolCategoryMapQuery"
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    response: MCPToolCategoryMapQueryResponse | None = None
+    tags: QueryLogTags | None = None
+    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
+
+
 class MCPToolDailyStatsQuery(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -25816,6 +26266,14 @@ class MaxRecordingUniversalFilters(BaseModel):
             " order direction here"
         ),
     )
+    session_ids: list[str] | None = Field(
+        default=None,
+        description=(
+            "Pin the result to specific recordings by their session id, e.g. the ones"
+            " just summarized. `$session_id` is not a session property, so it cannot be"
+            " filtered on in `filter_group`."
+        ),
+    )
 
 
 class MetricsQuery(BaseModel):
@@ -26019,7 +26477,7 @@ class PropertyValuesQuery(BaseModel):
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
 
-class QueryResponseAlternative15(BaseModel):
+class QueryResponseAlternative16(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -26459,6 +26917,19 @@ class AssistantLifecycleActorsQuery(BaseModel):
         description=("Bucket date for the data point. Must be an ISO date string (YYYY-MM-DD), e.g. '2024-01-15'."),
     )
     kind: Literal["InsightActorsQuery"] = "InsightActorsQuery"
+    limit: int | None = Field(
+        default=100,
+        description=("Maximum number of persons to return in one page, from 1 to 1000. Higher values are clamped."),
+    )
+    offset: int | None = Field(
+        default=0,
+        description=(
+            "Number of persons to skip before the returned page. Use it with `limit` to"
+            " walk the whole result set: the response reports `limit`, `offset`, and"
+            " `hasMore`, so when `hasMore` is true, call again with `offset` raised by"
+            " `limit`."
+        ),
+    )
     source: AssistantLifecycleQuery = Field(
         ...,
         description=("The source lifecycle insight query whose bucket we are drilling into."),
@@ -27068,6 +27539,23 @@ class TraceSpansTreeQuery(BaseModel):
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
 
+class ErrorTrackingBreakdownsQuery(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    breakdownProperties: list[str]
+    dateRange: DateRange | None = None
+    filterGroup: PropertyGroupFilter | None = None
+    filterTestAccounts: bool | None = None
+    issueId: str
+    kind: Literal["ErrorTrackingBreakdownsQuery"] = "ErrorTrackingBreakdownsQuery"
+    maxValuesPerProperty: int | None = None
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    response: ErrorTrackingBreakdownsQueryResponse | None = None
+    tags: QueryLogTags | None = None
+    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
+
+
 class ErrorTrackingQuery(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -27135,6 +27623,14 @@ class ExperimentExposureQuery(BaseModel):
 class ExperimentFunnelMetricTypeProps(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
+    )
+    breakdownAttributionType: BreakdownAttributionType | None = Field(
+        default=BreakdownAttributionType.FIRST_TOUCH,
+        description="How to attribute the breakdown value across funnel steps.",
+    )
+    breakdownAttributionValue: int | None = Field(
+        default=None,
+        description=("When breakdownAttributionType is `step`, the 0-indexed step to attribute from."),
     )
     funnel_order_type: StepOrderValue | None = None
     metric_type: Literal["funnel"] = "funnel"
@@ -27512,7 +28008,7 @@ class PathsV2Query(BaseModel):
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
 
-class QueryResponseAlternative67(BaseModel):
+class QueryResponseAlternative68(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -27636,6 +28132,14 @@ class DatabaseSchemaQueryResponse(BaseModel):
 class ExperimentFunnelMetric(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
+    )
+    breakdownAttributionType: BreakdownAttributionType | None = Field(
+        default=BreakdownAttributionType.FIRST_TOUCH,
+        description="How to attribute the breakdown value across funnel steps.",
+    )
+    breakdownAttributionValue: int | None = Field(
+        default=None,
+        description=("When breakdownAttributionType is `step`, the 0-indexed step to attribute from."),
     )
     breakdownFilter: BreakdownFilter | None = None
     conversion_window: int | None = None
@@ -27921,7 +28425,7 @@ class LegacyExperimentQueryResponse(BaseModel):
     )
 
 
-class QueryResponseAlternative18(BaseModel):
+class QueryResponseAlternative19(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -28322,7 +28826,7 @@ class FunnelsQuery(BaseModel):
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
 
-class QueryResponseAlternative16(BaseModel):
+class QueryResponseAlternative17(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -28342,7 +28846,7 @@ class QueryResponseAlternative16(BaseModel):
     )
 
 
-class QueryResponseAlternative17(BaseModel):
+class QueryResponseAlternative18(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -28363,7 +28867,7 @@ class QueryResponseAlternative17(BaseModel):
     )
 
 
-class QueryResponseAlternative52(BaseModel):
+class QueryResponseAlternative53(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -28383,7 +28887,7 @@ class QueryResponseAlternative52(BaseModel):
     )
 
 
-class QueryResponseAlternative53(BaseModel):
+class QueryResponseAlternative54(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -28441,8 +28945,8 @@ class QueryResponseAlternative(
         | QueryResponseAlternative32
         | QueryResponseAlternative33
         | QueryResponseAlternative34
-        | Any
         | QueryResponseAlternative35
+        | Any
         | QueryResponseAlternative36
         | QueryResponseAlternative37
         | QueryResponseAlternative38
@@ -28458,10 +28962,10 @@ class QueryResponseAlternative(
         | QueryResponseAlternative48
         | QueryResponseAlternative49
         | QueryResponseAlternative50
-        | QueryResponseAlternative52
+        | QueryResponseAlternative51
         | QueryResponseAlternative53
         | QueryResponseAlternative54
-        | QueryResponseAlternative56
+        | QueryResponseAlternative55
         | QueryResponseAlternative57
         | QueryResponseAlternative58
         | QueryResponseAlternative59
@@ -28470,7 +28974,7 @@ class QueryResponseAlternative(
         | QueryResponseAlternative62
         | QueryResponseAlternative63
         | QueryResponseAlternative64
-        | QueryResponseAlternative66
+        | QueryResponseAlternative65
         | QueryResponseAlternative67
         | QueryResponseAlternative68
         | QueryResponseAlternative69
@@ -28486,7 +28990,7 @@ class QueryResponseAlternative(
         | QueryResponseAlternative79
         | QueryResponseAlternative80
         | QueryResponseAlternative81
-        | QueryResponseAlternative84
+        | QueryResponseAlternative82
         | QueryResponseAlternative85
         | QueryResponseAlternative86
         | QueryResponseAlternative87
@@ -28510,6 +29014,8 @@ class QueryResponseAlternative(
         | QueryResponseAlternative105
         | QueryResponseAlternative106
         | QueryResponseAlternative107
+        | QueryResponseAlternative108
+        | QueryResponseAlternative109
     ]
 ):
     root: (
@@ -28548,8 +29054,8 @@ class QueryResponseAlternative(
         | QueryResponseAlternative32
         | QueryResponseAlternative33
         | QueryResponseAlternative34
-        | Any
         | QueryResponseAlternative35
+        | Any
         | QueryResponseAlternative36
         | QueryResponseAlternative37
         | QueryResponseAlternative38
@@ -28565,10 +29071,10 @@ class QueryResponseAlternative(
         | QueryResponseAlternative48
         | QueryResponseAlternative49
         | QueryResponseAlternative50
-        | QueryResponseAlternative52
+        | QueryResponseAlternative51
         | QueryResponseAlternative53
         | QueryResponseAlternative54
-        | QueryResponseAlternative56
+        | QueryResponseAlternative55
         | QueryResponseAlternative57
         | QueryResponseAlternative58
         | QueryResponseAlternative59
@@ -28577,7 +29083,7 @@ class QueryResponseAlternative(
         | QueryResponseAlternative62
         | QueryResponseAlternative63
         | QueryResponseAlternative64
-        | QueryResponseAlternative66
+        | QueryResponseAlternative65
         | QueryResponseAlternative67
         | QueryResponseAlternative68
         | QueryResponseAlternative69
@@ -28593,7 +29099,7 @@ class QueryResponseAlternative(
         | QueryResponseAlternative79
         | QueryResponseAlternative80
         | QueryResponseAlternative81
-        | QueryResponseAlternative84
+        | QueryResponseAlternative82
         | QueryResponseAlternative85
         | QueryResponseAlternative86
         | QueryResponseAlternative87
@@ -28617,6 +29123,8 @@ class QueryResponseAlternative(
         | QueryResponseAlternative105
         | QueryResponseAlternative106
         | QueryResponseAlternative107
+        | QueryResponseAlternative108
+        | QueryResponseAlternative109
     )
 
 
@@ -29548,6 +30056,7 @@ class HogQLAutocomplete(BaseModel):
         | SessionAttributionExplorerQuery
         | ErrorTrackingQuery
         | ErrorTrackingSimilarIssuesQuery
+        | ErrorTrackingFingerprintProjectionQuery
         | ErrorTrackingBreakdownsQuery
         | ErrorTrackingIssueCorrelationQuery
         | LogsQuery
@@ -29585,6 +30094,7 @@ class HogQLAutocomplete(BaseModel):
         | MCPToolQualityDailyStatsQuery
         | MCPToolCategoryCountsQuery
         | MCPToolCategoriesQuery
+        | MCPToolCategoryMapQuery
         | MCPToolDescriptionsQuery
         | MCPToolSampleIntentsQuery
         | MCPToolNeighborsQuery
@@ -29660,6 +30170,7 @@ class HogQLMetadata(BaseModel):
         | SessionAttributionExplorerQuery
         | ErrorTrackingQuery
         | ErrorTrackingSimilarIssuesQuery
+        | ErrorTrackingFingerprintProjectionQuery
         | ErrorTrackingBreakdownsQuery
         | ErrorTrackingIssueCorrelationQuery
         | LogsQuery
@@ -29697,6 +30208,7 @@ class HogQLMetadata(BaseModel):
         | MCPToolQualityDailyStatsQuery
         | MCPToolCategoryCountsQuery
         | MCPToolCategoriesQuery
+        | MCPToolCategoryMapQuery
         | MCPToolDescriptionsQuery
         | MCPToolSampleIntentsQuery
         | MCPToolNeighborsQuery
@@ -29766,6 +30278,7 @@ class MaxInsightContext(BaseModel):
         | SessionAttributionExplorerQuery
         | ErrorTrackingQuery
         | ErrorTrackingSimilarIssuesQuery
+        | ErrorTrackingFingerprintProjectionQuery
         | ErrorTrackingBreakdownsQuery
         | ErrorTrackingIssueCorrelationQuery
         | ExperimentFunnelsQuery
@@ -29837,6 +30350,7 @@ class MaxInsightContext(BaseModel):
         | MCPToolQualityDailyStatsQuery
         | MCPToolCategoryCountsQuery
         | MCPToolCategoriesQuery
+        | MCPToolCategoryMapQuery
         | MCPToolDescriptionsQuery
         | MCPToolSampleIntentsQuery
         | MCPToolNeighborsQuery
@@ -29902,6 +30416,7 @@ class QueryRequest(BaseModel):
         | SessionAttributionExplorerQuery
         | ErrorTrackingQuery
         | ErrorTrackingSimilarIssuesQuery
+        | ErrorTrackingFingerprintProjectionQuery
         | ErrorTrackingBreakdownsQuery
         | ErrorTrackingIssueCorrelationQuery
         | ExperimentFunnelsQuery
@@ -29973,6 +30488,7 @@ class QueryRequest(BaseModel):
         | MCPToolQualityDailyStatsQuery
         | MCPToolCategoryCountsQuery
         | MCPToolCategoriesQuery
+        | MCPToolCategoryMapQuery
         | MCPToolDescriptionsQuery
         | MCPToolSampleIntentsQuery
         | MCPToolNeighborsQuery
@@ -30030,6 +30546,7 @@ class QuerySchemaRoot(
         | SessionAttributionExplorerQuery
         | ErrorTrackingQuery
         | ErrorTrackingSimilarIssuesQuery
+        | ErrorTrackingFingerprintProjectionQuery
         | ErrorTrackingBreakdownsQuery
         | ErrorTrackingIssueCorrelationQuery
         | ExperimentFunnelsQuery
@@ -30101,6 +30618,7 @@ class QuerySchemaRoot(
         | MCPToolQualityDailyStatsQuery
         | MCPToolCategoryCountsQuery
         | MCPToolCategoriesQuery
+        | MCPToolCategoryMapQuery
         | MCPToolDescriptionsQuery
         | MCPToolSampleIntentsQuery
         | MCPToolNeighborsQuery
@@ -30128,6 +30646,7 @@ class QuerySchemaRoot(
         | SessionAttributionExplorerQuery
         | ErrorTrackingQuery
         | ErrorTrackingSimilarIssuesQuery
+        | ErrorTrackingFingerprintProjectionQuery
         | ErrorTrackingBreakdownsQuery
         | ErrorTrackingIssueCorrelationQuery
         | ExperimentFunnelsQuery
@@ -30199,6 +30718,7 @@ class QuerySchemaRoot(
         | MCPToolQualityDailyStatsQuery
         | MCPToolCategoryCountsQuery
         | MCPToolCategoriesQuery
+        | MCPToolCategoryMapQuery
         | MCPToolDescriptionsQuery
         | MCPToolSampleIntentsQuery
         | MCPToolNeighborsQuery
@@ -30231,6 +30751,7 @@ class QueryUpgradeRequest(BaseModel):
         | SessionAttributionExplorerQuery
         | ErrorTrackingQuery
         | ErrorTrackingSimilarIssuesQuery
+        | ErrorTrackingFingerprintProjectionQuery
         | ErrorTrackingBreakdownsQuery
         | ErrorTrackingIssueCorrelationQuery
         | ExperimentFunnelsQuery
@@ -30302,6 +30823,7 @@ class QueryUpgradeRequest(BaseModel):
         | MCPToolQualityDailyStatsQuery
         | MCPToolCategoryCountsQuery
         | MCPToolCategoriesQuery
+        | MCPToolCategoryMapQuery
         | MCPToolDescriptionsQuery
         | MCPToolSampleIntentsQuery
         | MCPToolNeighborsQuery
@@ -30334,6 +30856,7 @@ class QueryUpgradeResponse(BaseModel):
         | SessionAttributionExplorerQuery
         | ErrorTrackingQuery
         | ErrorTrackingSimilarIssuesQuery
+        | ErrorTrackingFingerprintProjectionQuery
         | ErrorTrackingBreakdownsQuery
         | ErrorTrackingIssueCorrelationQuery
         | ExperimentFunnelsQuery
@@ -30405,6 +30928,7 @@ class QueryUpgradeResponse(BaseModel):
         | MCPToolQualityDailyStatsQuery
         | MCPToolCategoryCountsQuery
         | MCPToolCategoriesQuery
+        | MCPToolCategoryMapQuery
         | MCPToolDescriptionsQuery
         | MCPToolSampleIntentsQuery
         | MCPToolNeighborsQuery
@@ -30623,6 +31147,7 @@ class VisualizationArtifactContent(BaseModel):
         | SessionAttributionExplorerQuery
         | ErrorTrackingQuery
         | ErrorTrackingSimilarIssuesQuery
+        | ErrorTrackingFingerprintProjectionQuery
         | ErrorTrackingBreakdownsQuery
         | ErrorTrackingIssueCorrelationQuery
         | ExperimentFunnelsQuery
@@ -30694,6 +31219,7 @@ class VisualizationArtifactContent(BaseModel):
         | MCPToolQualityDailyStatsQuery
         | MCPToolCategoryCountsQuery
         | MCPToolCategoriesQuery
+        | MCPToolCategoryMapQuery
         | MCPToolDescriptionsQuery
         | MCPToolSampleIntentsQuery
         | MCPToolNeighborsQuery

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -29221,7 +29221,6 @@ class ActorsQuery(BaseModel):
             | CohortPropertyFilter
             | HogQLPropertyFilter
             | EmptyPropertyFilter
-            | BehavioralPropertyFilter
         ]
         | None
     ) = Field(
@@ -29243,7 +29242,6 @@ class ActorsQuery(BaseModel):
             | CohortPropertyFilter
             | HogQLPropertyFilter
             | EmptyPropertyFilter
-            | BehavioralPropertyFilter
         ]
         | PropertyGroupFilterValue
         | None

--- a/posthog/schema_enums.py
+++ b/posthog/schema_enums.py
@@ -602,6 +602,11 @@ class BaseMathType(StrEnum):
     FIRST_MATCHING_EVENT_FOR_USER = "first_matching_event_for_user"
 
 
+class BehavioralEventSource(StrEnum):
+    EVENTS = "events"
+    ACTIONS = "actions"
+
+
 class BillingSpendResponseBreakdownType(StrEnum):
     TYPE = "type"
     TEAM = "team"
@@ -2921,6 +2926,11 @@ class InfinityValue(float, Enum):
     NUMBER__999999 = -999999
 
 
+class InlineBehavioralType(StrEnum):
+    PERFORMED_EVENT = "performed_event"
+    PERFORMED_EVENT_MULTIPLE = "performed_event_multiple"
+
+
 class InsightFilterProperty(StrEnum):
     TRENDS_FILTER = "trendsFilter"
     FUNNELS_FILTER = "funnelsFilter"
@@ -3627,6 +3637,7 @@ class PropertyFilterType(StrEnum):
     FEATURE = "feature"
     SESSION = "session"
     COHORT = "cohort"
+    BEHAVIORAL = "behavioral"
     RECORDING = "recording"
     LOG_ENTRY = "log_entry"
     GROUP = "group"
@@ -4079,6 +4090,13 @@ class TaxonomicFilterGroupType(StrEnum):
 
 class TikTokAdsDefaultSources(StrEnum):
     TIKTOK = "tiktok"
+
+
+class TimeUnitType(StrEnum):
+    DAY = "day"
+    WEEK = "week"
+    MONTH = "month"
+    YEAR = "year"
 
 
 class TraceOrderColumn(StrEnum):

--- a/posthog/test/test_property_filter_discriminator.py
+++ b/posthog/test/test_property_filter_discriminator.py
@@ -5,6 +5,7 @@ from pydantic import ValidationError
 
 from posthog.schema import (
     AccountCustomPropertyFilter,
+    BehavioralPropertyFilter,
     CohortPropertyFilter,
     DashboardFilter,
     DataWarehousePersonPropertyFilter,
@@ -114,6 +115,18 @@ class TestPropertyFilterDiscriminator(SimpleTestCase):
                 "workflow_variable",
                 {"type": "workflow_variable", "key": "k", "operator": "exact"},
                 WorkflowVariablePropertyFilter,
+            ),
+            (
+                "behavioral",
+                {
+                    "type": "behavioral",
+                    "key": "$pageview",
+                    "value": "performed_event",
+                    "event_type": "events",
+                    "time_value": 30,
+                    "time_interval": "day",
+                },
+                BehavioralPropertyFilter,
             ),
         ]
     )

--- a/posthog/types.py
+++ b/posthog/types.py
@@ -3,6 +3,7 @@ from typing import Union
 from posthog.schema import (
     AccountCustomPropertyFilter,
     ActionsNode,
+    BehavioralPropertyFilter,
     CohortPropertyFilter,
     DataWarehouseNode,
     DataWarehousePersonPropertyFilter,
@@ -92,6 +93,7 @@ type AnyPropertyFilter = Union[
     MetricPropertyFilter,
     SpanPropertyFilter,
     WorkflowVariablePropertyFilter,
+    BehavioralPropertyFilter,
 ]
 
 type EntityNode = Union[

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -6532,7 +6532,6 @@ export interface ActorsQueryApi {
               | CohortPropertyFilterApi
               | HogQLPropertyFilterApi
               | EmptyPropertyFilterApi
-              | BehavioralPropertyFilterApi
           )[]
         | null
     kind?: 'ActorsQuery'
@@ -6549,7 +6548,6 @@ export interface ActorsQueryApi {
               | CohortPropertyFilterApi
               | HogQLPropertyFilterApi
               | EmptyPropertyFilterApi
-              | BehavioralPropertyFilterApi
           )[]
         | PropertyGroupFilterValueApi
         | null

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -1633,6 +1633,61 @@ export interface WorkflowVariablePropertyFilterApi {
     value?: (string | number | boolean)[] | string | number | boolean | null
 }
 
+export type BehavioralEventSourceApi = (typeof BehavioralEventSourceApi)[keyof typeof BehavioralEventSourceApi]
+
+export const BehavioralEventSourceApi = {
+    Events: 'events',
+    Actions: 'actions',
+} as const
+
+export type TimeUnitTypeApi = (typeof TimeUnitTypeApi)[keyof typeof TimeUnitTypeApi]
+
+export const TimeUnitTypeApi = {
+    Day: 'day',
+    Week: 'week',
+    Month: 'month',
+    Year: 'year',
+} as const
+
+export type InlineBehavioralTypeApi = (typeof InlineBehavioralTypeApi)[keyof typeof InlineBehavioralTypeApi]
+
+export const InlineBehavioralTypeApi = {
+    PerformedEvent: 'performed_event',
+    PerformedEventMultiple: 'performed_event_multiple',
+} as const
+
+export interface BehavioralPropertyFilterApi {
+    /** Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral/cohort filters and groups */
+    event_filters?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | HogQLPropertyFilterApi
+          )[]
+        | null
+    event_type: BehavioralEventSourceApi
+    /** Absolute or relative (e.g. -30d) lower date bound — alternative to time_value/time_interval */
+    explicit_datetime?: string | null
+    explicit_datetime_to?: string | null
+    /** Event name, or action id when event_type is 'actions' */
+    key: string
+    label?: string | null
+    /** Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators */
+    negation?: boolean | null
+    /** Count comparison for performed_event_multiple, defaults to exact */
+    operator?: PropertyOperatorApi | null
+    /** Count threshold for performed_event_multiple */
+    operator_value?: number | null
+    time_interval?: TimeUnitTypeApi | null
+    /** Relative time window size, paired with time_interval */
+    time_value?: number | null
+    /** Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP */
+    type?: 'behavioral'
+    value: InlineBehavioralTypeApi
+}
+
 export interface PropertyGroupFilterValueApi {
     type: FilterLogicalOperatorApi
     values: (
@@ -1660,6 +1715,7 @@ export interface PropertyGroupFilterValueApi {
         | RevenueAnalyticsPropertyFilterApi
         | AccountCustomPropertyFilterApi
         | WorkflowVariablePropertyFilterApi
+        | BehavioralPropertyFilterApi
     )[]
 }
 
@@ -2070,6 +2126,7 @@ export interface EventsNodeApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     kind?: 'EventsNode'
@@ -2120,6 +2177,7 @@ export interface EventsNodeApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     response?: EventsNodeApiResponse
@@ -2157,6 +2215,7 @@ export interface ActionsNodeApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     id: number
@@ -2205,6 +2264,7 @@ export interface ActionsNodeApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     response?: ActionsNodeApiResponse
@@ -2244,6 +2304,7 @@ export interface DataWarehouseNodeApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     id: string
@@ -2293,6 +2354,7 @@ export interface DataWarehouseNodeApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     response?: DataWarehouseNodeApiResponse
@@ -2332,6 +2394,7 @@ export interface GroupNodeApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     kind?: 'GroupNode'
@@ -2386,6 +2449,7 @@ export interface GroupNodeApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     response?: GroupNodeApiResponse
@@ -2682,6 +2746,7 @@ export interface TrendsQueryApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | PropertyGroupFilterApi
         | null
@@ -2739,6 +2804,7 @@ export interface FunnelExclusionEventsNodeApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     funnelFromStep: number
@@ -2791,6 +2857,7 @@ export interface FunnelExclusionEventsNodeApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     response?: FunnelExclusionEventsNodeApiResponse
@@ -2828,6 +2895,7 @@ export interface FunnelExclusionActionsNodeApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     funnelFromStep: number
@@ -2878,6 +2946,7 @@ export interface FunnelExclusionActionsNodeApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     response?: FunnelExclusionActionsNodeApiResponse
@@ -3029,6 +3098,7 @@ export interface FunnelsDataWarehouseNodeApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     id: string
@@ -3078,6 +3148,7 @@ export interface FunnelsDataWarehouseNodeApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     response?: FunnelsDataWarehouseNodeApiResponse
@@ -3133,6 +3204,7 @@ export interface FunnelsQueryApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | PropertyGroupFilterApi
         | null
@@ -3291,6 +3363,7 @@ export interface RetentionEntityApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     /** Data warehouse table name */
@@ -3384,6 +3457,7 @@ export interface RetentionQueryApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | PropertyGroupFilterApi
         | null
@@ -3521,6 +3595,7 @@ export interface PathsQueryApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | PropertyGroupFilterApi
         | null
@@ -3690,6 +3765,7 @@ export interface PathsV2QueryApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | PropertyGroupFilterApi
         | null
@@ -3814,6 +3890,7 @@ export interface StickinessQueryApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | PropertyGroupFilterApi
         | null
@@ -3906,6 +3983,7 @@ export interface LifecycleDataWarehouseNodeApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     id: string
@@ -3954,6 +4032,7 @@ export interface LifecycleDataWarehouseNodeApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     response?: LifecycleDataWarehouseNodeApiResponse
@@ -4007,6 +4086,7 @@ export interface LifecycleQueryApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | PropertyGroupFilterApi
         | null
@@ -5437,6 +5517,7 @@ export interface EventsQueryActionStepApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     selector?: string | null
@@ -5582,6 +5663,7 @@ export interface EventsQueryApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     kind?: 'EventsQuery'
@@ -5621,6 +5703,7 @@ export interface EventsQueryApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     response?: EventsQueryResponseApi | null
@@ -5666,6 +5749,7 @@ export interface PersonsNodeApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     kind?: 'PersonsNode'
@@ -5699,6 +5783,7 @@ export interface PersonsNodeApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     response?: PersonsNodeApiResponse
@@ -5835,6 +5920,7 @@ export interface FunnelCorrelationActorsQueryApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     includeRecordings?: boolean | null
@@ -5877,6 +5963,7 @@ export interface ExperimentEventExposureConfigApi {
         | RevenueAnalyticsPropertyFilterApi
         | AccountCustomPropertyFilterApi
         | WorkflowVariablePropertyFilterApi
+        | BehavioralPropertyFilterApi
     )[]
     response?: ExperimentEventExposureConfigApiResponse
     /** version of the node, used for schema migrations */
@@ -5929,6 +6016,7 @@ export interface ExperimentDataWarehouseNodeApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     kind?: 'ExperimentDataWarehouseNode'
@@ -5976,6 +6064,7 @@ export interface ExperimentDataWarehouseNodeApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     response?: ExperimentDataWarehouseNodeApiResponse
@@ -6349,6 +6438,7 @@ export interface HogQLFiltersApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
 }
@@ -6442,6 +6532,7 @@ export interface ActorsQueryApi {
               | CohortPropertyFilterApi
               | HogQLPropertyFilterApi
               | EmptyPropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     kind?: 'ActorsQuery'
@@ -6458,6 +6549,7 @@ export interface ActorsQueryApi {
               | CohortPropertyFilterApi
               | HogQLPropertyFilterApi
               | EmptyPropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | PropertyGroupFilterValueApi
         | null
@@ -6970,6 +7062,7 @@ export interface SessionsQueryApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     /** Filter test accounts */
@@ -7002,6 +7095,7 @@ export interface SessionsQueryApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     kind?: 'SessionsQuery'
@@ -7041,6 +7135,7 @@ export interface SessionsQueryApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     response?: SessionsQueryResponseApi | null
@@ -7093,6 +7188,7 @@ export interface ConversionGoalFilter1Api {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     kind?: 'EventsNode'
@@ -7143,6 +7239,7 @@ export interface ConversionGoalFilter1Api {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     response?: ConversionGoalFilter1ApiResponse
@@ -7189,6 +7286,7 @@ export interface ConversionGoalFilter2Api {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     id: number
@@ -7237,6 +7335,7 @@ export interface ConversionGoalFilter2Api {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     response?: ConversionGoalFilter2ApiResponse
@@ -7285,6 +7384,7 @@ export interface ConversionGoalFilter3Api {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     id: string
@@ -7334,6 +7434,7 @@ export interface ConversionGoalFilter3Api {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     response?: ConversionGoalFilter3ApiResponse
@@ -7861,6 +7962,7 @@ export interface TracesQueryApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     /** Use random ordering instead of timestamp DESC. Useful for representative sampling to avoid recency bias. */
@@ -7932,6 +8034,7 @@ export interface TraceQueryApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     response?: TraceQueryResponseApi | null
@@ -8811,6 +8914,7 @@ export interface DashboardFilterApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
 }
@@ -8849,6 +8953,7 @@ export interface TileFiltersApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
 }

--- a/products/endpoints/frontend/generated/api.schemas.ts
+++ b/products/endpoints/frontend/generated/api.schemas.ts
@@ -860,6 +860,61 @@ export interface WorkflowVariablePropertyFilterApi {
     value?: (string | number | boolean)[] | string | number | boolean | null
 }
 
+export type BehavioralEventSourceApi = (typeof BehavioralEventSourceApi)[keyof typeof BehavioralEventSourceApi]
+
+export const BehavioralEventSourceApi = {
+    Events: 'events',
+    Actions: 'actions',
+} as const
+
+export type TimeUnitTypeApi = (typeof TimeUnitTypeApi)[keyof typeof TimeUnitTypeApi]
+
+export const TimeUnitTypeApi = {
+    Day: 'day',
+    Week: 'week',
+    Month: 'month',
+    Year: 'year',
+} as const
+
+export type InlineBehavioralTypeApi = (typeof InlineBehavioralTypeApi)[keyof typeof InlineBehavioralTypeApi]
+
+export const InlineBehavioralTypeApi = {
+    PerformedEvent: 'performed_event',
+    PerformedEventMultiple: 'performed_event_multiple',
+} as const
+
+export interface BehavioralPropertyFilterApi {
+    /** Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral/cohort filters and groups */
+    event_filters?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | HogQLPropertyFilterApi
+          )[]
+        | null
+    event_type: BehavioralEventSourceApi
+    /** Absolute or relative (e.g. -30d) lower date bound — alternative to time_value/time_interval */
+    explicit_datetime?: string | null
+    explicit_datetime_to?: string | null
+    /** Event name, or action id when event_type is 'actions' */
+    key: string
+    label?: string | null
+    /** Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators */
+    negation?: boolean | null
+    /** Count comparison for performed_event_multiple, defaults to exact */
+    operator?: PropertyOperatorApi | null
+    /** Count threshold for performed_event_multiple */
+    operator_value?: number | null
+    time_interval?: TimeUnitTypeApi | null
+    /** Relative time window size, paired with time_interval */
+    time_value?: number | null
+    /** Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP */
+    type?: 'behavioral'
+    value: InlineBehavioralTypeApi
+}
+
 export interface DashboardFilterApi {
     breakdown_filter?: BreakdownFilterApi | null
     date_from?: string | null
@@ -894,6 +949,7 @@ export interface DashboardFilterApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
 }

--- a/products/error_tracking/frontend/generated/api.schemas.ts
+++ b/products/error_tracking/frontend/generated/api.schemas.ts
@@ -312,6 +312,61 @@ export interface WorkflowVariablePropertyFilterApi {
     value?: (string | number | boolean)[] | string | number | boolean | null
 }
 
+export type BehavioralEventSourceApi = (typeof BehavioralEventSourceApi)[keyof typeof BehavioralEventSourceApi]
+
+export const BehavioralEventSourceApi = {
+    Events: 'events',
+    Actions: 'actions',
+} as const
+
+export type TimeUnitTypeApi = (typeof TimeUnitTypeApi)[keyof typeof TimeUnitTypeApi]
+
+export const TimeUnitTypeApi = {
+    Day: 'day',
+    Week: 'week',
+    Month: 'month',
+    Year: 'year',
+} as const
+
+export type InlineBehavioralTypeApi = (typeof InlineBehavioralTypeApi)[keyof typeof InlineBehavioralTypeApi]
+
+export const InlineBehavioralTypeApi = {
+    PerformedEvent: 'performed_event',
+    PerformedEventMultiple: 'performed_event_multiple',
+} as const
+
+export interface BehavioralPropertyFilterApi {
+    /** Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral/cohort filters and groups */
+    event_filters?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | HogQLPropertyFilterApi
+          )[]
+        | null
+    event_type: BehavioralEventSourceApi
+    /** Absolute or relative (e.g. -30d) lower date bound — alternative to time_value/time_interval */
+    explicit_datetime?: string | null
+    explicit_datetime_to?: string | null
+    /** Event name, or action id when event_type is 'actions' */
+    key: string
+    label?: string | null
+    /** Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators */
+    negation?: boolean | null
+    /** Count comparison for performed_event_multiple, defaults to exact */
+    operator?: PropertyOperatorApi | null
+    /** Count threshold for performed_event_multiple */
+    operator_value?: number | null
+    time_interval?: TimeUnitTypeApi | null
+    /** Relative time window size, paired with time_interval */
+    time_value?: number | null
+    /** Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP */
+    type?: 'behavioral'
+    value: InlineBehavioralTypeApi
+}
+
 export interface PropertyGroupFilterValueApi {
     type: FilterLogicalOperatorApi
     values: (
@@ -339,6 +394,7 @@ export interface PropertyGroupFilterValueApi {
         | RevenueAnalyticsPropertyFilterApi
         | AccountCustomPropertyFilterApi
         | WorkflowVariablePropertyFilterApi
+        | BehavioralPropertyFilterApi
     )[]
 }
 

--- a/products/experiments/frontend/generated/api.schemas.ts
+++ b/products/experiments/frontend/generated/api.schemas.ts
@@ -1201,6 +1201,61 @@ export interface WorkflowVariablePropertyFilterApi {
     value?: (string | number | boolean)[] | string | number | boolean | null
 }
 
+export type BehavioralEventSourceApi = (typeof BehavioralEventSourceApi)[keyof typeof BehavioralEventSourceApi]
+
+export const BehavioralEventSourceApi = {
+    Events: 'events',
+    Actions: 'actions',
+} as const
+
+export type TimeUnitTypeApi = (typeof TimeUnitTypeApi)[keyof typeof TimeUnitTypeApi]
+
+export const TimeUnitTypeApi = {
+    Day: 'day',
+    Week: 'week',
+    Month: 'month',
+    Year: 'year',
+} as const
+
+export type InlineBehavioralTypeApi = (typeof InlineBehavioralTypeApi)[keyof typeof InlineBehavioralTypeApi]
+
+export const InlineBehavioralTypeApi = {
+    PerformedEvent: 'performed_event',
+    PerformedEventMultiple: 'performed_event_multiple',
+} as const
+
+export interface BehavioralPropertyFilterApi {
+    /** Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral/cohort filters and groups */
+    event_filters?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | HogQLPropertyFilterApi
+          )[]
+        | null
+    event_type: BehavioralEventSourceApi
+    /** Absolute or relative (e.g. -30d) lower date bound — alternative to time_value/time_interval */
+    explicit_datetime?: string | null
+    explicit_datetime_to?: string | null
+    /** Event name, or action id when event_type is 'actions' */
+    key: string
+    label?: string | null
+    /** Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators */
+    negation?: boolean | null
+    /** Count comparison for performed_event_multiple, defaults to exact */
+    operator?: PropertyOperatorApi | null
+    /** Count threshold for performed_event_multiple */
+    operator_value?: number | null
+    time_interval?: TimeUnitTypeApi | null
+    /** Relative time window size, paired with time_interval */
+    time_value?: number | null
+    /** Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP */
+    type?: 'behavioral'
+    value: InlineBehavioralTypeApi
+}
+
 export interface ExperimentApiExposureConfigApi {
     /** Custom exposure event name. Required when kind is 'ExperimentEventExposureConfig'. */
     event?: string | null
@@ -1233,6 +1288,7 @@ export interface ExperimentApiExposureConfigApi {
         | RevenueAnalyticsPropertyFilterApi
         | AccountCustomPropertyFilterApi
         | WorkflowVariablePropertyFilterApi
+        | BehavioralPropertyFilterApi
     )[]
 }
 

--- a/products/feature_flags/backend/test/test_filters_validation.py
+++ b/products/feature_flags/backend/test/test_filters_validation.py
@@ -362,6 +362,9 @@ class TestRejectSerdeUnsafeFilters(SimpleTestCase):
             ("property_type_not_string", {"groups": [{"properties": [{"key": "k", "type": 1}]}]}),
             # Rust has no `event` variant, so one of these fails the team's whole cached set.
             ("property_type_event", {"groups": [{"properties": [{"key": "k", "type": "event"}]}]}),
+            # `behavioral` is a real insight filter type, but Rust flag matching has no variant
+            # for it (it can't evaluate events history) — it must stay rejected here.
+            ("property_type_behavioral", {"groups": [{"properties": [{"key": "$pageview", "type": "behavioral"}]}]}),
             ("property_type_missing", {"groups": [{"properties": [{"key": "k"}]}]}),
             ("property_empty", {"groups": [{"properties": [{}]}]}),
             ("property_key_missing", {"groups": [{"properties": [{"type": "person"}]}]}),

--- a/products/logs/frontend/generated/api.schemas.ts
+++ b/products/logs/frontend/generated/api.schemas.ts
@@ -284,6 +284,61 @@ export interface WorkflowVariablePropertyFilterApi {
     value?: (string | number | boolean)[] | string | number | boolean | null
 }
 
+export type BehavioralEventSourceApi = (typeof BehavioralEventSourceApi)[keyof typeof BehavioralEventSourceApi]
+
+export const BehavioralEventSourceApi = {
+    Events: 'events',
+    Actions: 'actions',
+} as const
+
+export type TimeUnitTypeApi = (typeof TimeUnitTypeApi)[keyof typeof TimeUnitTypeApi]
+
+export const TimeUnitTypeApi = {
+    Day: 'day',
+    Week: 'week',
+    Month: 'month',
+    Year: 'year',
+} as const
+
+export type InlineBehavioralTypeApi = (typeof InlineBehavioralTypeApi)[keyof typeof InlineBehavioralTypeApi]
+
+export const InlineBehavioralTypeApi = {
+    PerformedEvent: 'performed_event',
+    PerformedEventMultiple: 'performed_event_multiple',
+} as const
+
+export interface BehavioralPropertyFilterApi {
+    /** Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral/cohort filters and groups */
+    event_filters?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | HogQLPropertyFilterApi
+          )[]
+        | null
+    event_type: BehavioralEventSourceApi
+    /** Absolute or relative (e.g. -30d) lower date bound — alternative to time_value/time_interval */
+    explicit_datetime?: string | null
+    explicit_datetime_to?: string | null
+    /** Event name, or action id when event_type is 'actions' */
+    key: string
+    label?: string | null
+    /** Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators */
+    negation?: boolean | null
+    /** Count comparison for performed_event_multiple, defaults to exact */
+    operator?: PropertyOperatorApi | null
+    /** Count threshold for performed_event_multiple */
+    operator_value?: number | null
+    time_interval?: TimeUnitTypeApi | null
+    /** Relative time window size, paired with time_interval */
+    time_value?: number | null
+    /** Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP */
+    type?: 'behavioral'
+    value: InlineBehavioralTypeApi
+}
+
 export interface PropertyGroupFilterValueApi {
     type: FilterLogicalOperatorApi
     values: (
@@ -311,6 +366,7 @@ export interface PropertyGroupFilterValueApi {
         | RevenueAnalyticsPropertyFilterApi
         | AccountCustomPropertyFilterApi
         | WorkflowVariablePropertyFilterApi
+        | BehavioralPropertyFilterApi
     )[]
 }
 

--- a/products/marketing_analytics/frontend/generated/api.schemas.ts
+++ b/products/marketing_analytics/frontend/generated/api.schemas.ts
@@ -390,6 +390,61 @@ export interface WorkflowVariablePropertyFilterApi {
     value?: (string | number | boolean)[] | string | number | boolean | null
 }
 
+export type BehavioralEventSourceApi = (typeof BehavioralEventSourceApi)[keyof typeof BehavioralEventSourceApi]
+
+export const BehavioralEventSourceApi = {
+    Events: 'events',
+    Actions: 'actions',
+} as const
+
+export type TimeUnitTypeApi = (typeof TimeUnitTypeApi)[keyof typeof TimeUnitTypeApi]
+
+export const TimeUnitTypeApi = {
+    Day: 'day',
+    Week: 'week',
+    Month: 'month',
+    Year: 'year',
+} as const
+
+export type InlineBehavioralTypeApi = (typeof InlineBehavioralTypeApi)[keyof typeof InlineBehavioralTypeApi]
+
+export const InlineBehavioralTypeApi = {
+    PerformedEvent: 'performed_event',
+    PerformedEventMultiple: 'performed_event_multiple',
+} as const
+
+export interface BehavioralPropertyFilterApi {
+    /** Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral/cohort filters and groups */
+    event_filters?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | HogQLPropertyFilterApi
+          )[]
+        | null
+    event_type: BehavioralEventSourceApi
+    /** Absolute or relative (e.g. -30d) lower date bound — alternative to time_value/time_interval */
+    explicit_datetime?: string | null
+    explicit_datetime_to?: string | null
+    /** Event name, or action id when event_type is 'actions' */
+    key: string
+    label?: string | null
+    /** Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators */
+    negation?: boolean | null
+    /** Count comparison for performed_event_multiple, defaults to exact */
+    operator?: PropertyOperatorApi | null
+    /** Count threshold for performed_event_multiple */
+    operator_value?: number | null
+    time_interval?: TimeUnitTypeApi | null
+    /** Relative time window size, paired with time_interval */
+    time_value?: number | null
+    /** Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP */
+    type?: 'behavioral'
+    value: InlineBehavioralTypeApi
+}
+
 export type BaseMathTypeApi = (typeof BaseMathTypeApi)[keyof typeof BaseMathTypeApi]
 
 export const BaseMathTypeApi = {
@@ -678,6 +733,7 @@ export interface ConversionGoalFilter1Api {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     kind?: 'EventsNode'
@@ -728,6 +784,7 @@ export interface ConversionGoalFilter1Api {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     response?: ConversionGoalFilter1ApiResponse
@@ -774,6 +831,7 @@ export interface ConversionGoalFilter2Api {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     id: number
@@ -822,6 +880,7 @@ export interface ConversionGoalFilter2Api {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     response?: ConversionGoalFilter2ApiResponse
@@ -870,6 +929,7 @@ export interface ConversionGoalFilter3Api {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     id: string
@@ -919,6 +979,7 @@ export interface ConversionGoalFilter3Api {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     response?: ConversionGoalFilter3ApiResponse
@@ -989,6 +1050,7 @@ export interface PartialConversionGoalFilter1Api {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     kind?: 'EventsNode' | null
@@ -1037,6 +1099,7 @@ export interface PartialConversionGoalFilter1Api {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     response?: PartialConversionGoalFilter1ApiResponse
@@ -1082,6 +1145,7 @@ export interface PartialConversionGoalFilter2Api {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     id?: number | null
@@ -1129,6 +1193,7 @@ export interface PartialConversionGoalFilter2Api {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     response?: PartialConversionGoalFilter2ApiResponse
@@ -1176,6 +1241,7 @@ export interface PartialConversionGoalFilter3Api {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     id?: string | null
@@ -1224,6 +1290,7 @@ export interface PartialConversionGoalFilter3Api {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     response?: PartialConversionGoalFilter3ApiResponse

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -5694,7 +5694,6 @@ export interface ActorsQueryApi {
               | CohortPropertyFilterApi
               | HogQLPropertyFilterApi
               | EmptyPropertyFilterApi
-              | BehavioralPropertyFilterApi
           )[]
         | null
     kind?: 'ActorsQuery'
@@ -5711,7 +5710,6 @@ export interface ActorsQueryApi {
               | CohortPropertyFilterApi
               | HogQLPropertyFilterApi
               | EmptyPropertyFilterApi
-              | BehavioralPropertyFilterApi
           )[]
         | PropertyGroupFilterValueApi
         | null

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -795,6 +795,61 @@ export interface WorkflowVariablePropertyFilterApi {
     value?: (string | number | boolean)[] | string | number | boolean | null
 }
 
+export type BehavioralEventSourceApi = (typeof BehavioralEventSourceApi)[keyof typeof BehavioralEventSourceApi]
+
+export const BehavioralEventSourceApi = {
+    Events: 'events',
+    Actions: 'actions',
+} as const
+
+export type TimeUnitTypeApi = (typeof TimeUnitTypeApi)[keyof typeof TimeUnitTypeApi]
+
+export const TimeUnitTypeApi = {
+    Day: 'day',
+    Week: 'week',
+    Month: 'month',
+    Year: 'year',
+} as const
+
+export type InlineBehavioralTypeApi = (typeof InlineBehavioralTypeApi)[keyof typeof InlineBehavioralTypeApi]
+
+export const InlineBehavioralTypeApi = {
+    PerformedEvent: 'performed_event',
+    PerformedEventMultiple: 'performed_event_multiple',
+} as const
+
+export interface BehavioralPropertyFilterApi {
+    /** Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral/cohort filters and groups */
+    event_filters?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | HogQLPropertyFilterApi
+          )[]
+        | null
+    event_type: BehavioralEventSourceApi
+    /** Absolute or relative (e.g. -30d) lower date bound — alternative to time_value/time_interval */
+    explicit_datetime?: string | null
+    explicit_datetime_to?: string | null
+    /** Event name, or action id when event_type is 'actions' */
+    key: string
+    label?: string | null
+    /** Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators */
+    negation?: boolean | null
+    /** Count comparison for performed_event_multiple, defaults to exact */
+    operator?: PropertyOperatorApi | null
+    /** Count threshold for performed_event_multiple */
+    operator_value?: number | null
+    time_interval?: TimeUnitTypeApi | null
+    /** Relative time window size, paired with time_interval */
+    time_value?: number | null
+    /** Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP */
+    type?: 'behavioral'
+    value: InlineBehavioralTypeApi
+}
+
 export interface PropertyGroupFilterValueApi {
     type: FilterLogicalOperatorApi
     values: (
@@ -822,6 +877,7 @@ export interface PropertyGroupFilterValueApi {
         | RevenueAnalyticsPropertyFilterApi
         | AccountCustomPropertyFilterApi
         | WorkflowVariablePropertyFilterApi
+        | BehavioralPropertyFilterApi
     )[]
 }
 
@@ -1232,6 +1288,7 @@ export interface EventsNodeApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     kind?: 'EventsNode'
@@ -1282,6 +1339,7 @@ export interface EventsNodeApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     response?: EventsNodeApiResponse
@@ -1319,6 +1377,7 @@ export interface ActionsNodeApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     id: number
@@ -1367,6 +1426,7 @@ export interface ActionsNodeApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     response?: ActionsNodeApiResponse
@@ -1406,6 +1466,7 @@ export interface DataWarehouseNodeApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     id: string
@@ -1455,6 +1516,7 @@ export interface DataWarehouseNodeApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     response?: DataWarehouseNodeApiResponse
@@ -1494,6 +1556,7 @@ export interface GroupNodeApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     kind?: 'GroupNode'
@@ -1548,6 +1611,7 @@ export interface GroupNodeApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     response?: GroupNodeApiResponse
@@ -1844,6 +1908,7 @@ export interface TrendsQueryApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | PropertyGroupFilterApi
         | null
@@ -1901,6 +1966,7 @@ export interface FunnelExclusionEventsNodeApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     funnelFromStep: number
@@ -1953,6 +2019,7 @@ export interface FunnelExclusionEventsNodeApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     response?: FunnelExclusionEventsNodeApiResponse
@@ -1990,6 +2057,7 @@ export interface FunnelExclusionActionsNodeApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     funnelFromStep: number
@@ -2040,6 +2108,7 @@ export interface FunnelExclusionActionsNodeApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     response?: FunnelExclusionActionsNodeApiResponse
@@ -2191,6 +2260,7 @@ export interface FunnelsDataWarehouseNodeApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     id: string
@@ -2240,6 +2310,7 @@ export interface FunnelsDataWarehouseNodeApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     response?: FunnelsDataWarehouseNodeApiResponse
@@ -2295,6 +2366,7 @@ export interface FunnelsQueryApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | PropertyGroupFilterApi
         | null
@@ -2453,6 +2525,7 @@ export interface RetentionEntityApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     /** Data warehouse table name */
@@ -2546,6 +2619,7 @@ export interface RetentionQueryApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | PropertyGroupFilterApi
         | null
@@ -2683,6 +2757,7 @@ export interface PathsQueryApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | PropertyGroupFilterApi
         | null
@@ -2852,6 +2927,7 @@ export interface PathsV2QueryApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | PropertyGroupFilterApi
         | null
@@ -2976,6 +3052,7 @@ export interface StickinessQueryApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | PropertyGroupFilterApi
         | null
@@ -3068,6 +3145,7 @@ export interface LifecycleDataWarehouseNodeApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     id: string
@@ -3116,6 +3194,7 @@ export interface LifecycleDataWarehouseNodeApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     response?: LifecycleDataWarehouseNodeApiResponse
@@ -3169,6 +3248,7 @@ export interface LifecycleQueryApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | PropertyGroupFilterApi
         | null
@@ -4599,6 +4679,7 @@ export interface EventsQueryActionStepApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     selector?: string | null
@@ -4744,6 +4825,7 @@ export interface EventsQueryApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     kind?: 'EventsQuery'
@@ -4783,6 +4865,7 @@ export interface EventsQueryApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     response?: EventsQueryResponseApi | null
@@ -4828,6 +4911,7 @@ export interface PersonsNodeApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     kind?: 'PersonsNode'
@@ -4861,6 +4945,7 @@ export interface PersonsNodeApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     response?: PersonsNodeApiResponse
@@ -4997,6 +5082,7 @@ export interface FunnelCorrelationActorsQueryApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     includeRecordings?: boolean | null
@@ -5039,6 +5125,7 @@ export interface ExperimentEventExposureConfigApi {
         | RevenueAnalyticsPropertyFilterApi
         | AccountCustomPropertyFilterApi
         | WorkflowVariablePropertyFilterApi
+        | BehavioralPropertyFilterApi
     )[]
     response?: ExperimentEventExposureConfigApiResponse
     /** version of the node, used for schema migrations */
@@ -5091,6 +5178,7 @@ export interface ExperimentDataWarehouseNodeApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     kind?: 'ExperimentDataWarehouseNode'
@@ -5138,6 +5226,7 @@ export interface ExperimentDataWarehouseNodeApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     response?: ExperimentDataWarehouseNodeApiResponse
@@ -5511,6 +5600,7 @@ export interface HogQLFiltersApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
 }
@@ -5604,6 +5694,7 @@ export interface ActorsQueryApi {
               | CohortPropertyFilterApi
               | HogQLPropertyFilterApi
               | EmptyPropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     kind?: 'ActorsQuery'
@@ -5620,6 +5711,7 @@ export interface ActorsQueryApi {
               | CohortPropertyFilterApi
               | HogQLPropertyFilterApi
               | EmptyPropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | PropertyGroupFilterValueApi
         | null
@@ -6132,6 +6224,7 @@ export interface SessionsQueryApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     /** Filter test accounts */
@@ -6164,6 +6257,7 @@ export interface SessionsQueryApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     kind?: 'SessionsQuery'
@@ -6203,6 +6297,7 @@ export interface SessionsQueryApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     response?: SessionsQueryResponseApi | null
@@ -6255,6 +6350,7 @@ export interface ConversionGoalFilter1Api {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     kind?: 'EventsNode'
@@ -6305,6 +6401,7 @@ export interface ConversionGoalFilter1Api {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     response?: ConversionGoalFilter1ApiResponse
@@ -6351,6 +6448,7 @@ export interface ConversionGoalFilter2Api {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     id: number
@@ -6399,6 +6497,7 @@ export interface ConversionGoalFilter2Api {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     response?: ConversionGoalFilter2ApiResponse
@@ -6447,6 +6546,7 @@ export interface ConversionGoalFilter3Api {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     id: string
@@ -6496,6 +6596,7 @@ export interface ConversionGoalFilter3Api {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     response?: ConversionGoalFilter3ApiResponse
@@ -7023,6 +7124,7 @@ export interface TracesQueryApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     /** Use random ordering instead of timestamp DESC. Useful for representative sampling to avoid recency bias. */
@@ -7094,6 +7196,7 @@ export interface TraceQueryApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
     response?: TraceQueryResponseApi | null
@@ -8038,6 +8141,7 @@ export interface DashboardFilterApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
 }
@@ -8076,6 +8180,7 @@ export interface TileFiltersApi {
               | RevenueAnalyticsPropertyFilterApi
               | AccountCustomPropertyFilterApi
               | WorkflowVariablePropertyFilterApi
+              | BehavioralPropertyFilterApi
           )[]
         | null
 }

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -2163,6 +2163,56 @@ export namespace Schemas {
       value?: (string | number | boolean)[] | string | number | boolean | null;
     }
 
+    export type BehavioralEventSource = typeof BehavioralEventSource[keyof typeof BehavioralEventSource];
+
+
+    export const BehavioralEventSource = {
+      Events: 'events',
+      Actions: 'actions',
+    } as const;
+
+    export type TimeUnitType = typeof TimeUnitType[keyof typeof TimeUnitType];
+
+
+    export const TimeUnitType = {
+      Day: 'day',
+      Week: 'week',
+      Month: 'month',
+      Year: 'year',
+    } as const;
+
+    export type InlineBehavioralType = typeof InlineBehavioralType[keyof typeof InlineBehavioralType];
+
+
+    export const InlineBehavioralType = {
+      PerformedEvent: 'performed_event',
+      PerformedEventMultiple: 'performed_event_multiple',
+    } as const;
+
+    export interface BehavioralPropertyFilter {
+      /** Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral/cohort filters and groups */
+      event_filters?: (EventPropertyFilter | PersonPropertyFilter | ElementPropertyFilter | FeaturePropertyFilter | HogQLPropertyFilter)[] | null;
+      event_type: BehavioralEventSource;
+      /** Absolute or relative (e.g. -30d) lower date bound — alternative to time_value/time_interval */
+      explicit_datetime?: string | null;
+      explicit_datetime_to?: string | null;
+      /** Event name, or action id when event_type is 'actions' */
+      key: string;
+      label?: string | null;
+      /** Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators */
+      negation?: boolean | null;
+      /** Count comparison for performed_event_multiple, defaults to exact */
+      operator?: PropertyOperator | null;
+      /** Count threshold for performed_event_multiple */
+      operator_value?: number | null;
+      time_interval?: TimeUnitType | null;
+      /** Relative time window size, paired with time_interval */
+      time_value?: number | null;
+      /** Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP */
+      type?: 'behavioral';
+      value: InlineBehavioralType;
+    }
+
     export type BaseMathType = typeof BaseMathType[keyof typeof BaseMathType];
 
 
@@ -2423,7 +2473,7 @@ export namespace Schemas {
     export interface ActionsNode {
       custom_name?: string | null;
       /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
-      fixedProperties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      fixedProperties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       id: number;
       kind?: 'ActionsNode';
       math?: BaseMathType | FunnelMathType | PropertyMathType | CountPerActorMathType | GroupMathType | ExperimentMetricMathType | CalendarHeatmapMathType | 'hogql' | null;
@@ -2436,7 +2486,7 @@ export namespace Schemas {
       name?: string | null;
       optionalInFunnel?: boolean | null;
       /** Properties configurable in the interface */
-      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       response?: ActionsNodeResponse;
       /** version of the node, used for schema migrations */
       version?: number | null;
@@ -2904,7 +2954,7 @@ export namespace Schemas {
 
     export interface PropertyGroupFilterValue {
       type: FilterLogicalOperator;
-      values: (PropertyGroupFilterValue | EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[];
+      values: (PropertyGroupFilterValue | EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[];
     }
 
     export interface ActorsQueryResponse {
@@ -3104,7 +3154,7 @@ export namespace Schemas {
       /** The event or `null` for all events. */
       event?: string | null;
       /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
-      fixedProperties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      fixedProperties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       kind?: 'EventsNode';
       limit?: number | null;
       math?: BaseMathType | FunnelMathType | PropertyMathType | CountPerActorMathType | GroupMathType | ExperimentMetricMathType | CalendarHeatmapMathType | 'hogql' | null;
@@ -3119,7 +3169,7 @@ export namespace Schemas {
       /** Columns to order by */
       orderBy?: string[] | null;
       /** Properties configurable in the interface */
-      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       response?: EventsNodeResponse;
       /** version of the node, used for schema migrations */
       version?: number | null;
@@ -3132,7 +3182,7 @@ export namespace Schemas {
       distinct_id_field: string;
       dw_source_type?: string | null;
       /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
-      fixedProperties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      fixedProperties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       id: string;
       id_field: string;
       kind?: 'DataWarehouseNode';
@@ -3146,7 +3196,7 @@ export namespace Schemas {
       name?: string | null;
       optionalInFunnel?: boolean | null;
       /** Properties configurable in the interface */
-      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       response?: DataWarehouseNodeResponse;
       table_name: string;
       timestamp_field: string;
@@ -3159,7 +3209,7 @@ export namespace Schemas {
     export interface GroupNode {
       custom_name?: string | null;
       /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
-      fixedProperties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      fixedProperties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       kind?: 'GroupNode';
       limit?: number | null;
       math?: BaseMathType | FunnelMathType | PropertyMathType | CountPerActorMathType | GroupMathType | ExperimentMetricMathType | CalendarHeatmapMathType | 'hogql' | null;
@@ -3178,7 +3228,7 @@ export namespace Schemas {
       /** Columns to order by */
       orderBy?: string[] | null;
       /** Properties configurable in the interface */
-      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       response?: GroupNodeResponse;
       /** version of the node, used for schema migrations */
       version?: number | null;
@@ -3445,7 +3495,7 @@ export namespace Schemas {
       /** Modifiers used when performing the query */
       modifiers?: HogQLQueryModifiers | null;
       /** Property filters for all series */
-      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | PropertyGroupFilter | null;
+      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | PropertyGroupFilter | null;
       response?: TrendsQueryResponse | null;
       /** Sampling rate */
       samplingFactor?: number | null;
@@ -3476,7 +3526,7 @@ export namespace Schemas {
       /** The event or `null` for all events. */
       event?: string | null;
       /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
-      fixedProperties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      fixedProperties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       funnelFromStep: number;
       funnelToStep: number;
       kind?: 'EventsNode';
@@ -3493,7 +3543,7 @@ export namespace Schemas {
       /** Columns to order by */
       orderBy?: string[] | null;
       /** Properties configurable in the interface */
-      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       response?: FunnelExclusionEventsNodeResponse;
       /** version of the node, used for schema migrations */
       version?: number | null;
@@ -3504,7 +3554,7 @@ export namespace Schemas {
     export interface FunnelExclusionActionsNode {
       custom_name?: string | null;
       /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
-      fixedProperties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      fixedProperties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       funnelFromStep: number;
       funnelToStep: number;
       id: number;
@@ -3519,7 +3569,7 @@ export namespace Schemas {
       name?: string | null;
       optionalInFunnel?: boolean | null;
       /** Properties configurable in the interface */
-      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       response?: FunnelExclusionActionsNodeResponse;
       /** version of the node, used for schema migrations */
       version?: number | null;
@@ -3648,7 +3698,7 @@ export namespace Schemas {
       custom_name?: string | null;
       dw_source_type?: string | null;
       /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
-      fixedProperties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      fixedProperties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       id: string;
       id_field: string;
       kind?: 'FunnelsDataWarehouseNode';
@@ -3662,7 +3712,7 @@ export namespace Schemas {
       name?: string | null;
       optionalInFunnel?: boolean | null;
       /** Properties configurable in the interface */
-      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       response?: FunnelsDataWarehouseNodeResponse;
       table_name: string;
       timestamp_field: string;
@@ -3691,7 +3741,7 @@ export namespace Schemas {
       /** Modifiers used when performing the query */
       modifiers?: HogQLQueryModifiers | null;
       /** Property filters for all series */
-      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | PropertyGroupFilter | null;
+      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | PropertyGroupFilter | null;
       response?: FunnelsQueryResponse | null;
       /** Sampling rate */
       samplingFactor?: number | null;
@@ -3830,7 +3880,7 @@ export namespace Schemas {
       name?: string | null;
       order?: number | null;
       /** filters on the event */
-      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       /** Data warehouse table name */
       table_name?: string | null;
       /** Data warehouse timestamp field */
@@ -3898,7 +3948,7 @@ export namespace Schemas {
       /** Modifiers used when performing the query */
       modifiers?: HogQLQueryModifiers | null;
       /** Property filters for all series */
-      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | PropertyGroupFilter | null;
+      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | PropertyGroupFilter | null;
       response?: RetentionQueryResponse | null;
       /** Properties specific to the retention insight */
       retentionFilter: RetentionFilter;
@@ -4010,7 +4060,7 @@ export namespace Schemas {
       /** Properties specific to the paths insight */
       pathsFilter: PathsFilter;
       /** Property filters for all series */
-      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | PropertyGroupFilter | null;
+      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | PropertyGroupFilter | null;
       response?: PathsQueryResponse | null;
       /** Sampling rate */
       samplingFactor?: number | null;
@@ -4153,7 +4203,7 @@ export namespace Schemas {
       /** Properties specific to the paths v2 insight */
       pathsV2Filter?: PathsV2Filter | null;
       /** Property filters for all series */
-      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | PropertyGroupFilter | null;
+      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | PropertyGroupFilter | null;
       response?: PathsV2QueryResponse | null;
       /** Tags that will be added to the Query log comment */
       tags?: QueryLogTags | null;
@@ -4248,7 +4298,7 @@ export namespace Schemas {
       /** Modifiers used when performing the query */
       modifiers?: HogQLQueryModifiers | null;
       /** Property filters for all series */
-      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | PropertyGroupFilter | null;
+      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | PropertyGroupFilter | null;
       response?: StickinessQueryResponse | null;
       /** Sampling rate */
       samplingFactor?: number | null;
@@ -4314,7 +4364,7 @@ export namespace Schemas {
       created_at_field: string;
       custom_name?: string | null;
       /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
-      fixedProperties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      fixedProperties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       id: string;
       kind?: 'LifecycleDataWarehouseNode';
       math?: BaseMathType | FunnelMathType | PropertyMathType | CountPerActorMathType | GroupMathType | ExperimentMetricMathType | CalendarHeatmapMathType | 'hogql' | null;
@@ -4327,7 +4377,7 @@ export namespace Schemas {
       name?: string | null;
       optionalInFunnel?: boolean | null;
       /** Properties configurable in the interface */
-      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       response?: LifecycleDataWarehouseNodeResponse;
       table_name: string;
       timestamp_field: string;
@@ -4354,7 +4404,7 @@ export namespace Schemas {
       /** Modifiers used when performing the query */
       modifiers?: HogQLQueryModifiers | null;
       /** Property filters for all series */
-      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | PropertyGroupFilter | null;
+      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | PropertyGroupFilter | null;
       response?: LifecycleQueryResponse | null;
       /** Sampling rate */
       samplingFactor?: number | null;
@@ -4717,7 +4767,7 @@ export namespace Schemas {
     export interface FunnelCorrelationActorsQuery {
       funnelCorrelationPersonConverted?: boolean | null;
       funnelCorrelationPersonEntity?: EventsNode | ActionsNode | DataWarehouseNode | null;
-      funnelCorrelationPropertyValues?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      funnelCorrelationPropertyValues?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       includeRecordings?: boolean | null;
       kind?: 'FunnelCorrelationActorsQuery';
       /** Modifiers used when performing the query */
@@ -4734,7 +4784,7 @@ export namespace Schemas {
     export interface ExperimentEventExposureConfig {
       event: string;
       kind?: 'ExperimentEventExposureConfig';
-      properties: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[];
+      properties: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[];
       response?: ExperimentEventExposureConfigResponse;
       /** version of the node, used for schema migrations */
       version?: number | null;
@@ -4763,7 +4813,7 @@ export namespace Schemas {
       data_warehouse_join_key: string;
       events_join_key: string;
       /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
-      fixedProperties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      fixedProperties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       kind?: 'ExperimentDataWarehouseNode';
       math?: BaseMathType | FunnelMathType | PropertyMathType | CountPerActorMathType | GroupMathType | ExperimentMetricMathType | CalendarHeatmapMathType | 'hogql' | null;
       math_group_type_index?: MathGroupTypeIndex | null;
@@ -4775,7 +4825,7 @@ export namespace Schemas {
       name?: string | null;
       optionalInFunnel?: boolean | null;
       /** Properties configurable in the interface */
-      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       response?: ExperimentDataWarehouseNodeResponse;
       table_name: string;
       timestamp_field: string;
@@ -5140,7 +5190,7 @@ export namespace Schemas {
       filterTestAccounts?: boolean | null;
       /** Time granularity consumed by the {filters.interval} placeholder. Set from the dashboard-level interval. */
       interval?: IntervalType | null;
-      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
     }
 
     export interface HogQLNotice {
@@ -5253,7 +5303,7 @@ export namespace Schemas {
       /** Exclude persons matching the team's "internal and test account" filters. Only person-scoped filters (person properties, cohorts) are applied. Event-scoped test account filters have no meaning in a persons query and are ignored. */
       filterTestAccounts?: boolean | null;
       /** Currently only person filters supported. No filters for querying groups. See `filter_conditions()` in actor_strategies.py. */
-      fixedProperties?: (PersonPropertyFilter | PersonMetadataPropertyFilter | CohortPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter)[] | null;
+      fixedProperties?: (PersonPropertyFilter | PersonMetadataPropertyFilter | CohortPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | BehavioralPropertyFilter)[] | null;
       kind?: 'ActorsQuery';
       limit?: number | null;
       /** Modifiers used when performing the query */
@@ -5261,7 +5311,7 @@ export namespace Schemas {
       offset?: number | null;
       orderBy?: string[] | null;
       /** Currently only person filters supported. No filters for querying groups. See `filter_conditions()` in actor_strategies.py. */
-      properties?: (PersonPropertyFilter | PersonMetadataPropertyFilter | CohortPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter)[] | PropertyGroupFilterValue | null;
+      properties?: (PersonPropertyFilter | PersonMetadataPropertyFilter | CohortPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | BehavioralPropertyFilter)[] | PropertyGroupFilterValue | null;
       response?: ActorsQueryResponse | null;
       search?: string | null;
       select?: string[] | null;
@@ -6840,7 +6890,7 @@ export namespace Schemas {
       event?: string | null;
       href?: string | null;
       href_matching?: HrefMatching | null;
-      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       selector?: string | null;
       tag_name?: string | null;
       text?: string | null;
@@ -6894,7 +6944,7 @@ export namespace Schemas {
       /** Filter test accounts */
       filterTestAccounts?: boolean | null;
       /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
-      fixedProperties?: (PropertyGroupFilter | PropertyGroupFilterValue | EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      fixedProperties?: (PropertyGroupFilter | PropertyGroupFilterValue | EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       kind?: 'EventsQuery';
       /** Number of rows to return */
       limit?: number | null;
@@ -6907,7 +6957,7 @@ export namespace Schemas {
       /** Show events for a given person */
       personId?: string | null;
       /** Properties configurable in the interface */
-      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       response?: EventsQueryResponse | null;
       /** Return a limited set of data. Required. */
       select: string[];
@@ -6926,14 +6976,14 @@ export namespace Schemas {
       cohort?: number | null;
       distinctId?: string | null;
       /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
-      fixedProperties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      fixedProperties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       kind?: 'PersonsNode';
       limit?: number | null;
       /** Modifiers used when performing the query */
       modifiers?: HogQLQueryModifiers | null;
       offset?: number | null;
       /** Properties configurable in the interface */
-      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       response?: PersonsNodeResponse;
       search?: string | null;
       tags?: QueryLogTags | null;
@@ -7377,11 +7427,11 @@ export namespace Schemas {
       /** Filter sessions by event name - sessions that contain this event */
       event?: string | null;
       /** Event property filters - filters sessions that contain events matching these properties */
-      eventProperties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      eventProperties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       /** Filter test accounts */
       filterTestAccounts?: boolean | null;
       /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
-      fixedProperties?: (PropertyGroupFilter | PropertyGroupFilterValue | EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      fixedProperties?: (PropertyGroupFilter | PropertyGroupFilterValue | EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       kind?: 'SessionsQuery';
       /** Number of rows to return */
       limit?: number | null;
@@ -7394,7 +7444,7 @@ export namespace Schemas {
       /** Show sessions for a given person */
       personId?: string | null;
       /** Properties configurable in the interface */
-      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       response?: SessionsQueryResponse | null;
       /** Return a limited set of data. Required. */
       select: string[];
@@ -7420,7 +7470,7 @@ export namespace Schemas {
       /** The event or `null` for all events. */
       event?: string | null;
       /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
-      fixedProperties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      fixedProperties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       kind?: 'EventsNode';
       limit?: number | null;
       math?: BaseMathType | FunnelMathType | PropertyMathType | CountPerActorMathType | GroupMathType | ExperimentMetricMathType | CalendarHeatmapMathType | 'hogql' | null;
@@ -7435,7 +7485,7 @@ export namespace Schemas {
       /** Columns to order by */
       orderBy?: string[] | null;
       /** Properties configurable in the interface */
-      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       response?: ConversionGoalFilter1Response;
       schema_map: ConversionGoalFilter1SchemaMap;
       /** version of the node, used for schema migrations */
@@ -7455,7 +7505,7 @@ export namespace Schemas {
       counts_as_revenue?: boolean | null;
       custom_name?: string | null;
       /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
-      fixedProperties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      fixedProperties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       id: number;
       kind?: 'ActionsNode';
       math?: BaseMathType | FunnelMathType | PropertyMathType | CountPerActorMathType | GroupMathType | ExperimentMetricMathType | CalendarHeatmapMathType | 'hogql' | null;
@@ -7468,7 +7518,7 @@ export namespace Schemas {
       name?: string | null;
       optionalInFunnel?: boolean | null;
       /** Properties configurable in the interface */
-      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       response?: ConversionGoalFilter2Response;
       schema_map: ConversionGoalFilter2SchemaMap;
       /** version of the node, used for schema migrations */
@@ -7490,7 +7540,7 @@ export namespace Schemas {
       distinct_id_field: string;
       dw_source_type?: string | null;
       /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
-      fixedProperties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      fixedProperties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       id: string;
       id_field: string;
       kind?: 'DataWarehouseNode';
@@ -7504,7 +7554,7 @@ export namespace Schemas {
       name?: string | null;
       optionalInFunnel?: boolean | null;
       /** Properties configurable in the interface */
-      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       response?: ConversionGoalFilter3Response;
       schema_map: ConversionGoalFilter3SchemaMap;
       table_name: string;
@@ -7992,7 +8042,7 @@ export namespace Schemas {
       /** Person who performed the event */
       personId?: string | null;
       /** Properties configurable in the interface */
-      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       /** Use random ordering instead of timestamp DESC. Useful for representative sampling to avoid recency bias. */
       randomOrder?: boolean | null;
       response?: TracesQueryResponse | null;
@@ -8037,7 +8087,7 @@ export namespace Schemas {
       /** Modifiers used when performing the query */
       modifiers?: HogQLQueryModifiers | null;
       /** Properties configurable in the interface */
-      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       response?: TraceQueryResponse | null;
       tags?: QueryLogTags | null;
       traceId: string;
@@ -8533,7 +8583,7 @@ export namespace Schemas {
       filterTestAccounts?: boolean | null;
       /** Time granularity forced onto every insight that supports one. Absent/null = inherit. */
       interval?: IntervalType | null;
-      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
     }
 
     export interface TileFilters {
@@ -8545,7 +8595,7 @@ export namespace Schemas {
       /** When true, this tile ignores every dashboard-level filter; the tile's own overrides still apply. */
       ignoreDashboardFilters?: boolean | null;
       interval?: IntervalType | null;
-      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
     }
 
     export interface InsightFilterOverrideContext {
@@ -14716,7 +14766,7 @@ export namespace Schemas {
       /** Modifiers used when performing the query */
       modifiers?: HogQLQueryModifiers | null;
       /** Property filters for all series */
-      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | PropertyGroupFilter | null;
+      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | PropertyGroupFilter | null;
       response?: CalendarHeatmapResponse | null;
       /** Sampling rate */
       samplingFactor?: number | null;
@@ -18639,7 +18689,7 @@ export namespace Schemas {
       counts_as_revenue?: boolean | null;
       custom_name?: string | null;
       event?: string | null;
-      fixedProperties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      fixedProperties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       kind?: 'EventsNode' | null;
       limit?: number | null;
       math?: BaseMathType | FunnelMathType | PropertyMathType | CountPerActorMathType | GroupMathType | ExperimentMetricMathType | CalendarHeatmapMathType | 'hogql' | null;
@@ -18652,7 +18702,7 @@ export namespace Schemas {
       name?: string | null;
       optionalInFunnel?: boolean | null;
       orderBy?: string[] | null;
-      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       response?: PartialConversionGoalFilter1Response;
       schema_map?: PartialConversionGoalFilter1SchemaMap;
       version?: number | null;
@@ -18671,7 +18721,7 @@ export namespace Schemas {
       counts_as_customer?: boolean | null;
       counts_as_revenue?: boolean | null;
       custom_name?: string | null;
-      fixedProperties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      fixedProperties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       id?: number | null;
       kind?: 'ActionsNode' | null;
       math?: BaseMathType | FunnelMathType | PropertyMathType | CountPerActorMathType | GroupMathType | ExperimentMetricMathType | CalendarHeatmapMathType | 'hogql' | null;
@@ -18683,7 +18733,7 @@ export namespace Schemas {
       math_property_type?: string | null;
       name?: string | null;
       optionalInFunnel?: boolean | null;
-      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       response?: PartialConversionGoalFilter2Response;
       schema_map?: PartialConversionGoalFilter2SchemaMap;
       version?: number | null;
@@ -18704,7 +18754,7 @@ export namespace Schemas {
       custom_name?: string | null;
       distinct_id_field?: string | null;
       dw_source_type?: string | null;
-      fixedProperties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      fixedProperties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       id?: string | null;
       id_field?: string | null;
       kind?: 'DataWarehouseNode' | null;
@@ -18717,7 +18767,7 @@ export namespace Schemas {
       math_property_type?: string | null;
       name?: string | null;
       optionalInFunnel?: boolean | null;
-      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       response?: PartialConversionGoalFilter3Response;
       schema_map?: PartialConversionGoalFilter3SchemaMap;
       table_name?: string | null;
@@ -32874,7 +32924,7 @@ export namespace Schemas {
       /** Defaults to 'ExperimentEventExposureConfig' when omitted. Pass 'ActionsNode' for an action-based exposure. */
       kind?: Kind1 | null;
       /** Property filters (event, person, and other supported types). Pass an empty array if no filters needed. */
-      properties: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[];
+      properties: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[];
     }
 
     export interface ExperimentApiExposureCriteria {
@@ -33212,7 +33262,7 @@ export namespace Schemas {
       exposure_frozen?: boolean | null;
       /** Snapshot cohort the exposure freeze AND'd into this group's properties. */
       exposure_frozen_cohort?: number | null;
-      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       rollout_percentage?: number | null;
       sort_key?: string | null;
       users_affected?: number | null;
@@ -42724,7 +42774,7 @@ export namespace Schemas {
       /** Only sessions of persons exposed to this experiment, each ending at or after the person's first exposure as the experiment's exposure criteria count it. Resolved server-side from the experiment, so it links sessions even when the exposure events themselves carry no session id (e.g. server-side SDKs). Composes with the query's date range like any other filter, so set date_from to the experiment's start (or earlier) to cover the full run: the default window only reaches back a few days. */
       experiment_exposure?: RecordingsQueryExperimentExposureFilter | null;
       filter_test_accounts?: boolean | null;
-      having_predicates?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      having_predicates?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       /** Exclude recordings already viewed by the current user ('current-user'), by any team member ('any-user'), or none (default). Applied server-side so pagination and the result cursor operate on the filtered set. */
       hide_viewed_recordings?: HideViewedRecordings | null;
       kind?: 'RecordingsQuery';
@@ -42737,7 +42787,7 @@ export namespace Schemas {
       /** Replay originally had all ordering as descending by specifying the field name, this runs counter to Django behavior where the field name specifies ascending sorting (e.g. the_field_name) and -the_field_name would indicate descending order to avoid invalidating or migrating all existing filters we keep DESC as the default or allow specification of an explicit order direction here */
       order_direction?: RecordingOrderDirection | null;
       person_uuid?: string | null;
-      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       response?: RecordingsQueryResponse | null;
       session_ids?: string[] | null;
       /** If provided, this recording will be fetched and prepended to the results, even if it doesn't match the filters */
@@ -42771,7 +42821,7 @@ export namespace Schemas {
       /** Modifiers used when performing the query */
       modifiers?: HogQLQueryModifiers | null;
       /** Properties configurable in the interface */
-      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       response?: TraceNeighborsQueryResponse | null;
       tags?: QueryLogTags | null;
       /** Timestamp of the current trace to find neighbors for */
@@ -42927,7 +42977,7 @@ export namespace Schemas {
       kind?: 'MCPToolCallBreakdownQuery';
       /** Modifiers used when performing the query */
       modifiers?: HogQLQueryModifiers | null;
-      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       response?: MCPToolCallBreakdownQueryResponse | null;
       tags?: QueryLogTags | null;
       /** version of the node, used for schema migrations */
@@ -42971,7 +43021,7 @@ export namespace Schemas {
       kind?: 'MCPToolCallsAndErrorsQuery';
       /** Modifiers used when performing the query */
       modifiers?: HogQLQueryModifiers | null;
-      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       response?: MCPToolCallsAndErrorsQueryResponse | null;
       tags?: QueryLogTags | null;
       /** version of the node, used for schema migrations */
@@ -43015,7 +43065,7 @@ export namespace Schemas {
       kind?: 'MCPHarnessBreakdownQuery';
       /** Modifiers used when performing the query */
       modifiers?: HogQLQueryModifiers | null;
-      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter | BehavioralPropertyFilter)[] | null;
       response?: MCPHarnessBreakdownQueryResponse | null;
       tags?: QueryLogTags | null;
       /** When set, scope to a single effective tool's new-SDK calls (the per-tool "By harness" table). */

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -5303,7 +5303,7 @@ export namespace Schemas {
       /** Exclude persons matching the team's "internal and test account" filters. Only person-scoped filters (person properties, cohorts) are applied. Event-scoped test account filters have no meaning in a persons query and are ignored. */
       filterTestAccounts?: boolean | null;
       /** Currently only person filters supported. No filters for querying groups. See `filter_conditions()` in actor_strategies.py. */
-      fixedProperties?: (PersonPropertyFilter | PersonMetadataPropertyFilter | CohortPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | BehavioralPropertyFilter)[] | null;
+      fixedProperties?: (PersonPropertyFilter | PersonMetadataPropertyFilter | CohortPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter)[] | null;
       kind?: 'ActorsQuery';
       limit?: number | null;
       /** Modifiers used when performing the query */
@@ -5311,7 +5311,7 @@ export namespace Schemas {
       offset?: number | null;
       orderBy?: string[] | null;
       /** Currently only person filters supported. No filters for querying groups. See `filter_conditions()` in actor_strategies.py. */
-      properties?: (PersonPropertyFilter | PersonMetadataPropertyFilter | CohortPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | BehavioralPropertyFilter)[] | PropertyGroupFilterValue | null;
+      properties?: (PersonPropertyFilter | PersonMetadataPropertyFilter | CohortPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter)[] | PropertyGroupFilterValue | null;
       response?: ActorsQueryResponse | null;
       search?: string | null;
       select?: string[] | null;

--- a/services/mcp/src/generated/endpoints/api.ts
+++ b/services/mcp/src/generated/endpoints/api.ts
@@ -324,6 +324,13 @@ export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOnenineTyp
 export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemTwooneTypeDefault = `revenue_analytics`
 export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemTwotwoTypeDefault = `account_custom_property`
 export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemTwothreeTypeDefault = `workflow_variable`
+export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemTwofourEventFiltersOneItemOneOperatorDefault = `exact`
+export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemTwofourEventFiltersOneItemOneTypeDefault = `event`
+export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemTwofourEventFiltersOneItemTwoTypeDefault = `person`
+export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemTwofourEventFiltersOneItemThreeTypeDefault = `element`
+export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemTwofourEventFiltersOneItemFourTypeDefault = `feature`
+export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemTwofourEventFiltersOneItemFiveTypeDefault = `hogql`
+export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemTwofourTypeDefault = `behavioral`
 export const endpointsRunCreateBodyRefreshDefault = `cache`
 
 export const EndpointsRunCreateBody = /* @__PURE__ */ zod.object({
@@ -1654,6 +1661,392 @@ export const EndpointsRunCreateBody = /* @__PURE__ */ zod.object({
                                             zod.null(),
                                         ])
                                         .optional(),
+                                }),
+                                zod.object({
+                                    event_filters: zod
+                                        .union([
+                                            zod.array(
+                                                zod.union([
+                                                    zod.object({
+                                                        key: zod.string(),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
+                                                        operator: zod
+                                                            .union([
+                                                                zod.enum([
+                                                                    'exact',
+                                                                    'is_not',
+                                                                    'icontains',
+                                                                    'not_icontains',
+                                                                    'starts_with',
+                                                                    'not_starts_with',
+                                                                    'ends_with',
+                                                                    'not_ends_with',
+                                                                    'regex',
+                                                                    'not_regex',
+                                                                    'gt',
+                                                                    'gte',
+                                                                    'lt',
+                                                                    'lte',
+                                                                    'is_set',
+                                                                    'is_not_set',
+                                                                    'is_date_exact',
+                                                                    'is_date_before',
+                                                                    'is_date_after',
+                                                                    'between',
+                                                                    'not_between',
+                                                                    'min',
+                                                                    'max',
+                                                                    'in',
+                                                                    'not_in',
+                                                                    'is_cleaned_path_exact',
+                                                                    'flag_evaluates_to',
+                                                                    'semver_eq',
+                                                                    'semver_neq',
+                                                                    'semver_gt',
+                                                                    'semver_gte',
+                                                                    'semver_lt',
+                                                                    'semver_lte',
+                                                                    'semver_tilde',
+                                                                    'semver_caret',
+                                                                    'semver_wildcard',
+                                                                    'icontains_multi',
+                                                                    'not_icontains_multi',
+                                                                ]),
+                                                                zod.null(),
+                                                            ])
+                                                            .default(
+                                                                endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemTwofourEventFiltersOneItemOneOperatorDefault
+                                                            ),
+                                                        type: zod
+                                                            .literal('event')
+                                                            .default(
+                                                                endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemTwofourEventFiltersOneItemOneTypeDefault
+                                                            )
+                                                            .describe('Event properties'),
+                                                        value: zod
+                                                            .union([
+                                                                zod.array(
+                                                                    zod.union([
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                    ])
+                                                                ),
+                                                                zod.string(),
+                                                                zod.number(),
+                                                                zod.boolean(),
+                                                                zod.null(),
+                                                            ])
+                                                            .optional(),
+                                                    }),
+                                                    zod.object({
+                                                        key: zod.string(),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
+                                                        operator: zod.enum([
+                                                            'exact',
+                                                            'is_not',
+                                                            'icontains',
+                                                            'not_icontains',
+                                                            'starts_with',
+                                                            'not_starts_with',
+                                                            'ends_with',
+                                                            'not_ends_with',
+                                                            'regex',
+                                                            'not_regex',
+                                                            'gt',
+                                                            'gte',
+                                                            'lt',
+                                                            'lte',
+                                                            'is_set',
+                                                            'is_not_set',
+                                                            'is_date_exact',
+                                                            'is_date_before',
+                                                            'is_date_after',
+                                                            'between',
+                                                            'not_between',
+                                                            'min',
+                                                            'max',
+                                                            'in',
+                                                            'not_in',
+                                                            'is_cleaned_path_exact',
+                                                            'flag_evaluates_to',
+                                                            'semver_eq',
+                                                            'semver_neq',
+                                                            'semver_gt',
+                                                            'semver_gte',
+                                                            'semver_lt',
+                                                            'semver_lte',
+                                                            'semver_tilde',
+                                                            'semver_caret',
+                                                            'semver_wildcard',
+                                                            'icontains_multi',
+                                                            'not_icontains_multi',
+                                                        ]),
+                                                        type: zod
+                                                            .literal('person')
+                                                            .default(
+                                                                endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemTwofourEventFiltersOneItemTwoTypeDefault
+                                                            )
+                                                            .describe('Person properties'),
+                                                        value: zod
+                                                            .union([
+                                                                zod.array(
+                                                                    zod.union([
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                    ])
+                                                                ),
+                                                                zod.string(),
+                                                                zod.number(),
+                                                                zod.boolean(),
+                                                                zod.null(),
+                                                            ])
+                                                            .optional(),
+                                                    }),
+                                                    zod.object({
+                                                        key: zod.enum(['tag_name', 'text', 'href', 'selector']),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
+                                                        operator: zod.enum([
+                                                            'exact',
+                                                            'is_not',
+                                                            'icontains',
+                                                            'not_icontains',
+                                                            'starts_with',
+                                                            'not_starts_with',
+                                                            'ends_with',
+                                                            'not_ends_with',
+                                                            'regex',
+                                                            'not_regex',
+                                                            'gt',
+                                                            'gte',
+                                                            'lt',
+                                                            'lte',
+                                                            'is_set',
+                                                            'is_not_set',
+                                                            'is_date_exact',
+                                                            'is_date_before',
+                                                            'is_date_after',
+                                                            'between',
+                                                            'not_between',
+                                                            'min',
+                                                            'max',
+                                                            'in',
+                                                            'not_in',
+                                                            'is_cleaned_path_exact',
+                                                            'flag_evaluates_to',
+                                                            'semver_eq',
+                                                            'semver_neq',
+                                                            'semver_gt',
+                                                            'semver_gte',
+                                                            'semver_lt',
+                                                            'semver_lte',
+                                                            'semver_tilde',
+                                                            'semver_caret',
+                                                            'semver_wildcard',
+                                                            'icontains_multi',
+                                                            'not_icontains_multi',
+                                                        ]),
+                                                        type: zod
+                                                            .literal('element')
+                                                            .default(
+                                                                endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemTwofourEventFiltersOneItemThreeTypeDefault
+                                                            ),
+                                                        value: zod
+                                                            .union([
+                                                                zod.array(
+                                                                    zod.union([
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                    ])
+                                                                ),
+                                                                zod.string(),
+                                                                zod.number(),
+                                                                zod.boolean(),
+                                                                zod.null(),
+                                                            ])
+                                                            .optional(),
+                                                    }),
+                                                    zod.object({
+                                                        key: zod.string(),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
+                                                        operator: zod.enum([
+                                                            'exact',
+                                                            'is_not',
+                                                            'icontains',
+                                                            'not_icontains',
+                                                            'starts_with',
+                                                            'not_starts_with',
+                                                            'ends_with',
+                                                            'not_ends_with',
+                                                            'regex',
+                                                            'not_regex',
+                                                            'gt',
+                                                            'gte',
+                                                            'lt',
+                                                            'lte',
+                                                            'is_set',
+                                                            'is_not_set',
+                                                            'is_date_exact',
+                                                            'is_date_before',
+                                                            'is_date_after',
+                                                            'between',
+                                                            'not_between',
+                                                            'min',
+                                                            'max',
+                                                            'in',
+                                                            'not_in',
+                                                            'is_cleaned_path_exact',
+                                                            'flag_evaluates_to',
+                                                            'semver_eq',
+                                                            'semver_neq',
+                                                            'semver_gt',
+                                                            'semver_gte',
+                                                            'semver_lt',
+                                                            'semver_lte',
+                                                            'semver_tilde',
+                                                            'semver_caret',
+                                                            'semver_wildcard',
+                                                            'icontains_multi',
+                                                            'not_icontains_multi',
+                                                        ]),
+                                                        type: zod
+                                                            .literal('feature')
+                                                            .default(
+                                                                endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemTwofourEventFiltersOneItemFourTypeDefault
+                                                            )
+                                                            .describe('Event property with \"$feature\/\" prepended'),
+                                                        value: zod
+                                                            .union([
+                                                                zod.array(
+                                                                    zod.union([
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                    ])
+                                                                ),
+                                                                zod.string(),
+                                                                zod.number(),
+                                                                zod.boolean(),
+                                                                zod.null(),
+                                                            ])
+                                                            .optional(),
+                                                    }),
+                                                    zod.object({
+                                                        key: zod.string(),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
+                                                        type: zod
+                                                            .literal('hogql')
+                                                            .default(
+                                                                endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemTwofourEventFiltersOneItemFiveTypeDefault
+                                                            ),
+                                                        value: zod
+                                                            .union([
+                                                                zod.array(
+                                                                    zod.union([
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                    ])
+                                                                ),
+                                                                zod.string(),
+                                                                zod.number(),
+                                                                zod.boolean(),
+                                                                zod.null(),
+                                                            ])
+                                                            .optional(),
+                                                    }),
+                                                ])
+                                            ),
+                                            zod.null(),
+                                        ])
+                                        .optional()
+                                        .describe(
+                                            'Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral\/cohort filters and groups'
+                                        ),
+                                    event_type: zod.enum(['events', 'actions']),
+                                    explicit_datetime: zod
+                                        .union([zod.string(), zod.null()])
+                                        .optional()
+                                        .describe(
+                                            'Absolute or relative (e.g. -30d) lower date bound — alternative to time_value\/time_interval'
+                                        ),
+                                    explicit_datetime_to: zod.union([zod.string(), zod.null()]).optional(),
+                                    key: zod.string().describe("Event name, or action id when event_type is 'actions'"),
+                                    label: zod.union([zod.string(), zod.null()]).optional(),
+                                    negation: zod
+                                        .union([zod.boolean(), zod.null()])
+                                        .optional()
+                                        .describe(
+                                            'Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators'
+                                        ),
+                                    operator: zod
+                                        .union([
+                                            zod.enum([
+                                                'exact',
+                                                'is_not',
+                                                'icontains',
+                                                'not_icontains',
+                                                'starts_with',
+                                                'not_starts_with',
+                                                'ends_with',
+                                                'not_ends_with',
+                                                'regex',
+                                                'not_regex',
+                                                'gt',
+                                                'gte',
+                                                'lt',
+                                                'lte',
+                                                'is_set',
+                                                'is_not_set',
+                                                'is_date_exact',
+                                                'is_date_before',
+                                                'is_date_after',
+                                                'between',
+                                                'not_between',
+                                                'min',
+                                                'max',
+                                                'in',
+                                                'not_in',
+                                                'is_cleaned_path_exact',
+                                                'flag_evaluates_to',
+                                                'semver_eq',
+                                                'semver_neq',
+                                                'semver_gt',
+                                                'semver_gte',
+                                                'semver_lt',
+                                                'semver_lte',
+                                                'semver_tilde',
+                                                'semver_caret',
+                                                'semver_wildcard',
+                                                'icontains_multi',
+                                                'not_icontains_multi',
+                                            ]),
+                                            zod.null(),
+                                        ])
+                                        .optional()
+                                        .describe('Count comparison for performed_event_multiple, defaults to exact'),
+                                    operator_value: zod
+                                        .union([zod.number(), zod.null()])
+                                        .optional()
+                                        .describe('Count threshold for performed_event_multiple'),
+                                    time_interval: zod
+                                        .union([zod.enum(['day', 'week', 'month', 'year']), zod.null()])
+                                        .optional(),
+                                    time_value: zod
+                                        .union([zod.number(), zod.null()])
+                                        .optional()
+                                        .describe('Relative time window size, paired with time_interval'),
+                                    type: zod
+                                        .literal('behavioral')
+                                        .default(
+                                            endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemTwofourTypeDefault
+                                        )
+                                        .describe(
+                                            "Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP"
+                                        ),
+                                    value: zod.enum(['performed_event', 'performed_event_multiple']),
                                 }),
                             ])
                         ),

--- a/services/mcp/src/generated/error_tracking/api.ts
+++ b/services/mcp/src/generated/error_tracking/api.ts
@@ -54,6 +54,13 @@ export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemTwozeroTy
 export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemTwotwoTypeDefault = `revenue_analytics`
 export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemTwothreeTypeDefault = `account_custom_property`
 export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemTwofourTypeDefault = `workflow_variable`
+export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemOneOperatorDefault = `exact`
+export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemOneTypeDefault = `event`
+export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemTwoTypeDefault = `person`
+export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemThreeTypeDefault = `element`
+export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemFourTypeDefault = `feature`
+export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemFiveTypeDefault = `hogql`
+export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemTwofiveTypeDefault = `behavioral`
 export const errorTrackingAssignmentRulesCreateBodyOrderKeyDefault = 0
 
 export const ErrorTrackingAssignmentRulesCreateBody = /* @__PURE__ */ zod.object({
@@ -1229,6 +1236,358 @@ export const ErrorTrackingAssignmentRulesCreateBody = /* @__PURE__ */ zod.object
                             ])
                             .optional(),
                     }),
+                    zod.object({
+                        event_filters: zod
+                            .union([
+                                zod.array(
+                                    zod.union([
+                                        zod.object({
+                                            key: zod.string(),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
+                                            operator: zod
+                                                .union([
+                                                    zod.enum([
+                                                        'exact',
+                                                        'is_not',
+                                                        'icontains',
+                                                        'not_icontains',
+                                                        'starts_with',
+                                                        'not_starts_with',
+                                                        'ends_with',
+                                                        'not_ends_with',
+                                                        'regex',
+                                                        'not_regex',
+                                                        'gt',
+                                                        'gte',
+                                                        'lt',
+                                                        'lte',
+                                                        'is_set',
+                                                        'is_not_set',
+                                                        'is_date_exact',
+                                                        'is_date_before',
+                                                        'is_date_after',
+                                                        'between',
+                                                        'not_between',
+                                                        'min',
+                                                        'max',
+                                                        'in',
+                                                        'not_in',
+                                                        'is_cleaned_path_exact',
+                                                        'flag_evaluates_to',
+                                                        'semver_eq',
+                                                        'semver_neq',
+                                                        'semver_gt',
+                                                        'semver_gte',
+                                                        'semver_lt',
+                                                        'semver_lte',
+                                                        'semver_tilde',
+                                                        'semver_caret',
+                                                        'semver_wildcard',
+                                                        'icontains_multi',
+                                                        'not_icontains_multi',
+                                                    ]),
+                                                    zod.null(),
+                                                ])
+                                                .default(
+                                                    errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemOneOperatorDefault
+                                                ),
+                                            type: zod
+                                                .literal('event')
+                                                .default(
+                                                    errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemOneTypeDefault
+                                                )
+                                                .describe('Event properties'),
+                                            value: zod
+                                                .union([
+                                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                                    zod.string(),
+                                                    zod.number(),
+                                                    zod.boolean(),
+                                                    zod.null(),
+                                                ])
+                                                .optional(),
+                                        }),
+                                        zod.object({
+                                            key: zod.string(),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
+                                            operator: zod.enum([
+                                                'exact',
+                                                'is_not',
+                                                'icontains',
+                                                'not_icontains',
+                                                'starts_with',
+                                                'not_starts_with',
+                                                'ends_with',
+                                                'not_ends_with',
+                                                'regex',
+                                                'not_regex',
+                                                'gt',
+                                                'gte',
+                                                'lt',
+                                                'lte',
+                                                'is_set',
+                                                'is_not_set',
+                                                'is_date_exact',
+                                                'is_date_before',
+                                                'is_date_after',
+                                                'between',
+                                                'not_between',
+                                                'min',
+                                                'max',
+                                                'in',
+                                                'not_in',
+                                                'is_cleaned_path_exact',
+                                                'flag_evaluates_to',
+                                                'semver_eq',
+                                                'semver_neq',
+                                                'semver_gt',
+                                                'semver_gte',
+                                                'semver_lt',
+                                                'semver_lte',
+                                                'semver_tilde',
+                                                'semver_caret',
+                                                'semver_wildcard',
+                                                'icontains_multi',
+                                                'not_icontains_multi',
+                                            ]),
+                                            type: zod
+                                                .literal('person')
+                                                .default(
+                                                    errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemTwoTypeDefault
+                                                )
+                                                .describe('Person properties'),
+                                            value: zod
+                                                .union([
+                                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                                    zod.string(),
+                                                    zod.number(),
+                                                    zod.boolean(),
+                                                    zod.null(),
+                                                ])
+                                                .optional(),
+                                        }),
+                                        zod.object({
+                                            key: zod.enum(['tag_name', 'text', 'href', 'selector']),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
+                                            operator: zod.enum([
+                                                'exact',
+                                                'is_not',
+                                                'icontains',
+                                                'not_icontains',
+                                                'starts_with',
+                                                'not_starts_with',
+                                                'ends_with',
+                                                'not_ends_with',
+                                                'regex',
+                                                'not_regex',
+                                                'gt',
+                                                'gte',
+                                                'lt',
+                                                'lte',
+                                                'is_set',
+                                                'is_not_set',
+                                                'is_date_exact',
+                                                'is_date_before',
+                                                'is_date_after',
+                                                'between',
+                                                'not_between',
+                                                'min',
+                                                'max',
+                                                'in',
+                                                'not_in',
+                                                'is_cleaned_path_exact',
+                                                'flag_evaluates_to',
+                                                'semver_eq',
+                                                'semver_neq',
+                                                'semver_gt',
+                                                'semver_gte',
+                                                'semver_lt',
+                                                'semver_lte',
+                                                'semver_tilde',
+                                                'semver_caret',
+                                                'semver_wildcard',
+                                                'icontains_multi',
+                                                'not_icontains_multi',
+                                            ]),
+                                            type: zod
+                                                .literal('element')
+                                                .default(
+                                                    errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemThreeTypeDefault
+                                                ),
+                                            value: zod
+                                                .union([
+                                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                                    zod.string(),
+                                                    zod.number(),
+                                                    zod.boolean(),
+                                                    zod.null(),
+                                                ])
+                                                .optional(),
+                                        }),
+                                        zod.object({
+                                            key: zod.string(),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
+                                            operator: zod.enum([
+                                                'exact',
+                                                'is_not',
+                                                'icontains',
+                                                'not_icontains',
+                                                'starts_with',
+                                                'not_starts_with',
+                                                'ends_with',
+                                                'not_ends_with',
+                                                'regex',
+                                                'not_regex',
+                                                'gt',
+                                                'gte',
+                                                'lt',
+                                                'lte',
+                                                'is_set',
+                                                'is_not_set',
+                                                'is_date_exact',
+                                                'is_date_before',
+                                                'is_date_after',
+                                                'between',
+                                                'not_between',
+                                                'min',
+                                                'max',
+                                                'in',
+                                                'not_in',
+                                                'is_cleaned_path_exact',
+                                                'flag_evaluates_to',
+                                                'semver_eq',
+                                                'semver_neq',
+                                                'semver_gt',
+                                                'semver_gte',
+                                                'semver_lt',
+                                                'semver_lte',
+                                                'semver_tilde',
+                                                'semver_caret',
+                                                'semver_wildcard',
+                                                'icontains_multi',
+                                                'not_icontains_multi',
+                                            ]),
+                                            type: zod
+                                                .literal('feature')
+                                                .default(
+                                                    errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemFourTypeDefault
+                                                )
+                                                .describe('Event property with \"$feature\/\" prepended'),
+                                            value: zod
+                                                .union([
+                                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                                    zod.string(),
+                                                    zod.number(),
+                                                    zod.boolean(),
+                                                    zod.null(),
+                                                ])
+                                                .optional(),
+                                        }),
+                                        zod.object({
+                                            key: zod.string(),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
+                                            type: zod
+                                                .literal('hogql')
+                                                .default(
+                                                    errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemFiveTypeDefault
+                                                ),
+                                            value: zod
+                                                .union([
+                                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                                    zod.string(),
+                                                    zod.number(),
+                                                    zod.boolean(),
+                                                    zod.null(),
+                                                ])
+                                                .optional(),
+                                        }),
+                                    ])
+                                ),
+                                zod.null(),
+                            ])
+                            .optional()
+                            .describe(
+                                'Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral\/cohort filters and groups'
+                            ),
+                        event_type: zod.enum(['events', 'actions']),
+                        explicit_datetime: zod
+                            .union([zod.string(), zod.null()])
+                            .optional()
+                            .describe(
+                                'Absolute or relative (e.g. -30d) lower date bound — alternative to time_value\/time_interval'
+                            ),
+                        explicit_datetime_to: zod.union([zod.string(), zod.null()]).optional(),
+                        key: zod.string().describe("Event name, or action id when event_type is 'actions'"),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
+                        negation: zod
+                            .union([zod.boolean(), zod.null()])
+                            .optional()
+                            .describe(
+                                'Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators'
+                            ),
+                        operator: zod
+                            .union([
+                                zod.enum([
+                                    'exact',
+                                    'is_not',
+                                    'icontains',
+                                    'not_icontains',
+                                    'starts_with',
+                                    'not_starts_with',
+                                    'ends_with',
+                                    'not_ends_with',
+                                    'regex',
+                                    'not_regex',
+                                    'gt',
+                                    'gte',
+                                    'lt',
+                                    'lte',
+                                    'is_set',
+                                    'is_not_set',
+                                    'is_date_exact',
+                                    'is_date_before',
+                                    'is_date_after',
+                                    'between',
+                                    'not_between',
+                                    'min',
+                                    'max',
+                                    'in',
+                                    'not_in',
+                                    'is_cleaned_path_exact',
+                                    'flag_evaluates_to',
+                                    'semver_eq',
+                                    'semver_neq',
+                                    'semver_gt',
+                                    'semver_gte',
+                                    'semver_lt',
+                                    'semver_lte',
+                                    'semver_tilde',
+                                    'semver_caret',
+                                    'semver_wildcard',
+                                    'icontains_multi',
+                                    'not_icontains_multi',
+                                ]),
+                                zod.null(),
+                            ])
+                            .optional()
+                            .describe('Count comparison for performed_event_multiple, defaults to exact'),
+                        operator_value: zod
+                            .union([zod.number(), zod.null()])
+                            .optional()
+                            .describe('Count threshold for performed_event_multiple'),
+                        time_interval: zod.union([zod.enum(['day', 'week', 'month', 'year']), zod.null()]).optional(),
+                        time_value: zod
+                            .union([zod.number(), zod.null()])
+                            .optional()
+                            .describe('Relative time window size, paired with time_interval'),
+                        type: zod
+                            .literal('behavioral')
+                            .default(errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemTwofiveTypeDefault)
+                            .describe(
+                                "Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP"
+                            ),
+                        value: zod.enum(['performed_event', 'performed_event_multiple']),
+                    }),
                 ])
             ),
         })
@@ -1300,6 +1659,13 @@ export const errorTrackingBypassRulesCreateBodyFiltersOneValuesItemTwozeroTypeDe
 export const errorTrackingBypassRulesCreateBodyFiltersOneValuesItemTwotwoTypeDefault = `revenue_analytics`
 export const errorTrackingBypassRulesCreateBodyFiltersOneValuesItemTwothreeTypeDefault = `account_custom_property`
 export const errorTrackingBypassRulesCreateBodyFiltersOneValuesItemTwofourTypeDefault = `workflow_variable`
+export const errorTrackingBypassRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemOneOperatorDefault = `exact`
+export const errorTrackingBypassRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemOneTypeDefault = `event`
+export const errorTrackingBypassRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemTwoTypeDefault = `person`
+export const errorTrackingBypassRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemThreeTypeDefault = `element`
+export const errorTrackingBypassRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemFourTypeDefault = `feature`
+export const errorTrackingBypassRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemFiveTypeDefault = `hogql`
+export const errorTrackingBypassRulesCreateBodyFiltersOneValuesItemTwofiveTypeDefault = `behavioral`
 
 export const ErrorTrackingBypassRulesCreateBody = /* @__PURE__ */ zod.object({
     filters: zod
@@ -2474,6 +2840,358 @@ export const ErrorTrackingBypassRulesCreateBody = /* @__PURE__ */ zod.object({
                             ])
                             .optional(),
                     }),
+                    zod.object({
+                        event_filters: zod
+                            .union([
+                                zod.array(
+                                    zod.union([
+                                        zod.object({
+                                            key: zod.string(),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
+                                            operator: zod
+                                                .union([
+                                                    zod.enum([
+                                                        'exact',
+                                                        'is_not',
+                                                        'icontains',
+                                                        'not_icontains',
+                                                        'starts_with',
+                                                        'not_starts_with',
+                                                        'ends_with',
+                                                        'not_ends_with',
+                                                        'regex',
+                                                        'not_regex',
+                                                        'gt',
+                                                        'gte',
+                                                        'lt',
+                                                        'lte',
+                                                        'is_set',
+                                                        'is_not_set',
+                                                        'is_date_exact',
+                                                        'is_date_before',
+                                                        'is_date_after',
+                                                        'between',
+                                                        'not_between',
+                                                        'min',
+                                                        'max',
+                                                        'in',
+                                                        'not_in',
+                                                        'is_cleaned_path_exact',
+                                                        'flag_evaluates_to',
+                                                        'semver_eq',
+                                                        'semver_neq',
+                                                        'semver_gt',
+                                                        'semver_gte',
+                                                        'semver_lt',
+                                                        'semver_lte',
+                                                        'semver_tilde',
+                                                        'semver_caret',
+                                                        'semver_wildcard',
+                                                        'icontains_multi',
+                                                        'not_icontains_multi',
+                                                    ]),
+                                                    zod.null(),
+                                                ])
+                                                .default(
+                                                    errorTrackingBypassRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemOneOperatorDefault
+                                                ),
+                                            type: zod
+                                                .literal('event')
+                                                .default(
+                                                    errorTrackingBypassRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemOneTypeDefault
+                                                )
+                                                .describe('Event properties'),
+                                            value: zod
+                                                .union([
+                                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                                    zod.string(),
+                                                    zod.number(),
+                                                    zod.boolean(),
+                                                    zod.null(),
+                                                ])
+                                                .optional(),
+                                        }),
+                                        zod.object({
+                                            key: zod.string(),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
+                                            operator: zod.enum([
+                                                'exact',
+                                                'is_not',
+                                                'icontains',
+                                                'not_icontains',
+                                                'starts_with',
+                                                'not_starts_with',
+                                                'ends_with',
+                                                'not_ends_with',
+                                                'regex',
+                                                'not_regex',
+                                                'gt',
+                                                'gte',
+                                                'lt',
+                                                'lte',
+                                                'is_set',
+                                                'is_not_set',
+                                                'is_date_exact',
+                                                'is_date_before',
+                                                'is_date_after',
+                                                'between',
+                                                'not_between',
+                                                'min',
+                                                'max',
+                                                'in',
+                                                'not_in',
+                                                'is_cleaned_path_exact',
+                                                'flag_evaluates_to',
+                                                'semver_eq',
+                                                'semver_neq',
+                                                'semver_gt',
+                                                'semver_gte',
+                                                'semver_lt',
+                                                'semver_lte',
+                                                'semver_tilde',
+                                                'semver_caret',
+                                                'semver_wildcard',
+                                                'icontains_multi',
+                                                'not_icontains_multi',
+                                            ]),
+                                            type: zod
+                                                .literal('person')
+                                                .default(
+                                                    errorTrackingBypassRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemTwoTypeDefault
+                                                )
+                                                .describe('Person properties'),
+                                            value: zod
+                                                .union([
+                                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                                    zod.string(),
+                                                    zod.number(),
+                                                    zod.boolean(),
+                                                    zod.null(),
+                                                ])
+                                                .optional(),
+                                        }),
+                                        zod.object({
+                                            key: zod.enum(['tag_name', 'text', 'href', 'selector']),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
+                                            operator: zod.enum([
+                                                'exact',
+                                                'is_not',
+                                                'icontains',
+                                                'not_icontains',
+                                                'starts_with',
+                                                'not_starts_with',
+                                                'ends_with',
+                                                'not_ends_with',
+                                                'regex',
+                                                'not_regex',
+                                                'gt',
+                                                'gte',
+                                                'lt',
+                                                'lte',
+                                                'is_set',
+                                                'is_not_set',
+                                                'is_date_exact',
+                                                'is_date_before',
+                                                'is_date_after',
+                                                'between',
+                                                'not_between',
+                                                'min',
+                                                'max',
+                                                'in',
+                                                'not_in',
+                                                'is_cleaned_path_exact',
+                                                'flag_evaluates_to',
+                                                'semver_eq',
+                                                'semver_neq',
+                                                'semver_gt',
+                                                'semver_gte',
+                                                'semver_lt',
+                                                'semver_lte',
+                                                'semver_tilde',
+                                                'semver_caret',
+                                                'semver_wildcard',
+                                                'icontains_multi',
+                                                'not_icontains_multi',
+                                            ]),
+                                            type: zod
+                                                .literal('element')
+                                                .default(
+                                                    errorTrackingBypassRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemThreeTypeDefault
+                                                ),
+                                            value: zod
+                                                .union([
+                                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                                    zod.string(),
+                                                    zod.number(),
+                                                    zod.boolean(),
+                                                    zod.null(),
+                                                ])
+                                                .optional(),
+                                        }),
+                                        zod.object({
+                                            key: zod.string(),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
+                                            operator: zod.enum([
+                                                'exact',
+                                                'is_not',
+                                                'icontains',
+                                                'not_icontains',
+                                                'starts_with',
+                                                'not_starts_with',
+                                                'ends_with',
+                                                'not_ends_with',
+                                                'regex',
+                                                'not_regex',
+                                                'gt',
+                                                'gte',
+                                                'lt',
+                                                'lte',
+                                                'is_set',
+                                                'is_not_set',
+                                                'is_date_exact',
+                                                'is_date_before',
+                                                'is_date_after',
+                                                'between',
+                                                'not_between',
+                                                'min',
+                                                'max',
+                                                'in',
+                                                'not_in',
+                                                'is_cleaned_path_exact',
+                                                'flag_evaluates_to',
+                                                'semver_eq',
+                                                'semver_neq',
+                                                'semver_gt',
+                                                'semver_gte',
+                                                'semver_lt',
+                                                'semver_lte',
+                                                'semver_tilde',
+                                                'semver_caret',
+                                                'semver_wildcard',
+                                                'icontains_multi',
+                                                'not_icontains_multi',
+                                            ]),
+                                            type: zod
+                                                .literal('feature')
+                                                .default(
+                                                    errorTrackingBypassRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemFourTypeDefault
+                                                )
+                                                .describe('Event property with \"$feature\/\" prepended'),
+                                            value: zod
+                                                .union([
+                                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                                    zod.string(),
+                                                    zod.number(),
+                                                    zod.boolean(),
+                                                    zod.null(),
+                                                ])
+                                                .optional(),
+                                        }),
+                                        zod.object({
+                                            key: zod.string(),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
+                                            type: zod
+                                                .literal('hogql')
+                                                .default(
+                                                    errorTrackingBypassRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemFiveTypeDefault
+                                                ),
+                                            value: zod
+                                                .union([
+                                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                                    zod.string(),
+                                                    zod.number(),
+                                                    zod.boolean(),
+                                                    zod.null(),
+                                                ])
+                                                .optional(),
+                                        }),
+                                    ])
+                                ),
+                                zod.null(),
+                            ])
+                            .optional()
+                            .describe(
+                                'Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral\/cohort filters and groups'
+                            ),
+                        event_type: zod.enum(['events', 'actions']),
+                        explicit_datetime: zod
+                            .union([zod.string(), zod.null()])
+                            .optional()
+                            .describe(
+                                'Absolute or relative (e.g. -30d) lower date bound — alternative to time_value\/time_interval'
+                            ),
+                        explicit_datetime_to: zod.union([zod.string(), zod.null()]).optional(),
+                        key: zod.string().describe("Event name, or action id when event_type is 'actions'"),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
+                        negation: zod
+                            .union([zod.boolean(), zod.null()])
+                            .optional()
+                            .describe(
+                                'Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators'
+                            ),
+                        operator: zod
+                            .union([
+                                zod.enum([
+                                    'exact',
+                                    'is_not',
+                                    'icontains',
+                                    'not_icontains',
+                                    'starts_with',
+                                    'not_starts_with',
+                                    'ends_with',
+                                    'not_ends_with',
+                                    'regex',
+                                    'not_regex',
+                                    'gt',
+                                    'gte',
+                                    'lt',
+                                    'lte',
+                                    'is_set',
+                                    'is_not_set',
+                                    'is_date_exact',
+                                    'is_date_before',
+                                    'is_date_after',
+                                    'between',
+                                    'not_between',
+                                    'min',
+                                    'max',
+                                    'in',
+                                    'not_in',
+                                    'is_cleaned_path_exact',
+                                    'flag_evaluates_to',
+                                    'semver_eq',
+                                    'semver_neq',
+                                    'semver_gt',
+                                    'semver_gte',
+                                    'semver_lt',
+                                    'semver_lte',
+                                    'semver_tilde',
+                                    'semver_caret',
+                                    'semver_wildcard',
+                                    'icontains_multi',
+                                    'not_icontains_multi',
+                                ]),
+                                zod.null(),
+                            ])
+                            .optional()
+                            .describe('Count comparison for performed_event_multiple, defaults to exact'),
+                        operator_value: zod
+                            .union([zod.number(), zod.null()])
+                            .optional()
+                            .describe('Count threshold for performed_event_multiple'),
+                        time_interval: zod.union([zod.enum(['day', 'week', 'month', 'year']), zod.null()]).optional(),
+                        time_value: zod
+                            .union([zod.number(), zod.null()])
+                            .optional()
+                            .describe('Relative time window size, paired with time_interval'),
+                        type: zod
+                            .literal('behavioral')
+                            .default(errorTrackingBypassRulesCreateBodyFiltersOneValuesItemTwofiveTypeDefault)
+                            .describe(
+                                "Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP"
+                            ),
+                        value: zod.enum(['performed_event', 'performed_event_multiple']),
+                    }),
                 ])
             ),
         })
@@ -2516,6 +3234,13 @@ export const errorTrackingBypassRulesUpdateBodyFiltersOneValuesItemTwozeroTypeDe
 export const errorTrackingBypassRulesUpdateBodyFiltersOneValuesItemTwotwoTypeDefault = `revenue_analytics`
 export const errorTrackingBypassRulesUpdateBodyFiltersOneValuesItemTwothreeTypeDefault = `account_custom_property`
 export const errorTrackingBypassRulesUpdateBodyFiltersOneValuesItemTwofourTypeDefault = `workflow_variable`
+export const errorTrackingBypassRulesUpdateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemOneOperatorDefault = `exact`
+export const errorTrackingBypassRulesUpdateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemOneTypeDefault = `event`
+export const errorTrackingBypassRulesUpdateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemTwoTypeDefault = `person`
+export const errorTrackingBypassRulesUpdateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemThreeTypeDefault = `element`
+export const errorTrackingBypassRulesUpdateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemFourTypeDefault = `feature`
+export const errorTrackingBypassRulesUpdateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemFiveTypeDefault = `hogql`
+export const errorTrackingBypassRulesUpdateBodyFiltersOneValuesItemTwofiveTypeDefault = `behavioral`
 
 export const ErrorTrackingBypassRulesUpdateBody = /* @__PURE__ */ zod.object({
     filters: zod
@@ -3690,6 +4415,358 @@ export const ErrorTrackingBypassRulesUpdateBody = /* @__PURE__ */ zod.object({
                             ])
                             .optional(),
                     }),
+                    zod.object({
+                        event_filters: zod
+                            .union([
+                                zod.array(
+                                    zod.union([
+                                        zod.object({
+                                            key: zod.string(),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
+                                            operator: zod
+                                                .union([
+                                                    zod.enum([
+                                                        'exact',
+                                                        'is_not',
+                                                        'icontains',
+                                                        'not_icontains',
+                                                        'starts_with',
+                                                        'not_starts_with',
+                                                        'ends_with',
+                                                        'not_ends_with',
+                                                        'regex',
+                                                        'not_regex',
+                                                        'gt',
+                                                        'gte',
+                                                        'lt',
+                                                        'lte',
+                                                        'is_set',
+                                                        'is_not_set',
+                                                        'is_date_exact',
+                                                        'is_date_before',
+                                                        'is_date_after',
+                                                        'between',
+                                                        'not_between',
+                                                        'min',
+                                                        'max',
+                                                        'in',
+                                                        'not_in',
+                                                        'is_cleaned_path_exact',
+                                                        'flag_evaluates_to',
+                                                        'semver_eq',
+                                                        'semver_neq',
+                                                        'semver_gt',
+                                                        'semver_gte',
+                                                        'semver_lt',
+                                                        'semver_lte',
+                                                        'semver_tilde',
+                                                        'semver_caret',
+                                                        'semver_wildcard',
+                                                        'icontains_multi',
+                                                        'not_icontains_multi',
+                                                    ]),
+                                                    zod.null(),
+                                                ])
+                                                .default(
+                                                    errorTrackingBypassRulesUpdateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemOneOperatorDefault
+                                                ),
+                                            type: zod
+                                                .literal('event')
+                                                .default(
+                                                    errorTrackingBypassRulesUpdateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemOneTypeDefault
+                                                )
+                                                .describe('Event properties'),
+                                            value: zod
+                                                .union([
+                                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                                    zod.string(),
+                                                    zod.number(),
+                                                    zod.boolean(),
+                                                    zod.null(),
+                                                ])
+                                                .optional(),
+                                        }),
+                                        zod.object({
+                                            key: zod.string(),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
+                                            operator: zod.enum([
+                                                'exact',
+                                                'is_not',
+                                                'icontains',
+                                                'not_icontains',
+                                                'starts_with',
+                                                'not_starts_with',
+                                                'ends_with',
+                                                'not_ends_with',
+                                                'regex',
+                                                'not_regex',
+                                                'gt',
+                                                'gte',
+                                                'lt',
+                                                'lte',
+                                                'is_set',
+                                                'is_not_set',
+                                                'is_date_exact',
+                                                'is_date_before',
+                                                'is_date_after',
+                                                'between',
+                                                'not_between',
+                                                'min',
+                                                'max',
+                                                'in',
+                                                'not_in',
+                                                'is_cleaned_path_exact',
+                                                'flag_evaluates_to',
+                                                'semver_eq',
+                                                'semver_neq',
+                                                'semver_gt',
+                                                'semver_gte',
+                                                'semver_lt',
+                                                'semver_lte',
+                                                'semver_tilde',
+                                                'semver_caret',
+                                                'semver_wildcard',
+                                                'icontains_multi',
+                                                'not_icontains_multi',
+                                            ]),
+                                            type: zod
+                                                .literal('person')
+                                                .default(
+                                                    errorTrackingBypassRulesUpdateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemTwoTypeDefault
+                                                )
+                                                .describe('Person properties'),
+                                            value: zod
+                                                .union([
+                                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                                    zod.string(),
+                                                    zod.number(),
+                                                    zod.boolean(),
+                                                    zod.null(),
+                                                ])
+                                                .optional(),
+                                        }),
+                                        zod.object({
+                                            key: zod.enum(['tag_name', 'text', 'href', 'selector']),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
+                                            operator: zod.enum([
+                                                'exact',
+                                                'is_not',
+                                                'icontains',
+                                                'not_icontains',
+                                                'starts_with',
+                                                'not_starts_with',
+                                                'ends_with',
+                                                'not_ends_with',
+                                                'regex',
+                                                'not_regex',
+                                                'gt',
+                                                'gte',
+                                                'lt',
+                                                'lte',
+                                                'is_set',
+                                                'is_not_set',
+                                                'is_date_exact',
+                                                'is_date_before',
+                                                'is_date_after',
+                                                'between',
+                                                'not_between',
+                                                'min',
+                                                'max',
+                                                'in',
+                                                'not_in',
+                                                'is_cleaned_path_exact',
+                                                'flag_evaluates_to',
+                                                'semver_eq',
+                                                'semver_neq',
+                                                'semver_gt',
+                                                'semver_gte',
+                                                'semver_lt',
+                                                'semver_lte',
+                                                'semver_tilde',
+                                                'semver_caret',
+                                                'semver_wildcard',
+                                                'icontains_multi',
+                                                'not_icontains_multi',
+                                            ]),
+                                            type: zod
+                                                .literal('element')
+                                                .default(
+                                                    errorTrackingBypassRulesUpdateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemThreeTypeDefault
+                                                ),
+                                            value: zod
+                                                .union([
+                                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                                    zod.string(),
+                                                    zod.number(),
+                                                    zod.boolean(),
+                                                    zod.null(),
+                                                ])
+                                                .optional(),
+                                        }),
+                                        zod.object({
+                                            key: zod.string(),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
+                                            operator: zod.enum([
+                                                'exact',
+                                                'is_not',
+                                                'icontains',
+                                                'not_icontains',
+                                                'starts_with',
+                                                'not_starts_with',
+                                                'ends_with',
+                                                'not_ends_with',
+                                                'regex',
+                                                'not_regex',
+                                                'gt',
+                                                'gte',
+                                                'lt',
+                                                'lte',
+                                                'is_set',
+                                                'is_not_set',
+                                                'is_date_exact',
+                                                'is_date_before',
+                                                'is_date_after',
+                                                'between',
+                                                'not_between',
+                                                'min',
+                                                'max',
+                                                'in',
+                                                'not_in',
+                                                'is_cleaned_path_exact',
+                                                'flag_evaluates_to',
+                                                'semver_eq',
+                                                'semver_neq',
+                                                'semver_gt',
+                                                'semver_gte',
+                                                'semver_lt',
+                                                'semver_lte',
+                                                'semver_tilde',
+                                                'semver_caret',
+                                                'semver_wildcard',
+                                                'icontains_multi',
+                                                'not_icontains_multi',
+                                            ]),
+                                            type: zod
+                                                .literal('feature')
+                                                .default(
+                                                    errorTrackingBypassRulesUpdateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemFourTypeDefault
+                                                )
+                                                .describe('Event property with \"$feature\/\" prepended'),
+                                            value: zod
+                                                .union([
+                                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                                    zod.string(),
+                                                    zod.number(),
+                                                    zod.boolean(),
+                                                    zod.null(),
+                                                ])
+                                                .optional(),
+                                        }),
+                                        zod.object({
+                                            key: zod.string(),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
+                                            type: zod
+                                                .literal('hogql')
+                                                .default(
+                                                    errorTrackingBypassRulesUpdateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemFiveTypeDefault
+                                                ),
+                                            value: zod
+                                                .union([
+                                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                                    zod.string(),
+                                                    zod.number(),
+                                                    zod.boolean(),
+                                                    zod.null(),
+                                                ])
+                                                .optional(),
+                                        }),
+                                    ])
+                                ),
+                                zod.null(),
+                            ])
+                            .optional()
+                            .describe(
+                                'Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral\/cohort filters and groups'
+                            ),
+                        event_type: zod.enum(['events', 'actions']),
+                        explicit_datetime: zod
+                            .union([zod.string(), zod.null()])
+                            .optional()
+                            .describe(
+                                'Absolute or relative (e.g. -30d) lower date bound — alternative to time_value\/time_interval'
+                            ),
+                        explicit_datetime_to: zod.union([zod.string(), zod.null()]).optional(),
+                        key: zod.string().describe("Event name, or action id when event_type is 'actions'"),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
+                        negation: zod
+                            .union([zod.boolean(), zod.null()])
+                            .optional()
+                            .describe(
+                                'Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators'
+                            ),
+                        operator: zod
+                            .union([
+                                zod.enum([
+                                    'exact',
+                                    'is_not',
+                                    'icontains',
+                                    'not_icontains',
+                                    'starts_with',
+                                    'not_starts_with',
+                                    'ends_with',
+                                    'not_ends_with',
+                                    'regex',
+                                    'not_regex',
+                                    'gt',
+                                    'gte',
+                                    'lt',
+                                    'lte',
+                                    'is_set',
+                                    'is_not_set',
+                                    'is_date_exact',
+                                    'is_date_before',
+                                    'is_date_after',
+                                    'between',
+                                    'not_between',
+                                    'min',
+                                    'max',
+                                    'in',
+                                    'not_in',
+                                    'is_cleaned_path_exact',
+                                    'flag_evaluates_to',
+                                    'semver_eq',
+                                    'semver_neq',
+                                    'semver_gt',
+                                    'semver_gte',
+                                    'semver_lt',
+                                    'semver_lte',
+                                    'semver_tilde',
+                                    'semver_caret',
+                                    'semver_wildcard',
+                                    'icontains_multi',
+                                    'not_icontains_multi',
+                                ]),
+                                zod.null(),
+                            ])
+                            .optional()
+                            .describe('Count comparison for performed_event_multiple, defaults to exact'),
+                        operator_value: zod
+                            .union([zod.number(), zod.null()])
+                            .optional()
+                            .describe('Count threshold for performed_event_multiple'),
+                        time_interval: zod.union([zod.enum(['day', 'week', 'month', 'year']), zod.null()]).optional(),
+                        time_value: zod
+                            .union([zod.number(), zod.null()])
+                            .optional()
+                            .describe('Relative time window size, paired with time_interval'),
+                        type: zod
+                            .literal('behavioral')
+                            .default(errorTrackingBypassRulesUpdateBodyFiltersOneValuesItemTwofiveTypeDefault)
+                            .describe(
+                                "Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP"
+                            ),
+                        value: zod.enum(['performed_event', 'performed_event_multiple']),
+                    }),
                 ])
             ),
         })
@@ -3764,6 +4841,13 @@ export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemTwozeroType
 export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemTwotwoTypeDefault = `revenue_analytics`
 export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemTwothreeTypeDefault = `account_custom_property`
 export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemTwofourTypeDefault = `workflow_variable`
+export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemOneOperatorDefault = `exact`
+export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemOneTypeDefault = `event`
+export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemTwoTypeDefault = `person`
+export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemThreeTypeDefault = `element`
+export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemFourTypeDefault = `feature`
+export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemFiveTypeDefault = `hogql`
+export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemTwofiveTypeDefault = `behavioral`
 
 export const ErrorTrackingGroupingRulesCreateBody = /* @__PURE__ */ zod.object({
     filters: zod
@@ -4938,6 +6022,358 @@ export const ErrorTrackingGroupingRulesCreateBody = /* @__PURE__ */ zod.object({
                             ])
                             .optional(),
                     }),
+                    zod.object({
+                        event_filters: zod
+                            .union([
+                                zod.array(
+                                    zod.union([
+                                        zod.object({
+                                            key: zod.string(),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
+                                            operator: zod
+                                                .union([
+                                                    zod.enum([
+                                                        'exact',
+                                                        'is_not',
+                                                        'icontains',
+                                                        'not_icontains',
+                                                        'starts_with',
+                                                        'not_starts_with',
+                                                        'ends_with',
+                                                        'not_ends_with',
+                                                        'regex',
+                                                        'not_regex',
+                                                        'gt',
+                                                        'gte',
+                                                        'lt',
+                                                        'lte',
+                                                        'is_set',
+                                                        'is_not_set',
+                                                        'is_date_exact',
+                                                        'is_date_before',
+                                                        'is_date_after',
+                                                        'between',
+                                                        'not_between',
+                                                        'min',
+                                                        'max',
+                                                        'in',
+                                                        'not_in',
+                                                        'is_cleaned_path_exact',
+                                                        'flag_evaluates_to',
+                                                        'semver_eq',
+                                                        'semver_neq',
+                                                        'semver_gt',
+                                                        'semver_gte',
+                                                        'semver_lt',
+                                                        'semver_lte',
+                                                        'semver_tilde',
+                                                        'semver_caret',
+                                                        'semver_wildcard',
+                                                        'icontains_multi',
+                                                        'not_icontains_multi',
+                                                    ]),
+                                                    zod.null(),
+                                                ])
+                                                .default(
+                                                    errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemOneOperatorDefault
+                                                ),
+                                            type: zod
+                                                .literal('event')
+                                                .default(
+                                                    errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemOneTypeDefault
+                                                )
+                                                .describe('Event properties'),
+                                            value: zod
+                                                .union([
+                                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                                    zod.string(),
+                                                    zod.number(),
+                                                    zod.boolean(),
+                                                    zod.null(),
+                                                ])
+                                                .optional(),
+                                        }),
+                                        zod.object({
+                                            key: zod.string(),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
+                                            operator: zod.enum([
+                                                'exact',
+                                                'is_not',
+                                                'icontains',
+                                                'not_icontains',
+                                                'starts_with',
+                                                'not_starts_with',
+                                                'ends_with',
+                                                'not_ends_with',
+                                                'regex',
+                                                'not_regex',
+                                                'gt',
+                                                'gte',
+                                                'lt',
+                                                'lte',
+                                                'is_set',
+                                                'is_not_set',
+                                                'is_date_exact',
+                                                'is_date_before',
+                                                'is_date_after',
+                                                'between',
+                                                'not_between',
+                                                'min',
+                                                'max',
+                                                'in',
+                                                'not_in',
+                                                'is_cleaned_path_exact',
+                                                'flag_evaluates_to',
+                                                'semver_eq',
+                                                'semver_neq',
+                                                'semver_gt',
+                                                'semver_gte',
+                                                'semver_lt',
+                                                'semver_lte',
+                                                'semver_tilde',
+                                                'semver_caret',
+                                                'semver_wildcard',
+                                                'icontains_multi',
+                                                'not_icontains_multi',
+                                            ]),
+                                            type: zod
+                                                .literal('person')
+                                                .default(
+                                                    errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemTwoTypeDefault
+                                                )
+                                                .describe('Person properties'),
+                                            value: zod
+                                                .union([
+                                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                                    zod.string(),
+                                                    zod.number(),
+                                                    zod.boolean(),
+                                                    zod.null(),
+                                                ])
+                                                .optional(),
+                                        }),
+                                        zod.object({
+                                            key: zod.enum(['tag_name', 'text', 'href', 'selector']),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
+                                            operator: zod.enum([
+                                                'exact',
+                                                'is_not',
+                                                'icontains',
+                                                'not_icontains',
+                                                'starts_with',
+                                                'not_starts_with',
+                                                'ends_with',
+                                                'not_ends_with',
+                                                'regex',
+                                                'not_regex',
+                                                'gt',
+                                                'gte',
+                                                'lt',
+                                                'lte',
+                                                'is_set',
+                                                'is_not_set',
+                                                'is_date_exact',
+                                                'is_date_before',
+                                                'is_date_after',
+                                                'between',
+                                                'not_between',
+                                                'min',
+                                                'max',
+                                                'in',
+                                                'not_in',
+                                                'is_cleaned_path_exact',
+                                                'flag_evaluates_to',
+                                                'semver_eq',
+                                                'semver_neq',
+                                                'semver_gt',
+                                                'semver_gte',
+                                                'semver_lt',
+                                                'semver_lte',
+                                                'semver_tilde',
+                                                'semver_caret',
+                                                'semver_wildcard',
+                                                'icontains_multi',
+                                                'not_icontains_multi',
+                                            ]),
+                                            type: zod
+                                                .literal('element')
+                                                .default(
+                                                    errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemThreeTypeDefault
+                                                ),
+                                            value: zod
+                                                .union([
+                                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                                    zod.string(),
+                                                    zod.number(),
+                                                    zod.boolean(),
+                                                    zod.null(),
+                                                ])
+                                                .optional(),
+                                        }),
+                                        zod.object({
+                                            key: zod.string(),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
+                                            operator: zod.enum([
+                                                'exact',
+                                                'is_not',
+                                                'icontains',
+                                                'not_icontains',
+                                                'starts_with',
+                                                'not_starts_with',
+                                                'ends_with',
+                                                'not_ends_with',
+                                                'regex',
+                                                'not_regex',
+                                                'gt',
+                                                'gte',
+                                                'lt',
+                                                'lte',
+                                                'is_set',
+                                                'is_not_set',
+                                                'is_date_exact',
+                                                'is_date_before',
+                                                'is_date_after',
+                                                'between',
+                                                'not_between',
+                                                'min',
+                                                'max',
+                                                'in',
+                                                'not_in',
+                                                'is_cleaned_path_exact',
+                                                'flag_evaluates_to',
+                                                'semver_eq',
+                                                'semver_neq',
+                                                'semver_gt',
+                                                'semver_gte',
+                                                'semver_lt',
+                                                'semver_lte',
+                                                'semver_tilde',
+                                                'semver_caret',
+                                                'semver_wildcard',
+                                                'icontains_multi',
+                                                'not_icontains_multi',
+                                            ]),
+                                            type: zod
+                                                .literal('feature')
+                                                .default(
+                                                    errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemFourTypeDefault
+                                                )
+                                                .describe('Event property with \"$feature\/\" prepended'),
+                                            value: zod
+                                                .union([
+                                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                                    zod.string(),
+                                                    zod.number(),
+                                                    zod.boolean(),
+                                                    zod.null(),
+                                                ])
+                                                .optional(),
+                                        }),
+                                        zod.object({
+                                            key: zod.string(),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
+                                            type: zod
+                                                .literal('hogql')
+                                                .default(
+                                                    errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemFiveTypeDefault
+                                                ),
+                                            value: zod
+                                                .union([
+                                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                                    zod.string(),
+                                                    zod.number(),
+                                                    zod.boolean(),
+                                                    zod.null(),
+                                                ])
+                                                .optional(),
+                                        }),
+                                    ])
+                                ),
+                                zod.null(),
+                            ])
+                            .optional()
+                            .describe(
+                                'Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral\/cohort filters and groups'
+                            ),
+                        event_type: zod.enum(['events', 'actions']),
+                        explicit_datetime: zod
+                            .union([zod.string(), zod.null()])
+                            .optional()
+                            .describe(
+                                'Absolute or relative (e.g. -30d) lower date bound — alternative to time_value\/time_interval'
+                            ),
+                        explicit_datetime_to: zod.union([zod.string(), zod.null()]).optional(),
+                        key: zod.string().describe("Event name, or action id when event_type is 'actions'"),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
+                        negation: zod
+                            .union([zod.boolean(), zod.null()])
+                            .optional()
+                            .describe(
+                                'Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators'
+                            ),
+                        operator: zod
+                            .union([
+                                zod.enum([
+                                    'exact',
+                                    'is_not',
+                                    'icontains',
+                                    'not_icontains',
+                                    'starts_with',
+                                    'not_starts_with',
+                                    'ends_with',
+                                    'not_ends_with',
+                                    'regex',
+                                    'not_regex',
+                                    'gt',
+                                    'gte',
+                                    'lt',
+                                    'lte',
+                                    'is_set',
+                                    'is_not_set',
+                                    'is_date_exact',
+                                    'is_date_before',
+                                    'is_date_after',
+                                    'between',
+                                    'not_between',
+                                    'min',
+                                    'max',
+                                    'in',
+                                    'not_in',
+                                    'is_cleaned_path_exact',
+                                    'flag_evaluates_to',
+                                    'semver_eq',
+                                    'semver_neq',
+                                    'semver_gt',
+                                    'semver_gte',
+                                    'semver_lt',
+                                    'semver_lte',
+                                    'semver_tilde',
+                                    'semver_caret',
+                                    'semver_wildcard',
+                                    'icontains_multi',
+                                    'not_icontains_multi',
+                                ]),
+                                zod.null(),
+                            ])
+                            .optional()
+                            .describe('Count comparison for performed_event_multiple, defaults to exact'),
+                        operator_value: zod
+                            .union([zod.number(), zod.null()])
+                            .optional()
+                            .describe('Count threshold for performed_event_multiple'),
+                        time_interval: zod.union([zod.enum(['day', 'week', 'month', 'year']), zod.null()]).optional(),
+                        time_value: zod
+                            .union([zod.number(), zod.null()])
+                            .optional()
+                            .describe('Relative time window size, paired with time_interval'),
+                        type: zod
+                            .literal('behavioral')
+                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemTwofiveTypeDefault)
+                            .describe(
+                                "Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP"
+                            ),
+                        value: zod.enum(['performed_event', 'performed_event_multiple']),
+                    }),
                 ])
             ),
         })
@@ -4999,6 +6435,13 @@ export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwozeroType
 export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwotwoTypeDefault = `revenue_analytics`
 export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwothreeTypeDefault = `account_custom_property`
 export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwofourTypeDefault = `workflow_variable`
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemOneOperatorDefault = `exact`
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemOneTypeDefault = `event`
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemTwoTypeDefault = `person`
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemThreeTypeDefault = `element`
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemFourTypeDefault = `feature`
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemFiveTypeDefault = `hogql`
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwofiveTypeDefault = `behavioral`
 
 export const ErrorTrackingGroupingRulesUpdateBody = /* @__PURE__ */ zod.object({
     filters: zod
@@ -6181,6 +7624,370 @@ export const ErrorTrackingGroupingRulesUpdateBody = /* @__PURE__ */ zod.object({
                                 ])
                                 .optional(),
                         }),
+                        zod.object({
+                            event_filters: zod
+                                .union([
+                                    zod.array(
+                                        zod.union([
+                                            zod.object({
+                                                key: zod.string(),
+                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                operator: zod
+                                                    .union([
+                                                        zod.enum([
+                                                            'exact',
+                                                            'is_not',
+                                                            'icontains',
+                                                            'not_icontains',
+                                                            'starts_with',
+                                                            'not_starts_with',
+                                                            'ends_with',
+                                                            'not_ends_with',
+                                                            'regex',
+                                                            'not_regex',
+                                                            'gt',
+                                                            'gte',
+                                                            'lt',
+                                                            'lte',
+                                                            'is_set',
+                                                            'is_not_set',
+                                                            'is_date_exact',
+                                                            'is_date_before',
+                                                            'is_date_after',
+                                                            'between',
+                                                            'not_between',
+                                                            'min',
+                                                            'max',
+                                                            'in',
+                                                            'not_in',
+                                                            'is_cleaned_path_exact',
+                                                            'flag_evaluates_to',
+                                                            'semver_eq',
+                                                            'semver_neq',
+                                                            'semver_gt',
+                                                            'semver_gte',
+                                                            'semver_lt',
+                                                            'semver_lte',
+                                                            'semver_tilde',
+                                                            'semver_caret',
+                                                            'semver_wildcard',
+                                                            'icontains_multi',
+                                                            'not_icontains_multi',
+                                                        ]),
+                                                        zod.null(),
+                                                    ])
+                                                    .default(
+                                                        errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemOneOperatorDefault
+                                                    ),
+                                                type: zod
+                                                    .literal('event')
+                                                    .default(
+                                                        errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemOneTypeDefault
+                                                    )
+                                                    .describe('Event properties'),
+                                                value: zod
+                                                    .union([
+                                                        zod.array(
+                                                            zod.union([zod.string(), zod.number(), zod.boolean()])
+                                                        ),
+                                                        zod.string(),
+                                                        zod.number(),
+                                                        zod.boolean(),
+                                                        zod.null(),
+                                                    ])
+                                                    .optional(),
+                                            }),
+                                            zod.object({
+                                                key: zod.string(),
+                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                operator: zod.enum([
+                                                    'exact',
+                                                    'is_not',
+                                                    'icontains',
+                                                    'not_icontains',
+                                                    'starts_with',
+                                                    'not_starts_with',
+                                                    'ends_with',
+                                                    'not_ends_with',
+                                                    'regex',
+                                                    'not_regex',
+                                                    'gt',
+                                                    'gte',
+                                                    'lt',
+                                                    'lte',
+                                                    'is_set',
+                                                    'is_not_set',
+                                                    'is_date_exact',
+                                                    'is_date_before',
+                                                    'is_date_after',
+                                                    'between',
+                                                    'not_between',
+                                                    'min',
+                                                    'max',
+                                                    'in',
+                                                    'not_in',
+                                                    'is_cleaned_path_exact',
+                                                    'flag_evaluates_to',
+                                                    'semver_eq',
+                                                    'semver_neq',
+                                                    'semver_gt',
+                                                    'semver_gte',
+                                                    'semver_lt',
+                                                    'semver_lte',
+                                                    'semver_tilde',
+                                                    'semver_caret',
+                                                    'semver_wildcard',
+                                                    'icontains_multi',
+                                                    'not_icontains_multi',
+                                                ]),
+                                                type: zod
+                                                    .literal('person')
+                                                    .default(
+                                                        errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemTwoTypeDefault
+                                                    )
+                                                    .describe('Person properties'),
+                                                value: zod
+                                                    .union([
+                                                        zod.array(
+                                                            zod.union([zod.string(), zod.number(), zod.boolean()])
+                                                        ),
+                                                        zod.string(),
+                                                        zod.number(),
+                                                        zod.boolean(),
+                                                        zod.null(),
+                                                    ])
+                                                    .optional(),
+                                            }),
+                                            zod.object({
+                                                key: zod.enum(['tag_name', 'text', 'href', 'selector']),
+                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                operator: zod.enum([
+                                                    'exact',
+                                                    'is_not',
+                                                    'icontains',
+                                                    'not_icontains',
+                                                    'starts_with',
+                                                    'not_starts_with',
+                                                    'ends_with',
+                                                    'not_ends_with',
+                                                    'regex',
+                                                    'not_regex',
+                                                    'gt',
+                                                    'gte',
+                                                    'lt',
+                                                    'lte',
+                                                    'is_set',
+                                                    'is_not_set',
+                                                    'is_date_exact',
+                                                    'is_date_before',
+                                                    'is_date_after',
+                                                    'between',
+                                                    'not_between',
+                                                    'min',
+                                                    'max',
+                                                    'in',
+                                                    'not_in',
+                                                    'is_cleaned_path_exact',
+                                                    'flag_evaluates_to',
+                                                    'semver_eq',
+                                                    'semver_neq',
+                                                    'semver_gt',
+                                                    'semver_gte',
+                                                    'semver_lt',
+                                                    'semver_lte',
+                                                    'semver_tilde',
+                                                    'semver_caret',
+                                                    'semver_wildcard',
+                                                    'icontains_multi',
+                                                    'not_icontains_multi',
+                                                ]),
+                                                type: zod
+                                                    .literal('element')
+                                                    .default(
+                                                        errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemThreeTypeDefault
+                                                    ),
+                                                value: zod
+                                                    .union([
+                                                        zod.array(
+                                                            zod.union([zod.string(), zod.number(), zod.boolean()])
+                                                        ),
+                                                        zod.string(),
+                                                        zod.number(),
+                                                        zod.boolean(),
+                                                        zod.null(),
+                                                    ])
+                                                    .optional(),
+                                            }),
+                                            zod.object({
+                                                key: zod.string(),
+                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                operator: zod.enum([
+                                                    'exact',
+                                                    'is_not',
+                                                    'icontains',
+                                                    'not_icontains',
+                                                    'starts_with',
+                                                    'not_starts_with',
+                                                    'ends_with',
+                                                    'not_ends_with',
+                                                    'regex',
+                                                    'not_regex',
+                                                    'gt',
+                                                    'gte',
+                                                    'lt',
+                                                    'lte',
+                                                    'is_set',
+                                                    'is_not_set',
+                                                    'is_date_exact',
+                                                    'is_date_before',
+                                                    'is_date_after',
+                                                    'between',
+                                                    'not_between',
+                                                    'min',
+                                                    'max',
+                                                    'in',
+                                                    'not_in',
+                                                    'is_cleaned_path_exact',
+                                                    'flag_evaluates_to',
+                                                    'semver_eq',
+                                                    'semver_neq',
+                                                    'semver_gt',
+                                                    'semver_gte',
+                                                    'semver_lt',
+                                                    'semver_lte',
+                                                    'semver_tilde',
+                                                    'semver_caret',
+                                                    'semver_wildcard',
+                                                    'icontains_multi',
+                                                    'not_icontains_multi',
+                                                ]),
+                                                type: zod
+                                                    .literal('feature')
+                                                    .default(
+                                                        errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemFourTypeDefault
+                                                    )
+                                                    .describe('Event property with \"$feature\/\" prepended'),
+                                                value: zod
+                                                    .union([
+                                                        zod.array(
+                                                            zod.union([zod.string(), zod.number(), zod.boolean()])
+                                                        ),
+                                                        zod.string(),
+                                                        zod.number(),
+                                                        zod.boolean(),
+                                                        zod.null(),
+                                                    ])
+                                                    .optional(),
+                                            }),
+                                            zod.object({
+                                                key: zod.string(),
+                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                type: zod
+                                                    .literal('hogql')
+                                                    .default(
+                                                        errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemFiveTypeDefault
+                                                    ),
+                                                value: zod
+                                                    .union([
+                                                        zod.array(
+                                                            zod.union([zod.string(), zod.number(), zod.boolean()])
+                                                        ),
+                                                        zod.string(),
+                                                        zod.number(),
+                                                        zod.boolean(),
+                                                        zod.null(),
+                                                    ])
+                                                    .optional(),
+                                            }),
+                                        ])
+                                    ),
+                                    zod.null(),
+                                ])
+                                .optional()
+                                .describe(
+                                    'Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral\/cohort filters and groups'
+                                ),
+                            event_type: zod.enum(['events', 'actions']),
+                            explicit_datetime: zod
+                                .union([zod.string(), zod.null()])
+                                .optional()
+                                .describe(
+                                    'Absolute or relative (e.g. -30d) lower date bound — alternative to time_value\/time_interval'
+                                ),
+                            explicit_datetime_to: zod.union([zod.string(), zod.null()]).optional(),
+                            key: zod.string().describe("Event name, or action id when event_type is 'actions'"),
+                            label: zod.union([zod.string(), zod.null()]).optional(),
+                            negation: zod
+                                .union([zod.boolean(), zod.null()])
+                                .optional()
+                                .describe(
+                                    'Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators'
+                                ),
+                            operator: zod
+                                .union([
+                                    zod.enum([
+                                        'exact',
+                                        'is_not',
+                                        'icontains',
+                                        'not_icontains',
+                                        'starts_with',
+                                        'not_starts_with',
+                                        'ends_with',
+                                        'not_ends_with',
+                                        'regex',
+                                        'not_regex',
+                                        'gt',
+                                        'gte',
+                                        'lt',
+                                        'lte',
+                                        'is_set',
+                                        'is_not_set',
+                                        'is_date_exact',
+                                        'is_date_before',
+                                        'is_date_after',
+                                        'between',
+                                        'not_between',
+                                        'min',
+                                        'max',
+                                        'in',
+                                        'not_in',
+                                        'is_cleaned_path_exact',
+                                        'flag_evaluates_to',
+                                        'semver_eq',
+                                        'semver_neq',
+                                        'semver_gt',
+                                        'semver_gte',
+                                        'semver_lt',
+                                        'semver_lte',
+                                        'semver_tilde',
+                                        'semver_caret',
+                                        'semver_wildcard',
+                                        'icontains_multi',
+                                        'not_icontains_multi',
+                                    ]),
+                                    zod.null(),
+                                ])
+                                .optional()
+                                .describe('Count comparison for performed_event_multiple, defaults to exact'),
+                            operator_value: zod
+                                .union([zod.number(), zod.null()])
+                                .optional()
+                                .describe('Count threshold for performed_event_multiple'),
+                            time_interval: zod
+                                .union([zod.enum(['day', 'week', 'month', 'year']), zod.null()])
+                                .optional(),
+                            time_value: zod
+                                .union([zod.number(), zod.null()])
+                                .optional()
+                                .describe('Relative time window size, paired with time_interval'),
+                            type: zod
+                                .literal('behavioral')
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwofiveTypeDefault)
+                                .describe(
+                                    "Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP"
+                                ),
+                            value: zod.enum(['performed_event', 'performed_event_multiple']),
+                        }),
                     ])
                 ),
             }),
@@ -6838,6 +8645,13 @@ export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemTwozeroT
 export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemTwotwoTypeDefault = `revenue_analytics`
 export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemTwothreeTypeDefault = `account_custom_property`
 export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemTwofourTypeDefault = `workflow_variable`
+export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemOneOperatorDefault = `exact`
+export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemOneTypeDefault = `event`
+export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemTwoTypeDefault = `person`
+export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemThreeTypeDefault = `element`
+export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemFourTypeDefault = `feature`
+export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemFiveTypeDefault = `hogql`
+export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemTwofiveTypeDefault = `behavioral`
 export const errorTrackingSuppressionRulesCreateBodySamplingRateDefault = 1
 export const errorTrackingSuppressionRulesCreateBodySamplingRateMin = 0
 export const errorTrackingSuppressionRulesCreateBodySamplingRateMax = 1
@@ -8015,6 +9829,358 @@ export const ErrorTrackingSuppressionRulesCreateBody = /* @__PURE__ */ zod.objec
                             ])
                             .optional(),
                     }),
+                    zod.object({
+                        event_filters: zod
+                            .union([
+                                zod.array(
+                                    zod.union([
+                                        zod.object({
+                                            key: zod.string(),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
+                                            operator: zod
+                                                .union([
+                                                    zod.enum([
+                                                        'exact',
+                                                        'is_not',
+                                                        'icontains',
+                                                        'not_icontains',
+                                                        'starts_with',
+                                                        'not_starts_with',
+                                                        'ends_with',
+                                                        'not_ends_with',
+                                                        'regex',
+                                                        'not_regex',
+                                                        'gt',
+                                                        'gte',
+                                                        'lt',
+                                                        'lte',
+                                                        'is_set',
+                                                        'is_not_set',
+                                                        'is_date_exact',
+                                                        'is_date_before',
+                                                        'is_date_after',
+                                                        'between',
+                                                        'not_between',
+                                                        'min',
+                                                        'max',
+                                                        'in',
+                                                        'not_in',
+                                                        'is_cleaned_path_exact',
+                                                        'flag_evaluates_to',
+                                                        'semver_eq',
+                                                        'semver_neq',
+                                                        'semver_gt',
+                                                        'semver_gte',
+                                                        'semver_lt',
+                                                        'semver_lte',
+                                                        'semver_tilde',
+                                                        'semver_caret',
+                                                        'semver_wildcard',
+                                                        'icontains_multi',
+                                                        'not_icontains_multi',
+                                                    ]),
+                                                    zod.null(),
+                                                ])
+                                                .default(
+                                                    errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemOneOperatorDefault
+                                                ),
+                                            type: zod
+                                                .literal('event')
+                                                .default(
+                                                    errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemOneTypeDefault
+                                                )
+                                                .describe('Event properties'),
+                                            value: zod
+                                                .union([
+                                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                                    zod.string(),
+                                                    zod.number(),
+                                                    zod.boolean(),
+                                                    zod.null(),
+                                                ])
+                                                .optional(),
+                                        }),
+                                        zod.object({
+                                            key: zod.string(),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
+                                            operator: zod.enum([
+                                                'exact',
+                                                'is_not',
+                                                'icontains',
+                                                'not_icontains',
+                                                'starts_with',
+                                                'not_starts_with',
+                                                'ends_with',
+                                                'not_ends_with',
+                                                'regex',
+                                                'not_regex',
+                                                'gt',
+                                                'gte',
+                                                'lt',
+                                                'lte',
+                                                'is_set',
+                                                'is_not_set',
+                                                'is_date_exact',
+                                                'is_date_before',
+                                                'is_date_after',
+                                                'between',
+                                                'not_between',
+                                                'min',
+                                                'max',
+                                                'in',
+                                                'not_in',
+                                                'is_cleaned_path_exact',
+                                                'flag_evaluates_to',
+                                                'semver_eq',
+                                                'semver_neq',
+                                                'semver_gt',
+                                                'semver_gte',
+                                                'semver_lt',
+                                                'semver_lte',
+                                                'semver_tilde',
+                                                'semver_caret',
+                                                'semver_wildcard',
+                                                'icontains_multi',
+                                                'not_icontains_multi',
+                                            ]),
+                                            type: zod
+                                                .literal('person')
+                                                .default(
+                                                    errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemTwoTypeDefault
+                                                )
+                                                .describe('Person properties'),
+                                            value: zod
+                                                .union([
+                                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                                    zod.string(),
+                                                    zod.number(),
+                                                    zod.boolean(),
+                                                    zod.null(),
+                                                ])
+                                                .optional(),
+                                        }),
+                                        zod.object({
+                                            key: zod.enum(['tag_name', 'text', 'href', 'selector']),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
+                                            operator: zod.enum([
+                                                'exact',
+                                                'is_not',
+                                                'icontains',
+                                                'not_icontains',
+                                                'starts_with',
+                                                'not_starts_with',
+                                                'ends_with',
+                                                'not_ends_with',
+                                                'regex',
+                                                'not_regex',
+                                                'gt',
+                                                'gte',
+                                                'lt',
+                                                'lte',
+                                                'is_set',
+                                                'is_not_set',
+                                                'is_date_exact',
+                                                'is_date_before',
+                                                'is_date_after',
+                                                'between',
+                                                'not_between',
+                                                'min',
+                                                'max',
+                                                'in',
+                                                'not_in',
+                                                'is_cleaned_path_exact',
+                                                'flag_evaluates_to',
+                                                'semver_eq',
+                                                'semver_neq',
+                                                'semver_gt',
+                                                'semver_gte',
+                                                'semver_lt',
+                                                'semver_lte',
+                                                'semver_tilde',
+                                                'semver_caret',
+                                                'semver_wildcard',
+                                                'icontains_multi',
+                                                'not_icontains_multi',
+                                            ]),
+                                            type: zod
+                                                .literal('element')
+                                                .default(
+                                                    errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemThreeTypeDefault
+                                                ),
+                                            value: zod
+                                                .union([
+                                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                                    zod.string(),
+                                                    zod.number(),
+                                                    zod.boolean(),
+                                                    zod.null(),
+                                                ])
+                                                .optional(),
+                                        }),
+                                        zod.object({
+                                            key: zod.string(),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
+                                            operator: zod.enum([
+                                                'exact',
+                                                'is_not',
+                                                'icontains',
+                                                'not_icontains',
+                                                'starts_with',
+                                                'not_starts_with',
+                                                'ends_with',
+                                                'not_ends_with',
+                                                'regex',
+                                                'not_regex',
+                                                'gt',
+                                                'gte',
+                                                'lt',
+                                                'lte',
+                                                'is_set',
+                                                'is_not_set',
+                                                'is_date_exact',
+                                                'is_date_before',
+                                                'is_date_after',
+                                                'between',
+                                                'not_between',
+                                                'min',
+                                                'max',
+                                                'in',
+                                                'not_in',
+                                                'is_cleaned_path_exact',
+                                                'flag_evaluates_to',
+                                                'semver_eq',
+                                                'semver_neq',
+                                                'semver_gt',
+                                                'semver_gte',
+                                                'semver_lt',
+                                                'semver_lte',
+                                                'semver_tilde',
+                                                'semver_caret',
+                                                'semver_wildcard',
+                                                'icontains_multi',
+                                                'not_icontains_multi',
+                                            ]),
+                                            type: zod
+                                                .literal('feature')
+                                                .default(
+                                                    errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemFourTypeDefault
+                                                )
+                                                .describe('Event property with \"$feature\/\" prepended'),
+                                            value: zod
+                                                .union([
+                                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                                    zod.string(),
+                                                    zod.number(),
+                                                    zod.boolean(),
+                                                    zod.null(),
+                                                ])
+                                                .optional(),
+                                        }),
+                                        zod.object({
+                                            key: zod.string(),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
+                                            type: zod
+                                                .literal('hogql')
+                                                .default(
+                                                    errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemFiveTypeDefault
+                                                ),
+                                            value: zod
+                                                .union([
+                                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                                    zod.string(),
+                                                    zod.number(),
+                                                    zod.boolean(),
+                                                    zod.null(),
+                                                ])
+                                                .optional(),
+                                        }),
+                                    ])
+                                ),
+                                zod.null(),
+                            ])
+                            .optional()
+                            .describe(
+                                'Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral\/cohort filters and groups'
+                            ),
+                        event_type: zod.enum(['events', 'actions']),
+                        explicit_datetime: zod
+                            .union([zod.string(), zod.null()])
+                            .optional()
+                            .describe(
+                                'Absolute or relative (e.g. -30d) lower date bound — alternative to time_value\/time_interval'
+                            ),
+                        explicit_datetime_to: zod.union([zod.string(), zod.null()]).optional(),
+                        key: zod.string().describe("Event name, or action id when event_type is 'actions'"),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
+                        negation: zod
+                            .union([zod.boolean(), zod.null()])
+                            .optional()
+                            .describe(
+                                'Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators'
+                            ),
+                        operator: zod
+                            .union([
+                                zod.enum([
+                                    'exact',
+                                    'is_not',
+                                    'icontains',
+                                    'not_icontains',
+                                    'starts_with',
+                                    'not_starts_with',
+                                    'ends_with',
+                                    'not_ends_with',
+                                    'regex',
+                                    'not_regex',
+                                    'gt',
+                                    'gte',
+                                    'lt',
+                                    'lte',
+                                    'is_set',
+                                    'is_not_set',
+                                    'is_date_exact',
+                                    'is_date_before',
+                                    'is_date_after',
+                                    'between',
+                                    'not_between',
+                                    'min',
+                                    'max',
+                                    'in',
+                                    'not_in',
+                                    'is_cleaned_path_exact',
+                                    'flag_evaluates_to',
+                                    'semver_eq',
+                                    'semver_neq',
+                                    'semver_gt',
+                                    'semver_gte',
+                                    'semver_lt',
+                                    'semver_lte',
+                                    'semver_tilde',
+                                    'semver_caret',
+                                    'semver_wildcard',
+                                    'icontains_multi',
+                                    'not_icontains_multi',
+                                ]),
+                                zod.null(),
+                            ])
+                            .optional()
+                            .describe('Count comparison for performed_event_multiple, defaults to exact'),
+                        operator_value: zod
+                            .union([zod.number(), zod.null()])
+                            .optional()
+                            .describe('Count threshold for performed_event_multiple'),
+                        time_interval: zod.union([zod.enum(['day', 'week', 'month', 'year']), zod.null()]).optional(),
+                        time_value: zod
+                            .union([zod.number(), zod.null()])
+                            .optional()
+                            .describe('Relative time window size, paired with time_interval'),
+                        type: zod
+                            .literal('behavioral')
+                            .default(errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemTwofiveTypeDefault)
+                            .describe(
+                                "Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP"
+                            ),
+                        value: zod.enum(['performed_event', 'performed_event_multiple']),
+                    }),
                 ])
             ),
         })
@@ -8066,6 +10232,13 @@ export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemTwozeroT
 export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemTwotwoTypeDefault = `revenue_analytics`
 export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemTwothreeTypeDefault = `account_custom_property`
 export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemTwofourTypeDefault = `workflow_variable`
+export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemOneOperatorDefault = `exact`
+export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemOneTypeDefault = `event`
+export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemTwoTypeDefault = `person`
+export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemThreeTypeDefault = `element`
+export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemFourTypeDefault = `feature`
+export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemFiveTypeDefault = `hogql`
+export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemTwofiveTypeDefault = `behavioral`
 export const errorTrackingSuppressionRulesUpdateBodySamplingRateMin = 0
 export const errorTrackingSuppressionRulesUpdateBodySamplingRateMax = 1
 
@@ -9241,6 +11414,358 @@ export const ErrorTrackingSuppressionRulesUpdateBody = /* @__PURE__ */ zod.objec
                                 zod.null(),
                             ])
                             .optional(),
+                    }),
+                    zod.object({
+                        event_filters: zod
+                            .union([
+                                zod.array(
+                                    zod.union([
+                                        zod.object({
+                                            key: zod.string(),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
+                                            operator: zod
+                                                .union([
+                                                    zod.enum([
+                                                        'exact',
+                                                        'is_not',
+                                                        'icontains',
+                                                        'not_icontains',
+                                                        'starts_with',
+                                                        'not_starts_with',
+                                                        'ends_with',
+                                                        'not_ends_with',
+                                                        'regex',
+                                                        'not_regex',
+                                                        'gt',
+                                                        'gte',
+                                                        'lt',
+                                                        'lte',
+                                                        'is_set',
+                                                        'is_not_set',
+                                                        'is_date_exact',
+                                                        'is_date_before',
+                                                        'is_date_after',
+                                                        'between',
+                                                        'not_between',
+                                                        'min',
+                                                        'max',
+                                                        'in',
+                                                        'not_in',
+                                                        'is_cleaned_path_exact',
+                                                        'flag_evaluates_to',
+                                                        'semver_eq',
+                                                        'semver_neq',
+                                                        'semver_gt',
+                                                        'semver_gte',
+                                                        'semver_lt',
+                                                        'semver_lte',
+                                                        'semver_tilde',
+                                                        'semver_caret',
+                                                        'semver_wildcard',
+                                                        'icontains_multi',
+                                                        'not_icontains_multi',
+                                                    ]),
+                                                    zod.null(),
+                                                ])
+                                                .default(
+                                                    errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemOneOperatorDefault
+                                                ),
+                                            type: zod
+                                                .literal('event')
+                                                .default(
+                                                    errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemOneTypeDefault
+                                                )
+                                                .describe('Event properties'),
+                                            value: zod
+                                                .union([
+                                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                                    zod.string(),
+                                                    zod.number(),
+                                                    zod.boolean(),
+                                                    zod.null(),
+                                                ])
+                                                .optional(),
+                                        }),
+                                        zod.object({
+                                            key: zod.string(),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
+                                            operator: zod.enum([
+                                                'exact',
+                                                'is_not',
+                                                'icontains',
+                                                'not_icontains',
+                                                'starts_with',
+                                                'not_starts_with',
+                                                'ends_with',
+                                                'not_ends_with',
+                                                'regex',
+                                                'not_regex',
+                                                'gt',
+                                                'gte',
+                                                'lt',
+                                                'lte',
+                                                'is_set',
+                                                'is_not_set',
+                                                'is_date_exact',
+                                                'is_date_before',
+                                                'is_date_after',
+                                                'between',
+                                                'not_between',
+                                                'min',
+                                                'max',
+                                                'in',
+                                                'not_in',
+                                                'is_cleaned_path_exact',
+                                                'flag_evaluates_to',
+                                                'semver_eq',
+                                                'semver_neq',
+                                                'semver_gt',
+                                                'semver_gte',
+                                                'semver_lt',
+                                                'semver_lte',
+                                                'semver_tilde',
+                                                'semver_caret',
+                                                'semver_wildcard',
+                                                'icontains_multi',
+                                                'not_icontains_multi',
+                                            ]),
+                                            type: zod
+                                                .literal('person')
+                                                .default(
+                                                    errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemTwoTypeDefault
+                                                )
+                                                .describe('Person properties'),
+                                            value: zod
+                                                .union([
+                                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                                    zod.string(),
+                                                    zod.number(),
+                                                    zod.boolean(),
+                                                    zod.null(),
+                                                ])
+                                                .optional(),
+                                        }),
+                                        zod.object({
+                                            key: zod.enum(['tag_name', 'text', 'href', 'selector']),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
+                                            operator: zod.enum([
+                                                'exact',
+                                                'is_not',
+                                                'icontains',
+                                                'not_icontains',
+                                                'starts_with',
+                                                'not_starts_with',
+                                                'ends_with',
+                                                'not_ends_with',
+                                                'regex',
+                                                'not_regex',
+                                                'gt',
+                                                'gte',
+                                                'lt',
+                                                'lte',
+                                                'is_set',
+                                                'is_not_set',
+                                                'is_date_exact',
+                                                'is_date_before',
+                                                'is_date_after',
+                                                'between',
+                                                'not_between',
+                                                'min',
+                                                'max',
+                                                'in',
+                                                'not_in',
+                                                'is_cleaned_path_exact',
+                                                'flag_evaluates_to',
+                                                'semver_eq',
+                                                'semver_neq',
+                                                'semver_gt',
+                                                'semver_gte',
+                                                'semver_lt',
+                                                'semver_lte',
+                                                'semver_tilde',
+                                                'semver_caret',
+                                                'semver_wildcard',
+                                                'icontains_multi',
+                                                'not_icontains_multi',
+                                            ]),
+                                            type: zod
+                                                .literal('element')
+                                                .default(
+                                                    errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemThreeTypeDefault
+                                                ),
+                                            value: zod
+                                                .union([
+                                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                                    zod.string(),
+                                                    zod.number(),
+                                                    zod.boolean(),
+                                                    zod.null(),
+                                                ])
+                                                .optional(),
+                                        }),
+                                        zod.object({
+                                            key: zod.string(),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
+                                            operator: zod.enum([
+                                                'exact',
+                                                'is_not',
+                                                'icontains',
+                                                'not_icontains',
+                                                'starts_with',
+                                                'not_starts_with',
+                                                'ends_with',
+                                                'not_ends_with',
+                                                'regex',
+                                                'not_regex',
+                                                'gt',
+                                                'gte',
+                                                'lt',
+                                                'lte',
+                                                'is_set',
+                                                'is_not_set',
+                                                'is_date_exact',
+                                                'is_date_before',
+                                                'is_date_after',
+                                                'between',
+                                                'not_between',
+                                                'min',
+                                                'max',
+                                                'in',
+                                                'not_in',
+                                                'is_cleaned_path_exact',
+                                                'flag_evaluates_to',
+                                                'semver_eq',
+                                                'semver_neq',
+                                                'semver_gt',
+                                                'semver_gte',
+                                                'semver_lt',
+                                                'semver_lte',
+                                                'semver_tilde',
+                                                'semver_caret',
+                                                'semver_wildcard',
+                                                'icontains_multi',
+                                                'not_icontains_multi',
+                                            ]),
+                                            type: zod
+                                                .literal('feature')
+                                                .default(
+                                                    errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemFourTypeDefault
+                                                )
+                                                .describe('Event property with \"$feature\/\" prepended'),
+                                            value: zod
+                                                .union([
+                                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                                    zod.string(),
+                                                    zod.number(),
+                                                    zod.boolean(),
+                                                    zod.null(),
+                                                ])
+                                                .optional(),
+                                        }),
+                                        zod.object({
+                                            key: zod.string(),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
+                                            type: zod
+                                                .literal('hogql')
+                                                .default(
+                                                    errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemTwofiveEventFiltersOneItemFiveTypeDefault
+                                                ),
+                                            value: zod
+                                                .union([
+                                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                                    zod.string(),
+                                                    zod.number(),
+                                                    zod.boolean(),
+                                                    zod.null(),
+                                                ])
+                                                .optional(),
+                                        }),
+                                    ])
+                                ),
+                                zod.null(),
+                            ])
+                            .optional()
+                            .describe(
+                                'Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral\/cohort filters and groups'
+                            ),
+                        event_type: zod.enum(['events', 'actions']),
+                        explicit_datetime: zod
+                            .union([zod.string(), zod.null()])
+                            .optional()
+                            .describe(
+                                'Absolute or relative (e.g. -30d) lower date bound — alternative to time_value\/time_interval'
+                            ),
+                        explicit_datetime_to: zod.union([zod.string(), zod.null()]).optional(),
+                        key: zod.string().describe("Event name, or action id when event_type is 'actions'"),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
+                        negation: zod
+                            .union([zod.boolean(), zod.null()])
+                            .optional()
+                            .describe(
+                                'Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators'
+                            ),
+                        operator: zod
+                            .union([
+                                zod.enum([
+                                    'exact',
+                                    'is_not',
+                                    'icontains',
+                                    'not_icontains',
+                                    'starts_with',
+                                    'not_starts_with',
+                                    'ends_with',
+                                    'not_ends_with',
+                                    'regex',
+                                    'not_regex',
+                                    'gt',
+                                    'gte',
+                                    'lt',
+                                    'lte',
+                                    'is_set',
+                                    'is_not_set',
+                                    'is_date_exact',
+                                    'is_date_before',
+                                    'is_date_after',
+                                    'between',
+                                    'not_between',
+                                    'min',
+                                    'max',
+                                    'in',
+                                    'not_in',
+                                    'is_cleaned_path_exact',
+                                    'flag_evaluates_to',
+                                    'semver_eq',
+                                    'semver_neq',
+                                    'semver_gt',
+                                    'semver_gte',
+                                    'semver_lt',
+                                    'semver_lte',
+                                    'semver_tilde',
+                                    'semver_caret',
+                                    'semver_wildcard',
+                                    'icontains_multi',
+                                    'not_icontains_multi',
+                                ]),
+                                zod.null(),
+                            ])
+                            .optional()
+                            .describe('Count comparison for performed_event_multiple, defaults to exact'),
+                        operator_value: zod
+                            .union([zod.number(), zod.null()])
+                            .optional()
+                            .describe('Count threshold for performed_event_multiple'),
+                        time_interval: zod.union([zod.enum(['day', 'week', 'month', 'year']), zod.null()]).optional(),
+                        time_value: zod
+                            .union([zod.number(), zod.null()])
+                            .optional()
+                            .describe('Relative time window size, paired with time_interval'),
+                        type: zod
+                            .literal('behavioral')
+                            .default(errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemTwofiveTypeDefault)
+                            .describe(
+                                "Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP"
+                            ),
+                        value: zod.enum(['performed_event', 'performed_event_multiple']),
                     }),
                 ])
             ),

--- a/services/mcp/src/generated/experiments/api.ts
+++ b/services/mcp/src/generated/experiments/api.ts
@@ -784,6 +784,13 @@ export const experimentsCreateBodyExposureCriteriaOneActivationConfigOneProperti
 export const experimentsCreateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwooneTypeDefault = `revenue_analytics`
 export const experimentsCreateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwotwoTypeDefault = `account_custom_property`
 export const experimentsCreateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwothreeTypeDefault = `workflow_variable`
+export const experimentsCreateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwofourEventFiltersOneItemOneOperatorDefault = `exact`
+export const experimentsCreateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwofourEventFiltersOneItemOneTypeDefault = `event`
+export const experimentsCreateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwofourEventFiltersOneItemTwoTypeDefault = `person`
+export const experimentsCreateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwofourEventFiltersOneItemThreeTypeDefault = `element`
+export const experimentsCreateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwofourEventFiltersOneItemFourTypeDefault = `feature`
+export const experimentsCreateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwofourEventFiltersOneItemFiveTypeDefault = `hogql`
+export const experimentsCreateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwofourTypeDefault = `behavioral`
 export const experimentsCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemOneOperatorDefault = `exact`
 export const experimentsCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemOneTypeDefault = `event`
 export const experimentsCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwoTypeDefault = `person`
@@ -809,6 +816,13 @@ export const experimentsCreateBodyExposureCriteriaOneExposureConfigOneProperties
 export const experimentsCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwooneTypeDefault = `revenue_analytics`
 export const experimentsCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwotwoTypeDefault = `account_custom_property`
 export const experimentsCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwothreeTypeDefault = `workflow_variable`
+export const experimentsCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwofourEventFiltersOneItemOneOperatorDefault = `exact`
+export const experimentsCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwofourEventFiltersOneItemOneTypeDefault = `event`
+export const experimentsCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwofourEventFiltersOneItemTwoTypeDefault = `person`
+export const experimentsCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwofourEventFiltersOneItemThreeTypeDefault = `element`
+export const experimentsCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwofourEventFiltersOneItemFourTypeDefault = `feature`
+export const experimentsCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwofourEventFiltersOneItemFiveTypeDefault = `hogql`
+export const experimentsCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwofourTypeDefault = `behavioral`
 export const experimentsCreateBodyMetricsOneItemCompletionEventOnePropertiesOneItemOperatorDefault = `exact`
 export const experimentsCreateBodyMetricsOneItemCompletionEventOnePropertiesOneItemTypeDefault = `event`
 export const experimentsCreateBodyMetricsOneItemDenominatorOnePropertiesOneItemOperatorDefault = `exact`
@@ -2392,6 +2406,413 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                     ])
                                                     .optional(),
                                             }),
+                                            zod.object({
+                                                event_filters: zod
+                                                    .union([
+                                                        zod.array(
+                                                            zod.union([
+                                                                zod.object({
+                                                                    key: zod.string(),
+                                                                    label: zod
+                                                                        .union([zod.string(), zod.null()])
+                                                                        .optional(),
+                                                                    operator: zod
+                                                                        .union([
+                                                                            zod.enum([
+                                                                                'exact',
+                                                                                'is_not',
+                                                                                'icontains',
+                                                                                'not_icontains',
+                                                                                'starts_with',
+                                                                                'not_starts_with',
+                                                                                'ends_with',
+                                                                                'not_ends_with',
+                                                                                'regex',
+                                                                                'not_regex',
+                                                                                'gt',
+                                                                                'gte',
+                                                                                'lt',
+                                                                                'lte',
+                                                                                'is_set',
+                                                                                'is_not_set',
+                                                                                'is_date_exact',
+                                                                                'is_date_before',
+                                                                                'is_date_after',
+                                                                                'between',
+                                                                                'not_between',
+                                                                                'min',
+                                                                                'max',
+                                                                                'in',
+                                                                                'not_in',
+                                                                                'is_cleaned_path_exact',
+                                                                                'flag_evaluates_to',
+                                                                                'semver_eq',
+                                                                                'semver_neq',
+                                                                                'semver_gt',
+                                                                                'semver_gte',
+                                                                                'semver_lt',
+                                                                                'semver_lte',
+                                                                                'semver_tilde',
+                                                                                'semver_caret',
+                                                                                'semver_wildcard',
+                                                                                'icontains_multi',
+                                                                                'not_icontains_multi',
+                                                                            ]),
+                                                                            zod.null(),
+                                                                        ])
+                                                                        .default(
+                                                                            experimentsCreateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwofourEventFiltersOneItemOneOperatorDefault
+                                                                        ),
+                                                                    type: zod
+                                                                        .literal('event')
+                                                                        .default(
+                                                                            experimentsCreateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwofourEventFiltersOneItemOneTypeDefault
+                                                                        )
+                                                                        .describe('Event properties'),
+                                                                    value: zod
+                                                                        .union([
+                                                                            zod.array(
+                                                                                zod.union([
+                                                                                    zod.string(),
+                                                                                    zod.number(),
+                                                                                    zod.boolean(),
+                                                                                ])
+                                                                            ),
+                                                                            zod.string(),
+                                                                            zod.number(),
+                                                                            zod.boolean(),
+                                                                            zod.null(),
+                                                                        ])
+                                                                        .optional(),
+                                                                }),
+                                                                zod.object({
+                                                                    key: zod.string(),
+                                                                    label: zod
+                                                                        .union([zod.string(), zod.null()])
+                                                                        .optional(),
+                                                                    operator: zod.enum([
+                                                                        'exact',
+                                                                        'is_not',
+                                                                        'icontains',
+                                                                        'not_icontains',
+                                                                        'starts_with',
+                                                                        'not_starts_with',
+                                                                        'ends_with',
+                                                                        'not_ends_with',
+                                                                        'regex',
+                                                                        'not_regex',
+                                                                        'gt',
+                                                                        'gte',
+                                                                        'lt',
+                                                                        'lte',
+                                                                        'is_set',
+                                                                        'is_not_set',
+                                                                        'is_date_exact',
+                                                                        'is_date_before',
+                                                                        'is_date_after',
+                                                                        'between',
+                                                                        'not_between',
+                                                                        'min',
+                                                                        'max',
+                                                                        'in',
+                                                                        'not_in',
+                                                                        'is_cleaned_path_exact',
+                                                                        'flag_evaluates_to',
+                                                                        'semver_eq',
+                                                                        'semver_neq',
+                                                                        'semver_gt',
+                                                                        'semver_gte',
+                                                                        'semver_lt',
+                                                                        'semver_lte',
+                                                                        'semver_tilde',
+                                                                        'semver_caret',
+                                                                        'semver_wildcard',
+                                                                        'icontains_multi',
+                                                                        'not_icontains_multi',
+                                                                    ]),
+                                                                    type: zod
+                                                                        .literal('person')
+                                                                        .default(
+                                                                            experimentsCreateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwofourEventFiltersOneItemTwoTypeDefault
+                                                                        )
+                                                                        .describe('Person properties'),
+                                                                    value: zod
+                                                                        .union([
+                                                                            zod.array(
+                                                                                zod.union([
+                                                                                    zod.string(),
+                                                                                    zod.number(),
+                                                                                    zod.boolean(),
+                                                                                ])
+                                                                            ),
+                                                                            zod.string(),
+                                                                            zod.number(),
+                                                                            zod.boolean(),
+                                                                            zod.null(),
+                                                                        ])
+                                                                        .optional(),
+                                                                }),
+                                                                zod.object({
+                                                                    key: zod.enum([
+                                                                        'tag_name',
+                                                                        'text',
+                                                                        'href',
+                                                                        'selector',
+                                                                    ]),
+                                                                    label: zod
+                                                                        .union([zod.string(), zod.null()])
+                                                                        .optional(),
+                                                                    operator: zod.enum([
+                                                                        'exact',
+                                                                        'is_not',
+                                                                        'icontains',
+                                                                        'not_icontains',
+                                                                        'starts_with',
+                                                                        'not_starts_with',
+                                                                        'ends_with',
+                                                                        'not_ends_with',
+                                                                        'regex',
+                                                                        'not_regex',
+                                                                        'gt',
+                                                                        'gte',
+                                                                        'lt',
+                                                                        'lte',
+                                                                        'is_set',
+                                                                        'is_not_set',
+                                                                        'is_date_exact',
+                                                                        'is_date_before',
+                                                                        'is_date_after',
+                                                                        'between',
+                                                                        'not_between',
+                                                                        'min',
+                                                                        'max',
+                                                                        'in',
+                                                                        'not_in',
+                                                                        'is_cleaned_path_exact',
+                                                                        'flag_evaluates_to',
+                                                                        'semver_eq',
+                                                                        'semver_neq',
+                                                                        'semver_gt',
+                                                                        'semver_gte',
+                                                                        'semver_lt',
+                                                                        'semver_lte',
+                                                                        'semver_tilde',
+                                                                        'semver_caret',
+                                                                        'semver_wildcard',
+                                                                        'icontains_multi',
+                                                                        'not_icontains_multi',
+                                                                    ]),
+                                                                    type: zod
+                                                                        .literal('element')
+                                                                        .default(
+                                                                            experimentsCreateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwofourEventFiltersOneItemThreeTypeDefault
+                                                                        ),
+                                                                    value: zod
+                                                                        .union([
+                                                                            zod.array(
+                                                                                zod.union([
+                                                                                    zod.string(),
+                                                                                    zod.number(),
+                                                                                    zod.boolean(),
+                                                                                ])
+                                                                            ),
+                                                                            zod.string(),
+                                                                            zod.number(),
+                                                                            zod.boolean(),
+                                                                            zod.null(),
+                                                                        ])
+                                                                        .optional(),
+                                                                }),
+                                                                zod.object({
+                                                                    key: zod.string(),
+                                                                    label: zod
+                                                                        .union([zod.string(), zod.null()])
+                                                                        .optional(),
+                                                                    operator: zod.enum([
+                                                                        'exact',
+                                                                        'is_not',
+                                                                        'icontains',
+                                                                        'not_icontains',
+                                                                        'starts_with',
+                                                                        'not_starts_with',
+                                                                        'ends_with',
+                                                                        'not_ends_with',
+                                                                        'regex',
+                                                                        'not_regex',
+                                                                        'gt',
+                                                                        'gte',
+                                                                        'lt',
+                                                                        'lte',
+                                                                        'is_set',
+                                                                        'is_not_set',
+                                                                        'is_date_exact',
+                                                                        'is_date_before',
+                                                                        'is_date_after',
+                                                                        'between',
+                                                                        'not_between',
+                                                                        'min',
+                                                                        'max',
+                                                                        'in',
+                                                                        'not_in',
+                                                                        'is_cleaned_path_exact',
+                                                                        'flag_evaluates_to',
+                                                                        'semver_eq',
+                                                                        'semver_neq',
+                                                                        'semver_gt',
+                                                                        'semver_gte',
+                                                                        'semver_lt',
+                                                                        'semver_lte',
+                                                                        'semver_tilde',
+                                                                        'semver_caret',
+                                                                        'semver_wildcard',
+                                                                        'icontains_multi',
+                                                                        'not_icontains_multi',
+                                                                    ]),
+                                                                    type: zod
+                                                                        .literal('feature')
+                                                                        .default(
+                                                                            experimentsCreateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwofourEventFiltersOneItemFourTypeDefault
+                                                                        )
+                                                                        .describe(
+                                                                            'Event property with \"$feature\/\" prepended'
+                                                                        ),
+                                                                    value: zod
+                                                                        .union([
+                                                                            zod.array(
+                                                                                zod.union([
+                                                                                    zod.string(),
+                                                                                    zod.number(),
+                                                                                    zod.boolean(),
+                                                                                ])
+                                                                            ),
+                                                                            zod.string(),
+                                                                            zod.number(),
+                                                                            zod.boolean(),
+                                                                            zod.null(),
+                                                                        ])
+                                                                        .optional(),
+                                                                }),
+                                                                zod.object({
+                                                                    key: zod.string(),
+                                                                    label: zod
+                                                                        .union([zod.string(), zod.null()])
+                                                                        .optional(),
+                                                                    type: zod
+                                                                        .literal('hogql')
+                                                                        .default(
+                                                                            experimentsCreateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwofourEventFiltersOneItemFiveTypeDefault
+                                                                        ),
+                                                                    value: zod
+                                                                        .union([
+                                                                            zod.array(
+                                                                                zod.union([
+                                                                                    zod.string(),
+                                                                                    zod.number(),
+                                                                                    zod.boolean(),
+                                                                                ])
+                                                                            ),
+                                                                            zod.string(),
+                                                                            zod.number(),
+                                                                            zod.boolean(),
+                                                                            zod.null(),
+                                                                        ])
+                                                                        .optional(),
+                                                                }),
+                                                            ])
+                                                        ),
+                                                        zod.null(),
+                                                    ])
+                                                    .optional()
+                                                    .describe(
+                                                        'Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral\/cohort filters and groups'
+                                                    ),
+                                                event_type: zod.enum(['events', 'actions']),
+                                                explicit_datetime: zod
+                                                    .union([zod.string(), zod.null()])
+                                                    .optional()
+                                                    .describe(
+                                                        'Absolute or relative (e.g. -30d) lower date bound — alternative to time_value\/time_interval'
+                                                    ),
+                                                explicit_datetime_to: zod.union([zod.string(), zod.null()]).optional(),
+                                                key: zod
+                                                    .string()
+                                                    .describe("Event name, or action id when event_type is 'actions'"),
+                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                negation: zod
+                                                    .union([zod.boolean(), zod.null()])
+                                                    .optional()
+                                                    .describe(
+                                                        'Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators'
+                                                    ),
+                                                operator: zod
+                                                    .union([
+                                                        zod.enum([
+                                                            'exact',
+                                                            'is_not',
+                                                            'icontains',
+                                                            'not_icontains',
+                                                            'starts_with',
+                                                            'not_starts_with',
+                                                            'ends_with',
+                                                            'not_ends_with',
+                                                            'regex',
+                                                            'not_regex',
+                                                            'gt',
+                                                            'gte',
+                                                            'lt',
+                                                            'lte',
+                                                            'is_set',
+                                                            'is_not_set',
+                                                            'is_date_exact',
+                                                            'is_date_before',
+                                                            'is_date_after',
+                                                            'between',
+                                                            'not_between',
+                                                            'min',
+                                                            'max',
+                                                            'in',
+                                                            'not_in',
+                                                            'is_cleaned_path_exact',
+                                                            'flag_evaluates_to',
+                                                            'semver_eq',
+                                                            'semver_neq',
+                                                            'semver_gt',
+                                                            'semver_gte',
+                                                            'semver_lt',
+                                                            'semver_lte',
+                                                            'semver_tilde',
+                                                            'semver_caret',
+                                                            'semver_wildcard',
+                                                            'icontains_multi',
+                                                            'not_icontains_multi',
+                                                        ]),
+                                                        zod.null(),
+                                                    ])
+                                                    .optional()
+                                                    .describe(
+                                                        'Count comparison for performed_event_multiple, defaults to exact'
+                                                    ),
+                                                operator_value: zod
+                                                    .union([zod.number(), zod.null()])
+                                                    .optional()
+                                                    .describe('Count threshold for performed_event_multiple'),
+                                                time_interval: zod
+                                                    .union([zod.enum(['day', 'week', 'month', 'year']), zod.null()])
+                                                    .optional(),
+                                                time_value: zod
+                                                    .union([zod.number(), zod.null()])
+                                                    .optional()
+                                                    .describe('Relative time window size, paired with time_interval'),
+                                                type: zod
+                                                    .literal('behavioral')
+                                                    .default(
+                                                        experimentsCreateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwofourTypeDefault
+                                                    )
+                                                    .describe(
+                                                        "Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP"
+                                                    ),
+                                                value: zod.enum(['performed_event', 'performed_event_multiple']),
+                                            }),
                                         ])
                                     )
                                     .describe(
@@ -3690,6 +4111,413 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                         zod.null(),
                                                     ])
                                                     .optional(),
+                                            }),
+                                            zod.object({
+                                                event_filters: zod
+                                                    .union([
+                                                        zod.array(
+                                                            zod.union([
+                                                                zod.object({
+                                                                    key: zod.string(),
+                                                                    label: zod
+                                                                        .union([zod.string(), zod.null()])
+                                                                        .optional(),
+                                                                    operator: zod
+                                                                        .union([
+                                                                            zod.enum([
+                                                                                'exact',
+                                                                                'is_not',
+                                                                                'icontains',
+                                                                                'not_icontains',
+                                                                                'starts_with',
+                                                                                'not_starts_with',
+                                                                                'ends_with',
+                                                                                'not_ends_with',
+                                                                                'regex',
+                                                                                'not_regex',
+                                                                                'gt',
+                                                                                'gte',
+                                                                                'lt',
+                                                                                'lte',
+                                                                                'is_set',
+                                                                                'is_not_set',
+                                                                                'is_date_exact',
+                                                                                'is_date_before',
+                                                                                'is_date_after',
+                                                                                'between',
+                                                                                'not_between',
+                                                                                'min',
+                                                                                'max',
+                                                                                'in',
+                                                                                'not_in',
+                                                                                'is_cleaned_path_exact',
+                                                                                'flag_evaluates_to',
+                                                                                'semver_eq',
+                                                                                'semver_neq',
+                                                                                'semver_gt',
+                                                                                'semver_gte',
+                                                                                'semver_lt',
+                                                                                'semver_lte',
+                                                                                'semver_tilde',
+                                                                                'semver_caret',
+                                                                                'semver_wildcard',
+                                                                                'icontains_multi',
+                                                                                'not_icontains_multi',
+                                                                            ]),
+                                                                            zod.null(),
+                                                                        ])
+                                                                        .default(
+                                                                            experimentsCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwofourEventFiltersOneItemOneOperatorDefault
+                                                                        ),
+                                                                    type: zod
+                                                                        .literal('event')
+                                                                        .default(
+                                                                            experimentsCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwofourEventFiltersOneItemOneTypeDefault
+                                                                        )
+                                                                        .describe('Event properties'),
+                                                                    value: zod
+                                                                        .union([
+                                                                            zod.array(
+                                                                                zod.union([
+                                                                                    zod.string(),
+                                                                                    zod.number(),
+                                                                                    zod.boolean(),
+                                                                                ])
+                                                                            ),
+                                                                            zod.string(),
+                                                                            zod.number(),
+                                                                            zod.boolean(),
+                                                                            zod.null(),
+                                                                        ])
+                                                                        .optional(),
+                                                                }),
+                                                                zod.object({
+                                                                    key: zod.string(),
+                                                                    label: zod
+                                                                        .union([zod.string(), zod.null()])
+                                                                        .optional(),
+                                                                    operator: zod.enum([
+                                                                        'exact',
+                                                                        'is_not',
+                                                                        'icontains',
+                                                                        'not_icontains',
+                                                                        'starts_with',
+                                                                        'not_starts_with',
+                                                                        'ends_with',
+                                                                        'not_ends_with',
+                                                                        'regex',
+                                                                        'not_regex',
+                                                                        'gt',
+                                                                        'gte',
+                                                                        'lt',
+                                                                        'lte',
+                                                                        'is_set',
+                                                                        'is_not_set',
+                                                                        'is_date_exact',
+                                                                        'is_date_before',
+                                                                        'is_date_after',
+                                                                        'between',
+                                                                        'not_between',
+                                                                        'min',
+                                                                        'max',
+                                                                        'in',
+                                                                        'not_in',
+                                                                        'is_cleaned_path_exact',
+                                                                        'flag_evaluates_to',
+                                                                        'semver_eq',
+                                                                        'semver_neq',
+                                                                        'semver_gt',
+                                                                        'semver_gte',
+                                                                        'semver_lt',
+                                                                        'semver_lte',
+                                                                        'semver_tilde',
+                                                                        'semver_caret',
+                                                                        'semver_wildcard',
+                                                                        'icontains_multi',
+                                                                        'not_icontains_multi',
+                                                                    ]),
+                                                                    type: zod
+                                                                        .literal('person')
+                                                                        .default(
+                                                                            experimentsCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwofourEventFiltersOneItemTwoTypeDefault
+                                                                        )
+                                                                        .describe('Person properties'),
+                                                                    value: zod
+                                                                        .union([
+                                                                            zod.array(
+                                                                                zod.union([
+                                                                                    zod.string(),
+                                                                                    zod.number(),
+                                                                                    zod.boolean(),
+                                                                                ])
+                                                                            ),
+                                                                            zod.string(),
+                                                                            zod.number(),
+                                                                            zod.boolean(),
+                                                                            zod.null(),
+                                                                        ])
+                                                                        .optional(),
+                                                                }),
+                                                                zod.object({
+                                                                    key: zod.enum([
+                                                                        'tag_name',
+                                                                        'text',
+                                                                        'href',
+                                                                        'selector',
+                                                                    ]),
+                                                                    label: zod
+                                                                        .union([zod.string(), zod.null()])
+                                                                        .optional(),
+                                                                    operator: zod.enum([
+                                                                        'exact',
+                                                                        'is_not',
+                                                                        'icontains',
+                                                                        'not_icontains',
+                                                                        'starts_with',
+                                                                        'not_starts_with',
+                                                                        'ends_with',
+                                                                        'not_ends_with',
+                                                                        'regex',
+                                                                        'not_regex',
+                                                                        'gt',
+                                                                        'gte',
+                                                                        'lt',
+                                                                        'lte',
+                                                                        'is_set',
+                                                                        'is_not_set',
+                                                                        'is_date_exact',
+                                                                        'is_date_before',
+                                                                        'is_date_after',
+                                                                        'between',
+                                                                        'not_between',
+                                                                        'min',
+                                                                        'max',
+                                                                        'in',
+                                                                        'not_in',
+                                                                        'is_cleaned_path_exact',
+                                                                        'flag_evaluates_to',
+                                                                        'semver_eq',
+                                                                        'semver_neq',
+                                                                        'semver_gt',
+                                                                        'semver_gte',
+                                                                        'semver_lt',
+                                                                        'semver_lte',
+                                                                        'semver_tilde',
+                                                                        'semver_caret',
+                                                                        'semver_wildcard',
+                                                                        'icontains_multi',
+                                                                        'not_icontains_multi',
+                                                                    ]),
+                                                                    type: zod
+                                                                        .literal('element')
+                                                                        .default(
+                                                                            experimentsCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwofourEventFiltersOneItemThreeTypeDefault
+                                                                        ),
+                                                                    value: zod
+                                                                        .union([
+                                                                            zod.array(
+                                                                                zod.union([
+                                                                                    zod.string(),
+                                                                                    zod.number(),
+                                                                                    zod.boolean(),
+                                                                                ])
+                                                                            ),
+                                                                            zod.string(),
+                                                                            zod.number(),
+                                                                            zod.boolean(),
+                                                                            zod.null(),
+                                                                        ])
+                                                                        .optional(),
+                                                                }),
+                                                                zod.object({
+                                                                    key: zod.string(),
+                                                                    label: zod
+                                                                        .union([zod.string(), zod.null()])
+                                                                        .optional(),
+                                                                    operator: zod.enum([
+                                                                        'exact',
+                                                                        'is_not',
+                                                                        'icontains',
+                                                                        'not_icontains',
+                                                                        'starts_with',
+                                                                        'not_starts_with',
+                                                                        'ends_with',
+                                                                        'not_ends_with',
+                                                                        'regex',
+                                                                        'not_regex',
+                                                                        'gt',
+                                                                        'gte',
+                                                                        'lt',
+                                                                        'lte',
+                                                                        'is_set',
+                                                                        'is_not_set',
+                                                                        'is_date_exact',
+                                                                        'is_date_before',
+                                                                        'is_date_after',
+                                                                        'between',
+                                                                        'not_between',
+                                                                        'min',
+                                                                        'max',
+                                                                        'in',
+                                                                        'not_in',
+                                                                        'is_cleaned_path_exact',
+                                                                        'flag_evaluates_to',
+                                                                        'semver_eq',
+                                                                        'semver_neq',
+                                                                        'semver_gt',
+                                                                        'semver_gte',
+                                                                        'semver_lt',
+                                                                        'semver_lte',
+                                                                        'semver_tilde',
+                                                                        'semver_caret',
+                                                                        'semver_wildcard',
+                                                                        'icontains_multi',
+                                                                        'not_icontains_multi',
+                                                                    ]),
+                                                                    type: zod
+                                                                        .literal('feature')
+                                                                        .default(
+                                                                            experimentsCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwofourEventFiltersOneItemFourTypeDefault
+                                                                        )
+                                                                        .describe(
+                                                                            'Event property with \"$feature\/\" prepended'
+                                                                        ),
+                                                                    value: zod
+                                                                        .union([
+                                                                            zod.array(
+                                                                                zod.union([
+                                                                                    zod.string(),
+                                                                                    zod.number(),
+                                                                                    zod.boolean(),
+                                                                                ])
+                                                                            ),
+                                                                            zod.string(),
+                                                                            zod.number(),
+                                                                            zod.boolean(),
+                                                                            zod.null(),
+                                                                        ])
+                                                                        .optional(),
+                                                                }),
+                                                                zod.object({
+                                                                    key: zod.string(),
+                                                                    label: zod
+                                                                        .union([zod.string(), zod.null()])
+                                                                        .optional(),
+                                                                    type: zod
+                                                                        .literal('hogql')
+                                                                        .default(
+                                                                            experimentsCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwofourEventFiltersOneItemFiveTypeDefault
+                                                                        ),
+                                                                    value: zod
+                                                                        .union([
+                                                                            zod.array(
+                                                                                zod.union([
+                                                                                    zod.string(),
+                                                                                    zod.number(),
+                                                                                    zod.boolean(),
+                                                                                ])
+                                                                            ),
+                                                                            zod.string(),
+                                                                            zod.number(),
+                                                                            zod.boolean(),
+                                                                            zod.null(),
+                                                                        ])
+                                                                        .optional(),
+                                                                }),
+                                                            ])
+                                                        ),
+                                                        zod.null(),
+                                                    ])
+                                                    .optional()
+                                                    .describe(
+                                                        'Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral\/cohort filters and groups'
+                                                    ),
+                                                event_type: zod.enum(['events', 'actions']),
+                                                explicit_datetime: zod
+                                                    .union([zod.string(), zod.null()])
+                                                    .optional()
+                                                    .describe(
+                                                        'Absolute or relative (e.g. -30d) lower date bound — alternative to time_value\/time_interval'
+                                                    ),
+                                                explicit_datetime_to: zod.union([zod.string(), zod.null()]).optional(),
+                                                key: zod
+                                                    .string()
+                                                    .describe("Event name, or action id when event_type is 'actions'"),
+                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                negation: zod
+                                                    .union([zod.boolean(), zod.null()])
+                                                    .optional()
+                                                    .describe(
+                                                        'Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators'
+                                                    ),
+                                                operator: zod
+                                                    .union([
+                                                        zod.enum([
+                                                            'exact',
+                                                            'is_not',
+                                                            'icontains',
+                                                            'not_icontains',
+                                                            'starts_with',
+                                                            'not_starts_with',
+                                                            'ends_with',
+                                                            'not_ends_with',
+                                                            'regex',
+                                                            'not_regex',
+                                                            'gt',
+                                                            'gte',
+                                                            'lt',
+                                                            'lte',
+                                                            'is_set',
+                                                            'is_not_set',
+                                                            'is_date_exact',
+                                                            'is_date_before',
+                                                            'is_date_after',
+                                                            'between',
+                                                            'not_between',
+                                                            'min',
+                                                            'max',
+                                                            'in',
+                                                            'not_in',
+                                                            'is_cleaned_path_exact',
+                                                            'flag_evaluates_to',
+                                                            'semver_eq',
+                                                            'semver_neq',
+                                                            'semver_gt',
+                                                            'semver_gte',
+                                                            'semver_lt',
+                                                            'semver_lte',
+                                                            'semver_tilde',
+                                                            'semver_caret',
+                                                            'semver_wildcard',
+                                                            'icontains_multi',
+                                                            'not_icontains_multi',
+                                                        ]),
+                                                        zod.null(),
+                                                    ])
+                                                    .optional()
+                                                    .describe(
+                                                        'Count comparison for performed_event_multiple, defaults to exact'
+                                                    ),
+                                                operator_value: zod
+                                                    .union([zod.number(), zod.null()])
+                                                    .optional()
+                                                    .describe('Count threshold for performed_event_multiple'),
+                                                time_interval: zod
+                                                    .union([zod.enum(['day', 'week', 'month', 'year']), zod.null()])
+                                                    .optional(),
+                                                time_value: zod
+                                                    .union([zod.number(), zod.null()])
+                                                    .optional()
+                                                    .describe('Relative time window size, paired with time_interval'),
+                                                type: zod
+                                                    .literal('behavioral')
+                                                    .default(
+                                                        experimentsCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwofourTypeDefault
+                                                    )
+                                                    .describe(
+                                                        "Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP"
+                                                    ),
+                                                value: zod.enum(['performed_event', 'performed_event_multiple']),
                                             }),
                                         ])
                                     )
@@ -5873,6 +6701,13 @@ export const experimentsPartialUpdateBodyExposureCriteriaOneActivationConfigOneP
 export const experimentsPartialUpdateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwooneTypeDefault = `revenue_analytics`
 export const experimentsPartialUpdateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwotwoTypeDefault = `account_custom_property`
 export const experimentsPartialUpdateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwothreeTypeDefault = `workflow_variable`
+export const experimentsPartialUpdateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwofourEventFiltersOneItemOneOperatorDefault = `exact`
+export const experimentsPartialUpdateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwofourEventFiltersOneItemOneTypeDefault = `event`
+export const experimentsPartialUpdateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwofourEventFiltersOneItemTwoTypeDefault = `person`
+export const experimentsPartialUpdateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwofourEventFiltersOneItemThreeTypeDefault = `element`
+export const experimentsPartialUpdateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwofourEventFiltersOneItemFourTypeDefault = `feature`
+export const experimentsPartialUpdateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwofourEventFiltersOneItemFiveTypeDefault = `hogql`
+export const experimentsPartialUpdateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwofourTypeDefault = `behavioral`
 export const experimentsPartialUpdateBodyExposureCriteriaOneExposureConfigOnePropertiesItemOneOperatorDefault = `exact`
 export const experimentsPartialUpdateBodyExposureCriteriaOneExposureConfigOnePropertiesItemOneTypeDefault = `event`
 export const experimentsPartialUpdateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwoTypeDefault = `person`
@@ -5898,6 +6733,13 @@ export const experimentsPartialUpdateBodyExposureCriteriaOneExposureConfigOnePro
 export const experimentsPartialUpdateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwooneTypeDefault = `revenue_analytics`
 export const experimentsPartialUpdateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwotwoTypeDefault = `account_custom_property`
 export const experimentsPartialUpdateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwothreeTypeDefault = `workflow_variable`
+export const experimentsPartialUpdateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwofourEventFiltersOneItemOneOperatorDefault = `exact`
+export const experimentsPartialUpdateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwofourEventFiltersOneItemOneTypeDefault = `event`
+export const experimentsPartialUpdateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwofourEventFiltersOneItemTwoTypeDefault = `person`
+export const experimentsPartialUpdateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwofourEventFiltersOneItemThreeTypeDefault = `element`
+export const experimentsPartialUpdateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwofourEventFiltersOneItemFourTypeDefault = `feature`
+export const experimentsPartialUpdateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwofourEventFiltersOneItemFiveTypeDefault = `hogql`
+export const experimentsPartialUpdateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwofourTypeDefault = `behavioral`
 export const experimentsPartialUpdateBodyMetricsOneItemCompletionEventOnePropertiesOneItemOperatorDefault = `exact`
 export const experimentsPartialUpdateBodyMetricsOneItemCompletionEventOnePropertiesOneItemTypeDefault = `event`
 export const experimentsPartialUpdateBodyMetricsOneItemDenominatorOnePropertiesOneItemOperatorDefault = `exact`
@@ -7478,6 +8320,413 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                     ])
                                                     .optional(),
                                             }),
+                                            zod.object({
+                                                event_filters: zod
+                                                    .union([
+                                                        zod.array(
+                                                            zod.union([
+                                                                zod.object({
+                                                                    key: zod.string(),
+                                                                    label: zod
+                                                                        .union([zod.string(), zod.null()])
+                                                                        .optional(),
+                                                                    operator: zod
+                                                                        .union([
+                                                                            zod.enum([
+                                                                                'exact',
+                                                                                'is_not',
+                                                                                'icontains',
+                                                                                'not_icontains',
+                                                                                'starts_with',
+                                                                                'not_starts_with',
+                                                                                'ends_with',
+                                                                                'not_ends_with',
+                                                                                'regex',
+                                                                                'not_regex',
+                                                                                'gt',
+                                                                                'gte',
+                                                                                'lt',
+                                                                                'lte',
+                                                                                'is_set',
+                                                                                'is_not_set',
+                                                                                'is_date_exact',
+                                                                                'is_date_before',
+                                                                                'is_date_after',
+                                                                                'between',
+                                                                                'not_between',
+                                                                                'min',
+                                                                                'max',
+                                                                                'in',
+                                                                                'not_in',
+                                                                                'is_cleaned_path_exact',
+                                                                                'flag_evaluates_to',
+                                                                                'semver_eq',
+                                                                                'semver_neq',
+                                                                                'semver_gt',
+                                                                                'semver_gte',
+                                                                                'semver_lt',
+                                                                                'semver_lte',
+                                                                                'semver_tilde',
+                                                                                'semver_caret',
+                                                                                'semver_wildcard',
+                                                                                'icontains_multi',
+                                                                                'not_icontains_multi',
+                                                                            ]),
+                                                                            zod.null(),
+                                                                        ])
+                                                                        .default(
+                                                                            experimentsPartialUpdateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwofourEventFiltersOneItemOneOperatorDefault
+                                                                        ),
+                                                                    type: zod
+                                                                        .literal('event')
+                                                                        .default(
+                                                                            experimentsPartialUpdateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwofourEventFiltersOneItemOneTypeDefault
+                                                                        )
+                                                                        .describe('Event properties'),
+                                                                    value: zod
+                                                                        .union([
+                                                                            zod.array(
+                                                                                zod.union([
+                                                                                    zod.string(),
+                                                                                    zod.number(),
+                                                                                    zod.boolean(),
+                                                                                ])
+                                                                            ),
+                                                                            zod.string(),
+                                                                            zod.number(),
+                                                                            zod.boolean(),
+                                                                            zod.null(),
+                                                                        ])
+                                                                        .optional(),
+                                                                }),
+                                                                zod.object({
+                                                                    key: zod.string(),
+                                                                    label: zod
+                                                                        .union([zod.string(), zod.null()])
+                                                                        .optional(),
+                                                                    operator: zod.enum([
+                                                                        'exact',
+                                                                        'is_not',
+                                                                        'icontains',
+                                                                        'not_icontains',
+                                                                        'starts_with',
+                                                                        'not_starts_with',
+                                                                        'ends_with',
+                                                                        'not_ends_with',
+                                                                        'regex',
+                                                                        'not_regex',
+                                                                        'gt',
+                                                                        'gte',
+                                                                        'lt',
+                                                                        'lte',
+                                                                        'is_set',
+                                                                        'is_not_set',
+                                                                        'is_date_exact',
+                                                                        'is_date_before',
+                                                                        'is_date_after',
+                                                                        'between',
+                                                                        'not_between',
+                                                                        'min',
+                                                                        'max',
+                                                                        'in',
+                                                                        'not_in',
+                                                                        'is_cleaned_path_exact',
+                                                                        'flag_evaluates_to',
+                                                                        'semver_eq',
+                                                                        'semver_neq',
+                                                                        'semver_gt',
+                                                                        'semver_gte',
+                                                                        'semver_lt',
+                                                                        'semver_lte',
+                                                                        'semver_tilde',
+                                                                        'semver_caret',
+                                                                        'semver_wildcard',
+                                                                        'icontains_multi',
+                                                                        'not_icontains_multi',
+                                                                    ]),
+                                                                    type: zod
+                                                                        .literal('person')
+                                                                        .default(
+                                                                            experimentsPartialUpdateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwofourEventFiltersOneItemTwoTypeDefault
+                                                                        )
+                                                                        .describe('Person properties'),
+                                                                    value: zod
+                                                                        .union([
+                                                                            zod.array(
+                                                                                zod.union([
+                                                                                    zod.string(),
+                                                                                    zod.number(),
+                                                                                    zod.boolean(),
+                                                                                ])
+                                                                            ),
+                                                                            zod.string(),
+                                                                            zod.number(),
+                                                                            zod.boolean(),
+                                                                            zod.null(),
+                                                                        ])
+                                                                        .optional(),
+                                                                }),
+                                                                zod.object({
+                                                                    key: zod.enum([
+                                                                        'tag_name',
+                                                                        'text',
+                                                                        'href',
+                                                                        'selector',
+                                                                    ]),
+                                                                    label: zod
+                                                                        .union([zod.string(), zod.null()])
+                                                                        .optional(),
+                                                                    operator: zod.enum([
+                                                                        'exact',
+                                                                        'is_not',
+                                                                        'icontains',
+                                                                        'not_icontains',
+                                                                        'starts_with',
+                                                                        'not_starts_with',
+                                                                        'ends_with',
+                                                                        'not_ends_with',
+                                                                        'regex',
+                                                                        'not_regex',
+                                                                        'gt',
+                                                                        'gte',
+                                                                        'lt',
+                                                                        'lte',
+                                                                        'is_set',
+                                                                        'is_not_set',
+                                                                        'is_date_exact',
+                                                                        'is_date_before',
+                                                                        'is_date_after',
+                                                                        'between',
+                                                                        'not_between',
+                                                                        'min',
+                                                                        'max',
+                                                                        'in',
+                                                                        'not_in',
+                                                                        'is_cleaned_path_exact',
+                                                                        'flag_evaluates_to',
+                                                                        'semver_eq',
+                                                                        'semver_neq',
+                                                                        'semver_gt',
+                                                                        'semver_gte',
+                                                                        'semver_lt',
+                                                                        'semver_lte',
+                                                                        'semver_tilde',
+                                                                        'semver_caret',
+                                                                        'semver_wildcard',
+                                                                        'icontains_multi',
+                                                                        'not_icontains_multi',
+                                                                    ]),
+                                                                    type: zod
+                                                                        .literal('element')
+                                                                        .default(
+                                                                            experimentsPartialUpdateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwofourEventFiltersOneItemThreeTypeDefault
+                                                                        ),
+                                                                    value: zod
+                                                                        .union([
+                                                                            zod.array(
+                                                                                zod.union([
+                                                                                    zod.string(),
+                                                                                    zod.number(),
+                                                                                    zod.boolean(),
+                                                                                ])
+                                                                            ),
+                                                                            zod.string(),
+                                                                            zod.number(),
+                                                                            zod.boolean(),
+                                                                            zod.null(),
+                                                                        ])
+                                                                        .optional(),
+                                                                }),
+                                                                zod.object({
+                                                                    key: zod.string(),
+                                                                    label: zod
+                                                                        .union([zod.string(), zod.null()])
+                                                                        .optional(),
+                                                                    operator: zod.enum([
+                                                                        'exact',
+                                                                        'is_not',
+                                                                        'icontains',
+                                                                        'not_icontains',
+                                                                        'starts_with',
+                                                                        'not_starts_with',
+                                                                        'ends_with',
+                                                                        'not_ends_with',
+                                                                        'regex',
+                                                                        'not_regex',
+                                                                        'gt',
+                                                                        'gte',
+                                                                        'lt',
+                                                                        'lte',
+                                                                        'is_set',
+                                                                        'is_not_set',
+                                                                        'is_date_exact',
+                                                                        'is_date_before',
+                                                                        'is_date_after',
+                                                                        'between',
+                                                                        'not_between',
+                                                                        'min',
+                                                                        'max',
+                                                                        'in',
+                                                                        'not_in',
+                                                                        'is_cleaned_path_exact',
+                                                                        'flag_evaluates_to',
+                                                                        'semver_eq',
+                                                                        'semver_neq',
+                                                                        'semver_gt',
+                                                                        'semver_gte',
+                                                                        'semver_lt',
+                                                                        'semver_lte',
+                                                                        'semver_tilde',
+                                                                        'semver_caret',
+                                                                        'semver_wildcard',
+                                                                        'icontains_multi',
+                                                                        'not_icontains_multi',
+                                                                    ]),
+                                                                    type: zod
+                                                                        .literal('feature')
+                                                                        .default(
+                                                                            experimentsPartialUpdateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwofourEventFiltersOneItemFourTypeDefault
+                                                                        )
+                                                                        .describe(
+                                                                            'Event property with \"$feature\/\" prepended'
+                                                                        ),
+                                                                    value: zod
+                                                                        .union([
+                                                                            zod.array(
+                                                                                zod.union([
+                                                                                    zod.string(),
+                                                                                    zod.number(),
+                                                                                    zod.boolean(),
+                                                                                ])
+                                                                            ),
+                                                                            zod.string(),
+                                                                            zod.number(),
+                                                                            zod.boolean(),
+                                                                            zod.null(),
+                                                                        ])
+                                                                        .optional(),
+                                                                }),
+                                                                zod.object({
+                                                                    key: zod.string(),
+                                                                    label: zod
+                                                                        .union([zod.string(), zod.null()])
+                                                                        .optional(),
+                                                                    type: zod
+                                                                        .literal('hogql')
+                                                                        .default(
+                                                                            experimentsPartialUpdateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwofourEventFiltersOneItemFiveTypeDefault
+                                                                        ),
+                                                                    value: zod
+                                                                        .union([
+                                                                            zod.array(
+                                                                                zod.union([
+                                                                                    zod.string(),
+                                                                                    zod.number(),
+                                                                                    zod.boolean(),
+                                                                                ])
+                                                                            ),
+                                                                            zod.string(),
+                                                                            zod.number(),
+                                                                            zod.boolean(),
+                                                                            zod.null(),
+                                                                        ])
+                                                                        .optional(),
+                                                                }),
+                                                            ])
+                                                        ),
+                                                        zod.null(),
+                                                    ])
+                                                    .optional()
+                                                    .describe(
+                                                        'Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral\/cohort filters and groups'
+                                                    ),
+                                                event_type: zod.enum(['events', 'actions']),
+                                                explicit_datetime: zod
+                                                    .union([zod.string(), zod.null()])
+                                                    .optional()
+                                                    .describe(
+                                                        'Absolute or relative (e.g. -30d) lower date bound — alternative to time_value\/time_interval'
+                                                    ),
+                                                explicit_datetime_to: zod.union([zod.string(), zod.null()]).optional(),
+                                                key: zod
+                                                    .string()
+                                                    .describe("Event name, or action id when event_type is 'actions'"),
+                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                negation: zod
+                                                    .union([zod.boolean(), zod.null()])
+                                                    .optional()
+                                                    .describe(
+                                                        'Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators'
+                                                    ),
+                                                operator: zod
+                                                    .union([
+                                                        zod.enum([
+                                                            'exact',
+                                                            'is_not',
+                                                            'icontains',
+                                                            'not_icontains',
+                                                            'starts_with',
+                                                            'not_starts_with',
+                                                            'ends_with',
+                                                            'not_ends_with',
+                                                            'regex',
+                                                            'not_regex',
+                                                            'gt',
+                                                            'gte',
+                                                            'lt',
+                                                            'lte',
+                                                            'is_set',
+                                                            'is_not_set',
+                                                            'is_date_exact',
+                                                            'is_date_before',
+                                                            'is_date_after',
+                                                            'between',
+                                                            'not_between',
+                                                            'min',
+                                                            'max',
+                                                            'in',
+                                                            'not_in',
+                                                            'is_cleaned_path_exact',
+                                                            'flag_evaluates_to',
+                                                            'semver_eq',
+                                                            'semver_neq',
+                                                            'semver_gt',
+                                                            'semver_gte',
+                                                            'semver_lt',
+                                                            'semver_lte',
+                                                            'semver_tilde',
+                                                            'semver_caret',
+                                                            'semver_wildcard',
+                                                            'icontains_multi',
+                                                            'not_icontains_multi',
+                                                        ]),
+                                                        zod.null(),
+                                                    ])
+                                                    .optional()
+                                                    .describe(
+                                                        'Count comparison for performed_event_multiple, defaults to exact'
+                                                    ),
+                                                operator_value: zod
+                                                    .union([zod.number(), zod.null()])
+                                                    .optional()
+                                                    .describe('Count threshold for performed_event_multiple'),
+                                                time_interval: zod
+                                                    .union([zod.enum(['day', 'week', 'month', 'year']), zod.null()])
+                                                    .optional(),
+                                                time_value: zod
+                                                    .union([zod.number(), zod.null()])
+                                                    .optional()
+                                                    .describe('Relative time window size, paired with time_interval'),
+                                                type: zod
+                                                    .literal('behavioral')
+                                                    .default(
+                                                        experimentsPartialUpdateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwofourTypeDefault
+                                                    )
+                                                    .describe(
+                                                        "Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP"
+                                                    ),
+                                                value: zod.enum(['performed_event', 'performed_event_multiple']),
+                                            }),
                                         ])
                                     )
                                     .describe(
@@ -8776,6 +10025,413 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                         zod.null(),
                                                     ])
                                                     .optional(),
+                                            }),
+                                            zod.object({
+                                                event_filters: zod
+                                                    .union([
+                                                        zod.array(
+                                                            zod.union([
+                                                                zod.object({
+                                                                    key: zod.string(),
+                                                                    label: zod
+                                                                        .union([zod.string(), zod.null()])
+                                                                        .optional(),
+                                                                    operator: zod
+                                                                        .union([
+                                                                            zod.enum([
+                                                                                'exact',
+                                                                                'is_not',
+                                                                                'icontains',
+                                                                                'not_icontains',
+                                                                                'starts_with',
+                                                                                'not_starts_with',
+                                                                                'ends_with',
+                                                                                'not_ends_with',
+                                                                                'regex',
+                                                                                'not_regex',
+                                                                                'gt',
+                                                                                'gte',
+                                                                                'lt',
+                                                                                'lte',
+                                                                                'is_set',
+                                                                                'is_not_set',
+                                                                                'is_date_exact',
+                                                                                'is_date_before',
+                                                                                'is_date_after',
+                                                                                'between',
+                                                                                'not_between',
+                                                                                'min',
+                                                                                'max',
+                                                                                'in',
+                                                                                'not_in',
+                                                                                'is_cleaned_path_exact',
+                                                                                'flag_evaluates_to',
+                                                                                'semver_eq',
+                                                                                'semver_neq',
+                                                                                'semver_gt',
+                                                                                'semver_gte',
+                                                                                'semver_lt',
+                                                                                'semver_lte',
+                                                                                'semver_tilde',
+                                                                                'semver_caret',
+                                                                                'semver_wildcard',
+                                                                                'icontains_multi',
+                                                                                'not_icontains_multi',
+                                                                            ]),
+                                                                            zod.null(),
+                                                                        ])
+                                                                        .default(
+                                                                            experimentsPartialUpdateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwofourEventFiltersOneItemOneOperatorDefault
+                                                                        ),
+                                                                    type: zod
+                                                                        .literal('event')
+                                                                        .default(
+                                                                            experimentsPartialUpdateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwofourEventFiltersOneItemOneTypeDefault
+                                                                        )
+                                                                        .describe('Event properties'),
+                                                                    value: zod
+                                                                        .union([
+                                                                            zod.array(
+                                                                                zod.union([
+                                                                                    zod.string(),
+                                                                                    zod.number(),
+                                                                                    zod.boolean(),
+                                                                                ])
+                                                                            ),
+                                                                            zod.string(),
+                                                                            zod.number(),
+                                                                            zod.boolean(),
+                                                                            zod.null(),
+                                                                        ])
+                                                                        .optional(),
+                                                                }),
+                                                                zod.object({
+                                                                    key: zod.string(),
+                                                                    label: zod
+                                                                        .union([zod.string(), zod.null()])
+                                                                        .optional(),
+                                                                    operator: zod.enum([
+                                                                        'exact',
+                                                                        'is_not',
+                                                                        'icontains',
+                                                                        'not_icontains',
+                                                                        'starts_with',
+                                                                        'not_starts_with',
+                                                                        'ends_with',
+                                                                        'not_ends_with',
+                                                                        'regex',
+                                                                        'not_regex',
+                                                                        'gt',
+                                                                        'gte',
+                                                                        'lt',
+                                                                        'lte',
+                                                                        'is_set',
+                                                                        'is_not_set',
+                                                                        'is_date_exact',
+                                                                        'is_date_before',
+                                                                        'is_date_after',
+                                                                        'between',
+                                                                        'not_between',
+                                                                        'min',
+                                                                        'max',
+                                                                        'in',
+                                                                        'not_in',
+                                                                        'is_cleaned_path_exact',
+                                                                        'flag_evaluates_to',
+                                                                        'semver_eq',
+                                                                        'semver_neq',
+                                                                        'semver_gt',
+                                                                        'semver_gte',
+                                                                        'semver_lt',
+                                                                        'semver_lte',
+                                                                        'semver_tilde',
+                                                                        'semver_caret',
+                                                                        'semver_wildcard',
+                                                                        'icontains_multi',
+                                                                        'not_icontains_multi',
+                                                                    ]),
+                                                                    type: zod
+                                                                        .literal('person')
+                                                                        .default(
+                                                                            experimentsPartialUpdateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwofourEventFiltersOneItemTwoTypeDefault
+                                                                        )
+                                                                        .describe('Person properties'),
+                                                                    value: zod
+                                                                        .union([
+                                                                            zod.array(
+                                                                                zod.union([
+                                                                                    zod.string(),
+                                                                                    zod.number(),
+                                                                                    zod.boolean(),
+                                                                                ])
+                                                                            ),
+                                                                            zod.string(),
+                                                                            zod.number(),
+                                                                            zod.boolean(),
+                                                                            zod.null(),
+                                                                        ])
+                                                                        .optional(),
+                                                                }),
+                                                                zod.object({
+                                                                    key: zod.enum([
+                                                                        'tag_name',
+                                                                        'text',
+                                                                        'href',
+                                                                        'selector',
+                                                                    ]),
+                                                                    label: zod
+                                                                        .union([zod.string(), zod.null()])
+                                                                        .optional(),
+                                                                    operator: zod.enum([
+                                                                        'exact',
+                                                                        'is_not',
+                                                                        'icontains',
+                                                                        'not_icontains',
+                                                                        'starts_with',
+                                                                        'not_starts_with',
+                                                                        'ends_with',
+                                                                        'not_ends_with',
+                                                                        'regex',
+                                                                        'not_regex',
+                                                                        'gt',
+                                                                        'gte',
+                                                                        'lt',
+                                                                        'lte',
+                                                                        'is_set',
+                                                                        'is_not_set',
+                                                                        'is_date_exact',
+                                                                        'is_date_before',
+                                                                        'is_date_after',
+                                                                        'between',
+                                                                        'not_between',
+                                                                        'min',
+                                                                        'max',
+                                                                        'in',
+                                                                        'not_in',
+                                                                        'is_cleaned_path_exact',
+                                                                        'flag_evaluates_to',
+                                                                        'semver_eq',
+                                                                        'semver_neq',
+                                                                        'semver_gt',
+                                                                        'semver_gte',
+                                                                        'semver_lt',
+                                                                        'semver_lte',
+                                                                        'semver_tilde',
+                                                                        'semver_caret',
+                                                                        'semver_wildcard',
+                                                                        'icontains_multi',
+                                                                        'not_icontains_multi',
+                                                                    ]),
+                                                                    type: zod
+                                                                        .literal('element')
+                                                                        .default(
+                                                                            experimentsPartialUpdateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwofourEventFiltersOneItemThreeTypeDefault
+                                                                        ),
+                                                                    value: zod
+                                                                        .union([
+                                                                            zod.array(
+                                                                                zod.union([
+                                                                                    zod.string(),
+                                                                                    zod.number(),
+                                                                                    zod.boolean(),
+                                                                                ])
+                                                                            ),
+                                                                            zod.string(),
+                                                                            zod.number(),
+                                                                            zod.boolean(),
+                                                                            zod.null(),
+                                                                        ])
+                                                                        .optional(),
+                                                                }),
+                                                                zod.object({
+                                                                    key: zod.string(),
+                                                                    label: zod
+                                                                        .union([zod.string(), zod.null()])
+                                                                        .optional(),
+                                                                    operator: zod.enum([
+                                                                        'exact',
+                                                                        'is_not',
+                                                                        'icontains',
+                                                                        'not_icontains',
+                                                                        'starts_with',
+                                                                        'not_starts_with',
+                                                                        'ends_with',
+                                                                        'not_ends_with',
+                                                                        'regex',
+                                                                        'not_regex',
+                                                                        'gt',
+                                                                        'gte',
+                                                                        'lt',
+                                                                        'lte',
+                                                                        'is_set',
+                                                                        'is_not_set',
+                                                                        'is_date_exact',
+                                                                        'is_date_before',
+                                                                        'is_date_after',
+                                                                        'between',
+                                                                        'not_between',
+                                                                        'min',
+                                                                        'max',
+                                                                        'in',
+                                                                        'not_in',
+                                                                        'is_cleaned_path_exact',
+                                                                        'flag_evaluates_to',
+                                                                        'semver_eq',
+                                                                        'semver_neq',
+                                                                        'semver_gt',
+                                                                        'semver_gte',
+                                                                        'semver_lt',
+                                                                        'semver_lte',
+                                                                        'semver_tilde',
+                                                                        'semver_caret',
+                                                                        'semver_wildcard',
+                                                                        'icontains_multi',
+                                                                        'not_icontains_multi',
+                                                                    ]),
+                                                                    type: zod
+                                                                        .literal('feature')
+                                                                        .default(
+                                                                            experimentsPartialUpdateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwofourEventFiltersOneItemFourTypeDefault
+                                                                        )
+                                                                        .describe(
+                                                                            'Event property with \"$feature\/\" prepended'
+                                                                        ),
+                                                                    value: zod
+                                                                        .union([
+                                                                            zod.array(
+                                                                                zod.union([
+                                                                                    zod.string(),
+                                                                                    zod.number(),
+                                                                                    zod.boolean(),
+                                                                                ])
+                                                                            ),
+                                                                            zod.string(),
+                                                                            zod.number(),
+                                                                            zod.boolean(),
+                                                                            zod.null(),
+                                                                        ])
+                                                                        .optional(),
+                                                                }),
+                                                                zod.object({
+                                                                    key: zod.string(),
+                                                                    label: zod
+                                                                        .union([zod.string(), zod.null()])
+                                                                        .optional(),
+                                                                    type: zod
+                                                                        .literal('hogql')
+                                                                        .default(
+                                                                            experimentsPartialUpdateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwofourEventFiltersOneItemFiveTypeDefault
+                                                                        ),
+                                                                    value: zod
+                                                                        .union([
+                                                                            zod.array(
+                                                                                zod.union([
+                                                                                    zod.string(),
+                                                                                    zod.number(),
+                                                                                    zod.boolean(),
+                                                                                ])
+                                                                            ),
+                                                                            zod.string(),
+                                                                            zod.number(),
+                                                                            zod.boolean(),
+                                                                            zod.null(),
+                                                                        ])
+                                                                        .optional(),
+                                                                }),
+                                                            ])
+                                                        ),
+                                                        zod.null(),
+                                                    ])
+                                                    .optional()
+                                                    .describe(
+                                                        'Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral\/cohort filters and groups'
+                                                    ),
+                                                event_type: zod.enum(['events', 'actions']),
+                                                explicit_datetime: zod
+                                                    .union([zod.string(), zod.null()])
+                                                    .optional()
+                                                    .describe(
+                                                        'Absolute or relative (e.g. -30d) lower date bound — alternative to time_value\/time_interval'
+                                                    ),
+                                                explicit_datetime_to: zod.union([zod.string(), zod.null()]).optional(),
+                                                key: zod
+                                                    .string()
+                                                    .describe("Event name, or action id when event_type is 'actions'"),
+                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                negation: zod
+                                                    .union([zod.boolean(), zod.null()])
+                                                    .optional()
+                                                    .describe(
+                                                        'Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators'
+                                                    ),
+                                                operator: zod
+                                                    .union([
+                                                        zod.enum([
+                                                            'exact',
+                                                            'is_not',
+                                                            'icontains',
+                                                            'not_icontains',
+                                                            'starts_with',
+                                                            'not_starts_with',
+                                                            'ends_with',
+                                                            'not_ends_with',
+                                                            'regex',
+                                                            'not_regex',
+                                                            'gt',
+                                                            'gte',
+                                                            'lt',
+                                                            'lte',
+                                                            'is_set',
+                                                            'is_not_set',
+                                                            'is_date_exact',
+                                                            'is_date_before',
+                                                            'is_date_after',
+                                                            'between',
+                                                            'not_between',
+                                                            'min',
+                                                            'max',
+                                                            'in',
+                                                            'not_in',
+                                                            'is_cleaned_path_exact',
+                                                            'flag_evaluates_to',
+                                                            'semver_eq',
+                                                            'semver_neq',
+                                                            'semver_gt',
+                                                            'semver_gte',
+                                                            'semver_lt',
+                                                            'semver_lte',
+                                                            'semver_tilde',
+                                                            'semver_caret',
+                                                            'semver_wildcard',
+                                                            'icontains_multi',
+                                                            'not_icontains_multi',
+                                                        ]),
+                                                        zod.null(),
+                                                    ])
+                                                    .optional()
+                                                    .describe(
+                                                        'Count comparison for performed_event_multiple, defaults to exact'
+                                                    ),
+                                                operator_value: zod
+                                                    .union([zod.number(), zod.null()])
+                                                    .optional()
+                                                    .describe('Count threshold for performed_event_multiple'),
+                                                time_interval: zod
+                                                    .union([zod.enum(['day', 'week', 'month', 'year']), zod.null()])
+                                                    .optional(),
+                                                time_value: zod
+                                                    .union([zod.number(), zod.null()])
+                                                    .optional()
+                                                    .describe('Relative time window size, paired with time_interval'),
+                                                type: zod
+                                                    .literal('behavioral')
+                                                    .default(
+                                                        experimentsPartialUpdateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwofourTypeDefault
+                                                    )
+                                                    .describe(
+                                                        "Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP"
+                                                    ),
+                                                value: zod.enum(['performed_event', 'performed_event_multiple']),
                                             }),
                                         ])
                                     )
@@ -11040,6 +12696,13 @@ export const experimentsDuplicateCreateBodyExposureCriteriaOneActivationConfigOn
 export const experimentsDuplicateCreateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwooneTypeDefault = `revenue_analytics`
 export const experimentsDuplicateCreateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwotwoTypeDefault = `account_custom_property`
 export const experimentsDuplicateCreateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwothreeTypeDefault = `workflow_variable`
+export const experimentsDuplicateCreateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwofourEventFiltersOneItemOneOperatorDefault = `exact`
+export const experimentsDuplicateCreateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwofourEventFiltersOneItemOneTypeDefault = `event`
+export const experimentsDuplicateCreateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwofourEventFiltersOneItemTwoTypeDefault = `person`
+export const experimentsDuplicateCreateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwofourEventFiltersOneItemThreeTypeDefault = `element`
+export const experimentsDuplicateCreateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwofourEventFiltersOneItemFourTypeDefault = `feature`
+export const experimentsDuplicateCreateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwofourEventFiltersOneItemFiveTypeDefault = `hogql`
+export const experimentsDuplicateCreateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwofourTypeDefault = `behavioral`
 export const experimentsDuplicateCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemOneOperatorDefault = `exact`
 export const experimentsDuplicateCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemOneTypeDefault = `event`
 export const experimentsDuplicateCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwoTypeDefault = `person`
@@ -11065,6 +12728,13 @@ export const experimentsDuplicateCreateBodyExposureCriteriaOneExposureConfigOneP
 export const experimentsDuplicateCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwooneTypeDefault = `revenue_analytics`
 export const experimentsDuplicateCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwotwoTypeDefault = `account_custom_property`
 export const experimentsDuplicateCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwothreeTypeDefault = `workflow_variable`
+export const experimentsDuplicateCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwofourEventFiltersOneItemOneOperatorDefault = `exact`
+export const experimentsDuplicateCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwofourEventFiltersOneItemOneTypeDefault = `event`
+export const experimentsDuplicateCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwofourEventFiltersOneItemTwoTypeDefault = `person`
+export const experimentsDuplicateCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwofourEventFiltersOneItemThreeTypeDefault = `element`
+export const experimentsDuplicateCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwofourEventFiltersOneItemFourTypeDefault = `feature`
+export const experimentsDuplicateCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwofourEventFiltersOneItemFiveTypeDefault = `hogql`
+export const experimentsDuplicateCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwofourTypeDefault = `behavioral`
 export const experimentsDuplicateCreateBodyMetricsOneItemCompletionEventOnePropertiesOneItemOperatorDefault = `exact`
 export const experimentsDuplicateCreateBodyMetricsOneItemCompletionEventOnePropertiesOneItemTypeDefault = `event`
 export const experimentsDuplicateCreateBodyMetricsOneItemDenominatorOnePropertiesOneItemOperatorDefault = `exact`
@@ -12544,6 +14214,413 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                     ])
                                                     .optional(),
                                             }),
+                                            zod.object({
+                                                event_filters: zod
+                                                    .union([
+                                                        zod.array(
+                                                            zod.union([
+                                                                zod.object({
+                                                                    key: zod.string(),
+                                                                    label: zod
+                                                                        .union([zod.string(), zod.null()])
+                                                                        .optional(),
+                                                                    operator: zod
+                                                                        .union([
+                                                                            zod.enum([
+                                                                                'exact',
+                                                                                'is_not',
+                                                                                'icontains',
+                                                                                'not_icontains',
+                                                                                'starts_with',
+                                                                                'not_starts_with',
+                                                                                'ends_with',
+                                                                                'not_ends_with',
+                                                                                'regex',
+                                                                                'not_regex',
+                                                                                'gt',
+                                                                                'gte',
+                                                                                'lt',
+                                                                                'lte',
+                                                                                'is_set',
+                                                                                'is_not_set',
+                                                                                'is_date_exact',
+                                                                                'is_date_before',
+                                                                                'is_date_after',
+                                                                                'between',
+                                                                                'not_between',
+                                                                                'min',
+                                                                                'max',
+                                                                                'in',
+                                                                                'not_in',
+                                                                                'is_cleaned_path_exact',
+                                                                                'flag_evaluates_to',
+                                                                                'semver_eq',
+                                                                                'semver_neq',
+                                                                                'semver_gt',
+                                                                                'semver_gte',
+                                                                                'semver_lt',
+                                                                                'semver_lte',
+                                                                                'semver_tilde',
+                                                                                'semver_caret',
+                                                                                'semver_wildcard',
+                                                                                'icontains_multi',
+                                                                                'not_icontains_multi',
+                                                                            ]),
+                                                                            zod.null(),
+                                                                        ])
+                                                                        .default(
+                                                                            experimentsDuplicateCreateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwofourEventFiltersOneItemOneOperatorDefault
+                                                                        ),
+                                                                    type: zod
+                                                                        .literal('event')
+                                                                        .default(
+                                                                            experimentsDuplicateCreateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwofourEventFiltersOneItemOneTypeDefault
+                                                                        )
+                                                                        .describe('Event properties'),
+                                                                    value: zod
+                                                                        .union([
+                                                                            zod.array(
+                                                                                zod.union([
+                                                                                    zod.string(),
+                                                                                    zod.number(),
+                                                                                    zod.boolean(),
+                                                                                ])
+                                                                            ),
+                                                                            zod.string(),
+                                                                            zod.number(),
+                                                                            zod.boolean(),
+                                                                            zod.null(),
+                                                                        ])
+                                                                        .optional(),
+                                                                }),
+                                                                zod.object({
+                                                                    key: zod.string(),
+                                                                    label: zod
+                                                                        .union([zod.string(), zod.null()])
+                                                                        .optional(),
+                                                                    operator: zod.enum([
+                                                                        'exact',
+                                                                        'is_not',
+                                                                        'icontains',
+                                                                        'not_icontains',
+                                                                        'starts_with',
+                                                                        'not_starts_with',
+                                                                        'ends_with',
+                                                                        'not_ends_with',
+                                                                        'regex',
+                                                                        'not_regex',
+                                                                        'gt',
+                                                                        'gte',
+                                                                        'lt',
+                                                                        'lte',
+                                                                        'is_set',
+                                                                        'is_not_set',
+                                                                        'is_date_exact',
+                                                                        'is_date_before',
+                                                                        'is_date_after',
+                                                                        'between',
+                                                                        'not_between',
+                                                                        'min',
+                                                                        'max',
+                                                                        'in',
+                                                                        'not_in',
+                                                                        'is_cleaned_path_exact',
+                                                                        'flag_evaluates_to',
+                                                                        'semver_eq',
+                                                                        'semver_neq',
+                                                                        'semver_gt',
+                                                                        'semver_gte',
+                                                                        'semver_lt',
+                                                                        'semver_lte',
+                                                                        'semver_tilde',
+                                                                        'semver_caret',
+                                                                        'semver_wildcard',
+                                                                        'icontains_multi',
+                                                                        'not_icontains_multi',
+                                                                    ]),
+                                                                    type: zod
+                                                                        .literal('person')
+                                                                        .default(
+                                                                            experimentsDuplicateCreateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwofourEventFiltersOneItemTwoTypeDefault
+                                                                        )
+                                                                        .describe('Person properties'),
+                                                                    value: zod
+                                                                        .union([
+                                                                            zod.array(
+                                                                                zod.union([
+                                                                                    zod.string(),
+                                                                                    zod.number(),
+                                                                                    zod.boolean(),
+                                                                                ])
+                                                                            ),
+                                                                            zod.string(),
+                                                                            zod.number(),
+                                                                            zod.boolean(),
+                                                                            zod.null(),
+                                                                        ])
+                                                                        .optional(),
+                                                                }),
+                                                                zod.object({
+                                                                    key: zod.enum([
+                                                                        'tag_name',
+                                                                        'text',
+                                                                        'href',
+                                                                        'selector',
+                                                                    ]),
+                                                                    label: zod
+                                                                        .union([zod.string(), zod.null()])
+                                                                        .optional(),
+                                                                    operator: zod.enum([
+                                                                        'exact',
+                                                                        'is_not',
+                                                                        'icontains',
+                                                                        'not_icontains',
+                                                                        'starts_with',
+                                                                        'not_starts_with',
+                                                                        'ends_with',
+                                                                        'not_ends_with',
+                                                                        'regex',
+                                                                        'not_regex',
+                                                                        'gt',
+                                                                        'gte',
+                                                                        'lt',
+                                                                        'lte',
+                                                                        'is_set',
+                                                                        'is_not_set',
+                                                                        'is_date_exact',
+                                                                        'is_date_before',
+                                                                        'is_date_after',
+                                                                        'between',
+                                                                        'not_between',
+                                                                        'min',
+                                                                        'max',
+                                                                        'in',
+                                                                        'not_in',
+                                                                        'is_cleaned_path_exact',
+                                                                        'flag_evaluates_to',
+                                                                        'semver_eq',
+                                                                        'semver_neq',
+                                                                        'semver_gt',
+                                                                        'semver_gte',
+                                                                        'semver_lt',
+                                                                        'semver_lte',
+                                                                        'semver_tilde',
+                                                                        'semver_caret',
+                                                                        'semver_wildcard',
+                                                                        'icontains_multi',
+                                                                        'not_icontains_multi',
+                                                                    ]),
+                                                                    type: zod
+                                                                        .literal('element')
+                                                                        .default(
+                                                                            experimentsDuplicateCreateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwofourEventFiltersOneItemThreeTypeDefault
+                                                                        ),
+                                                                    value: zod
+                                                                        .union([
+                                                                            zod.array(
+                                                                                zod.union([
+                                                                                    zod.string(),
+                                                                                    zod.number(),
+                                                                                    zod.boolean(),
+                                                                                ])
+                                                                            ),
+                                                                            zod.string(),
+                                                                            zod.number(),
+                                                                            zod.boolean(),
+                                                                            zod.null(),
+                                                                        ])
+                                                                        .optional(),
+                                                                }),
+                                                                zod.object({
+                                                                    key: zod.string(),
+                                                                    label: zod
+                                                                        .union([zod.string(), zod.null()])
+                                                                        .optional(),
+                                                                    operator: zod.enum([
+                                                                        'exact',
+                                                                        'is_not',
+                                                                        'icontains',
+                                                                        'not_icontains',
+                                                                        'starts_with',
+                                                                        'not_starts_with',
+                                                                        'ends_with',
+                                                                        'not_ends_with',
+                                                                        'regex',
+                                                                        'not_regex',
+                                                                        'gt',
+                                                                        'gte',
+                                                                        'lt',
+                                                                        'lte',
+                                                                        'is_set',
+                                                                        'is_not_set',
+                                                                        'is_date_exact',
+                                                                        'is_date_before',
+                                                                        'is_date_after',
+                                                                        'between',
+                                                                        'not_between',
+                                                                        'min',
+                                                                        'max',
+                                                                        'in',
+                                                                        'not_in',
+                                                                        'is_cleaned_path_exact',
+                                                                        'flag_evaluates_to',
+                                                                        'semver_eq',
+                                                                        'semver_neq',
+                                                                        'semver_gt',
+                                                                        'semver_gte',
+                                                                        'semver_lt',
+                                                                        'semver_lte',
+                                                                        'semver_tilde',
+                                                                        'semver_caret',
+                                                                        'semver_wildcard',
+                                                                        'icontains_multi',
+                                                                        'not_icontains_multi',
+                                                                    ]),
+                                                                    type: zod
+                                                                        .literal('feature')
+                                                                        .default(
+                                                                            experimentsDuplicateCreateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwofourEventFiltersOneItemFourTypeDefault
+                                                                        )
+                                                                        .describe(
+                                                                            'Event property with \"$feature\/\" prepended'
+                                                                        ),
+                                                                    value: zod
+                                                                        .union([
+                                                                            zod.array(
+                                                                                zod.union([
+                                                                                    zod.string(),
+                                                                                    zod.number(),
+                                                                                    zod.boolean(),
+                                                                                ])
+                                                                            ),
+                                                                            zod.string(),
+                                                                            zod.number(),
+                                                                            zod.boolean(),
+                                                                            zod.null(),
+                                                                        ])
+                                                                        .optional(),
+                                                                }),
+                                                                zod.object({
+                                                                    key: zod.string(),
+                                                                    label: zod
+                                                                        .union([zod.string(), zod.null()])
+                                                                        .optional(),
+                                                                    type: zod
+                                                                        .literal('hogql')
+                                                                        .default(
+                                                                            experimentsDuplicateCreateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwofourEventFiltersOneItemFiveTypeDefault
+                                                                        ),
+                                                                    value: zod
+                                                                        .union([
+                                                                            zod.array(
+                                                                                zod.union([
+                                                                                    zod.string(),
+                                                                                    zod.number(),
+                                                                                    zod.boolean(),
+                                                                                ])
+                                                                            ),
+                                                                            zod.string(),
+                                                                            zod.number(),
+                                                                            zod.boolean(),
+                                                                            zod.null(),
+                                                                        ])
+                                                                        .optional(),
+                                                                }),
+                                                            ])
+                                                        ),
+                                                        zod.null(),
+                                                    ])
+                                                    .optional()
+                                                    .describe(
+                                                        'Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral\/cohort filters and groups'
+                                                    ),
+                                                event_type: zod.enum(['events', 'actions']),
+                                                explicit_datetime: zod
+                                                    .union([zod.string(), zod.null()])
+                                                    .optional()
+                                                    .describe(
+                                                        'Absolute or relative (e.g. -30d) lower date bound — alternative to time_value\/time_interval'
+                                                    ),
+                                                explicit_datetime_to: zod.union([zod.string(), zod.null()]).optional(),
+                                                key: zod
+                                                    .string()
+                                                    .describe("Event name, or action id when event_type is 'actions'"),
+                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                negation: zod
+                                                    .union([zod.boolean(), zod.null()])
+                                                    .optional()
+                                                    .describe(
+                                                        'Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators'
+                                                    ),
+                                                operator: zod
+                                                    .union([
+                                                        zod.enum([
+                                                            'exact',
+                                                            'is_not',
+                                                            'icontains',
+                                                            'not_icontains',
+                                                            'starts_with',
+                                                            'not_starts_with',
+                                                            'ends_with',
+                                                            'not_ends_with',
+                                                            'regex',
+                                                            'not_regex',
+                                                            'gt',
+                                                            'gte',
+                                                            'lt',
+                                                            'lte',
+                                                            'is_set',
+                                                            'is_not_set',
+                                                            'is_date_exact',
+                                                            'is_date_before',
+                                                            'is_date_after',
+                                                            'between',
+                                                            'not_between',
+                                                            'min',
+                                                            'max',
+                                                            'in',
+                                                            'not_in',
+                                                            'is_cleaned_path_exact',
+                                                            'flag_evaluates_to',
+                                                            'semver_eq',
+                                                            'semver_neq',
+                                                            'semver_gt',
+                                                            'semver_gte',
+                                                            'semver_lt',
+                                                            'semver_lte',
+                                                            'semver_tilde',
+                                                            'semver_caret',
+                                                            'semver_wildcard',
+                                                            'icontains_multi',
+                                                            'not_icontains_multi',
+                                                        ]),
+                                                        zod.null(),
+                                                    ])
+                                                    .optional()
+                                                    .describe(
+                                                        'Count comparison for performed_event_multiple, defaults to exact'
+                                                    ),
+                                                operator_value: zod
+                                                    .union([zod.number(), zod.null()])
+                                                    .optional()
+                                                    .describe('Count threshold for performed_event_multiple'),
+                                                time_interval: zod
+                                                    .union([zod.enum(['day', 'week', 'month', 'year']), zod.null()])
+                                                    .optional(),
+                                                time_value: zod
+                                                    .union([zod.number(), zod.null()])
+                                                    .optional()
+                                                    .describe('Relative time window size, paired with time_interval'),
+                                                type: zod
+                                                    .literal('behavioral')
+                                                    .default(
+                                                        experimentsDuplicateCreateBodyExposureCriteriaOneActivationConfigOnePropertiesItemTwofourTypeDefault
+                                                    )
+                                                    .describe(
+                                                        "Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP"
+                                                    ),
+                                                value: zod.enum(['performed_event', 'performed_event_multiple']),
+                                            }),
                                         ])
                                     )
                                     .describe(
@@ -13842,6 +15919,413 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                         zod.null(),
                                                     ])
                                                     .optional(),
+                                            }),
+                                            zod.object({
+                                                event_filters: zod
+                                                    .union([
+                                                        zod.array(
+                                                            zod.union([
+                                                                zod.object({
+                                                                    key: zod.string(),
+                                                                    label: zod
+                                                                        .union([zod.string(), zod.null()])
+                                                                        .optional(),
+                                                                    operator: zod
+                                                                        .union([
+                                                                            zod.enum([
+                                                                                'exact',
+                                                                                'is_not',
+                                                                                'icontains',
+                                                                                'not_icontains',
+                                                                                'starts_with',
+                                                                                'not_starts_with',
+                                                                                'ends_with',
+                                                                                'not_ends_with',
+                                                                                'regex',
+                                                                                'not_regex',
+                                                                                'gt',
+                                                                                'gte',
+                                                                                'lt',
+                                                                                'lte',
+                                                                                'is_set',
+                                                                                'is_not_set',
+                                                                                'is_date_exact',
+                                                                                'is_date_before',
+                                                                                'is_date_after',
+                                                                                'between',
+                                                                                'not_between',
+                                                                                'min',
+                                                                                'max',
+                                                                                'in',
+                                                                                'not_in',
+                                                                                'is_cleaned_path_exact',
+                                                                                'flag_evaluates_to',
+                                                                                'semver_eq',
+                                                                                'semver_neq',
+                                                                                'semver_gt',
+                                                                                'semver_gte',
+                                                                                'semver_lt',
+                                                                                'semver_lte',
+                                                                                'semver_tilde',
+                                                                                'semver_caret',
+                                                                                'semver_wildcard',
+                                                                                'icontains_multi',
+                                                                                'not_icontains_multi',
+                                                                            ]),
+                                                                            zod.null(),
+                                                                        ])
+                                                                        .default(
+                                                                            experimentsDuplicateCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwofourEventFiltersOneItemOneOperatorDefault
+                                                                        ),
+                                                                    type: zod
+                                                                        .literal('event')
+                                                                        .default(
+                                                                            experimentsDuplicateCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwofourEventFiltersOneItemOneTypeDefault
+                                                                        )
+                                                                        .describe('Event properties'),
+                                                                    value: zod
+                                                                        .union([
+                                                                            zod.array(
+                                                                                zod.union([
+                                                                                    zod.string(),
+                                                                                    zod.number(),
+                                                                                    zod.boolean(),
+                                                                                ])
+                                                                            ),
+                                                                            zod.string(),
+                                                                            zod.number(),
+                                                                            zod.boolean(),
+                                                                            zod.null(),
+                                                                        ])
+                                                                        .optional(),
+                                                                }),
+                                                                zod.object({
+                                                                    key: zod.string(),
+                                                                    label: zod
+                                                                        .union([zod.string(), zod.null()])
+                                                                        .optional(),
+                                                                    operator: zod.enum([
+                                                                        'exact',
+                                                                        'is_not',
+                                                                        'icontains',
+                                                                        'not_icontains',
+                                                                        'starts_with',
+                                                                        'not_starts_with',
+                                                                        'ends_with',
+                                                                        'not_ends_with',
+                                                                        'regex',
+                                                                        'not_regex',
+                                                                        'gt',
+                                                                        'gte',
+                                                                        'lt',
+                                                                        'lte',
+                                                                        'is_set',
+                                                                        'is_not_set',
+                                                                        'is_date_exact',
+                                                                        'is_date_before',
+                                                                        'is_date_after',
+                                                                        'between',
+                                                                        'not_between',
+                                                                        'min',
+                                                                        'max',
+                                                                        'in',
+                                                                        'not_in',
+                                                                        'is_cleaned_path_exact',
+                                                                        'flag_evaluates_to',
+                                                                        'semver_eq',
+                                                                        'semver_neq',
+                                                                        'semver_gt',
+                                                                        'semver_gte',
+                                                                        'semver_lt',
+                                                                        'semver_lte',
+                                                                        'semver_tilde',
+                                                                        'semver_caret',
+                                                                        'semver_wildcard',
+                                                                        'icontains_multi',
+                                                                        'not_icontains_multi',
+                                                                    ]),
+                                                                    type: zod
+                                                                        .literal('person')
+                                                                        .default(
+                                                                            experimentsDuplicateCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwofourEventFiltersOneItemTwoTypeDefault
+                                                                        )
+                                                                        .describe('Person properties'),
+                                                                    value: zod
+                                                                        .union([
+                                                                            zod.array(
+                                                                                zod.union([
+                                                                                    zod.string(),
+                                                                                    zod.number(),
+                                                                                    zod.boolean(),
+                                                                                ])
+                                                                            ),
+                                                                            zod.string(),
+                                                                            zod.number(),
+                                                                            zod.boolean(),
+                                                                            zod.null(),
+                                                                        ])
+                                                                        .optional(),
+                                                                }),
+                                                                zod.object({
+                                                                    key: zod.enum([
+                                                                        'tag_name',
+                                                                        'text',
+                                                                        'href',
+                                                                        'selector',
+                                                                    ]),
+                                                                    label: zod
+                                                                        .union([zod.string(), zod.null()])
+                                                                        .optional(),
+                                                                    operator: zod.enum([
+                                                                        'exact',
+                                                                        'is_not',
+                                                                        'icontains',
+                                                                        'not_icontains',
+                                                                        'starts_with',
+                                                                        'not_starts_with',
+                                                                        'ends_with',
+                                                                        'not_ends_with',
+                                                                        'regex',
+                                                                        'not_regex',
+                                                                        'gt',
+                                                                        'gte',
+                                                                        'lt',
+                                                                        'lte',
+                                                                        'is_set',
+                                                                        'is_not_set',
+                                                                        'is_date_exact',
+                                                                        'is_date_before',
+                                                                        'is_date_after',
+                                                                        'between',
+                                                                        'not_between',
+                                                                        'min',
+                                                                        'max',
+                                                                        'in',
+                                                                        'not_in',
+                                                                        'is_cleaned_path_exact',
+                                                                        'flag_evaluates_to',
+                                                                        'semver_eq',
+                                                                        'semver_neq',
+                                                                        'semver_gt',
+                                                                        'semver_gte',
+                                                                        'semver_lt',
+                                                                        'semver_lte',
+                                                                        'semver_tilde',
+                                                                        'semver_caret',
+                                                                        'semver_wildcard',
+                                                                        'icontains_multi',
+                                                                        'not_icontains_multi',
+                                                                    ]),
+                                                                    type: zod
+                                                                        .literal('element')
+                                                                        .default(
+                                                                            experimentsDuplicateCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwofourEventFiltersOneItemThreeTypeDefault
+                                                                        ),
+                                                                    value: zod
+                                                                        .union([
+                                                                            zod.array(
+                                                                                zod.union([
+                                                                                    zod.string(),
+                                                                                    zod.number(),
+                                                                                    zod.boolean(),
+                                                                                ])
+                                                                            ),
+                                                                            zod.string(),
+                                                                            zod.number(),
+                                                                            zod.boolean(),
+                                                                            zod.null(),
+                                                                        ])
+                                                                        .optional(),
+                                                                }),
+                                                                zod.object({
+                                                                    key: zod.string(),
+                                                                    label: zod
+                                                                        .union([zod.string(), zod.null()])
+                                                                        .optional(),
+                                                                    operator: zod.enum([
+                                                                        'exact',
+                                                                        'is_not',
+                                                                        'icontains',
+                                                                        'not_icontains',
+                                                                        'starts_with',
+                                                                        'not_starts_with',
+                                                                        'ends_with',
+                                                                        'not_ends_with',
+                                                                        'regex',
+                                                                        'not_regex',
+                                                                        'gt',
+                                                                        'gte',
+                                                                        'lt',
+                                                                        'lte',
+                                                                        'is_set',
+                                                                        'is_not_set',
+                                                                        'is_date_exact',
+                                                                        'is_date_before',
+                                                                        'is_date_after',
+                                                                        'between',
+                                                                        'not_between',
+                                                                        'min',
+                                                                        'max',
+                                                                        'in',
+                                                                        'not_in',
+                                                                        'is_cleaned_path_exact',
+                                                                        'flag_evaluates_to',
+                                                                        'semver_eq',
+                                                                        'semver_neq',
+                                                                        'semver_gt',
+                                                                        'semver_gte',
+                                                                        'semver_lt',
+                                                                        'semver_lte',
+                                                                        'semver_tilde',
+                                                                        'semver_caret',
+                                                                        'semver_wildcard',
+                                                                        'icontains_multi',
+                                                                        'not_icontains_multi',
+                                                                    ]),
+                                                                    type: zod
+                                                                        .literal('feature')
+                                                                        .default(
+                                                                            experimentsDuplicateCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwofourEventFiltersOneItemFourTypeDefault
+                                                                        )
+                                                                        .describe(
+                                                                            'Event property with \"$feature\/\" prepended'
+                                                                        ),
+                                                                    value: zod
+                                                                        .union([
+                                                                            zod.array(
+                                                                                zod.union([
+                                                                                    zod.string(),
+                                                                                    zod.number(),
+                                                                                    zod.boolean(),
+                                                                                ])
+                                                                            ),
+                                                                            zod.string(),
+                                                                            zod.number(),
+                                                                            zod.boolean(),
+                                                                            zod.null(),
+                                                                        ])
+                                                                        .optional(),
+                                                                }),
+                                                                zod.object({
+                                                                    key: zod.string(),
+                                                                    label: zod
+                                                                        .union([zod.string(), zod.null()])
+                                                                        .optional(),
+                                                                    type: zod
+                                                                        .literal('hogql')
+                                                                        .default(
+                                                                            experimentsDuplicateCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwofourEventFiltersOneItemFiveTypeDefault
+                                                                        ),
+                                                                    value: zod
+                                                                        .union([
+                                                                            zod.array(
+                                                                                zod.union([
+                                                                                    zod.string(),
+                                                                                    zod.number(),
+                                                                                    zod.boolean(),
+                                                                                ])
+                                                                            ),
+                                                                            zod.string(),
+                                                                            zod.number(),
+                                                                            zod.boolean(),
+                                                                            zod.null(),
+                                                                        ])
+                                                                        .optional(),
+                                                                }),
+                                                            ])
+                                                        ),
+                                                        zod.null(),
+                                                    ])
+                                                    .optional()
+                                                    .describe(
+                                                        'Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral\/cohort filters and groups'
+                                                    ),
+                                                event_type: zod.enum(['events', 'actions']),
+                                                explicit_datetime: zod
+                                                    .union([zod.string(), zod.null()])
+                                                    .optional()
+                                                    .describe(
+                                                        'Absolute or relative (e.g. -30d) lower date bound — alternative to time_value\/time_interval'
+                                                    ),
+                                                explicit_datetime_to: zod.union([zod.string(), zod.null()]).optional(),
+                                                key: zod
+                                                    .string()
+                                                    .describe("Event name, or action id when event_type is 'actions'"),
+                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                negation: zod
+                                                    .union([zod.boolean(), zod.null()])
+                                                    .optional()
+                                                    .describe(
+                                                        'Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators'
+                                                    ),
+                                                operator: zod
+                                                    .union([
+                                                        zod.enum([
+                                                            'exact',
+                                                            'is_not',
+                                                            'icontains',
+                                                            'not_icontains',
+                                                            'starts_with',
+                                                            'not_starts_with',
+                                                            'ends_with',
+                                                            'not_ends_with',
+                                                            'regex',
+                                                            'not_regex',
+                                                            'gt',
+                                                            'gte',
+                                                            'lt',
+                                                            'lte',
+                                                            'is_set',
+                                                            'is_not_set',
+                                                            'is_date_exact',
+                                                            'is_date_before',
+                                                            'is_date_after',
+                                                            'between',
+                                                            'not_between',
+                                                            'min',
+                                                            'max',
+                                                            'in',
+                                                            'not_in',
+                                                            'is_cleaned_path_exact',
+                                                            'flag_evaluates_to',
+                                                            'semver_eq',
+                                                            'semver_neq',
+                                                            'semver_gt',
+                                                            'semver_gte',
+                                                            'semver_lt',
+                                                            'semver_lte',
+                                                            'semver_tilde',
+                                                            'semver_caret',
+                                                            'semver_wildcard',
+                                                            'icontains_multi',
+                                                            'not_icontains_multi',
+                                                        ]),
+                                                        zod.null(),
+                                                    ])
+                                                    .optional()
+                                                    .describe(
+                                                        'Count comparison for performed_event_multiple, defaults to exact'
+                                                    ),
+                                                operator_value: zod
+                                                    .union([zod.number(), zod.null()])
+                                                    .optional()
+                                                    .describe('Count threshold for performed_event_multiple'),
+                                                time_interval: zod
+                                                    .union([zod.enum(['day', 'week', 'month', 'year']), zod.null()])
+                                                    .optional(),
+                                                time_value: zod
+                                                    .union([zod.number(), zod.null()])
+                                                    .optional()
+                                                    .describe('Relative time window size, paired with time_interval'),
+                                                type: zod
+                                                    .literal('behavioral')
+                                                    .default(
+                                                        experimentsDuplicateCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTwofourTypeDefault
+                                                    )
+                                                    .describe(
+                                                        "Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP"
+                                                    ),
+                                                value: zod.enum(['performed_event', 'performed_event_multiple']),
                                             }),
                                         ])
                                     )

--- a/services/mcp/src/generated/logs/api.ts
+++ b/services/mcp/src/generated/logs/api.ts
@@ -58,6 +58,13 @@ export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwo
 export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwotwoTypeDefault = `revenue_analytics`
 export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwothreeTypeDefault = `account_custom_property`
 export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofourTypeDefault = `workflow_variable`
+export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveEventFiltersOneItemOneOperatorDefault = `exact`
+export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveEventFiltersOneItemOneTypeDefault = `event`
+export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveEventFiltersOneItemTwoTypeDefault = `person`
+export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveEventFiltersOneItemThreeTypeDefault = `element`
+export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveEventFiltersOneItemFourTypeDefault = `feature`
+export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveEventFiltersOneItemFiveTypeDefault = `hogql`
+export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveTypeDefault = `behavioral`
 export const logsAlertsCreateBodyThresholdCountDefault = 100
 export const logsAlertsCreateBodyThresholdCountMin = 0
 
@@ -1319,6 +1326,398 @@ export const LogsAlertsCreateBody = /* @__PURE__ */ zod.object({
                                                 ])
                                                 .optional(),
                                         }),
+                                        zod.object({
+                                            event_filters: zod
+                                                .union([
+                                                    zod.array(
+                                                        zod.union([
+                                                            zod.object({
+                                                                key: zod.string(),
+                                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                                operator: zod
+                                                                    .union([
+                                                                        zod.enum([
+                                                                            'exact',
+                                                                            'is_not',
+                                                                            'icontains',
+                                                                            'not_icontains',
+                                                                            'starts_with',
+                                                                            'not_starts_with',
+                                                                            'ends_with',
+                                                                            'not_ends_with',
+                                                                            'regex',
+                                                                            'not_regex',
+                                                                            'gt',
+                                                                            'gte',
+                                                                            'lt',
+                                                                            'lte',
+                                                                            'is_set',
+                                                                            'is_not_set',
+                                                                            'is_date_exact',
+                                                                            'is_date_before',
+                                                                            'is_date_after',
+                                                                            'between',
+                                                                            'not_between',
+                                                                            'min',
+                                                                            'max',
+                                                                            'in',
+                                                                            'not_in',
+                                                                            'is_cleaned_path_exact',
+                                                                            'flag_evaluates_to',
+                                                                            'semver_eq',
+                                                                            'semver_neq',
+                                                                            'semver_gt',
+                                                                            'semver_gte',
+                                                                            'semver_lt',
+                                                                            'semver_lte',
+                                                                            'semver_tilde',
+                                                                            'semver_caret',
+                                                                            'semver_wildcard',
+                                                                            'icontains_multi',
+                                                                            'not_icontains_multi',
+                                                                        ]),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .default(
+                                                                        logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveEventFiltersOneItemOneOperatorDefault
+                                                                    ),
+                                                                type: zod
+                                                                    .literal('event')
+                                                                    .default(
+                                                                        logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveEventFiltersOneItemOneTypeDefault
+                                                                    )
+                                                                    .describe('Event properties'),
+                                                                value: zod
+                                                                    .union([
+                                                                        zod.array(
+                                                                            zod.union([
+                                                                                zod.string(),
+                                                                                zod.number(),
+                                                                                zod.boolean(),
+                                                                            ])
+                                                                        ),
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .optional(),
+                                                            }),
+                                                            zod.object({
+                                                                key: zod.string(),
+                                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                                operator: zod.enum([
+                                                                    'exact',
+                                                                    'is_not',
+                                                                    'icontains',
+                                                                    'not_icontains',
+                                                                    'starts_with',
+                                                                    'not_starts_with',
+                                                                    'ends_with',
+                                                                    'not_ends_with',
+                                                                    'regex',
+                                                                    'not_regex',
+                                                                    'gt',
+                                                                    'gte',
+                                                                    'lt',
+                                                                    'lte',
+                                                                    'is_set',
+                                                                    'is_not_set',
+                                                                    'is_date_exact',
+                                                                    'is_date_before',
+                                                                    'is_date_after',
+                                                                    'between',
+                                                                    'not_between',
+                                                                    'min',
+                                                                    'max',
+                                                                    'in',
+                                                                    'not_in',
+                                                                    'is_cleaned_path_exact',
+                                                                    'flag_evaluates_to',
+                                                                    'semver_eq',
+                                                                    'semver_neq',
+                                                                    'semver_gt',
+                                                                    'semver_gte',
+                                                                    'semver_lt',
+                                                                    'semver_lte',
+                                                                    'semver_tilde',
+                                                                    'semver_caret',
+                                                                    'semver_wildcard',
+                                                                    'icontains_multi',
+                                                                    'not_icontains_multi',
+                                                                ]),
+                                                                type: zod
+                                                                    .literal('person')
+                                                                    .default(
+                                                                        logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveEventFiltersOneItemTwoTypeDefault
+                                                                    )
+                                                                    .describe('Person properties'),
+                                                                value: zod
+                                                                    .union([
+                                                                        zod.array(
+                                                                            zod.union([
+                                                                                zod.string(),
+                                                                                zod.number(),
+                                                                                zod.boolean(),
+                                                                            ])
+                                                                        ),
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .optional(),
+                                                            }),
+                                                            zod.object({
+                                                                key: zod.enum(['tag_name', 'text', 'href', 'selector']),
+                                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                                operator: zod.enum([
+                                                                    'exact',
+                                                                    'is_not',
+                                                                    'icontains',
+                                                                    'not_icontains',
+                                                                    'starts_with',
+                                                                    'not_starts_with',
+                                                                    'ends_with',
+                                                                    'not_ends_with',
+                                                                    'regex',
+                                                                    'not_regex',
+                                                                    'gt',
+                                                                    'gte',
+                                                                    'lt',
+                                                                    'lte',
+                                                                    'is_set',
+                                                                    'is_not_set',
+                                                                    'is_date_exact',
+                                                                    'is_date_before',
+                                                                    'is_date_after',
+                                                                    'between',
+                                                                    'not_between',
+                                                                    'min',
+                                                                    'max',
+                                                                    'in',
+                                                                    'not_in',
+                                                                    'is_cleaned_path_exact',
+                                                                    'flag_evaluates_to',
+                                                                    'semver_eq',
+                                                                    'semver_neq',
+                                                                    'semver_gt',
+                                                                    'semver_gte',
+                                                                    'semver_lt',
+                                                                    'semver_lte',
+                                                                    'semver_tilde',
+                                                                    'semver_caret',
+                                                                    'semver_wildcard',
+                                                                    'icontains_multi',
+                                                                    'not_icontains_multi',
+                                                                ]),
+                                                                type: zod
+                                                                    .literal('element')
+                                                                    .default(
+                                                                        logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveEventFiltersOneItemThreeTypeDefault
+                                                                    ),
+                                                                value: zod
+                                                                    .union([
+                                                                        zod.array(
+                                                                            zod.union([
+                                                                                zod.string(),
+                                                                                zod.number(),
+                                                                                zod.boolean(),
+                                                                            ])
+                                                                        ),
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .optional(),
+                                                            }),
+                                                            zod.object({
+                                                                key: zod.string(),
+                                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                                operator: zod.enum([
+                                                                    'exact',
+                                                                    'is_not',
+                                                                    'icontains',
+                                                                    'not_icontains',
+                                                                    'starts_with',
+                                                                    'not_starts_with',
+                                                                    'ends_with',
+                                                                    'not_ends_with',
+                                                                    'regex',
+                                                                    'not_regex',
+                                                                    'gt',
+                                                                    'gte',
+                                                                    'lt',
+                                                                    'lte',
+                                                                    'is_set',
+                                                                    'is_not_set',
+                                                                    'is_date_exact',
+                                                                    'is_date_before',
+                                                                    'is_date_after',
+                                                                    'between',
+                                                                    'not_between',
+                                                                    'min',
+                                                                    'max',
+                                                                    'in',
+                                                                    'not_in',
+                                                                    'is_cleaned_path_exact',
+                                                                    'flag_evaluates_to',
+                                                                    'semver_eq',
+                                                                    'semver_neq',
+                                                                    'semver_gt',
+                                                                    'semver_gte',
+                                                                    'semver_lt',
+                                                                    'semver_lte',
+                                                                    'semver_tilde',
+                                                                    'semver_caret',
+                                                                    'semver_wildcard',
+                                                                    'icontains_multi',
+                                                                    'not_icontains_multi',
+                                                                ]),
+                                                                type: zod
+                                                                    .literal('feature')
+                                                                    .default(
+                                                                        logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveEventFiltersOneItemFourTypeDefault
+                                                                    )
+                                                                    .describe(
+                                                                        'Event property with \"$feature\/\" prepended'
+                                                                    ),
+                                                                value: zod
+                                                                    .union([
+                                                                        zod.array(
+                                                                            zod.union([
+                                                                                zod.string(),
+                                                                                zod.number(),
+                                                                                zod.boolean(),
+                                                                            ])
+                                                                        ),
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .optional(),
+                                                            }),
+                                                            zod.object({
+                                                                key: zod.string(),
+                                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                                type: zod
+                                                                    .literal('hogql')
+                                                                    .default(
+                                                                        logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveEventFiltersOneItemFiveTypeDefault
+                                                                    ),
+                                                                value: zod
+                                                                    .union([
+                                                                        zod.array(
+                                                                            zod.union([
+                                                                                zod.string(),
+                                                                                zod.number(),
+                                                                                zod.boolean(),
+                                                                            ])
+                                                                        ),
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .optional(),
+                                                            }),
+                                                        ])
+                                                    ),
+                                                    zod.null(),
+                                                ])
+                                                .optional()
+                                                .describe(
+                                                    'Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral\/cohort filters and groups'
+                                                ),
+                                            event_type: zod.enum(['events', 'actions']),
+                                            explicit_datetime: zod
+                                                .union([zod.string(), zod.null()])
+                                                .optional()
+                                                .describe(
+                                                    'Absolute or relative (e.g. -30d) lower date bound — alternative to time_value\/time_interval'
+                                                ),
+                                            explicit_datetime_to: zod.union([zod.string(), zod.null()]).optional(),
+                                            key: zod
+                                                .string()
+                                                .describe("Event name, or action id when event_type is 'actions'"),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
+                                            negation: zod
+                                                .union([zod.boolean(), zod.null()])
+                                                .optional()
+                                                .describe(
+                                                    'Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators'
+                                                ),
+                                            operator: zod
+                                                .union([
+                                                    zod.enum([
+                                                        'exact',
+                                                        'is_not',
+                                                        'icontains',
+                                                        'not_icontains',
+                                                        'starts_with',
+                                                        'not_starts_with',
+                                                        'ends_with',
+                                                        'not_ends_with',
+                                                        'regex',
+                                                        'not_regex',
+                                                        'gt',
+                                                        'gte',
+                                                        'lt',
+                                                        'lte',
+                                                        'is_set',
+                                                        'is_not_set',
+                                                        'is_date_exact',
+                                                        'is_date_before',
+                                                        'is_date_after',
+                                                        'between',
+                                                        'not_between',
+                                                        'min',
+                                                        'max',
+                                                        'in',
+                                                        'not_in',
+                                                        'is_cleaned_path_exact',
+                                                        'flag_evaluates_to',
+                                                        'semver_eq',
+                                                        'semver_neq',
+                                                        'semver_gt',
+                                                        'semver_gte',
+                                                        'semver_lt',
+                                                        'semver_lte',
+                                                        'semver_tilde',
+                                                        'semver_caret',
+                                                        'semver_wildcard',
+                                                        'icontains_multi',
+                                                        'not_icontains_multi',
+                                                    ]),
+                                                    zod.null(),
+                                                ])
+                                                .optional()
+                                                .describe(
+                                                    'Count comparison for performed_event_multiple, defaults to exact'
+                                                ),
+                                            operator_value: zod
+                                                .union([zod.number(), zod.null()])
+                                                .optional()
+                                                .describe('Count threshold for performed_event_multiple'),
+                                            time_interval: zod
+                                                .union([zod.enum(['day', 'week', 'month', 'year']), zod.null()])
+                                                .optional(),
+                                            time_value: zod
+                                                .union([zod.number(), zod.null()])
+                                                .optional()
+                                                .describe('Relative time window size, paired with time_interval'),
+                                            type: zod
+                                                .literal('behavioral')
+                                                .default(
+                                                    logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveTypeDefault
+                                                )
+                                                .describe(
+                                                    "Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP"
+                                                ),
+                                            value: zod.enum(['performed_event', 'performed_event_multiple']),
+                                        }),
                                     ])
                                 ),
                             })
@@ -1450,6 +1849,13 @@ export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValues
 export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwotwoTypeDefault = `revenue_analytics`
 export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwothreeTypeDefault = `account_custom_property`
 export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofourTypeDefault = `workflow_variable`
+export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveEventFiltersOneItemOneOperatorDefault = `exact`
+export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveEventFiltersOneItemOneTypeDefault = `event`
+export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveEventFiltersOneItemTwoTypeDefault = `person`
+export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveEventFiltersOneItemThreeTypeDefault = `element`
+export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveEventFiltersOneItemFourTypeDefault = `feature`
+export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveEventFiltersOneItemFiveTypeDefault = `hogql`
+export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveTypeDefault = `behavioral`
 export const logsAlertsPartialUpdateBodyThresholdCountMin = 0
 
 export const logsAlertsPartialUpdateBodyEvaluationPeriodsMax = 10
@@ -2705,6 +3111,398 @@ export const LogsAlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 ])
                                                 .optional(),
                                         }),
+                                        zod.object({
+                                            event_filters: zod
+                                                .union([
+                                                    zod.array(
+                                                        zod.union([
+                                                            zod.object({
+                                                                key: zod.string(),
+                                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                                operator: zod
+                                                                    .union([
+                                                                        zod.enum([
+                                                                            'exact',
+                                                                            'is_not',
+                                                                            'icontains',
+                                                                            'not_icontains',
+                                                                            'starts_with',
+                                                                            'not_starts_with',
+                                                                            'ends_with',
+                                                                            'not_ends_with',
+                                                                            'regex',
+                                                                            'not_regex',
+                                                                            'gt',
+                                                                            'gte',
+                                                                            'lt',
+                                                                            'lte',
+                                                                            'is_set',
+                                                                            'is_not_set',
+                                                                            'is_date_exact',
+                                                                            'is_date_before',
+                                                                            'is_date_after',
+                                                                            'between',
+                                                                            'not_between',
+                                                                            'min',
+                                                                            'max',
+                                                                            'in',
+                                                                            'not_in',
+                                                                            'is_cleaned_path_exact',
+                                                                            'flag_evaluates_to',
+                                                                            'semver_eq',
+                                                                            'semver_neq',
+                                                                            'semver_gt',
+                                                                            'semver_gte',
+                                                                            'semver_lt',
+                                                                            'semver_lte',
+                                                                            'semver_tilde',
+                                                                            'semver_caret',
+                                                                            'semver_wildcard',
+                                                                            'icontains_multi',
+                                                                            'not_icontains_multi',
+                                                                        ]),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .default(
+                                                                        logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveEventFiltersOneItemOneOperatorDefault
+                                                                    ),
+                                                                type: zod
+                                                                    .literal('event')
+                                                                    .default(
+                                                                        logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveEventFiltersOneItemOneTypeDefault
+                                                                    )
+                                                                    .describe('Event properties'),
+                                                                value: zod
+                                                                    .union([
+                                                                        zod.array(
+                                                                            zod.union([
+                                                                                zod.string(),
+                                                                                zod.number(),
+                                                                                zod.boolean(),
+                                                                            ])
+                                                                        ),
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .optional(),
+                                                            }),
+                                                            zod.object({
+                                                                key: zod.string(),
+                                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                                operator: zod.enum([
+                                                                    'exact',
+                                                                    'is_not',
+                                                                    'icontains',
+                                                                    'not_icontains',
+                                                                    'starts_with',
+                                                                    'not_starts_with',
+                                                                    'ends_with',
+                                                                    'not_ends_with',
+                                                                    'regex',
+                                                                    'not_regex',
+                                                                    'gt',
+                                                                    'gte',
+                                                                    'lt',
+                                                                    'lte',
+                                                                    'is_set',
+                                                                    'is_not_set',
+                                                                    'is_date_exact',
+                                                                    'is_date_before',
+                                                                    'is_date_after',
+                                                                    'between',
+                                                                    'not_between',
+                                                                    'min',
+                                                                    'max',
+                                                                    'in',
+                                                                    'not_in',
+                                                                    'is_cleaned_path_exact',
+                                                                    'flag_evaluates_to',
+                                                                    'semver_eq',
+                                                                    'semver_neq',
+                                                                    'semver_gt',
+                                                                    'semver_gte',
+                                                                    'semver_lt',
+                                                                    'semver_lte',
+                                                                    'semver_tilde',
+                                                                    'semver_caret',
+                                                                    'semver_wildcard',
+                                                                    'icontains_multi',
+                                                                    'not_icontains_multi',
+                                                                ]),
+                                                                type: zod
+                                                                    .literal('person')
+                                                                    .default(
+                                                                        logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveEventFiltersOneItemTwoTypeDefault
+                                                                    )
+                                                                    .describe('Person properties'),
+                                                                value: zod
+                                                                    .union([
+                                                                        zod.array(
+                                                                            zod.union([
+                                                                                zod.string(),
+                                                                                zod.number(),
+                                                                                zod.boolean(),
+                                                                            ])
+                                                                        ),
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .optional(),
+                                                            }),
+                                                            zod.object({
+                                                                key: zod.enum(['tag_name', 'text', 'href', 'selector']),
+                                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                                operator: zod.enum([
+                                                                    'exact',
+                                                                    'is_not',
+                                                                    'icontains',
+                                                                    'not_icontains',
+                                                                    'starts_with',
+                                                                    'not_starts_with',
+                                                                    'ends_with',
+                                                                    'not_ends_with',
+                                                                    'regex',
+                                                                    'not_regex',
+                                                                    'gt',
+                                                                    'gte',
+                                                                    'lt',
+                                                                    'lte',
+                                                                    'is_set',
+                                                                    'is_not_set',
+                                                                    'is_date_exact',
+                                                                    'is_date_before',
+                                                                    'is_date_after',
+                                                                    'between',
+                                                                    'not_between',
+                                                                    'min',
+                                                                    'max',
+                                                                    'in',
+                                                                    'not_in',
+                                                                    'is_cleaned_path_exact',
+                                                                    'flag_evaluates_to',
+                                                                    'semver_eq',
+                                                                    'semver_neq',
+                                                                    'semver_gt',
+                                                                    'semver_gte',
+                                                                    'semver_lt',
+                                                                    'semver_lte',
+                                                                    'semver_tilde',
+                                                                    'semver_caret',
+                                                                    'semver_wildcard',
+                                                                    'icontains_multi',
+                                                                    'not_icontains_multi',
+                                                                ]),
+                                                                type: zod
+                                                                    .literal('element')
+                                                                    .default(
+                                                                        logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveEventFiltersOneItemThreeTypeDefault
+                                                                    ),
+                                                                value: zod
+                                                                    .union([
+                                                                        zod.array(
+                                                                            zod.union([
+                                                                                zod.string(),
+                                                                                zod.number(),
+                                                                                zod.boolean(),
+                                                                            ])
+                                                                        ),
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .optional(),
+                                                            }),
+                                                            zod.object({
+                                                                key: zod.string(),
+                                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                                operator: zod.enum([
+                                                                    'exact',
+                                                                    'is_not',
+                                                                    'icontains',
+                                                                    'not_icontains',
+                                                                    'starts_with',
+                                                                    'not_starts_with',
+                                                                    'ends_with',
+                                                                    'not_ends_with',
+                                                                    'regex',
+                                                                    'not_regex',
+                                                                    'gt',
+                                                                    'gte',
+                                                                    'lt',
+                                                                    'lte',
+                                                                    'is_set',
+                                                                    'is_not_set',
+                                                                    'is_date_exact',
+                                                                    'is_date_before',
+                                                                    'is_date_after',
+                                                                    'between',
+                                                                    'not_between',
+                                                                    'min',
+                                                                    'max',
+                                                                    'in',
+                                                                    'not_in',
+                                                                    'is_cleaned_path_exact',
+                                                                    'flag_evaluates_to',
+                                                                    'semver_eq',
+                                                                    'semver_neq',
+                                                                    'semver_gt',
+                                                                    'semver_gte',
+                                                                    'semver_lt',
+                                                                    'semver_lte',
+                                                                    'semver_tilde',
+                                                                    'semver_caret',
+                                                                    'semver_wildcard',
+                                                                    'icontains_multi',
+                                                                    'not_icontains_multi',
+                                                                ]),
+                                                                type: zod
+                                                                    .literal('feature')
+                                                                    .default(
+                                                                        logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveEventFiltersOneItemFourTypeDefault
+                                                                    )
+                                                                    .describe(
+                                                                        'Event property with \"$feature\/\" prepended'
+                                                                    ),
+                                                                value: zod
+                                                                    .union([
+                                                                        zod.array(
+                                                                            zod.union([
+                                                                                zod.string(),
+                                                                                zod.number(),
+                                                                                zod.boolean(),
+                                                                            ])
+                                                                        ),
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .optional(),
+                                                            }),
+                                                            zod.object({
+                                                                key: zod.string(),
+                                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                                type: zod
+                                                                    .literal('hogql')
+                                                                    .default(
+                                                                        logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveEventFiltersOneItemFiveTypeDefault
+                                                                    ),
+                                                                value: zod
+                                                                    .union([
+                                                                        zod.array(
+                                                                            zod.union([
+                                                                                zod.string(),
+                                                                                zod.number(),
+                                                                                zod.boolean(),
+                                                                            ])
+                                                                        ),
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .optional(),
+                                                            }),
+                                                        ])
+                                                    ),
+                                                    zod.null(),
+                                                ])
+                                                .optional()
+                                                .describe(
+                                                    'Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral\/cohort filters and groups'
+                                                ),
+                                            event_type: zod.enum(['events', 'actions']),
+                                            explicit_datetime: zod
+                                                .union([zod.string(), zod.null()])
+                                                .optional()
+                                                .describe(
+                                                    'Absolute or relative (e.g. -30d) lower date bound — alternative to time_value\/time_interval'
+                                                ),
+                                            explicit_datetime_to: zod.union([zod.string(), zod.null()]).optional(),
+                                            key: zod
+                                                .string()
+                                                .describe("Event name, or action id when event_type is 'actions'"),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
+                                            negation: zod
+                                                .union([zod.boolean(), zod.null()])
+                                                .optional()
+                                                .describe(
+                                                    'Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators'
+                                                ),
+                                            operator: zod
+                                                .union([
+                                                    zod.enum([
+                                                        'exact',
+                                                        'is_not',
+                                                        'icontains',
+                                                        'not_icontains',
+                                                        'starts_with',
+                                                        'not_starts_with',
+                                                        'ends_with',
+                                                        'not_ends_with',
+                                                        'regex',
+                                                        'not_regex',
+                                                        'gt',
+                                                        'gte',
+                                                        'lt',
+                                                        'lte',
+                                                        'is_set',
+                                                        'is_not_set',
+                                                        'is_date_exact',
+                                                        'is_date_before',
+                                                        'is_date_after',
+                                                        'between',
+                                                        'not_between',
+                                                        'min',
+                                                        'max',
+                                                        'in',
+                                                        'not_in',
+                                                        'is_cleaned_path_exact',
+                                                        'flag_evaluates_to',
+                                                        'semver_eq',
+                                                        'semver_neq',
+                                                        'semver_gt',
+                                                        'semver_gte',
+                                                        'semver_lt',
+                                                        'semver_lte',
+                                                        'semver_tilde',
+                                                        'semver_caret',
+                                                        'semver_wildcard',
+                                                        'icontains_multi',
+                                                        'not_icontains_multi',
+                                                    ]),
+                                                    zod.null(),
+                                                ])
+                                                .optional()
+                                                .describe(
+                                                    'Count comparison for performed_event_multiple, defaults to exact'
+                                                ),
+                                            operator_value: zod
+                                                .union([zod.number(), zod.null()])
+                                                .optional()
+                                                .describe('Count threshold for performed_event_multiple'),
+                                            time_interval: zod
+                                                .union([zod.enum(['day', 'week', 'month', 'year']), zod.null()])
+                                                .optional(),
+                                            time_value: zod
+                                                .union([zod.number(), zod.null()])
+                                                .optional()
+                                                .describe('Relative time window size, paired with time_interval'),
+                                            type: zod
+                                                .literal('behavioral')
+                                                .default(
+                                                    logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveTypeDefault
+                                                )
+                                                .describe(
+                                                    "Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP"
+                                                ),
+                                            value: zod.enum(['performed_event', 'performed_event_multiple']),
+                                        }),
                                     ])
                                 ),
                             })
@@ -2901,6 +3699,13 @@ export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValue
 export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwotwoTypeDefault = `revenue_analytics`
 export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwothreeTypeDefault = `account_custom_property`
 export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofourTypeDefault = `workflow_variable`
+export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveEventFiltersOneItemOneOperatorDefault = `exact`
+export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveEventFiltersOneItemOneTypeDefault = `event`
+export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveEventFiltersOneItemTwoTypeDefault = `person`
+export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveEventFiltersOneItemThreeTypeDefault = `element`
+export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveEventFiltersOneItemFourTypeDefault = `feature`
+export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveEventFiltersOneItemFiveTypeDefault = `hogql`
+export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveTypeDefault = `behavioral`
 export const logsAlertsSimulateCreateBodyThresholdCountMin = 0
 
 export const logsAlertsSimulateCreateBodyCheckIntervalMinutesDefault = 5
@@ -4152,6 +4957,398 @@ export const LogsAlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                                                     zod.null(),
                                                 ])
                                                 .optional(),
+                                        }),
+                                        zod.object({
+                                            event_filters: zod
+                                                .union([
+                                                    zod.array(
+                                                        zod.union([
+                                                            zod.object({
+                                                                key: zod.string(),
+                                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                                operator: zod
+                                                                    .union([
+                                                                        zod.enum([
+                                                                            'exact',
+                                                                            'is_not',
+                                                                            'icontains',
+                                                                            'not_icontains',
+                                                                            'starts_with',
+                                                                            'not_starts_with',
+                                                                            'ends_with',
+                                                                            'not_ends_with',
+                                                                            'regex',
+                                                                            'not_regex',
+                                                                            'gt',
+                                                                            'gte',
+                                                                            'lt',
+                                                                            'lte',
+                                                                            'is_set',
+                                                                            'is_not_set',
+                                                                            'is_date_exact',
+                                                                            'is_date_before',
+                                                                            'is_date_after',
+                                                                            'between',
+                                                                            'not_between',
+                                                                            'min',
+                                                                            'max',
+                                                                            'in',
+                                                                            'not_in',
+                                                                            'is_cleaned_path_exact',
+                                                                            'flag_evaluates_to',
+                                                                            'semver_eq',
+                                                                            'semver_neq',
+                                                                            'semver_gt',
+                                                                            'semver_gte',
+                                                                            'semver_lt',
+                                                                            'semver_lte',
+                                                                            'semver_tilde',
+                                                                            'semver_caret',
+                                                                            'semver_wildcard',
+                                                                            'icontains_multi',
+                                                                            'not_icontains_multi',
+                                                                        ]),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .default(
+                                                                        logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveEventFiltersOneItemOneOperatorDefault
+                                                                    ),
+                                                                type: zod
+                                                                    .literal('event')
+                                                                    .default(
+                                                                        logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveEventFiltersOneItemOneTypeDefault
+                                                                    )
+                                                                    .describe('Event properties'),
+                                                                value: zod
+                                                                    .union([
+                                                                        zod.array(
+                                                                            zod.union([
+                                                                                zod.string(),
+                                                                                zod.number(),
+                                                                                zod.boolean(),
+                                                                            ])
+                                                                        ),
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .optional(),
+                                                            }),
+                                                            zod.object({
+                                                                key: zod.string(),
+                                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                                operator: zod.enum([
+                                                                    'exact',
+                                                                    'is_not',
+                                                                    'icontains',
+                                                                    'not_icontains',
+                                                                    'starts_with',
+                                                                    'not_starts_with',
+                                                                    'ends_with',
+                                                                    'not_ends_with',
+                                                                    'regex',
+                                                                    'not_regex',
+                                                                    'gt',
+                                                                    'gte',
+                                                                    'lt',
+                                                                    'lte',
+                                                                    'is_set',
+                                                                    'is_not_set',
+                                                                    'is_date_exact',
+                                                                    'is_date_before',
+                                                                    'is_date_after',
+                                                                    'between',
+                                                                    'not_between',
+                                                                    'min',
+                                                                    'max',
+                                                                    'in',
+                                                                    'not_in',
+                                                                    'is_cleaned_path_exact',
+                                                                    'flag_evaluates_to',
+                                                                    'semver_eq',
+                                                                    'semver_neq',
+                                                                    'semver_gt',
+                                                                    'semver_gte',
+                                                                    'semver_lt',
+                                                                    'semver_lte',
+                                                                    'semver_tilde',
+                                                                    'semver_caret',
+                                                                    'semver_wildcard',
+                                                                    'icontains_multi',
+                                                                    'not_icontains_multi',
+                                                                ]),
+                                                                type: zod
+                                                                    .literal('person')
+                                                                    .default(
+                                                                        logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveEventFiltersOneItemTwoTypeDefault
+                                                                    )
+                                                                    .describe('Person properties'),
+                                                                value: zod
+                                                                    .union([
+                                                                        zod.array(
+                                                                            zod.union([
+                                                                                zod.string(),
+                                                                                zod.number(),
+                                                                                zod.boolean(),
+                                                                            ])
+                                                                        ),
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .optional(),
+                                                            }),
+                                                            zod.object({
+                                                                key: zod.enum(['tag_name', 'text', 'href', 'selector']),
+                                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                                operator: zod.enum([
+                                                                    'exact',
+                                                                    'is_not',
+                                                                    'icontains',
+                                                                    'not_icontains',
+                                                                    'starts_with',
+                                                                    'not_starts_with',
+                                                                    'ends_with',
+                                                                    'not_ends_with',
+                                                                    'regex',
+                                                                    'not_regex',
+                                                                    'gt',
+                                                                    'gte',
+                                                                    'lt',
+                                                                    'lte',
+                                                                    'is_set',
+                                                                    'is_not_set',
+                                                                    'is_date_exact',
+                                                                    'is_date_before',
+                                                                    'is_date_after',
+                                                                    'between',
+                                                                    'not_between',
+                                                                    'min',
+                                                                    'max',
+                                                                    'in',
+                                                                    'not_in',
+                                                                    'is_cleaned_path_exact',
+                                                                    'flag_evaluates_to',
+                                                                    'semver_eq',
+                                                                    'semver_neq',
+                                                                    'semver_gt',
+                                                                    'semver_gte',
+                                                                    'semver_lt',
+                                                                    'semver_lte',
+                                                                    'semver_tilde',
+                                                                    'semver_caret',
+                                                                    'semver_wildcard',
+                                                                    'icontains_multi',
+                                                                    'not_icontains_multi',
+                                                                ]),
+                                                                type: zod
+                                                                    .literal('element')
+                                                                    .default(
+                                                                        logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveEventFiltersOneItemThreeTypeDefault
+                                                                    ),
+                                                                value: zod
+                                                                    .union([
+                                                                        zod.array(
+                                                                            zod.union([
+                                                                                zod.string(),
+                                                                                zod.number(),
+                                                                                zod.boolean(),
+                                                                            ])
+                                                                        ),
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .optional(),
+                                                            }),
+                                                            zod.object({
+                                                                key: zod.string(),
+                                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                                operator: zod.enum([
+                                                                    'exact',
+                                                                    'is_not',
+                                                                    'icontains',
+                                                                    'not_icontains',
+                                                                    'starts_with',
+                                                                    'not_starts_with',
+                                                                    'ends_with',
+                                                                    'not_ends_with',
+                                                                    'regex',
+                                                                    'not_regex',
+                                                                    'gt',
+                                                                    'gte',
+                                                                    'lt',
+                                                                    'lte',
+                                                                    'is_set',
+                                                                    'is_not_set',
+                                                                    'is_date_exact',
+                                                                    'is_date_before',
+                                                                    'is_date_after',
+                                                                    'between',
+                                                                    'not_between',
+                                                                    'min',
+                                                                    'max',
+                                                                    'in',
+                                                                    'not_in',
+                                                                    'is_cleaned_path_exact',
+                                                                    'flag_evaluates_to',
+                                                                    'semver_eq',
+                                                                    'semver_neq',
+                                                                    'semver_gt',
+                                                                    'semver_gte',
+                                                                    'semver_lt',
+                                                                    'semver_lte',
+                                                                    'semver_tilde',
+                                                                    'semver_caret',
+                                                                    'semver_wildcard',
+                                                                    'icontains_multi',
+                                                                    'not_icontains_multi',
+                                                                ]),
+                                                                type: zod
+                                                                    .literal('feature')
+                                                                    .default(
+                                                                        logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveEventFiltersOneItemFourTypeDefault
+                                                                    )
+                                                                    .describe(
+                                                                        'Event property with \"$feature\/\" prepended'
+                                                                    ),
+                                                                value: zod
+                                                                    .union([
+                                                                        zod.array(
+                                                                            zod.union([
+                                                                                zod.string(),
+                                                                                zod.number(),
+                                                                                zod.boolean(),
+                                                                            ])
+                                                                        ),
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .optional(),
+                                                            }),
+                                                            zod.object({
+                                                                key: zod.string(),
+                                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                                type: zod
+                                                                    .literal('hogql')
+                                                                    .default(
+                                                                        logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveEventFiltersOneItemFiveTypeDefault
+                                                                    ),
+                                                                value: zod
+                                                                    .union([
+                                                                        zod.array(
+                                                                            zod.union([
+                                                                                zod.string(),
+                                                                                zod.number(),
+                                                                                zod.boolean(),
+                                                                            ])
+                                                                        ),
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .optional(),
+                                                            }),
+                                                        ])
+                                                    ),
+                                                    zod.null(),
+                                                ])
+                                                .optional()
+                                                .describe(
+                                                    'Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral\/cohort filters and groups'
+                                                ),
+                                            event_type: zod.enum(['events', 'actions']),
+                                            explicit_datetime: zod
+                                                .union([zod.string(), zod.null()])
+                                                .optional()
+                                                .describe(
+                                                    'Absolute or relative (e.g. -30d) lower date bound — alternative to time_value\/time_interval'
+                                                ),
+                                            explicit_datetime_to: zod.union([zod.string(), zod.null()]).optional(),
+                                            key: zod
+                                                .string()
+                                                .describe("Event name, or action id when event_type is 'actions'"),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
+                                            negation: zod
+                                                .union([zod.boolean(), zod.null()])
+                                                .optional()
+                                                .describe(
+                                                    'Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators'
+                                                ),
+                                            operator: zod
+                                                .union([
+                                                    zod.enum([
+                                                        'exact',
+                                                        'is_not',
+                                                        'icontains',
+                                                        'not_icontains',
+                                                        'starts_with',
+                                                        'not_starts_with',
+                                                        'ends_with',
+                                                        'not_ends_with',
+                                                        'regex',
+                                                        'not_regex',
+                                                        'gt',
+                                                        'gte',
+                                                        'lt',
+                                                        'lte',
+                                                        'is_set',
+                                                        'is_not_set',
+                                                        'is_date_exact',
+                                                        'is_date_before',
+                                                        'is_date_after',
+                                                        'between',
+                                                        'not_between',
+                                                        'min',
+                                                        'max',
+                                                        'in',
+                                                        'not_in',
+                                                        'is_cleaned_path_exact',
+                                                        'flag_evaluates_to',
+                                                        'semver_eq',
+                                                        'semver_neq',
+                                                        'semver_gt',
+                                                        'semver_gte',
+                                                        'semver_lt',
+                                                        'semver_lte',
+                                                        'semver_tilde',
+                                                        'semver_caret',
+                                                        'semver_wildcard',
+                                                        'icontains_multi',
+                                                        'not_icontains_multi',
+                                                    ]),
+                                                    zod.null(),
+                                                ])
+                                                .optional()
+                                                .describe(
+                                                    'Count comparison for performed_event_multiple, defaults to exact'
+                                                ),
+                                            operator_value: zod
+                                                .union([zod.number(), zod.null()])
+                                                .optional()
+                                                .describe('Count threshold for performed_event_multiple'),
+                                            time_interval: zod
+                                                .union([zod.enum(['day', 'week', 'month', 'year']), zod.null()])
+                                                .optional(),
+                                            time_value: zod
+                                                .union([zod.number(), zod.null()])
+                                                .optional()
+                                                .describe('Relative time window size, paired with time_interval'),
+                                            type: zod
+                                                .literal('behavioral')
+                                                .default(
+                                                    logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveTypeDefault
+                                                )
+                                                .describe(
+                                                    "Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP"
+                                                ),
+                                            value: zod.enum(['performed_event', 'performed_event_multiple']),
                                         }),
                                     ])
                                 ),

--- a/services/mcp/src/generated/marketing_analytics/api.ts
+++ b/services/mcp/src/generated/marketing_analytics/api.ts
@@ -71,6 +71,13 @@ export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneOneF
 export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneOneFixedPropertiesOneItemTwooneTypeDefault = `revenue_analytics`
 export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneOneFixedPropertiesOneItemTwotwoTypeDefault = `account_custom_property`
 export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneOneFixedPropertiesOneItemTwothreeTypeDefault = `workflow_variable`
+export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneOneFixedPropertiesOneItemTwofourEventFiltersOneItemOneOperatorDefault = `exact`
+export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneOneFixedPropertiesOneItemTwofourEventFiltersOneItemOneTypeDefault = `event`
+export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneOneFixedPropertiesOneItemTwofourEventFiltersOneItemTwoTypeDefault = `person`
+export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneOneFixedPropertiesOneItemTwofourEventFiltersOneItemThreeTypeDefault = `element`
+export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneOneFixedPropertiesOneItemTwofourEventFiltersOneItemFourTypeDefault = `feature`
+export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneOneFixedPropertiesOneItemTwofourEventFiltersOneItemFiveTypeDefault = `hogql`
+export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneOneFixedPropertiesOneItemTwofourTypeDefault = `behavioral`
 export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneOneKindDefault = `EventsNode`
 export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneOnePropertiesOneItemOneOperatorDefault = `exact`
 export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneOnePropertiesOneItemOneTypeDefault = `event`
@@ -97,6 +104,13 @@ export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneOneP
 export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneOnePropertiesOneItemTwooneTypeDefault = `revenue_analytics`
 export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneOnePropertiesOneItemTwotwoTypeDefault = `account_custom_property`
 export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneOnePropertiesOneItemTwothreeTypeDefault = `workflow_variable`
+export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneOnePropertiesOneItemTwofourEventFiltersOneItemOneOperatorDefault = `exact`
+export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneOnePropertiesOneItemTwofourEventFiltersOneItemOneTypeDefault = `event`
+export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneOnePropertiesOneItemTwofourEventFiltersOneItemTwoTypeDefault = `person`
+export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneOnePropertiesOneItemTwofourEventFiltersOneItemThreeTypeDefault = `element`
+export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneOnePropertiesOneItemTwofourEventFiltersOneItemFourTypeDefault = `feature`
+export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneOnePropertiesOneItemTwofourEventFiltersOneItemFiveTypeDefault = `hogql`
+export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneOnePropertiesOneItemTwofourTypeDefault = `behavioral`
 export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneTwoFixedPropertiesOneItemOneOperatorDefault = `exact`
 export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneTwoFixedPropertiesOneItemOneTypeDefault = `event`
 export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneTwoFixedPropertiesOneItemTwoTypeDefault = `person`
@@ -122,6 +136,13 @@ export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneTwoF
 export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneTwoFixedPropertiesOneItemTwooneTypeDefault = `revenue_analytics`
 export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneTwoFixedPropertiesOneItemTwotwoTypeDefault = `account_custom_property`
 export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneTwoFixedPropertiesOneItemTwothreeTypeDefault = `workflow_variable`
+export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneTwoFixedPropertiesOneItemTwofourEventFiltersOneItemOneOperatorDefault = `exact`
+export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneTwoFixedPropertiesOneItemTwofourEventFiltersOneItemOneTypeDefault = `event`
+export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneTwoFixedPropertiesOneItemTwofourEventFiltersOneItemTwoTypeDefault = `person`
+export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneTwoFixedPropertiesOneItemTwofourEventFiltersOneItemThreeTypeDefault = `element`
+export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneTwoFixedPropertiesOneItemTwofourEventFiltersOneItemFourTypeDefault = `feature`
+export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneTwoFixedPropertiesOneItemTwofourEventFiltersOneItemFiveTypeDefault = `hogql`
+export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneTwoFixedPropertiesOneItemTwofourTypeDefault = `behavioral`
 export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneTwoKindDefault = `ActionsNode`
 export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneTwoPropertiesOneItemOneOperatorDefault = `exact`
 export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneTwoPropertiesOneItemOneTypeDefault = `event`
@@ -148,6 +169,13 @@ export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneTwoP
 export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneTwoPropertiesOneItemTwooneTypeDefault = `revenue_analytics`
 export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneTwoPropertiesOneItemTwotwoTypeDefault = `account_custom_property`
 export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneTwoPropertiesOneItemTwothreeTypeDefault = `workflow_variable`
+export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneTwoPropertiesOneItemTwofourEventFiltersOneItemOneOperatorDefault = `exact`
+export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneTwoPropertiesOneItemTwofourEventFiltersOneItemOneTypeDefault = `event`
+export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneTwoPropertiesOneItemTwofourEventFiltersOneItemTwoTypeDefault = `person`
+export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneTwoPropertiesOneItemTwofourEventFiltersOneItemThreeTypeDefault = `element`
+export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneTwoPropertiesOneItemTwofourEventFiltersOneItemFourTypeDefault = `feature`
+export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneTwoPropertiesOneItemTwofourEventFiltersOneItemFiveTypeDefault = `hogql`
+export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneTwoPropertiesOneItemTwofourTypeDefault = `behavioral`
 export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneThreeFixedPropertiesOneItemOneOperatorDefault = `exact`
 export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneThreeFixedPropertiesOneItemOneTypeDefault = `event`
 export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneThreeFixedPropertiesOneItemTwoTypeDefault = `person`
@@ -173,6 +201,13 @@ export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneThre
 export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneThreeFixedPropertiesOneItemTwooneTypeDefault = `revenue_analytics`
 export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneThreeFixedPropertiesOneItemTwotwoTypeDefault = `account_custom_property`
 export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneThreeFixedPropertiesOneItemTwothreeTypeDefault = `workflow_variable`
+export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneThreeFixedPropertiesOneItemTwofourEventFiltersOneItemOneOperatorDefault = `exact`
+export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneThreeFixedPropertiesOneItemTwofourEventFiltersOneItemOneTypeDefault = `event`
+export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneThreeFixedPropertiesOneItemTwofourEventFiltersOneItemTwoTypeDefault = `person`
+export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneThreeFixedPropertiesOneItemTwofourEventFiltersOneItemThreeTypeDefault = `element`
+export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneThreeFixedPropertiesOneItemTwofourEventFiltersOneItemFourTypeDefault = `feature`
+export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneThreeFixedPropertiesOneItemTwofourEventFiltersOneItemFiveTypeDefault = `hogql`
+export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneThreeFixedPropertiesOneItemTwofourTypeDefault = `behavioral`
 export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneThreeKindDefault = `DataWarehouseNode`
 export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneThreePropertiesOneItemOneOperatorDefault = `exact`
 export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneThreePropertiesOneItemOneTypeDefault = `event`
@@ -199,6 +234,13 @@ export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneThre
 export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneThreePropertiesOneItemTwooneTypeDefault = `revenue_analytics`
 export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneThreePropertiesOneItemTwotwoTypeDefault = `account_custom_property`
 export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneThreePropertiesOneItemTwothreeTypeDefault = `workflow_variable`
+export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneThreePropertiesOneItemTwofourEventFiltersOneItemOneOperatorDefault = `exact`
+export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneThreePropertiesOneItemTwofourEventFiltersOneItemOneTypeDefault = `event`
+export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneThreePropertiesOneItemTwofourEventFiltersOneItemTwoTypeDefault = `person`
+export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneThreePropertiesOneItemTwofourEventFiltersOneItemThreeTypeDefault = `element`
+export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneThreePropertiesOneItemTwofourEventFiltersOneItemFourTypeDefault = `feature`
+export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneThreePropertiesOneItemTwofourEventFiltersOneItemFiveTypeDefault = `hogql`
+export const marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneThreePropertiesOneItemTwofourTypeDefault = `behavioral`
 
 export const MarketingAnalyticsConversionGoalsUpdatePartialUpdateBody = /* @__PURE__ */ zod
     .object({
@@ -1440,6 +1482,398 @@ export const MarketingAnalyticsConversionGoalsUpdatePartialUpdateBody = /* @__PU
                                                     zod.null(),
                                                 ])
                                                 .optional(),
+                                        }),
+                                        zod.object({
+                                            event_filters: zod
+                                                .union([
+                                                    zod.array(
+                                                        zod.union([
+                                                            zod.object({
+                                                                key: zod.string(),
+                                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                                operator: zod
+                                                                    .union([
+                                                                        zod.enum([
+                                                                            'exact',
+                                                                            'is_not',
+                                                                            'icontains',
+                                                                            'not_icontains',
+                                                                            'starts_with',
+                                                                            'not_starts_with',
+                                                                            'ends_with',
+                                                                            'not_ends_with',
+                                                                            'regex',
+                                                                            'not_regex',
+                                                                            'gt',
+                                                                            'gte',
+                                                                            'lt',
+                                                                            'lte',
+                                                                            'is_set',
+                                                                            'is_not_set',
+                                                                            'is_date_exact',
+                                                                            'is_date_before',
+                                                                            'is_date_after',
+                                                                            'between',
+                                                                            'not_between',
+                                                                            'min',
+                                                                            'max',
+                                                                            'in',
+                                                                            'not_in',
+                                                                            'is_cleaned_path_exact',
+                                                                            'flag_evaluates_to',
+                                                                            'semver_eq',
+                                                                            'semver_neq',
+                                                                            'semver_gt',
+                                                                            'semver_gte',
+                                                                            'semver_lt',
+                                                                            'semver_lte',
+                                                                            'semver_tilde',
+                                                                            'semver_caret',
+                                                                            'semver_wildcard',
+                                                                            'icontains_multi',
+                                                                            'not_icontains_multi',
+                                                                        ]),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .default(
+                                                                        marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneOneFixedPropertiesOneItemTwofourEventFiltersOneItemOneOperatorDefault
+                                                                    ),
+                                                                type: zod
+                                                                    .literal('event')
+                                                                    .default(
+                                                                        marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneOneFixedPropertiesOneItemTwofourEventFiltersOneItemOneTypeDefault
+                                                                    )
+                                                                    .describe('Event properties'),
+                                                                value: zod
+                                                                    .union([
+                                                                        zod.array(
+                                                                            zod.union([
+                                                                                zod.string(),
+                                                                                zod.number(),
+                                                                                zod.boolean(),
+                                                                            ])
+                                                                        ),
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .optional(),
+                                                            }),
+                                                            zod.object({
+                                                                key: zod.string(),
+                                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                                operator: zod.enum([
+                                                                    'exact',
+                                                                    'is_not',
+                                                                    'icontains',
+                                                                    'not_icontains',
+                                                                    'starts_with',
+                                                                    'not_starts_with',
+                                                                    'ends_with',
+                                                                    'not_ends_with',
+                                                                    'regex',
+                                                                    'not_regex',
+                                                                    'gt',
+                                                                    'gte',
+                                                                    'lt',
+                                                                    'lte',
+                                                                    'is_set',
+                                                                    'is_not_set',
+                                                                    'is_date_exact',
+                                                                    'is_date_before',
+                                                                    'is_date_after',
+                                                                    'between',
+                                                                    'not_between',
+                                                                    'min',
+                                                                    'max',
+                                                                    'in',
+                                                                    'not_in',
+                                                                    'is_cleaned_path_exact',
+                                                                    'flag_evaluates_to',
+                                                                    'semver_eq',
+                                                                    'semver_neq',
+                                                                    'semver_gt',
+                                                                    'semver_gte',
+                                                                    'semver_lt',
+                                                                    'semver_lte',
+                                                                    'semver_tilde',
+                                                                    'semver_caret',
+                                                                    'semver_wildcard',
+                                                                    'icontains_multi',
+                                                                    'not_icontains_multi',
+                                                                ]),
+                                                                type: zod
+                                                                    .literal('person')
+                                                                    .default(
+                                                                        marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneOneFixedPropertiesOneItemTwofourEventFiltersOneItemTwoTypeDefault
+                                                                    )
+                                                                    .describe('Person properties'),
+                                                                value: zod
+                                                                    .union([
+                                                                        zod.array(
+                                                                            zod.union([
+                                                                                zod.string(),
+                                                                                zod.number(),
+                                                                                zod.boolean(),
+                                                                            ])
+                                                                        ),
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .optional(),
+                                                            }),
+                                                            zod.object({
+                                                                key: zod.enum(['tag_name', 'text', 'href', 'selector']),
+                                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                                operator: zod.enum([
+                                                                    'exact',
+                                                                    'is_not',
+                                                                    'icontains',
+                                                                    'not_icontains',
+                                                                    'starts_with',
+                                                                    'not_starts_with',
+                                                                    'ends_with',
+                                                                    'not_ends_with',
+                                                                    'regex',
+                                                                    'not_regex',
+                                                                    'gt',
+                                                                    'gte',
+                                                                    'lt',
+                                                                    'lte',
+                                                                    'is_set',
+                                                                    'is_not_set',
+                                                                    'is_date_exact',
+                                                                    'is_date_before',
+                                                                    'is_date_after',
+                                                                    'between',
+                                                                    'not_between',
+                                                                    'min',
+                                                                    'max',
+                                                                    'in',
+                                                                    'not_in',
+                                                                    'is_cleaned_path_exact',
+                                                                    'flag_evaluates_to',
+                                                                    'semver_eq',
+                                                                    'semver_neq',
+                                                                    'semver_gt',
+                                                                    'semver_gte',
+                                                                    'semver_lt',
+                                                                    'semver_lte',
+                                                                    'semver_tilde',
+                                                                    'semver_caret',
+                                                                    'semver_wildcard',
+                                                                    'icontains_multi',
+                                                                    'not_icontains_multi',
+                                                                ]),
+                                                                type: zod
+                                                                    .literal('element')
+                                                                    .default(
+                                                                        marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneOneFixedPropertiesOneItemTwofourEventFiltersOneItemThreeTypeDefault
+                                                                    ),
+                                                                value: zod
+                                                                    .union([
+                                                                        zod.array(
+                                                                            zod.union([
+                                                                                zod.string(),
+                                                                                zod.number(),
+                                                                                zod.boolean(),
+                                                                            ])
+                                                                        ),
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .optional(),
+                                                            }),
+                                                            zod.object({
+                                                                key: zod.string(),
+                                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                                operator: zod.enum([
+                                                                    'exact',
+                                                                    'is_not',
+                                                                    'icontains',
+                                                                    'not_icontains',
+                                                                    'starts_with',
+                                                                    'not_starts_with',
+                                                                    'ends_with',
+                                                                    'not_ends_with',
+                                                                    'regex',
+                                                                    'not_regex',
+                                                                    'gt',
+                                                                    'gte',
+                                                                    'lt',
+                                                                    'lte',
+                                                                    'is_set',
+                                                                    'is_not_set',
+                                                                    'is_date_exact',
+                                                                    'is_date_before',
+                                                                    'is_date_after',
+                                                                    'between',
+                                                                    'not_between',
+                                                                    'min',
+                                                                    'max',
+                                                                    'in',
+                                                                    'not_in',
+                                                                    'is_cleaned_path_exact',
+                                                                    'flag_evaluates_to',
+                                                                    'semver_eq',
+                                                                    'semver_neq',
+                                                                    'semver_gt',
+                                                                    'semver_gte',
+                                                                    'semver_lt',
+                                                                    'semver_lte',
+                                                                    'semver_tilde',
+                                                                    'semver_caret',
+                                                                    'semver_wildcard',
+                                                                    'icontains_multi',
+                                                                    'not_icontains_multi',
+                                                                ]),
+                                                                type: zod
+                                                                    .literal('feature')
+                                                                    .default(
+                                                                        marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneOneFixedPropertiesOneItemTwofourEventFiltersOneItemFourTypeDefault
+                                                                    )
+                                                                    .describe(
+                                                                        'Event property with \"$feature\/\" prepended'
+                                                                    ),
+                                                                value: zod
+                                                                    .union([
+                                                                        zod.array(
+                                                                            zod.union([
+                                                                                zod.string(),
+                                                                                zod.number(),
+                                                                                zod.boolean(),
+                                                                            ])
+                                                                        ),
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .optional(),
+                                                            }),
+                                                            zod.object({
+                                                                key: zod.string(),
+                                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                                type: zod
+                                                                    .literal('hogql')
+                                                                    .default(
+                                                                        marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneOneFixedPropertiesOneItemTwofourEventFiltersOneItemFiveTypeDefault
+                                                                    ),
+                                                                value: zod
+                                                                    .union([
+                                                                        zod.array(
+                                                                            zod.union([
+                                                                                zod.string(),
+                                                                                zod.number(),
+                                                                                zod.boolean(),
+                                                                            ])
+                                                                        ),
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .optional(),
+                                                            }),
+                                                        ])
+                                                    ),
+                                                    zod.null(),
+                                                ])
+                                                .optional()
+                                                .describe(
+                                                    'Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral\/cohort filters and groups'
+                                                ),
+                                            event_type: zod.enum(['events', 'actions']),
+                                            explicit_datetime: zod
+                                                .union([zod.string(), zod.null()])
+                                                .optional()
+                                                .describe(
+                                                    'Absolute or relative (e.g. -30d) lower date bound — alternative to time_value\/time_interval'
+                                                ),
+                                            explicit_datetime_to: zod.union([zod.string(), zod.null()]).optional(),
+                                            key: zod
+                                                .string()
+                                                .describe("Event name, or action id when event_type is 'actions'"),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
+                                            negation: zod
+                                                .union([zod.boolean(), zod.null()])
+                                                .optional()
+                                                .describe(
+                                                    'Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators'
+                                                ),
+                                            operator: zod
+                                                .union([
+                                                    zod.enum([
+                                                        'exact',
+                                                        'is_not',
+                                                        'icontains',
+                                                        'not_icontains',
+                                                        'starts_with',
+                                                        'not_starts_with',
+                                                        'ends_with',
+                                                        'not_ends_with',
+                                                        'regex',
+                                                        'not_regex',
+                                                        'gt',
+                                                        'gte',
+                                                        'lt',
+                                                        'lte',
+                                                        'is_set',
+                                                        'is_not_set',
+                                                        'is_date_exact',
+                                                        'is_date_before',
+                                                        'is_date_after',
+                                                        'between',
+                                                        'not_between',
+                                                        'min',
+                                                        'max',
+                                                        'in',
+                                                        'not_in',
+                                                        'is_cleaned_path_exact',
+                                                        'flag_evaluates_to',
+                                                        'semver_eq',
+                                                        'semver_neq',
+                                                        'semver_gt',
+                                                        'semver_gte',
+                                                        'semver_lt',
+                                                        'semver_lte',
+                                                        'semver_tilde',
+                                                        'semver_caret',
+                                                        'semver_wildcard',
+                                                        'icontains_multi',
+                                                        'not_icontains_multi',
+                                                    ]),
+                                                    zod.null(),
+                                                ])
+                                                .optional()
+                                                .describe(
+                                                    'Count comparison for performed_event_multiple, defaults to exact'
+                                                ),
+                                            operator_value: zod
+                                                .union([zod.number(), zod.null()])
+                                                .optional()
+                                                .describe('Count threshold for performed_event_multiple'),
+                                            time_interval: zod
+                                                .union([zod.enum(['day', 'week', 'month', 'year']), zod.null()])
+                                                .optional(),
+                                            time_value: zod
+                                                .union([zod.number(), zod.null()])
+                                                .optional()
+                                                .describe('Relative time window size, paired with time_interval'),
+                                            type: zod
+                                                .literal('behavioral')
+                                                .default(
+                                                    marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneOneFixedPropertiesOneItemTwofourTypeDefault
+                                                )
+                                                .describe(
+                                                    "Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP"
+                                                ),
+                                            value: zod.enum(['performed_event', 'performed_event_multiple']),
                                         }),
                                     ])
                                 ),
@@ -2905,6 +3339,398 @@ export const MarketingAnalyticsConversionGoalsUpdatePartialUpdateBody = /* @__PU
                                                 ])
                                                 .optional(),
                                         }),
+                                        zod.object({
+                                            event_filters: zod
+                                                .union([
+                                                    zod.array(
+                                                        zod.union([
+                                                            zod.object({
+                                                                key: zod.string(),
+                                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                                operator: zod
+                                                                    .union([
+                                                                        zod.enum([
+                                                                            'exact',
+                                                                            'is_not',
+                                                                            'icontains',
+                                                                            'not_icontains',
+                                                                            'starts_with',
+                                                                            'not_starts_with',
+                                                                            'ends_with',
+                                                                            'not_ends_with',
+                                                                            'regex',
+                                                                            'not_regex',
+                                                                            'gt',
+                                                                            'gte',
+                                                                            'lt',
+                                                                            'lte',
+                                                                            'is_set',
+                                                                            'is_not_set',
+                                                                            'is_date_exact',
+                                                                            'is_date_before',
+                                                                            'is_date_after',
+                                                                            'between',
+                                                                            'not_between',
+                                                                            'min',
+                                                                            'max',
+                                                                            'in',
+                                                                            'not_in',
+                                                                            'is_cleaned_path_exact',
+                                                                            'flag_evaluates_to',
+                                                                            'semver_eq',
+                                                                            'semver_neq',
+                                                                            'semver_gt',
+                                                                            'semver_gte',
+                                                                            'semver_lt',
+                                                                            'semver_lte',
+                                                                            'semver_tilde',
+                                                                            'semver_caret',
+                                                                            'semver_wildcard',
+                                                                            'icontains_multi',
+                                                                            'not_icontains_multi',
+                                                                        ]),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .default(
+                                                                        marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneOnePropertiesOneItemTwofourEventFiltersOneItemOneOperatorDefault
+                                                                    ),
+                                                                type: zod
+                                                                    .literal('event')
+                                                                    .default(
+                                                                        marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneOnePropertiesOneItemTwofourEventFiltersOneItemOneTypeDefault
+                                                                    )
+                                                                    .describe('Event properties'),
+                                                                value: zod
+                                                                    .union([
+                                                                        zod.array(
+                                                                            zod.union([
+                                                                                zod.string(),
+                                                                                zod.number(),
+                                                                                zod.boolean(),
+                                                                            ])
+                                                                        ),
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .optional(),
+                                                            }),
+                                                            zod.object({
+                                                                key: zod.string(),
+                                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                                operator: zod.enum([
+                                                                    'exact',
+                                                                    'is_not',
+                                                                    'icontains',
+                                                                    'not_icontains',
+                                                                    'starts_with',
+                                                                    'not_starts_with',
+                                                                    'ends_with',
+                                                                    'not_ends_with',
+                                                                    'regex',
+                                                                    'not_regex',
+                                                                    'gt',
+                                                                    'gte',
+                                                                    'lt',
+                                                                    'lte',
+                                                                    'is_set',
+                                                                    'is_not_set',
+                                                                    'is_date_exact',
+                                                                    'is_date_before',
+                                                                    'is_date_after',
+                                                                    'between',
+                                                                    'not_between',
+                                                                    'min',
+                                                                    'max',
+                                                                    'in',
+                                                                    'not_in',
+                                                                    'is_cleaned_path_exact',
+                                                                    'flag_evaluates_to',
+                                                                    'semver_eq',
+                                                                    'semver_neq',
+                                                                    'semver_gt',
+                                                                    'semver_gte',
+                                                                    'semver_lt',
+                                                                    'semver_lte',
+                                                                    'semver_tilde',
+                                                                    'semver_caret',
+                                                                    'semver_wildcard',
+                                                                    'icontains_multi',
+                                                                    'not_icontains_multi',
+                                                                ]),
+                                                                type: zod
+                                                                    .literal('person')
+                                                                    .default(
+                                                                        marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneOnePropertiesOneItemTwofourEventFiltersOneItemTwoTypeDefault
+                                                                    )
+                                                                    .describe('Person properties'),
+                                                                value: zod
+                                                                    .union([
+                                                                        zod.array(
+                                                                            zod.union([
+                                                                                zod.string(),
+                                                                                zod.number(),
+                                                                                zod.boolean(),
+                                                                            ])
+                                                                        ),
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .optional(),
+                                                            }),
+                                                            zod.object({
+                                                                key: zod.enum(['tag_name', 'text', 'href', 'selector']),
+                                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                                operator: zod.enum([
+                                                                    'exact',
+                                                                    'is_not',
+                                                                    'icontains',
+                                                                    'not_icontains',
+                                                                    'starts_with',
+                                                                    'not_starts_with',
+                                                                    'ends_with',
+                                                                    'not_ends_with',
+                                                                    'regex',
+                                                                    'not_regex',
+                                                                    'gt',
+                                                                    'gte',
+                                                                    'lt',
+                                                                    'lte',
+                                                                    'is_set',
+                                                                    'is_not_set',
+                                                                    'is_date_exact',
+                                                                    'is_date_before',
+                                                                    'is_date_after',
+                                                                    'between',
+                                                                    'not_between',
+                                                                    'min',
+                                                                    'max',
+                                                                    'in',
+                                                                    'not_in',
+                                                                    'is_cleaned_path_exact',
+                                                                    'flag_evaluates_to',
+                                                                    'semver_eq',
+                                                                    'semver_neq',
+                                                                    'semver_gt',
+                                                                    'semver_gte',
+                                                                    'semver_lt',
+                                                                    'semver_lte',
+                                                                    'semver_tilde',
+                                                                    'semver_caret',
+                                                                    'semver_wildcard',
+                                                                    'icontains_multi',
+                                                                    'not_icontains_multi',
+                                                                ]),
+                                                                type: zod
+                                                                    .literal('element')
+                                                                    .default(
+                                                                        marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneOnePropertiesOneItemTwofourEventFiltersOneItemThreeTypeDefault
+                                                                    ),
+                                                                value: zod
+                                                                    .union([
+                                                                        zod.array(
+                                                                            zod.union([
+                                                                                zod.string(),
+                                                                                zod.number(),
+                                                                                zod.boolean(),
+                                                                            ])
+                                                                        ),
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .optional(),
+                                                            }),
+                                                            zod.object({
+                                                                key: zod.string(),
+                                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                                operator: zod.enum([
+                                                                    'exact',
+                                                                    'is_not',
+                                                                    'icontains',
+                                                                    'not_icontains',
+                                                                    'starts_with',
+                                                                    'not_starts_with',
+                                                                    'ends_with',
+                                                                    'not_ends_with',
+                                                                    'regex',
+                                                                    'not_regex',
+                                                                    'gt',
+                                                                    'gte',
+                                                                    'lt',
+                                                                    'lte',
+                                                                    'is_set',
+                                                                    'is_not_set',
+                                                                    'is_date_exact',
+                                                                    'is_date_before',
+                                                                    'is_date_after',
+                                                                    'between',
+                                                                    'not_between',
+                                                                    'min',
+                                                                    'max',
+                                                                    'in',
+                                                                    'not_in',
+                                                                    'is_cleaned_path_exact',
+                                                                    'flag_evaluates_to',
+                                                                    'semver_eq',
+                                                                    'semver_neq',
+                                                                    'semver_gt',
+                                                                    'semver_gte',
+                                                                    'semver_lt',
+                                                                    'semver_lte',
+                                                                    'semver_tilde',
+                                                                    'semver_caret',
+                                                                    'semver_wildcard',
+                                                                    'icontains_multi',
+                                                                    'not_icontains_multi',
+                                                                ]),
+                                                                type: zod
+                                                                    .literal('feature')
+                                                                    .default(
+                                                                        marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneOnePropertiesOneItemTwofourEventFiltersOneItemFourTypeDefault
+                                                                    )
+                                                                    .describe(
+                                                                        'Event property with \"$feature\/\" prepended'
+                                                                    ),
+                                                                value: zod
+                                                                    .union([
+                                                                        zod.array(
+                                                                            zod.union([
+                                                                                zod.string(),
+                                                                                zod.number(),
+                                                                                zod.boolean(),
+                                                                            ])
+                                                                        ),
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .optional(),
+                                                            }),
+                                                            zod.object({
+                                                                key: zod.string(),
+                                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                                type: zod
+                                                                    .literal('hogql')
+                                                                    .default(
+                                                                        marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneOnePropertiesOneItemTwofourEventFiltersOneItemFiveTypeDefault
+                                                                    ),
+                                                                value: zod
+                                                                    .union([
+                                                                        zod.array(
+                                                                            zod.union([
+                                                                                zod.string(),
+                                                                                zod.number(),
+                                                                                zod.boolean(),
+                                                                            ])
+                                                                        ),
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .optional(),
+                                                            }),
+                                                        ])
+                                                    ),
+                                                    zod.null(),
+                                                ])
+                                                .optional()
+                                                .describe(
+                                                    'Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral\/cohort filters and groups'
+                                                ),
+                                            event_type: zod.enum(['events', 'actions']),
+                                            explicit_datetime: zod
+                                                .union([zod.string(), zod.null()])
+                                                .optional()
+                                                .describe(
+                                                    'Absolute or relative (e.g. -30d) lower date bound — alternative to time_value\/time_interval'
+                                                ),
+                                            explicit_datetime_to: zod.union([zod.string(), zod.null()]).optional(),
+                                            key: zod
+                                                .string()
+                                                .describe("Event name, or action id when event_type is 'actions'"),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
+                                            negation: zod
+                                                .union([zod.boolean(), zod.null()])
+                                                .optional()
+                                                .describe(
+                                                    'Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators'
+                                                ),
+                                            operator: zod
+                                                .union([
+                                                    zod.enum([
+                                                        'exact',
+                                                        'is_not',
+                                                        'icontains',
+                                                        'not_icontains',
+                                                        'starts_with',
+                                                        'not_starts_with',
+                                                        'ends_with',
+                                                        'not_ends_with',
+                                                        'regex',
+                                                        'not_regex',
+                                                        'gt',
+                                                        'gte',
+                                                        'lt',
+                                                        'lte',
+                                                        'is_set',
+                                                        'is_not_set',
+                                                        'is_date_exact',
+                                                        'is_date_before',
+                                                        'is_date_after',
+                                                        'between',
+                                                        'not_between',
+                                                        'min',
+                                                        'max',
+                                                        'in',
+                                                        'not_in',
+                                                        'is_cleaned_path_exact',
+                                                        'flag_evaluates_to',
+                                                        'semver_eq',
+                                                        'semver_neq',
+                                                        'semver_gt',
+                                                        'semver_gte',
+                                                        'semver_lt',
+                                                        'semver_lte',
+                                                        'semver_tilde',
+                                                        'semver_caret',
+                                                        'semver_wildcard',
+                                                        'icontains_multi',
+                                                        'not_icontains_multi',
+                                                    ]),
+                                                    zod.null(),
+                                                ])
+                                                .optional()
+                                                .describe(
+                                                    'Count comparison for performed_event_multiple, defaults to exact'
+                                                ),
+                                            operator_value: zod
+                                                .union([zod.number(), zod.null()])
+                                                .optional()
+                                                .describe('Count threshold for performed_event_multiple'),
+                                            time_interval: zod
+                                                .union([zod.enum(['day', 'week', 'month', 'year']), zod.null()])
+                                                .optional(),
+                                            time_value: zod
+                                                .union([zod.number(), zod.null()])
+                                                .optional()
+                                                .describe('Relative time window size, paired with time_interval'),
+                                            type: zod
+                                                .literal('behavioral')
+                                                .default(
+                                                    marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneOnePropertiesOneItemTwofourTypeDefault
+                                                )
+                                                .describe(
+                                                    "Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP"
+                                                ),
+                                            value: zod.enum(['performed_event', 'performed_event_multiple']),
+                                        }),
                                     ])
                                 ),
                                 zod.null(),
@@ -4154,6 +4980,398 @@ export const MarketingAnalyticsConversionGoalsUpdatePartialUpdateBody = /* @__PU
                                                     zod.null(),
                                                 ])
                                                 .optional(),
+                                        }),
+                                        zod.object({
+                                            event_filters: zod
+                                                .union([
+                                                    zod.array(
+                                                        zod.union([
+                                                            zod.object({
+                                                                key: zod.string(),
+                                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                                operator: zod
+                                                                    .union([
+                                                                        zod.enum([
+                                                                            'exact',
+                                                                            'is_not',
+                                                                            'icontains',
+                                                                            'not_icontains',
+                                                                            'starts_with',
+                                                                            'not_starts_with',
+                                                                            'ends_with',
+                                                                            'not_ends_with',
+                                                                            'regex',
+                                                                            'not_regex',
+                                                                            'gt',
+                                                                            'gte',
+                                                                            'lt',
+                                                                            'lte',
+                                                                            'is_set',
+                                                                            'is_not_set',
+                                                                            'is_date_exact',
+                                                                            'is_date_before',
+                                                                            'is_date_after',
+                                                                            'between',
+                                                                            'not_between',
+                                                                            'min',
+                                                                            'max',
+                                                                            'in',
+                                                                            'not_in',
+                                                                            'is_cleaned_path_exact',
+                                                                            'flag_evaluates_to',
+                                                                            'semver_eq',
+                                                                            'semver_neq',
+                                                                            'semver_gt',
+                                                                            'semver_gte',
+                                                                            'semver_lt',
+                                                                            'semver_lte',
+                                                                            'semver_tilde',
+                                                                            'semver_caret',
+                                                                            'semver_wildcard',
+                                                                            'icontains_multi',
+                                                                            'not_icontains_multi',
+                                                                        ]),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .default(
+                                                                        marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneTwoFixedPropertiesOneItemTwofourEventFiltersOneItemOneOperatorDefault
+                                                                    ),
+                                                                type: zod
+                                                                    .literal('event')
+                                                                    .default(
+                                                                        marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneTwoFixedPropertiesOneItemTwofourEventFiltersOneItemOneTypeDefault
+                                                                    )
+                                                                    .describe('Event properties'),
+                                                                value: zod
+                                                                    .union([
+                                                                        zod.array(
+                                                                            zod.union([
+                                                                                zod.string(),
+                                                                                zod.number(),
+                                                                                zod.boolean(),
+                                                                            ])
+                                                                        ),
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .optional(),
+                                                            }),
+                                                            zod.object({
+                                                                key: zod.string(),
+                                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                                operator: zod.enum([
+                                                                    'exact',
+                                                                    'is_not',
+                                                                    'icontains',
+                                                                    'not_icontains',
+                                                                    'starts_with',
+                                                                    'not_starts_with',
+                                                                    'ends_with',
+                                                                    'not_ends_with',
+                                                                    'regex',
+                                                                    'not_regex',
+                                                                    'gt',
+                                                                    'gte',
+                                                                    'lt',
+                                                                    'lte',
+                                                                    'is_set',
+                                                                    'is_not_set',
+                                                                    'is_date_exact',
+                                                                    'is_date_before',
+                                                                    'is_date_after',
+                                                                    'between',
+                                                                    'not_between',
+                                                                    'min',
+                                                                    'max',
+                                                                    'in',
+                                                                    'not_in',
+                                                                    'is_cleaned_path_exact',
+                                                                    'flag_evaluates_to',
+                                                                    'semver_eq',
+                                                                    'semver_neq',
+                                                                    'semver_gt',
+                                                                    'semver_gte',
+                                                                    'semver_lt',
+                                                                    'semver_lte',
+                                                                    'semver_tilde',
+                                                                    'semver_caret',
+                                                                    'semver_wildcard',
+                                                                    'icontains_multi',
+                                                                    'not_icontains_multi',
+                                                                ]),
+                                                                type: zod
+                                                                    .literal('person')
+                                                                    .default(
+                                                                        marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneTwoFixedPropertiesOneItemTwofourEventFiltersOneItemTwoTypeDefault
+                                                                    )
+                                                                    .describe('Person properties'),
+                                                                value: zod
+                                                                    .union([
+                                                                        zod.array(
+                                                                            zod.union([
+                                                                                zod.string(),
+                                                                                zod.number(),
+                                                                                zod.boolean(),
+                                                                            ])
+                                                                        ),
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .optional(),
+                                                            }),
+                                                            zod.object({
+                                                                key: zod.enum(['tag_name', 'text', 'href', 'selector']),
+                                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                                operator: zod.enum([
+                                                                    'exact',
+                                                                    'is_not',
+                                                                    'icontains',
+                                                                    'not_icontains',
+                                                                    'starts_with',
+                                                                    'not_starts_with',
+                                                                    'ends_with',
+                                                                    'not_ends_with',
+                                                                    'regex',
+                                                                    'not_regex',
+                                                                    'gt',
+                                                                    'gte',
+                                                                    'lt',
+                                                                    'lte',
+                                                                    'is_set',
+                                                                    'is_not_set',
+                                                                    'is_date_exact',
+                                                                    'is_date_before',
+                                                                    'is_date_after',
+                                                                    'between',
+                                                                    'not_between',
+                                                                    'min',
+                                                                    'max',
+                                                                    'in',
+                                                                    'not_in',
+                                                                    'is_cleaned_path_exact',
+                                                                    'flag_evaluates_to',
+                                                                    'semver_eq',
+                                                                    'semver_neq',
+                                                                    'semver_gt',
+                                                                    'semver_gte',
+                                                                    'semver_lt',
+                                                                    'semver_lte',
+                                                                    'semver_tilde',
+                                                                    'semver_caret',
+                                                                    'semver_wildcard',
+                                                                    'icontains_multi',
+                                                                    'not_icontains_multi',
+                                                                ]),
+                                                                type: zod
+                                                                    .literal('element')
+                                                                    .default(
+                                                                        marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneTwoFixedPropertiesOneItemTwofourEventFiltersOneItemThreeTypeDefault
+                                                                    ),
+                                                                value: zod
+                                                                    .union([
+                                                                        zod.array(
+                                                                            zod.union([
+                                                                                zod.string(),
+                                                                                zod.number(),
+                                                                                zod.boolean(),
+                                                                            ])
+                                                                        ),
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .optional(),
+                                                            }),
+                                                            zod.object({
+                                                                key: zod.string(),
+                                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                                operator: zod.enum([
+                                                                    'exact',
+                                                                    'is_not',
+                                                                    'icontains',
+                                                                    'not_icontains',
+                                                                    'starts_with',
+                                                                    'not_starts_with',
+                                                                    'ends_with',
+                                                                    'not_ends_with',
+                                                                    'regex',
+                                                                    'not_regex',
+                                                                    'gt',
+                                                                    'gte',
+                                                                    'lt',
+                                                                    'lte',
+                                                                    'is_set',
+                                                                    'is_not_set',
+                                                                    'is_date_exact',
+                                                                    'is_date_before',
+                                                                    'is_date_after',
+                                                                    'between',
+                                                                    'not_between',
+                                                                    'min',
+                                                                    'max',
+                                                                    'in',
+                                                                    'not_in',
+                                                                    'is_cleaned_path_exact',
+                                                                    'flag_evaluates_to',
+                                                                    'semver_eq',
+                                                                    'semver_neq',
+                                                                    'semver_gt',
+                                                                    'semver_gte',
+                                                                    'semver_lt',
+                                                                    'semver_lte',
+                                                                    'semver_tilde',
+                                                                    'semver_caret',
+                                                                    'semver_wildcard',
+                                                                    'icontains_multi',
+                                                                    'not_icontains_multi',
+                                                                ]),
+                                                                type: zod
+                                                                    .literal('feature')
+                                                                    .default(
+                                                                        marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneTwoFixedPropertiesOneItemTwofourEventFiltersOneItemFourTypeDefault
+                                                                    )
+                                                                    .describe(
+                                                                        'Event property with \"$feature\/\" prepended'
+                                                                    ),
+                                                                value: zod
+                                                                    .union([
+                                                                        zod.array(
+                                                                            zod.union([
+                                                                                zod.string(),
+                                                                                zod.number(),
+                                                                                zod.boolean(),
+                                                                            ])
+                                                                        ),
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .optional(),
+                                                            }),
+                                                            zod.object({
+                                                                key: zod.string(),
+                                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                                type: zod
+                                                                    .literal('hogql')
+                                                                    .default(
+                                                                        marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneTwoFixedPropertiesOneItemTwofourEventFiltersOneItemFiveTypeDefault
+                                                                    ),
+                                                                value: zod
+                                                                    .union([
+                                                                        zod.array(
+                                                                            zod.union([
+                                                                                zod.string(),
+                                                                                zod.number(),
+                                                                                zod.boolean(),
+                                                                            ])
+                                                                        ),
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .optional(),
+                                                            }),
+                                                        ])
+                                                    ),
+                                                    zod.null(),
+                                                ])
+                                                .optional()
+                                                .describe(
+                                                    'Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral\/cohort filters and groups'
+                                                ),
+                                            event_type: zod.enum(['events', 'actions']),
+                                            explicit_datetime: zod
+                                                .union([zod.string(), zod.null()])
+                                                .optional()
+                                                .describe(
+                                                    'Absolute or relative (e.g. -30d) lower date bound — alternative to time_value\/time_interval'
+                                                ),
+                                            explicit_datetime_to: zod.union([zod.string(), zod.null()]).optional(),
+                                            key: zod
+                                                .string()
+                                                .describe("Event name, or action id when event_type is 'actions'"),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
+                                            negation: zod
+                                                .union([zod.boolean(), zod.null()])
+                                                .optional()
+                                                .describe(
+                                                    'Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators'
+                                                ),
+                                            operator: zod
+                                                .union([
+                                                    zod.enum([
+                                                        'exact',
+                                                        'is_not',
+                                                        'icontains',
+                                                        'not_icontains',
+                                                        'starts_with',
+                                                        'not_starts_with',
+                                                        'ends_with',
+                                                        'not_ends_with',
+                                                        'regex',
+                                                        'not_regex',
+                                                        'gt',
+                                                        'gte',
+                                                        'lt',
+                                                        'lte',
+                                                        'is_set',
+                                                        'is_not_set',
+                                                        'is_date_exact',
+                                                        'is_date_before',
+                                                        'is_date_after',
+                                                        'between',
+                                                        'not_between',
+                                                        'min',
+                                                        'max',
+                                                        'in',
+                                                        'not_in',
+                                                        'is_cleaned_path_exact',
+                                                        'flag_evaluates_to',
+                                                        'semver_eq',
+                                                        'semver_neq',
+                                                        'semver_gt',
+                                                        'semver_gte',
+                                                        'semver_lt',
+                                                        'semver_lte',
+                                                        'semver_tilde',
+                                                        'semver_caret',
+                                                        'semver_wildcard',
+                                                        'icontains_multi',
+                                                        'not_icontains_multi',
+                                                    ]),
+                                                    zod.null(),
+                                                ])
+                                                .optional()
+                                                .describe(
+                                                    'Count comparison for performed_event_multiple, defaults to exact'
+                                                ),
+                                            operator_value: zod
+                                                .union([zod.number(), zod.null()])
+                                                .optional()
+                                                .describe('Count threshold for performed_event_multiple'),
+                                            time_interval: zod
+                                                .union([zod.enum(['day', 'week', 'month', 'year']), zod.null()])
+                                                .optional(),
+                                            time_value: zod
+                                                .union([zod.number(), zod.null()])
+                                                .optional()
+                                                .describe('Relative time window size, paired with time_interval'),
+                                            type: zod
+                                                .literal('behavioral')
+                                                .default(
+                                                    marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneTwoFixedPropertiesOneItemTwofourTypeDefault
+                                                )
+                                                .describe(
+                                                    "Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP"
+                                                ),
+                                            value: zod.enum(['performed_event', 'performed_event_multiple']),
                                         }),
                                     ])
                                 ),
@@ -5618,6 +6836,398 @@ export const MarketingAnalyticsConversionGoalsUpdatePartialUpdateBody = /* @__PU
                                                 ])
                                                 .optional(),
                                         }),
+                                        zod.object({
+                                            event_filters: zod
+                                                .union([
+                                                    zod.array(
+                                                        zod.union([
+                                                            zod.object({
+                                                                key: zod.string(),
+                                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                                operator: zod
+                                                                    .union([
+                                                                        zod.enum([
+                                                                            'exact',
+                                                                            'is_not',
+                                                                            'icontains',
+                                                                            'not_icontains',
+                                                                            'starts_with',
+                                                                            'not_starts_with',
+                                                                            'ends_with',
+                                                                            'not_ends_with',
+                                                                            'regex',
+                                                                            'not_regex',
+                                                                            'gt',
+                                                                            'gte',
+                                                                            'lt',
+                                                                            'lte',
+                                                                            'is_set',
+                                                                            'is_not_set',
+                                                                            'is_date_exact',
+                                                                            'is_date_before',
+                                                                            'is_date_after',
+                                                                            'between',
+                                                                            'not_between',
+                                                                            'min',
+                                                                            'max',
+                                                                            'in',
+                                                                            'not_in',
+                                                                            'is_cleaned_path_exact',
+                                                                            'flag_evaluates_to',
+                                                                            'semver_eq',
+                                                                            'semver_neq',
+                                                                            'semver_gt',
+                                                                            'semver_gte',
+                                                                            'semver_lt',
+                                                                            'semver_lte',
+                                                                            'semver_tilde',
+                                                                            'semver_caret',
+                                                                            'semver_wildcard',
+                                                                            'icontains_multi',
+                                                                            'not_icontains_multi',
+                                                                        ]),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .default(
+                                                                        marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneTwoPropertiesOneItemTwofourEventFiltersOneItemOneOperatorDefault
+                                                                    ),
+                                                                type: zod
+                                                                    .literal('event')
+                                                                    .default(
+                                                                        marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneTwoPropertiesOneItemTwofourEventFiltersOneItemOneTypeDefault
+                                                                    )
+                                                                    .describe('Event properties'),
+                                                                value: zod
+                                                                    .union([
+                                                                        zod.array(
+                                                                            zod.union([
+                                                                                zod.string(),
+                                                                                zod.number(),
+                                                                                zod.boolean(),
+                                                                            ])
+                                                                        ),
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .optional(),
+                                                            }),
+                                                            zod.object({
+                                                                key: zod.string(),
+                                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                                operator: zod.enum([
+                                                                    'exact',
+                                                                    'is_not',
+                                                                    'icontains',
+                                                                    'not_icontains',
+                                                                    'starts_with',
+                                                                    'not_starts_with',
+                                                                    'ends_with',
+                                                                    'not_ends_with',
+                                                                    'regex',
+                                                                    'not_regex',
+                                                                    'gt',
+                                                                    'gte',
+                                                                    'lt',
+                                                                    'lte',
+                                                                    'is_set',
+                                                                    'is_not_set',
+                                                                    'is_date_exact',
+                                                                    'is_date_before',
+                                                                    'is_date_after',
+                                                                    'between',
+                                                                    'not_between',
+                                                                    'min',
+                                                                    'max',
+                                                                    'in',
+                                                                    'not_in',
+                                                                    'is_cleaned_path_exact',
+                                                                    'flag_evaluates_to',
+                                                                    'semver_eq',
+                                                                    'semver_neq',
+                                                                    'semver_gt',
+                                                                    'semver_gte',
+                                                                    'semver_lt',
+                                                                    'semver_lte',
+                                                                    'semver_tilde',
+                                                                    'semver_caret',
+                                                                    'semver_wildcard',
+                                                                    'icontains_multi',
+                                                                    'not_icontains_multi',
+                                                                ]),
+                                                                type: zod
+                                                                    .literal('person')
+                                                                    .default(
+                                                                        marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneTwoPropertiesOneItemTwofourEventFiltersOneItemTwoTypeDefault
+                                                                    )
+                                                                    .describe('Person properties'),
+                                                                value: zod
+                                                                    .union([
+                                                                        zod.array(
+                                                                            zod.union([
+                                                                                zod.string(),
+                                                                                zod.number(),
+                                                                                zod.boolean(),
+                                                                            ])
+                                                                        ),
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .optional(),
+                                                            }),
+                                                            zod.object({
+                                                                key: zod.enum(['tag_name', 'text', 'href', 'selector']),
+                                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                                operator: zod.enum([
+                                                                    'exact',
+                                                                    'is_not',
+                                                                    'icontains',
+                                                                    'not_icontains',
+                                                                    'starts_with',
+                                                                    'not_starts_with',
+                                                                    'ends_with',
+                                                                    'not_ends_with',
+                                                                    'regex',
+                                                                    'not_regex',
+                                                                    'gt',
+                                                                    'gte',
+                                                                    'lt',
+                                                                    'lte',
+                                                                    'is_set',
+                                                                    'is_not_set',
+                                                                    'is_date_exact',
+                                                                    'is_date_before',
+                                                                    'is_date_after',
+                                                                    'between',
+                                                                    'not_between',
+                                                                    'min',
+                                                                    'max',
+                                                                    'in',
+                                                                    'not_in',
+                                                                    'is_cleaned_path_exact',
+                                                                    'flag_evaluates_to',
+                                                                    'semver_eq',
+                                                                    'semver_neq',
+                                                                    'semver_gt',
+                                                                    'semver_gte',
+                                                                    'semver_lt',
+                                                                    'semver_lte',
+                                                                    'semver_tilde',
+                                                                    'semver_caret',
+                                                                    'semver_wildcard',
+                                                                    'icontains_multi',
+                                                                    'not_icontains_multi',
+                                                                ]),
+                                                                type: zod
+                                                                    .literal('element')
+                                                                    .default(
+                                                                        marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneTwoPropertiesOneItemTwofourEventFiltersOneItemThreeTypeDefault
+                                                                    ),
+                                                                value: zod
+                                                                    .union([
+                                                                        zod.array(
+                                                                            zod.union([
+                                                                                zod.string(),
+                                                                                zod.number(),
+                                                                                zod.boolean(),
+                                                                            ])
+                                                                        ),
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .optional(),
+                                                            }),
+                                                            zod.object({
+                                                                key: zod.string(),
+                                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                                operator: zod.enum([
+                                                                    'exact',
+                                                                    'is_not',
+                                                                    'icontains',
+                                                                    'not_icontains',
+                                                                    'starts_with',
+                                                                    'not_starts_with',
+                                                                    'ends_with',
+                                                                    'not_ends_with',
+                                                                    'regex',
+                                                                    'not_regex',
+                                                                    'gt',
+                                                                    'gte',
+                                                                    'lt',
+                                                                    'lte',
+                                                                    'is_set',
+                                                                    'is_not_set',
+                                                                    'is_date_exact',
+                                                                    'is_date_before',
+                                                                    'is_date_after',
+                                                                    'between',
+                                                                    'not_between',
+                                                                    'min',
+                                                                    'max',
+                                                                    'in',
+                                                                    'not_in',
+                                                                    'is_cleaned_path_exact',
+                                                                    'flag_evaluates_to',
+                                                                    'semver_eq',
+                                                                    'semver_neq',
+                                                                    'semver_gt',
+                                                                    'semver_gte',
+                                                                    'semver_lt',
+                                                                    'semver_lte',
+                                                                    'semver_tilde',
+                                                                    'semver_caret',
+                                                                    'semver_wildcard',
+                                                                    'icontains_multi',
+                                                                    'not_icontains_multi',
+                                                                ]),
+                                                                type: zod
+                                                                    .literal('feature')
+                                                                    .default(
+                                                                        marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneTwoPropertiesOneItemTwofourEventFiltersOneItemFourTypeDefault
+                                                                    )
+                                                                    .describe(
+                                                                        'Event property with \"$feature\/\" prepended'
+                                                                    ),
+                                                                value: zod
+                                                                    .union([
+                                                                        zod.array(
+                                                                            zod.union([
+                                                                                zod.string(),
+                                                                                zod.number(),
+                                                                                zod.boolean(),
+                                                                            ])
+                                                                        ),
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .optional(),
+                                                            }),
+                                                            zod.object({
+                                                                key: zod.string(),
+                                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                                type: zod
+                                                                    .literal('hogql')
+                                                                    .default(
+                                                                        marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneTwoPropertiesOneItemTwofourEventFiltersOneItemFiveTypeDefault
+                                                                    ),
+                                                                value: zod
+                                                                    .union([
+                                                                        zod.array(
+                                                                            zod.union([
+                                                                                zod.string(),
+                                                                                zod.number(),
+                                                                                zod.boolean(),
+                                                                            ])
+                                                                        ),
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .optional(),
+                                                            }),
+                                                        ])
+                                                    ),
+                                                    zod.null(),
+                                                ])
+                                                .optional()
+                                                .describe(
+                                                    'Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral\/cohort filters and groups'
+                                                ),
+                                            event_type: zod.enum(['events', 'actions']),
+                                            explicit_datetime: zod
+                                                .union([zod.string(), zod.null()])
+                                                .optional()
+                                                .describe(
+                                                    'Absolute or relative (e.g. -30d) lower date bound — alternative to time_value\/time_interval'
+                                                ),
+                                            explicit_datetime_to: zod.union([zod.string(), zod.null()]).optional(),
+                                            key: zod
+                                                .string()
+                                                .describe("Event name, or action id when event_type is 'actions'"),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
+                                            negation: zod
+                                                .union([zod.boolean(), zod.null()])
+                                                .optional()
+                                                .describe(
+                                                    'Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators'
+                                                ),
+                                            operator: zod
+                                                .union([
+                                                    zod.enum([
+                                                        'exact',
+                                                        'is_not',
+                                                        'icontains',
+                                                        'not_icontains',
+                                                        'starts_with',
+                                                        'not_starts_with',
+                                                        'ends_with',
+                                                        'not_ends_with',
+                                                        'regex',
+                                                        'not_regex',
+                                                        'gt',
+                                                        'gte',
+                                                        'lt',
+                                                        'lte',
+                                                        'is_set',
+                                                        'is_not_set',
+                                                        'is_date_exact',
+                                                        'is_date_before',
+                                                        'is_date_after',
+                                                        'between',
+                                                        'not_between',
+                                                        'min',
+                                                        'max',
+                                                        'in',
+                                                        'not_in',
+                                                        'is_cleaned_path_exact',
+                                                        'flag_evaluates_to',
+                                                        'semver_eq',
+                                                        'semver_neq',
+                                                        'semver_gt',
+                                                        'semver_gte',
+                                                        'semver_lt',
+                                                        'semver_lte',
+                                                        'semver_tilde',
+                                                        'semver_caret',
+                                                        'semver_wildcard',
+                                                        'icontains_multi',
+                                                        'not_icontains_multi',
+                                                    ]),
+                                                    zod.null(),
+                                                ])
+                                                .optional()
+                                                .describe(
+                                                    'Count comparison for performed_event_multiple, defaults to exact'
+                                                ),
+                                            operator_value: zod
+                                                .union([zod.number(), zod.null()])
+                                                .optional()
+                                                .describe('Count threshold for performed_event_multiple'),
+                                            time_interval: zod
+                                                .union([zod.enum(['day', 'week', 'month', 'year']), zod.null()])
+                                                .optional(),
+                                            time_value: zod
+                                                .union([zod.number(), zod.null()])
+                                                .optional()
+                                                .describe('Relative time window size, paired with time_interval'),
+                                            type: zod
+                                                .literal('behavioral')
+                                                .default(
+                                                    marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneTwoPropertiesOneItemTwofourTypeDefault
+                                                )
+                                                .describe(
+                                                    "Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP"
+                                                ),
+                                            value: zod.enum(['performed_event', 'performed_event_multiple']),
+                                        }),
                                     ])
                                 ),
                                 zod.null(),
@@ -6869,6 +8479,398 @@ export const MarketingAnalyticsConversionGoalsUpdatePartialUpdateBody = /* @__PU
                                                     zod.null(),
                                                 ])
                                                 .optional(),
+                                        }),
+                                        zod.object({
+                                            event_filters: zod
+                                                .union([
+                                                    zod.array(
+                                                        zod.union([
+                                                            zod.object({
+                                                                key: zod.string(),
+                                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                                operator: zod
+                                                                    .union([
+                                                                        zod.enum([
+                                                                            'exact',
+                                                                            'is_not',
+                                                                            'icontains',
+                                                                            'not_icontains',
+                                                                            'starts_with',
+                                                                            'not_starts_with',
+                                                                            'ends_with',
+                                                                            'not_ends_with',
+                                                                            'regex',
+                                                                            'not_regex',
+                                                                            'gt',
+                                                                            'gte',
+                                                                            'lt',
+                                                                            'lte',
+                                                                            'is_set',
+                                                                            'is_not_set',
+                                                                            'is_date_exact',
+                                                                            'is_date_before',
+                                                                            'is_date_after',
+                                                                            'between',
+                                                                            'not_between',
+                                                                            'min',
+                                                                            'max',
+                                                                            'in',
+                                                                            'not_in',
+                                                                            'is_cleaned_path_exact',
+                                                                            'flag_evaluates_to',
+                                                                            'semver_eq',
+                                                                            'semver_neq',
+                                                                            'semver_gt',
+                                                                            'semver_gte',
+                                                                            'semver_lt',
+                                                                            'semver_lte',
+                                                                            'semver_tilde',
+                                                                            'semver_caret',
+                                                                            'semver_wildcard',
+                                                                            'icontains_multi',
+                                                                            'not_icontains_multi',
+                                                                        ]),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .default(
+                                                                        marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneThreeFixedPropertiesOneItemTwofourEventFiltersOneItemOneOperatorDefault
+                                                                    ),
+                                                                type: zod
+                                                                    .literal('event')
+                                                                    .default(
+                                                                        marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneThreeFixedPropertiesOneItemTwofourEventFiltersOneItemOneTypeDefault
+                                                                    )
+                                                                    .describe('Event properties'),
+                                                                value: zod
+                                                                    .union([
+                                                                        zod.array(
+                                                                            zod.union([
+                                                                                zod.string(),
+                                                                                zod.number(),
+                                                                                zod.boolean(),
+                                                                            ])
+                                                                        ),
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .optional(),
+                                                            }),
+                                                            zod.object({
+                                                                key: zod.string(),
+                                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                                operator: zod.enum([
+                                                                    'exact',
+                                                                    'is_not',
+                                                                    'icontains',
+                                                                    'not_icontains',
+                                                                    'starts_with',
+                                                                    'not_starts_with',
+                                                                    'ends_with',
+                                                                    'not_ends_with',
+                                                                    'regex',
+                                                                    'not_regex',
+                                                                    'gt',
+                                                                    'gte',
+                                                                    'lt',
+                                                                    'lte',
+                                                                    'is_set',
+                                                                    'is_not_set',
+                                                                    'is_date_exact',
+                                                                    'is_date_before',
+                                                                    'is_date_after',
+                                                                    'between',
+                                                                    'not_between',
+                                                                    'min',
+                                                                    'max',
+                                                                    'in',
+                                                                    'not_in',
+                                                                    'is_cleaned_path_exact',
+                                                                    'flag_evaluates_to',
+                                                                    'semver_eq',
+                                                                    'semver_neq',
+                                                                    'semver_gt',
+                                                                    'semver_gte',
+                                                                    'semver_lt',
+                                                                    'semver_lte',
+                                                                    'semver_tilde',
+                                                                    'semver_caret',
+                                                                    'semver_wildcard',
+                                                                    'icontains_multi',
+                                                                    'not_icontains_multi',
+                                                                ]),
+                                                                type: zod
+                                                                    .literal('person')
+                                                                    .default(
+                                                                        marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneThreeFixedPropertiesOneItemTwofourEventFiltersOneItemTwoTypeDefault
+                                                                    )
+                                                                    .describe('Person properties'),
+                                                                value: zod
+                                                                    .union([
+                                                                        zod.array(
+                                                                            zod.union([
+                                                                                zod.string(),
+                                                                                zod.number(),
+                                                                                zod.boolean(),
+                                                                            ])
+                                                                        ),
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .optional(),
+                                                            }),
+                                                            zod.object({
+                                                                key: zod.enum(['tag_name', 'text', 'href', 'selector']),
+                                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                                operator: zod.enum([
+                                                                    'exact',
+                                                                    'is_not',
+                                                                    'icontains',
+                                                                    'not_icontains',
+                                                                    'starts_with',
+                                                                    'not_starts_with',
+                                                                    'ends_with',
+                                                                    'not_ends_with',
+                                                                    'regex',
+                                                                    'not_regex',
+                                                                    'gt',
+                                                                    'gte',
+                                                                    'lt',
+                                                                    'lte',
+                                                                    'is_set',
+                                                                    'is_not_set',
+                                                                    'is_date_exact',
+                                                                    'is_date_before',
+                                                                    'is_date_after',
+                                                                    'between',
+                                                                    'not_between',
+                                                                    'min',
+                                                                    'max',
+                                                                    'in',
+                                                                    'not_in',
+                                                                    'is_cleaned_path_exact',
+                                                                    'flag_evaluates_to',
+                                                                    'semver_eq',
+                                                                    'semver_neq',
+                                                                    'semver_gt',
+                                                                    'semver_gte',
+                                                                    'semver_lt',
+                                                                    'semver_lte',
+                                                                    'semver_tilde',
+                                                                    'semver_caret',
+                                                                    'semver_wildcard',
+                                                                    'icontains_multi',
+                                                                    'not_icontains_multi',
+                                                                ]),
+                                                                type: zod
+                                                                    .literal('element')
+                                                                    .default(
+                                                                        marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneThreeFixedPropertiesOneItemTwofourEventFiltersOneItemThreeTypeDefault
+                                                                    ),
+                                                                value: zod
+                                                                    .union([
+                                                                        zod.array(
+                                                                            zod.union([
+                                                                                zod.string(),
+                                                                                zod.number(),
+                                                                                zod.boolean(),
+                                                                            ])
+                                                                        ),
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .optional(),
+                                                            }),
+                                                            zod.object({
+                                                                key: zod.string(),
+                                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                                operator: zod.enum([
+                                                                    'exact',
+                                                                    'is_not',
+                                                                    'icontains',
+                                                                    'not_icontains',
+                                                                    'starts_with',
+                                                                    'not_starts_with',
+                                                                    'ends_with',
+                                                                    'not_ends_with',
+                                                                    'regex',
+                                                                    'not_regex',
+                                                                    'gt',
+                                                                    'gte',
+                                                                    'lt',
+                                                                    'lte',
+                                                                    'is_set',
+                                                                    'is_not_set',
+                                                                    'is_date_exact',
+                                                                    'is_date_before',
+                                                                    'is_date_after',
+                                                                    'between',
+                                                                    'not_between',
+                                                                    'min',
+                                                                    'max',
+                                                                    'in',
+                                                                    'not_in',
+                                                                    'is_cleaned_path_exact',
+                                                                    'flag_evaluates_to',
+                                                                    'semver_eq',
+                                                                    'semver_neq',
+                                                                    'semver_gt',
+                                                                    'semver_gte',
+                                                                    'semver_lt',
+                                                                    'semver_lte',
+                                                                    'semver_tilde',
+                                                                    'semver_caret',
+                                                                    'semver_wildcard',
+                                                                    'icontains_multi',
+                                                                    'not_icontains_multi',
+                                                                ]),
+                                                                type: zod
+                                                                    .literal('feature')
+                                                                    .default(
+                                                                        marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneThreeFixedPropertiesOneItemTwofourEventFiltersOneItemFourTypeDefault
+                                                                    )
+                                                                    .describe(
+                                                                        'Event property with \"$feature\/\" prepended'
+                                                                    ),
+                                                                value: zod
+                                                                    .union([
+                                                                        zod.array(
+                                                                            zod.union([
+                                                                                zod.string(),
+                                                                                zod.number(),
+                                                                                zod.boolean(),
+                                                                            ])
+                                                                        ),
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .optional(),
+                                                            }),
+                                                            zod.object({
+                                                                key: zod.string(),
+                                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                                type: zod
+                                                                    .literal('hogql')
+                                                                    .default(
+                                                                        marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneThreeFixedPropertiesOneItemTwofourEventFiltersOneItemFiveTypeDefault
+                                                                    ),
+                                                                value: zod
+                                                                    .union([
+                                                                        zod.array(
+                                                                            zod.union([
+                                                                                zod.string(),
+                                                                                zod.number(),
+                                                                                zod.boolean(),
+                                                                            ])
+                                                                        ),
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .optional(),
+                                                            }),
+                                                        ])
+                                                    ),
+                                                    zod.null(),
+                                                ])
+                                                .optional()
+                                                .describe(
+                                                    'Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral\/cohort filters and groups'
+                                                ),
+                                            event_type: zod.enum(['events', 'actions']),
+                                            explicit_datetime: zod
+                                                .union([zod.string(), zod.null()])
+                                                .optional()
+                                                .describe(
+                                                    'Absolute or relative (e.g. -30d) lower date bound — alternative to time_value\/time_interval'
+                                                ),
+                                            explicit_datetime_to: zod.union([zod.string(), zod.null()]).optional(),
+                                            key: zod
+                                                .string()
+                                                .describe("Event name, or action id when event_type is 'actions'"),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
+                                            negation: zod
+                                                .union([zod.boolean(), zod.null()])
+                                                .optional()
+                                                .describe(
+                                                    'Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators'
+                                                ),
+                                            operator: zod
+                                                .union([
+                                                    zod.enum([
+                                                        'exact',
+                                                        'is_not',
+                                                        'icontains',
+                                                        'not_icontains',
+                                                        'starts_with',
+                                                        'not_starts_with',
+                                                        'ends_with',
+                                                        'not_ends_with',
+                                                        'regex',
+                                                        'not_regex',
+                                                        'gt',
+                                                        'gte',
+                                                        'lt',
+                                                        'lte',
+                                                        'is_set',
+                                                        'is_not_set',
+                                                        'is_date_exact',
+                                                        'is_date_before',
+                                                        'is_date_after',
+                                                        'between',
+                                                        'not_between',
+                                                        'min',
+                                                        'max',
+                                                        'in',
+                                                        'not_in',
+                                                        'is_cleaned_path_exact',
+                                                        'flag_evaluates_to',
+                                                        'semver_eq',
+                                                        'semver_neq',
+                                                        'semver_gt',
+                                                        'semver_gte',
+                                                        'semver_lt',
+                                                        'semver_lte',
+                                                        'semver_tilde',
+                                                        'semver_caret',
+                                                        'semver_wildcard',
+                                                        'icontains_multi',
+                                                        'not_icontains_multi',
+                                                    ]),
+                                                    zod.null(),
+                                                ])
+                                                .optional()
+                                                .describe(
+                                                    'Count comparison for performed_event_multiple, defaults to exact'
+                                                ),
+                                            operator_value: zod
+                                                .union([zod.number(), zod.null()])
+                                                .optional()
+                                                .describe('Count threshold for performed_event_multiple'),
+                                            time_interval: zod
+                                                .union([zod.enum(['day', 'week', 'month', 'year']), zod.null()])
+                                                .optional(),
+                                            time_value: zod
+                                                .union([zod.number(), zod.null()])
+                                                .optional()
+                                                .describe('Relative time window size, paired with time_interval'),
+                                            type: zod
+                                                .literal('behavioral')
+                                                .default(
+                                                    marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneThreeFixedPropertiesOneItemTwofourTypeDefault
+                                                )
+                                                .describe(
+                                                    "Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP"
+                                                ),
+                                            value: zod.enum(['performed_event', 'performed_event_multiple']),
                                         }),
                                     ])
                                 ),
@@ -8334,6 +10336,398 @@ export const MarketingAnalyticsConversionGoalsUpdatePartialUpdateBody = /* @__PU
                                                 ])
                                                 .optional(),
                                         }),
+                                        zod.object({
+                                            event_filters: zod
+                                                .union([
+                                                    zod.array(
+                                                        zod.union([
+                                                            zod.object({
+                                                                key: zod.string(),
+                                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                                operator: zod
+                                                                    .union([
+                                                                        zod.enum([
+                                                                            'exact',
+                                                                            'is_not',
+                                                                            'icontains',
+                                                                            'not_icontains',
+                                                                            'starts_with',
+                                                                            'not_starts_with',
+                                                                            'ends_with',
+                                                                            'not_ends_with',
+                                                                            'regex',
+                                                                            'not_regex',
+                                                                            'gt',
+                                                                            'gte',
+                                                                            'lt',
+                                                                            'lte',
+                                                                            'is_set',
+                                                                            'is_not_set',
+                                                                            'is_date_exact',
+                                                                            'is_date_before',
+                                                                            'is_date_after',
+                                                                            'between',
+                                                                            'not_between',
+                                                                            'min',
+                                                                            'max',
+                                                                            'in',
+                                                                            'not_in',
+                                                                            'is_cleaned_path_exact',
+                                                                            'flag_evaluates_to',
+                                                                            'semver_eq',
+                                                                            'semver_neq',
+                                                                            'semver_gt',
+                                                                            'semver_gte',
+                                                                            'semver_lt',
+                                                                            'semver_lte',
+                                                                            'semver_tilde',
+                                                                            'semver_caret',
+                                                                            'semver_wildcard',
+                                                                            'icontains_multi',
+                                                                            'not_icontains_multi',
+                                                                        ]),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .default(
+                                                                        marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneThreePropertiesOneItemTwofourEventFiltersOneItemOneOperatorDefault
+                                                                    ),
+                                                                type: zod
+                                                                    .literal('event')
+                                                                    .default(
+                                                                        marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneThreePropertiesOneItemTwofourEventFiltersOneItemOneTypeDefault
+                                                                    )
+                                                                    .describe('Event properties'),
+                                                                value: zod
+                                                                    .union([
+                                                                        zod.array(
+                                                                            zod.union([
+                                                                                zod.string(),
+                                                                                zod.number(),
+                                                                                zod.boolean(),
+                                                                            ])
+                                                                        ),
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .optional(),
+                                                            }),
+                                                            zod.object({
+                                                                key: zod.string(),
+                                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                                operator: zod.enum([
+                                                                    'exact',
+                                                                    'is_not',
+                                                                    'icontains',
+                                                                    'not_icontains',
+                                                                    'starts_with',
+                                                                    'not_starts_with',
+                                                                    'ends_with',
+                                                                    'not_ends_with',
+                                                                    'regex',
+                                                                    'not_regex',
+                                                                    'gt',
+                                                                    'gte',
+                                                                    'lt',
+                                                                    'lte',
+                                                                    'is_set',
+                                                                    'is_not_set',
+                                                                    'is_date_exact',
+                                                                    'is_date_before',
+                                                                    'is_date_after',
+                                                                    'between',
+                                                                    'not_between',
+                                                                    'min',
+                                                                    'max',
+                                                                    'in',
+                                                                    'not_in',
+                                                                    'is_cleaned_path_exact',
+                                                                    'flag_evaluates_to',
+                                                                    'semver_eq',
+                                                                    'semver_neq',
+                                                                    'semver_gt',
+                                                                    'semver_gte',
+                                                                    'semver_lt',
+                                                                    'semver_lte',
+                                                                    'semver_tilde',
+                                                                    'semver_caret',
+                                                                    'semver_wildcard',
+                                                                    'icontains_multi',
+                                                                    'not_icontains_multi',
+                                                                ]),
+                                                                type: zod
+                                                                    .literal('person')
+                                                                    .default(
+                                                                        marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneThreePropertiesOneItemTwofourEventFiltersOneItemTwoTypeDefault
+                                                                    )
+                                                                    .describe('Person properties'),
+                                                                value: zod
+                                                                    .union([
+                                                                        zod.array(
+                                                                            zod.union([
+                                                                                zod.string(),
+                                                                                zod.number(),
+                                                                                zod.boolean(),
+                                                                            ])
+                                                                        ),
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .optional(),
+                                                            }),
+                                                            zod.object({
+                                                                key: zod.enum(['tag_name', 'text', 'href', 'selector']),
+                                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                                operator: zod.enum([
+                                                                    'exact',
+                                                                    'is_not',
+                                                                    'icontains',
+                                                                    'not_icontains',
+                                                                    'starts_with',
+                                                                    'not_starts_with',
+                                                                    'ends_with',
+                                                                    'not_ends_with',
+                                                                    'regex',
+                                                                    'not_regex',
+                                                                    'gt',
+                                                                    'gte',
+                                                                    'lt',
+                                                                    'lte',
+                                                                    'is_set',
+                                                                    'is_not_set',
+                                                                    'is_date_exact',
+                                                                    'is_date_before',
+                                                                    'is_date_after',
+                                                                    'between',
+                                                                    'not_between',
+                                                                    'min',
+                                                                    'max',
+                                                                    'in',
+                                                                    'not_in',
+                                                                    'is_cleaned_path_exact',
+                                                                    'flag_evaluates_to',
+                                                                    'semver_eq',
+                                                                    'semver_neq',
+                                                                    'semver_gt',
+                                                                    'semver_gte',
+                                                                    'semver_lt',
+                                                                    'semver_lte',
+                                                                    'semver_tilde',
+                                                                    'semver_caret',
+                                                                    'semver_wildcard',
+                                                                    'icontains_multi',
+                                                                    'not_icontains_multi',
+                                                                ]),
+                                                                type: zod
+                                                                    .literal('element')
+                                                                    .default(
+                                                                        marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneThreePropertiesOneItemTwofourEventFiltersOneItemThreeTypeDefault
+                                                                    ),
+                                                                value: zod
+                                                                    .union([
+                                                                        zod.array(
+                                                                            zod.union([
+                                                                                zod.string(),
+                                                                                zod.number(),
+                                                                                zod.boolean(),
+                                                                            ])
+                                                                        ),
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .optional(),
+                                                            }),
+                                                            zod.object({
+                                                                key: zod.string(),
+                                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                                operator: zod.enum([
+                                                                    'exact',
+                                                                    'is_not',
+                                                                    'icontains',
+                                                                    'not_icontains',
+                                                                    'starts_with',
+                                                                    'not_starts_with',
+                                                                    'ends_with',
+                                                                    'not_ends_with',
+                                                                    'regex',
+                                                                    'not_regex',
+                                                                    'gt',
+                                                                    'gte',
+                                                                    'lt',
+                                                                    'lte',
+                                                                    'is_set',
+                                                                    'is_not_set',
+                                                                    'is_date_exact',
+                                                                    'is_date_before',
+                                                                    'is_date_after',
+                                                                    'between',
+                                                                    'not_between',
+                                                                    'min',
+                                                                    'max',
+                                                                    'in',
+                                                                    'not_in',
+                                                                    'is_cleaned_path_exact',
+                                                                    'flag_evaluates_to',
+                                                                    'semver_eq',
+                                                                    'semver_neq',
+                                                                    'semver_gt',
+                                                                    'semver_gte',
+                                                                    'semver_lt',
+                                                                    'semver_lte',
+                                                                    'semver_tilde',
+                                                                    'semver_caret',
+                                                                    'semver_wildcard',
+                                                                    'icontains_multi',
+                                                                    'not_icontains_multi',
+                                                                ]),
+                                                                type: zod
+                                                                    .literal('feature')
+                                                                    .default(
+                                                                        marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneThreePropertiesOneItemTwofourEventFiltersOneItemFourTypeDefault
+                                                                    )
+                                                                    .describe(
+                                                                        'Event property with \"$feature\/\" prepended'
+                                                                    ),
+                                                                value: zod
+                                                                    .union([
+                                                                        zod.array(
+                                                                            zod.union([
+                                                                                zod.string(),
+                                                                                zod.number(),
+                                                                                zod.boolean(),
+                                                                            ])
+                                                                        ),
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .optional(),
+                                                            }),
+                                                            zod.object({
+                                                                key: zod.string(),
+                                                                label: zod.union([zod.string(), zod.null()]).optional(),
+                                                                type: zod
+                                                                    .literal('hogql')
+                                                                    .default(
+                                                                        marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneThreePropertiesOneItemTwofourEventFiltersOneItemFiveTypeDefault
+                                                                    ),
+                                                                value: zod
+                                                                    .union([
+                                                                        zod.array(
+                                                                            zod.union([
+                                                                                zod.string(),
+                                                                                zod.number(),
+                                                                                zod.boolean(),
+                                                                            ])
+                                                                        ),
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                        zod.null(),
+                                                                    ])
+                                                                    .optional(),
+                                                            }),
+                                                        ])
+                                                    ),
+                                                    zod.null(),
+                                                ])
+                                                .optional()
+                                                .describe(
+                                                    'Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral\/cohort filters and groups'
+                                                ),
+                                            event_type: zod.enum(['events', 'actions']),
+                                            explicit_datetime: zod
+                                                .union([zod.string(), zod.null()])
+                                                .optional()
+                                                .describe(
+                                                    'Absolute or relative (e.g. -30d) lower date bound — alternative to time_value\/time_interval'
+                                                ),
+                                            explicit_datetime_to: zod.union([zod.string(), zod.null()]).optional(),
+                                            key: zod
+                                                .string()
+                                                .describe("Event name, or action id when event_type is 'actions'"),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
+                                            negation: zod
+                                                .union([zod.boolean(), zod.null()])
+                                                .optional()
+                                                .describe(
+                                                    'Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators'
+                                                ),
+                                            operator: zod
+                                                .union([
+                                                    zod.enum([
+                                                        'exact',
+                                                        'is_not',
+                                                        'icontains',
+                                                        'not_icontains',
+                                                        'starts_with',
+                                                        'not_starts_with',
+                                                        'ends_with',
+                                                        'not_ends_with',
+                                                        'regex',
+                                                        'not_regex',
+                                                        'gt',
+                                                        'gte',
+                                                        'lt',
+                                                        'lte',
+                                                        'is_set',
+                                                        'is_not_set',
+                                                        'is_date_exact',
+                                                        'is_date_before',
+                                                        'is_date_after',
+                                                        'between',
+                                                        'not_between',
+                                                        'min',
+                                                        'max',
+                                                        'in',
+                                                        'not_in',
+                                                        'is_cleaned_path_exact',
+                                                        'flag_evaluates_to',
+                                                        'semver_eq',
+                                                        'semver_neq',
+                                                        'semver_gt',
+                                                        'semver_gte',
+                                                        'semver_lt',
+                                                        'semver_lte',
+                                                        'semver_tilde',
+                                                        'semver_caret',
+                                                        'semver_wildcard',
+                                                        'icontains_multi',
+                                                        'not_icontains_multi',
+                                                    ]),
+                                                    zod.null(),
+                                                ])
+                                                .optional()
+                                                .describe(
+                                                    'Count comparison for performed_event_multiple, defaults to exact'
+                                                ),
+                                            operator_value: zod
+                                                .union([zod.number(), zod.null()])
+                                                .optional()
+                                                .describe('Count threshold for performed_event_multiple'),
+                                            time_interval: zod
+                                                .union([zod.enum(['day', 'week', 'month', 'year']), zod.null()])
+                                                .optional(),
+                                            time_value: zod
+                                                .union([zod.number(), zod.null()])
+                                                .optional()
+                                                .describe('Relative time window size, paired with time_interval'),
+                                            type: zod
+                                                .literal('behavioral')
+                                                .default(
+                                                    marketingAnalyticsConversionGoalsUpdatePartialUpdateBodyGoalOneThreePropertiesOneItemTwofourTypeDefault
+                                                )
+                                                .describe(
+                                                    "Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP"
+                                                ),
+                                            value: zod.enum(['performed_event', 'performed_event_multiple']),
+                                        }),
                                     ])
                                 ),
                                 zod.null(),
@@ -8395,6 +10789,13 @@ export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneOneFixedPro
 export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneOneFixedPropertiesOneItemTwooneTypeDefault = `revenue_analytics`
 export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneOneFixedPropertiesOneItemTwotwoTypeDefault = `account_custom_property`
 export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneOneFixedPropertiesOneItemTwothreeTypeDefault = `workflow_variable`
+export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneOneFixedPropertiesOneItemTwofourEventFiltersOneItemOneOperatorDefault = `exact`
+export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneOneFixedPropertiesOneItemTwofourEventFiltersOneItemOneTypeDefault = `event`
+export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneOneFixedPropertiesOneItemTwofourEventFiltersOneItemTwoTypeDefault = `person`
+export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneOneFixedPropertiesOneItemTwofourEventFiltersOneItemThreeTypeDefault = `element`
+export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneOneFixedPropertiesOneItemTwofourEventFiltersOneItemFourTypeDefault = `feature`
+export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneOneFixedPropertiesOneItemTwofourEventFiltersOneItemFiveTypeDefault = `hogql`
+export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneOneFixedPropertiesOneItemTwofourTypeDefault = `behavioral`
 export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneOneKindDefault = `EventsNode`
 export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneOnePropertiesOneItemOneOperatorDefault = `exact`
 export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneOnePropertiesOneItemOneTypeDefault = `event`
@@ -8421,6 +10822,13 @@ export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneOneProperti
 export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneOnePropertiesOneItemTwooneTypeDefault = `revenue_analytics`
 export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneOnePropertiesOneItemTwotwoTypeDefault = `account_custom_property`
 export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneOnePropertiesOneItemTwothreeTypeDefault = `workflow_variable`
+export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneOnePropertiesOneItemTwofourEventFiltersOneItemOneOperatorDefault = `exact`
+export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneOnePropertiesOneItemTwofourEventFiltersOneItemOneTypeDefault = `event`
+export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneOnePropertiesOneItemTwofourEventFiltersOneItemTwoTypeDefault = `person`
+export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneOnePropertiesOneItemTwofourEventFiltersOneItemThreeTypeDefault = `element`
+export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneOnePropertiesOneItemTwofourEventFiltersOneItemFourTypeDefault = `feature`
+export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneOnePropertiesOneItemTwofourEventFiltersOneItemFiveTypeDefault = `hogql`
+export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneOnePropertiesOneItemTwofourTypeDefault = `behavioral`
 export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneTwoFixedPropertiesOneItemOneOperatorDefault = `exact`
 export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneTwoFixedPropertiesOneItemOneTypeDefault = `event`
 export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneTwoFixedPropertiesOneItemTwoTypeDefault = `person`
@@ -8446,6 +10854,13 @@ export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneTwoFixedPro
 export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneTwoFixedPropertiesOneItemTwooneTypeDefault = `revenue_analytics`
 export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneTwoFixedPropertiesOneItemTwotwoTypeDefault = `account_custom_property`
 export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneTwoFixedPropertiesOneItemTwothreeTypeDefault = `workflow_variable`
+export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneTwoFixedPropertiesOneItemTwofourEventFiltersOneItemOneOperatorDefault = `exact`
+export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneTwoFixedPropertiesOneItemTwofourEventFiltersOneItemOneTypeDefault = `event`
+export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneTwoFixedPropertiesOneItemTwofourEventFiltersOneItemTwoTypeDefault = `person`
+export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneTwoFixedPropertiesOneItemTwofourEventFiltersOneItemThreeTypeDefault = `element`
+export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneTwoFixedPropertiesOneItemTwofourEventFiltersOneItemFourTypeDefault = `feature`
+export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneTwoFixedPropertiesOneItemTwofourEventFiltersOneItemFiveTypeDefault = `hogql`
+export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneTwoFixedPropertiesOneItemTwofourTypeDefault = `behavioral`
 export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneTwoKindDefault = `ActionsNode`
 export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneTwoPropertiesOneItemOneOperatorDefault = `exact`
 export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneTwoPropertiesOneItemOneTypeDefault = `event`
@@ -8472,6 +10887,13 @@ export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneTwoProperti
 export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneTwoPropertiesOneItemTwooneTypeDefault = `revenue_analytics`
 export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneTwoPropertiesOneItemTwotwoTypeDefault = `account_custom_property`
 export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneTwoPropertiesOneItemTwothreeTypeDefault = `workflow_variable`
+export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneTwoPropertiesOneItemTwofourEventFiltersOneItemOneOperatorDefault = `exact`
+export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneTwoPropertiesOneItemTwofourEventFiltersOneItemOneTypeDefault = `event`
+export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneTwoPropertiesOneItemTwofourEventFiltersOneItemTwoTypeDefault = `person`
+export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneTwoPropertiesOneItemTwofourEventFiltersOneItemThreeTypeDefault = `element`
+export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneTwoPropertiesOneItemTwofourEventFiltersOneItemFourTypeDefault = `feature`
+export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneTwoPropertiesOneItemTwofourEventFiltersOneItemFiveTypeDefault = `hogql`
+export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneTwoPropertiesOneItemTwofourTypeDefault = `behavioral`
 export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneThreeFixedPropertiesOneItemOneOperatorDefault = `exact`
 export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneThreeFixedPropertiesOneItemOneTypeDefault = `event`
 export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneThreeFixedPropertiesOneItemTwoTypeDefault = `person`
@@ -8497,6 +10919,13 @@ export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneThreeFixedP
 export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneThreeFixedPropertiesOneItemTwooneTypeDefault = `revenue_analytics`
 export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneThreeFixedPropertiesOneItemTwotwoTypeDefault = `account_custom_property`
 export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneThreeFixedPropertiesOneItemTwothreeTypeDefault = `workflow_variable`
+export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneThreeFixedPropertiesOneItemTwofourEventFiltersOneItemOneOperatorDefault = `exact`
+export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneThreeFixedPropertiesOneItemTwofourEventFiltersOneItemOneTypeDefault = `event`
+export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneThreeFixedPropertiesOneItemTwofourEventFiltersOneItemTwoTypeDefault = `person`
+export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneThreeFixedPropertiesOneItemTwofourEventFiltersOneItemThreeTypeDefault = `element`
+export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneThreeFixedPropertiesOneItemTwofourEventFiltersOneItemFourTypeDefault = `feature`
+export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneThreeFixedPropertiesOneItemTwofourEventFiltersOneItemFiveTypeDefault = `hogql`
+export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneThreeFixedPropertiesOneItemTwofourTypeDefault = `behavioral`
 export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneThreeKindDefault = `DataWarehouseNode`
 export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneThreePropertiesOneItemOneOperatorDefault = `exact`
 export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneThreePropertiesOneItemOneTypeDefault = `event`
@@ -8523,6 +10952,13 @@ export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneThreeProper
 export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneThreePropertiesOneItemTwooneTypeDefault = `revenue_analytics`
 export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneThreePropertiesOneItemTwotwoTypeDefault = `account_custom_property`
 export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneThreePropertiesOneItemTwothreeTypeDefault = `workflow_variable`
+export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneThreePropertiesOneItemTwofourEventFiltersOneItemOneOperatorDefault = `exact`
+export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneThreePropertiesOneItemTwofourEventFiltersOneItemOneTypeDefault = `event`
+export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneThreePropertiesOneItemTwofourEventFiltersOneItemTwoTypeDefault = `person`
+export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneThreePropertiesOneItemTwofourEventFiltersOneItemThreeTypeDefault = `element`
+export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneThreePropertiesOneItemTwofourEventFiltersOneItemFourTypeDefault = `feature`
+export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneThreePropertiesOneItemTwofourEventFiltersOneItemFiveTypeDefault = `hogql`
+export const marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneThreePropertiesOneItemTwofourTypeDefault = `behavioral`
 
 export const MarketingAnalyticsConversionGoalsCreateCreateBody = /* @__PURE__ */ zod.object({
     goal: zod
@@ -9770,6 +12206,392 @@ export const MarketingAnalyticsConversionGoalsCreateCreateBody = /* @__PURE__ */
                                             zod.null(),
                                         ])
                                         .optional(),
+                                }),
+                                zod.object({
+                                    event_filters: zod
+                                        .union([
+                                            zod.array(
+                                                zod.union([
+                                                    zod.object({
+                                                        key: zod.string(),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
+                                                        operator: zod
+                                                            .union([
+                                                                zod.enum([
+                                                                    'exact',
+                                                                    'is_not',
+                                                                    'icontains',
+                                                                    'not_icontains',
+                                                                    'starts_with',
+                                                                    'not_starts_with',
+                                                                    'ends_with',
+                                                                    'not_ends_with',
+                                                                    'regex',
+                                                                    'not_regex',
+                                                                    'gt',
+                                                                    'gte',
+                                                                    'lt',
+                                                                    'lte',
+                                                                    'is_set',
+                                                                    'is_not_set',
+                                                                    'is_date_exact',
+                                                                    'is_date_before',
+                                                                    'is_date_after',
+                                                                    'between',
+                                                                    'not_between',
+                                                                    'min',
+                                                                    'max',
+                                                                    'in',
+                                                                    'not_in',
+                                                                    'is_cleaned_path_exact',
+                                                                    'flag_evaluates_to',
+                                                                    'semver_eq',
+                                                                    'semver_neq',
+                                                                    'semver_gt',
+                                                                    'semver_gte',
+                                                                    'semver_lt',
+                                                                    'semver_lte',
+                                                                    'semver_tilde',
+                                                                    'semver_caret',
+                                                                    'semver_wildcard',
+                                                                    'icontains_multi',
+                                                                    'not_icontains_multi',
+                                                                ]),
+                                                                zod.null(),
+                                                            ])
+                                                            .default(
+                                                                marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneOneFixedPropertiesOneItemTwofourEventFiltersOneItemOneOperatorDefault
+                                                            ),
+                                                        type: zod
+                                                            .literal('event')
+                                                            .default(
+                                                                marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneOneFixedPropertiesOneItemTwofourEventFiltersOneItemOneTypeDefault
+                                                            )
+                                                            .describe('Event properties'),
+                                                        value: zod
+                                                            .union([
+                                                                zod.array(
+                                                                    zod.union([
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                    ])
+                                                                ),
+                                                                zod.string(),
+                                                                zod.number(),
+                                                                zod.boolean(),
+                                                                zod.null(),
+                                                            ])
+                                                            .optional(),
+                                                    }),
+                                                    zod.object({
+                                                        key: zod.string(),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
+                                                        operator: zod.enum([
+                                                            'exact',
+                                                            'is_not',
+                                                            'icontains',
+                                                            'not_icontains',
+                                                            'starts_with',
+                                                            'not_starts_with',
+                                                            'ends_with',
+                                                            'not_ends_with',
+                                                            'regex',
+                                                            'not_regex',
+                                                            'gt',
+                                                            'gte',
+                                                            'lt',
+                                                            'lte',
+                                                            'is_set',
+                                                            'is_not_set',
+                                                            'is_date_exact',
+                                                            'is_date_before',
+                                                            'is_date_after',
+                                                            'between',
+                                                            'not_between',
+                                                            'min',
+                                                            'max',
+                                                            'in',
+                                                            'not_in',
+                                                            'is_cleaned_path_exact',
+                                                            'flag_evaluates_to',
+                                                            'semver_eq',
+                                                            'semver_neq',
+                                                            'semver_gt',
+                                                            'semver_gte',
+                                                            'semver_lt',
+                                                            'semver_lte',
+                                                            'semver_tilde',
+                                                            'semver_caret',
+                                                            'semver_wildcard',
+                                                            'icontains_multi',
+                                                            'not_icontains_multi',
+                                                        ]),
+                                                        type: zod
+                                                            .literal('person')
+                                                            .default(
+                                                                marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneOneFixedPropertiesOneItemTwofourEventFiltersOneItemTwoTypeDefault
+                                                            )
+                                                            .describe('Person properties'),
+                                                        value: zod
+                                                            .union([
+                                                                zod.array(
+                                                                    zod.union([
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                    ])
+                                                                ),
+                                                                zod.string(),
+                                                                zod.number(),
+                                                                zod.boolean(),
+                                                                zod.null(),
+                                                            ])
+                                                            .optional(),
+                                                    }),
+                                                    zod.object({
+                                                        key: zod.enum(['tag_name', 'text', 'href', 'selector']),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
+                                                        operator: zod.enum([
+                                                            'exact',
+                                                            'is_not',
+                                                            'icontains',
+                                                            'not_icontains',
+                                                            'starts_with',
+                                                            'not_starts_with',
+                                                            'ends_with',
+                                                            'not_ends_with',
+                                                            'regex',
+                                                            'not_regex',
+                                                            'gt',
+                                                            'gte',
+                                                            'lt',
+                                                            'lte',
+                                                            'is_set',
+                                                            'is_not_set',
+                                                            'is_date_exact',
+                                                            'is_date_before',
+                                                            'is_date_after',
+                                                            'between',
+                                                            'not_between',
+                                                            'min',
+                                                            'max',
+                                                            'in',
+                                                            'not_in',
+                                                            'is_cleaned_path_exact',
+                                                            'flag_evaluates_to',
+                                                            'semver_eq',
+                                                            'semver_neq',
+                                                            'semver_gt',
+                                                            'semver_gte',
+                                                            'semver_lt',
+                                                            'semver_lte',
+                                                            'semver_tilde',
+                                                            'semver_caret',
+                                                            'semver_wildcard',
+                                                            'icontains_multi',
+                                                            'not_icontains_multi',
+                                                        ]),
+                                                        type: zod
+                                                            .literal('element')
+                                                            .default(
+                                                                marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneOneFixedPropertiesOneItemTwofourEventFiltersOneItemThreeTypeDefault
+                                                            ),
+                                                        value: zod
+                                                            .union([
+                                                                zod.array(
+                                                                    zod.union([
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                    ])
+                                                                ),
+                                                                zod.string(),
+                                                                zod.number(),
+                                                                zod.boolean(),
+                                                                zod.null(),
+                                                            ])
+                                                            .optional(),
+                                                    }),
+                                                    zod.object({
+                                                        key: zod.string(),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
+                                                        operator: zod.enum([
+                                                            'exact',
+                                                            'is_not',
+                                                            'icontains',
+                                                            'not_icontains',
+                                                            'starts_with',
+                                                            'not_starts_with',
+                                                            'ends_with',
+                                                            'not_ends_with',
+                                                            'regex',
+                                                            'not_regex',
+                                                            'gt',
+                                                            'gte',
+                                                            'lt',
+                                                            'lte',
+                                                            'is_set',
+                                                            'is_not_set',
+                                                            'is_date_exact',
+                                                            'is_date_before',
+                                                            'is_date_after',
+                                                            'between',
+                                                            'not_between',
+                                                            'min',
+                                                            'max',
+                                                            'in',
+                                                            'not_in',
+                                                            'is_cleaned_path_exact',
+                                                            'flag_evaluates_to',
+                                                            'semver_eq',
+                                                            'semver_neq',
+                                                            'semver_gt',
+                                                            'semver_gte',
+                                                            'semver_lt',
+                                                            'semver_lte',
+                                                            'semver_tilde',
+                                                            'semver_caret',
+                                                            'semver_wildcard',
+                                                            'icontains_multi',
+                                                            'not_icontains_multi',
+                                                        ]),
+                                                        type: zod
+                                                            .literal('feature')
+                                                            .default(
+                                                                marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneOneFixedPropertiesOneItemTwofourEventFiltersOneItemFourTypeDefault
+                                                            )
+                                                            .describe('Event property with \"$feature\/\" prepended'),
+                                                        value: zod
+                                                            .union([
+                                                                zod.array(
+                                                                    zod.union([
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                    ])
+                                                                ),
+                                                                zod.string(),
+                                                                zod.number(),
+                                                                zod.boolean(),
+                                                                zod.null(),
+                                                            ])
+                                                            .optional(),
+                                                    }),
+                                                    zod.object({
+                                                        key: zod.string(),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
+                                                        type: zod
+                                                            .literal('hogql')
+                                                            .default(
+                                                                marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneOneFixedPropertiesOneItemTwofourEventFiltersOneItemFiveTypeDefault
+                                                            ),
+                                                        value: zod
+                                                            .union([
+                                                                zod.array(
+                                                                    zod.union([
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                    ])
+                                                                ),
+                                                                zod.string(),
+                                                                zod.number(),
+                                                                zod.boolean(),
+                                                                zod.null(),
+                                                            ])
+                                                            .optional(),
+                                                    }),
+                                                ])
+                                            ),
+                                            zod.null(),
+                                        ])
+                                        .optional()
+                                        .describe(
+                                            'Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral\/cohort filters and groups'
+                                        ),
+                                    event_type: zod.enum(['events', 'actions']),
+                                    explicit_datetime: zod
+                                        .union([zod.string(), zod.null()])
+                                        .optional()
+                                        .describe(
+                                            'Absolute or relative (e.g. -30d) lower date bound — alternative to time_value\/time_interval'
+                                        ),
+                                    explicit_datetime_to: zod.union([zod.string(), zod.null()]).optional(),
+                                    key: zod.string().describe("Event name, or action id when event_type is 'actions'"),
+                                    label: zod.union([zod.string(), zod.null()]).optional(),
+                                    negation: zod
+                                        .union([zod.boolean(), zod.null()])
+                                        .optional()
+                                        .describe(
+                                            'Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators'
+                                        ),
+                                    operator: zod
+                                        .union([
+                                            zod.enum([
+                                                'exact',
+                                                'is_not',
+                                                'icontains',
+                                                'not_icontains',
+                                                'starts_with',
+                                                'not_starts_with',
+                                                'ends_with',
+                                                'not_ends_with',
+                                                'regex',
+                                                'not_regex',
+                                                'gt',
+                                                'gte',
+                                                'lt',
+                                                'lte',
+                                                'is_set',
+                                                'is_not_set',
+                                                'is_date_exact',
+                                                'is_date_before',
+                                                'is_date_after',
+                                                'between',
+                                                'not_between',
+                                                'min',
+                                                'max',
+                                                'in',
+                                                'not_in',
+                                                'is_cleaned_path_exact',
+                                                'flag_evaluates_to',
+                                                'semver_eq',
+                                                'semver_neq',
+                                                'semver_gt',
+                                                'semver_gte',
+                                                'semver_lt',
+                                                'semver_lte',
+                                                'semver_tilde',
+                                                'semver_caret',
+                                                'semver_wildcard',
+                                                'icontains_multi',
+                                                'not_icontains_multi',
+                                            ]),
+                                            zod.null(),
+                                        ])
+                                        .optional()
+                                        .describe('Count comparison for performed_event_multiple, defaults to exact'),
+                                    operator_value: zod
+                                        .union([zod.number(), zod.null()])
+                                        .optional()
+                                        .describe('Count threshold for performed_event_multiple'),
+                                    time_interval: zod
+                                        .union([zod.enum(['day', 'week', 'month', 'year']), zod.null()])
+                                        .optional(),
+                                    time_value: zod
+                                        .union([zod.number(), zod.null()])
+                                        .optional()
+                                        .describe('Relative time window size, paired with time_interval'),
+                                    type: zod
+                                        .literal('behavioral')
+                                        .default(
+                                            marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneOneFixedPropertiesOneItemTwofourTypeDefault
+                                        )
+                                        .describe(
+                                            "Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP"
+                                        ),
+                                    value: zod.enum(['performed_event', 'performed_event_multiple']),
                                 }),
                             ])
                         ),
@@ -11233,6 +14055,392 @@ export const MarketingAnalyticsConversionGoalsCreateCreateBody = /* @__PURE__ */
                                         ])
                                         .optional(),
                                 }),
+                                zod.object({
+                                    event_filters: zod
+                                        .union([
+                                            zod.array(
+                                                zod.union([
+                                                    zod.object({
+                                                        key: zod.string(),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
+                                                        operator: zod
+                                                            .union([
+                                                                zod.enum([
+                                                                    'exact',
+                                                                    'is_not',
+                                                                    'icontains',
+                                                                    'not_icontains',
+                                                                    'starts_with',
+                                                                    'not_starts_with',
+                                                                    'ends_with',
+                                                                    'not_ends_with',
+                                                                    'regex',
+                                                                    'not_regex',
+                                                                    'gt',
+                                                                    'gte',
+                                                                    'lt',
+                                                                    'lte',
+                                                                    'is_set',
+                                                                    'is_not_set',
+                                                                    'is_date_exact',
+                                                                    'is_date_before',
+                                                                    'is_date_after',
+                                                                    'between',
+                                                                    'not_between',
+                                                                    'min',
+                                                                    'max',
+                                                                    'in',
+                                                                    'not_in',
+                                                                    'is_cleaned_path_exact',
+                                                                    'flag_evaluates_to',
+                                                                    'semver_eq',
+                                                                    'semver_neq',
+                                                                    'semver_gt',
+                                                                    'semver_gte',
+                                                                    'semver_lt',
+                                                                    'semver_lte',
+                                                                    'semver_tilde',
+                                                                    'semver_caret',
+                                                                    'semver_wildcard',
+                                                                    'icontains_multi',
+                                                                    'not_icontains_multi',
+                                                                ]),
+                                                                zod.null(),
+                                                            ])
+                                                            .default(
+                                                                marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneOnePropertiesOneItemTwofourEventFiltersOneItemOneOperatorDefault
+                                                            ),
+                                                        type: zod
+                                                            .literal('event')
+                                                            .default(
+                                                                marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneOnePropertiesOneItemTwofourEventFiltersOneItemOneTypeDefault
+                                                            )
+                                                            .describe('Event properties'),
+                                                        value: zod
+                                                            .union([
+                                                                zod.array(
+                                                                    zod.union([
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                    ])
+                                                                ),
+                                                                zod.string(),
+                                                                zod.number(),
+                                                                zod.boolean(),
+                                                                zod.null(),
+                                                            ])
+                                                            .optional(),
+                                                    }),
+                                                    zod.object({
+                                                        key: zod.string(),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
+                                                        operator: zod.enum([
+                                                            'exact',
+                                                            'is_not',
+                                                            'icontains',
+                                                            'not_icontains',
+                                                            'starts_with',
+                                                            'not_starts_with',
+                                                            'ends_with',
+                                                            'not_ends_with',
+                                                            'regex',
+                                                            'not_regex',
+                                                            'gt',
+                                                            'gte',
+                                                            'lt',
+                                                            'lte',
+                                                            'is_set',
+                                                            'is_not_set',
+                                                            'is_date_exact',
+                                                            'is_date_before',
+                                                            'is_date_after',
+                                                            'between',
+                                                            'not_between',
+                                                            'min',
+                                                            'max',
+                                                            'in',
+                                                            'not_in',
+                                                            'is_cleaned_path_exact',
+                                                            'flag_evaluates_to',
+                                                            'semver_eq',
+                                                            'semver_neq',
+                                                            'semver_gt',
+                                                            'semver_gte',
+                                                            'semver_lt',
+                                                            'semver_lte',
+                                                            'semver_tilde',
+                                                            'semver_caret',
+                                                            'semver_wildcard',
+                                                            'icontains_multi',
+                                                            'not_icontains_multi',
+                                                        ]),
+                                                        type: zod
+                                                            .literal('person')
+                                                            .default(
+                                                                marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneOnePropertiesOneItemTwofourEventFiltersOneItemTwoTypeDefault
+                                                            )
+                                                            .describe('Person properties'),
+                                                        value: zod
+                                                            .union([
+                                                                zod.array(
+                                                                    zod.union([
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                    ])
+                                                                ),
+                                                                zod.string(),
+                                                                zod.number(),
+                                                                zod.boolean(),
+                                                                zod.null(),
+                                                            ])
+                                                            .optional(),
+                                                    }),
+                                                    zod.object({
+                                                        key: zod.enum(['tag_name', 'text', 'href', 'selector']),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
+                                                        operator: zod.enum([
+                                                            'exact',
+                                                            'is_not',
+                                                            'icontains',
+                                                            'not_icontains',
+                                                            'starts_with',
+                                                            'not_starts_with',
+                                                            'ends_with',
+                                                            'not_ends_with',
+                                                            'regex',
+                                                            'not_regex',
+                                                            'gt',
+                                                            'gte',
+                                                            'lt',
+                                                            'lte',
+                                                            'is_set',
+                                                            'is_not_set',
+                                                            'is_date_exact',
+                                                            'is_date_before',
+                                                            'is_date_after',
+                                                            'between',
+                                                            'not_between',
+                                                            'min',
+                                                            'max',
+                                                            'in',
+                                                            'not_in',
+                                                            'is_cleaned_path_exact',
+                                                            'flag_evaluates_to',
+                                                            'semver_eq',
+                                                            'semver_neq',
+                                                            'semver_gt',
+                                                            'semver_gte',
+                                                            'semver_lt',
+                                                            'semver_lte',
+                                                            'semver_tilde',
+                                                            'semver_caret',
+                                                            'semver_wildcard',
+                                                            'icontains_multi',
+                                                            'not_icontains_multi',
+                                                        ]),
+                                                        type: zod
+                                                            .literal('element')
+                                                            .default(
+                                                                marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneOnePropertiesOneItemTwofourEventFiltersOneItemThreeTypeDefault
+                                                            ),
+                                                        value: zod
+                                                            .union([
+                                                                zod.array(
+                                                                    zod.union([
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                    ])
+                                                                ),
+                                                                zod.string(),
+                                                                zod.number(),
+                                                                zod.boolean(),
+                                                                zod.null(),
+                                                            ])
+                                                            .optional(),
+                                                    }),
+                                                    zod.object({
+                                                        key: zod.string(),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
+                                                        operator: zod.enum([
+                                                            'exact',
+                                                            'is_not',
+                                                            'icontains',
+                                                            'not_icontains',
+                                                            'starts_with',
+                                                            'not_starts_with',
+                                                            'ends_with',
+                                                            'not_ends_with',
+                                                            'regex',
+                                                            'not_regex',
+                                                            'gt',
+                                                            'gte',
+                                                            'lt',
+                                                            'lte',
+                                                            'is_set',
+                                                            'is_not_set',
+                                                            'is_date_exact',
+                                                            'is_date_before',
+                                                            'is_date_after',
+                                                            'between',
+                                                            'not_between',
+                                                            'min',
+                                                            'max',
+                                                            'in',
+                                                            'not_in',
+                                                            'is_cleaned_path_exact',
+                                                            'flag_evaluates_to',
+                                                            'semver_eq',
+                                                            'semver_neq',
+                                                            'semver_gt',
+                                                            'semver_gte',
+                                                            'semver_lt',
+                                                            'semver_lte',
+                                                            'semver_tilde',
+                                                            'semver_caret',
+                                                            'semver_wildcard',
+                                                            'icontains_multi',
+                                                            'not_icontains_multi',
+                                                        ]),
+                                                        type: zod
+                                                            .literal('feature')
+                                                            .default(
+                                                                marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneOnePropertiesOneItemTwofourEventFiltersOneItemFourTypeDefault
+                                                            )
+                                                            .describe('Event property with \"$feature\/\" prepended'),
+                                                        value: zod
+                                                            .union([
+                                                                zod.array(
+                                                                    zod.union([
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                    ])
+                                                                ),
+                                                                zod.string(),
+                                                                zod.number(),
+                                                                zod.boolean(),
+                                                                zod.null(),
+                                                            ])
+                                                            .optional(),
+                                                    }),
+                                                    zod.object({
+                                                        key: zod.string(),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
+                                                        type: zod
+                                                            .literal('hogql')
+                                                            .default(
+                                                                marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneOnePropertiesOneItemTwofourEventFiltersOneItemFiveTypeDefault
+                                                            ),
+                                                        value: zod
+                                                            .union([
+                                                                zod.array(
+                                                                    zod.union([
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                    ])
+                                                                ),
+                                                                zod.string(),
+                                                                zod.number(),
+                                                                zod.boolean(),
+                                                                zod.null(),
+                                                            ])
+                                                            .optional(),
+                                                    }),
+                                                ])
+                                            ),
+                                            zod.null(),
+                                        ])
+                                        .optional()
+                                        .describe(
+                                            'Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral\/cohort filters and groups'
+                                        ),
+                                    event_type: zod.enum(['events', 'actions']),
+                                    explicit_datetime: zod
+                                        .union([zod.string(), zod.null()])
+                                        .optional()
+                                        .describe(
+                                            'Absolute or relative (e.g. -30d) lower date bound — alternative to time_value\/time_interval'
+                                        ),
+                                    explicit_datetime_to: zod.union([zod.string(), zod.null()]).optional(),
+                                    key: zod.string().describe("Event name, or action id when event_type is 'actions'"),
+                                    label: zod.union([zod.string(), zod.null()]).optional(),
+                                    negation: zod
+                                        .union([zod.boolean(), zod.null()])
+                                        .optional()
+                                        .describe(
+                                            'Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators'
+                                        ),
+                                    operator: zod
+                                        .union([
+                                            zod.enum([
+                                                'exact',
+                                                'is_not',
+                                                'icontains',
+                                                'not_icontains',
+                                                'starts_with',
+                                                'not_starts_with',
+                                                'ends_with',
+                                                'not_ends_with',
+                                                'regex',
+                                                'not_regex',
+                                                'gt',
+                                                'gte',
+                                                'lt',
+                                                'lte',
+                                                'is_set',
+                                                'is_not_set',
+                                                'is_date_exact',
+                                                'is_date_before',
+                                                'is_date_after',
+                                                'between',
+                                                'not_between',
+                                                'min',
+                                                'max',
+                                                'in',
+                                                'not_in',
+                                                'is_cleaned_path_exact',
+                                                'flag_evaluates_to',
+                                                'semver_eq',
+                                                'semver_neq',
+                                                'semver_gt',
+                                                'semver_gte',
+                                                'semver_lt',
+                                                'semver_lte',
+                                                'semver_tilde',
+                                                'semver_caret',
+                                                'semver_wildcard',
+                                                'icontains_multi',
+                                                'not_icontains_multi',
+                                            ]),
+                                            zod.null(),
+                                        ])
+                                        .optional()
+                                        .describe('Count comparison for performed_event_multiple, defaults to exact'),
+                                    operator_value: zod
+                                        .union([zod.number(), zod.null()])
+                                        .optional()
+                                        .describe('Count threshold for performed_event_multiple'),
+                                    time_interval: zod
+                                        .union([zod.enum(['day', 'week', 'month', 'year']), zod.null()])
+                                        .optional(),
+                                    time_value: zod
+                                        .union([zod.number(), zod.null()])
+                                        .optional()
+                                        .describe('Relative time window size, paired with time_interval'),
+                                    type: zod
+                                        .literal('behavioral')
+                                        .default(
+                                            marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneOnePropertiesOneItemTwofourTypeDefault
+                                        )
+                                        .describe(
+                                            "Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP"
+                                        ),
+                                    value: zod.enum(['performed_event', 'performed_event_multiple']),
+                                }),
                             ])
                         ),
                         zod.null(),
@@ -12488,6 +15696,392 @@ export const MarketingAnalyticsConversionGoalsCreateCreateBody = /* @__PURE__ */
                                             zod.null(),
                                         ])
                                         .optional(),
+                                }),
+                                zod.object({
+                                    event_filters: zod
+                                        .union([
+                                            zod.array(
+                                                zod.union([
+                                                    zod.object({
+                                                        key: zod.string(),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
+                                                        operator: zod
+                                                            .union([
+                                                                zod.enum([
+                                                                    'exact',
+                                                                    'is_not',
+                                                                    'icontains',
+                                                                    'not_icontains',
+                                                                    'starts_with',
+                                                                    'not_starts_with',
+                                                                    'ends_with',
+                                                                    'not_ends_with',
+                                                                    'regex',
+                                                                    'not_regex',
+                                                                    'gt',
+                                                                    'gte',
+                                                                    'lt',
+                                                                    'lte',
+                                                                    'is_set',
+                                                                    'is_not_set',
+                                                                    'is_date_exact',
+                                                                    'is_date_before',
+                                                                    'is_date_after',
+                                                                    'between',
+                                                                    'not_between',
+                                                                    'min',
+                                                                    'max',
+                                                                    'in',
+                                                                    'not_in',
+                                                                    'is_cleaned_path_exact',
+                                                                    'flag_evaluates_to',
+                                                                    'semver_eq',
+                                                                    'semver_neq',
+                                                                    'semver_gt',
+                                                                    'semver_gte',
+                                                                    'semver_lt',
+                                                                    'semver_lte',
+                                                                    'semver_tilde',
+                                                                    'semver_caret',
+                                                                    'semver_wildcard',
+                                                                    'icontains_multi',
+                                                                    'not_icontains_multi',
+                                                                ]),
+                                                                zod.null(),
+                                                            ])
+                                                            .default(
+                                                                marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneTwoFixedPropertiesOneItemTwofourEventFiltersOneItemOneOperatorDefault
+                                                            ),
+                                                        type: zod
+                                                            .literal('event')
+                                                            .default(
+                                                                marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneTwoFixedPropertiesOneItemTwofourEventFiltersOneItemOneTypeDefault
+                                                            )
+                                                            .describe('Event properties'),
+                                                        value: zod
+                                                            .union([
+                                                                zod.array(
+                                                                    zod.union([
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                    ])
+                                                                ),
+                                                                zod.string(),
+                                                                zod.number(),
+                                                                zod.boolean(),
+                                                                zod.null(),
+                                                            ])
+                                                            .optional(),
+                                                    }),
+                                                    zod.object({
+                                                        key: zod.string(),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
+                                                        operator: zod.enum([
+                                                            'exact',
+                                                            'is_not',
+                                                            'icontains',
+                                                            'not_icontains',
+                                                            'starts_with',
+                                                            'not_starts_with',
+                                                            'ends_with',
+                                                            'not_ends_with',
+                                                            'regex',
+                                                            'not_regex',
+                                                            'gt',
+                                                            'gte',
+                                                            'lt',
+                                                            'lte',
+                                                            'is_set',
+                                                            'is_not_set',
+                                                            'is_date_exact',
+                                                            'is_date_before',
+                                                            'is_date_after',
+                                                            'between',
+                                                            'not_between',
+                                                            'min',
+                                                            'max',
+                                                            'in',
+                                                            'not_in',
+                                                            'is_cleaned_path_exact',
+                                                            'flag_evaluates_to',
+                                                            'semver_eq',
+                                                            'semver_neq',
+                                                            'semver_gt',
+                                                            'semver_gte',
+                                                            'semver_lt',
+                                                            'semver_lte',
+                                                            'semver_tilde',
+                                                            'semver_caret',
+                                                            'semver_wildcard',
+                                                            'icontains_multi',
+                                                            'not_icontains_multi',
+                                                        ]),
+                                                        type: zod
+                                                            .literal('person')
+                                                            .default(
+                                                                marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneTwoFixedPropertiesOneItemTwofourEventFiltersOneItemTwoTypeDefault
+                                                            )
+                                                            .describe('Person properties'),
+                                                        value: zod
+                                                            .union([
+                                                                zod.array(
+                                                                    zod.union([
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                    ])
+                                                                ),
+                                                                zod.string(),
+                                                                zod.number(),
+                                                                zod.boolean(),
+                                                                zod.null(),
+                                                            ])
+                                                            .optional(),
+                                                    }),
+                                                    zod.object({
+                                                        key: zod.enum(['tag_name', 'text', 'href', 'selector']),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
+                                                        operator: zod.enum([
+                                                            'exact',
+                                                            'is_not',
+                                                            'icontains',
+                                                            'not_icontains',
+                                                            'starts_with',
+                                                            'not_starts_with',
+                                                            'ends_with',
+                                                            'not_ends_with',
+                                                            'regex',
+                                                            'not_regex',
+                                                            'gt',
+                                                            'gte',
+                                                            'lt',
+                                                            'lte',
+                                                            'is_set',
+                                                            'is_not_set',
+                                                            'is_date_exact',
+                                                            'is_date_before',
+                                                            'is_date_after',
+                                                            'between',
+                                                            'not_between',
+                                                            'min',
+                                                            'max',
+                                                            'in',
+                                                            'not_in',
+                                                            'is_cleaned_path_exact',
+                                                            'flag_evaluates_to',
+                                                            'semver_eq',
+                                                            'semver_neq',
+                                                            'semver_gt',
+                                                            'semver_gte',
+                                                            'semver_lt',
+                                                            'semver_lte',
+                                                            'semver_tilde',
+                                                            'semver_caret',
+                                                            'semver_wildcard',
+                                                            'icontains_multi',
+                                                            'not_icontains_multi',
+                                                        ]),
+                                                        type: zod
+                                                            .literal('element')
+                                                            .default(
+                                                                marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneTwoFixedPropertiesOneItemTwofourEventFiltersOneItemThreeTypeDefault
+                                                            ),
+                                                        value: zod
+                                                            .union([
+                                                                zod.array(
+                                                                    zod.union([
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                    ])
+                                                                ),
+                                                                zod.string(),
+                                                                zod.number(),
+                                                                zod.boolean(),
+                                                                zod.null(),
+                                                            ])
+                                                            .optional(),
+                                                    }),
+                                                    zod.object({
+                                                        key: zod.string(),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
+                                                        operator: zod.enum([
+                                                            'exact',
+                                                            'is_not',
+                                                            'icontains',
+                                                            'not_icontains',
+                                                            'starts_with',
+                                                            'not_starts_with',
+                                                            'ends_with',
+                                                            'not_ends_with',
+                                                            'regex',
+                                                            'not_regex',
+                                                            'gt',
+                                                            'gte',
+                                                            'lt',
+                                                            'lte',
+                                                            'is_set',
+                                                            'is_not_set',
+                                                            'is_date_exact',
+                                                            'is_date_before',
+                                                            'is_date_after',
+                                                            'between',
+                                                            'not_between',
+                                                            'min',
+                                                            'max',
+                                                            'in',
+                                                            'not_in',
+                                                            'is_cleaned_path_exact',
+                                                            'flag_evaluates_to',
+                                                            'semver_eq',
+                                                            'semver_neq',
+                                                            'semver_gt',
+                                                            'semver_gte',
+                                                            'semver_lt',
+                                                            'semver_lte',
+                                                            'semver_tilde',
+                                                            'semver_caret',
+                                                            'semver_wildcard',
+                                                            'icontains_multi',
+                                                            'not_icontains_multi',
+                                                        ]),
+                                                        type: zod
+                                                            .literal('feature')
+                                                            .default(
+                                                                marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneTwoFixedPropertiesOneItemTwofourEventFiltersOneItemFourTypeDefault
+                                                            )
+                                                            .describe('Event property with \"$feature\/\" prepended'),
+                                                        value: zod
+                                                            .union([
+                                                                zod.array(
+                                                                    zod.union([
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                    ])
+                                                                ),
+                                                                zod.string(),
+                                                                zod.number(),
+                                                                zod.boolean(),
+                                                                zod.null(),
+                                                            ])
+                                                            .optional(),
+                                                    }),
+                                                    zod.object({
+                                                        key: zod.string(),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
+                                                        type: zod
+                                                            .literal('hogql')
+                                                            .default(
+                                                                marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneTwoFixedPropertiesOneItemTwofourEventFiltersOneItemFiveTypeDefault
+                                                            ),
+                                                        value: zod
+                                                            .union([
+                                                                zod.array(
+                                                                    zod.union([
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                    ])
+                                                                ),
+                                                                zod.string(),
+                                                                zod.number(),
+                                                                zod.boolean(),
+                                                                zod.null(),
+                                                            ])
+                                                            .optional(),
+                                                    }),
+                                                ])
+                                            ),
+                                            zod.null(),
+                                        ])
+                                        .optional()
+                                        .describe(
+                                            'Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral\/cohort filters and groups'
+                                        ),
+                                    event_type: zod.enum(['events', 'actions']),
+                                    explicit_datetime: zod
+                                        .union([zod.string(), zod.null()])
+                                        .optional()
+                                        .describe(
+                                            'Absolute or relative (e.g. -30d) lower date bound — alternative to time_value\/time_interval'
+                                        ),
+                                    explicit_datetime_to: zod.union([zod.string(), zod.null()]).optional(),
+                                    key: zod.string().describe("Event name, or action id when event_type is 'actions'"),
+                                    label: zod.union([zod.string(), zod.null()]).optional(),
+                                    negation: zod
+                                        .union([zod.boolean(), zod.null()])
+                                        .optional()
+                                        .describe(
+                                            'Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators'
+                                        ),
+                                    operator: zod
+                                        .union([
+                                            zod.enum([
+                                                'exact',
+                                                'is_not',
+                                                'icontains',
+                                                'not_icontains',
+                                                'starts_with',
+                                                'not_starts_with',
+                                                'ends_with',
+                                                'not_ends_with',
+                                                'regex',
+                                                'not_regex',
+                                                'gt',
+                                                'gte',
+                                                'lt',
+                                                'lte',
+                                                'is_set',
+                                                'is_not_set',
+                                                'is_date_exact',
+                                                'is_date_before',
+                                                'is_date_after',
+                                                'between',
+                                                'not_between',
+                                                'min',
+                                                'max',
+                                                'in',
+                                                'not_in',
+                                                'is_cleaned_path_exact',
+                                                'flag_evaluates_to',
+                                                'semver_eq',
+                                                'semver_neq',
+                                                'semver_gt',
+                                                'semver_gte',
+                                                'semver_lt',
+                                                'semver_lte',
+                                                'semver_tilde',
+                                                'semver_caret',
+                                                'semver_wildcard',
+                                                'icontains_multi',
+                                                'not_icontains_multi',
+                                            ]),
+                                            zod.null(),
+                                        ])
+                                        .optional()
+                                        .describe('Count comparison for performed_event_multiple, defaults to exact'),
+                                    operator_value: zod
+                                        .union([zod.number(), zod.null()])
+                                        .optional()
+                                        .describe('Count threshold for performed_event_multiple'),
+                                    time_interval: zod
+                                        .union([zod.enum(['day', 'week', 'month', 'year']), zod.null()])
+                                        .optional(),
+                                    time_value: zod
+                                        .union([zod.number(), zod.null()])
+                                        .optional()
+                                        .describe('Relative time window size, paired with time_interval'),
+                                    type: zod
+                                        .literal('behavioral')
+                                        .default(
+                                            marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneTwoFixedPropertiesOneItemTwofourTypeDefault
+                                        )
+                                        .describe(
+                                            "Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP"
+                                        ),
+                                    value: zod.enum(['performed_event', 'performed_event_multiple']),
                                 }),
                             ])
                         ),
@@ -13947,6 +17541,392 @@ export const MarketingAnalyticsConversionGoalsCreateCreateBody = /* @__PURE__ */
                                         ])
                                         .optional(),
                                 }),
+                                zod.object({
+                                    event_filters: zod
+                                        .union([
+                                            zod.array(
+                                                zod.union([
+                                                    zod.object({
+                                                        key: zod.string(),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
+                                                        operator: zod
+                                                            .union([
+                                                                zod.enum([
+                                                                    'exact',
+                                                                    'is_not',
+                                                                    'icontains',
+                                                                    'not_icontains',
+                                                                    'starts_with',
+                                                                    'not_starts_with',
+                                                                    'ends_with',
+                                                                    'not_ends_with',
+                                                                    'regex',
+                                                                    'not_regex',
+                                                                    'gt',
+                                                                    'gte',
+                                                                    'lt',
+                                                                    'lte',
+                                                                    'is_set',
+                                                                    'is_not_set',
+                                                                    'is_date_exact',
+                                                                    'is_date_before',
+                                                                    'is_date_after',
+                                                                    'between',
+                                                                    'not_between',
+                                                                    'min',
+                                                                    'max',
+                                                                    'in',
+                                                                    'not_in',
+                                                                    'is_cleaned_path_exact',
+                                                                    'flag_evaluates_to',
+                                                                    'semver_eq',
+                                                                    'semver_neq',
+                                                                    'semver_gt',
+                                                                    'semver_gte',
+                                                                    'semver_lt',
+                                                                    'semver_lte',
+                                                                    'semver_tilde',
+                                                                    'semver_caret',
+                                                                    'semver_wildcard',
+                                                                    'icontains_multi',
+                                                                    'not_icontains_multi',
+                                                                ]),
+                                                                zod.null(),
+                                                            ])
+                                                            .default(
+                                                                marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneTwoPropertiesOneItemTwofourEventFiltersOneItemOneOperatorDefault
+                                                            ),
+                                                        type: zod
+                                                            .literal('event')
+                                                            .default(
+                                                                marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneTwoPropertiesOneItemTwofourEventFiltersOneItemOneTypeDefault
+                                                            )
+                                                            .describe('Event properties'),
+                                                        value: zod
+                                                            .union([
+                                                                zod.array(
+                                                                    zod.union([
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                    ])
+                                                                ),
+                                                                zod.string(),
+                                                                zod.number(),
+                                                                zod.boolean(),
+                                                                zod.null(),
+                                                            ])
+                                                            .optional(),
+                                                    }),
+                                                    zod.object({
+                                                        key: zod.string(),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
+                                                        operator: zod.enum([
+                                                            'exact',
+                                                            'is_not',
+                                                            'icontains',
+                                                            'not_icontains',
+                                                            'starts_with',
+                                                            'not_starts_with',
+                                                            'ends_with',
+                                                            'not_ends_with',
+                                                            'regex',
+                                                            'not_regex',
+                                                            'gt',
+                                                            'gte',
+                                                            'lt',
+                                                            'lte',
+                                                            'is_set',
+                                                            'is_not_set',
+                                                            'is_date_exact',
+                                                            'is_date_before',
+                                                            'is_date_after',
+                                                            'between',
+                                                            'not_between',
+                                                            'min',
+                                                            'max',
+                                                            'in',
+                                                            'not_in',
+                                                            'is_cleaned_path_exact',
+                                                            'flag_evaluates_to',
+                                                            'semver_eq',
+                                                            'semver_neq',
+                                                            'semver_gt',
+                                                            'semver_gte',
+                                                            'semver_lt',
+                                                            'semver_lte',
+                                                            'semver_tilde',
+                                                            'semver_caret',
+                                                            'semver_wildcard',
+                                                            'icontains_multi',
+                                                            'not_icontains_multi',
+                                                        ]),
+                                                        type: zod
+                                                            .literal('person')
+                                                            .default(
+                                                                marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneTwoPropertiesOneItemTwofourEventFiltersOneItemTwoTypeDefault
+                                                            )
+                                                            .describe('Person properties'),
+                                                        value: zod
+                                                            .union([
+                                                                zod.array(
+                                                                    zod.union([
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                    ])
+                                                                ),
+                                                                zod.string(),
+                                                                zod.number(),
+                                                                zod.boolean(),
+                                                                zod.null(),
+                                                            ])
+                                                            .optional(),
+                                                    }),
+                                                    zod.object({
+                                                        key: zod.enum(['tag_name', 'text', 'href', 'selector']),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
+                                                        operator: zod.enum([
+                                                            'exact',
+                                                            'is_not',
+                                                            'icontains',
+                                                            'not_icontains',
+                                                            'starts_with',
+                                                            'not_starts_with',
+                                                            'ends_with',
+                                                            'not_ends_with',
+                                                            'regex',
+                                                            'not_regex',
+                                                            'gt',
+                                                            'gte',
+                                                            'lt',
+                                                            'lte',
+                                                            'is_set',
+                                                            'is_not_set',
+                                                            'is_date_exact',
+                                                            'is_date_before',
+                                                            'is_date_after',
+                                                            'between',
+                                                            'not_between',
+                                                            'min',
+                                                            'max',
+                                                            'in',
+                                                            'not_in',
+                                                            'is_cleaned_path_exact',
+                                                            'flag_evaluates_to',
+                                                            'semver_eq',
+                                                            'semver_neq',
+                                                            'semver_gt',
+                                                            'semver_gte',
+                                                            'semver_lt',
+                                                            'semver_lte',
+                                                            'semver_tilde',
+                                                            'semver_caret',
+                                                            'semver_wildcard',
+                                                            'icontains_multi',
+                                                            'not_icontains_multi',
+                                                        ]),
+                                                        type: zod
+                                                            .literal('element')
+                                                            .default(
+                                                                marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneTwoPropertiesOneItemTwofourEventFiltersOneItemThreeTypeDefault
+                                                            ),
+                                                        value: zod
+                                                            .union([
+                                                                zod.array(
+                                                                    zod.union([
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                    ])
+                                                                ),
+                                                                zod.string(),
+                                                                zod.number(),
+                                                                zod.boolean(),
+                                                                zod.null(),
+                                                            ])
+                                                            .optional(),
+                                                    }),
+                                                    zod.object({
+                                                        key: zod.string(),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
+                                                        operator: zod.enum([
+                                                            'exact',
+                                                            'is_not',
+                                                            'icontains',
+                                                            'not_icontains',
+                                                            'starts_with',
+                                                            'not_starts_with',
+                                                            'ends_with',
+                                                            'not_ends_with',
+                                                            'regex',
+                                                            'not_regex',
+                                                            'gt',
+                                                            'gte',
+                                                            'lt',
+                                                            'lte',
+                                                            'is_set',
+                                                            'is_not_set',
+                                                            'is_date_exact',
+                                                            'is_date_before',
+                                                            'is_date_after',
+                                                            'between',
+                                                            'not_between',
+                                                            'min',
+                                                            'max',
+                                                            'in',
+                                                            'not_in',
+                                                            'is_cleaned_path_exact',
+                                                            'flag_evaluates_to',
+                                                            'semver_eq',
+                                                            'semver_neq',
+                                                            'semver_gt',
+                                                            'semver_gte',
+                                                            'semver_lt',
+                                                            'semver_lte',
+                                                            'semver_tilde',
+                                                            'semver_caret',
+                                                            'semver_wildcard',
+                                                            'icontains_multi',
+                                                            'not_icontains_multi',
+                                                        ]),
+                                                        type: zod
+                                                            .literal('feature')
+                                                            .default(
+                                                                marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneTwoPropertiesOneItemTwofourEventFiltersOneItemFourTypeDefault
+                                                            )
+                                                            .describe('Event property with \"$feature\/\" prepended'),
+                                                        value: zod
+                                                            .union([
+                                                                zod.array(
+                                                                    zod.union([
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                    ])
+                                                                ),
+                                                                zod.string(),
+                                                                zod.number(),
+                                                                zod.boolean(),
+                                                                zod.null(),
+                                                            ])
+                                                            .optional(),
+                                                    }),
+                                                    zod.object({
+                                                        key: zod.string(),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
+                                                        type: zod
+                                                            .literal('hogql')
+                                                            .default(
+                                                                marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneTwoPropertiesOneItemTwofourEventFiltersOneItemFiveTypeDefault
+                                                            ),
+                                                        value: zod
+                                                            .union([
+                                                                zod.array(
+                                                                    zod.union([
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                    ])
+                                                                ),
+                                                                zod.string(),
+                                                                zod.number(),
+                                                                zod.boolean(),
+                                                                zod.null(),
+                                                            ])
+                                                            .optional(),
+                                                    }),
+                                                ])
+                                            ),
+                                            zod.null(),
+                                        ])
+                                        .optional()
+                                        .describe(
+                                            'Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral\/cohort filters and groups'
+                                        ),
+                                    event_type: zod.enum(['events', 'actions']),
+                                    explicit_datetime: zod
+                                        .union([zod.string(), zod.null()])
+                                        .optional()
+                                        .describe(
+                                            'Absolute or relative (e.g. -30d) lower date bound — alternative to time_value\/time_interval'
+                                        ),
+                                    explicit_datetime_to: zod.union([zod.string(), zod.null()]).optional(),
+                                    key: zod.string().describe("Event name, or action id when event_type is 'actions'"),
+                                    label: zod.union([zod.string(), zod.null()]).optional(),
+                                    negation: zod
+                                        .union([zod.boolean(), zod.null()])
+                                        .optional()
+                                        .describe(
+                                            'Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators'
+                                        ),
+                                    operator: zod
+                                        .union([
+                                            zod.enum([
+                                                'exact',
+                                                'is_not',
+                                                'icontains',
+                                                'not_icontains',
+                                                'starts_with',
+                                                'not_starts_with',
+                                                'ends_with',
+                                                'not_ends_with',
+                                                'regex',
+                                                'not_regex',
+                                                'gt',
+                                                'gte',
+                                                'lt',
+                                                'lte',
+                                                'is_set',
+                                                'is_not_set',
+                                                'is_date_exact',
+                                                'is_date_before',
+                                                'is_date_after',
+                                                'between',
+                                                'not_between',
+                                                'min',
+                                                'max',
+                                                'in',
+                                                'not_in',
+                                                'is_cleaned_path_exact',
+                                                'flag_evaluates_to',
+                                                'semver_eq',
+                                                'semver_neq',
+                                                'semver_gt',
+                                                'semver_gte',
+                                                'semver_lt',
+                                                'semver_lte',
+                                                'semver_tilde',
+                                                'semver_caret',
+                                                'semver_wildcard',
+                                                'icontains_multi',
+                                                'not_icontains_multi',
+                                            ]),
+                                            zod.null(),
+                                        ])
+                                        .optional()
+                                        .describe('Count comparison for performed_event_multiple, defaults to exact'),
+                                    operator_value: zod
+                                        .union([zod.number(), zod.null()])
+                                        .optional()
+                                        .describe('Count threshold for performed_event_multiple'),
+                                    time_interval: zod
+                                        .union([zod.enum(['day', 'week', 'month', 'year']), zod.null()])
+                                        .optional(),
+                                    time_value: zod
+                                        .union([zod.number(), zod.null()])
+                                        .optional()
+                                        .describe('Relative time window size, paired with time_interval'),
+                                    type: zod
+                                        .literal('behavioral')
+                                        .default(
+                                            marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneTwoPropertiesOneItemTwofourTypeDefault
+                                        )
+                                        .describe(
+                                            "Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP"
+                                        ),
+                                    value: zod.enum(['performed_event', 'performed_event_multiple']),
+                                }),
                             ])
                         ),
                         zod.null(),
@@ -15204,6 +19184,392 @@ export const MarketingAnalyticsConversionGoalsCreateCreateBody = /* @__PURE__ */
                                             zod.null(),
                                         ])
                                         .optional(),
+                                }),
+                                zod.object({
+                                    event_filters: zod
+                                        .union([
+                                            zod.array(
+                                                zod.union([
+                                                    zod.object({
+                                                        key: zod.string(),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
+                                                        operator: zod
+                                                            .union([
+                                                                zod.enum([
+                                                                    'exact',
+                                                                    'is_not',
+                                                                    'icontains',
+                                                                    'not_icontains',
+                                                                    'starts_with',
+                                                                    'not_starts_with',
+                                                                    'ends_with',
+                                                                    'not_ends_with',
+                                                                    'regex',
+                                                                    'not_regex',
+                                                                    'gt',
+                                                                    'gte',
+                                                                    'lt',
+                                                                    'lte',
+                                                                    'is_set',
+                                                                    'is_not_set',
+                                                                    'is_date_exact',
+                                                                    'is_date_before',
+                                                                    'is_date_after',
+                                                                    'between',
+                                                                    'not_between',
+                                                                    'min',
+                                                                    'max',
+                                                                    'in',
+                                                                    'not_in',
+                                                                    'is_cleaned_path_exact',
+                                                                    'flag_evaluates_to',
+                                                                    'semver_eq',
+                                                                    'semver_neq',
+                                                                    'semver_gt',
+                                                                    'semver_gte',
+                                                                    'semver_lt',
+                                                                    'semver_lte',
+                                                                    'semver_tilde',
+                                                                    'semver_caret',
+                                                                    'semver_wildcard',
+                                                                    'icontains_multi',
+                                                                    'not_icontains_multi',
+                                                                ]),
+                                                                zod.null(),
+                                                            ])
+                                                            .default(
+                                                                marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneThreeFixedPropertiesOneItemTwofourEventFiltersOneItemOneOperatorDefault
+                                                            ),
+                                                        type: zod
+                                                            .literal('event')
+                                                            .default(
+                                                                marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneThreeFixedPropertiesOneItemTwofourEventFiltersOneItemOneTypeDefault
+                                                            )
+                                                            .describe('Event properties'),
+                                                        value: zod
+                                                            .union([
+                                                                zod.array(
+                                                                    zod.union([
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                    ])
+                                                                ),
+                                                                zod.string(),
+                                                                zod.number(),
+                                                                zod.boolean(),
+                                                                zod.null(),
+                                                            ])
+                                                            .optional(),
+                                                    }),
+                                                    zod.object({
+                                                        key: zod.string(),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
+                                                        operator: zod.enum([
+                                                            'exact',
+                                                            'is_not',
+                                                            'icontains',
+                                                            'not_icontains',
+                                                            'starts_with',
+                                                            'not_starts_with',
+                                                            'ends_with',
+                                                            'not_ends_with',
+                                                            'regex',
+                                                            'not_regex',
+                                                            'gt',
+                                                            'gte',
+                                                            'lt',
+                                                            'lte',
+                                                            'is_set',
+                                                            'is_not_set',
+                                                            'is_date_exact',
+                                                            'is_date_before',
+                                                            'is_date_after',
+                                                            'between',
+                                                            'not_between',
+                                                            'min',
+                                                            'max',
+                                                            'in',
+                                                            'not_in',
+                                                            'is_cleaned_path_exact',
+                                                            'flag_evaluates_to',
+                                                            'semver_eq',
+                                                            'semver_neq',
+                                                            'semver_gt',
+                                                            'semver_gte',
+                                                            'semver_lt',
+                                                            'semver_lte',
+                                                            'semver_tilde',
+                                                            'semver_caret',
+                                                            'semver_wildcard',
+                                                            'icontains_multi',
+                                                            'not_icontains_multi',
+                                                        ]),
+                                                        type: zod
+                                                            .literal('person')
+                                                            .default(
+                                                                marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneThreeFixedPropertiesOneItemTwofourEventFiltersOneItemTwoTypeDefault
+                                                            )
+                                                            .describe('Person properties'),
+                                                        value: zod
+                                                            .union([
+                                                                zod.array(
+                                                                    zod.union([
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                    ])
+                                                                ),
+                                                                zod.string(),
+                                                                zod.number(),
+                                                                zod.boolean(),
+                                                                zod.null(),
+                                                            ])
+                                                            .optional(),
+                                                    }),
+                                                    zod.object({
+                                                        key: zod.enum(['tag_name', 'text', 'href', 'selector']),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
+                                                        operator: zod.enum([
+                                                            'exact',
+                                                            'is_not',
+                                                            'icontains',
+                                                            'not_icontains',
+                                                            'starts_with',
+                                                            'not_starts_with',
+                                                            'ends_with',
+                                                            'not_ends_with',
+                                                            'regex',
+                                                            'not_regex',
+                                                            'gt',
+                                                            'gte',
+                                                            'lt',
+                                                            'lte',
+                                                            'is_set',
+                                                            'is_not_set',
+                                                            'is_date_exact',
+                                                            'is_date_before',
+                                                            'is_date_after',
+                                                            'between',
+                                                            'not_between',
+                                                            'min',
+                                                            'max',
+                                                            'in',
+                                                            'not_in',
+                                                            'is_cleaned_path_exact',
+                                                            'flag_evaluates_to',
+                                                            'semver_eq',
+                                                            'semver_neq',
+                                                            'semver_gt',
+                                                            'semver_gte',
+                                                            'semver_lt',
+                                                            'semver_lte',
+                                                            'semver_tilde',
+                                                            'semver_caret',
+                                                            'semver_wildcard',
+                                                            'icontains_multi',
+                                                            'not_icontains_multi',
+                                                        ]),
+                                                        type: zod
+                                                            .literal('element')
+                                                            .default(
+                                                                marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneThreeFixedPropertiesOneItemTwofourEventFiltersOneItemThreeTypeDefault
+                                                            ),
+                                                        value: zod
+                                                            .union([
+                                                                zod.array(
+                                                                    zod.union([
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                    ])
+                                                                ),
+                                                                zod.string(),
+                                                                zod.number(),
+                                                                zod.boolean(),
+                                                                zod.null(),
+                                                            ])
+                                                            .optional(),
+                                                    }),
+                                                    zod.object({
+                                                        key: zod.string(),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
+                                                        operator: zod.enum([
+                                                            'exact',
+                                                            'is_not',
+                                                            'icontains',
+                                                            'not_icontains',
+                                                            'starts_with',
+                                                            'not_starts_with',
+                                                            'ends_with',
+                                                            'not_ends_with',
+                                                            'regex',
+                                                            'not_regex',
+                                                            'gt',
+                                                            'gte',
+                                                            'lt',
+                                                            'lte',
+                                                            'is_set',
+                                                            'is_not_set',
+                                                            'is_date_exact',
+                                                            'is_date_before',
+                                                            'is_date_after',
+                                                            'between',
+                                                            'not_between',
+                                                            'min',
+                                                            'max',
+                                                            'in',
+                                                            'not_in',
+                                                            'is_cleaned_path_exact',
+                                                            'flag_evaluates_to',
+                                                            'semver_eq',
+                                                            'semver_neq',
+                                                            'semver_gt',
+                                                            'semver_gte',
+                                                            'semver_lt',
+                                                            'semver_lte',
+                                                            'semver_tilde',
+                                                            'semver_caret',
+                                                            'semver_wildcard',
+                                                            'icontains_multi',
+                                                            'not_icontains_multi',
+                                                        ]),
+                                                        type: zod
+                                                            .literal('feature')
+                                                            .default(
+                                                                marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneThreeFixedPropertiesOneItemTwofourEventFiltersOneItemFourTypeDefault
+                                                            )
+                                                            .describe('Event property with \"$feature\/\" prepended'),
+                                                        value: zod
+                                                            .union([
+                                                                zod.array(
+                                                                    zod.union([
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                    ])
+                                                                ),
+                                                                zod.string(),
+                                                                zod.number(),
+                                                                zod.boolean(),
+                                                                zod.null(),
+                                                            ])
+                                                            .optional(),
+                                                    }),
+                                                    zod.object({
+                                                        key: zod.string(),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
+                                                        type: zod
+                                                            .literal('hogql')
+                                                            .default(
+                                                                marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneThreeFixedPropertiesOneItemTwofourEventFiltersOneItemFiveTypeDefault
+                                                            ),
+                                                        value: zod
+                                                            .union([
+                                                                zod.array(
+                                                                    zod.union([
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                    ])
+                                                                ),
+                                                                zod.string(),
+                                                                zod.number(),
+                                                                zod.boolean(),
+                                                                zod.null(),
+                                                            ])
+                                                            .optional(),
+                                                    }),
+                                                ])
+                                            ),
+                                            zod.null(),
+                                        ])
+                                        .optional()
+                                        .describe(
+                                            'Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral\/cohort filters and groups'
+                                        ),
+                                    event_type: zod.enum(['events', 'actions']),
+                                    explicit_datetime: zod
+                                        .union([zod.string(), zod.null()])
+                                        .optional()
+                                        .describe(
+                                            'Absolute or relative (e.g. -30d) lower date bound — alternative to time_value\/time_interval'
+                                        ),
+                                    explicit_datetime_to: zod.union([zod.string(), zod.null()]).optional(),
+                                    key: zod.string().describe("Event name, or action id when event_type is 'actions'"),
+                                    label: zod.union([zod.string(), zod.null()]).optional(),
+                                    negation: zod
+                                        .union([zod.boolean(), zod.null()])
+                                        .optional()
+                                        .describe(
+                                            'Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators'
+                                        ),
+                                    operator: zod
+                                        .union([
+                                            zod.enum([
+                                                'exact',
+                                                'is_not',
+                                                'icontains',
+                                                'not_icontains',
+                                                'starts_with',
+                                                'not_starts_with',
+                                                'ends_with',
+                                                'not_ends_with',
+                                                'regex',
+                                                'not_regex',
+                                                'gt',
+                                                'gte',
+                                                'lt',
+                                                'lte',
+                                                'is_set',
+                                                'is_not_set',
+                                                'is_date_exact',
+                                                'is_date_before',
+                                                'is_date_after',
+                                                'between',
+                                                'not_between',
+                                                'min',
+                                                'max',
+                                                'in',
+                                                'not_in',
+                                                'is_cleaned_path_exact',
+                                                'flag_evaluates_to',
+                                                'semver_eq',
+                                                'semver_neq',
+                                                'semver_gt',
+                                                'semver_gte',
+                                                'semver_lt',
+                                                'semver_lte',
+                                                'semver_tilde',
+                                                'semver_caret',
+                                                'semver_wildcard',
+                                                'icontains_multi',
+                                                'not_icontains_multi',
+                                            ]),
+                                            zod.null(),
+                                        ])
+                                        .optional()
+                                        .describe('Count comparison for performed_event_multiple, defaults to exact'),
+                                    operator_value: zod
+                                        .union([zod.number(), zod.null()])
+                                        .optional()
+                                        .describe('Count threshold for performed_event_multiple'),
+                                    time_interval: zod
+                                        .union([zod.enum(['day', 'week', 'month', 'year']), zod.null()])
+                                        .optional(),
+                                    time_value: zod
+                                        .union([zod.number(), zod.null()])
+                                        .optional()
+                                        .describe('Relative time window size, paired with time_interval'),
+                                    type: zod
+                                        .literal('behavioral')
+                                        .default(
+                                            marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneThreeFixedPropertiesOneItemTwofourTypeDefault
+                                        )
+                                        .describe(
+                                            "Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP"
+                                        ),
+                                    value: zod.enum(['performed_event', 'performed_event_multiple']),
                                 }),
                             ])
                         ),
@@ -16663,6 +21029,392 @@ export const MarketingAnalyticsConversionGoalsCreateCreateBody = /* @__PURE__ */
                                             zod.null(),
                                         ])
                                         .optional(),
+                                }),
+                                zod.object({
+                                    event_filters: zod
+                                        .union([
+                                            zod.array(
+                                                zod.union([
+                                                    zod.object({
+                                                        key: zod.string(),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
+                                                        operator: zod
+                                                            .union([
+                                                                zod.enum([
+                                                                    'exact',
+                                                                    'is_not',
+                                                                    'icontains',
+                                                                    'not_icontains',
+                                                                    'starts_with',
+                                                                    'not_starts_with',
+                                                                    'ends_with',
+                                                                    'not_ends_with',
+                                                                    'regex',
+                                                                    'not_regex',
+                                                                    'gt',
+                                                                    'gte',
+                                                                    'lt',
+                                                                    'lte',
+                                                                    'is_set',
+                                                                    'is_not_set',
+                                                                    'is_date_exact',
+                                                                    'is_date_before',
+                                                                    'is_date_after',
+                                                                    'between',
+                                                                    'not_between',
+                                                                    'min',
+                                                                    'max',
+                                                                    'in',
+                                                                    'not_in',
+                                                                    'is_cleaned_path_exact',
+                                                                    'flag_evaluates_to',
+                                                                    'semver_eq',
+                                                                    'semver_neq',
+                                                                    'semver_gt',
+                                                                    'semver_gte',
+                                                                    'semver_lt',
+                                                                    'semver_lte',
+                                                                    'semver_tilde',
+                                                                    'semver_caret',
+                                                                    'semver_wildcard',
+                                                                    'icontains_multi',
+                                                                    'not_icontains_multi',
+                                                                ]),
+                                                                zod.null(),
+                                                            ])
+                                                            .default(
+                                                                marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneThreePropertiesOneItemTwofourEventFiltersOneItemOneOperatorDefault
+                                                            ),
+                                                        type: zod
+                                                            .literal('event')
+                                                            .default(
+                                                                marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneThreePropertiesOneItemTwofourEventFiltersOneItemOneTypeDefault
+                                                            )
+                                                            .describe('Event properties'),
+                                                        value: zod
+                                                            .union([
+                                                                zod.array(
+                                                                    zod.union([
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                    ])
+                                                                ),
+                                                                zod.string(),
+                                                                zod.number(),
+                                                                zod.boolean(),
+                                                                zod.null(),
+                                                            ])
+                                                            .optional(),
+                                                    }),
+                                                    zod.object({
+                                                        key: zod.string(),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
+                                                        operator: zod.enum([
+                                                            'exact',
+                                                            'is_not',
+                                                            'icontains',
+                                                            'not_icontains',
+                                                            'starts_with',
+                                                            'not_starts_with',
+                                                            'ends_with',
+                                                            'not_ends_with',
+                                                            'regex',
+                                                            'not_regex',
+                                                            'gt',
+                                                            'gte',
+                                                            'lt',
+                                                            'lte',
+                                                            'is_set',
+                                                            'is_not_set',
+                                                            'is_date_exact',
+                                                            'is_date_before',
+                                                            'is_date_after',
+                                                            'between',
+                                                            'not_between',
+                                                            'min',
+                                                            'max',
+                                                            'in',
+                                                            'not_in',
+                                                            'is_cleaned_path_exact',
+                                                            'flag_evaluates_to',
+                                                            'semver_eq',
+                                                            'semver_neq',
+                                                            'semver_gt',
+                                                            'semver_gte',
+                                                            'semver_lt',
+                                                            'semver_lte',
+                                                            'semver_tilde',
+                                                            'semver_caret',
+                                                            'semver_wildcard',
+                                                            'icontains_multi',
+                                                            'not_icontains_multi',
+                                                        ]),
+                                                        type: zod
+                                                            .literal('person')
+                                                            .default(
+                                                                marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneThreePropertiesOneItemTwofourEventFiltersOneItemTwoTypeDefault
+                                                            )
+                                                            .describe('Person properties'),
+                                                        value: zod
+                                                            .union([
+                                                                zod.array(
+                                                                    zod.union([
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                    ])
+                                                                ),
+                                                                zod.string(),
+                                                                zod.number(),
+                                                                zod.boolean(),
+                                                                zod.null(),
+                                                            ])
+                                                            .optional(),
+                                                    }),
+                                                    zod.object({
+                                                        key: zod.enum(['tag_name', 'text', 'href', 'selector']),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
+                                                        operator: zod.enum([
+                                                            'exact',
+                                                            'is_not',
+                                                            'icontains',
+                                                            'not_icontains',
+                                                            'starts_with',
+                                                            'not_starts_with',
+                                                            'ends_with',
+                                                            'not_ends_with',
+                                                            'regex',
+                                                            'not_regex',
+                                                            'gt',
+                                                            'gte',
+                                                            'lt',
+                                                            'lte',
+                                                            'is_set',
+                                                            'is_not_set',
+                                                            'is_date_exact',
+                                                            'is_date_before',
+                                                            'is_date_after',
+                                                            'between',
+                                                            'not_between',
+                                                            'min',
+                                                            'max',
+                                                            'in',
+                                                            'not_in',
+                                                            'is_cleaned_path_exact',
+                                                            'flag_evaluates_to',
+                                                            'semver_eq',
+                                                            'semver_neq',
+                                                            'semver_gt',
+                                                            'semver_gte',
+                                                            'semver_lt',
+                                                            'semver_lte',
+                                                            'semver_tilde',
+                                                            'semver_caret',
+                                                            'semver_wildcard',
+                                                            'icontains_multi',
+                                                            'not_icontains_multi',
+                                                        ]),
+                                                        type: zod
+                                                            .literal('element')
+                                                            .default(
+                                                                marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneThreePropertiesOneItemTwofourEventFiltersOneItemThreeTypeDefault
+                                                            ),
+                                                        value: zod
+                                                            .union([
+                                                                zod.array(
+                                                                    zod.union([
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                    ])
+                                                                ),
+                                                                zod.string(),
+                                                                zod.number(),
+                                                                zod.boolean(),
+                                                                zod.null(),
+                                                            ])
+                                                            .optional(),
+                                                    }),
+                                                    zod.object({
+                                                        key: zod.string(),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
+                                                        operator: zod.enum([
+                                                            'exact',
+                                                            'is_not',
+                                                            'icontains',
+                                                            'not_icontains',
+                                                            'starts_with',
+                                                            'not_starts_with',
+                                                            'ends_with',
+                                                            'not_ends_with',
+                                                            'regex',
+                                                            'not_regex',
+                                                            'gt',
+                                                            'gte',
+                                                            'lt',
+                                                            'lte',
+                                                            'is_set',
+                                                            'is_not_set',
+                                                            'is_date_exact',
+                                                            'is_date_before',
+                                                            'is_date_after',
+                                                            'between',
+                                                            'not_between',
+                                                            'min',
+                                                            'max',
+                                                            'in',
+                                                            'not_in',
+                                                            'is_cleaned_path_exact',
+                                                            'flag_evaluates_to',
+                                                            'semver_eq',
+                                                            'semver_neq',
+                                                            'semver_gt',
+                                                            'semver_gte',
+                                                            'semver_lt',
+                                                            'semver_lte',
+                                                            'semver_tilde',
+                                                            'semver_caret',
+                                                            'semver_wildcard',
+                                                            'icontains_multi',
+                                                            'not_icontains_multi',
+                                                        ]),
+                                                        type: zod
+                                                            .literal('feature')
+                                                            .default(
+                                                                marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneThreePropertiesOneItemTwofourEventFiltersOneItemFourTypeDefault
+                                                            )
+                                                            .describe('Event property with \"$feature\/\" prepended'),
+                                                        value: zod
+                                                            .union([
+                                                                zod.array(
+                                                                    zod.union([
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                    ])
+                                                                ),
+                                                                zod.string(),
+                                                                zod.number(),
+                                                                zod.boolean(),
+                                                                zod.null(),
+                                                            ])
+                                                            .optional(),
+                                                    }),
+                                                    zod.object({
+                                                        key: zod.string(),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
+                                                        type: zod
+                                                            .literal('hogql')
+                                                            .default(
+                                                                marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneThreePropertiesOneItemTwofourEventFiltersOneItemFiveTypeDefault
+                                                            ),
+                                                        value: zod
+                                                            .union([
+                                                                zod.array(
+                                                                    zod.union([
+                                                                        zod.string(),
+                                                                        zod.number(),
+                                                                        zod.boolean(),
+                                                                    ])
+                                                                ),
+                                                                zod.string(),
+                                                                zod.number(),
+                                                                zod.boolean(),
+                                                                zod.null(),
+                                                            ])
+                                                            .optional(),
+                                                    }),
+                                                ])
+                                            ),
+                                            zod.null(),
+                                        ])
+                                        .optional()
+                                        .describe(
+                                            'Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral\/cohort filters and groups'
+                                        ),
+                                    event_type: zod.enum(['events', 'actions']),
+                                    explicit_datetime: zod
+                                        .union([zod.string(), zod.null()])
+                                        .optional()
+                                        .describe(
+                                            'Absolute or relative (e.g. -30d) lower date bound — alternative to time_value\/time_interval'
+                                        ),
+                                    explicit_datetime_to: zod.union([zod.string(), zod.null()]).optional(),
+                                    key: zod.string().describe("Event name, or action id when event_type is 'actions'"),
+                                    label: zod.union([zod.string(), zod.null()]).optional(),
+                                    negation: zod
+                                        .union([zod.boolean(), zod.null()])
+                                        .optional()
+                                        .describe(
+                                            'Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators'
+                                        ),
+                                    operator: zod
+                                        .union([
+                                            zod.enum([
+                                                'exact',
+                                                'is_not',
+                                                'icontains',
+                                                'not_icontains',
+                                                'starts_with',
+                                                'not_starts_with',
+                                                'ends_with',
+                                                'not_ends_with',
+                                                'regex',
+                                                'not_regex',
+                                                'gt',
+                                                'gte',
+                                                'lt',
+                                                'lte',
+                                                'is_set',
+                                                'is_not_set',
+                                                'is_date_exact',
+                                                'is_date_before',
+                                                'is_date_after',
+                                                'between',
+                                                'not_between',
+                                                'min',
+                                                'max',
+                                                'in',
+                                                'not_in',
+                                                'is_cleaned_path_exact',
+                                                'flag_evaluates_to',
+                                                'semver_eq',
+                                                'semver_neq',
+                                                'semver_gt',
+                                                'semver_gte',
+                                                'semver_lt',
+                                                'semver_lte',
+                                                'semver_tilde',
+                                                'semver_caret',
+                                                'semver_wildcard',
+                                                'icontains_multi',
+                                                'not_icontains_multi',
+                                            ]),
+                                            zod.null(),
+                                        ])
+                                        .optional()
+                                        .describe('Count comparison for performed_event_multiple, defaults to exact'),
+                                    operator_value: zod
+                                        .union([zod.number(), zod.null()])
+                                        .optional()
+                                        .describe('Count threshold for performed_event_multiple'),
+                                    time_interval: zod
+                                        .union([zod.enum(['day', 'week', 'month', 'year']), zod.null()])
+                                        .optional(),
+                                    time_value: zod
+                                        .union([zod.number(), zod.null()])
+                                        .optional()
+                                        .describe('Relative time window size, paired with time_interval'),
+                                    type: zod
+                                        .literal('behavioral')
+                                        .default(
+                                            marketingAnalyticsConversionGoalsCreateCreateBodyGoalOneThreePropertiesOneItemTwofourTypeDefault
+                                        )
+                                        .describe(
+                                            "Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP"
+                                        ),
+                                    value: zod.enum(['performed_event', 'performed_event_multiple']),
                                 }),
                             ])
                         ),

--- a/services/mcp/src/tools/generated/mcp_analytics.ts
+++ b/services/mcp/src/tools/generated/mcp_analytics.ts
@@ -507,6 +507,54 @@ const WorkflowVariablePropertyFilter = z.object({
     value: PropertyFilterValue.optional(),
 })
 
+const BehavioralEventSource = z.enum(['events', 'actions'])
+
+const TimeUnitType = z.enum(['day', 'week', 'month', 'year'])
+
+const InlineBehavioralType = z.enum(['performed_event', 'performed_event_multiple'])
+
+const BehavioralPropertyFilter = z.object({
+    event_filters: z
+        .array(
+            z.union([
+                EventPropertyFilter,
+                PersonPropertyFilter,
+                ElementPropertyFilter,
+                FeaturePropertyFilter,
+                HogQLPropertyFilter,
+            ])
+        )
+        .describe(
+            'Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral/cohort filters and groups'
+        )
+        .optional(),
+    event_type: BehavioralEventSource,
+    explicit_datetime: z
+        .string()
+        .describe('Absolute or relative (e.g. -30d) lower date bound — alternative to time_value/time_interval')
+        .optional(),
+    explicit_datetime_to: z.string().optional(),
+    key: z.string().describe("Event name, or action id when event_type is 'actions'"),
+    label: z.string().optional(),
+    negation: z.coerce
+        .boolean()
+        .describe(
+            'Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators'
+        )
+        .optional(),
+    operator: PropertyOperator.describe('Count comparison for performed_event_multiple, defaults to exact').optional(),
+    operator_value: z.coerce.number().int().describe('Count threshold for performed_event_multiple').optional(),
+    time_interval: TimeUnitType.optional(),
+    time_value: z.coerce.number().int().describe('Relative time window size, paired with time_interval').optional(),
+    type: z
+        .literal('behavioral')
+        .describe(
+            "Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP"
+        )
+        .default('behavioral'),
+    value: InlineBehavioralType,
+})
+
 const AnyPropertyFilter = z.union([
     EventPropertyFilter,
     PersonPropertyFilter,
@@ -531,6 +579,7 @@ const AnyPropertyFilter = z.union([
     RevenueAnalyticsPropertyFilter,
     AccountCustomPropertyFilter,
     WorkflowVariablePropertyFilter,
+    BehavioralPropertyFilter,
 ])
 
 const MCPHarnessBreakdownQuery = z.object({

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/error-tracking-assignment-rules-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/error-tracking-assignment-rules-create.json
@@ -2160,6 +2160,635 @@
                                 },
                                 "required": ["key", "operator"],
                                 "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "event_filters": {
+                                        "anyOf": [
+                                            {
+                                                "items": {
+                                                    "anyOf": [
+                                                        {
+                                                            "properties": {
+                                                                "key": {
+                                                                    "type": "string"
+                                                                },
+                                                                "label": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "operator": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "exact",
+                                                                                "is_not",
+                                                                                "icontains",
+                                                                                "not_icontains",
+                                                                                "starts_with",
+                                                                                "not_starts_with",
+                                                                                "ends_with",
+                                                                                "not_ends_with",
+                                                                                "regex",
+                                                                                "not_regex",
+                                                                                "gt",
+                                                                                "gte",
+                                                                                "lt",
+                                                                                "lte",
+                                                                                "is_set",
+                                                                                "is_not_set",
+                                                                                "is_date_exact",
+                                                                                "is_date_before",
+                                                                                "is_date_after",
+                                                                                "between",
+                                                                                "not_between",
+                                                                                "min",
+                                                                                "max",
+                                                                                "in",
+                                                                                "not_in",
+                                                                                "is_cleaned_path_exact",
+                                                                                "flag_evaluates_to",
+                                                                                "semver_eq",
+                                                                                "semver_neq",
+                                                                                "semver_gt",
+                                                                                "semver_gte",
+                                                                                "semver_lt",
+                                                                                "semver_lte",
+                                                                                "semver_tilde",
+                                                                                "semver_caret",
+                                                                                "semver_wildcard",
+                                                                                "icontains_multi",
+                                                                                "not_icontains_multi"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ],
+                                                                    "default": "exact"
+                                                                },
+                                                                "type": {
+                                                                    "const": "event",
+                                                                    "default": "event",
+                                                                    "description": "Event properties",
+                                                                    "type": "string"
+                                                                },
+                                                                "value": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "items": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "number"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "boolean"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "type": "array"
+                                                                        },
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "number"
+                                                                        },
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": ["key"],
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "properties": {
+                                                                "key": {
+                                                                    "type": "string"
+                                                                },
+                                                                "label": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "operator": {
+                                                                    "enum": [
+                                                                        "exact",
+                                                                        "is_not",
+                                                                        "icontains",
+                                                                        "not_icontains",
+                                                                        "starts_with",
+                                                                        "not_starts_with",
+                                                                        "ends_with",
+                                                                        "not_ends_with",
+                                                                        "regex",
+                                                                        "not_regex",
+                                                                        "gt",
+                                                                        "gte",
+                                                                        "lt",
+                                                                        "lte",
+                                                                        "is_set",
+                                                                        "is_not_set",
+                                                                        "is_date_exact",
+                                                                        "is_date_before",
+                                                                        "is_date_after",
+                                                                        "between",
+                                                                        "not_between",
+                                                                        "min",
+                                                                        "max",
+                                                                        "in",
+                                                                        "not_in",
+                                                                        "is_cleaned_path_exact",
+                                                                        "flag_evaluates_to",
+                                                                        "semver_eq",
+                                                                        "semver_neq",
+                                                                        "semver_gt",
+                                                                        "semver_gte",
+                                                                        "semver_lt",
+                                                                        "semver_lte",
+                                                                        "semver_tilde",
+                                                                        "semver_caret",
+                                                                        "semver_wildcard",
+                                                                        "icontains_multi",
+                                                                        "not_icontains_multi"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "type": {
+                                                                    "const": "person",
+                                                                    "default": "person",
+                                                                    "description": "Person properties",
+                                                                    "type": "string"
+                                                                },
+                                                                "value": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "items": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "number"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "boolean"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "type": "array"
+                                                                        },
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "number"
+                                                                        },
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": ["key", "operator"],
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "properties": {
+                                                                "key": {
+                                                                    "enum": ["tag_name", "text", "href", "selector"],
+                                                                    "type": "string"
+                                                                },
+                                                                "label": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "operator": {
+                                                                    "enum": [
+                                                                        "exact",
+                                                                        "is_not",
+                                                                        "icontains",
+                                                                        "not_icontains",
+                                                                        "starts_with",
+                                                                        "not_starts_with",
+                                                                        "ends_with",
+                                                                        "not_ends_with",
+                                                                        "regex",
+                                                                        "not_regex",
+                                                                        "gt",
+                                                                        "gte",
+                                                                        "lt",
+                                                                        "lte",
+                                                                        "is_set",
+                                                                        "is_not_set",
+                                                                        "is_date_exact",
+                                                                        "is_date_before",
+                                                                        "is_date_after",
+                                                                        "between",
+                                                                        "not_between",
+                                                                        "min",
+                                                                        "max",
+                                                                        "in",
+                                                                        "not_in",
+                                                                        "is_cleaned_path_exact",
+                                                                        "flag_evaluates_to",
+                                                                        "semver_eq",
+                                                                        "semver_neq",
+                                                                        "semver_gt",
+                                                                        "semver_gte",
+                                                                        "semver_lt",
+                                                                        "semver_lte",
+                                                                        "semver_tilde",
+                                                                        "semver_caret",
+                                                                        "semver_wildcard",
+                                                                        "icontains_multi",
+                                                                        "not_icontains_multi"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "type": {
+                                                                    "const": "element",
+                                                                    "default": "element",
+                                                                    "type": "string"
+                                                                },
+                                                                "value": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "items": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "number"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "boolean"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "type": "array"
+                                                                        },
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "number"
+                                                                        },
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": ["key", "operator"],
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "properties": {
+                                                                "key": {
+                                                                    "type": "string"
+                                                                },
+                                                                "label": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "operator": {
+                                                                    "enum": [
+                                                                        "exact",
+                                                                        "is_not",
+                                                                        "icontains",
+                                                                        "not_icontains",
+                                                                        "starts_with",
+                                                                        "not_starts_with",
+                                                                        "ends_with",
+                                                                        "not_ends_with",
+                                                                        "regex",
+                                                                        "not_regex",
+                                                                        "gt",
+                                                                        "gte",
+                                                                        "lt",
+                                                                        "lte",
+                                                                        "is_set",
+                                                                        "is_not_set",
+                                                                        "is_date_exact",
+                                                                        "is_date_before",
+                                                                        "is_date_after",
+                                                                        "between",
+                                                                        "not_between",
+                                                                        "min",
+                                                                        "max",
+                                                                        "in",
+                                                                        "not_in",
+                                                                        "is_cleaned_path_exact",
+                                                                        "flag_evaluates_to",
+                                                                        "semver_eq",
+                                                                        "semver_neq",
+                                                                        "semver_gt",
+                                                                        "semver_gte",
+                                                                        "semver_lt",
+                                                                        "semver_lte",
+                                                                        "semver_tilde",
+                                                                        "semver_caret",
+                                                                        "semver_wildcard",
+                                                                        "icontains_multi",
+                                                                        "not_icontains_multi"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "type": {
+                                                                    "const": "feature",
+                                                                    "default": "feature",
+                                                                    "description": "Event property with \"$feature/\" prepended",
+                                                                    "type": "string"
+                                                                },
+                                                                "value": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "items": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "number"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "boolean"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "type": "array"
+                                                                        },
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "number"
+                                                                        },
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": ["key", "operator"],
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "properties": {
+                                                                "key": {
+                                                                    "type": "string"
+                                                                },
+                                                                "label": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "type": {
+                                                                    "const": "hogql",
+                                                                    "default": "hogql",
+                                                                    "type": "string"
+                                                                },
+                                                                "value": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "items": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "number"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "boolean"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "type": "array"
+                                                                        },
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "number"
+                                                                        },
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": ["key"],
+                                                            "type": "object"
+                                                        }
+                                                    ]
+                                                },
+                                                "type": "array"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ],
+                                        "description": "Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral/cohort filters and groups"
+                                    },
+                                    "event_type": {
+                                        "enum": ["events", "actions"],
+                                        "type": "string"
+                                    },
+                                    "explicit_datetime": {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ],
+                                        "description": "Absolute or relative (e.g. -30d) lower date bound — alternative to time_value/time_interval"
+                                    },
+                                    "explicit_datetime_to": {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    },
+                                    "key": {
+                                        "description": "Event name, or action id when event_type is 'actions'",
+                                        "type": "string"
+                                    },
+                                    "label": {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    },
+                                    "negation": {
+                                        "anyOf": [
+                                            {
+                                                "type": "boolean"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ],
+                                        "description": "Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators"
+                                    },
+                                    "operator": {
+                                        "anyOf": [
+                                            {
+                                                "enum": [
+                                                    "exact",
+                                                    "is_not",
+                                                    "icontains",
+                                                    "not_icontains",
+                                                    "starts_with",
+                                                    "not_starts_with",
+                                                    "ends_with",
+                                                    "not_ends_with",
+                                                    "regex",
+                                                    "not_regex",
+                                                    "gt",
+                                                    "gte",
+                                                    "lt",
+                                                    "lte",
+                                                    "is_set",
+                                                    "is_not_set",
+                                                    "is_date_exact",
+                                                    "is_date_before",
+                                                    "is_date_after",
+                                                    "between",
+                                                    "not_between",
+                                                    "min",
+                                                    "max",
+                                                    "in",
+                                                    "not_in",
+                                                    "is_cleaned_path_exact",
+                                                    "flag_evaluates_to",
+                                                    "semver_eq",
+                                                    "semver_neq",
+                                                    "semver_gt",
+                                                    "semver_gte",
+                                                    "semver_lt",
+                                                    "semver_lte",
+                                                    "semver_tilde",
+                                                    "semver_caret",
+                                                    "semver_wildcard",
+                                                    "icontains_multi",
+                                                    "not_icontains_multi"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ],
+                                        "description": "Count comparison for performed_event_multiple, defaults to exact"
+                                    },
+                                    "operator_value": {
+                                        "anyOf": [
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ],
+                                        "description": "Count threshold for performed_event_multiple"
+                                    },
+                                    "time_interval": {
+                                        "anyOf": [
+                                            {
+                                                "enum": ["day", "week", "month", "year"],
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    },
+                                    "time_value": {
+                                        "anyOf": [
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ],
+                                        "description": "Relative time window size, paired with time_interval"
+                                    },
+                                    "type": {
+                                        "const": "behavioral",
+                                        "default": "behavioral",
+                                        "description": "Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP",
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "enum": ["performed_event", "performed_event_multiple"],
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["event_type", "key", "value"],
+                                "type": "object"
                             }
                         ]
                     },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/error-tracking-bypass-rules-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/error-tracking-bypass-rules-create.json
@@ -2137,6 +2137,635 @@
                                 },
                                 "required": ["key", "operator"],
                                 "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "event_filters": {
+                                        "anyOf": [
+                                            {
+                                                "items": {
+                                                    "anyOf": [
+                                                        {
+                                                            "properties": {
+                                                                "key": {
+                                                                    "type": "string"
+                                                                },
+                                                                "label": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "operator": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "exact",
+                                                                                "is_not",
+                                                                                "icontains",
+                                                                                "not_icontains",
+                                                                                "starts_with",
+                                                                                "not_starts_with",
+                                                                                "ends_with",
+                                                                                "not_ends_with",
+                                                                                "regex",
+                                                                                "not_regex",
+                                                                                "gt",
+                                                                                "gte",
+                                                                                "lt",
+                                                                                "lte",
+                                                                                "is_set",
+                                                                                "is_not_set",
+                                                                                "is_date_exact",
+                                                                                "is_date_before",
+                                                                                "is_date_after",
+                                                                                "between",
+                                                                                "not_between",
+                                                                                "min",
+                                                                                "max",
+                                                                                "in",
+                                                                                "not_in",
+                                                                                "is_cleaned_path_exact",
+                                                                                "flag_evaluates_to",
+                                                                                "semver_eq",
+                                                                                "semver_neq",
+                                                                                "semver_gt",
+                                                                                "semver_gte",
+                                                                                "semver_lt",
+                                                                                "semver_lte",
+                                                                                "semver_tilde",
+                                                                                "semver_caret",
+                                                                                "semver_wildcard",
+                                                                                "icontains_multi",
+                                                                                "not_icontains_multi"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ],
+                                                                    "default": "exact"
+                                                                },
+                                                                "type": {
+                                                                    "const": "event",
+                                                                    "default": "event",
+                                                                    "description": "Event properties",
+                                                                    "type": "string"
+                                                                },
+                                                                "value": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "items": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "number"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "boolean"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "type": "array"
+                                                                        },
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "number"
+                                                                        },
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": ["key"],
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "properties": {
+                                                                "key": {
+                                                                    "type": "string"
+                                                                },
+                                                                "label": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "operator": {
+                                                                    "enum": [
+                                                                        "exact",
+                                                                        "is_not",
+                                                                        "icontains",
+                                                                        "not_icontains",
+                                                                        "starts_with",
+                                                                        "not_starts_with",
+                                                                        "ends_with",
+                                                                        "not_ends_with",
+                                                                        "regex",
+                                                                        "not_regex",
+                                                                        "gt",
+                                                                        "gte",
+                                                                        "lt",
+                                                                        "lte",
+                                                                        "is_set",
+                                                                        "is_not_set",
+                                                                        "is_date_exact",
+                                                                        "is_date_before",
+                                                                        "is_date_after",
+                                                                        "between",
+                                                                        "not_between",
+                                                                        "min",
+                                                                        "max",
+                                                                        "in",
+                                                                        "not_in",
+                                                                        "is_cleaned_path_exact",
+                                                                        "flag_evaluates_to",
+                                                                        "semver_eq",
+                                                                        "semver_neq",
+                                                                        "semver_gt",
+                                                                        "semver_gte",
+                                                                        "semver_lt",
+                                                                        "semver_lte",
+                                                                        "semver_tilde",
+                                                                        "semver_caret",
+                                                                        "semver_wildcard",
+                                                                        "icontains_multi",
+                                                                        "not_icontains_multi"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "type": {
+                                                                    "const": "person",
+                                                                    "default": "person",
+                                                                    "description": "Person properties",
+                                                                    "type": "string"
+                                                                },
+                                                                "value": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "items": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "number"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "boolean"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "type": "array"
+                                                                        },
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "number"
+                                                                        },
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": ["key", "operator"],
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "properties": {
+                                                                "key": {
+                                                                    "enum": ["tag_name", "text", "href", "selector"],
+                                                                    "type": "string"
+                                                                },
+                                                                "label": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "operator": {
+                                                                    "enum": [
+                                                                        "exact",
+                                                                        "is_not",
+                                                                        "icontains",
+                                                                        "not_icontains",
+                                                                        "starts_with",
+                                                                        "not_starts_with",
+                                                                        "ends_with",
+                                                                        "not_ends_with",
+                                                                        "regex",
+                                                                        "not_regex",
+                                                                        "gt",
+                                                                        "gte",
+                                                                        "lt",
+                                                                        "lte",
+                                                                        "is_set",
+                                                                        "is_not_set",
+                                                                        "is_date_exact",
+                                                                        "is_date_before",
+                                                                        "is_date_after",
+                                                                        "between",
+                                                                        "not_between",
+                                                                        "min",
+                                                                        "max",
+                                                                        "in",
+                                                                        "not_in",
+                                                                        "is_cleaned_path_exact",
+                                                                        "flag_evaluates_to",
+                                                                        "semver_eq",
+                                                                        "semver_neq",
+                                                                        "semver_gt",
+                                                                        "semver_gte",
+                                                                        "semver_lt",
+                                                                        "semver_lte",
+                                                                        "semver_tilde",
+                                                                        "semver_caret",
+                                                                        "semver_wildcard",
+                                                                        "icontains_multi",
+                                                                        "not_icontains_multi"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "type": {
+                                                                    "const": "element",
+                                                                    "default": "element",
+                                                                    "type": "string"
+                                                                },
+                                                                "value": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "items": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "number"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "boolean"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "type": "array"
+                                                                        },
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "number"
+                                                                        },
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": ["key", "operator"],
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "properties": {
+                                                                "key": {
+                                                                    "type": "string"
+                                                                },
+                                                                "label": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "operator": {
+                                                                    "enum": [
+                                                                        "exact",
+                                                                        "is_not",
+                                                                        "icontains",
+                                                                        "not_icontains",
+                                                                        "starts_with",
+                                                                        "not_starts_with",
+                                                                        "ends_with",
+                                                                        "not_ends_with",
+                                                                        "regex",
+                                                                        "not_regex",
+                                                                        "gt",
+                                                                        "gte",
+                                                                        "lt",
+                                                                        "lte",
+                                                                        "is_set",
+                                                                        "is_not_set",
+                                                                        "is_date_exact",
+                                                                        "is_date_before",
+                                                                        "is_date_after",
+                                                                        "between",
+                                                                        "not_between",
+                                                                        "min",
+                                                                        "max",
+                                                                        "in",
+                                                                        "not_in",
+                                                                        "is_cleaned_path_exact",
+                                                                        "flag_evaluates_to",
+                                                                        "semver_eq",
+                                                                        "semver_neq",
+                                                                        "semver_gt",
+                                                                        "semver_gte",
+                                                                        "semver_lt",
+                                                                        "semver_lte",
+                                                                        "semver_tilde",
+                                                                        "semver_caret",
+                                                                        "semver_wildcard",
+                                                                        "icontains_multi",
+                                                                        "not_icontains_multi"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "type": {
+                                                                    "const": "feature",
+                                                                    "default": "feature",
+                                                                    "description": "Event property with \"$feature/\" prepended",
+                                                                    "type": "string"
+                                                                },
+                                                                "value": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "items": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "number"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "boolean"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "type": "array"
+                                                                        },
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "number"
+                                                                        },
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": ["key", "operator"],
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "properties": {
+                                                                "key": {
+                                                                    "type": "string"
+                                                                },
+                                                                "label": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "type": {
+                                                                    "const": "hogql",
+                                                                    "default": "hogql",
+                                                                    "type": "string"
+                                                                },
+                                                                "value": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "items": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "number"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "boolean"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "type": "array"
+                                                                        },
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "number"
+                                                                        },
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": ["key"],
+                                                            "type": "object"
+                                                        }
+                                                    ]
+                                                },
+                                                "type": "array"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ],
+                                        "description": "Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral/cohort filters and groups"
+                                    },
+                                    "event_type": {
+                                        "enum": ["events", "actions"],
+                                        "type": "string"
+                                    },
+                                    "explicit_datetime": {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ],
+                                        "description": "Absolute or relative (e.g. -30d) lower date bound — alternative to time_value/time_interval"
+                                    },
+                                    "explicit_datetime_to": {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    },
+                                    "key": {
+                                        "description": "Event name, or action id when event_type is 'actions'",
+                                        "type": "string"
+                                    },
+                                    "label": {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    },
+                                    "negation": {
+                                        "anyOf": [
+                                            {
+                                                "type": "boolean"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ],
+                                        "description": "Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators"
+                                    },
+                                    "operator": {
+                                        "anyOf": [
+                                            {
+                                                "enum": [
+                                                    "exact",
+                                                    "is_not",
+                                                    "icontains",
+                                                    "not_icontains",
+                                                    "starts_with",
+                                                    "not_starts_with",
+                                                    "ends_with",
+                                                    "not_ends_with",
+                                                    "regex",
+                                                    "not_regex",
+                                                    "gt",
+                                                    "gte",
+                                                    "lt",
+                                                    "lte",
+                                                    "is_set",
+                                                    "is_not_set",
+                                                    "is_date_exact",
+                                                    "is_date_before",
+                                                    "is_date_after",
+                                                    "between",
+                                                    "not_between",
+                                                    "min",
+                                                    "max",
+                                                    "in",
+                                                    "not_in",
+                                                    "is_cleaned_path_exact",
+                                                    "flag_evaluates_to",
+                                                    "semver_eq",
+                                                    "semver_neq",
+                                                    "semver_gt",
+                                                    "semver_gte",
+                                                    "semver_lt",
+                                                    "semver_lte",
+                                                    "semver_tilde",
+                                                    "semver_caret",
+                                                    "semver_wildcard",
+                                                    "icontains_multi",
+                                                    "not_icontains_multi"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ],
+                                        "description": "Count comparison for performed_event_multiple, defaults to exact"
+                                    },
+                                    "operator_value": {
+                                        "anyOf": [
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ],
+                                        "description": "Count threshold for performed_event_multiple"
+                                    },
+                                    "time_interval": {
+                                        "anyOf": [
+                                            {
+                                                "enum": ["day", "week", "month", "year"],
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    },
+                                    "time_value": {
+                                        "anyOf": [
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ],
+                                        "description": "Relative time window size, paired with time_interval"
+                                    },
+                                    "type": {
+                                        "const": "behavioral",
+                                        "default": "behavioral",
+                                        "description": "Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP",
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "enum": ["performed_event", "performed_event_multiple"],
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["event_type", "key", "value"],
+                                "type": "object"
                             }
                         ]
                     },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/error-tracking-bypass-rules-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/error-tracking-bypass-rules-update.json
@@ -2137,6 +2137,635 @@
                                 },
                                 "required": ["key", "operator"],
                                 "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "event_filters": {
+                                        "anyOf": [
+                                            {
+                                                "items": {
+                                                    "anyOf": [
+                                                        {
+                                                            "properties": {
+                                                                "key": {
+                                                                    "type": "string"
+                                                                },
+                                                                "label": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "operator": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "exact",
+                                                                                "is_not",
+                                                                                "icontains",
+                                                                                "not_icontains",
+                                                                                "starts_with",
+                                                                                "not_starts_with",
+                                                                                "ends_with",
+                                                                                "not_ends_with",
+                                                                                "regex",
+                                                                                "not_regex",
+                                                                                "gt",
+                                                                                "gte",
+                                                                                "lt",
+                                                                                "lte",
+                                                                                "is_set",
+                                                                                "is_not_set",
+                                                                                "is_date_exact",
+                                                                                "is_date_before",
+                                                                                "is_date_after",
+                                                                                "between",
+                                                                                "not_between",
+                                                                                "min",
+                                                                                "max",
+                                                                                "in",
+                                                                                "not_in",
+                                                                                "is_cleaned_path_exact",
+                                                                                "flag_evaluates_to",
+                                                                                "semver_eq",
+                                                                                "semver_neq",
+                                                                                "semver_gt",
+                                                                                "semver_gte",
+                                                                                "semver_lt",
+                                                                                "semver_lte",
+                                                                                "semver_tilde",
+                                                                                "semver_caret",
+                                                                                "semver_wildcard",
+                                                                                "icontains_multi",
+                                                                                "not_icontains_multi"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ],
+                                                                    "default": "exact"
+                                                                },
+                                                                "type": {
+                                                                    "const": "event",
+                                                                    "default": "event",
+                                                                    "description": "Event properties",
+                                                                    "type": "string"
+                                                                },
+                                                                "value": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "items": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "number"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "boolean"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "type": "array"
+                                                                        },
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "number"
+                                                                        },
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": ["key"],
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "properties": {
+                                                                "key": {
+                                                                    "type": "string"
+                                                                },
+                                                                "label": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "operator": {
+                                                                    "enum": [
+                                                                        "exact",
+                                                                        "is_not",
+                                                                        "icontains",
+                                                                        "not_icontains",
+                                                                        "starts_with",
+                                                                        "not_starts_with",
+                                                                        "ends_with",
+                                                                        "not_ends_with",
+                                                                        "regex",
+                                                                        "not_regex",
+                                                                        "gt",
+                                                                        "gte",
+                                                                        "lt",
+                                                                        "lte",
+                                                                        "is_set",
+                                                                        "is_not_set",
+                                                                        "is_date_exact",
+                                                                        "is_date_before",
+                                                                        "is_date_after",
+                                                                        "between",
+                                                                        "not_between",
+                                                                        "min",
+                                                                        "max",
+                                                                        "in",
+                                                                        "not_in",
+                                                                        "is_cleaned_path_exact",
+                                                                        "flag_evaluates_to",
+                                                                        "semver_eq",
+                                                                        "semver_neq",
+                                                                        "semver_gt",
+                                                                        "semver_gte",
+                                                                        "semver_lt",
+                                                                        "semver_lte",
+                                                                        "semver_tilde",
+                                                                        "semver_caret",
+                                                                        "semver_wildcard",
+                                                                        "icontains_multi",
+                                                                        "not_icontains_multi"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "type": {
+                                                                    "const": "person",
+                                                                    "default": "person",
+                                                                    "description": "Person properties",
+                                                                    "type": "string"
+                                                                },
+                                                                "value": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "items": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "number"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "boolean"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "type": "array"
+                                                                        },
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "number"
+                                                                        },
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": ["key", "operator"],
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "properties": {
+                                                                "key": {
+                                                                    "enum": ["tag_name", "text", "href", "selector"],
+                                                                    "type": "string"
+                                                                },
+                                                                "label": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "operator": {
+                                                                    "enum": [
+                                                                        "exact",
+                                                                        "is_not",
+                                                                        "icontains",
+                                                                        "not_icontains",
+                                                                        "starts_with",
+                                                                        "not_starts_with",
+                                                                        "ends_with",
+                                                                        "not_ends_with",
+                                                                        "regex",
+                                                                        "not_regex",
+                                                                        "gt",
+                                                                        "gte",
+                                                                        "lt",
+                                                                        "lte",
+                                                                        "is_set",
+                                                                        "is_not_set",
+                                                                        "is_date_exact",
+                                                                        "is_date_before",
+                                                                        "is_date_after",
+                                                                        "between",
+                                                                        "not_between",
+                                                                        "min",
+                                                                        "max",
+                                                                        "in",
+                                                                        "not_in",
+                                                                        "is_cleaned_path_exact",
+                                                                        "flag_evaluates_to",
+                                                                        "semver_eq",
+                                                                        "semver_neq",
+                                                                        "semver_gt",
+                                                                        "semver_gte",
+                                                                        "semver_lt",
+                                                                        "semver_lte",
+                                                                        "semver_tilde",
+                                                                        "semver_caret",
+                                                                        "semver_wildcard",
+                                                                        "icontains_multi",
+                                                                        "not_icontains_multi"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "type": {
+                                                                    "const": "element",
+                                                                    "default": "element",
+                                                                    "type": "string"
+                                                                },
+                                                                "value": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "items": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "number"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "boolean"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "type": "array"
+                                                                        },
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "number"
+                                                                        },
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": ["key", "operator"],
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "properties": {
+                                                                "key": {
+                                                                    "type": "string"
+                                                                },
+                                                                "label": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "operator": {
+                                                                    "enum": [
+                                                                        "exact",
+                                                                        "is_not",
+                                                                        "icontains",
+                                                                        "not_icontains",
+                                                                        "starts_with",
+                                                                        "not_starts_with",
+                                                                        "ends_with",
+                                                                        "not_ends_with",
+                                                                        "regex",
+                                                                        "not_regex",
+                                                                        "gt",
+                                                                        "gte",
+                                                                        "lt",
+                                                                        "lte",
+                                                                        "is_set",
+                                                                        "is_not_set",
+                                                                        "is_date_exact",
+                                                                        "is_date_before",
+                                                                        "is_date_after",
+                                                                        "between",
+                                                                        "not_between",
+                                                                        "min",
+                                                                        "max",
+                                                                        "in",
+                                                                        "not_in",
+                                                                        "is_cleaned_path_exact",
+                                                                        "flag_evaluates_to",
+                                                                        "semver_eq",
+                                                                        "semver_neq",
+                                                                        "semver_gt",
+                                                                        "semver_gte",
+                                                                        "semver_lt",
+                                                                        "semver_lte",
+                                                                        "semver_tilde",
+                                                                        "semver_caret",
+                                                                        "semver_wildcard",
+                                                                        "icontains_multi",
+                                                                        "not_icontains_multi"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "type": {
+                                                                    "const": "feature",
+                                                                    "default": "feature",
+                                                                    "description": "Event property with \"$feature/\" prepended",
+                                                                    "type": "string"
+                                                                },
+                                                                "value": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "items": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "number"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "boolean"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "type": "array"
+                                                                        },
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "number"
+                                                                        },
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": ["key", "operator"],
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "properties": {
+                                                                "key": {
+                                                                    "type": "string"
+                                                                },
+                                                                "label": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "type": {
+                                                                    "const": "hogql",
+                                                                    "default": "hogql",
+                                                                    "type": "string"
+                                                                },
+                                                                "value": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "items": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "number"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "boolean"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "type": "array"
+                                                                        },
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "number"
+                                                                        },
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": ["key"],
+                                                            "type": "object"
+                                                        }
+                                                    ]
+                                                },
+                                                "type": "array"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ],
+                                        "description": "Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral/cohort filters and groups"
+                                    },
+                                    "event_type": {
+                                        "enum": ["events", "actions"],
+                                        "type": "string"
+                                    },
+                                    "explicit_datetime": {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ],
+                                        "description": "Absolute or relative (e.g. -30d) lower date bound — alternative to time_value/time_interval"
+                                    },
+                                    "explicit_datetime_to": {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    },
+                                    "key": {
+                                        "description": "Event name, or action id when event_type is 'actions'",
+                                        "type": "string"
+                                    },
+                                    "label": {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    },
+                                    "negation": {
+                                        "anyOf": [
+                                            {
+                                                "type": "boolean"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ],
+                                        "description": "Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators"
+                                    },
+                                    "operator": {
+                                        "anyOf": [
+                                            {
+                                                "enum": [
+                                                    "exact",
+                                                    "is_not",
+                                                    "icontains",
+                                                    "not_icontains",
+                                                    "starts_with",
+                                                    "not_starts_with",
+                                                    "ends_with",
+                                                    "not_ends_with",
+                                                    "regex",
+                                                    "not_regex",
+                                                    "gt",
+                                                    "gte",
+                                                    "lt",
+                                                    "lte",
+                                                    "is_set",
+                                                    "is_not_set",
+                                                    "is_date_exact",
+                                                    "is_date_before",
+                                                    "is_date_after",
+                                                    "between",
+                                                    "not_between",
+                                                    "min",
+                                                    "max",
+                                                    "in",
+                                                    "not_in",
+                                                    "is_cleaned_path_exact",
+                                                    "flag_evaluates_to",
+                                                    "semver_eq",
+                                                    "semver_neq",
+                                                    "semver_gt",
+                                                    "semver_gte",
+                                                    "semver_lt",
+                                                    "semver_lte",
+                                                    "semver_tilde",
+                                                    "semver_caret",
+                                                    "semver_wildcard",
+                                                    "icontains_multi",
+                                                    "not_icontains_multi"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ],
+                                        "description": "Count comparison for performed_event_multiple, defaults to exact"
+                                    },
+                                    "operator_value": {
+                                        "anyOf": [
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ],
+                                        "description": "Count threshold for performed_event_multiple"
+                                    },
+                                    "time_interval": {
+                                        "anyOf": [
+                                            {
+                                                "enum": ["day", "week", "month", "year"],
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    },
+                                    "time_value": {
+                                        "anyOf": [
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ],
+                                        "description": "Relative time window size, paired with time_interval"
+                                    },
+                                    "type": {
+                                        "const": "behavioral",
+                                        "default": "behavioral",
+                                        "description": "Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP",
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "enum": ["performed_event", "performed_event_multiple"],
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["event_type", "key", "value"],
+                                "type": "object"
                             }
                         ]
                     },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/error-tracking-grouping-rules-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/error-tracking-grouping-rules-create.json
@@ -2178,6 +2178,635 @@
                                 },
                                 "required": ["key", "operator"],
                                 "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "event_filters": {
+                                        "anyOf": [
+                                            {
+                                                "items": {
+                                                    "anyOf": [
+                                                        {
+                                                            "properties": {
+                                                                "key": {
+                                                                    "type": "string"
+                                                                },
+                                                                "label": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "operator": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "exact",
+                                                                                "is_not",
+                                                                                "icontains",
+                                                                                "not_icontains",
+                                                                                "starts_with",
+                                                                                "not_starts_with",
+                                                                                "ends_with",
+                                                                                "not_ends_with",
+                                                                                "regex",
+                                                                                "not_regex",
+                                                                                "gt",
+                                                                                "gte",
+                                                                                "lt",
+                                                                                "lte",
+                                                                                "is_set",
+                                                                                "is_not_set",
+                                                                                "is_date_exact",
+                                                                                "is_date_before",
+                                                                                "is_date_after",
+                                                                                "between",
+                                                                                "not_between",
+                                                                                "min",
+                                                                                "max",
+                                                                                "in",
+                                                                                "not_in",
+                                                                                "is_cleaned_path_exact",
+                                                                                "flag_evaluates_to",
+                                                                                "semver_eq",
+                                                                                "semver_neq",
+                                                                                "semver_gt",
+                                                                                "semver_gte",
+                                                                                "semver_lt",
+                                                                                "semver_lte",
+                                                                                "semver_tilde",
+                                                                                "semver_caret",
+                                                                                "semver_wildcard",
+                                                                                "icontains_multi",
+                                                                                "not_icontains_multi"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ],
+                                                                    "default": "exact"
+                                                                },
+                                                                "type": {
+                                                                    "const": "event",
+                                                                    "default": "event",
+                                                                    "description": "Event properties",
+                                                                    "type": "string"
+                                                                },
+                                                                "value": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "items": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "number"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "boolean"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "type": "array"
+                                                                        },
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "number"
+                                                                        },
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": ["key"],
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "properties": {
+                                                                "key": {
+                                                                    "type": "string"
+                                                                },
+                                                                "label": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "operator": {
+                                                                    "enum": [
+                                                                        "exact",
+                                                                        "is_not",
+                                                                        "icontains",
+                                                                        "not_icontains",
+                                                                        "starts_with",
+                                                                        "not_starts_with",
+                                                                        "ends_with",
+                                                                        "not_ends_with",
+                                                                        "regex",
+                                                                        "not_regex",
+                                                                        "gt",
+                                                                        "gte",
+                                                                        "lt",
+                                                                        "lte",
+                                                                        "is_set",
+                                                                        "is_not_set",
+                                                                        "is_date_exact",
+                                                                        "is_date_before",
+                                                                        "is_date_after",
+                                                                        "between",
+                                                                        "not_between",
+                                                                        "min",
+                                                                        "max",
+                                                                        "in",
+                                                                        "not_in",
+                                                                        "is_cleaned_path_exact",
+                                                                        "flag_evaluates_to",
+                                                                        "semver_eq",
+                                                                        "semver_neq",
+                                                                        "semver_gt",
+                                                                        "semver_gte",
+                                                                        "semver_lt",
+                                                                        "semver_lte",
+                                                                        "semver_tilde",
+                                                                        "semver_caret",
+                                                                        "semver_wildcard",
+                                                                        "icontains_multi",
+                                                                        "not_icontains_multi"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "type": {
+                                                                    "const": "person",
+                                                                    "default": "person",
+                                                                    "description": "Person properties",
+                                                                    "type": "string"
+                                                                },
+                                                                "value": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "items": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "number"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "boolean"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "type": "array"
+                                                                        },
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "number"
+                                                                        },
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": ["key", "operator"],
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "properties": {
+                                                                "key": {
+                                                                    "enum": ["tag_name", "text", "href", "selector"],
+                                                                    "type": "string"
+                                                                },
+                                                                "label": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "operator": {
+                                                                    "enum": [
+                                                                        "exact",
+                                                                        "is_not",
+                                                                        "icontains",
+                                                                        "not_icontains",
+                                                                        "starts_with",
+                                                                        "not_starts_with",
+                                                                        "ends_with",
+                                                                        "not_ends_with",
+                                                                        "regex",
+                                                                        "not_regex",
+                                                                        "gt",
+                                                                        "gte",
+                                                                        "lt",
+                                                                        "lte",
+                                                                        "is_set",
+                                                                        "is_not_set",
+                                                                        "is_date_exact",
+                                                                        "is_date_before",
+                                                                        "is_date_after",
+                                                                        "between",
+                                                                        "not_between",
+                                                                        "min",
+                                                                        "max",
+                                                                        "in",
+                                                                        "not_in",
+                                                                        "is_cleaned_path_exact",
+                                                                        "flag_evaluates_to",
+                                                                        "semver_eq",
+                                                                        "semver_neq",
+                                                                        "semver_gt",
+                                                                        "semver_gte",
+                                                                        "semver_lt",
+                                                                        "semver_lte",
+                                                                        "semver_tilde",
+                                                                        "semver_caret",
+                                                                        "semver_wildcard",
+                                                                        "icontains_multi",
+                                                                        "not_icontains_multi"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "type": {
+                                                                    "const": "element",
+                                                                    "default": "element",
+                                                                    "type": "string"
+                                                                },
+                                                                "value": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "items": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "number"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "boolean"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "type": "array"
+                                                                        },
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "number"
+                                                                        },
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": ["key", "operator"],
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "properties": {
+                                                                "key": {
+                                                                    "type": "string"
+                                                                },
+                                                                "label": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "operator": {
+                                                                    "enum": [
+                                                                        "exact",
+                                                                        "is_not",
+                                                                        "icontains",
+                                                                        "not_icontains",
+                                                                        "starts_with",
+                                                                        "not_starts_with",
+                                                                        "ends_with",
+                                                                        "not_ends_with",
+                                                                        "regex",
+                                                                        "not_regex",
+                                                                        "gt",
+                                                                        "gte",
+                                                                        "lt",
+                                                                        "lte",
+                                                                        "is_set",
+                                                                        "is_not_set",
+                                                                        "is_date_exact",
+                                                                        "is_date_before",
+                                                                        "is_date_after",
+                                                                        "between",
+                                                                        "not_between",
+                                                                        "min",
+                                                                        "max",
+                                                                        "in",
+                                                                        "not_in",
+                                                                        "is_cleaned_path_exact",
+                                                                        "flag_evaluates_to",
+                                                                        "semver_eq",
+                                                                        "semver_neq",
+                                                                        "semver_gt",
+                                                                        "semver_gte",
+                                                                        "semver_lt",
+                                                                        "semver_lte",
+                                                                        "semver_tilde",
+                                                                        "semver_caret",
+                                                                        "semver_wildcard",
+                                                                        "icontains_multi",
+                                                                        "not_icontains_multi"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "type": {
+                                                                    "const": "feature",
+                                                                    "default": "feature",
+                                                                    "description": "Event property with \"$feature/\" prepended",
+                                                                    "type": "string"
+                                                                },
+                                                                "value": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "items": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "number"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "boolean"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "type": "array"
+                                                                        },
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "number"
+                                                                        },
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": ["key", "operator"],
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "properties": {
+                                                                "key": {
+                                                                    "type": "string"
+                                                                },
+                                                                "label": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "type": {
+                                                                    "const": "hogql",
+                                                                    "default": "hogql",
+                                                                    "type": "string"
+                                                                },
+                                                                "value": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "items": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "number"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "boolean"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "type": "array"
+                                                                        },
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "number"
+                                                                        },
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": ["key"],
+                                                            "type": "object"
+                                                        }
+                                                    ]
+                                                },
+                                                "type": "array"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ],
+                                        "description": "Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral/cohort filters and groups"
+                                    },
+                                    "event_type": {
+                                        "enum": ["events", "actions"],
+                                        "type": "string"
+                                    },
+                                    "explicit_datetime": {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ],
+                                        "description": "Absolute or relative (e.g. -30d) lower date bound — alternative to time_value/time_interval"
+                                    },
+                                    "explicit_datetime_to": {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    },
+                                    "key": {
+                                        "description": "Event name, or action id when event_type is 'actions'",
+                                        "type": "string"
+                                    },
+                                    "label": {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    },
+                                    "negation": {
+                                        "anyOf": [
+                                            {
+                                                "type": "boolean"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ],
+                                        "description": "Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators"
+                                    },
+                                    "operator": {
+                                        "anyOf": [
+                                            {
+                                                "enum": [
+                                                    "exact",
+                                                    "is_not",
+                                                    "icontains",
+                                                    "not_icontains",
+                                                    "starts_with",
+                                                    "not_starts_with",
+                                                    "ends_with",
+                                                    "not_ends_with",
+                                                    "regex",
+                                                    "not_regex",
+                                                    "gt",
+                                                    "gte",
+                                                    "lt",
+                                                    "lte",
+                                                    "is_set",
+                                                    "is_not_set",
+                                                    "is_date_exact",
+                                                    "is_date_before",
+                                                    "is_date_after",
+                                                    "between",
+                                                    "not_between",
+                                                    "min",
+                                                    "max",
+                                                    "in",
+                                                    "not_in",
+                                                    "is_cleaned_path_exact",
+                                                    "flag_evaluates_to",
+                                                    "semver_eq",
+                                                    "semver_neq",
+                                                    "semver_gt",
+                                                    "semver_gte",
+                                                    "semver_lt",
+                                                    "semver_lte",
+                                                    "semver_tilde",
+                                                    "semver_caret",
+                                                    "semver_wildcard",
+                                                    "icontains_multi",
+                                                    "not_icontains_multi"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ],
+                                        "description": "Count comparison for performed_event_multiple, defaults to exact"
+                                    },
+                                    "operator_value": {
+                                        "anyOf": [
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ],
+                                        "description": "Count threshold for performed_event_multiple"
+                                    },
+                                    "time_interval": {
+                                        "anyOf": [
+                                            {
+                                                "enum": ["day", "week", "month", "year"],
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    },
+                                    "time_value": {
+                                        "anyOf": [
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ],
+                                        "description": "Relative time window size, paired with time_interval"
+                                    },
+                                    "type": {
+                                        "const": "behavioral",
+                                        "default": "behavioral",
+                                        "description": "Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP",
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "enum": ["performed_event", "performed_event_multiple"],
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["event_type", "key", "value"],
+                                "type": "object"
                             }
                         ]
                     },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/error-tracking-grouping-rules-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/error-tracking-grouping-rules-update.json
@@ -2138,6 +2138,640 @@
                                         },
                                         "required": ["key", "operator"],
                                         "type": "object"
+                                    },
+                                    {
+                                        "properties": {
+                                            "event_filters": {
+                                                "anyOf": [
+                                                    {
+                                                        "items": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "properties": {
+                                                                        "key": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "label": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                {
+                                                                                    "type": "null"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "operator": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "exact",
+                                                                                        "is_not",
+                                                                                        "icontains",
+                                                                                        "not_icontains",
+                                                                                        "starts_with",
+                                                                                        "not_starts_with",
+                                                                                        "ends_with",
+                                                                                        "not_ends_with",
+                                                                                        "regex",
+                                                                                        "not_regex",
+                                                                                        "gt",
+                                                                                        "gte",
+                                                                                        "lt",
+                                                                                        "lte",
+                                                                                        "is_set",
+                                                                                        "is_not_set",
+                                                                                        "is_date_exact",
+                                                                                        "is_date_before",
+                                                                                        "is_date_after",
+                                                                                        "between",
+                                                                                        "not_between",
+                                                                                        "min",
+                                                                                        "max",
+                                                                                        "in",
+                                                                                        "not_in",
+                                                                                        "is_cleaned_path_exact",
+                                                                                        "flag_evaluates_to",
+                                                                                        "semver_eq",
+                                                                                        "semver_neq",
+                                                                                        "semver_gt",
+                                                                                        "semver_gte",
+                                                                                        "semver_lt",
+                                                                                        "semver_lte",
+                                                                                        "semver_tilde",
+                                                                                        "semver_caret",
+                                                                                        "semver_wildcard",
+                                                                                        "icontains_multi",
+                                                                                        "not_icontains_multi"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                },
+                                                                                {
+                                                                                    "type": "null"
+                                                                                }
+                                                                            ],
+                                                                            "default": "exact"
+                                                                        },
+                                                                        "type": {
+                                                                            "const": "event",
+                                                                            "default": "event",
+                                                                            "description": "Event properties",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "value": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "items": {
+                                                                                        "anyOf": [
+                                                                                            {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            {
+                                                                                                "type": "number"
+                                                                                            },
+                                                                                            {
+                                                                                                "type": "boolean"
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    "type": "array"
+                                                                                },
+                                                                                {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                {
+                                                                                    "type": "number"
+                                                                                },
+                                                                                {
+                                                                                    "type": "boolean"
+                                                                                },
+                                                                                {
+                                                                                    "type": "null"
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    "required": ["key"],
+                                                                    "type": "object"
+                                                                },
+                                                                {
+                                                                    "properties": {
+                                                                        "key": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "label": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                {
+                                                                                    "type": "null"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "operator": {
+                                                                            "enum": [
+                                                                                "exact",
+                                                                                "is_not",
+                                                                                "icontains",
+                                                                                "not_icontains",
+                                                                                "starts_with",
+                                                                                "not_starts_with",
+                                                                                "ends_with",
+                                                                                "not_ends_with",
+                                                                                "regex",
+                                                                                "not_regex",
+                                                                                "gt",
+                                                                                "gte",
+                                                                                "lt",
+                                                                                "lte",
+                                                                                "is_set",
+                                                                                "is_not_set",
+                                                                                "is_date_exact",
+                                                                                "is_date_before",
+                                                                                "is_date_after",
+                                                                                "between",
+                                                                                "not_between",
+                                                                                "min",
+                                                                                "max",
+                                                                                "in",
+                                                                                "not_in",
+                                                                                "is_cleaned_path_exact",
+                                                                                "flag_evaluates_to",
+                                                                                "semver_eq",
+                                                                                "semver_neq",
+                                                                                "semver_gt",
+                                                                                "semver_gte",
+                                                                                "semver_lt",
+                                                                                "semver_lte",
+                                                                                "semver_tilde",
+                                                                                "semver_caret",
+                                                                                "semver_wildcard",
+                                                                                "icontains_multi",
+                                                                                "not_icontains_multi"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        "type": {
+                                                                            "const": "person",
+                                                                            "default": "person",
+                                                                            "description": "Person properties",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "value": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "items": {
+                                                                                        "anyOf": [
+                                                                                            {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            {
+                                                                                                "type": "number"
+                                                                                            },
+                                                                                            {
+                                                                                                "type": "boolean"
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    "type": "array"
+                                                                                },
+                                                                                {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                {
+                                                                                    "type": "number"
+                                                                                },
+                                                                                {
+                                                                                    "type": "boolean"
+                                                                                },
+                                                                                {
+                                                                                    "type": "null"
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    "required": ["key", "operator"],
+                                                                    "type": "object"
+                                                                },
+                                                                {
+                                                                    "properties": {
+                                                                        "key": {
+                                                                            "enum": [
+                                                                                "tag_name",
+                                                                                "text",
+                                                                                "href",
+                                                                                "selector"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        "label": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                {
+                                                                                    "type": "null"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "operator": {
+                                                                            "enum": [
+                                                                                "exact",
+                                                                                "is_not",
+                                                                                "icontains",
+                                                                                "not_icontains",
+                                                                                "starts_with",
+                                                                                "not_starts_with",
+                                                                                "ends_with",
+                                                                                "not_ends_with",
+                                                                                "regex",
+                                                                                "not_regex",
+                                                                                "gt",
+                                                                                "gte",
+                                                                                "lt",
+                                                                                "lte",
+                                                                                "is_set",
+                                                                                "is_not_set",
+                                                                                "is_date_exact",
+                                                                                "is_date_before",
+                                                                                "is_date_after",
+                                                                                "between",
+                                                                                "not_between",
+                                                                                "min",
+                                                                                "max",
+                                                                                "in",
+                                                                                "not_in",
+                                                                                "is_cleaned_path_exact",
+                                                                                "flag_evaluates_to",
+                                                                                "semver_eq",
+                                                                                "semver_neq",
+                                                                                "semver_gt",
+                                                                                "semver_gte",
+                                                                                "semver_lt",
+                                                                                "semver_lte",
+                                                                                "semver_tilde",
+                                                                                "semver_caret",
+                                                                                "semver_wildcard",
+                                                                                "icontains_multi",
+                                                                                "not_icontains_multi"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        "type": {
+                                                                            "const": "element",
+                                                                            "default": "element",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "value": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "items": {
+                                                                                        "anyOf": [
+                                                                                            {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            {
+                                                                                                "type": "number"
+                                                                                            },
+                                                                                            {
+                                                                                                "type": "boolean"
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    "type": "array"
+                                                                                },
+                                                                                {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                {
+                                                                                    "type": "number"
+                                                                                },
+                                                                                {
+                                                                                    "type": "boolean"
+                                                                                },
+                                                                                {
+                                                                                    "type": "null"
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    "required": ["key", "operator"],
+                                                                    "type": "object"
+                                                                },
+                                                                {
+                                                                    "properties": {
+                                                                        "key": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "label": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                {
+                                                                                    "type": "null"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "operator": {
+                                                                            "enum": [
+                                                                                "exact",
+                                                                                "is_not",
+                                                                                "icontains",
+                                                                                "not_icontains",
+                                                                                "starts_with",
+                                                                                "not_starts_with",
+                                                                                "ends_with",
+                                                                                "not_ends_with",
+                                                                                "regex",
+                                                                                "not_regex",
+                                                                                "gt",
+                                                                                "gte",
+                                                                                "lt",
+                                                                                "lte",
+                                                                                "is_set",
+                                                                                "is_not_set",
+                                                                                "is_date_exact",
+                                                                                "is_date_before",
+                                                                                "is_date_after",
+                                                                                "between",
+                                                                                "not_between",
+                                                                                "min",
+                                                                                "max",
+                                                                                "in",
+                                                                                "not_in",
+                                                                                "is_cleaned_path_exact",
+                                                                                "flag_evaluates_to",
+                                                                                "semver_eq",
+                                                                                "semver_neq",
+                                                                                "semver_gt",
+                                                                                "semver_gte",
+                                                                                "semver_lt",
+                                                                                "semver_lte",
+                                                                                "semver_tilde",
+                                                                                "semver_caret",
+                                                                                "semver_wildcard",
+                                                                                "icontains_multi",
+                                                                                "not_icontains_multi"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        "type": {
+                                                                            "const": "feature",
+                                                                            "default": "feature",
+                                                                            "description": "Event property with \"$feature/\" prepended",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "value": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "items": {
+                                                                                        "anyOf": [
+                                                                                            {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            {
+                                                                                                "type": "number"
+                                                                                            },
+                                                                                            {
+                                                                                                "type": "boolean"
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    "type": "array"
+                                                                                },
+                                                                                {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                {
+                                                                                    "type": "number"
+                                                                                },
+                                                                                {
+                                                                                    "type": "boolean"
+                                                                                },
+                                                                                {
+                                                                                    "type": "null"
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    "required": ["key", "operator"],
+                                                                    "type": "object"
+                                                                },
+                                                                {
+                                                                    "properties": {
+                                                                        "key": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "label": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                {
+                                                                                    "type": "null"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "type": {
+                                                                            "const": "hogql",
+                                                                            "default": "hogql",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "value": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "items": {
+                                                                                        "anyOf": [
+                                                                                            {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            {
+                                                                                                "type": "number"
+                                                                                            },
+                                                                                            {
+                                                                                                "type": "boolean"
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    "type": "array"
+                                                                                },
+                                                                                {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                {
+                                                                                    "type": "number"
+                                                                                },
+                                                                                {
+                                                                                    "type": "boolean"
+                                                                                },
+                                                                                {
+                                                                                    "type": "null"
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    "required": ["key"],
+                                                                    "type": "object"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral/cohort filters and groups"
+                                            },
+                                            "event_type": {
+                                                "enum": ["events", "actions"],
+                                                "type": "string"
+                                            },
+                                            "explicit_datetime": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Absolute or relative (e.g. -30d) lower date bound — alternative to time_value/time_interval"
+                                            },
+                                            "explicit_datetime_to": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ]
+                                            },
+                                            "key": {
+                                                "description": "Event name, or action id when event_type is 'actions'",
+                                                "type": "string"
+                                            },
+                                            "label": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ]
+                                            },
+                                            "negation": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators"
+                                            },
+                                            "operator": {
+                                                "anyOf": [
+                                                    {
+                                                        "enum": [
+                                                            "exact",
+                                                            "is_not",
+                                                            "icontains",
+                                                            "not_icontains",
+                                                            "starts_with",
+                                                            "not_starts_with",
+                                                            "ends_with",
+                                                            "not_ends_with",
+                                                            "regex",
+                                                            "not_regex",
+                                                            "gt",
+                                                            "gte",
+                                                            "lt",
+                                                            "lte",
+                                                            "is_set",
+                                                            "is_not_set",
+                                                            "is_date_exact",
+                                                            "is_date_before",
+                                                            "is_date_after",
+                                                            "between",
+                                                            "not_between",
+                                                            "min",
+                                                            "max",
+                                                            "in",
+                                                            "not_in",
+                                                            "is_cleaned_path_exact",
+                                                            "flag_evaluates_to",
+                                                            "semver_eq",
+                                                            "semver_neq",
+                                                            "semver_gt",
+                                                            "semver_gte",
+                                                            "semver_lt",
+                                                            "semver_lte",
+                                                            "semver_tilde",
+                                                            "semver_caret",
+                                                            "semver_wildcard",
+                                                            "icontains_multi",
+                                                            "not_icontains_multi"
+                                                        ],
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Count comparison for performed_event_multiple, defaults to exact"
+                                            },
+                                            "operator_value": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Count threshold for performed_event_multiple"
+                                            },
+                                            "time_interval": {
+                                                "anyOf": [
+                                                    {
+                                                        "enum": ["day", "week", "month", "year"],
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ]
+                                            },
+                                            "time_value": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Relative time window size, paired with time_interval"
+                                            },
+                                            "type": {
+                                                "const": "behavioral",
+                                                "default": "behavioral",
+                                                "description": "Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP",
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "enum": ["performed_event", "performed_event_multiple"],
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": ["event_type", "key", "value"],
+                                        "type": "object"
                                     }
                                 ]
                             },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/error-tracking-suppression-rules-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/error-tracking-suppression-rules-create.json
@@ -2137,6 +2137,635 @@
                                 },
                                 "required": ["key", "operator"],
                                 "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "event_filters": {
+                                        "anyOf": [
+                                            {
+                                                "items": {
+                                                    "anyOf": [
+                                                        {
+                                                            "properties": {
+                                                                "key": {
+                                                                    "type": "string"
+                                                                },
+                                                                "label": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "operator": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "exact",
+                                                                                "is_not",
+                                                                                "icontains",
+                                                                                "not_icontains",
+                                                                                "starts_with",
+                                                                                "not_starts_with",
+                                                                                "ends_with",
+                                                                                "not_ends_with",
+                                                                                "regex",
+                                                                                "not_regex",
+                                                                                "gt",
+                                                                                "gte",
+                                                                                "lt",
+                                                                                "lte",
+                                                                                "is_set",
+                                                                                "is_not_set",
+                                                                                "is_date_exact",
+                                                                                "is_date_before",
+                                                                                "is_date_after",
+                                                                                "between",
+                                                                                "not_between",
+                                                                                "min",
+                                                                                "max",
+                                                                                "in",
+                                                                                "not_in",
+                                                                                "is_cleaned_path_exact",
+                                                                                "flag_evaluates_to",
+                                                                                "semver_eq",
+                                                                                "semver_neq",
+                                                                                "semver_gt",
+                                                                                "semver_gte",
+                                                                                "semver_lt",
+                                                                                "semver_lte",
+                                                                                "semver_tilde",
+                                                                                "semver_caret",
+                                                                                "semver_wildcard",
+                                                                                "icontains_multi",
+                                                                                "not_icontains_multi"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ],
+                                                                    "default": "exact"
+                                                                },
+                                                                "type": {
+                                                                    "const": "event",
+                                                                    "default": "event",
+                                                                    "description": "Event properties",
+                                                                    "type": "string"
+                                                                },
+                                                                "value": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "items": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "number"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "boolean"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "type": "array"
+                                                                        },
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "number"
+                                                                        },
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": ["key"],
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "properties": {
+                                                                "key": {
+                                                                    "type": "string"
+                                                                },
+                                                                "label": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "operator": {
+                                                                    "enum": [
+                                                                        "exact",
+                                                                        "is_not",
+                                                                        "icontains",
+                                                                        "not_icontains",
+                                                                        "starts_with",
+                                                                        "not_starts_with",
+                                                                        "ends_with",
+                                                                        "not_ends_with",
+                                                                        "regex",
+                                                                        "not_regex",
+                                                                        "gt",
+                                                                        "gte",
+                                                                        "lt",
+                                                                        "lte",
+                                                                        "is_set",
+                                                                        "is_not_set",
+                                                                        "is_date_exact",
+                                                                        "is_date_before",
+                                                                        "is_date_after",
+                                                                        "between",
+                                                                        "not_between",
+                                                                        "min",
+                                                                        "max",
+                                                                        "in",
+                                                                        "not_in",
+                                                                        "is_cleaned_path_exact",
+                                                                        "flag_evaluates_to",
+                                                                        "semver_eq",
+                                                                        "semver_neq",
+                                                                        "semver_gt",
+                                                                        "semver_gte",
+                                                                        "semver_lt",
+                                                                        "semver_lte",
+                                                                        "semver_tilde",
+                                                                        "semver_caret",
+                                                                        "semver_wildcard",
+                                                                        "icontains_multi",
+                                                                        "not_icontains_multi"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "type": {
+                                                                    "const": "person",
+                                                                    "default": "person",
+                                                                    "description": "Person properties",
+                                                                    "type": "string"
+                                                                },
+                                                                "value": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "items": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "number"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "boolean"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "type": "array"
+                                                                        },
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "number"
+                                                                        },
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": ["key", "operator"],
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "properties": {
+                                                                "key": {
+                                                                    "enum": ["tag_name", "text", "href", "selector"],
+                                                                    "type": "string"
+                                                                },
+                                                                "label": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "operator": {
+                                                                    "enum": [
+                                                                        "exact",
+                                                                        "is_not",
+                                                                        "icontains",
+                                                                        "not_icontains",
+                                                                        "starts_with",
+                                                                        "not_starts_with",
+                                                                        "ends_with",
+                                                                        "not_ends_with",
+                                                                        "regex",
+                                                                        "not_regex",
+                                                                        "gt",
+                                                                        "gte",
+                                                                        "lt",
+                                                                        "lte",
+                                                                        "is_set",
+                                                                        "is_not_set",
+                                                                        "is_date_exact",
+                                                                        "is_date_before",
+                                                                        "is_date_after",
+                                                                        "between",
+                                                                        "not_between",
+                                                                        "min",
+                                                                        "max",
+                                                                        "in",
+                                                                        "not_in",
+                                                                        "is_cleaned_path_exact",
+                                                                        "flag_evaluates_to",
+                                                                        "semver_eq",
+                                                                        "semver_neq",
+                                                                        "semver_gt",
+                                                                        "semver_gte",
+                                                                        "semver_lt",
+                                                                        "semver_lte",
+                                                                        "semver_tilde",
+                                                                        "semver_caret",
+                                                                        "semver_wildcard",
+                                                                        "icontains_multi",
+                                                                        "not_icontains_multi"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "type": {
+                                                                    "const": "element",
+                                                                    "default": "element",
+                                                                    "type": "string"
+                                                                },
+                                                                "value": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "items": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "number"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "boolean"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "type": "array"
+                                                                        },
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "number"
+                                                                        },
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": ["key", "operator"],
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "properties": {
+                                                                "key": {
+                                                                    "type": "string"
+                                                                },
+                                                                "label": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "operator": {
+                                                                    "enum": [
+                                                                        "exact",
+                                                                        "is_not",
+                                                                        "icontains",
+                                                                        "not_icontains",
+                                                                        "starts_with",
+                                                                        "not_starts_with",
+                                                                        "ends_with",
+                                                                        "not_ends_with",
+                                                                        "regex",
+                                                                        "not_regex",
+                                                                        "gt",
+                                                                        "gte",
+                                                                        "lt",
+                                                                        "lte",
+                                                                        "is_set",
+                                                                        "is_not_set",
+                                                                        "is_date_exact",
+                                                                        "is_date_before",
+                                                                        "is_date_after",
+                                                                        "between",
+                                                                        "not_between",
+                                                                        "min",
+                                                                        "max",
+                                                                        "in",
+                                                                        "not_in",
+                                                                        "is_cleaned_path_exact",
+                                                                        "flag_evaluates_to",
+                                                                        "semver_eq",
+                                                                        "semver_neq",
+                                                                        "semver_gt",
+                                                                        "semver_gte",
+                                                                        "semver_lt",
+                                                                        "semver_lte",
+                                                                        "semver_tilde",
+                                                                        "semver_caret",
+                                                                        "semver_wildcard",
+                                                                        "icontains_multi",
+                                                                        "not_icontains_multi"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "type": {
+                                                                    "const": "feature",
+                                                                    "default": "feature",
+                                                                    "description": "Event property with \"$feature/\" prepended",
+                                                                    "type": "string"
+                                                                },
+                                                                "value": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "items": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "number"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "boolean"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "type": "array"
+                                                                        },
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "number"
+                                                                        },
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": ["key", "operator"],
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "properties": {
+                                                                "key": {
+                                                                    "type": "string"
+                                                                },
+                                                                "label": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "type": {
+                                                                    "const": "hogql",
+                                                                    "default": "hogql",
+                                                                    "type": "string"
+                                                                },
+                                                                "value": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "items": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "number"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "boolean"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "type": "array"
+                                                                        },
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "number"
+                                                                        },
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": ["key"],
+                                                            "type": "object"
+                                                        }
+                                                    ]
+                                                },
+                                                "type": "array"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ],
+                                        "description": "Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral/cohort filters and groups"
+                                    },
+                                    "event_type": {
+                                        "enum": ["events", "actions"],
+                                        "type": "string"
+                                    },
+                                    "explicit_datetime": {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ],
+                                        "description": "Absolute or relative (e.g. -30d) lower date bound — alternative to time_value/time_interval"
+                                    },
+                                    "explicit_datetime_to": {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    },
+                                    "key": {
+                                        "description": "Event name, or action id when event_type is 'actions'",
+                                        "type": "string"
+                                    },
+                                    "label": {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    },
+                                    "negation": {
+                                        "anyOf": [
+                                            {
+                                                "type": "boolean"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ],
+                                        "description": "Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators"
+                                    },
+                                    "operator": {
+                                        "anyOf": [
+                                            {
+                                                "enum": [
+                                                    "exact",
+                                                    "is_not",
+                                                    "icontains",
+                                                    "not_icontains",
+                                                    "starts_with",
+                                                    "not_starts_with",
+                                                    "ends_with",
+                                                    "not_ends_with",
+                                                    "regex",
+                                                    "not_regex",
+                                                    "gt",
+                                                    "gte",
+                                                    "lt",
+                                                    "lte",
+                                                    "is_set",
+                                                    "is_not_set",
+                                                    "is_date_exact",
+                                                    "is_date_before",
+                                                    "is_date_after",
+                                                    "between",
+                                                    "not_between",
+                                                    "min",
+                                                    "max",
+                                                    "in",
+                                                    "not_in",
+                                                    "is_cleaned_path_exact",
+                                                    "flag_evaluates_to",
+                                                    "semver_eq",
+                                                    "semver_neq",
+                                                    "semver_gt",
+                                                    "semver_gte",
+                                                    "semver_lt",
+                                                    "semver_lte",
+                                                    "semver_tilde",
+                                                    "semver_caret",
+                                                    "semver_wildcard",
+                                                    "icontains_multi",
+                                                    "not_icontains_multi"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ],
+                                        "description": "Count comparison for performed_event_multiple, defaults to exact"
+                                    },
+                                    "operator_value": {
+                                        "anyOf": [
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ],
+                                        "description": "Count threshold for performed_event_multiple"
+                                    },
+                                    "time_interval": {
+                                        "anyOf": [
+                                            {
+                                                "enum": ["day", "week", "month", "year"],
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    },
+                                    "time_value": {
+                                        "anyOf": [
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ],
+                                        "description": "Relative time window size, paired with time_interval"
+                                    },
+                                    "type": {
+                                        "const": "behavioral",
+                                        "default": "behavioral",
+                                        "description": "Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP",
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "enum": ["performed_event", "performed_event_multiple"],
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["event_type", "key", "value"],
+                                "type": "object"
                             }
                         ]
                     },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/error-tracking-suppression-rules-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/error-tracking-suppression-rules-update.json
@@ -2137,6 +2137,635 @@
                                 },
                                 "required": ["key", "operator"],
                                 "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "event_filters": {
+                                        "anyOf": [
+                                            {
+                                                "items": {
+                                                    "anyOf": [
+                                                        {
+                                                            "properties": {
+                                                                "key": {
+                                                                    "type": "string"
+                                                                },
+                                                                "label": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "operator": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "exact",
+                                                                                "is_not",
+                                                                                "icontains",
+                                                                                "not_icontains",
+                                                                                "starts_with",
+                                                                                "not_starts_with",
+                                                                                "ends_with",
+                                                                                "not_ends_with",
+                                                                                "regex",
+                                                                                "not_regex",
+                                                                                "gt",
+                                                                                "gte",
+                                                                                "lt",
+                                                                                "lte",
+                                                                                "is_set",
+                                                                                "is_not_set",
+                                                                                "is_date_exact",
+                                                                                "is_date_before",
+                                                                                "is_date_after",
+                                                                                "between",
+                                                                                "not_between",
+                                                                                "min",
+                                                                                "max",
+                                                                                "in",
+                                                                                "not_in",
+                                                                                "is_cleaned_path_exact",
+                                                                                "flag_evaluates_to",
+                                                                                "semver_eq",
+                                                                                "semver_neq",
+                                                                                "semver_gt",
+                                                                                "semver_gte",
+                                                                                "semver_lt",
+                                                                                "semver_lte",
+                                                                                "semver_tilde",
+                                                                                "semver_caret",
+                                                                                "semver_wildcard",
+                                                                                "icontains_multi",
+                                                                                "not_icontains_multi"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ],
+                                                                    "default": "exact"
+                                                                },
+                                                                "type": {
+                                                                    "const": "event",
+                                                                    "default": "event",
+                                                                    "description": "Event properties",
+                                                                    "type": "string"
+                                                                },
+                                                                "value": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "items": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "number"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "boolean"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "type": "array"
+                                                                        },
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "number"
+                                                                        },
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": ["key"],
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "properties": {
+                                                                "key": {
+                                                                    "type": "string"
+                                                                },
+                                                                "label": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "operator": {
+                                                                    "enum": [
+                                                                        "exact",
+                                                                        "is_not",
+                                                                        "icontains",
+                                                                        "not_icontains",
+                                                                        "starts_with",
+                                                                        "not_starts_with",
+                                                                        "ends_with",
+                                                                        "not_ends_with",
+                                                                        "regex",
+                                                                        "not_regex",
+                                                                        "gt",
+                                                                        "gte",
+                                                                        "lt",
+                                                                        "lte",
+                                                                        "is_set",
+                                                                        "is_not_set",
+                                                                        "is_date_exact",
+                                                                        "is_date_before",
+                                                                        "is_date_after",
+                                                                        "between",
+                                                                        "not_between",
+                                                                        "min",
+                                                                        "max",
+                                                                        "in",
+                                                                        "not_in",
+                                                                        "is_cleaned_path_exact",
+                                                                        "flag_evaluates_to",
+                                                                        "semver_eq",
+                                                                        "semver_neq",
+                                                                        "semver_gt",
+                                                                        "semver_gte",
+                                                                        "semver_lt",
+                                                                        "semver_lte",
+                                                                        "semver_tilde",
+                                                                        "semver_caret",
+                                                                        "semver_wildcard",
+                                                                        "icontains_multi",
+                                                                        "not_icontains_multi"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "type": {
+                                                                    "const": "person",
+                                                                    "default": "person",
+                                                                    "description": "Person properties",
+                                                                    "type": "string"
+                                                                },
+                                                                "value": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "items": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "number"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "boolean"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "type": "array"
+                                                                        },
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "number"
+                                                                        },
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": ["key", "operator"],
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "properties": {
+                                                                "key": {
+                                                                    "enum": ["tag_name", "text", "href", "selector"],
+                                                                    "type": "string"
+                                                                },
+                                                                "label": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "operator": {
+                                                                    "enum": [
+                                                                        "exact",
+                                                                        "is_not",
+                                                                        "icontains",
+                                                                        "not_icontains",
+                                                                        "starts_with",
+                                                                        "not_starts_with",
+                                                                        "ends_with",
+                                                                        "not_ends_with",
+                                                                        "regex",
+                                                                        "not_regex",
+                                                                        "gt",
+                                                                        "gte",
+                                                                        "lt",
+                                                                        "lte",
+                                                                        "is_set",
+                                                                        "is_not_set",
+                                                                        "is_date_exact",
+                                                                        "is_date_before",
+                                                                        "is_date_after",
+                                                                        "between",
+                                                                        "not_between",
+                                                                        "min",
+                                                                        "max",
+                                                                        "in",
+                                                                        "not_in",
+                                                                        "is_cleaned_path_exact",
+                                                                        "flag_evaluates_to",
+                                                                        "semver_eq",
+                                                                        "semver_neq",
+                                                                        "semver_gt",
+                                                                        "semver_gte",
+                                                                        "semver_lt",
+                                                                        "semver_lte",
+                                                                        "semver_tilde",
+                                                                        "semver_caret",
+                                                                        "semver_wildcard",
+                                                                        "icontains_multi",
+                                                                        "not_icontains_multi"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "type": {
+                                                                    "const": "element",
+                                                                    "default": "element",
+                                                                    "type": "string"
+                                                                },
+                                                                "value": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "items": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "number"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "boolean"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "type": "array"
+                                                                        },
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "number"
+                                                                        },
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": ["key", "operator"],
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "properties": {
+                                                                "key": {
+                                                                    "type": "string"
+                                                                },
+                                                                "label": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "operator": {
+                                                                    "enum": [
+                                                                        "exact",
+                                                                        "is_not",
+                                                                        "icontains",
+                                                                        "not_icontains",
+                                                                        "starts_with",
+                                                                        "not_starts_with",
+                                                                        "ends_with",
+                                                                        "not_ends_with",
+                                                                        "regex",
+                                                                        "not_regex",
+                                                                        "gt",
+                                                                        "gte",
+                                                                        "lt",
+                                                                        "lte",
+                                                                        "is_set",
+                                                                        "is_not_set",
+                                                                        "is_date_exact",
+                                                                        "is_date_before",
+                                                                        "is_date_after",
+                                                                        "between",
+                                                                        "not_between",
+                                                                        "min",
+                                                                        "max",
+                                                                        "in",
+                                                                        "not_in",
+                                                                        "is_cleaned_path_exact",
+                                                                        "flag_evaluates_to",
+                                                                        "semver_eq",
+                                                                        "semver_neq",
+                                                                        "semver_gt",
+                                                                        "semver_gte",
+                                                                        "semver_lt",
+                                                                        "semver_lte",
+                                                                        "semver_tilde",
+                                                                        "semver_caret",
+                                                                        "semver_wildcard",
+                                                                        "icontains_multi",
+                                                                        "not_icontains_multi"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "type": {
+                                                                    "const": "feature",
+                                                                    "default": "feature",
+                                                                    "description": "Event property with \"$feature/\" prepended",
+                                                                    "type": "string"
+                                                                },
+                                                                "value": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "items": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "number"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "boolean"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "type": "array"
+                                                                        },
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "number"
+                                                                        },
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": ["key", "operator"],
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "properties": {
+                                                                "key": {
+                                                                    "type": "string"
+                                                                },
+                                                                "label": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "type": {
+                                                                    "const": "hogql",
+                                                                    "default": "hogql",
+                                                                    "type": "string"
+                                                                },
+                                                                "value": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "items": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "number"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "boolean"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "type": "array"
+                                                                        },
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "number"
+                                                                        },
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": ["key"],
+                                                            "type": "object"
+                                                        }
+                                                    ]
+                                                },
+                                                "type": "array"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ],
+                                        "description": "Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral/cohort filters and groups"
+                                    },
+                                    "event_type": {
+                                        "enum": ["events", "actions"],
+                                        "type": "string"
+                                    },
+                                    "explicit_datetime": {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ],
+                                        "description": "Absolute or relative (e.g. -30d) lower date bound — alternative to time_value/time_interval"
+                                    },
+                                    "explicit_datetime_to": {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    },
+                                    "key": {
+                                        "description": "Event name, or action id when event_type is 'actions'",
+                                        "type": "string"
+                                    },
+                                    "label": {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    },
+                                    "negation": {
+                                        "anyOf": [
+                                            {
+                                                "type": "boolean"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ],
+                                        "description": "Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators"
+                                    },
+                                    "operator": {
+                                        "anyOf": [
+                                            {
+                                                "enum": [
+                                                    "exact",
+                                                    "is_not",
+                                                    "icontains",
+                                                    "not_icontains",
+                                                    "starts_with",
+                                                    "not_starts_with",
+                                                    "ends_with",
+                                                    "not_ends_with",
+                                                    "regex",
+                                                    "not_regex",
+                                                    "gt",
+                                                    "gte",
+                                                    "lt",
+                                                    "lte",
+                                                    "is_set",
+                                                    "is_not_set",
+                                                    "is_date_exact",
+                                                    "is_date_before",
+                                                    "is_date_after",
+                                                    "between",
+                                                    "not_between",
+                                                    "min",
+                                                    "max",
+                                                    "in",
+                                                    "not_in",
+                                                    "is_cleaned_path_exact",
+                                                    "flag_evaluates_to",
+                                                    "semver_eq",
+                                                    "semver_neq",
+                                                    "semver_gt",
+                                                    "semver_gte",
+                                                    "semver_lt",
+                                                    "semver_lte",
+                                                    "semver_tilde",
+                                                    "semver_caret",
+                                                    "semver_wildcard",
+                                                    "icontains_multi",
+                                                    "not_icontains_multi"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ],
+                                        "description": "Count comparison for performed_event_multiple, defaults to exact"
+                                    },
+                                    "operator_value": {
+                                        "anyOf": [
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ],
+                                        "description": "Count threshold for performed_event_multiple"
+                                    },
+                                    "time_interval": {
+                                        "anyOf": [
+                                            {
+                                                "enum": ["day", "week", "month", "year"],
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    },
+                                    "time_value": {
+                                        "anyOf": [
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ],
+                                        "description": "Relative time window size, paired with time_interval"
+                                    },
+                                    "type": {
+                                        "const": "behavioral",
+                                        "default": "behavioral",
+                                        "description": "Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP",
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "enum": ["performed_event", "performed_event_multiple"],
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["event_type", "key", "value"],
+                                "type": "object"
                             }
                         ]
                     },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-create.json
@@ -2201,6 +2201,640 @@
                                                         },
                                                         "required": ["key", "operator"],
                                                         "type": "object"
+                                                    },
+                                                    {
+                                                        "properties": {
+                                                            "event_filters": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "items": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "properties": {
+                                                                                        "key": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "label": {
+                                                                                            "anyOf": [
+                                                                                                {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "null"
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        "operator": {
+                                                                                            "anyOf": [
+                                                                                                {
+                                                                                                    "enum": [
+                                                                                                        "exact",
+                                                                                                        "is_not",
+                                                                                                        "icontains",
+                                                                                                        "not_icontains",
+                                                                                                        "starts_with",
+                                                                                                        "not_starts_with",
+                                                                                                        "ends_with",
+                                                                                                        "not_ends_with",
+                                                                                                        "regex",
+                                                                                                        "not_regex",
+                                                                                                        "gt",
+                                                                                                        "gte",
+                                                                                                        "lt",
+                                                                                                        "lte",
+                                                                                                        "is_set",
+                                                                                                        "is_not_set",
+                                                                                                        "is_date_exact",
+                                                                                                        "is_date_before",
+                                                                                                        "is_date_after",
+                                                                                                        "between",
+                                                                                                        "not_between",
+                                                                                                        "min",
+                                                                                                        "max",
+                                                                                                        "in",
+                                                                                                        "not_in",
+                                                                                                        "is_cleaned_path_exact",
+                                                                                                        "flag_evaluates_to",
+                                                                                                        "semver_eq",
+                                                                                                        "semver_neq",
+                                                                                                        "semver_gt",
+                                                                                                        "semver_gte",
+                                                                                                        "semver_lt",
+                                                                                                        "semver_lte",
+                                                                                                        "semver_tilde",
+                                                                                                        "semver_caret",
+                                                                                                        "semver_wildcard",
+                                                                                                        "icontains_multi",
+                                                                                                        "not_icontains_multi"
+                                                                                                    ],
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "null"
+                                                                                                }
+                                                                                            ],
+                                                                                            "default": "exact"
+                                                                                        },
+                                                                                        "type": {
+                                                                                            "const": "event",
+                                                                                            "default": "event",
+                                                                                            "description": "Event properties",
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "value": {
+                                                                                            "anyOf": [
+                                                                                                {
+                                                                                                    "items": {
+                                                                                                        "anyOf": [
+                                                                                                            {
+                                                                                                                "type": "string"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "number"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "boolean"
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    "type": "array"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "number"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "boolean"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "null"
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "required": ["key"],
+                                                                                    "type": "object"
+                                                                                },
+                                                                                {
+                                                                                    "properties": {
+                                                                                        "key": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "label": {
+                                                                                            "anyOf": [
+                                                                                                {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "null"
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        "operator": {
+                                                                                            "enum": [
+                                                                                                "exact",
+                                                                                                "is_not",
+                                                                                                "icontains",
+                                                                                                "not_icontains",
+                                                                                                "starts_with",
+                                                                                                "not_starts_with",
+                                                                                                "ends_with",
+                                                                                                "not_ends_with",
+                                                                                                "regex",
+                                                                                                "not_regex",
+                                                                                                "gt",
+                                                                                                "gte",
+                                                                                                "lt",
+                                                                                                "lte",
+                                                                                                "is_set",
+                                                                                                "is_not_set",
+                                                                                                "is_date_exact",
+                                                                                                "is_date_before",
+                                                                                                "is_date_after",
+                                                                                                "between",
+                                                                                                "not_between",
+                                                                                                "min",
+                                                                                                "max",
+                                                                                                "in",
+                                                                                                "not_in",
+                                                                                                "is_cleaned_path_exact",
+                                                                                                "flag_evaluates_to",
+                                                                                                "semver_eq",
+                                                                                                "semver_neq",
+                                                                                                "semver_gt",
+                                                                                                "semver_gte",
+                                                                                                "semver_lt",
+                                                                                                "semver_lte",
+                                                                                                "semver_tilde",
+                                                                                                "semver_caret",
+                                                                                                "semver_wildcard",
+                                                                                                "icontains_multi",
+                                                                                                "not_icontains_multi"
+                                                                                            ],
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "type": {
+                                                                                            "const": "person",
+                                                                                            "default": "person",
+                                                                                            "description": "Person properties",
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "value": {
+                                                                                            "anyOf": [
+                                                                                                {
+                                                                                                    "items": {
+                                                                                                        "anyOf": [
+                                                                                                            {
+                                                                                                                "type": "string"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "number"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "boolean"
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    "type": "array"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "number"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "boolean"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "null"
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "required": ["key", "operator"],
+                                                                                    "type": "object"
+                                                                                },
+                                                                                {
+                                                                                    "properties": {
+                                                                                        "key": {
+                                                                                            "enum": [
+                                                                                                "tag_name",
+                                                                                                "text",
+                                                                                                "href",
+                                                                                                "selector"
+                                                                                            ],
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "label": {
+                                                                                            "anyOf": [
+                                                                                                {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "null"
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        "operator": {
+                                                                                            "enum": [
+                                                                                                "exact",
+                                                                                                "is_not",
+                                                                                                "icontains",
+                                                                                                "not_icontains",
+                                                                                                "starts_with",
+                                                                                                "not_starts_with",
+                                                                                                "ends_with",
+                                                                                                "not_ends_with",
+                                                                                                "regex",
+                                                                                                "not_regex",
+                                                                                                "gt",
+                                                                                                "gte",
+                                                                                                "lt",
+                                                                                                "lte",
+                                                                                                "is_set",
+                                                                                                "is_not_set",
+                                                                                                "is_date_exact",
+                                                                                                "is_date_before",
+                                                                                                "is_date_after",
+                                                                                                "between",
+                                                                                                "not_between",
+                                                                                                "min",
+                                                                                                "max",
+                                                                                                "in",
+                                                                                                "not_in",
+                                                                                                "is_cleaned_path_exact",
+                                                                                                "flag_evaluates_to",
+                                                                                                "semver_eq",
+                                                                                                "semver_neq",
+                                                                                                "semver_gt",
+                                                                                                "semver_gte",
+                                                                                                "semver_lt",
+                                                                                                "semver_lte",
+                                                                                                "semver_tilde",
+                                                                                                "semver_caret",
+                                                                                                "semver_wildcard",
+                                                                                                "icontains_multi",
+                                                                                                "not_icontains_multi"
+                                                                                            ],
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "type": {
+                                                                                            "const": "element",
+                                                                                            "default": "element",
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "value": {
+                                                                                            "anyOf": [
+                                                                                                {
+                                                                                                    "items": {
+                                                                                                        "anyOf": [
+                                                                                                            {
+                                                                                                                "type": "string"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "number"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "boolean"
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    "type": "array"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "number"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "boolean"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "null"
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "required": ["key", "operator"],
+                                                                                    "type": "object"
+                                                                                },
+                                                                                {
+                                                                                    "properties": {
+                                                                                        "key": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "label": {
+                                                                                            "anyOf": [
+                                                                                                {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "null"
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        "operator": {
+                                                                                            "enum": [
+                                                                                                "exact",
+                                                                                                "is_not",
+                                                                                                "icontains",
+                                                                                                "not_icontains",
+                                                                                                "starts_with",
+                                                                                                "not_starts_with",
+                                                                                                "ends_with",
+                                                                                                "not_ends_with",
+                                                                                                "regex",
+                                                                                                "not_regex",
+                                                                                                "gt",
+                                                                                                "gte",
+                                                                                                "lt",
+                                                                                                "lte",
+                                                                                                "is_set",
+                                                                                                "is_not_set",
+                                                                                                "is_date_exact",
+                                                                                                "is_date_before",
+                                                                                                "is_date_after",
+                                                                                                "between",
+                                                                                                "not_between",
+                                                                                                "min",
+                                                                                                "max",
+                                                                                                "in",
+                                                                                                "not_in",
+                                                                                                "is_cleaned_path_exact",
+                                                                                                "flag_evaluates_to",
+                                                                                                "semver_eq",
+                                                                                                "semver_neq",
+                                                                                                "semver_gt",
+                                                                                                "semver_gte",
+                                                                                                "semver_lt",
+                                                                                                "semver_lte",
+                                                                                                "semver_tilde",
+                                                                                                "semver_caret",
+                                                                                                "semver_wildcard",
+                                                                                                "icontains_multi",
+                                                                                                "not_icontains_multi"
+                                                                                            ],
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "type": {
+                                                                                            "const": "feature",
+                                                                                            "default": "feature",
+                                                                                            "description": "Event property with \"$feature/\" prepended",
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "value": {
+                                                                                            "anyOf": [
+                                                                                                {
+                                                                                                    "items": {
+                                                                                                        "anyOf": [
+                                                                                                            {
+                                                                                                                "type": "string"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "number"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "boolean"
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    "type": "array"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "number"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "boolean"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "null"
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "required": ["key", "operator"],
+                                                                                    "type": "object"
+                                                                                },
+                                                                                {
+                                                                                    "properties": {
+                                                                                        "key": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "label": {
+                                                                                            "anyOf": [
+                                                                                                {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "null"
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        "type": {
+                                                                                            "const": "hogql",
+                                                                                            "default": "hogql",
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "value": {
+                                                                                            "anyOf": [
+                                                                                                {
+                                                                                                    "items": {
+                                                                                                        "anyOf": [
+                                                                                                            {
+                                                                                                                "type": "string"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "number"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "boolean"
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    "type": "array"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "number"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "boolean"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "null"
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "required": ["key"],
+                                                                                    "type": "object"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "type": "array"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral/cohort filters and groups"
+                                                            },
+                                                            "event_type": {
+                                                                "enum": ["events", "actions"],
+                                                                "type": "string"
+                                                            },
+                                                            "explicit_datetime": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Absolute or relative (e.g. -30d) lower date bound — alternative to time_value/time_interval"
+                                                            },
+                                                            "explicit_datetime_to": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "key": {
+                                                                "description": "Event name, or action id when event_type is 'actions'",
+                                                                "type": "string"
+                                                            },
+                                                            "label": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "negation": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators"
+                                                            },
+                                                            "operator": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "enum": [
+                                                                            "exact",
+                                                                            "is_not",
+                                                                            "icontains",
+                                                                            "not_icontains",
+                                                                            "starts_with",
+                                                                            "not_starts_with",
+                                                                            "ends_with",
+                                                                            "not_ends_with",
+                                                                            "regex",
+                                                                            "not_regex",
+                                                                            "gt",
+                                                                            "gte",
+                                                                            "lt",
+                                                                            "lte",
+                                                                            "is_set",
+                                                                            "is_not_set",
+                                                                            "is_date_exact",
+                                                                            "is_date_before",
+                                                                            "is_date_after",
+                                                                            "between",
+                                                                            "not_between",
+                                                                            "min",
+                                                                            "max",
+                                                                            "in",
+                                                                            "not_in",
+                                                                            "is_cleaned_path_exact",
+                                                                            "flag_evaluates_to",
+                                                                            "semver_eq",
+                                                                            "semver_neq",
+                                                                            "semver_gt",
+                                                                            "semver_gte",
+                                                                            "semver_lt",
+                                                                            "semver_lte",
+                                                                            "semver_tilde",
+                                                                            "semver_caret",
+                                                                            "semver_wildcard",
+                                                                            "icontains_multi",
+                                                                            "not_icontains_multi"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Count comparison for performed_event_multiple, defaults to exact"
+                                                            },
+                                                            "operator_value": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Count threshold for performed_event_multiple"
+                                                            },
+                                                            "time_interval": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "enum": ["day", "week", "month", "year"],
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "time_value": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Relative time window size, paired with time_interval"
+                                                            },
+                                                            "type": {
+                                                                "const": "behavioral",
+                                                                "default": "behavioral",
+                                                                "description": "Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP",
+                                                                "type": "string"
+                                                            },
+                                                            "value": {
+                                                                "enum": ["performed_event", "performed_event_multiple"],
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": ["event_type", "key", "value"],
+                                                        "type": "object"
                                                     }
                                                 ]
                                             },
@@ -4394,6 +5028,640 @@
                                                             }
                                                         },
                                                         "required": ["key", "operator"],
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "properties": {
+                                                            "event_filters": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "items": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "properties": {
+                                                                                        "key": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "label": {
+                                                                                            "anyOf": [
+                                                                                                {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "null"
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        "operator": {
+                                                                                            "anyOf": [
+                                                                                                {
+                                                                                                    "enum": [
+                                                                                                        "exact",
+                                                                                                        "is_not",
+                                                                                                        "icontains",
+                                                                                                        "not_icontains",
+                                                                                                        "starts_with",
+                                                                                                        "not_starts_with",
+                                                                                                        "ends_with",
+                                                                                                        "not_ends_with",
+                                                                                                        "regex",
+                                                                                                        "not_regex",
+                                                                                                        "gt",
+                                                                                                        "gte",
+                                                                                                        "lt",
+                                                                                                        "lte",
+                                                                                                        "is_set",
+                                                                                                        "is_not_set",
+                                                                                                        "is_date_exact",
+                                                                                                        "is_date_before",
+                                                                                                        "is_date_after",
+                                                                                                        "between",
+                                                                                                        "not_between",
+                                                                                                        "min",
+                                                                                                        "max",
+                                                                                                        "in",
+                                                                                                        "not_in",
+                                                                                                        "is_cleaned_path_exact",
+                                                                                                        "flag_evaluates_to",
+                                                                                                        "semver_eq",
+                                                                                                        "semver_neq",
+                                                                                                        "semver_gt",
+                                                                                                        "semver_gte",
+                                                                                                        "semver_lt",
+                                                                                                        "semver_lte",
+                                                                                                        "semver_tilde",
+                                                                                                        "semver_caret",
+                                                                                                        "semver_wildcard",
+                                                                                                        "icontains_multi",
+                                                                                                        "not_icontains_multi"
+                                                                                                    ],
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "null"
+                                                                                                }
+                                                                                            ],
+                                                                                            "default": "exact"
+                                                                                        },
+                                                                                        "type": {
+                                                                                            "const": "event",
+                                                                                            "default": "event",
+                                                                                            "description": "Event properties",
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "value": {
+                                                                                            "anyOf": [
+                                                                                                {
+                                                                                                    "items": {
+                                                                                                        "anyOf": [
+                                                                                                            {
+                                                                                                                "type": "string"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "number"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "boolean"
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    "type": "array"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "number"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "boolean"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "null"
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "required": ["key"],
+                                                                                    "type": "object"
+                                                                                },
+                                                                                {
+                                                                                    "properties": {
+                                                                                        "key": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "label": {
+                                                                                            "anyOf": [
+                                                                                                {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "null"
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        "operator": {
+                                                                                            "enum": [
+                                                                                                "exact",
+                                                                                                "is_not",
+                                                                                                "icontains",
+                                                                                                "not_icontains",
+                                                                                                "starts_with",
+                                                                                                "not_starts_with",
+                                                                                                "ends_with",
+                                                                                                "not_ends_with",
+                                                                                                "regex",
+                                                                                                "not_regex",
+                                                                                                "gt",
+                                                                                                "gte",
+                                                                                                "lt",
+                                                                                                "lte",
+                                                                                                "is_set",
+                                                                                                "is_not_set",
+                                                                                                "is_date_exact",
+                                                                                                "is_date_before",
+                                                                                                "is_date_after",
+                                                                                                "between",
+                                                                                                "not_between",
+                                                                                                "min",
+                                                                                                "max",
+                                                                                                "in",
+                                                                                                "not_in",
+                                                                                                "is_cleaned_path_exact",
+                                                                                                "flag_evaluates_to",
+                                                                                                "semver_eq",
+                                                                                                "semver_neq",
+                                                                                                "semver_gt",
+                                                                                                "semver_gte",
+                                                                                                "semver_lt",
+                                                                                                "semver_lte",
+                                                                                                "semver_tilde",
+                                                                                                "semver_caret",
+                                                                                                "semver_wildcard",
+                                                                                                "icontains_multi",
+                                                                                                "not_icontains_multi"
+                                                                                            ],
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "type": {
+                                                                                            "const": "person",
+                                                                                            "default": "person",
+                                                                                            "description": "Person properties",
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "value": {
+                                                                                            "anyOf": [
+                                                                                                {
+                                                                                                    "items": {
+                                                                                                        "anyOf": [
+                                                                                                            {
+                                                                                                                "type": "string"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "number"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "boolean"
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    "type": "array"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "number"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "boolean"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "null"
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "required": ["key", "operator"],
+                                                                                    "type": "object"
+                                                                                },
+                                                                                {
+                                                                                    "properties": {
+                                                                                        "key": {
+                                                                                            "enum": [
+                                                                                                "tag_name",
+                                                                                                "text",
+                                                                                                "href",
+                                                                                                "selector"
+                                                                                            ],
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "label": {
+                                                                                            "anyOf": [
+                                                                                                {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "null"
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        "operator": {
+                                                                                            "enum": [
+                                                                                                "exact",
+                                                                                                "is_not",
+                                                                                                "icontains",
+                                                                                                "not_icontains",
+                                                                                                "starts_with",
+                                                                                                "not_starts_with",
+                                                                                                "ends_with",
+                                                                                                "not_ends_with",
+                                                                                                "regex",
+                                                                                                "not_regex",
+                                                                                                "gt",
+                                                                                                "gte",
+                                                                                                "lt",
+                                                                                                "lte",
+                                                                                                "is_set",
+                                                                                                "is_not_set",
+                                                                                                "is_date_exact",
+                                                                                                "is_date_before",
+                                                                                                "is_date_after",
+                                                                                                "between",
+                                                                                                "not_between",
+                                                                                                "min",
+                                                                                                "max",
+                                                                                                "in",
+                                                                                                "not_in",
+                                                                                                "is_cleaned_path_exact",
+                                                                                                "flag_evaluates_to",
+                                                                                                "semver_eq",
+                                                                                                "semver_neq",
+                                                                                                "semver_gt",
+                                                                                                "semver_gte",
+                                                                                                "semver_lt",
+                                                                                                "semver_lte",
+                                                                                                "semver_tilde",
+                                                                                                "semver_caret",
+                                                                                                "semver_wildcard",
+                                                                                                "icontains_multi",
+                                                                                                "not_icontains_multi"
+                                                                                            ],
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "type": {
+                                                                                            "const": "element",
+                                                                                            "default": "element",
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "value": {
+                                                                                            "anyOf": [
+                                                                                                {
+                                                                                                    "items": {
+                                                                                                        "anyOf": [
+                                                                                                            {
+                                                                                                                "type": "string"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "number"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "boolean"
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    "type": "array"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "number"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "boolean"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "null"
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "required": ["key", "operator"],
+                                                                                    "type": "object"
+                                                                                },
+                                                                                {
+                                                                                    "properties": {
+                                                                                        "key": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "label": {
+                                                                                            "anyOf": [
+                                                                                                {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "null"
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        "operator": {
+                                                                                            "enum": [
+                                                                                                "exact",
+                                                                                                "is_not",
+                                                                                                "icontains",
+                                                                                                "not_icontains",
+                                                                                                "starts_with",
+                                                                                                "not_starts_with",
+                                                                                                "ends_with",
+                                                                                                "not_ends_with",
+                                                                                                "regex",
+                                                                                                "not_regex",
+                                                                                                "gt",
+                                                                                                "gte",
+                                                                                                "lt",
+                                                                                                "lte",
+                                                                                                "is_set",
+                                                                                                "is_not_set",
+                                                                                                "is_date_exact",
+                                                                                                "is_date_before",
+                                                                                                "is_date_after",
+                                                                                                "between",
+                                                                                                "not_between",
+                                                                                                "min",
+                                                                                                "max",
+                                                                                                "in",
+                                                                                                "not_in",
+                                                                                                "is_cleaned_path_exact",
+                                                                                                "flag_evaluates_to",
+                                                                                                "semver_eq",
+                                                                                                "semver_neq",
+                                                                                                "semver_gt",
+                                                                                                "semver_gte",
+                                                                                                "semver_lt",
+                                                                                                "semver_lte",
+                                                                                                "semver_tilde",
+                                                                                                "semver_caret",
+                                                                                                "semver_wildcard",
+                                                                                                "icontains_multi",
+                                                                                                "not_icontains_multi"
+                                                                                            ],
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "type": {
+                                                                                            "const": "feature",
+                                                                                            "default": "feature",
+                                                                                            "description": "Event property with \"$feature/\" prepended",
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "value": {
+                                                                                            "anyOf": [
+                                                                                                {
+                                                                                                    "items": {
+                                                                                                        "anyOf": [
+                                                                                                            {
+                                                                                                                "type": "string"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "number"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "boolean"
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    "type": "array"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "number"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "boolean"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "null"
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "required": ["key", "operator"],
+                                                                                    "type": "object"
+                                                                                },
+                                                                                {
+                                                                                    "properties": {
+                                                                                        "key": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "label": {
+                                                                                            "anyOf": [
+                                                                                                {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "null"
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        "type": {
+                                                                                            "const": "hogql",
+                                                                                            "default": "hogql",
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "value": {
+                                                                                            "anyOf": [
+                                                                                                {
+                                                                                                    "items": {
+                                                                                                        "anyOf": [
+                                                                                                            {
+                                                                                                                "type": "string"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "number"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "boolean"
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    "type": "array"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "number"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "boolean"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "null"
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "required": ["key"],
+                                                                                    "type": "object"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "type": "array"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral/cohort filters and groups"
+                                                            },
+                                                            "event_type": {
+                                                                "enum": ["events", "actions"],
+                                                                "type": "string"
+                                                            },
+                                                            "explicit_datetime": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Absolute or relative (e.g. -30d) lower date bound — alternative to time_value/time_interval"
+                                                            },
+                                                            "explicit_datetime_to": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "key": {
+                                                                "description": "Event name, or action id when event_type is 'actions'",
+                                                                "type": "string"
+                                                            },
+                                                            "label": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "negation": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators"
+                                                            },
+                                                            "operator": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "enum": [
+                                                                            "exact",
+                                                                            "is_not",
+                                                                            "icontains",
+                                                                            "not_icontains",
+                                                                            "starts_with",
+                                                                            "not_starts_with",
+                                                                            "ends_with",
+                                                                            "not_ends_with",
+                                                                            "regex",
+                                                                            "not_regex",
+                                                                            "gt",
+                                                                            "gte",
+                                                                            "lt",
+                                                                            "lte",
+                                                                            "is_set",
+                                                                            "is_not_set",
+                                                                            "is_date_exact",
+                                                                            "is_date_before",
+                                                                            "is_date_after",
+                                                                            "between",
+                                                                            "not_between",
+                                                                            "min",
+                                                                            "max",
+                                                                            "in",
+                                                                            "not_in",
+                                                                            "is_cleaned_path_exact",
+                                                                            "flag_evaluates_to",
+                                                                            "semver_eq",
+                                                                            "semver_neq",
+                                                                            "semver_gt",
+                                                                            "semver_gte",
+                                                                            "semver_lt",
+                                                                            "semver_lte",
+                                                                            "semver_tilde",
+                                                                            "semver_caret",
+                                                                            "semver_wildcard",
+                                                                            "icontains_multi",
+                                                                            "not_icontains_multi"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Count comparison for performed_event_multiple, defaults to exact"
+                                                            },
+                                                            "operator_value": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Count threshold for performed_event_multiple"
+                                                            },
+                                                            "time_interval": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "enum": ["day", "week", "month", "year"],
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "time_value": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Relative time window size, paired with time_interval"
+                                                            },
+                                                            "type": {
+                                                                "const": "behavioral",
+                                                                "default": "behavioral",
+                                                                "description": "Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP",
+                                                                "type": "string"
+                                                            },
+                                                            "value": {
+                                                                "enum": ["performed_event", "performed_event_multiple"],
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": ["event_type", "key", "value"],
                                                         "type": "object"
                                                     }
                                                 ]

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-update.json
@@ -2243,6 +2243,640 @@
                                                         },
                                                         "required": ["key", "operator"],
                                                         "type": "object"
+                                                    },
+                                                    {
+                                                        "properties": {
+                                                            "event_filters": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "items": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "properties": {
+                                                                                        "key": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "label": {
+                                                                                            "anyOf": [
+                                                                                                {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "null"
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        "operator": {
+                                                                                            "anyOf": [
+                                                                                                {
+                                                                                                    "enum": [
+                                                                                                        "exact",
+                                                                                                        "is_not",
+                                                                                                        "icontains",
+                                                                                                        "not_icontains",
+                                                                                                        "starts_with",
+                                                                                                        "not_starts_with",
+                                                                                                        "ends_with",
+                                                                                                        "not_ends_with",
+                                                                                                        "regex",
+                                                                                                        "not_regex",
+                                                                                                        "gt",
+                                                                                                        "gte",
+                                                                                                        "lt",
+                                                                                                        "lte",
+                                                                                                        "is_set",
+                                                                                                        "is_not_set",
+                                                                                                        "is_date_exact",
+                                                                                                        "is_date_before",
+                                                                                                        "is_date_after",
+                                                                                                        "between",
+                                                                                                        "not_between",
+                                                                                                        "min",
+                                                                                                        "max",
+                                                                                                        "in",
+                                                                                                        "not_in",
+                                                                                                        "is_cleaned_path_exact",
+                                                                                                        "flag_evaluates_to",
+                                                                                                        "semver_eq",
+                                                                                                        "semver_neq",
+                                                                                                        "semver_gt",
+                                                                                                        "semver_gte",
+                                                                                                        "semver_lt",
+                                                                                                        "semver_lte",
+                                                                                                        "semver_tilde",
+                                                                                                        "semver_caret",
+                                                                                                        "semver_wildcard",
+                                                                                                        "icontains_multi",
+                                                                                                        "not_icontains_multi"
+                                                                                                    ],
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "null"
+                                                                                                }
+                                                                                            ],
+                                                                                            "default": "exact"
+                                                                                        },
+                                                                                        "type": {
+                                                                                            "const": "event",
+                                                                                            "default": "event",
+                                                                                            "description": "Event properties",
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "value": {
+                                                                                            "anyOf": [
+                                                                                                {
+                                                                                                    "items": {
+                                                                                                        "anyOf": [
+                                                                                                            {
+                                                                                                                "type": "string"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "number"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "boolean"
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    "type": "array"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "number"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "boolean"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "null"
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "required": ["key"],
+                                                                                    "type": "object"
+                                                                                },
+                                                                                {
+                                                                                    "properties": {
+                                                                                        "key": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "label": {
+                                                                                            "anyOf": [
+                                                                                                {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "null"
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        "operator": {
+                                                                                            "enum": [
+                                                                                                "exact",
+                                                                                                "is_not",
+                                                                                                "icontains",
+                                                                                                "not_icontains",
+                                                                                                "starts_with",
+                                                                                                "not_starts_with",
+                                                                                                "ends_with",
+                                                                                                "not_ends_with",
+                                                                                                "regex",
+                                                                                                "not_regex",
+                                                                                                "gt",
+                                                                                                "gte",
+                                                                                                "lt",
+                                                                                                "lte",
+                                                                                                "is_set",
+                                                                                                "is_not_set",
+                                                                                                "is_date_exact",
+                                                                                                "is_date_before",
+                                                                                                "is_date_after",
+                                                                                                "between",
+                                                                                                "not_between",
+                                                                                                "min",
+                                                                                                "max",
+                                                                                                "in",
+                                                                                                "not_in",
+                                                                                                "is_cleaned_path_exact",
+                                                                                                "flag_evaluates_to",
+                                                                                                "semver_eq",
+                                                                                                "semver_neq",
+                                                                                                "semver_gt",
+                                                                                                "semver_gte",
+                                                                                                "semver_lt",
+                                                                                                "semver_lte",
+                                                                                                "semver_tilde",
+                                                                                                "semver_caret",
+                                                                                                "semver_wildcard",
+                                                                                                "icontains_multi",
+                                                                                                "not_icontains_multi"
+                                                                                            ],
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "type": {
+                                                                                            "const": "person",
+                                                                                            "default": "person",
+                                                                                            "description": "Person properties",
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "value": {
+                                                                                            "anyOf": [
+                                                                                                {
+                                                                                                    "items": {
+                                                                                                        "anyOf": [
+                                                                                                            {
+                                                                                                                "type": "string"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "number"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "boolean"
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    "type": "array"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "number"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "boolean"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "null"
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "required": ["key", "operator"],
+                                                                                    "type": "object"
+                                                                                },
+                                                                                {
+                                                                                    "properties": {
+                                                                                        "key": {
+                                                                                            "enum": [
+                                                                                                "tag_name",
+                                                                                                "text",
+                                                                                                "href",
+                                                                                                "selector"
+                                                                                            ],
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "label": {
+                                                                                            "anyOf": [
+                                                                                                {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "null"
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        "operator": {
+                                                                                            "enum": [
+                                                                                                "exact",
+                                                                                                "is_not",
+                                                                                                "icontains",
+                                                                                                "not_icontains",
+                                                                                                "starts_with",
+                                                                                                "not_starts_with",
+                                                                                                "ends_with",
+                                                                                                "not_ends_with",
+                                                                                                "regex",
+                                                                                                "not_regex",
+                                                                                                "gt",
+                                                                                                "gte",
+                                                                                                "lt",
+                                                                                                "lte",
+                                                                                                "is_set",
+                                                                                                "is_not_set",
+                                                                                                "is_date_exact",
+                                                                                                "is_date_before",
+                                                                                                "is_date_after",
+                                                                                                "between",
+                                                                                                "not_between",
+                                                                                                "min",
+                                                                                                "max",
+                                                                                                "in",
+                                                                                                "not_in",
+                                                                                                "is_cleaned_path_exact",
+                                                                                                "flag_evaluates_to",
+                                                                                                "semver_eq",
+                                                                                                "semver_neq",
+                                                                                                "semver_gt",
+                                                                                                "semver_gte",
+                                                                                                "semver_lt",
+                                                                                                "semver_lte",
+                                                                                                "semver_tilde",
+                                                                                                "semver_caret",
+                                                                                                "semver_wildcard",
+                                                                                                "icontains_multi",
+                                                                                                "not_icontains_multi"
+                                                                                            ],
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "type": {
+                                                                                            "const": "element",
+                                                                                            "default": "element",
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "value": {
+                                                                                            "anyOf": [
+                                                                                                {
+                                                                                                    "items": {
+                                                                                                        "anyOf": [
+                                                                                                            {
+                                                                                                                "type": "string"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "number"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "boolean"
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    "type": "array"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "number"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "boolean"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "null"
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "required": ["key", "operator"],
+                                                                                    "type": "object"
+                                                                                },
+                                                                                {
+                                                                                    "properties": {
+                                                                                        "key": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "label": {
+                                                                                            "anyOf": [
+                                                                                                {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "null"
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        "operator": {
+                                                                                            "enum": [
+                                                                                                "exact",
+                                                                                                "is_not",
+                                                                                                "icontains",
+                                                                                                "not_icontains",
+                                                                                                "starts_with",
+                                                                                                "not_starts_with",
+                                                                                                "ends_with",
+                                                                                                "not_ends_with",
+                                                                                                "regex",
+                                                                                                "not_regex",
+                                                                                                "gt",
+                                                                                                "gte",
+                                                                                                "lt",
+                                                                                                "lte",
+                                                                                                "is_set",
+                                                                                                "is_not_set",
+                                                                                                "is_date_exact",
+                                                                                                "is_date_before",
+                                                                                                "is_date_after",
+                                                                                                "between",
+                                                                                                "not_between",
+                                                                                                "min",
+                                                                                                "max",
+                                                                                                "in",
+                                                                                                "not_in",
+                                                                                                "is_cleaned_path_exact",
+                                                                                                "flag_evaluates_to",
+                                                                                                "semver_eq",
+                                                                                                "semver_neq",
+                                                                                                "semver_gt",
+                                                                                                "semver_gte",
+                                                                                                "semver_lt",
+                                                                                                "semver_lte",
+                                                                                                "semver_tilde",
+                                                                                                "semver_caret",
+                                                                                                "semver_wildcard",
+                                                                                                "icontains_multi",
+                                                                                                "not_icontains_multi"
+                                                                                            ],
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "type": {
+                                                                                            "const": "feature",
+                                                                                            "default": "feature",
+                                                                                            "description": "Event property with \"$feature/\" prepended",
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "value": {
+                                                                                            "anyOf": [
+                                                                                                {
+                                                                                                    "items": {
+                                                                                                        "anyOf": [
+                                                                                                            {
+                                                                                                                "type": "string"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "number"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "boolean"
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    "type": "array"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "number"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "boolean"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "null"
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "required": ["key", "operator"],
+                                                                                    "type": "object"
+                                                                                },
+                                                                                {
+                                                                                    "properties": {
+                                                                                        "key": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "label": {
+                                                                                            "anyOf": [
+                                                                                                {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "null"
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        "type": {
+                                                                                            "const": "hogql",
+                                                                                            "default": "hogql",
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "value": {
+                                                                                            "anyOf": [
+                                                                                                {
+                                                                                                    "items": {
+                                                                                                        "anyOf": [
+                                                                                                            {
+                                                                                                                "type": "string"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "number"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "boolean"
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    "type": "array"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "number"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "boolean"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "null"
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "required": ["key"],
+                                                                                    "type": "object"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "type": "array"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral/cohort filters and groups"
+                                                            },
+                                                            "event_type": {
+                                                                "enum": ["events", "actions"],
+                                                                "type": "string"
+                                                            },
+                                                            "explicit_datetime": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Absolute or relative (e.g. -30d) lower date bound — alternative to time_value/time_interval"
+                                                            },
+                                                            "explicit_datetime_to": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "key": {
+                                                                "description": "Event name, or action id when event_type is 'actions'",
+                                                                "type": "string"
+                                                            },
+                                                            "label": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "negation": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators"
+                                                            },
+                                                            "operator": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "enum": [
+                                                                            "exact",
+                                                                            "is_not",
+                                                                            "icontains",
+                                                                            "not_icontains",
+                                                                            "starts_with",
+                                                                            "not_starts_with",
+                                                                            "ends_with",
+                                                                            "not_ends_with",
+                                                                            "regex",
+                                                                            "not_regex",
+                                                                            "gt",
+                                                                            "gte",
+                                                                            "lt",
+                                                                            "lte",
+                                                                            "is_set",
+                                                                            "is_not_set",
+                                                                            "is_date_exact",
+                                                                            "is_date_before",
+                                                                            "is_date_after",
+                                                                            "between",
+                                                                            "not_between",
+                                                                            "min",
+                                                                            "max",
+                                                                            "in",
+                                                                            "not_in",
+                                                                            "is_cleaned_path_exact",
+                                                                            "flag_evaluates_to",
+                                                                            "semver_eq",
+                                                                            "semver_neq",
+                                                                            "semver_gt",
+                                                                            "semver_gte",
+                                                                            "semver_lt",
+                                                                            "semver_lte",
+                                                                            "semver_tilde",
+                                                                            "semver_caret",
+                                                                            "semver_wildcard",
+                                                                            "icontains_multi",
+                                                                            "not_icontains_multi"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Count comparison for performed_event_multiple, defaults to exact"
+                                                            },
+                                                            "operator_value": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Count threshold for performed_event_multiple"
+                                                            },
+                                                            "time_interval": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "enum": ["day", "week", "month", "year"],
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "time_value": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Relative time window size, paired with time_interval"
+                                                            },
+                                                            "type": {
+                                                                "const": "behavioral",
+                                                                "default": "behavioral",
+                                                                "description": "Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP",
+                                                                "type": "string"
+                                                            },
+                                                            "value": {
+                                                                "enum": ["performed_event", "performed_event_multiple"],
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": ["event_type", "key", "value"],
+                                                        "type": "object"
                                                     }
                                                 ]
                                             },
@@ -4436,6 +5070,640 @@
                                                             }
                                                         },
                                                         "required": ["key", "operator"],
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "properties": {
+                                                            "event_filters": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "items": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "properties": {
+                                                                                        "key": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "label": {
+                                                                                            "anyOf": [
+                                                                                                {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "null"
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        "operator": {
+                                                                                            "anyOf": [
+                                                                                                {
+                                                                                                    "enum": [
+                                                                                                        "exact",
+                                                                                                        "is_not",
+                                                                                                        "icontains",
+                                                                                                        "not_icontains",
+                                                                                                        "starts_with",
+                                                                                                        "not_starts_with",
+                                                                                                        "ends_with",
+                                                                                                        "not_ends_with",
+                                                                                                        "regex",
+                                                                                                        "not_regex",
+                                                                                                        "gt",
+                                                                                                        "gte",
+                                                                                                        "lt",
+                                                                                                        "lte",
+                                                                                                        "is_set",
+                                                                                                        "is_not_set",
+                                                                                                        "is_date_exact",
+                                                                                                        "is_date_before",
+                                                                                                        "is_date_after",
+                                                                                                        "between",
+                                                                                                        "not_between",
+                                                                                                        "min",
+                                                                                                        "max",
+                                                                                                        "in",
+                                                                                                        "not_in",
+                                                                                                        "is_cleaned_path_exact",
+                                                                                                        "flag_evaluates_to",
+                                                                                                        "semver_eq",
+                                                                                                        "semver_neq",
+                                                                                                        "semver_gt",
+                                                                                                        "semver_gte",
+                                                                                                        "semver_lt",
+                                                                                                        "semver_lte",
+                                                                                                        "semver_tilde",
+                                                                                                        "semver_caret",
+                                                                                                        "semver_wildcard",
+                                                                                                        "icontains_multi",
+                                                                                                        "not_icontains_multi"
+                                                                                                    ],
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "null"
+                                                                                                }
+                                                                                            ],
+                                                                                            "default": "exact"
+                                                                                        },
+                                                                                        "type": {
+                                                                                            "const": "event",
+                                                                                            "default": "event",
+                                                                                            "description": "Event properties",
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "value": {
+                                                                                            "anyOf": [
+                                                                                                {
+                                                                                                    "items": {
+                                                                                                        "anyOf": [
+                                                                                                            {
+                                                                                                                "type": "string"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "number"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "boolean"
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    "type": "array"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "number"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "boolean"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "null"
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "required": ["key"],
+                                                                                    "type": "object"
+                                                                                },
+                                                                                {
+                                                                                    "properties": {
+                                                                                        "key": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "label": {
+                                                                                            "anyOf": [
+                                                                                                {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "null"
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        "operator": {
+                                                                                            "enum": [
+                                                                                                "exact",
+                                                                                                "is_not",
+                                                                                                "icontains",
+                                                                                                "not_icontains",
+                                                                                                "starts_with",
+                                                                                                "not_starts_with",
+                                                                                                "ends_with",
+                                                                                                "not_ends_with",
+                                                                                                "regex",
+                                                                                                "not_regex",
+                                                                                                "gt",
+                                                                                                "gte",
+                                                                                                "lt",
+                                                                                                "lte",
+                                                                                                "is_set",
+                                                                                                "is_not_set",
+                                                                                                "is_date_exact",
+                                                                                                "is_date_before",
+                                                                                                "is_date_after",
+                                                                                                "between",
+                                                                                                "not_between",
+                                                                                                "min",
+                                                                                                "max",
+                                                                                                "in",
+                                                                                                "not_in",
+                                                                                                "is_cleaned_path_exact",
+                                                                                                "flag_evaluates_to",
+                                                                                                "semver_eq",
+                                                                                                "semver_neq",
+                                                                                                "semver_gt",
+                                                                                                "semver_gte",
+                                                                                                "semver_lt",
+                                                                                                "semver_lte",
+                                                                                                "semver_tilde",
+                                                                                                "semver_caret",
+                                                                                                "semver_wildcard",
+                                                                                                "icontains_multi",
+                                                                                                "not_icontains_multi"
+                                                                                            ],
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "type": {
+                                                                                            "const": "person",
+                                                                                            "default": "person",
+                                                                                            "description": "Person properties",
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "value": {
+                                                                                            "anyOf": [
+                                                                                                {
+                                                                                                    "items": {
+                                                                                                        "anyOf": [
+                                                                                                            {
+                                                                                                                "type": "string"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "number"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "boolean"
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    "type": "array"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "number"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "boolean"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "null"
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "required": ["key", "operator"],
+                                                                                    "type": "object"
+                                                                                },
+                                                                                {
+                                                                                    "properties": {
+                                                                                        "key": {
+                                                                                            "enum": [
+                                                                                                "tag_name",
+                                                                                                "text",
+                                                                                                "href",
+                                                                                                "selector"
+                                                                                            ],
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "label": {
+                                                                                            "anyOf": [
+                                                                                                {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "null"
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        "operator": {
+                                                                                            "enum": [
+                                                                                                "exact",
+                                                                                                "is_not",
+                                                                                                "icontains",
+                                                                                                "not_icontains",
+                                                                                                "starts_with",
+                                                                                                "not_starts_with",
+                                                                                                "ends_with",
+                                                                                                "not_ends_with",
+                                                                                                "regex",
+                                                                                                "not_regex",
+                                                                                                "gt",
+                                                                                                "gte",
+                                                                                                "lt",
+                                                                                                "lte",
+                                                                                                "is_set",
+                                                                                                "is_not_set",
+                                                                                                "is_date_exact",
+                                                                                                "is_date_before",
+                                                                                                "is_date_after",
+                                                                                                "between",
+                                                                                                "not_between",
+                                                                                                "min",
+                                                                                                "max",
+                                                                                                "in",
+                                                                                                "not_in",
+                                                                                                "is_cleaned_path_exact",
+                                                                                                "flag_evaluates_to",
+                                                                                                "semver_eq",
+                                                                                                "semver_neq",
+                                                                                                "semver_gt",
+                                                                                                "semver_gte",
+                                                                                                "semver_lt",
+                                                                                                "semver_lte",
+                                                                                                "semver_tilde",
+                                                                                                "semver_caret",
+                                                                                                "semver_wildcard",
+                                                                                                "icontains_multi",
+                                                                                                "not_icontains_multi"
+                                                                                            ],
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "type": {
+                                                                                            "const": "element",
+                                                                                            "default": "element",
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "value": {
+                                                                                            "anyOf": [
+                                                                                                {
+                                                                                                    "items": {
+                                                                                                        "anyOf": [
+                                                                                                            {
+                                                                                                                "type": "string"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "number"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "boolean"
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    "type": "array"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "number"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "boolean"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "null"
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "required": ["key", "operator"],
+                                                                                    "type": "object"
+                                                                                },
+                                                                                {
+                                                                                    "properties": {
+                                                                                        "key": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "label": {
+                                                                                            "anyOf": [
+                                                                                                {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "null"
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        "operator": {
+                                                                                            "enum": [
+                                                                                                "exact",
+                                                                                                "is_not",
+                                                                                                "icontains",
+                                                                                                "not_icontains",
+                                                                                                "starts_with",
+                                                                                                "not_starts_with",
+                                                                                                "ends_with",
+                                                                                                "not_ends_with",
+                                                                                                "regex",
+                                                                                                "not_regex",
+                                                                                                "gt",
+                                                                                                "gte",
+                                                                                                "lt",
+                                                                                                "lte",
+                                                                                                "is_set",
+                                                                                                "is_not_set",
+                                                                                                "is_date_exact",
+                                                                                                "is_date_before",
+                                                                                                "is_date_after",
+                                                                                                "between",
+                                                                                                "not_between",
+                                                                                                "min",
+                                                                                                "max",
+                                                                                                "in",
+                                                                                                "not_in",
+                                                                                                "is_cleaned_path_exact",
+                                                                                                "flag_evaluates_to",
+                                                                                                "semver_eq",
+                                                                                                "semver_neq",
+                                                                                                "semver_gt",
+                                                                                                "semver_gte",
+                                                                                                "semver_lt",
+                                                                                                "semver_lte",
+                                                                                                "semver_tilde",
+                                                                                                "semver_caret",
+                                                                                                "semver_wildcard",
+                                                                                                "icontains_multi",
+                                                                                                "not_icontains_multi"
+                                                                                            ],
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "type": {
+                                                                                            "const": "feature",
+                                                                                            "default": "feature",
+                                                                                            "description": "Event property with \"$feature/\" prepended",
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "value": {
+                                                                                            "anyOf": [
+                                                                                                {
+                                                                                                    "items": {
+                                                                                                        "anyOf": [
+                                                                                                            {
+                                                                                                                "type": "string"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "number"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "boolean"
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    "type": "array"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "number"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "boolean"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "null"
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "required": ["key", "operator"],
+                                                                                    "type": "object"
+                                                                                },
+                                                                                {
+                                                                                    "properties": {
+                                                                                        "key": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "label": {
+                                                                                            "anyOf": [
+                                                                                                {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "null"
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        "type": {
+                                                                                            "const": "hogql",
+                                                                                            "default": "hogql",
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "value": {
+                                                                                            "anyOf": [
+                                                                                                {
+                                                                                                    "items": {
+                                                                                                        "anyOf": [
+                                                                                                            {
+                                                                                                                "type": "string"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "number"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "boolean"
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    "type": "array"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "number"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "boolean"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "null"
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "required": ["key"],
+                                                                                    "type": "object"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "type": "array"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral/cohort filters and groups"
+                                                            },
+                                                            "event_type": {
+                                                                "enum": ["events", "actions"],
+                                                                "type": "string"
+                                                            },
+                                                            "explicit_datetime": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Absolute or relative (e.g. -30d) lower date bound — alternative to time_value/time_interval"
+                                                            },
+                                                            "explicit_datetime_to": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "key": {
+                                                                "description": "Event name, or action id when event_type is 'actions'",
+                                                                "type": "string"
+                                                            },
+                                                            "label": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "negation": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators"
+                                                            },
+                                                            "operator": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "enum": [
+                                                                            "exact",
+                                                                            "is_not",
+                                                                            "icontains",
+                                                                            "not_icontains",
+                                                                            "starts_with",
+                                                                            "not_starts_with",
+                                                                            "ends_with",
+                                                                            "not_ends_with",
+                                                                            "regex",
+                                                                            "not_regex",
+                                                                            "gt",
+                                                                            "gte",
+                                                                            "lt",
+                                                                            "lte",
+                                                                            "is_set",
+                                                                            "is_not_set",
+                                                                            "is_date_exact",
+                                                                            "is_date_before",
+                                                                            "is_date_after",
+                                                                            "between",
+                                                                            "not_between",
+                                                                            "min",
+                                                                            "max",
+                                                                            "in",
+                                                                            "not_in",
+                                                                            "is_cleaned_path_exact",
+                                                                            "flag_evaluates_to",
+                                                                            "semver_eq",
+                                                                            "semver_neq",
+                                                                            "semver_gt",
+                                                                            "semver_gte",
+                                                                            "semver_lt",
+                                                                            "semver_lte",
+                                                                            "semver_tilde",
+                                                                            "semver_caret",
+                                                                            "semver_wildcard",
+                                                                            "icontains_multi",
+                                                                            "not_icontains_multi"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Count comparison for performed_event_multiple, defaults to exact"
+                                                            },
+                                                            "operator_value": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Count threshold for performed_event_multiple"
+                                                            },
+                                                            "time_interval": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "enum": ["day", "week", "month", "year"],
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "time_value": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Relative time window size, paired with time_interval"
+                                                            },
+                                                            "type": {
+                                                                "const": "behavioral",
+                                                                "default": "behavioral",
+                                                                "description": "Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP",
+                                                                "type": "string"
+                                                            },
+                                                            "value": {
+                                                                "enum": ["performed_event", "performed_event_multiple"],
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": ["event_type", "key", "value"],
                                                         "type": "object"
                                                     }
                                                 ]

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/logs-alerts-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/logs-alerts-create.json
@@ -2185,6 +2185,643 @@
                                                             },
                                                             "required": ["key", "operator"],
                                                             "type": "object"
+                                                        },
+                                                        {
+                                                            "properties": {
+                                                                "event_filters": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "items": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "properties": {
+                                                                                            "key": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "label": {
+                                                                                                "anyOf": [
+                                                                                                    {
+                                                                                                        "type": "string"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "null"
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            "operator": {
+                                                                                                "anyOf": [
+                                                                                                    {
+                                                                                                        "enum": [
+                                                                                                            "exact",
+                                                                                                            "is_not",
+                                                                                                            "icontains",
+                                                                                                            "not_icontains",
+                                                                                                            "starts_with",
+                                                                                                            "not_starts_with",
+                                                                                                            "ends_with",
+                                                                                                            "not_ends_with",
+                                                                                                            "regex",
+                                                                                                            "not_regex",
+                                                                                                            "gt",
+                                                                                                            "gte",
+                                                                                                            "lt",
+                                                                                                            "lte",
+                                                                                                            "is_set",
+                                                                                                            "is_not_set",
+                                                                                                            "is_date_exact",
+                                                                                                            "is_date_before",
+                                                                                                            "is_date_after",
+                                                                                                            "between",
+                                                                                                            "not_between",
+                                                                                                            "min",
+                                                                                                            "max",
+                                                                                                            "in",
+                                                                                                            "not_in",
+                                                                                                            "is_cleaned_path_exact",
+                                                                                                            "flag_evaluates_to",
+                                                                                                            "semver_eq",
+                                                                                                            "semver_neq",
+                                                                                                            "semver_gt",
+                                                                                                            "semver_gte",
+                                                                                                            "semver_lt",
+                                                                                                            "semver_lte",
+                                                                                                            "semver_tilde",
+                                                                                                            "semver_caret",
+                                                                                                            "semver_wildcard",
+                                                                                                            "icontains_multi",
+                                                                                                            "not_icontains_multi"
+                                                                                                        ],
+                                                                                                        "type": "string"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "null"
+                                                                                                    }
+                                                                                                ],
+                                                                                                "default": "exact"
+                                                                                            },
+                                                                                            "type": {
+                                                                                                "const": "event",
+                                                                                                "default": "event",
+                                                                                                "description": "Event properties",
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "value": {
+                                                                                                "anyOf": [
+                                                                                                    {
+                                                                                                        "items": {
+                                                                                                            "anyOf": [
+                                                                                                                {
+                                                                                                                    "type": "string"
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    "type": "number"
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    "type": "boolean"
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        "type": "array"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "string"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "number"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "boolean"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "null"
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        },
+                                                                                        "required": ["key"],
+                                                                                        "type": "object"
+                                                                                    },
+                                                                                    {
+                                                                                        "properties": {
+                                                                                            "key": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "label": {
+                                                                                                "anyOf": [
+                                                                                                    {
+                                                                                                        "type": "string"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "null"
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            "operator": {
+                                                                                                "enum": [
+                                                                                                    "exact",
+                                                                                                    "is_not",
+                                                                                                    "icontains",
+                                                                                                    "not_icontains",
+                                                                                                    "starts_with",
+                                                                                                    "not_starts_with",
+                                                                                                    "ends_with",
+                                                                                                    "not_ends_with",
+                                                                                                    "regex",
+                                                                                                    "not_regex",
+                                                                                                    "gt",
+                                                                                                    "gte",
+                                                                                                    "lt",
+                                                                                                    "lte",
+                                                                                                    "is_set",
+                                                                                                    "is_not_set",
+                                                                                                    "is_date_exact",
+                                                                                                    "is_date_before",
+                                                                                                    "is_date_after",
+                                                                                                    "between",
+                                                                                                    "not_between",
+                                                                                                    "min",
+                                                                                                    "max",
+                                                                                                    "in",
+                                                                                                    "not_in",
+                                                                                                    "is_cleaned_path_exact",
+                                                                                                    "flag_evaluates_to",
+                                                                                                    "semver_eq",
+                                                                                                    "semver_neq",
+                                                                                                    "semver_gt",
+                                                                                                    "semver_gte",
+                                                                                                    "semver_lt",
+                                                                                                    "semver_lte",
+                                                                                                    "semver_tilde",
+                                                                                                    "semver_caret",
+                                                                                                    "semver_wildcard",
+                                                                                                    "icontains_multi",
+                                                                                                    "not_icontains_multi"
+                                                                                                ],
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "type": {
+                                                                                                "const": "person",
+                                                                                                "default": "person",
+                                                                                                "description": "Person properties",
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "value": {
+                                                                                                "anyOf": [
+                                                                                                    {
+                                                                                                        "items": {
+                                                                                                            "anyOf": [
+                                                                                                                {
+                                                                                                                    "type": "string"
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    "type": "number"
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    "type": "boolean"
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        "type": "array"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "string"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "number"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "boolean"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "null"
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        },
+                                                                                        "required": ["key", "operator"],
+                                                                                        "type": "object"
+                                                                                    },
+                                                                                    {
+                                                                                        "properties": {
+                                                                                            "key": {
+                                                                                                "enum": [
+                                                                                                    "tag_name",
+                                                                                                    "text",
+                                                                                                    "href",
+                                                                                                    "selector"
+                                                                                                ],
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "label": {
+                                                                                                "anyOf": [
+                                                                                                    {
+                                                                                                        "type": "string"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "null"
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            "operator": {
+                                                                                                "enum": [
+                                                                                                    "exact",
+                                                                                                    "is_not",
+                                                                                                    "icontains",
+                                                                                                    "not_icontains",
+                                                                                                    "starts_with",
+                                                                                                    "not_starts_with",
+                                                                                                    "ends_with",
+                                                                                                    "not_ends_with",
+                                                                                                    "regex",
+                                                                                                    "not_regex",
+                                                                                                    "gt",
+                                                                                                    "gte",
+                                                                                                    "lt",
+                                                                                                    "lte",
+                                                                                                    "is_set",
+                                                                                                    "is_not_set",
+                                                                                                    "is_date_exact",
+                                                                                                    "is_date_before",
+                                                                                                    "is_date_after",
+                                                                                                    "between",
+                                                                                                    "not_between",
+                                                                                                    "min",
+                                                                                                    "max",
+                                                                                                    "in",
+                                                                                                    "not_in",
+                                                                                                    "is_cleaned_path_exact",
+                                                                                                    "flag_evaluates_to",
+                                                                                                    "semver_eq",
+                                                                                                    "semver_neq",
+                                                                                                    "semver_gt",
+                                                                                                    "semver_gte",
+                                                                                                    "semver_lt",
+                                                                                                    "semver_lte",
+                                                                                                    "semver_tilde",
+                                                                                                    "semver_caret",
+                                                                                                    "semver_wildcard",
+                                                                                                    "icontains_multi",
+                                                                                                    "not_icontains_multi"
+                                                                                                ],
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "type": {
+                                                                                                "const": "element",
+                                                                                                "default": "element",
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "value": {
+                                                                                                "anyOf": [
+                                                                                                    {
+                                                                                                        "items": {
+                                                                                                            "anyOf": [
+                                                                                                                {
+                                                                                                                    "type": "string"
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    "type": "number"
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    "type": "boolean"
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        "type": "array"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "string"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "number"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "boolean"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "null"
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        },
+                                                                                        "required": ["key", "operator"],
+                                                                                        "type": "object"
+                                                                                    },
+                                                                                    {
+                                                                                        "properties": {
+                                                                                            "key": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "label": {
+                                                                                                "anyOf": [
+                                                                                                    {
+                                                                                                        "type": "string"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "null"
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            "operator": {
+                                                                                                "enum": [
+                                                                                                    "exact",
+                                                                                                    "is_not",
+                                                                                                    "icontains",
+                                                                                                    "not_icontains",
+                                                                                                    "starts_with",
+                                                                                                    "not_starts_with",
+                                                                                                    "ends_with",
+                                                                                                    "not_ends_with",
+                                                                                                    "regex",
+                                                                                                    "not_regex",
+                                                                                                    "gt",
+                                                                                                    "gte",
+                                                                                                    "lt",
+                                                                                                    "lte",
+                                                                                                    "is_set",
+                                                                                                    "is_not_set",
+                                                                                                    "is_date_exact",
+                                                                                                    "is_date_before",
+                                                                                                    "is_date_after",
+                                                                                                    "between",
+                                                                                                    "not_between",
+                                                                                                    "min",
+                                                                                                    "max",
+                                                                                                    "in",
+                                                                                                    "not_in",
+                                                                                                    "is_cleaned_path_exact",
+                                                                                                    "flag_evaluates_to",
+                                                                                                    "semver_eq",
+                                                                                                    "semver_neq",
+                                                                                                    "semver_gt",
+                                                                                                    "semver_gte",
+                                                                                                    "semver_lt",
+                                                                                                    "semver_lte",
+                                                                                                    "semver_tilde",
+                                                                                                    "semver_caret",
+                                                                                                    "semver_wildcard",
+                                                                                                    "icontains_multi",
+                                                                                                    "not_icontains_multi"
+                                                                                                ],
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "type": {
+                                                                                                "const": "feature",
+                                                                                                "default": "feature",
+                                                                                                "description": "Event property with \"$feature/\" prepended",
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "value": {
+                                                                                                "anyOf": [
+                                                                                                    {
+                                                                                                        "items": {
+                                                                                                            "anyOf": [
+                                                                                                                {
+                                                                                                                    "type": "string"
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    "type": "number"
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    "type": "boolean"
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        "type": "array"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "string"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "number"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "boolean"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "null"
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        },
+                                                                                        "required": ["key", "operator"],
+                                                                                        "type": "object"
+                                                                                    },
+                                                                                    {
+                                                                                        "properties": {
+                                                                                            "key": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "label": {
+                                                                                                "anyOf": [
+                                                                                                    {
+                                                                                                        "type": "string"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "null"
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            "type": {
+                                                                                                "const": "hogql",
+                                                                                                "default": "hogql",
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "value": {
+                                                                                                "anyOf": [
+                                                                                                    {
+                                                                                                        "items": {
+                                                                                                            "anyOf": [
+                                                                                                                {
+                                                                                                                    "type": "string"
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    "type": "number"
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    "type": "boolean"
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        "type": "array"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "string"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "number"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "boolean"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "null"
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        },
+                                                                                        "required": ["key"],
+                                                                                        "type": "object"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "type": "array"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ],
+                                                                    "description": "Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral/cohort filters and groups"
+                                                                },
+                                                                "event_type": {
+                                                                    "enum": ["events", "actions"],
+                                                                    "type": "string"
+                                                                },
+                                                                "explicit_datetime": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ],
+                                                                    "description": "Absolute or relative (e.g. -30d) lower date bound — alternative to time_value/time_interval"
+                                                                },
+                                                                "explicit_datetime_to": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "key": {
+                                                                    "description": "Event name, or action id when event_type is 'actions'",
+                                                                    "type": "string"
+                                                                },
+                                                                "label": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "negation": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ],
+                                                                    "description": "Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators"
+                                                                },
+                                                                "operator": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "exact",
+                                                                                "is_not",
+                                                                                "icontains",
+                                                                                "not_icontains",
+                                                                                "starts_with",
+                                                                                "not_starts_with",
+                                                                                "ends_with",
+                                                                                "not_ends_with",
+                                                                                "regex",
+                                                                                "not_regex",
+                                                                                "gt",
+                                                                                "gte",
+                                                                                "lt",
+                                                                                "lte",
+                                                                                "is_set",
+                                                                                "is_not_set",
+                                                                                "is_date_exact",
+                                                                                "is_date_before",
+                                                                                "is_date_after",
+                                                                                "between",
+                                                                                "not_between",
+                                                                                "min",
+                                                                                "max",
+                                                                                "in",
+                                                                                "not_in",
+                                                                                "is_cleaned_path_exact",
+                                                                                "flag_evaluates_to",
+                                                                                "semver_eq",
+                                                                                "semver_neq",
+                                                                                "semver_gt",
+                                                                                "semver_gte",
+                                                                                "semver_lt",
+                                                                                "semver_lte",
+                                                                                "semver_tilde",
+                                                                                "semver_caret",
+                                                                                "semver_wildcard",
+                                                                                "icontains_multi",
+                                                                                "not_icontains_multi"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ],
+                                                                    "description": "Count comparison for performed_event_multiple, defaults to exact"
+                                                                },
+                                                                "operator_value": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "number"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ],
+                                                                    "description": "Count threshold for performed_event_multiple"
+                                                                },
+                                                                "time_interval": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "enum": ["day", "week", "month", "year"],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "time_value": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "number"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ],
+                                                                    "description": "Relative time window size, paired with time_interval"
+                                                                },
+                                                                "type": {
+                                                                    "const": "behavioral",
+                                                                    "default": "behavioral",
+                                                                    "description": "Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP",
+                                                                    "type": "string"
+                                                                },
+                                                                "value": {
+                                                                    "enum": [
+                                                                        "performed_event",
+                                                                        "performed_event_multiple"
+                                                                    ],
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": ["event_type", "key", "value"],
+                                                            "type": "object"
                                                         }
                                                     ]
                                                 },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/logs-alerts-partial-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/logs-alerts-partial-update.json
@@ -2181,6 +2181,643 @@
                                                             },
                                                             "required": ["key", "operator"],
                                                             "type": "object"
+                                                        },
+                                                        {
+                                                            "properties": {
+                                                                "event_filters": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "items": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "properties": {
+                                                                                            "key": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "label": {
+                                                                                                "anyOf": [
+                                                                                                    {
+                                                                                                        "type": "string"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "null"
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            "operator": {
+                                                                                                "anyOf": [
+                                                                                                    {
+                                                                                                        "enum": [
+                                                                                                            "exact",
+                                                                                                            "is_not",
+                                                                                                            "icontains",
+                                                                                                            "not_icontains",
+                                                                                                            "starts_with",
+                                                                                                            "not_starts_with",
+                                                                                                            "ends_with",
+                                                                                                            "not_ends_with",
+                                                                                                            "regex",
+                                                                                                            "not_regex",
+                                                                                                            "gt",
+                                                                                                            "gte",
+                                                                                                            "lt",
+                                                                                                            "lte",
+                                                                                                            "is_set",
+                                                                                                            "is_not_set",
+                                                                                                            "is_date_exact",
+                                                                                                            "is_date_before",
+                                                                                                            "is_date_after",
+                                                                                                            "between",
+                                                                                                            "not_between",
+                                                                                                            "min",
+                                                                                                            "max",
+                                                                                                            "in",
+                                                                                                            "not_in",
+                                                                                                            "is_cleaned_path_exact",
+                                                                                                            "flag_evaluates_to",
+                                                                                                            "semver_eq",
+                                                                                                            "semver_neq",
+                                                                                                            "semver_gt",
+                                                                                                            "semver_gte",
+                                                                                                            "semver_lt",
+                                                                                                            "semver_lte",
+                                                                                                            "semver_tilde",
+                                                                                                            "semver_caret",
+                                                                                                            "semver_wildcard",
+                                                                                                            "icontains_multi",
+                                                                                                            "not_icontains_multi"
+                                                                                                        ],
+                                                                                                        "type": "string"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "null"
+                                                                                                    }
+                                                                                                ],
+                                                                                                "default": "exact"
+                                                                                            },
+                                                                                            "type": {
+                                                                                                "const": "event",
+                                                                                                "default": "event",
+                                                                                                "description": "Event properties",
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "value": {
+                                                                                                "anyOf": [
+                                                                                                    {
+                                                                                                        "items": {
+                                                                                                            "anyOf": [
+                                                                                                                {
+                                                                                                                    "type": "string"
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    "type": "number"
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    "type": "boolean"
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        "type": "array"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "string"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "number"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "boolean"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "null"
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        },
+                                                                                        "required": ["key"],
+                                                                                        "type": "object"
+                                                                                    },
+                                                                                    {
+                                                                                        "properties": {
+                                                                                            "key": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "label": {
+                                                                                                "anyOf": [
+                                                                                                    {
+                                                                                                        "type": "string"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "null"
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            "operator": {
+                                                                                                "enum": [
+                                                                                                    "exact",
+                                                                                                    "is_not",
+                                                                                                    "icontains",
+                                                                                                    "not_icontains",
+                                                                                                    "starts_with",
+                                                                                                    "not_starts_with",
+                                                                                                    "ends_with",
+                                                                                                    "not_ends_with",
+                                                                                                    "regex",
+                                                                                                    "not_regex",
+                                                                                                    "gt",
+                                                                                                    "gte",
+                                                                                                    "lt",
+                                                                                                    "lte",
+                                                                                                    "is_set",
+                                                                                                    "is_not_set",
+                                                                                                    "is_date_exact",
+                                                                                                    "is_date_before",
+                                                                                                    "is_date_after",
+                                                                                                    "between",
+                                                                                                    "not_between",
+                                                                                                    "min",
+                                                                                                    "max",
+                                                                                                    "in",
+                                                                                                    "not_in",
+                                                                                                    "is_cleaned_path_exact",
+                                                                                                    "flag_evaluates_to",
+                                                                                                    "semver_eq",
+                                                                                                    "semver_neq",
+                                                                                                    "semver_gt",
+                                                                                                    "semver_gte",
+                                                                                                    "semver_lt",
+                                                                                                    "semver_lte",
+                                                                                                    "semver_tilde",
+                                                                                                    "semver_caret",
+                                                                                                    "semver_wildcard",
+                                                                                                    "icontains_multi",
+                                                                                                    "not_icontains_multi"
+                                                                                                ],
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "type": {
+                                                                                                "const": "person",
+                                                                                                "default": "person",
+                                                                                                "description": "Person properties",
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "value": {
+                                                                                                "anyOf": [
+                                                                                                    {
+                                                                                                        "items": {
+                                                                                                            "anyOf": [
+                                                                                                                {
+                                                                                                                    "type": "string"
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    "type": "number"
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    "type": "boolean"
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        "type": "array"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "string"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "number"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "boolean"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "null"
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        },
+                                                                                        "required": ["key", "operator"],
+                                                                                        "type": "object"
+                                                                                    },
+                                                                                    {
+                                                                                        "properties": {
+                                                                                            "key": {
+                                                                                                "enum": [
+                                                                                                    "tag_name",
+                                                                                                    "text",
+                                                                                                    "href",
+                                                                                                    "selector"
+                                                                                                ],
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "label": {
+                                                                                                "anyOf": [
+                                                                                                    {
+                                                                                                        "type": "string"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "null"
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            "operator": {
+                                                                                                "enum": [
+                                                                                                    "exact",
+                                                                                                    "is_not",
+                                                                                                    "icontains",
+                                                                                                    "not_icontains",
+                                                                                                    "starts_with",
+                                                                                                    "not_starts_with",
+                                                                                                    "ends_with",
+                                                                                                    "not_ends_with",
+                                                                                                    "regex",
+                                                                                                    "not_regex",
+                                                                                                    "gt",
+                                                                                                    "gte",
+                                                                                                    "lt",
+                                                                                                    "lte",
+                                                                                                    "is_set",
+                                                                                                    "is_not_set",
+                                                                                                    "is_date_exact",
+                                                                                                    "is_date_before",
+                                                                                                    "is_date_after",
+                                                                                                    "between",
+                                                                                                    "not_between",
+                                                                                                    "min",
+                                                                                                    "max",
+                                                                                                    "in",
+                                                                                                    "not_in",
+                                                                                                    "is_cleaned_path_exact",
+                                                                                                    "flag_evaluates_to",
+                                                                                                    "semver_eq",
+                                                                                                    "semver_neq",
+                                                                                                    "semver_gt",
+                                                                                                    "semver_gte",
+                                                                                                    "semver_lt",
+                                                                                                    "semver_lte",
+                                                                                                    "semver_tilde",
+                                                                                                    "semver_caret",
+                                                                                                    "semver_wildcard",
+                                                                                                    "icontains_multi",
+                                                                                                    "not_icontains_multi"
+                                                                                                ],
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "type": {
+                                                                                                "const": "element",
+                                                                                                "default": "element",
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "value": {
+                                                                                                "anyOf": [
+                                                                                                    {
+                                                                                                        "items": {
+                                                                                                            "anyOf": [
+                                                                                                                {
+                                                                                                                    "type": "string"
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    "type": "number"
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    "type": "boolean"
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        "type": "array"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "string"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "number"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "boolean"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "null"
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        },
+                                                                                        "required": ["key", "operator"],
+                                                                                        "type": "object"
+                                                                                    },
+                                                                                    {
+                                                                                        "properties": {
+                                                                                            "key": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "label": {
+                                                                                                "anyOf": [
+                                                                                                    {
+                                                                                                        "type": "string"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "null"
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            "operator": {
+                                                                                                "enum": [
+                                                                                                    "exact",
+                                                                                                    "is_not",
+                                                                                                    "icontains",
+                                                                                                    "not_icontains",
+                                                                                                    "starts_with",
+                                                                                                    "not_starts_with",
+                                                                                                    "ends_with",
+                                                                                                    "not_ends_with",
+                                                                                                    "regex",
+                                                                                                    "not_regex",
+                                                                                                    "gt",
+                                                                                                    "gte",
+                                                                                                    "lt",
+                                                                                                    "lte",
+                                                                                                    "is_set",
+                                                                                                    "is_not_set",
+                                                                                                    "is_date_exact",
+                                                                                                    "is_date_before",
+                                                                                                    "is_date_after",
+                                                                                                    "between",
+                                                                                                    "not_between",
+                                                                                                    "min",
+                                                                                                    "max",
+                                                                                                    "in",
+                                                                                                    "not_in",
+                                                                                                    "is_cleaned_path_exact",
+                                                                                                    "flag_evaluates_to",
+                                                                                                    "semver_eq",
+                                                                                                    "semver_neq",
+                                                                                                    "semver_gt",
+                                                                                                    "semver_gte",
+                                                                                                    "semver_lt",
+                                                                                                    "semver_lte",
+                                                                                                    "semver_tilde",
+                                                                                                    "semver_caret",
+                                                                                                    "semver_wildcard",
+                                                                                                    "icontains_multi",
+                                                                                                    "not_icontains_multi"
+                                                                                                ],
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "type": {
+                                                                                                "const": "feature",
+                                                                                                "default": "feature",
+                                                                                                "description": "Event property with \"$feature/\" prepended",
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "value": {
+                                                                                                "anyOf": [
+                                                                                                    {
+                                                                                                        "items": {
+                                                                                                            "anyOf": [
+                                                                                                                {
+                                                                                                                    "type": "string"
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    "type": "number"
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    "type": "boolean"
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        "type": "array"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "string"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "number"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "boolean"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "null"
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        },
+                                                                                        "required": ["key", "operator"],
+                                                                                        "type": "object"
+                                                                                    },
+                                                                                    {
+                                                                                        "properties": {
+                                                                                            "key": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "label": {
+                                                                                                "anyOf": [
+                                                                                                    {
+                                                                                                        "type": "string"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "null"
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            "type": {
+                                                                                                "const": "hogql",
+                                                                                                "default": "hogql",
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "value": {
+                                                                                                "anyOf": [
+                                                                                                    {
+                                                                                                        "items": {
+                                                                                                            "anyOf": [
+                                                                                                                {
+                                                                                                                    "type": "string"
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    "type": "number"
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    "type": "boolean"
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        "type": "array"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "string"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "number"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "boolean"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "null"
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        },
+                                                                                        "required": ["key"],
+                                                                                        "type": "object"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "type": "array"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ],
+                                                                    "description": "Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral/cohort filters and groups"
+                                                                },
+                                                                "event_type": {
+                                                                    "enum": ["events", "actions"],
+                                                                    "type": "string"
+                                                                },
+                                                                "explicit_datetime": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ],
+                                                                    "description": "Absolute or relative (e.g. -30d) lower date bound — alternative to time_value/time_interval"
+                                                                },
+                                                                "explicit_datetime_to": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "key": {
+                                                                    "description": "Event name, or action id when event_type is 'actions'",
+                                                                    "type": "string"
+                                                                },
+                                                                "label": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "negation": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ],
+                                                                    "description": "Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators"
+                                                                },
+                                                                "operator": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "exact",
+                                                                                "is_not",
+                                                                                "icontains",
+                                                                                "not_icontains",
+                                                                                "starts_with",
+                                                                                "not_starts_with",
+                                                                                "ends_with",
+                                                                                "not_ends_with",
+                                                                                "regex",
+                                                                                "not_regex",
+                                                                                "gt",
+                                                                                "gte",
+                                                                                "lt",
+                                                                                "lte",
+                                                                                "is_set",
+                                                                                "is_not_set",
+                                                                                "is_date_exact",
+                                                                                "is_date_before",
+                                                                                "is_date_after",
+                                                                                "between",
+                                                                                "not_between",
+                                                                                "min",
+                                                                                "max",
+                                                                                "in",
+                                                                                "not_in",
+                                                                                "is_cleaned_path_exact",
+                                                                                "flag_evaluates_to",
+                                                                                "semver_eq",
+                                                                                "semver_neq",
+                                                                                "semver_gt",
+                                                                                "semver_gte",
+                                                                                "semver_lt",
+                                                                                "semver_lte",
+                                                                                "semver_tilde",
+                                                                                "semver_caret",
+                                                                                "semver_wildcard",
+                                                                                "icontains_multi",
+                                                                                "not_icontains_multi"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ],
+                                                                    "description": "Count comparison for performed_event_multiple, defaults to exact"
+                                                                },
+                                                                "operator_value": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "number"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ],
+                                                                    "description": "Count threshold for performed_event_multiple"
+                                                                },
+                                                                "time_interval": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "enum": ["day", "week", "month", "year"],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "time_value": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "number"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ],
+                                                                    "description": "Relative time window size, paired with time_interval"
+                                                                },
+                                                                "type": {
+                                                                    "const": "behavioral",
+                                                                    "default": "behavioral",
+                                                                    "description": "Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP",
+                                                                    "type": "string"
+                                                                },
+                                                                "value": {
+                                                                    "enum": [
+                                                                        "performed_event",
+                                                                        "performed_event_multiple"
+                                                                    ],
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": ["event_type", "key", "value"],
+                                                            "type": "object"
                                                         }
                                                     ]
                                                 },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/logs-alerts-simulate-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/logs-alerts-simulate-create.json
@@ -2191,6 +2191,643 @@
                                                             },
                                                             "required": ["key", "operator"],
                                                             "type": "object"
+                                                        },
+                                                        {
+                                                            "properties": {
+                                                                "event_filters": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "items": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "properties": {
+                                                                                            "key": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "label": {
+                                                                                                "anyOf": [
+                                                                                                    {
+                                                                                                        "type": "string"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "null"
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            "operator": {
+                                                                                                "anyOf": [
+                                                                                                    {
+                                                                                                        "enum": [
+                                                                                                            "exact",
+                                                                                                            "is_not",
+                                                                                                            "icontains",
+                                                                                                            "not_icontains",
+                                                                                                            "starts_with",
+                                                                                                            "not_starts_with",
+                                                                                                            "ends_with",
+                                                                                                            "not_ends_with",
+                                                                                                            "regex",
+                                                                                                            "not_regex",
+                                                                                                            "gt",
+                                                                                                            "gte",
+                                                                                                            "lt",
+                                                                                                            "lte",
+                                                                                                            "is_set",
+                                                                                                            "is_not_set",
+                                                                                                            "is_date_exact",
+                                                                                                            "is_date_before",
+                                                                                                            "is_date_after",
+                                                                                                            "between",
+                                                                                                            "not_between",
+                                                                                                            "min",
+                                                                                                            "max",
+                                                                                                            "in",
+                                                                                                            "not_in",
+                                                                                                            "is_cleaned_path_exact",
+                                                                                                            "flag_evaluates_to",
+                                                                                                            "semver_eq",
+                                                                                                            "semver_neq",
+                                                                                                            "semver_gt",
+                                                                                                            "semver_gte",
+                                                                                                            "semver_lt",
+                                                                                                            "semver_lte",
+                                                                                                            "semver_tilde",
+                                                                                                            "semver_caret",
+                                                                                                            "semver_wildcard",
+                                                                                                            "icontains_multi",
+                                                                                                            "not_icontains_multi"
+                                                                                                        ],
+                                                                                                        "type": "string"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "null"
+                                                                                                    }
+                                                                                                ],
+                                                                                                "default": "exact"
+                                                                                            },
+                                                                                            "type": {
+                                                                                                "const": "event",
+                                                                                                "default": "event",
+                                                                                                "description": "Event properties",
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "value": {
+                                                                                                "anyOf": [
+                                                                                                    {
+                                                                                                        "items": {
+                                                                                                            "anyOf": [
+                                                                                                                {
+                                                                                                                    "type": "string"
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    "type": "number"
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    "type": "boolean"
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        "type": "array"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "string"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "number"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "boolean"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "null"
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        },
+                                                                                        "required": ["key"],
+                                                                                        "type": "object"
+                                                                                    },
+                                                                                    {
+                                                                                        "properties": {
+                                                                                            "key": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "label": {
+                                                                                                "anyOf": [
+                                                                                                    {
+                                                                                                        "type": "string"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "null"
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            "operator": {
+                                                                                                "enum": [
+                                                                                                    "exact",
+                                                                                                    "is_not",
+                                                                                                    "icontains",
+                                                                                                    "not_icontains",
+                                                                                                    "starts_with",
+                                                                                                    "not_starts_with",
+                                                                                                    "ends_with",
+                                                                                                    "not_ends_with",
+                                                                                                    "regex",
+                                                                                                    "not_regex",
+                                                                                                    "gt",
+                                                                                                    "gte",
+                                                                                                    "lt",
+                                                                                                    "lte",
+                                                                                                    "is_set",
+                                                                                                    "is_not_set",
+                                                                                                    "is_date_exact",
+                                                                                                    "is_date_before",
+                                                                                                    "is_date_after",
+                                                                                                    "between",
+                                                                                                    "not_between",
+                                                                                                    "min",
+                                                                                                    "max",
+                                                                                                    "in",
+                                                                                                    "not_in",
+                                                                                                    "is_cleaned_path_exact",
+                                                                                                    "flag_evaluates_to",
+                                                                                                    "semver_eq",
+                                                                                                    "semver_neq",
+                                                                                                    "semver_gt",
+                                                                                                    "semver_gte",
+                                                                                                    "semver_lt",
+                                                                                                    "semver_lte",
+                                                                                                    "semver_tilde",
+                                                                                                    "semver_caret",
+                                                                                                    "semver_wildcard",
+                                                                                                    "icontains_multi",
+                                                                                                    "not_icontains_multi"
+                                                                                                ],
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "type": {
+                                                                                                "const": "person",
+                                                                                                "default": "person",
+                                                                                                "description": "Person properties",
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "value": {
+                                                                                                "anyOf": [
+                                                                                                    {
+                                                                                                        "items": {
+                                                                                                            "anyOf": [
+                                                                                                                {
+                                                                                                                    "type": "string"
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    "type": "number"
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    "type": "boolean"
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        "type": "array"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "string"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "number"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "boolean"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "null"
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        },
+                                                                                        "required": ["key", "operator"],
+                                                                                        "type": "object"
+                                                                                    },
+                                                                                    {
+                                                                                        "properties": {
+                                                                                            "key": {
+                                                                                                "enum": [
+                                                                                                    "tag_name",
+                                                                                                    "text",
+                                                                                                    "href",
+                                                                                                    "selector"
+                                                                                                ],
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "label": {
+                                                                                                "anyOf": [
+                                                                                                    {
+                                                                                                        "type": "string"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "null"
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            "operator": {
+                                                                                                "enum": [
+                                                                                                    "exact",
+                                                                                                    "is_not",
+                                                                                                    "icontains",
+                                                                                                    "not_icontains",
+                                                                                                    "starts_with",
+                                                                                                    "not_starts_with",
+                                                                                                    "ends_with",
+                                                                                                    "not_ends_with",
+                                                                                                    "regex",
+                                                                                                    "not_regex",
+                                                                                                    "gt",
+                                                                                                    "gte",
+                                                                                                    "lt",
+                                                                                                    "lte",
+                                                                                                    "is_set",
+                                                                                                    "is_not_set",
+                                                                                                    "is_date_exact",
+                                                                                                    "is_date_before",
+                                                                                                    "is_date_after",
+                                                                                                    "between",
+                                                                                                    "not_between",
+                                                                                                    "min",
+                                                                                                    "max",
+                                                                                                    "in",
+                                                                                                    "not_in",
+                                                                                                    "is_cleaned_path_exact",
+                                                                                                    "flag_evaluates_to",
+                                                                                                    "semver_eq",
+                                                                                                    "semver_neq",
+                                                                                                    "semver_gt",
+                                                                                                    "semver_gte",
+                                                                                                    "semver_lt",
+                                                                                                    "semver_lte",
+                                                                                                    "semver_tilde",
+                                                                                                    "semver_caret",
+                                                                                                    "semver_wildcard",
+                                                                                                    "icontains_multi",
+                                                                                                    "not_icontains_multi"
+                                                                                                ],
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "type": {
+                                                                                                "const": "element",
+                                                                                                "default": "element",
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "value": {
+                                                                                                "anyOf": [
+                                                                                                    {
+                                                                                                        "items": {
+                                                                                                            "anyOf": [
+                                                                                                                {
+                                                                                                                    "type": "string"
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    "type": "number"
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    "type": "boolean"
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        "type": "array"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "string"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "number"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "boolean"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "null"
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        },
+                                                                                        "required": ["key", "operator"],
+                                                                                        "type": "object"
+                                                                                    },
+                                                                                    {
+                                                                                        "properties": {
+                                                                                            "key": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "label": {
+                                                                                                "anyOf": [
+                                                                                                    {
+                                                                                                        "type": "string"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "null"
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            "operator": {
+                                                                                                "enum": [
+                                                                                                    "exact",
+                                                                                                    "is_not",
+                                                                                                    "icontains",
+                                                                                                    "not_icontains",
+                                                                                                    "starts_with",
+                                                                                                    "not_starts_with",
+                                                                                                    "ends_with",
+                                                                                                    "not_ends_with",
+                                                                                                    "regex",
+                                                                                                    "not_regex",
+                                                                                                    "gt",
+                                                                                                    "gte",
+                                                                                                    "lt",
+                                                                                                    "lte",
+                                                                                                    "is_set",
+                                                                                                    "is_not_set",
+                                                                                                    "is_date_exact",
+                                                                                                    "is_date_before",
+                                                                                                    "is_date_after",
+                                                                                                    "between",
+                                                                                                    "not_between",
+                                                                                                    "min",
+                                                                                                    "max",
+                                                                                                    "in",
+                                                                                                    "not_in",
+                                                                                                    "is_cleaned_path_exact",
+                                                                                                    "flag_evaluates_to",
+                                                                                                    "semver_eq",
+                                                                                                    "semver_neq",
+                                                                                                    "semver_gt",
+                                                                                                    "semver_gte",
+                                                                                                    "semver_lt",
+                                                                                                    "semver_lte",
+                                                                                                    "semver_tilde",
+                                                                                                    "semver_caret",
+                                                                                                    "semver_wildcard",
+                                                                                                    "icontains_multi",
+                                                                                                    "not_icontains_multi"
+                                                                                                ],
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "type": {
+                                                                                                "const": "feature",
+                                                                                                "default": "feature",
+                                                                                                "description": "Event property with \"$feature/\" prepended",
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "value": {
+                                                                                                "anyOf": [
+                                                                                                    {
+                                                                                                        "items": {
+                                                                                                            "anyOf": [
+                                                                                                                {
+                                                                                                                    "type": "string"
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    "type": "number"
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    "type": "boolean"
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        "type": "array"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "string"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "number"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "boolean"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "null"
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        },
+                                                                                        "required": ["key", "operator"],
+                                                                                        "type": "object"
+                                                                                    },
+                                                                                    {
+                                                                                        "properties": {
+                                                                                            "key": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "label": {
+                                                                                                "anyOf": [
+                                                                                                    {
+                                                                                                        "type": "string"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "null"
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            "type": {
+                                                                                                "const": "hogql",
+                                                                                                "default": "hogql",
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "value": {
+                                                                                                "anyOf": [
+                                                                                                    {
+                                                                                                        "items": {
+                                                                                                            "anyOf": [
+                                                                                                                {
+                                                                                                                    "type": "string"
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    "type": "number"
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    "type": "boolean"
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        "type": "array"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "string"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "number"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "boolean"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "null"
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        },
+                                                                                        "required": ["key"],
+                                                                                        "type": "object"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "type": "array"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ],
+                                                                    "description": "Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral/cohort filters and groups"
+                                                                },
+                                                                "event_type": {
+                                                                    "enum": ["events", "actions"],
+                                                                    "type": "string"
+                                                                },
+                                                                "explicit_datetime": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ],
+                                                                    "description": "Absolute or relative (e.g. -30d) lower date bound — alternative to time_value/time_interval"
+                                                                },
+                                                                "explicit_datetime_to": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "key": {
+                                                                    "description": "Event name, or action id when event_type is 'actions'",
+                                                                    "type": "string"
+                                                                },
+                                                                "label": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "negation": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ],
+                                                                    "description": "Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators"
+                                                                },
+                                                                "operator": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "exact",
+                                                                                "is_not",
+                                                                                "icontains",
+                                                                                "not_icontains",
+                                                                                "starts_with",
+                                                                                "not_starts_with",
+                                                                                "ends_with",
+                                                                                "not_ends_with",
+                                                                                "regex",
+                                                                                "not_regex",
+                                                                                "gt",
+                                                                                "gte",
+                                                                                "lt",
+                                                                                "lte",
+                                                                                "is_set",
+                                                                                "is_not_set",
+                                                                                "is_date_exact",
+                                                                                "is_date_before",
+                                                                                "is_date_after",
+                                                                                "between",
+                                                                                "not_between",
+                                                                                "min",
+                                                                                "max",
+                                                                                "in",
+                                                                                "not_in",
+                                                                                "is_cleaned_path_exact",
+                                                                                "flag_evaluates_to",
+                                                                                "semver_eq",
+                                                                                "semver_neq",
+                                                                                "semver_gt",
+                                                                                "semver_gte",
+                                                                                "semver_lt",
+                                                                                "semver_lte",
+                                                                                "semver_tilde",
+                                                                                "semver_caret",
+                                                                                "semver_wildcard",
+                                                                                "icontains_multi",
+                                                                                "not_icontains_multi"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ],
+                                                                    "description": "Count comparison for performed_event_multiple, defaults to exact"
+                                                                },
+                                                                "operator_value": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "number"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ],
+                                                                    "description": "Count threshold for performed_event_multiple"
+                                                                },
+                                                                "time_interval": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "enum": ["day", "week", "month", "year"],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "time_value": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "number"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ],
+                                                                    "description": "Relative time window size, paired with time_interval"
+                                                                },
+                                                                "type": {
+                                                                    "const": "behavioral",
+                                                                    "default": "behavioral",
+                                                                    "description": "Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP",
+                                                                    "type": "string"
+                                                                },
+                                                                "value": {
+                                                                    "enum": [
+                                                                        "performed_event",
+                                                                        "performed_event_multiple"
+                                                                    ],
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": ["event_type", "key", "value"],
+                                                            "type": "object"
                                                         }
                                                     ]
                                                 },


### PR DESCRIPTION
## Problem

Filtering an insight to people who performed an event requires creating and saving a cohort first, even for a one-off question. Requested in #2594 since 2020.

The cohort detour also adds staleness: results reflect the last cohort recalculation rather than query time.

## Changes

- Adds a `behavioral` property filter type (`BehavioralPropertyFilter`) to the query schema, reusing the cohort criteria vocabulary.
- `property_to_expr` compiles it to `person_id [NOT] IN (SELECT person_id FROM events ... GROUP BY person_id [HAVING count() <op> N])`, entirely at query time. No saved cohort, no precalculated cohortpeople, no `in_cohort` join pass.
- Supports performed / did not perform, an optional count, event property sub-filters, and both relative and explicit-date time windows.
- A time window is mandatory. An unbounded filter would scan every events partition, the one part of the 2020 performance concern that still holds.
- Only the performed-event family works inline. Sequences and lifecycle criteria raise a clear error pointing at cohorts.
- The subquery prunes on the events sort key (team, date, event), so the cost matches adding one series to a trends query.
- Gates the filter on the `behavioral-property-filter` feature flag, off by default.
- The gate sits in `_behavioral_property_to_expr`, the one point the query API, MCP query tools, and saved insights all reach.
- The gate fails closed. A flag-service error rejects the filter instead of allowing it.
- Saved cohorts keep working. Their behavioral criteria compile through `HogQLCohortQuery`, which never calls `property_to_expr`.
- Rejects behavioral properties in hog function filters when the function is saved, in global and per-event filter properties.
- Site destinations and site apps transpile their filters to JS that runs in the visitor's browser, and that path had no subquery guard.
- It emitted the query AST as a JS object literal and called `.includes()` on it, which an object does not have.
- The flag gate does not close that, because a team with the flag on still reaches the transpiled path.
- Feature flags already reject the type through their Rust serde allowlist, so no flag code changed.
- The UI ships in a stacked PR, behind the same flag.

> [!NOTE]
> The flag resolves per team, keyed on the organization and project groups. Target it on those groups rather than on a user. A user-targeted rollout can show the stacked PR's button to someone whose queries the backend still rejects.

Review risk concentrates in `posthog/hogql/property.py`. The large `schema.py` / `schema.json` / `validators.js` diffs are regenerated output; the churn beyond the new type is the codegen renumbering its auto-named duplicate models.

## How did you test this code?

- `posthog/hogql/test/test_property.py`: generated-SQL cases per criterion, count operator, scope, and negation. Also pins that `has_aggregation` ignores the subquery `count()` (otherwise trends would misroute the WHERE clause into HAVING), and that cohort-only criteria and missing time windows raise instead of silently matching everyone.
- `posthog/test/test_property_filter_discriminator.py`: the new type routes through the discriminated filter union.
- `posthog/hogql/test/test_property.py`: two cases pin the gate, one for the flag resolving off and one for the flag service raising. A removed gate or a widened `except` fails them.
- `posthog/cdp/test/test_validation.py`: rejection across `destination` and `site_destination`, and both filter placements. No existing test covered a subquery reaching the transpiled path.
- `products/feature_flags/backend/test/test_filters_validation.py`: one case pins `behavioral` as serde-unsafe. Allowlisting it without a Rust `PropertyType` variant fails deserialization of the team's whole cached flag set.
- Verified the browser failure by compiling a behavioral filter through the transpiled path with the guard removed. It produced JS calling `.includes()` on an object literal.
- The CDP and flag filter suites need migrations enabled. `--no-migrations` cannot create the `ltree` extension they use.
- Not run locally: ClickHouse-backed insight suites, the full frontend typecheck, and repo-wide mypy (the sandbox out-of-memory kills it; the touched module alone type checks clean). CI covers all three.
- Before regenerating, verified the schema toolchain (datamodel-code-generator 0.36.0 + pinned ruff) reproduces master's `schema.py` byte-for-byte from unchanged input.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Docs make sense once the UI PR ships; none here.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Desktop task). Skills invoked: /stacking-prs, /writing-tests, /writing-pr-descriptions. Session flow: verified the capability gap against the codebase, considered reusing `HogQLCohortQuery`'s builders directly but compiled a lean events subquery in `property_to_expr` instead (avoids query-runner layering and a circular import; the cohort builders route through `ActorsQueryRunner` and a persons join the filter does not need). The dead `type == "behavioral"` fallthrough in `property_to_expr` previously produced a meaningless generic comparison; it is now a real branch. The flag gate was added after review pointed out that flagging the UI alone still left the filter reachable through the API and MCP.

The CDP guard arrived separately, first as #83739 and then as #85189, and is now squashed onto this branch as `c897e4d9`. It closes a hole this PR opens: before it, `property_to_expr` had no `behavioral` branch, so the type never reached the hog function filter compilers. A stack lands bottom-first, so leaving the guard above this PR would have put the unguarded transpiled path on master first.
