### PR TITLE
fix(login): prevent browser-translate DOM crash on login and 2fa

### DIFF
--- a/frontend/src/scenes/authentication/login-2fa/Login2FA.tsx
+++ b/frontend/src/scenes/authentication/login-2fa/Login2FA.tsx
@@ -14,6 +14,9 @@ import { SceneExport } from 'scenes/sceneTypes'
 
 import { login2FALogic } from './login2FALogic'
 
+// The lead text below is wrapped in a <span>: in-page translation replaces text nodes with <font>
+// elements, so inserting the conditional support link beside a bare text node crashes React
+// (insertBefore / removeChild NotFoundError, see react#11538).
 export function Login2FA(): JSX.Element {
     const { isTwofactortokenSubmitting, generalError, passkey2FALoading, passkeysAvailable, totpAvailable } =
         useValues(login2FALogic)
@@ -26,7 +29,7 @@ export function Login2FA(): JSX.Element {
             <div className="deprecated-space-y-2">
                 <h2>Two-Factor Authentication</h2>
                 <p>
-                    Enter a token from your authenticator app, use your passkey, or enter a backup code.
+                    <span>Enter a token from your authenticator app, use your passkey, or enter a backup code.</span>
                     {preflight?.cloud && (
                         <>
                             {' '}

--- a/frontend/src/scenes/authentication/login/LoginForm.tsx
+++ b/frontend/src/scenes/authentication/login/LoginForm.tsx
@@ -32,6 +32,10 @@ import { SessionRiskBanner } from './SessionRiskBanner'
 
 const LAST_LOGIN_METHOD_COOKIE = 'ph_last_login_method'
 
+// Bare text nodes below are wrapped in <span>s: in-page translation replaces text nodes with
+// <font> elements, which crashes React's sibling insert/remove operations (removeChild /
+// insertBefore NotFoundError, see react#11538). Text that is its own element's only child is
+// already safe, so only text sharing a parent with element siblings needs wrapping.
 export function LoginForm(): JSX.Element {
     const { precheck, exitCodeVerification, resendCodeBasedVerification } = useActions(loginLogic)
     const { openSupportForm } = useActions(supportLogic)
@@ -69,7 +73,7 @@ export function LoginForm(): JSX.Element {
 
     const footer = (
         <p className="mt-5 mb-0 text-sm text-secondary text-center">
-            New to PostHog?{' '}
+            <span>New to PostHog?</span>{' '}
             <Link
                 to={[signupUrl, { email: login.email }]}
                 data-attr="signup"
@@ -90,7 +94,9 @@ export function LoginForm(): JSX.Element {
                             'Enter your login code'
                         ) : (
                             <>
-                                Log in to{' '}
+                                {/* This whole fragment is deleted when the title flips to the code-sent
+                                    string, so even the separator space lives inside an element */}
+                                <span>{'Log in to '}</span>
                                 <span className="px-1 rounded-md bg-[color-mix(in_srgb,var(--color-blue-500)_10%,transparent)] text-[var(--color-blue-500)]">
                                     @PostHog
                                 </span>
@@ -107,9 +113,11 @@ export function LoginForm(): JSX.Element {
                             isCodeSent ? 'bg-success-highlight border-success' : 'bg-danger-highlight border-danger'
                         )}
                     >
-                        {generalError.detail ||
-                            ERROR_MESSAGES[generalError.code] ||
-                            'Could not complete your login. Please try again.'}
+                        <span>
+                            {generalError.detail ||
+                                ERROR_MESSAGES[generalError.code] ||
+                                'Could not complete your login. Please try again.'}
+                        </span>
                         {preflight?.cloud && (
                             <>
                                 {' '}
@@ -177,7 +185,7 @@ export function LoginForm(): JSX.Element {
                             {resendResponse?.success && (
                                 <p className="flex items-center gap-1 text-success mb-0" role="status">
                                     <IconCheckCircle />
-                                    Code sent — check your inbox.
+                                    <span>Code sent — check your inbox.</span>
                                 </p>
                             )}
                             <Link
@@ -249,7 +257,7 @@ export function LoginForm(): JSX.Element {
                         )}
                         {hasNoConfiguredLoginMethod && (
                             <div className="py-2.5 px-3 text-sm leading-normal text-primary text-left bg-warning-highlight border border-warning rounded">
-                                No sign-in method is set up for this account. Use{' '}
+                                <span>No sign-in method is set up for this account. Use</span>{' '}
                                 <Link
                                     to={[urls.passwordReset(), { email: login.email }]}
                                     data-attr="forgot-password"
@@ -257,7 +265,7 @@ export function LoginForm(): JSX.Element {
                                 >
                                     Forgot password?
                                 </Link>{' '}
-                                to set a password by email.
+                                <span>to set a password by email.</span>
                             </div>
                         )}
                         {autoRedirectingToProvider && (


### PR DESCRIPTION
## Problem

Logging in with browser page translation on (Chrome/Edge in-page translate and similar) crashes React with `NotFoundError: Failed to execute 'removeChild' on 'Node'` ([react#11538](https://github.com/facebook/react/issues/11538)) and blocks the login. Tracked in error tracking issue [`019c29c3`](https://us.posthog.com/project/2/error_tracking/019c29c3-9af5-7f20-b993-82bfc23a628e).

The crash fires at the code-based verification step: the server answers `code_based_verification_required`, and the login form swaps its title from the `Log in to @PostHog` fragment to the `Enter your login code` string. That type change makes React delete the fragment's host children individually — but translation has replaced the bare `Log in to ` text node with a `<font>` element, so `removeChild` throws. Since code-based verification is the default for accounts without TOTP or passkeys, this breaks the *normal* login path in a fresh translated browser. A wrong password does not crash (it only mounts the error banner), which is why the bug looks intermittent.

## Changes

Ports the span-wrapping approach from #71012: every bare text node that shares a parent with element siblings is wrapped in its own `<span>`, so translation mutates inside the span and React's sibling operations stay valid. Translation itself keeps working; rendered text is identical.

- `LoginForm.tsx` — the title fragment (`<span>{'Log in to '}</span>`) is the load-bearing fix: it's the subtree deleted on the code-verification transition, so even the separator space moves inside an element.
- `LoginForm.tsx` — hardening for the same shape elsewhere: the `generalError` banner, `New to PostHog?` footer, `Code sent` confirmation, and the no-login-method notice.
- `Login2FA.tsx` — the lead paragraph text, which sits beside a conditionally-inserted support link.

## How did you test this code?

Reproduced locally with Chrome page translation (German) on `/login`, using a local-only backend scaffold (not committed) that raises `CodeBasedVerificationRequired`. Dev mode disables code-based verification and the email send needs a Customer.io key, so the real 401 is unreachable locally otherwise. 

_Before the change_: submitting correct credentials on a translated page threw the production `removeChild` DOMException at the step transition. 
_After_: the form transitions cleanly to the code entry step, translated. Manual verification by the PR author; both runs on the same local stack.

Also correlated the fix against production data: sessions hitting this issue on `/login` contain a `login verification code sent` event ~300ms before the exception in 34 of 35 cases over 14 days, confirming the step transition (not the error banner) as the trigger.

Automated: `tsgo --noEmit`, `oxlint`, and `oxfmt` clean. No unit test, jsdom can't simulate the browser translator's DOM mutations, so a test would only assert markup structure (same rationale as #71012).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
