### PR TITLE
fix(desktop): shorten codex stream idle timeout in cloud sandboxes

### DIFF
--- a/products/desktop/packages/agent/src/adapters/codex-app-server/spawn.test.ts
+++ b/products/desktop/packages/agent/src/adapters/codex-app-server/spawn.test.ts
@@ -1,7 +1,11 @@
 import { delimiter, dirname } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import type { Logger } from "../../utils/logger";
-import { buildAppServerArgs, spawnCodexAppServerProcess } from "./spawn";
+import {
+  buildAppServerArgs,
+  SANDBOX_STREAM_IDLE_TIMEOUT_MS,
+  spawnCodexAppServerProcess,
+} from "./spawn";
 
 const BINARY_PATH = "/bundle/codex";
 
@@ -136,6 +140,19 @@ describe("buildAppServerArgs", () => {
 
     expect(args).toContain("auto_compact_token_limit=16000");
     expect(args).toContain('model_verbosity="low"');
+  });
+
+  it("shortens the gateway stream idle timeout only in cloud sandboxes", () => {
+    const idleTimeoutArg = `model_providers.posthog.stream_idle_timeout_ms=${SANDBOX_STREAM_IDLE_TIMEOUT_MS}`;
+    const options = {
+      binaryPath: "/bundle/codex",
+      apiBaseUrl: "https://gateway.example/v1",
+    };
+
+    expect(buildAppServerArgs(options, { IS_SANDBOX: "1" })).toContain(
+      idleTimeoutArg,
+    );
+    expect(buildAppServerArgs(options, {})).not.toContain(idleTimeoutArg);
   });
 
   it("pins the cloud BASH_ENV into tool shells for secondary checkouts", () => {

--- a/products/desktop/packages/agent/src/adapters/codex-app-server/spawn.ts
+++ b/products/desktop/packages/agent/src/adapters/codex-app-server/spawn.ts
@@ -69,6 +69,9 @@ export interface CodexAppServerProcessOptions {
   processCallbacks?: ProcessSpawnedCallback;
 }
 
+/** Idle time on a gateway SSE stream before codex abandons it and retries, in cloud sandboxes. */
+export const SANDBOX_STREAM_IDLE_TIMEOUT_MS = 90_000;
+
 export interface CodexAppServerProcess {
   process: ChildProcess;
   stdin: Writable;
@@ -169,6 +172,19 @@ export function buildAppServerArgs(
       args.push(
         "-c",
         `model_providers.posthog.http_headers=${tomlInlineTable(options.httpHeaders)}`,
+      );
+    }
+
+    // Gateway response streams occasionally go silent mid-generation and stay
+    // open. Codex only retries once the stream has been idle for
+    // stream_idle_timeout_ms (default 300000), so each stall costs a cloud run
+    // five minutes of wall clock and sandbox occupancy. A shorter idle timeout
+    // bounds that cost; the retry re-issues the request. Cloud-only because a
+    // desktop user can see and interrupt a hung turn themselves.
+    if (environment.IS_SANDBOX) {
+      args.push(
+        "-c",
+        `model_providers.posthog.stream_idle_timeout_ms=${SANDBOX_STREAM_IDLE_TIMEOUT_MS}`,
       );
     }
   }


### PR DESCRIPTION
## Problem

- Cloud task runs on Codex sometimes sit idle for five minutes mid-run, then continue normally. Scout runs wear most of it: fleet p90 run duration stepped from ~100 s to ~370 s and about one run in ten now carries a +5 min stall.
- The stall is a gateway response stream that goes silent mid-generation and stays open.
- Codex only abandons and retries an idle stream after `stream_idle_timeout_ms`, which nothing sets today, so it waits the 300 s default.
- Each stall costs five minutes of wall clock and a sandbox slot; the run itself does not fail.
- Root cause of the silent streams (gateway vs upstream) is still open. This is the mitigation that holds regardless.

## Changes

- The codex app-server spawn args now set `model_providers.posthog.stream_idle_timeout_ms=90000` when `IS_SANDBOX` is set, so a stalled stream costs about 90 s instead of 300 s.
- Desktop and web hosts are unchanged. A person at the keyboard can see and interrupt a hung turn; an unattended sandbox cannot.
- 90 s sits at the top of the range from the investigation, to leave headroom for legitimately quiet reasoning gaps before Codex re-issues the request.

> [!NOTE]
> Reaches sandboxes only after `desktop-agent-tag` publishes `@posthog/agent` and the sandbox base image rebuilds against `latest`. The image workflow's path filter does not include the agent package, so it may need a manual `workflow_dispatch`.

## How did you test this code?

- New case in `spawn.test.ts` asserts the flag is present with `IS_SANDBOX` and absent without it, which no existing test covered.
- Ran `pnpm vitest run src/adapters/codex-app-server/spawn.test.ts`, `pnpm typecheck` and Biome on the agent package locally.
- Not checked: a real sandbox run against a stalled stream. The read-back is the scout run duration p90 once the image ships.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Fable 5) in a local session, directed by Andy. Skills invoked: `/phs` (scouts-work backlog, issue 40), `/writing-code-comments`, `/writing-pr-descriptions`.
- Considered passing the value through `configOverrides` from `agent-server.ts`; kept it in `spawn.ts` beside the other cloud-only override (`BASH_ENV`) so the gate and the test live in one place.
- Codex config key and default confirmed against the Codex config reference (`model_providers.<id>.stream_idle_timeout_ms`, default 300000).
