### PR TITLE
fix(ci): restore routed-app migration drop in rust flags job

### DIFF
--- a/.github/workflows/ci-rust-flags-integration.yml
+++ b/.github/workflows/ci-rust-flags-integration.yml
@@ -195,6 +195,14 @@ jobs:
                           | psql -q -v ON_ERROR_STOP=1 --single-transaction test_posthog || return 1
                       # The dump is schema-only, so rows written by data migrations are absent.
                       python manage.py ensure_migration_defaults || return 1
+                      # The dump omits tables for the apps that products/db_routing.yaml routes away
+                      # in ci-backend, yet still marks their migrations applied. This job configures
+                      # no product databases, so drop those records and let migrate create them here.
+                      APPS=$(python -c 'import yaml; print(",".join(sorted(r["app_label"] for r in yaml.safe_load(open("products/db_routing.yaml"))["routes"])))') || return 1
+                      if [ -n "$APPS" ]; then
+                          psql -q -v ON_ERROR_STOP=1 test_posthog \
+                              -c "DELETE FROM django_migrations WHERE app = ANY(string_to_array('$APPS', ','));" || return 1
+                      fi
                   }
                   if [ ! -f schema.sql.gz ]; then
                       echo "::notice::schema cache miss, so migrate runs from scratch"


### PR DESCRIPTION
## Problem

- Anyone adding a test to the rust flags integration job gets a `test_posthog` missing three products' tables, and only when the schema cache hits.
- The prime restores a dump from ci-backend, where `products/db_routing.yaml` routes `stamphog`, `visual_review` and `warehouse_sources_queue` to their own databases. The dump omits their tables but keeps their `django_migrations` rows.
- This job configures no product databases, so those apps belong on the default one. Django reads the dump's rows, reports "No migrations to apply", and never creates the tables.
- A cache miss runs the full migrate and does create them, so the two paths build different schemas.
- [Prime rust flags integration db from the schema cache](https://github.com/PostHog/posthog/pull/79929) dropped this delete in `54066d167bf9` as a no-op. It was not one: [run 32018527918](https://github.com/PostHog/posthog/actions/runs/32018527918) shows `DELETE 23`, then 23 migrations applied across the three apps.

## Changes

- The prime drops those apps' migration records again, so migrate creates their tables on a cache hit.
- A `python -c` call reads the app labels, replacing the heredoc that made the removed version awkward to indent inside the function.
- `ON_ERROR_STOP=1` and `= ANY(string_to_array(...))` mean a failed delete returns non-zero and the app list needs no nested SQL quoting.
- The prime's existing failure path covers the new step: any failure warns, recreates `test_posthog`, and leaves migrate to rebuild from scratch.
- `ci-mcp.yml` now holds the same logic. Sharing it belongs with the schema key computation, which is duplicated five times and out of scope here.

## How did you test this code?

I extracted the step's script from the workflow YAML and ran it under `bash -e` with `psql`, `gunzip` and `python` stubbed, which is the only way to reach the failure paths.

| Case | Result |
| --- | --- |
| Cache hit | delete runs with the three routed app labels |
| Delete fails | warns, recreates `test_posthog`, step green |
| Restore or migration defaults fails | same fallback |
| Cache miss | notice, no prime |

Not checked: the job itself. This branch edits the workflow, which its own path filter covers, so CI here runs the job and the log should show a real `DELETE 23`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None, CI-internal change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Opus 5). Skills: `monitor-ci`, `/writing-pr-descriptions`.
- Found while monitoring the parent PR on master. The parent's own runs stayed green because no test in the job touches the three products' tables, so the gap is latent rather than breaking.
- I confirmed the delete mattered by comparing the run before the removal against the run after it, rather than by reading the removal commit, which carried no reasoning.
