### PR TITLE
chore(agents): drop first-person PR descriptions

### DIFF
--- a/.agents/skills/writing-pr-descriptions/SKILL.md
+++ b/.agents/skills/writing-pr-descriptions/SKILL.md
@@ -200,7 +200,11 @@ Copy the second one. It is shorter, not just flatter.
 - Sentence case for titles, headings, and bolded text. Only the first word and proper nouns.
 - Spare use of inline code. Limited use of the colon and semicolon.
 - Do not hard-wrap at a column width and do not space-align tables. GitHub renders markdown and flows the text.
-- Write in first person as the author. When an agent did the work, say so: "I (actually Claude) moved the derivation into one place."
+- The subject of a sentence is the change, not its author.
+  Title in the imperative, body in the present tense: "Delete the FizzBuzz RPC", "The exporter now retries once".
+  Never "I", "me", or "my". Keep "we" for PostHog, never for whoever wrote the PR.
+  An agent writing as "I" hands the assignee an account of work they did not do, and a parenthetical does not undo it.
+  Authorship is one stated fact in `## 🤖 Agent context`, not a voice the body speaks in.
 
 ## Pass 5: check your own draft
 
@@ -226,12 +230,13 @@ A "no" anywhere means the body is ordered for the writer, not the reader. Go bac
 6. Read each bullet alone. Does it state one fact? If it states two, split it.
 7. Count the words in the longest sentence. Over 25, split it.
 8. Rewrite every passive sentence in active voice, unless the actor is genuinely unknown. Break every noun string longer than three words with a preposition.
-9. Is any fact in the wrong form? A visual change needs a screenshot. A flow change needs before and after diagrams. A comparison needs a table.
-10. Does every claim about what you ran, measured or saw link its evidence, or say it went unchecked? Descriptions of behavior need no link.
-11. Did a `<!-- -->` template comment survive anywhere? That section is unfilled. Fill it or delete it.
-12. Is the `## 🤖 Agent context` section filled, listing the skills invoked?
-13. Does the body claim manual testing that did not happen? Delete it.
-14. Does the body name an internal customer, incident, Slack quote, or operational metric? This repo is public. Delete it.
+9. Does any sentence take its author as the subject? Rewrite it around the change. "I", "me" and "my" appear nowhere.
+10. Is any fact in the wrong form? A visual change needs a screenshot. A flow change needs before and after diagrams. A comparison needs a table.
+11. Does every claim about what you ran, measured or saw link its evidence, or say it went unchecked? Descriptions of behavior need no link.
+12. Did a `<!-- -->` template comment survive anywhere? That section is unfilled. Fill it or delete it.
+13. Is the `## 🤖 Agent context` section filled, listing the skills invoked?
+14. Does the body claim manual testing that did not happen? Delete it.
+15. Does the body name an internal customer, incident, Slack quote, or operational metric? This repo is public. Delete it.
 
 ## Background
 

--- a/.agents/skills/writing-pr-descriptions/SKILL.md
+++ b/.agents/skills/writing-pr-descriptions/SKILL.md
@@ -200,9 +200,8 @@ Copy the second one. It is shorter, not just flatter.
 - Sentence case for titles, headings, and bolded text. Only the first word and proper nouns.
 - Spare use of inline code. Limited use of the colon and semicolon.
 - Do not hard-wrap at a column width and do not space-align tables. GitHub renders markdown and flows the text.
-- The subject of a sentence is the change, not its author.
-  Title in the imperative, body in the present tense: "Delete the FizzBuzz RPC", "The exporter now retries once".
-  Never "I", "me", or "my". Keep "we" for PostHog, never for whoever wrote the PR.
+- The subject of a sentence is the change, not its author. Never "I", "me" or "my", and keep "we" for PostHog.
+  "The exporter now retries once", never "I made the exporter retry once".
   An agent writing as "I" hands the assignee an account of work they did not do, and a parenthetical does not undo it.
   Authorship is one stated fact in `## 🤖 Agent context`, not a voice the body speaks in.
 

--- a/.agents/skills/writing-pr-descriptions/references/examples.md
+++ b/.agents/skills/writing-pr-descriptions/references/examples.md
@@ -38,11 +38,11 @@ Every fact survived. The reviewer now learns that tiles break and nobody can unb
 
 As shipped, the two sections a reviewer needs ran 190 words and the two under them ran 224. Three moves fix the ratio:
 
