### PR TITLE
feat(workflows): add cohort membership repository for behavioral cohort point lookups

### DIFF
--- a/nodejs/src/cdp/cdp-services.ts
+++ b/nodejs/src/cdp/cdp-services.ts
@@ -15,6 +15,8 @@ import { WarehouseSourceWebhooksOutput } from './outputs/outputs'
 import { CdpProducerName } from './outputs/producers'
 import { createCdpOutputsRegistry } from './outputs/registry'
 import { CapturedEventsService } from './services/captured-events/captured-events.service'
+import { CohortMembershipRepository } from './services/cohorts/cohort-membership-repository'
+import { PostgresCohortMembershipRepository } from './services/cohorts/postgres-cohort-membership-repository'
 import { HogExecutorAsyncService } from './services/hog-executor-async.service'
 import { HogExecutorService } from './services/hog-executor.service'
 import { HogInputsService } from './services/hog-inputs.service'
@@ -83,6 +85,8 @@ export interface CdpCoreServices {
     recipientPreferencesService: RecipientPreferencesService
     emailSuppressionService: EmailSuppressionService
     teamWorkflowsConfigService: TeamWorkflowsConfigService
+    /** Point lookups for realtime/behavioral cohort membership (behavioral cohorts DB). */
+    cohortMembershipRepository: CohortMembershipRepository
     hogFlowExecutor: HogFlowExecutorService
     hogFunctionMonitoringService: HogFunctionMonitoringService
     capturedEventsService: CapturedEventsService
@@ -466,6 +470,7 @@ export function createCdpCoreServices(
     // whose capabilities execute email actions; everywhere else this is null
     // and EmailValidationService degrades to the local cache + DNS.
     const emailValidationService = new EmailValidationService(deps.emailValidationValkey)
+    const cohortMembershipRepository = new PostgresCohortMembershipRepository(deps.postgres)
     // Observer writes to both stores; the read source decides which verdict drives the metric.
     const hogFlowDuplicateObserver = new HogFlowDuplicateObserverService(redis, valkeyShadow.writer)
     const hogFlowExecutor = new HogFlowExecutorService(
@@ -505,6 +510,7 @@ export function createCdpCoreServices(
         recipientPreferencesService,
         emailSuppressionService,
         teamWorkflowsConfigService,
+        cohortMembershipRepository,
         hogFlowExecutor,
         hogFunctionMonitoringService,
         capturedEventsService,

--- a/nodejs/src/cdp/services/cohorts/cohort-membership-repository.ts
+++ b/nodejs/src/cdp/services/cohorts/cohort-membership-repository.ts
@@ -1,0 +1,27 @@
+/**
+ * Point lookups for realtime/behavioral cohort membership, backed by the
+ * `cohort_membership` table in the behavioral cohorts database. Mirrors the
+ * Rust `CohortMembershipProvider` used by feature flags
+ * (rust/feature-flags/src/cohorts/membership).
+ */
+export interface CohortMembershipRepository {
+    /**
+     * Check membership for a person across multiple cohorts.
+     *
+     * Returns a map of cohort_id -> is_member covering every requested cohort.
+     * A cohort without a membership row is a non-member (`false`) — the write
+     * side only ever upserts rows, so absence means the person never entered.
+     */
+    getMemberships(teamId: number, personUuid: string, cohortIds: number[]): Promise<Map<number, boolean>>
+}
+
+/**
+ * Used where the behavioral cohorts database is not available (e.g. hobby
+ * deploys, where the pool falls back to the main app DB without the
+ * `cohort_membership` table). Conservatively reports non-membership.
+ */
+export class NoOpCohortMembershipRepository implements CohortMembershipRepository {
+    getMemberships(_teamId: number, _personUuid: string, cohortIds: number[]): Promise<Map<number, boolean>> {
+        return Promise.resolve(new Map(cohortIds.map((id) => [id, false])))
+    }
+}

--- a/nodejs/src/cdp/services/cohorts/cohort-membership-repository.ts
+++ b/nodejs/src/cdp/services/cohorts/cohort-membership-repository.ts
@@ -1,21 +1,8 @@
-/**
- * Point lookups for realtime/behavioral cohort membership, backed by the
- * `cohort_membership` table in the behavioral cohorts database. Mirrors the
- * Rust `CohortMembershipProvider` used by feature flags
- * (rust/feature-flags/src/cohorts/membership).
- */
 export interface CohortMembershipRepository {
     /**
-     * Check membership for a person across multiple cohorts.
-     *
-     * Returns a map of cohort_id -> is_member covering every requested cohort.
-     * A cohort without a membership row is a non-member (`false`) — the write
-     * side only ever upserts rows, so absence means the person never entered.
-     *
-     * There is deliberately no degraded implementation that fakes non-membership:
-     * environments without the behavioral cohorts pipeline (e.g. hobby) are kept
-     * fail-closed at save time, and a failed lookup must surface as an error
-     * rather than silently routing a person as a non-member.
+     * Returns cohort_id -> is_member for every requested cohort; a cohort without a
+     * membership row is a non-member. Deliberately no degraded implementation: a failed
+     * lookup must surface as an error, never silently answer non-member.
      */
     getMemberships(teamId: number, personUuid: string, cohortIds: number[]): Promise<Map<number, boolean>>
 }

--- a/nodejs/src/cdp/services/cohorts/cohort-membership-repository.ts
+++ b/nodejs/src/cdp/services/cohorts/cohort-membership-repository.ts
@@ -1,8 +1,8 @@
 export interface CohortMembershipRepository {
     /**
-     * Returns cohort_id -> is_member for every requested cohort; a cohort without a
-     * membership row is a non-member. Deliberately no degraded implementation: a failed
-     * lookup must surface as an error, never silently answer non-member.
+     * The full set of cohort ids the person is currently a member of. Deliberately no
+     * degraded implementation: a failed lookup must surface as an error, never silently
+     * answer non-member.
      */
-    getMemberships(teamId: number, personUuid: string, cohortIds: number[]): Promise<Map<number, boolean>>
+    getMemberCohortIds(teamId: number, personUuid: string): Promise<number[]>
 }

--- a/nodejs/src/cdp/services/cohorts/cohort-membership-repository.ts
+++ b/nodejs/src/cdp/services/cohorts/cohort-membership-repository.ts
@@ -11,17 +11,11 @@ export interface CohortMembershipRepository {
      * Returns a map of cohort_id -> is_member covering every requested cohort.
      * A cohort without a membership row is a non-member (`false`) — the write
      * side only ever upserts rows, so absence means the person never entered.
+     *
+     * There is deliberately no degraded implementation that fakes non-membership:
+     * environments without the behavioral cohorts pipeline (e.g. hobby) are kept
+     * fail-closed at save time, and a failed lookup must surface as an error
+     * rather than silently routing a person as a non-member.
      */
     getMemberships(teamId: number, personUuid: string, cohortIds: number[]): Promise<Map<number, boolean>>
-}
-
-/**
- * Used where the behavioral cohorts database is not available (e.g. hobby
- * deploys, where the pool falls back to the main app DB without the
- * `cohort_membership` table). Conservatively reports non-membership.
- */
-export class NoOpCohortMembershipRepository implements CohortMembershipRepository {
-    getMemberships(_teamId: number, _personUuid: string, cohortIds: number[]): Promise<Map<number, boolean>> {
-        return Promise.resolve(new Map(cohortIds.map((id) => [id, false])))
-    }
 }

--- a/nodejs/src/cdp/services/cohorts/postgres-cohort-membership-repository.test.ts
+++ b/nodejs/src/cdp/services/cohorts/postgres-cohort-membership-repository.test.ts
@@ -26,35 +26,25 @@ describe('PostgresCohortMembershipRepository', () => {
         repository = new PostgresCohortMembershipRepository(postgres)
     })
 
-    it('resolves membership from cohort_membership rows, scoped to the team', async () => {
+    it('returns the cohorts the person is currently in, scoped to the team', async () => {
         const teamId = 2
         const personUuid = new UUIDT().toString()
         await insertCohortMemberships(postgres, [
             { team_id: teamId, cohort_id: 101, person_id: personUuid, in_cohort: true },
-            { team_id: teamId, cohort_id: 102, person_id: personUuid, in_cohort: false },
-            { team_id: teamId + 1, cohort_id: 103, person_id: personUuid, in_cohort: true },
+            { team_id: teamId, cohort_id: 102, person_id: personUuid, in_cohort: false }, // person left
+            { team_id: teamId + 1, cohort_id: 103, person_id: personUuid, in_cohort: true }, // another team, must not leak
+            { team_id: teamId, cohort_id: 104, person_id: personUuid, in_cohort: true },
         ])
 
-        const result = await repository.getMemberships(teamId, personUuid, [101, 102, 103, 104])
+        const result = await repository.getMemberCohortIds(teamId, personUuid)
 
-        expect(result).toEqual(
-            new Map([
-                [101, true],
-                [102, false], // person left
-                [103, false], // another team, must not leak
-                [104, false], // no row
-            ])
-        )
+        expect(result.sort()).toEqual([101, 104])
     })
 
-    it('short-circuits on an empty cohort id list without querying', async () => {
-        const querySpy = jest.spyOn(postgres, 'query')
+    it('returns an empty set for a person the pipeline never wrote a row for', async () => {
+        const result = await repository.getMemberCohortIds(2, new UUIDT().toString())
 
-        const result = await repository.getMemberships(2, new UUIDT().toString(), [])
-
-        expect(result).toEqual(new Map())
-        expect(querySpy).not.toHaveBeenCalled()
-        querySpy.mockRestore()
+        expect(result).toEqual([])
     })
 
     it('rejects with a retriable timeout error when the lookup hangs', async () => {
@@ -63,7 +53,7 @@ describe('PostgresCohortMembershipRepository', () => {
             const hangingRouter = { query: () => new Promise(() => {}) } as unknown as PostgresRouter
             const hangingRepository = new PostgresCohortMembershipRepository(hangingRouter, 500)
 
-            const lookup = hangingRepository.getMemberships(2, new UUIDT().toString(), [1])
+            const lookup = hangingRepository.getMemberCohortIds(2, new UUIDT().toString())
             const assertion = expect(lookup).rejects.toThrow(CohortMembershipLookupTimeoutError)
             jest.advanceTimersByTime(500)
             await assertion

--- a/nodejs/src/cdp/services/cohorts/postgres-cohort-membership-repository.test.ts
+++ b/nodejs/src/cdp/services/cohorts/postgres-cohort-membership-repository.test.ts
@@ -1,0 +1,75 @@
+import { defaultConfig } from '~/common/config/config'
+import { PostgresRouter } from '~/common/utils/db/postgres'
+import { UUIDT } from '~/common/utils/utils'
+import { resetBehavioralCohortsDatabase } from '~/tests/helpers/sql'
+
+import { insertCohortMemberships } from '../../_tests/fixtures'
+import {
+    CohortMembershipLookupTimeoutError,
+    PostgresCohortMembershipRepository,
+} from './postgres-cohort-membership-repository'
+
+describe('PostgresCohortMembershipRepository', () => {
+    let postgres: PostgresRouter
+    let repository: PostgresCohortMembershipRepository
+
+    beforeAll(async () => {
+        postgres = new PostgresRouter(defaultConfig)
+        await resetBehavioralCohortsDatabase(postgres)
+    })
+
+    afterAll(async () => {
+        await postgres.end()
+    })
+
+    beforeEach(() => {
+        repository = new PostgresCohortMembershipRepository(postgres)
+    })
+
+    it('resolves membership from cohort_membership rows, scoped to the team', async () => {
+        const teamId = 2
+        const personUuid = new UUIDT().toString()
+        await insertCohortMemberships(postgres, [
+            { team_id: teamId, cohort_id: 101, person_id: personUuid, in_cohort: true },
+            { team_id: teamId, cohort_id: 102, person_id: personUuid, in_cohort: false },
+            { team_id: teamId + 1, cohort_id: 103, person_id: personUuid, in_cohort: true },
+        ])
+
+        const result = await repository.getMemberships(teamId, personUuid, [101, 102, 103, 104])
+
+        expect(result).toEqual(
+            new Map([
+                [101, true], // in_cohort=true row
+                [102, false], // in_cohort=false row (person left)
+                [103, false], // row belongs to another team — must not leak
+                [104, false], // no row at all
+            ])
+        )
+    })
+
+    it('short-circuits on an empty cohort id list without querying', async () => {
+        const querySpy = jest.spyOn(postgres, 'query')
+
+        const result = await repository.getMemberships(2, new UUIDT().toString(), [])
+
+        expect(result).toEqual(new Map())
+        expect(querySpy).not.toHaveBeenCalled()
+        querySpy.mockRestore()
+    })
+
+    it('rejects with a retriable timeout error when the lookup hangs', async () => {
+        jest.useFakeTimers()
+        try {
+            const hangingRouter = { query: () => new Promise(() => {}) } as unknown as PostgresRouter
+            const hangingRepository = new PostgresCohortMembershipRepository(hangingRouter, 500)
+
+            const lookup = hangingRepository.getMemberships(2, new UUIDT().toString(), [1])
+            const assertion = expect(lookup).rejects.toThrow(CohortMembershipLookupTimeoutError)
+            jest.advanceTimersByTime(500)
+            await assertion
+            await expect(lookup.catch((e) => e.isRetriable)).resolves.toBe(true)
+        } finally {
+            jest.useRealTimers()
+        }
+    })
+})

--- a/nodejs/src/cdp/services/cohorts/postgres-cohort-membership-repository.test.ts
+++ b/nodejs/src/cdp/services/cohorts/postgres-cohort-membership-repository.test.ts
@@ -39,10 +39,10 @@ describe('PostgresCohortMembershipRepository', () => {
 
         expect(result).toEqual(
             new Map([
-                [101, true], // in_cohort=true row
-                [102, false], // in_cohort=false row (person left)
-                [103, false], // row belongs to another team — must not leak
-                [104, false], // no row at all
+                [101, true],
+                [102, false], // person left
+                [103, false], // another team, must not leak
+                [104, false], // no row
             ])
         )
     })

--- a/nodejs/src/cdp/services/cohorts/postgres-cohort-membership-repository.test.ts
+++ b/nodejs/src/cdp/services/cohorts/postgres-cohort-membership-repository.test.ts
@@ -1,3 +1,5 @@
+import { register } from 'prom-client'
+
 import { defaultConfig } from '~/common/config/config'
 import { PostgresRouter } from '~/common/utils/db/postgres'
 import { UUIDT } from '~/common/utils/utils'
@@ -8,6 +10,16 @@ import {
     CohortMembershipLookupTimeoutError,
     PostgresCohortMembershipRepository,
 } from './postgres-cohort-membership-repository'
+
+// Counter is a module-scoped global, so compare deltas rather than reset shared state between tests.
+const outcomeCount = async (outcome: string): Promise<number> => {
+    const metric = register.getSingleMetric('cdp_cohort_membership_lookups_total')
+    if (!metric) {
+        return 0
+    }
+    const data = await metric.get()
+    return data.values.find((v) => (v.labels as Record<string, string>).outcome === outcome)?.value ?? 0
+}
 
 describe('PostgresCohortMembershipRepository', () => {
     let postgres: PostgresRouter
@@ -58,6 +70,34 @@ describe('PostgresCohortMembershipRepository', () => {
             jest.advanceTimersByTime(500)
             await assertion
             await expect(lookup.catch((e) => e.isRetriable)).resolves.toBe(true)
+        } finally {
+            jest.useRealTimers()
+        }
+    })
+
+    it('records exactly one outcome when the query settles after timing out', async () => {
+        jest.useFakeTimers()
+        try {
+            let resolveQuery!: (value: { rows: { cohort_id: string }[] }) => void
+            const lateRouter = {
+                query: () => new Promise((resolve) => (resolveQuery = resolve)),
+            } as unknown as PostgresRouter
+            const lateRepository = new PostgresCohortMembershipRepository(lateRouter, 500)
+
+            const timeoutBefore = await outcomeCount('timeout')
+            const successBefore = await outcomeCount('success')
+
+            const lookup = lateRepository.getMemberCohortIds(2, new UUIDT().toString())
+            jest.advanceTimersByTime(500)
+            await expect(lookup).rejects.toThrow(CohortMembershipLookupTimeoutError)
+
+            // The underlying query settles a moment later; its handler must not record a second outcome
+            resolveQuery({ rows: [{ cohort_id: '101' }] })
+            await Promise.resolve()
+            await Promise.resolve()
+
+            expect(await outcomeCount('timeout')).toBe(timeoutBefore + 1)
+            expect(await outcomeCount('success')).toBe(successBefore)
         } finally {
             jest.useRealTimers()
         }

--- a/nodejs/src/cdp/services/cohorts/postgres-cohort-membership-repository.ts
+++ b/nodejs/src/cdp/services/cohorts/postgres-cohort-membership-repository.ts
@@ -27,20 +27,15 @@ export class PostgresCohortMembershipRepository implements CohortMembershipRepos
         private lookupTimeoutMs: number = DEFAULT_LOOKUP_TIMEOUT_MS
     ) {}
 
-    async getMemberships(teamId: number, personUuid: string, cohortIds: number[]): Promise<Map<number, boolean>> {
-        if (cohortIds.length === 0) {
-            return new Map()
-        }
-
+    async getMemberCohortIds(teamId: number, personUuid: string): Promise<number[]> {
         const queryPromise = this.postgres.query<{ cohort_id: string }>(
             PostgresUse.BEHAVIORAL_COHORTS_RW,
             `SELECT cohort_id
              FROM cohort_membership
              WHERE team_id = $1
                AND person_id = $2
-               AND cohort_id = ANY($3)
                AND in_cohort = true`,
-            [teamId, personUuid, cohortIds],
+            [teamId, personUuid],
             'fetchCohortMemberships'
         )
 
@@ -67,7 +62,6 @@ export class PostgresCohortMembershipRepository implements CohortMembershipRepos
         })
 
         // BIGINT columns come back from pg as strings
-        const memberIds = new Set(result.rows.map((row) => Number(row.cohort_id)))
-        return new Map(cohortIds.map((id) => [id, memberIds.has(id)]))
+        return result.rows.map((row) => Number(row.cohort_id))
     }
 }

--- a/nodejs/src/cdp/services/cohorts/postgres-cohort-membership-repository.ts
+++ b/nodejs/src/cdp/services/cohorts/postgres-cohort-membership-repository.ts
@@ -40,7 +40,12 @@ export class PostgresCohortMembershipRepository implements CohortMembershipRepos
         )
 
         const result = await new Promise<Awaited<typeof queryPromise>>((resolve, reject) => {
+            // The timer and the query race. The query's handlers stay registered after the timer
+            // wins and fire when it settles late, so this flag stops the loser from recording a
+            // second outcome and double-counting the lookup in the metric.
+            let settled = false
             const timer = setTimeout(() => {
+                settled = true
                 // Swallow the losing query's settlement so it can't become an unhandled rejection
                 queryPromise.catch(() => undefined)
                 cohortMembershipLookupsCounter.labels('timeout').inc()
@@ -49,11 +54,19 @@ export class PostgresCohortMembershipRepository implements CohortMembershipRepos
 
             queryPromise.then(
                 (res) => {
+                    if (settled) {
+                        return
+                    }
+                    settled = true
                     clearTimeout(timer)
                     cohortMembershipLookupsCounter.labels('success').inc()
                     resolve(res)
                 },
                 (err) => {
+                    if (settled) {
+                        return
+                    }
+                    settled = true
                     clearTimeout(timer)
                     cohortMembershipLookupsCounter.labels('error').inc()
                     reject(err)

--- a/nodejs/src/cdp/services/cohorts/postgres-cohort-membership-repository.ts
+++ b/nodejs/src/cdp/services/cohorts/postgres-cohort-membership-repository.ts
@@ -1,0 +1,77 @@
+import { Counter } from 'prom-client'
+
+import { PostgresRouter, PostgresUse } from '~/common/utils/db/postgres'
+
+import { CohortMembershipRepository } from './cohort-membership-repository'
+
+const cohortMembershipLookupsCounter = new Counter({
+    name: 'cdp_cohort_membership_lookups_total',
+    help: 'Point lookups against the behavioral cohorts cohort_membership table, by outcome.',
+    labelNames: ['outcome'],
+})
+
+export class CohortMembershipLookupTimeoutError extends Error {
+    constructor(timeoutMs: number) {
+        super(`Cohort membership lookup timed out after ${timeoutMs}ms`)
+        this.name = 'CohortMembershipLookupTimeoutError'
+    }
+    readonly isRetriable = true
+}
+
+// Upper bound on one lookup, covering pool acquire + query. Matches the Rust flags
+// provider's 1s bound: its job is to cover what a statement timeout cannot — pool
+// acquire stalls and network black holes — so an unreachable behavioral cohorts DB
+// costs a bounded slice of the invocation, not a hung batch.
+export const DEFAULT_LOOKUP_TIMEOUT_MS = 1000
+
+export class PostgresCohortMembershipRepository implements CohortMembershipRepository {
+    constructor(
+        private postgres: PostgresRouter,
+        private lookupTimeoutMs: number = DEFAULT_LOOKUP_TIMEOUT_MS
+    ) {}
+
+    async getMemberships(teamId: number, personUuid: string, cohortIds: number[]): Promise<Map<number, boolean>> {
+        if (cohortIds.length === 0) {
+            return new Map()
+        }
+
+        const queryPromise = this.postgres.query<{ cohort_id: string }>(
+            PostgresUse.BEHAVIORAL_COHORTS_RW,
+            `SELECT cohort_id
+             FROM cohort_membership
+             WHERE team_id = $1
+               AND person_id = $2
+               AND cohort_id = ANY($3)
+               AND in_cohort = true`,
+            [teamId, personUuid, cohortIds],
+            'fetchCohortMemberships'
+        )
+
+        const result = await new Promise<Awaited<typeof queryPromise>>((resolve, reject) => {
+            const timer = setTimeout(() => {
+                // The losing query promise keeps running server-side; swallow its
+                // eventual settlement so it can't surface as an unhandled rejection.
+                queryPromise.catch(() => undefined)
+                cohortMembershipLookupsCounter.labels('timeout').inc()
+                reject(new CohortMembershipLookupTimeoutError(this.lookupTimeoutMs))
+            }, this.lookupTimeoutMs)
+
+            queryPromise.then(
+                (res) => {
+                    clearTimeout(timer)
+                    cohortMembershipLookupsCounter.labels('success').inc()
+                    resolve(res)
+                },
+                (err) => {
+                    clearTimeout(timer)
+                    cohortMembershipLookupsCounter.labels('error').inc()
+                    reject(err)
+                }
+            )
+        })
+
+        // BIGINT columns come back from pg as strings
+        const memberIds = new Set(result.rows.map((row) => Number(row.cohort_id)))
+        return new Map(cohortIds.map((id) => [id, memberIds.has(id)]))
+    }
+}

--- a/nodejs/src/cdp/services/cohorts/postgres-cohort-membership-repository.ts
+++ b/nodejs/src/cdp/services/cohorts/postgres-cohort-membership-repository.ts
@@ -18,10 +18,7 @@ export class CohortMembershipLookupTimeoutError extends Error {
     readonly isRetriable = true
 }
 
-// Upper bound on one lookup, covering pool acquire + query. Matches the Rust flags
-// provider's 1s bound: its job is to cover what a statement timeout cannot — pool
-// acquire stalls and network black holes — so an unreachable behavioral cohorts DB
-// costs a bounded slice of the invocation, not a hung batch.
+// Bounds pool-acquire stalls and network black holes that a statement timeout cannot cover
 export const DEFAULT_LOOKUP_TIMEOUT_MS = 1000
 
 export class PostgresCohortMembershipRepository implements CohortMembershipRepository {
@@ -49,8 +46,7 @@ export class PostgresCohortMembershipRepository implements CohortMembershipRepos
 
         const result = await new Promise<Awaited<typeof queryPromise>>((resolve, reject) => {
             const timer = setTimeout(() => {
-                // The losing query promise keeps running server-side; swallow its
-                // eventual settlement so it can't surface as an unhandled rejection.
+                // Swallow the losing query's settlement so it can't become an unhandled rejection
                 queryPromise.catch(() => undefined)
                 cohortMembershipLookupsCounter.labels('timeout').inc()
                 reject(new CohortMembershipLookupTimeoutError(this.lookupTimeoutMs))


### PR DESCRIPTION
## Problem

Workflow conditional branches need to answer "is this person in cohort X?" while a run executes. The realtime cohort pipeline already maintains the answer — membership lands in the behavioral cohorts database (`cohort_membership`, written by `CdpCohortMembershipConsumer`) — but nothing on the Node side reads that table yet.

This is the bottom layer of stack #83802 (behavioral cohorts in workflow conditional branches). It's the read side only: no callers until the next layer wires it into the conditional branch handler.

## Changes

**`CohortMembershipRepository`** — one method: `getMemberCohortIds(teamId, personUuid)` returns the full set of cohort ids the person is currently in. One indexed query against `cohort_membership` on the `BEHAVIORAL_COHORTS_RW` pool (the set is small: it's bounded by the team's realtime cohorts), capped at 1 second so an unreachable behavioral cohorts DB costs a bounded slice of an invocation rather than a hung batch. Fetching the *complete* set rather than specific ids is deliberate: it makes the downstream `inCohort(id)` evaluation a pure lookup over prefetched data (see #83799).

There's intentionally **no NoOp/degraded implementation**: environments without the pipeline (hobby) are fail-closed at save time by the rollout flag, and a failed lookup should surface as an error — silently answering "not a member" would route people down the wrong branch. Tests stub the interface inline.

Constructed in `createCdpCoreServices`, so downstream services get it via injection.

## How did you test this code?

I'm an agent: a functional test runs the real SQL against the test behavioral cohorts DB — schema drift on `cohort_membership`, a broken `in_cohort` predicate, or lost team scoping would surface only here, since nothing else exercises this query. A fake-timer test proves a hanging lookup rejects with a retriable timeout error instead of blocking forever. Typecheck and lint clean locally; I didn't run the wider jest suite (CI does).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code. Skills followed: writing-tests, stacking-prs, writing-pr-descriptions. Design notes: an earlier revision mirrored the Rust flags provider's contract (targeted per-cohort-id lookup returning a map) and a NoOp implementation; both were dropped at the assignee's direction — the full-set query enables the pure STL evaluation upstack, and the NoOp contradicted the fail-loud semantics the runtime builds on.
