### PR TITLE
feat(desktop): report whether a turn is in flight from /health

### DIFF
--- a/products/desktop/packages/agent/src/server/agent-server.test.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.test.ts
@@ -547,6 +547,9 @@ describe("AgentServer HTTP Mode", () => {
         hasSession: true,
         bootMs: expect.any(Number),
         sessionInitMs: expect.any(Number),
+        // The orchestrator reads this before reclaiming a sandbox whose idle window has closed,
+        // and only an explicit true defers that. A session with no turn running must say so.
+        turnInFlight: false,
       });
     }, 30000);
 

--- a/products/desktop/packages/agent/src/server/agent-server.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.ts
@@ -667,6 +667,15 @@ export class AgentServer {
         hasSession: !!this.session,
         bootMs: this.sessionReadyBootMs,
         sessionInitMs: this.sessionInitMs,
+        // Read before the orchestrator reclaims a sandbox whose idle window has closed. It has
+        // to be asked for rather than inferred from the event stream, because anything the
+        // server logs to prove it is alive re-arms that same window. This route logs nothing.
+        //
+        // Owned turns as well as deliveries: an autonomous run's first turn starts here rather
+        // than from a command, so deliveries alone report idle during long unattended work.
+        turnInFlight:
+          this.activeOwnedTurnCount > 0 ||
+          this.inFlightMessageDeliveries.size > 0,
       });
     });
 

--- a/products/desktop/packages/agent/src/server/pi-agent-server.ts
+++ b/products/desktop/packages/agent/src/server/pi-agent-server.ts
@@ -49,6 +49,8 @@ interface PiCloudSession {
 }
 
 const emptySchema = z.object({});
+// Bounds the liveness probe so a hung runtime cannot hold /health open.
+const TURN_STATE_PROBE_TIMEOUT_MS = 2_000;
 const MAX_PENDING_EVENTS = 1_000;
 const MAX_PENDING_LOG_ENTRIES = 10_000;
 const LOG_FLUSH_ENTRY_COUNT = 100;
@@ -290,12 +292,13 @@ export class PiAgentServer {
   private createApp(): Hono {
     const app = new Hono();
 
-    app.get("/health", (context) =>
+    app.get("/health", async (context) =>
       context.json({
         status: "ok",
         hasSession: this.session !== null,
         bootMs: this.sessionReadyBootMs,
         sessionInitMs: this.sessionInitMs,
+        turnInFlight: await this.readTurnInFlight(),
       }),
     );
 
@@ -698,6 +701,31 @@ export class PiAgentServer {
         }
         return runtime.sendCommand(command);
       }
+    }
+  }
+
+  /**
+   * Whether the runtime is part-way through a turn, for the orchestrator's idle check.
+   *
+   * Returns `undefined` rather than `false` when the runtime cannot say, keeping "don't know"
+   * distinct from "not working" for a caller that only defers on an explicit yes. Racing a
+   * timeout so an unanswered RPC cannot hold this route open.
+   */
+  private async readTurnInFlight(): Promise<boolean | undefined> {
+    const runtime = this.session?.runtime;
+    if (!runtime) {
+      return false;
+    }
+    try {
+      const state = await Promise.race([
+        runtime.client.getState(),
+        new Promise<null>((resolve) =>
+          setTimeout(() => resolve(null), TURN_STATE_PROBE_TIMEOUT_MS),
+        ),
+      ]);
+      return state === null ? undefined : state.isStreaming;
+    } catch {
+      return undefined;
     }
   }
 


### PR DESCRIPTION
## Problem

A cloud task that is still working can have its sandbox reclaimed, losing the uncommitted work of that turn.

- The orchestrator reclaims a sandbox once its inactivity window closes.
- That window closing means no events arrived, not that no work is happening.
- A turn can run for many minutes emitting nothing, such as a long build or test suite.
- From outside, that is indistinguishable from an agent that stopped.

## Changes

- Report `turnInFlight` from `/health` on both agent-server implementations.

The orchestrator has to be able to ask, because it cannot infer this from traffic. Anything the server logs to prove it is alive comes back as a stream event, and an event re-arms the very window being decided. `/health` logs nothing.

The default server counts owned turns as well as message deliveries. An autonomous run's first turn starts from the server rather than from a command, so deliveries alone report it idle during precisely the long unattended work this protects.

The pi server reports whether its runtime is streaming. That is an RPC rather than local state, so it races a short timeout and answers "cannot say" rather than "idle" when the runtime does not respond, which keeps a hung runtime from holding the route open.

Nothing reads the field yet. The orchestrator side is #83774, which treats an absent field as "cannot say" and terminates exactly as it does today, so the two are safe to ship in either order. The behaviour only takes effect once both are live.

## How did you test this code?

Automated tests only. I did not exercise `/health` against a live sandbox.

The existing `/health` shape test now asserts `turnInFlight: false` for a session with no turn running, rather than tolerating the new field.

`agent-server.test.ts` and `pi-agent-server.test.ts` pass locally (198 tests), and the package typechecks clean.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code via PostHog Desktop. Skills read from disk: `writing-tests`, `writing-code-comments`, `writing-pr-descriptions`, `qa-team`.

Split out of #83774 because CI blocks PRs touching both `products/desktop` and backend paths: desktop releases auto-update and are not orchestrated with backend deploys. The halves are independent, so this could have carried the skip label, but splitting makes the rollout ordering visible to a reviewer rather than resting on a label.

A multi-agent review of the combined change caught both defects fixed here: the signal was derived only from message deliveries, so it reported idle for an autonomous run's first turn, and the pi runtime had no such field at all.

Public artifact: the investigation behind this ran on production data and an internal document. Neither appears in the code, tests, commit message, or this description.