-| Text                                                                                                                                           | From                       | To                                     |
-| ---------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | -------------------------------------- |
-| "I considered returning a 400 for unknown keys on write and rejected it: the UI echoes persisted blobs into saves, so that would block saving" | Agent context, last bullet | Changes, as a bullet                   |
-| "Ran `pytest` on the two touched test files (52 passed), repo-wide `mypy` (clean), and `hogli ci:preflight --fix` (no failures)"               | Testing                    | Deleted. The checks report all three   |
-| "The existing PATCH round-trip test in `test_dashboard.py` guards the wiring"                                                                  | Testing                    | Deleted. An existing test still passes |
+| Text                                                                                                                             | From                       | To                                     |
+| -------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | -------------------------------------- |
+| "A 400 for unknown keys on write would block saving: the UI echoes persisted blobs back into saves"                              | Agent context, last bullet | Changes, as a bullet                   |
+| "Ran `pytest` on the two touched test files (52 passed), repo-wide `mypy` (clean), and `hogli ci:preflight --fix` (no failures)" | Testing                    | Deleted. The checks report all three   |
+| "The existing PATCH round-trip test in `test_dashboard.py` guards the wiring"                                                    | Testing                    | Deleted. An existing test still passes |
 
 The rejected alternative is the one line a reviewer needs to judge the design. It sat below the changelog checkbox.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -64,6 +64,7 @@
   ✅ feat(insights): add retention graph export
   ❌ feat: Added retention export.   (capitalized, period, no scope)
 - Description: high-level rationale, not a step-by-step replay.
+- Voice: the subject of every sentence is the change, never its author. "I", "me" and "my" appear nowhere in the body, and "I (actually Claude)" is worse than either half of it: an agent writing as the assignee hands them an account of work they did not do. Authorship is one stated fact in the Agent context section below.
 - Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
 - Public OSS repo: no internal customers, incidents, or operational metrics.
 - Stack instead of stuffing: if the diff holds two or more separable steps (migration then behavior, rename then rewrite), open a stack rather than one big PR. See AGENTS.md, "Stacked PRs" and /stacking-prs.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -64,7 +64,7 @@
   ✅ feat(insights): add retention graph export
   ❌ feat: Added retention export.   (capitalized, period, no scope)
 - Description: high-level rationale, not a step-by-step replay.
-- Voice: the subject of every sentence is the change, never its author. "I", "me" and "my" appear nowhere in the body, and "I (actually Claude)" is worse than either half of it: an agent writing as the assignee hands them an account of work they did not do. Authorship is one stated fact in the Agent context section below.
+- Voice: the subject of every sentence is the change, never its author. No "I", "me" or "my" anywhere in the body. "I (actually Claude)" is worse than either half: it hands the assignee an account of work they did not do. Authorship is one stated fact in the Agent context section below.
 - Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
 - Public OSS repo: no internal customers, incidents, or operational metrics.
 - Stack instead of stuffing: if the diff holds two or more separable steps (migration then behavior, rename then rewrite), open a stack rather than one big PR. See AGENTS.md, "Stacked PRs" and /stacking-prs.


### PR DESCRIPTION
## Problem

- The PR description skill told agents to write the body as the human author: "I (actually Claude) moved the derivation into one place."
- A reviewer reads that as the assignee's own account of work the assignee did not do.
- The rule predates the skill's STE work and never came from it. ASD-STE100 covers sentence length, voice and tense, never grammatical person.
- [Google's CL description guidance](https://google.github.io/eng-practices/review/developer/cl-descriptions.html), already cited in the skill, asks for the imperative and for what the change does, not who did it.

## Changes

- The change is now the subject of the sentence. "I", "me" and "my" are out, and "we" means PostHog.
- Pass 5 gains a line check for any sentence whose subject is its author.
- The PR template carries the same rule, so it holds when the skill is not loaded.
- The worked example that quoted "I considered ..." now reads in the change's voice.

## How did you test this code?

- Documentation only. No automated test covers skill prose.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code made the edits. The author directed them, and declined a CI check that would flag first person on agent-authored bodies.
- Skills invoked: /writing-skills, /authoring-ci-workflows, /writing-pr-descriptions.
