### PR TITLE
feat(desktop): cite enriched source objects

### DIFF
--- a/products/desktop/apps/code/src/main/platform-adapters/desktop-pi-rpc-client-factory.test.ts
+++ b/products/desktop/apps/code/src/main/platform-adapters/desktop-pi-rpc-client-factory.test.ts
@@ -93,6 +93,7 @@ describe("DesktopPiRpcClientFactory", () => {
       enrichment: {
         apiUrl: "http://127.0.0.1:5678",
         publicApiUrl: "https://eu.posthog.com",
+        enableObjectReferences: true,
         projectId: 1,
         apiKey: "posthog-code-auth-proxy",
       },

--- a/products/desktop/apps/code/src/main/platform-adapters/desktop-pi-rpc-client-factory.ts
+++ b/products/desktop/apps/code/src/main/platform-adapters/desktop-pi-rpc-client-factory.ts
@@ -61,6 +61,7 @@ export class DesktopPiRpcClientFactory implements PiRpcClientFactory {
       enrichment: {
         apiUrl: enrichmentApiUrl,
         publicApiUrl: access.apiHost,
+        enableObjectReferences: true,
         projectId,
         apiKey: PROXY_API_KEY,
       },

--- a/products/desktop/apps/code/tests/e2e/tests/pi-enrichment.spec.ts
+++ b/products/desktop/apps/code/tests/e2e/tests/pi-enrichment.spec.ts
@@ -127,6 +127,7 @@ test.describe("Pi enrichment", () => {
       'posthog.capture("checkout_completed");\n',
     );
 
+    let initialModelRequest = "";
     let enrichedModelRequest = "";
     let eventDefinitionRequests = 0;
     let eventStatsRequests = 0;
@@ -153,6 +154,8 @@ test.describe("Pi enrichment", () => {
         const hasToolResult = serialized.includes('"tool_result"');
         if (hasToolResult) {
           enrichedModelRequest = serialized;
+        } else {
+          initialModelRequest = serialized;
         }
         response.writeHead(200, {
           "Content-Type": "text/event-stream",
@@ -226,6 +229,7 @@ test.describe("Pi enrichment", () => {
         enrichment: {
           apiUrl: baseUrl,
           publicApiUrl: "https://us.posthog.com",
+          enableObjectReferences: true,
           projectId: 1,
           apiKey: "posthog-test-key",
         },
@@ -237,6 +241,12 @@ test.describe("Pi enrichment", () => {
 
       expect(eventDefinitionRequests).toBe(1);
       expect(eventStatsRequests).toBe(1);
+      expect(initialModelRequest).toContain(
+        '<event id=\\"event name\\">event name</event>',
+      );
+      expect(initialModelRequest).toContain(
+        '<flag id=\\"flag key\\">flag key</flag>',
+      );
       expect(enrichedModelRequest).toContain(
         '[PostHog] Event: \\"checkout_completed\\"',
       );

--- a/products/desktop/packages/agent/src/pi/enrichment-extension.test.ts
+++ b/products/desktop/packages/agent/src/pi/enrichment-extension.test.ts
@@ -7,6 +7,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createPiEnrichmentExtension } from "./enrichment-extension";
 
 type ToolResultPatch = { content?: ToolResultEvent["content"] };
+type BeforeAgentStartHandler = (event: { systemPrompt: string }) => {
+  systemPrompt: string;
+};
 type ToolResultHandler = (
   event: ToolResultEvent,
   ctx: ExtensionContext,
@@ -45,18 +48,36 @@ describe("createPiEnrichmentExtension", () => {
     );
 
     let handler: ToolResultHandler | undefined;
+    let beforeAgentStartHandler: BeforeAgentStartHandler | undefined;
     const extension = createPiEnrichmentExtension({
       apiUrl: "https://us.posthog.com",
+      enableObjectReferences: true,
       projectId: 1,
       apiKey: "token",
     });
     await extension.factory({
-      on: (event: string, registeredHandler: ToolResultHandler) => {
+      on: (
+        event: string,
+        registeredHandler: ToolResultHandler | BeforeAgentStartHandler,
+      ) => {
         if (event === "tool_result") {
-          handler = registeredHandler;
+          handler = registeredHandler as ToolResultHandler;
+        }
+        if (event === "before_agent_start") {
+          beforeAgentStartHandler =
+            registeredHandler as BeforeAgentStartHandler;
         }
       },
     } as unknown as ExtensionAPI);
+
+    expect(
+      beforeAgentStartHandler?.({ systemPrompt: "Base system prompt" })
+        .systemPrompt,
+    ).toContain('<event id="event name">event name</event>');
+    expect(
+      beforeAgentStartHandler?.({ systemPrompt: "Base system prompt" })
+        .systemPrompt,
+    ).toContain('<flag id="flag key">flag key</flag>');
 
     const result = await handler?.(
       {
@@ -79,5 +100,27 @@ describe("createPiEnrichmentExtension", () => {
         ),
       },
     ]);
+  });
+
+  it("does not add object-tag guidance unless enabled", async () => {
+    let beforeAgentStartHandler: BeforeAgentStartHandler | undefined;
+    const extension = createPiEnrichmentExtension({
+      apiUrl: "https://us.posthog.com",
+      projectId: 1,
+      apiKey: "token",
+    });
+    await extension.factory({
+      on: (
+        event: string,
+        registeredHandler: ToolResultHandler | BeforeAgentStartHandler,
+      ) => {
+        if (event === "before_agent_start") {
+          beforeAgentStartHandler =
+            registeredHandler as BeforeAgentStartHandler;
+        }
+      },
+    } as unknown as ExtensionAPI);
+
+    expect(beforeAgentStartHandler).toBeUndefined();
   });
 });

--- a/products/desktop/packages/agent/src/pi/enrichment-extension.ts
+++ b/products/desktop/packages/agent/src/pi/enrichment-extension.ts
@@ -9,9 +9,17 @@ import {
   enrichFileForAgent,
 } from "../enrichment/file-enricher";
 
+const POSTHOG_OBJECT_REFERENCES_SYSTEM_PROMPT = [
+  "## PostHog source references",
+  "When a source read includes a PostHog annotation, cite the relevant object in your reply.",
+  'Use `<event id="event name">event name</event>` for events and `<flag id="flag key">flag key</flag>` for feature flags.',
+  "Use only keys from the annotation. Put references in the reply, never in source code or code fences.",
+].join("\n");
+
 export interface PiEnrichmentConfig {
   apiUrl: string;
   publicApiUrl?: string;
+  enableObjectReferences?: boolean;
   projectId: number;
   apiKey: string;
 }
@@ -23,6 +31,12 @@ export function createPiEnrichmentExtension(config: PiEnrichmentConfig): {
   return {
     name: "posthog-enricher",
     factory: (pi: ExtensionAPI) => {
+      if (config.enableObjectReferences) {
+        pi.on("before_agent_start", (event) => ({
+          systemPrompt: `${event.systemPrompt}\n\n${POSTHOG_OBJECT_REFERENCES_SYSTEM_PROMPT}`,
+        }));
+      }
+
       const enrichment = createEnrichment({
         apiUrl: config.apiUrl,
         publicApiUrl: config.publicApiUrl,


### PR DESCRIPTION
## Problem

Desktop Pi agents can read live event and flag metadata, but their replies do not reliably link to the PostHog objects behind that metadata.

The merged object-tag renderer supports live event and flag references, but Pi has no Desktop-specific citation guidance.

## Changes

- Desktop Pi sessions receive object-tag guidance when source enrichment is enabled.
- The guidance tells agents to cite enriched events and flags as live PostHog objects.
- The Desktop factory opts in to the guidance.
- Standalone Pi and the `hog` CLI remain unchanged because they do not receive the opt-in bootstrap setting.
- The packaged Pi E2E test verifies the object-tag guidance reaches the model request.
- No new visual component. Agent replies use the existing object-reference chips from [#83182](https://github.com/PostHog/posthog/pull/83182).

## How did you test this code?

- Added unit coverage for enabled and disabled object-reference guidance.
- Added packaged Electron Playwright coverage for the opt-in model prompt.
- Ran affected agent and Desktop typechecks, agent unit tests, host-boundary checks, and packaging.
- Not run: a manual Desktop rendering check. The existing object-tag renderer was merged in [#83182](https://github.com/PostHog/posthog/pull/83182).

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This adds a Desktop-only prompt capability to existing object-tag documentation.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Pi used `gh stack`, the PostHog MCP, and Playwright.
- Invoked `/stacking-prs`, `/writing-tests`, `/playwright-test`, `/security-audit`, and `/writing-pr-descriptions`.
- This layer keeps object-tag guidance out of standalone Pi and the `hog` CLI.
