### PR TITLE
feat(workflows): compile cohort filters in conditional branch conditions

### DIFF
--- a/posthog/cdp/filters.py
+++ b/posthog/cdp/filters.py
@@ -321,6 +321,15 @@ def filter_cohort_ids(filters: Optional[dict]) -> list[int]:
                     pass
 
     _walk(filters.get("properties") or [])
+    # Each event/action entry carries its own `properties`, which the compiler compiles too
+    # (hog_function_filters_to_expr), so a cohort leaf there must be eligibility-validated and
+    # must enable cohort compilation, exactly like a top-level one.
+    for key in ("events", "actions"):
+        entries = filters.get(key)
+        if isinstance(entries, list):
+            for entry in entries:
+                if isinstance(entry, dict):
+                    _walk(entry.get("properties") or [])
     return sorted(ids)
 
 

--- a/posthog/cdp/filters.py
+++ b/posthog/cdp/filters.py
@@ -295,32 +295,38 @@ def filter_action_ids(filters: Optional[dict]) -> list[int]:
         return []
 
 
-def filter_cohort_ids(filters: Optional[dict]) -> list[int]:
-    """Cohort ids referenced by the filters' property tree, for save-time eligibility validation."""
-    if not filters:
-        return []
-
+def collect_property_cohort_ids(node: Any) -> set[int]:
+    """Cohort ids in a property tree (lists, AND/OR groups, and cohort leaves)."""
     ids: set[int] = set()
 
-    def _walk(node: Any) -> None:
-        if isinstance(node, list):
-            for item in node:
+    def _walk(current: Any) -> None:
+        if isinstance(current, list):
+            for item in current:
                 _walk(item)
             return
-        if not isinstance(node, dict):
+        if not isinstance(current, dict):
             return
-        if node.get("type") in ("AND", "OR"):
-            _walk(node.get("values") or [])
+        if current.get("type") in ("AND", "OR"):
+            _walk(current.get("values") or [])
             return
-        if _is_cohort_filter(node):
-            value = node.get("value")
+        if _is_cohort_filter(current):
+            value = current.get("value")
             if isinstance(value, str | int) and not isinstance(value, bool):
                 try:
                     ids.add(int(value))
                 except ValueError:
                     pass
 
-    _walk(filters.get("properties") or [])
+    _walk(node)
+    return ids
+
+
+def filter_cohort_ids(filters: Optional[dict]) -> list[int]:
+    """Cohort ids referenced by the filters' property tree, for save-time eligibility validation."""
+    if not filters:
+        return []
+
+    ids = collect_property_cohort_ids(filters.get("properties") or [])
     # Each event/action entry carries its own `properties`, which the compiler compiles too
     # (hog_function_filters_to_expr), so a cohort leaf there must be eligibility-validated and
     # must enable cohort compilation, exactly like a top-level one.
@@ -329,7 +335,7 @@ def filter_cohort_ids(filters: Optional[dict]) -> list[int]:
         if isinstance(entries, list):
             for entry in entries:
                 if isinstance(entry, dict):
-                    _walk(entry.get("properties") or [])
+                    ids |= collect_property_cohort_ids(entry.get("properties") or [])
     return sorted(ids)
 
 

--- a/posthog/cdp/filters.py
+++ b/posthog/cdp/filters.py
@@ -406,11 +406,7 @@ def compile_filters_bytecode(
         expr = _LowerConstantMembership().visit(expr)
         context = HogQLContext(team_id=team.id)
         filters["bytecode"] = create_bytecode(
-            expr,
-            context=context,
-            cohort_membership_supported=cohort_membership_supported,
-            # Host functions the runtime injects (conditional_branch.ts), not STL
-            supported_functions={"inCohort", "notInCohort"} if cohort_membership_supported else None,
+            expr, context=context, cohort_membership_supported=cohort_membership_supported
         ).bytecode
         if cohort_membership_supported:
             filters["cohort_ids"] = filter_cohort_ids(filters)

--- a/posthog/cdp/filters.py
+++ b/posthog/cdp/filters.py
@@ -287,11 +287,13 @@ def hog_function_filters_to_expr(filters: dict, team: Team, actions: dict[int, A
 
 
 def filter_action_ids(filters: Optional[dict]) -> list[int]:
-    if not filters:
+    # Total over untrusted input: callers scan raw client filters before DRF validation, so
+    # malformed shapes must yield [] here and get their structured 400 from the serializer.
+    if not isinstance(filters, dict):
         return []
     try:
         return [int(action["id"]) for action in filters.get("actions", [])]
-    except KeyError:
+    except (KeyError, TypeError, ValueError):
         return []
 
 
@@ -322,8 +324,12 @@ def collect_property_cohort_ids(node: Any) -> set[int]:
 
 
 def filter_cohort_ids(filters: Optional[dict]) -> list[int]:
-    """Cohort ids referenced by the filters' property tree, for save-time eligibility validation."""
-    if not filters:
+    """Cohort ids referenced by the filters' property tree, for save-time eligibility validation.
+
+    Total over untrusted input, like filter_action_ids: callers scan raw client filters
+    before DRF validation, so a malformed shape yields [] instead of raising.
+    """
+    if not isinstance(filters, dict):
         return []
 
     ids = collect_property_cohort_ids(filters.get("properties") or [])

--- a/posthog/cdp/filters.py
+++ b/posthog/cdp/filters.py
@@ -296,11 +296,8 @@ def filter_action_ids(filters: Optional[dict]) -> list[int]:
 
 
 def filter_cohort_ids(filters: Optional[dict]) -> list[int]:
-    """Cohort ids referenced by the filters' global property tree.
-
-    Stored on compiled filters (as `cohort_ids`) so the runtime can prefetch cohort
-    membership for the bytecode's inCohort/notInCohort calls without parsing bytecode.
-    """
+    """Cohort ids referenced by the filters' property tree, stored on compiled filters
+    so the runtime can prefetch membership without parsing bytecode."""
     if not filters:
         return []
 
@@ -412,8 +409,7 @@ def compile_filters_bytecode(
             expr,
             context=context,
             cohort_membership_supported=cohort_membership_supported,
-            # inCohort/notInCohort aren't STL functions; the runtime injects them as host
-            # functions closing over prefetched membership (see conditional_branch.ts)
+            # Host functions the runtime injects (conditional_branch.ts), not STL
             supported_functions={"inCohort", "notInCohort"} if cohort_membership_supported else None,
         ).bytecode
         if cohort_membership_supported:

--- a/posthog/cdp/filters.py
+++ b/posthog/cdp/filters.py
@@ -296,8 +296,7 @@ def filter_action_ids(filters: Optional[dict]) -> list[int]:
 
 
 def filter_cohort_ids(filters: Optional[dict]) -> list[int]:
-    """Cohort ids referenced by the filters' property tree, stored on compiled filters
-    so the runtime can prefetch membership without parsing bytecode."""
+    """Cohort ids referenced by the filters' property tree, for save-time eligibility validation."""
     if not filters:
         return []
 
@@ -396,8 +395,6 @@ def compile_filters_bytecode(
     cohort_membership_supported: bool = False,
 ) -> dict:
     filters = filters or {}
-    # Derived below on a successful compile; never trust a caller-supplied value
-    filters.pop("cohort_ids", None)
     try:
         expr = compile_filters_expr(filters, team, actions)
         if SelectFinder.has_select(expr):
@@ -408,8 +405,6 @@ def compile_filters_bytecode(
         filters["bytecode"] = create_bytecode(
             expr, context=context, cohort_membership_supported=cohort_membership_supported
         ).bytecode
-        if cohort_membership_supported:
-            filters["cohort_ids"] = filter_cohort_ids(filters)
 
         # context.errors here only contains "function not implemented" errors from the
         # bytecode compiler (the resolver doesn't run during create_bytecode). These are

--- a/posthog/cdp/filters.py
+++ b/posthog/cdp/filters.py
@@ -408,6 +408,7 @@ def compile_filters_bytecode(
     team: Team,
     actions: Optional[dict[int, Action]] = None,
     cohort_membership_supported: bool = False,
+    allowed_cohort_ids: Optional[set[int]] = None,
 ) -> dict:
     filters = filters or {}
     try:
@@ -418,7 +419,10 @@ def compile_filters_bytecode(
         expr = _LowerConstantMembership().visit(expr)
         context = HogQLContext(team_id=team.id)
         filters["bytecode"] = create_bytecode(
-            expr, context=context, cohort_membership_supported=cohort_membership_supported
+            expr,
+            context=context,
+            cohort_membership_supported=cohort_membership_supported,
+            allowed_cohort_ids=allowed_cohort_ids,
         ).bytecode
 
         # context.errors here only contains "function not implemented" errors from the

--- a/posthog/cdp/filters.py
+++ b/posthog/cdp/filters.py
@@ -295,6 +295,39 @@ def filter_action_ids(filters: Optional[dict]) -> list[int]:
         return []
 
 
+def filter_cohort_ids(filters: Optional[dict]) -> list[int]:
+    """Cohort ids referenced by the filters' global property tree.
+
+    Stored on compiled filters (as `cohort_ids`) so the runtime can prefetch cohort
+    membership for the bytecode's inCohort/notInCohort calls without parsing bytecode.
+    """
+    if not filters:
+        return []
+
+    ids: set[int] = set()
+
+    def _walk(node: Any) -> None:
+        if isinstance(node, list):
+            for item in node:
+                _walk(item)
+            return
+        if not isinstance(node, dict):
+            return
+        if node.get("type") in ("AND", "OR"):
+            _walk(node.get("values") or [])
+            return
+        if _is_cohort_filter(node):
+            value = node.get("value")
+            if isinstance(value, str | int) and not isinstance(value, bool):
+                try:
+                    ids.add(int(value))
+                except ValueError:
+                    pass
+
+    _walk(filters.get("properties") or [])
+    return sorted(ids)
+
+
 def compile_filters_expr(filters: Optional[dict], team: Team, actions: Optional[dict[int, Action]] = None) -> ast.Expr:
     filters = filters or {}
 
@@ -359,8 +392,15 @@ class _LowerConstantMembership(CloningVisitor):
         return super().visit_compare_operation(node)
 
 
-def compile_filters_bytecode(filters: Optional[dict], team: Team, actions: Optional[dict[int, Action]] = None) -> dict:
+def compile_filters_bytecode(
+    filters: Optional[dict],
+    team: Team,
+    actions: Optional[dict[int, Action]] = None,
+    cohort_membership_supported: bool = False,
+) -> dict:
     filters = filters or {}
+    # Derived below on a successful compile; never trust a caller-supplied value
+    filters.pop("cohort_ids", None)
     try:
         expr = compile_filters_expr(filters, team, actions)
         if SelectFinder.has_select(expr):
@@ -368,7 +408,16 @@ def compile_filters_bytecode(filters: Optional[dict], team: Team, actions: Optio
 
         expr = _LowerConstantMembership().visit(expr)
         context = HogQLContext(team_id=team.id)
-        filters["bytecode"] = create_bytecode(expr, context=context).bytecode
+        filters["bytecode"] = create_bytecode(
+            expr,
+            context=context,
+            cohort_membership_supported=cohort_membership_supported,
+            # inCohort/notInCohort aren't STL functions; the runtime injects them as host
+            # functions closing over prefetched membership (see conditional_branch.ts)
+            supported_functions={"inCohort", "notInCohort"} if cohort_membership_supported else None,
+        ).bytecode
+        if cohort_membership_supported:
+            filters["cohort_ids"] = filter_cohort_ids(filters)
 
         # context.errors here only contains "function not implemented" errors from the
         # bytecode compiler (the resolver doesn't run during create_bytecode). These are

--- a/posthog/cdp/validation.py
+++ b/posthog/cdp/validation.py
@@ -947,14 +947,15 @@ class HogFunctionFiltersSerializer(serializers.Serializer):
         if not cohort_ids:
             return set()
 
-        cohorts = {
-            cohort.pk: cohort
-            for cohort in Cohort.objects.filter(pk__in=cohort_ids, team__project_id=team.project_id, deleted=False)
-        }
+        # Scoped to the environment, not the project: the runtime queries cohort_membership with
+        # the workflow's team_id, and membership rows are keyed by the cohort's own team_id. A
+        # sibling environment's cohort would validate but never have rows under this team, so
+        # every person would evaluate as a non-member.
+        cohorts = {cohort.pk: cohort for cohort in Cohort.objects.filter(pk__in=cohort_ids, team=team, deleted=False)}
         for cohort_id in cohort_ids:
             cohort = cohorts.get(cohort_id)
             if cohort is None:
-                raise serializers.ValidationError(f"Cohort {cohort_id} doesn't exist in this project.")
+                raise serializers.ValidationError(f"Cohort {cohort_id} doesn't exist in this environment.")
             if cohort.is_static:
                 raise serializers.ValidationError(
                     f"Cohort {cohort_id} is a static cohort. Conditions can only use realtime cohorts."

--- a/posthog/cdp/validation.py
+++ b/posthog/cdp/validation.py
@@ -846,14 +846,6 @@ class HogFunctionFiltersSerializer(serializers.Serializer):
     transpiled = serializers.JSONField(required=False)
     filter_test_accounts = serializers.BooleanField(required=False)
     bytecode_error = serializers.CharField(required=False)
-    cohort_ids = serializers.ListField(
-        child=serializers.IntegerField(),
-        required=False,
-        help_text=(
-            "Cohorts referenced by the compiled filter bytecode's inCohort/notInCohort calls. "
-            "Derived at save time so the runtime can prefetch membership; caller-supplied values are ignored."
-        ),
-    )
 
     def to_internal_value(self, data):
         # Weirdly nested serializers don't get this set...

--- a/posthog/cdp/validation.py
+++ b/posthog/cdp/validation.py
@@ -923,9 +923,7 @@ class HogFunctionFiltersSerializer(serializers.Serializer):
         return data
 
     def _validate_realtime_cohorts(self, data: dict, team: Team) -> None:
-        """Only cohorts whose membership the realtime pipeline maintains in the cohort_membership
-        table may be referenced: the runtime answers inCohort with a point lookup against that
-        table, so any other cohort would evaluate everyone as a non-member."""
+        """A cohort without maintained cohort_membership rows would evaluate everyone as a non-member."""
         cohort_ids = filter_cohort_ids(data)
         if not cohort_ids:
             return

--- a/posthog/cdp/validation.py
+++ b/posthog/cdp/validation.py
@@ -14,10 +14,17 @@ from posthog.hogql.context import HogQLContext
 from posthog.hogql.parser import parse_program, parse_string_template
 from posthog.hogql.visitor import TraversingVisitor
 
-from posthog.cdp.filters import compile_filters_bytecode, compile_filters_expr, filter_cohort_ids
+from posthog.cdp.filters import (
+    collect_property_cohort_ids,
+    compile_filters_bytecode,
+    compile_filters_expr,
+    filter_action_ids,
+    filter_cohort_ids,
+)
 from posthog.models.integration import Integration
 from posthog.models.team.team import Team
 
+from products.actions.backend.models.action import Action
 from products.cdp.backend.models.hog_functions.hog_function import (
     TYPES_WITH_JAVASCRIPT_SOURCE,
     TYPES_WITH_TRANSPILED_FILTERS,
@@ -916,7 +923,16 @@ class HogFunctionFiltersSerializer(serializers.Serializer):
 
     def _validate_realtime_cohorts(self, data: dict, team: Team) -> None:
         """A cohort without maintained cohort_membership rows would evaluate everyone as a non-member."""
-        cohort_ids = filter_cohort_ids(data)
+        collected = set(filter_cohort_ids(data))
+        # A referenced Action's stored steps can carry cohort properties too, which
+        # action_to_expr inlines into the same compiled expression
+        action_ids = filter_action_ids(data)
+        if action_ids:
+            # nosemgrep: idor-lookup-without-team (scoped by team__project_id)
+            for action in Action.objects.filter(id__in=action_ids, team__project_id=team.project_id, deleted=False):
+                for step in action.steps:
+                    collected |= collect_property_cohort_ids(step.properties or [])
+        cohort_ids = sorted(collected)
         if not cohort_ids:
             return
 

--- a/posthog/cdp/validation.py
+++ b/posthog/cdp/validation.py
@@ -910,9 +910,15 @@ class HogFunctionFiltersSerializer(serializers.Serializer):
                 del data["bytecode"]
         else:
             cohort_membership_supported = bool(self.context.get("cohort_membership_supported"))
+            validated_cohort_ids: Optional[set[int]] = None
             if cohort_membership_supported:
-                self._validate_realtime_cohorts(data, team)
-            data = compile_filters_bytecode(data, team, cohort_membership_supported=cohort_membership_supported)
+                validated_cohort_ids = self._validate_realtime_cohorts(data, team)
+            data = compile_filters_bytecode(
+                data,
+                team,
+                cohort_membership_supported=cohort_membership_supported,
+                allowed_cohort_ids=validated_cohort_ids,
+            )
             # Uncompilable filters are only fatal when the function will run (stay enabled).
             # Callers that allow saving anyway (e.g. disabling/deleting a hog function) opt out
             # via context; the error stays persisted on the filters for the UI to surface.
@@ -921,8 +927,13 @@ class HogFunctionFiltersSerializer(serializers.Serializer):
 
         return data
 
-    def _validate_realtime_cohorts(self, data: dict, team: Team) -> None:
-        """A cohort without maintained cohort_membership rows would evaluate everyone as a non-member."""
+    def _validate_realtime_cohorts(self, data: dict, team: Team) -> set[int]:
+        """A cohort without maintained cohort_membership rows would evaluate everyone as a non-member.
+
+        Returns the validated ids so the compiler can reject any IN COHORT operand outside them.
+        Error messages carry the id rather than the name: they surface to callers holding only
+        workflow scopes, and a name would hand them a cohort-metadata oracle.
+        """
         collected = set(filter_cohort_ids(data))
         # A referenced Action's stored steps can carry cohort properties too, which
         # action_to_expr inlines into the same compiled expression
@@ -934,7 +945,7 @@ class HogFunctionFiltersSerializer(serializers.Serializer):
                     collected |= collect_property_cohort_ids(step.properties or [])
         cohort_ids = sorted(collected)
         if not cohort_ids:
-            return
+            return set()
 
         cohorts = {
             cohort.pk: cohort
@@ -946,13 +957,14 @@ class HogFunctionFiltersSerializer(serializers.Serializer):
                 raise serializers.ValidationError(f"Cohort {cohort_id} doesn't exist in this project.")
             if cohort.is_static:
                 raise serializers.ValidationError(
-                    f"Cohort '{cohort.name}' is a static cohort. Conditions can only use realtime cohorts."
+                    f"Cohort {cohort_id} is a static cohort. Conditions can only use realtime cohorts."
                 )
             if not cohort.is_flag_compatible:
                 raise serializers.ValidationError(
-                    f"Cohort '{cohort.name}' isn't ready for realtime evaluation. "
+                    f"Cohort {cohort_id} isn't ready for realtime evaluation. "
                     f"Conditions can only use realtime cohorts that have finished calculating."
                 )
+        return set(cohort_ids)
 
 
 class MappingsSerializer(serializers.Serializer):

--- a/posthog/cdp/validation.py
+++ b/posthog/cdp/validation.py
@@ -14,13 +14,15 @@ from posthog.hogql.context import HogQLContext
 from posthog.hogql.parser import parse_program, parse_string_template
 from posthog.hogql.visitor import TraversingVisitor
 
-from posthog.cdp.filters import compile_filters_bytecode, compile_filters_expr
+from posthog.cdp.filters import compile_filters_bytecode, compile_filters_expr, filter_cohort_ids
 from posthog.models.integration import Integration
+from posthog.models.team.team import Team
 
 from products.cdp.backend.models.hog_functions.hog_function import (
     TYPES_WITH_JAVASCRIPT_SOURCE,
     TYPES_WITH_TRANSPILED_FILTERS,
 )
+from products.cohorts.backend.models.cohort import Cohort
 
 from common.hogvm.python.stl import STL
 from common.hogvm.python.stl.bytecode import BYTECODE_STL
@@ -844,6 +846,14 @@ class HogFunctionFiltersSerializer(serializers.Serializer):
     transpiled = serializers.JSONField(required=False)
     filter_test_accounts = serializers.BooleanField(required=False)
     bytecode_error = serializers.CharField(required=False)
+    cohort_ids = serializers.ListField(
+        child=serializers.IntegerField(),
+        required=False,
+        help_text=(
+            "Cohorts referenced by the compiled filter bytecode's inCohort/notInCohort calls. "
+            "Derived at save time so the runtime can prefetch membership; caller-supplied values are ignored."
+        ),
+    )
 
     def to_internal_value(self, data):
         # Weirdly nested serializers don't get this set...
@@ -900,7 +910,10 @@ class HogFunctionFiltersSerializer(serializers.Serializer):
             if "bytecode" in data:
                 del data["bytecode"]
         else:
-            data = compile_filters_bytecode(data, team)
+            cohort_membership_supported = bool(self.context.get("cohort_membership_supported"))
+            if cohort_membership_supported:
+                self._validate_realtime_cohorts(data, team)
+            data = compile_filters_bytecode(data, team, cohort_membership_supported=cohort_membership_supported)
             # Uncompilable filters are only fatal when the function will run (stay enabled).
             # Callers that allow saving anyway (e.g. disabling/deleting a hog function) opt out
             # via context; the error stays persisted on the filters for the UI to surface.
@@ -908,6 +921,32 @@ class HogFunctionFiltersSerializer(serializers.Serializer):
                 raise serializers.ValidationError(f"Invalid filter configuration: {data['bytecode_error']}")
 
         return data
+
+    def _validate_realtime_cohorts(self, data: dict, team: Team) -> None:
+        """Only cohorts whose membership the realtime pipeline maintains in the cohort_membership
+        table may be referenced: the runtime answers inCohort with a point lookup against that
+        table, so any other cohort would evaluate everyone as a non-member."""
+        cohort_ids = filter_cohort_ids(data)
+        if not cohort_ids:
+            return
+
+        cohorts = {
+            cohort.pk: cohort
+            for cohort in Cohort.objects.filter(pk__in=cohort_ids, team__project_id=team.project_id, deleted=False)
+        }
+        for cohort_id in cohort_ids:
+            cohort = cohorts.get(cohort_id)
+            if cohort is None:
+                raise serializers.ValidationError(f"Cohort {cohort_id} doesn't exist in this project.")
+            if cohort.is_static:
+                raise serializers.ValidationError(
+                    f"Cohort '{cohort.name}' is a static cohort. Conditions can only use realtime cohorts."
+                )
+            if not cohort.is_flag_compatible:
+                raise serializers.ValidationError(
+                    f"Cohort '{cohort.name}' isn't ready for realtime evaluation. "
+                    f"Conditions can only use realtime cohorts that have finished calculating."
+                )
 
 
 class MappingsSerializer(serializers.Serializer):

--- a/posthog/hogql/compiler/bytecode.py
+++ b/posthog/hogql/compiler/bytecode.py
@@ -141,6 +141,9 @@ class BytecodeCompiler(Visitor):
         self.args = args
         self.cohort_membership_supported = cohort_membership_supported
         self.null_safe_comparisons = null_safe_comparisons
+        # True only while compiling the call visit_compare_operation generates for IN COHORT;
+        # visit_call rejects inCohort/notInCohort outside of it
+        self._compiling_cohort_membership_call = False
         # we're in a function definition
         if args is not None:
             for arg in args:
@@ -225,10 +228,17 @@ class BytecodeCompiler(Visitor):
         operation = COMPARE_OPERATIONS[node.op]
         if operation in [Operation.IN_COHORT, Operation.NOT_IN_COHORT]:
             if self.cohort_membership_supported:
-                if operation == Operation.IN_COHORT:
-                    return self.visit(ast.Call(name="inCohort", args=[node.right]))
-                else:
-                    return self.visit(ast.Call(name="notInCohort", args=[node.right]))
+                # The STL implementations are pure two-arg functions (stl/ chunks execute without
+                # globals), so pass the runtime-prefetched `cohort_ids` global as the second
+                # argument. Marked internal: only calls generated here pass the visit_call guard,
+                # since hand-authored calls would skip cohort eligibility validation.
+                name = "inCohort" if operation == Operation.IN_COHORT else "notInCohort"
+                call = ast.Call(name=name, args=[node.right, ast.Field(chain=["cohort_ids"])])
+                self._compiling_cohort_membership_call = True
+                try:
+                    return self.visit(call)
+                finally:
+                    self._compiling_cohort_membership_call = False
             else:
                 cohort_name = ""
                 if isinstance(node.right, ast.Constant):
@@ -450,10 +460,11 @@ class BytecodeCompiler(Visitor):
             raise QueryError(f"Constant type `{type(node.value)}` is not supported")
 
     def visit_call(self, node: ast.Call):
-        if node.name in ("inCohort", "notInCohort") and len(node.args) == 1:
-            # The STL implementations are pure two-arg functions (stl/ chunks execute without
-            # globals), so pass the runtime-prefetched `cohort_ids` global as the second argument
-            return self.visit(ast.Call(name=node.name, args=[node.args[0], ast.Field(chain=["cohort_ids"])]))
+        if node.name in ("inCohort", "notInCohort") and not self._compiling_cohort_membership_call:
+            # Hand-authored calls (e.g. inCohort(42) in a HogQL expression filter) would skip the
+            # save-time cohort eligibility validation, which only sees cohort property filters —
+            # an ineligible cohort id would then silently evaluate as a non-member for everyone
+            raise QueryError(f"Can't call {node.name}() directly in filters. Use a cohort property filter instead.")
         if node.name == "not" and len(node.args) == 1:
             return [*self.visit(node.args[0]), Operation.NOT]
         if node.name == "and" and len(node.args) > 1:

--- a/posthog/hogql/compiler/bytecode.py
+++ b/posthog/hogql/compiler/bytecode.py
@@ -450,6 +450,10 @@ class BytecodeCompiler(Visitor):
             raise QueryError(f"Constant type `{type(node.value)}` is not supported")
 
     def visit_call(self, node: ast.Call):
+        if node.name in ("inCohort", "notInCohort") and len(node.args) == 1:
+            # The STL implementations are pure two-arg functions (stl/ chunks execute without
+            # globals), so pass the runtime-prefetched `cohort_ids` global as the second argument
+            return self.visit(ast.Call(name=node.name, args=[node.args[0], ast.Field(chain=["cohort_ids"])]))
         if node.name == "not" and len(node.args) == 1:
             return [*self.visit(node.args[0]), Operation.NOT]
         if node.name == "and" and len(node.args) > 1:

--- a/posthog/hogql/compiler/bytecode.py
+++ b/posthog/hogql/compiler/bytecode.py
@@ -96,6 +96,7 @@ def create_bytecode(
     locals: Optional[list[Local]] = None,
     cohort_membership_supported: Optional[bool] = False,
     null_safe_comparisons: Optional[bool] = False,
+    allowed_cohort_ids: Optional[set[int]] = None,
 ) -> CompiledBytecode:
     supported_functions = supported_functions or set()
     bytecode: list[Any] = []
@@ -111,6 +112,7 @@ def create_bytecode(
         locals,
         cohort_membership_supported,
         null_safe_comparisons,
+        allowed_cohort_ids,
     )
     bytecode.extend(compiler.visit(expr))
     return CompiledBytecode(bytecode, locals=compiler.locals, upvalues=compiler.upvalues)
@@ -129,6 +131,7 @@ class BytecodeCompiler(Visitor):
         locals: Optional[list[Local]] = None,
         cohort_membership_supported: Optional[bool] = False,
         null_safe_comparisons: Optional[bool] = False,
+        allowed_cohort_ids: Optional[set[int]] = None,
     ):
         super().__init__()
         self.enclosing = enclosing
@@ -141,6 +144,10 @@ class BytecodeCompiler(Visitor):
         self.args = args
         self.cohort_membership_supported = cohort_membership_supported
         self.null_safe_comparisons = null_safe_comparisons
+        # When set, every IN COHORT operand must be a constant id from this set. Callers that
+        # eligibility-validate cohorts before compiling (workflow conditions) pass the validated
+        # ids, so an id smuggled in through a hogql property can't skip those checks.
+        self.allowed_cohort_ids = allowed_cohort_ids
         # True only while compiling the call visit_compare_operation generates for IN COHORT;
         # visit_call rejects inCohort/notInCohort outside of it
         self._compiling_cohort_membership_call = False
@@ -228,6 +235,14 @@ class BytecodeCompiler(Visitor):
         operation = COMPARE_OPERATIONS[node.op]
         if operation in [Operation.IN_COHORT, Operation.NOT_IN_COHORT]:
             if self.cohort_membership_supported:
+                if self.allowed_cohort_ids is not None:
+                    if not isinstance(node.right, ast.Constant) or not isinstance(node.right.value, int):
+                        raise QueryError("Cohort conditions require a constant cohort id.")
+                    if node.right.value not in self.allowed_cohort_ids:
+                        raise QueryError(
+                            f"Cohort {node.right.value} can't be used here. "
+                            "Reference cohorts through a cohort filter so they can be validated."
+                        )
                 # The STL implementations are pure two-arg functions (stl/ chunks execute without
                 # globals), so pass the runtime-prefetched `cohort_ids` global as the second
                 # argument. Marked internal: only calls generated here pass the visit_call guard,

--- a/posthog/hogql/compiler/bytecode.py
+++ b/posthog/hogql/compiler/bytecode.py
@@ -426,6 +426,18 @@ class BytecodeCompiler(Visitor):
 
         # Did not find a local nor an upvalue, must be a global.
 
+        # `cohort_ids` is the reserved global visit_compare_operation passes into the generated
+        # inCohort/notInCohort calls. When cohort membership is compilable, the runtime injects the
+        # person's real memberships under that name, so an authored read (e.g. `42 in cohort_ids`)
+        # would test membership of a cohort the allowlist never validated. Reject it outside the
+        # generated call.
+        if (
+            self.cohort_membership_supported
+            and node.chain[0] == "cohort_ids"
+            and not self._compiling_cohort_membership_call
+        ):
+            raise QueryError("cohort_ids is reserved here. Use a cohort property filter instead.")
+
         chain = []
         for element in reversed(node.chain):
             chain.extend([Operation.STRING, element])

--- a/posthog/hogql/compiler/bytecode.py
+++ b/posthog/hogql/compiler/bytecode.py
@@ -464,7 +464,7 @@ class BytecodeCompiler(Visitor):
             # Hand-authored calls (e.g. inCohort(42) in a HogQL expression filter) would skip the
             # save-time cohort eligibility validation, which only sees cohort property filters —
             # an ineligible cohort id would then silently evaluate as a non-member for everyone
-            raise QueryError(f"Can't call {node.name}() directly in filters. Use a cohort property filter instead.")
+            raise QueryError(f"Can't call {node.name}() directly. Use a cohort property filter instead.")
         if node.name == "not" and len(node.args) == 1:
             return [*self.visit(node.args[0]), Operation.NOT]
         if node.name == "and" and len(node.args) > 1:

--- a/products/workflows/backend/api/hog_flow.py
+++ b/products/workflows/backend/api/hog_flow.py
@@ -60,7 +60,7 @@ from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.api.utils import log_activity_from_viewset
 from posthog.auth import InternalAPIAuthentication
-from posthog.cdp.filters import compile_filters_expr
+from posthog.cdp.filters import compile_filters_expr, filter_cohort_ids
 from posthog.cdp.flag_gated_templates import FLAG_GATED_TEMPLATE_IDS, gated_template_enabled
 from posthog.cdp.validation import (
     DATA_WAREHOUSE_SOURCES,
@@ -73,6 +73,7 @@ from posthog.clickhouse.query_tagging import Feature, tag_queries
 from posthog.event_usage import AGENT_EVENT_SOURCES, EventSource, get_event_source, report_user_action
 from posthog.models import Team
 from posthog.models.filters import Filter
+from posthog.ph_client import feature_enabled_or_false
 from posthog.plugins.plugin_server_api import (
     cancel_hog_flow_batch_job,
     cancel_hog_flow_invocations,
@@ -193,6 +194,10 @@ EMAIL_SENDING_RATE_LIMIT_FLAG = "workflows-email-rate-limit"
 # Compiled from the author's filters rather than written by them, and only present once a condition has
 # been through validation. Comparing them would make an unchanged condition look edited.
 _DERIVED_FILTER_KEYS = ("bytecode", "bytecode_error", "source", "cohort_ids")
+
+# Rollout gate for cohort filters in conditional branches. Targeted per organization so the
+# feature can be proven on a few teams before general availability.
+WORKFLOWS_COHORT_CONDITIONS_FLAG = "workflows-cohort-conditions"
 
 
 def _authored_condition(condition: Optional[dict]) -> Optional[dict]:
@@ -1178,6 +1183,32 @@ class HogFlowActionSerializer(serializers.Serializer):
         self.initial_data = data
         return super().to_internal_value(data)
 
+    # Memoized per serializer instance: the same instance validates every action in the array,
+    # and the flag evaluation is a network call.
+    _cohort_conditions_flag: Optional[bool] = None
+
+    def _cohort_conditions_enabled(self) -> bool:
+        if self._cohort_conditions_flag is None:
+            self._cohort_conditions_flag = self._check_cohort_conditions_flag()
+        return self._cohort_conditions_flag
+
+    def _check_cohort_conditions_flag(self) -> bool:
+        try:
+            request = self.context.get("request")
+            user = getattr(request, "user", None)
+            if user is None or user.is_anonymous or isinstance(user, SyntheticUser):
+                return False
+            return feature_enabled_or_false(
+                WORKFLOWS_COHORT_CONDITIONS_FLAG,
+                user.distinct_id,
+                groups={"organization": str(user.organization.id)},
+                group_properties={"organization": {"id": str(user.organization.id)}},
+                only_evaluate_locally=False,
+                send_feature_flag_events=False,
+            )
+        except Exception:
+            return False
+
     def _reject_behavioral_cohorts_in_audience(self, properties) -> None:
         # Batch/schedule audiences resolve offline by precalculated membership and can't evaluate event
         # behavior the way it's intended; the UI hides behavioral cohorts from the audience picker. Mirror
@@ -1503,11 +1534,16 @@ class HogFlowActionSerializer(serializers.Serializer):
                     # Cohort filters are allowed in conditional_branch only: the branch evaluates
                     # membership on arrival via a point lookup. A wait_until_condition would only
                     # ever notice a membership change through its polling backstop (the matcher has
-                    # no cohort membership wake stream), so cohorts stay rejected there.
+                    # no cohort membership wake stream), so cohorts stay rejected there. The flag
+                    # check runs only when the condition actually references a cohort, so ordinary
+                    # saves never pay for it; with the flag off, cohorts fail compilation as before.
+                    cohorts_supported = (
+                        is_conditional_branch and bool(filter_cohort_ids(filters)) and self._cohort_conditions_enabled()
+                    )
                     serializer = HogFunctionFiltersSerializer(
                         data=filters,
                         context={**self.context, "cohort_membership_supported": True}
-                        if is_conditional_branch
+                        if cohorts_supported
                         else self.context,
                     )
                     if not strict:

--- a/products/workflows/backend/api/hog_flow.py
+++ b/products/workflows/backend/api/hog_flow.py
@@ -193,7 +193,7 @@ EMAIL_SENDING_RATE_LIMIT_FLAG = "workflows-email-rate-limit"
 
 # Compiled from the author's filters rather than written by them, and only present once a condition has
 # been through validation. Comparing them would make an unchanged condition look edited.
-_DERIVED_FILTER_KEYS = ("bytecode", "bytecode_error", "source", "cohort_ids")
+_DERIVED_FILTER_KEYS = ("bytecode", "bytecode_error", "source")
 
 # Rollout gate for cohort filters in conditional branches, targeted per organization
 WORKFLOWS_COHORT_CONDITIONS_FLAG = "workflows-cohort-conditions"

--- a/products/workflows/backend/api/hog_flow.py
+++ b/products/workflows/backend/api/hog_flow.py
@@ -192,7 +192,7 @@ EMAIL_SENDING_RATE_LIMIT_FLAG = "workflows-email-rate-limit"
 
 # Compiled from the author's filters rather than written by them, and only present once a condition has
 # been through validation. Comparing them would make an unchanged condition look edited.
-_DERIVED_FILTER_KEYS = ("bytecode", "bytecode_error", "source")
+_DERIVED_FILTER_KEYS = ("bytecode", "bytecode_error", "source", "cohort_ids")
 
 
 def _authored_condition(condition: Optional[dict]) -> Optional[dict]:
@@ -1500,7 +1500,16 @@ class HogFlowActionSerializer(serializers.Serializer):
                     if strict:
                         raise serializers.ValidationError("Event filters are not allowed in conditionals")
                 else:
-                    serializer = HogFunctionFiltersSerializer(data=filters, context=self.context)
+                    # Cohort filters are allowed in conditional_branch only: the branch evaluates
+                    # membership on arrival via a point lookup. A wait_until_condition would only
+                    # ever notice a membership change through its polling backstop (the matcher has
+                    # no cohort membership wake stream), so cohorts stay rejected there.
+                    serializer = HogFunctionFiltersSerializer(
+                        data=filters,
+                        context={**self.context, "cohort_membership_supported": True}
+                        if is_conditional_branch
+                        else self.context,
+                    )
                     if not strict:
                         if serializer.is_valid():
                             condition["filters"] = serializer.validated_data

--- a/products/workflows/backend/api/hog_flow.py
+++ b/products/workflows/backend/api/hog_flow.py
@@ -60,7 +60,7 @@ from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.api.utils import log_activity_from_viewset
 from posthog.auth import InternalAPIAuthentication
-from posthog.cdp.filters import compile_filters_expr, filter_cohort_ids
+from posthog.cdp.filters import compile_filters_expr, filter_action_ids, filter_cohort_ids
 from posthog.cdp.flag_gated_templates import FLAG_GATED_TEMPLATE_IDS, gated_template_enabled
 from posthog.cdp.validation import (
     DATA_WAREHOUSE_SOURCES,
@@ -1196,11 +1196,18 @@ class HogFlowActionSerializer(serializers.Serializer):
             user = getattr(request, "user", None)
             if user is None or user.is_anonymous or isinstance(user, SyntheticUser):
                 return False
+            get_team = self.context.get("get_team")
+            if get_team is None:
+                return False
+            # The flag targets organizations, so evaluate against the organization that owns the
+            # team being written to — a user saving into a project outside their active
+            # organization must get that project's rollout decision, not their own org's.
+            organization_id = str(get_team().organization_id)
             return feature_enabled_or_false(
                 WORKFLOWS_COHORT_CONDITIONS_FLAG,
                 user.distinct_id,
-                groups={"organization": str(user.organization.id)},
-                group_properties={"organization": {"id": str(user.organization.id)}},
+                groups={"organization": organization_id},
+                group_properties={"organization": {"id": organization_id}},
                 only_evaluate_locally=False,
                 send_feature_flag_events=False,
             )
@@ -1532,8 +1539,14 @@ class HogFlowActionSerializer(serializers.Serializer):
                     # Cohorts are allowed in conditional_branch only: a wait_until_condition has no
                     # membership wake stream, so it would only ever advance via the polling backstop.
                     # With the flag off, cohorts fail compilation exactly as before.
+                    # Action references count too: a referenced Action's stored steps can carry
+                    # cohort properties this shallow scan can't see. Enabling on the reference alone
+                    # is safe — the validator resolves the Action's steps and the compiler rejects
+                    # any cohort id the validator didn't clear.
                     cohorts_supported = (
-                        is_conditional_branch and bool(filter_cohort_ids(filters)) and self._cohort_conditions_enabled()
+                        is_conditional_branch
+                        and (bool(filter_cohort_ids(filters)) or bool(filter_action_ids(filters)))
+                        and self._cohort_conditions_enabled()
                     )
                     serializer = HogFunctionFiltersSerializer(
                         data=filters,

--- a/products/workflows/backend/api/hog_flow.py
+++ b/products/workflows/backend/api/hog_flow.py
@@ -229,6 +229,24 @@ def _wait_condition_already_stored(action: dict, context: dict) -> bool:
     return _authored_condition(stored[action_id]) == _authored_condition((action.get("config") or {}).get("condition"))
 
 
+def _cohort_condition_already_stored(action: dict, condition: dict, context: dict) -> bool:
+    """
+    True when this conditional_branch condition matches one already persisted for the same action.
+
+    Mirrors _wait_condition_already_stored: the cohort-conditions flag polices new adoption, not
+    edits around an accepted condition. Without this, a flag dial-down (or an internal re-save,
+    which has no request to evaluate the flag against) would fail compilation of an active flow's
+    unchanged cohort conditions.
+    """
+    stored = context.get("stored_cohort_conditions")
+    if not stored:
+        return False
+    action_id = action.get("id")
+    if action_id not in stored:
+        return False
+    return _authored_condition(condition) in stored[action_id]
+
+
 def _reject_clock_based_wait(config: dict, team: Team) -> None:
     """
     Refuse a wait whose condition depends on the clock rather than on something happening.
@@ -1543,10 +1561,15 @@ class HogFlowActionSerializer(serializers.Serializer):
                     # cohort properties this shallow scan can't see. Enabling on the reference alone
                     # is safe — the validator resolves the Action's steps and the compiler rejects
                     # any cohort id the validator didn't clear.
+                    # Grandfathered conditions short-circuit ahead of the flag so internal
+                    # re-saves never pay the flag-service call.
                     cohorts_supported = (
                         is_conditional_branch
                         and (bool(filter_cohort_ids(filters)) or bool(filter_action_ids(filters)))
-                        and self._cohort_conditions_enabled()
+                        and (
+                            _cohort_condition_already_stored(data, condition, self.context)
+                            or self._cohort_conditions_enabled()
+                        )
                     )
                     serializer = HogFunctionFiltersSerializer(
                         data=filters,
@@ -2305,6 +2328,24 @@ class HogFlowSerializer(HogFlowMinimalSerializer):
             if isinstance(action, dict)
             and action.get("id")
             and (action.get("config") or {}).get("template_id") in FLAG_GATED_TEMPLATE_IDS
+        }
+
+        # Conditional-branch conditions the active flow already carries, so the cohort-conditions
+        # flag only polices new adoption: a resubmitted stored condition keeps compiling with
+        # cohort support after a flag dial-down, an eval blip, or an internal re-save with no
+        # request context, instead of bricking the save. Same active-only rule as the gated
+        # templates above: a draft can hold a cohort condition without ever passing the gate.
+        self.context["stored_cohort_conditions"] = {
+            action["id"]: [
+                _authored_condition(stored_condition)
+                for stored_condition in [
+                    *((action.get("config") or {}).get("conditions") or []),
+                    (action.get("config") or {}).get("condition"),
+                ]
+                if isinstance(stored_condition, dict)
+            ]
+            for action in ((instance.actions if instance and instance.status == HogFlow.State.ACTIVE else None) or [])
+            if isinstance(action, dict) and action.get("id") and action.get("type") == "conditional_branch"
         }
 
         status = data.get("status")

--- a/products/workflows/backend/api/hog_flow.py
+++ b/products/workflows/backend/api/hog_flow.py
@@ -195,8 +195,7 @@ EMAIL_SENDING_RATE_LIMIT_FLAG = "workflows-email-rate-limit"
 # been through validation. Comparing them would make an unchanged condition look edited.
 _DERIVED_FILTER_KEYS = ("bytecode", "bytecode_error", "source", "cohort_ids")
 
-# Rollout gate for cohort filters in conditional branches. Targeted per organization so the
-# feature can be proven on a few teams before general availability.
+# Rollout gate for cohort filters in conditional branches, targeted per organization
 WORKFLOWS_COHORT_CONDITIONS_FLAG = "workflows-cohort-conditions"
 
 
@@ -1183,8 +1182,7 @@ class HogFlowActionSerializer(serializers.Serializer):
         self.initial_data = data
         return super().to_internal_value(data)
 
-    # Memoized per serializer instance: the same instance validates every action in the array,
-    # and the flag evaluation is a network call.
+    # Memoized because one instance validates every action and the flag check is a network call
     _cohort_conditions_flag: Optional[bool] = None
 
     def _cohort_conditions_enabled(self) -> bool:
@@ -1531,12 +1529,9 @@ class HogFlowActionSerializer(serializers.Serializer):
                     if strict:
                         raise serializers.ValidationError("Event filters are not allowed in conditionals")
                 else:
-                    # Cohort filters are allowed in conditional_branch only: the branch evaluates
-                    # membership on arrival via a point lookup. A wait_until_condition would only
-                    # ever notice a membership change through its polling backstop (the matcher has
-                    # no cohort membership wake stream), so cohorts stay rejected there. The flag
-                    # check runs only when the condition actually references a cohort, so ordinary
-                    # saves never pay for it; with the flag off, cohorts fail compilation as before.
+                    # Cohorts are allowed in conditional_branch only: a wait_until_condition has no
+                    # membership wake stream, so it would only ever advance via the polling backstop.
+                    # With the flag off, cohorts fail compilation exactly as before.
                     cohorts_supported = (
                         is_conditional_branch and bool(filter_cohort_ids(filters)) and self._cohort_conditions_enabled()
                     )

--- a/products/workflows/backend/api/test/test_hog_flow.py
+++ b/products/workflows/backend/api/test/test_hog_flow.py
@@ -1327,6 +1327,81 @@ class TestHogFlowAPI(APIBaseTest):
         assert response.status_code == 400, response.json()
         assert "is a static cohort" in response.json()["detail"]
 
+    @patch("products.workflows.backend.api.hog_flow.feature_enabled_or_false", return_value=True)
+    def test_hog_flow_compiles_eligible_cohort_referenced_only_through_an_action(self, _mock_flag):
+        # The enablement gate can't see into a referenced Action's stored steps, so it must switch
+        # cohort support on for the action reference alone — otherwise an eligible cohort that only
+        # lives there still hits the legacy rejection while the validator would have cleared it.
+        eligible = self._create_behavioral_cohort(CohortType.REALTIME, backfilled=True)
+        action = Action.objects.create(
+            team=self.team,
+            name="action with eligible cohort step",
+            steps_json=[{"event": "$pageview", "properties": [{"key": "id", "type": "cohort", "value": eligible.id}]}],
+        )
+        hog_flow = self._hog_flow_with_condition_filters(
+            "conditional_branch", {"actions": [{"id": action.id, "type": "actions"}]}
+        )
+
+        response = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
+
+        assert response.status_code == 201, response.json()
+        bytecode = response.json()["actions"][1]["config"]["conditions"][0]["filters"]["bytecode"]
+        assert "inCohort" in bytecode
+
+    @parameterized.expand(
+        [
+            ("unvalidated_id", "person.properties.plan in cohort 999999", "can't be used here"),
+            ("non_constant_id", "person.properties.plan in cohort person.properties.x", "constant cohort id"),
+        ]
+    )
+    @patch("products.workflows.backend.api.hog_flow.feature_enabled_or_false", return_value=True)
+    def test_hog_flow_rejects_in_cohort_operator_smuggled_through_hogql(
+        self, _name, hogql_key, expected_detail, _mock_flag
+    ):
+        # One eligible structured leaf turns cohort support on for the whole filter set; an
+        # IN COHORT operator in a hogql leaf must not ride along with an id the eligibility
+        # validation never saw.
+        cohort = self._create_behavioral_cohort(CohortType.REALTIME, backfilled=True)
+        hog_flow = self._hog_flow_with_condition_filters(
+            "conditional_branch",
+            {
+                "properties": [
+                    {"key": "id", "type": "cohort", "value": cohort.id},
+                    {"key": hogql_key, "type": "hogql"},
+                ]
+            },
+        )
+
+        response = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
+
+        assert response.status_code == 400, response.json()
+        assert expected_detail in response.json()["detail"]
+
+    @patch("products.workflows.backend.api.hog_flow.feature_enabled_or_false")
+    def test_hog_flow_cohort_flag_evaluates_the_target_teams_organization(self, mock_flag):
+        # A user saving into a project outside their active organization must get the target
+        # organization's rollout decision, not their own org's.
+        other_org = Organization.objects.create(name="Other Org")
+        OrganizationMembership.objects.create(user=self.user, organization=other_org)
+        other_team = Team.objects.create(organization=other_org, name="Other Team")
+        cohort = Cohort.objects.create(
+            team=other_team,
+            name="other-org-cohort",
+            cohort_type=CohortType.REALTIME,
+            last_backfill_person_properties_at=datetime.now(tz=UTC),
+            last_backfill_events_at=datetime.now(tz=UTC),
+            filters=self._create_behavioral_cohort(CohortType.REALTIME, backfilled=True).filters,
+        )
+        mock_flag.return_value = True
+        hog_flow = self._hog_flow_with_condition_filters(
+            "conditional_branch", {"properties": [{"key": "id", "type": "cohort", "value": cohort.id}]}
+        )
+
+        response = self.client.post(f"/api/projects/{other_team.id}/hog_flows", hog_flow)
+
+        assert response.status_code == 201, response.json()
+        assert mock_flag.call_args.kwargs["groups"] == {"organization": str(other_org.id)}
+
     def test_hog_flow_wait_until_condition_rejects_cohort_filters(self):
         cohort = self._create_behavioral_cohort(CohortType.REALTIME, backfilled=True)
         hog_flow = self._hog_flow_with_condition_filters(

--- a/products/workflows/backend/api/test/test_hog_flow.py
+++ b/products/workflows/backend/api/test/test_hog_flow.py
@@ -28,7 +28,7 @@ from posthog.test.fixtures import create_app_metric2
 
 from products.actions.backend.models.action import Action
 from products.cdp.backend.api.test.test_hog_function_templates import MOCK_NODE_TEMPLATES
-from products.cohorts.backend.models.cohort import Cohort
+from products.cohorts.backend.models.cohort import Cohort, CohortType
 from products.workflows.backend.api.hog_flow import (
     HogFlowActionSerializer,
     _should_validate_strictly,
@@ -1140,6 +1140,117 @@ class TestHogFlowAPI(APIBaseTest):
         assert "filters" in conditions[0]
         assert "bytecode" in conditions[0]["filters"], conditions[0]["filters"]
         assert conditions[0]["filters"]["bytecode"] == ["_H", 1, 32, "custom_event", 32, "event", 1, 1, 11]
+
+    def _create_behavioral_cohort(self, cohort_type: Optional[CohortType], backfilled: bool) -> Cohort:
+        cohort_kwargs: dict[str, Any] = {
+            "team": self.team,
+            "name": "power-users",
+            "filters": {
+                "properties": {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "key": "$pageview",
+                            "event_type": "events",
+                            "time_value": 2,
+                            "time_interval": "week",
+                            "value": "performed_event_first_time",
+                            "type": "behavioral",
+                        },
+                    ],
+                }
+            },
+        }
+        if cohort_type is not None:
+            cohort_kwargs["cohort_type"] = cohort_type
+        if backfilled:
+            cohort_kwargs["last_backfill_person_properties_at"] = datetime.now(tz=UTC)
+            cohort_kwargs["last_backfill_events_at"] = datetime.now(tz=UTC)
+        return Cohort.objects.create(**cohort_kwargs)
+
+    def _hog_flow_with_condition_filters(self, action_type: str, filters: dict) -> dict:
+        condition_key = "conditions" if action_type == "conditional_branch" else "condition"
+        config: dict[str, Any] = (
+            {"conditions": [{"filters": filters}]}
+            if action_type == "conditional_branch"
+            else {"condition": {"filters": filters}, "max_wait_duration": "1h"}
+        )
+        assert condition_key in config
+        return {
+            "name": "Test Flow",
+            "status": "active",
+            "actions": [
+                {
+                    "id": "trigger_node",
+                    "name": "trigger_1",
+                    "type": "trigger",
+                    "config": {
+                        "type": "event",
+                        "filters": {"events": [{"id": "$pageview", "name": "$pageview", "type": "events", "order": 0}]},
+                    },
+                },
+                {"id": "cond_1", "name": "cond_1", "type": action_type, "config": config},
+            ],
+        }
+
+    @parameterized.expand(
+        [
+            ("in_operator", None, "inCohort"),
+            ("not_in_operator", "not_in", "notInCohort"),
+        ]
+    )
+    def test_hog_flow_conditional_branch_cohort_filter_compiles(self, _name, operator, expected_call):
+        cohort = self._create_behavioral_cohort(CohortType.REALTIME, backfilled=True)
+        cohort_property: dict[str, Any] = {"key": "id", "type": "cohort", "value": cohort.id}
+        if operator:
+            cohort_property["operator"] = operator
+        hog_flow = self._hog_flow_with_condition_filters("conditional_branch", {"properties": [cohort_property]})
+
+        response = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
+
+        assert response.status_code == 201, response.json()
+        filters = response.json()["actions"][1]["config"]["conditions"][0]["filters"]
+        assert filters["bytecode"] == ["_H", 1, 33, cohort.id, 2, expected_call, 1]
+        assert filters["cohort_ids"] == [cohort.id]
+
+    @parameterized.expand(
+        [
+            ("static_cohort", "static", "is a static cohort"),
+            ("dynamic_behavioral_cohort", "dynamic", "isn't ready for realtime evaluation"),
+            ("realtime_not_backfilled", "realtime_unbackfilled", "isn't ready for realtime evaluation"),
+            ("missing_cohort", "missing", "doesn't exist in this project"),
+        ]
+    )
+    def test_hog_flow_conditional_branch_rejects_ineligible_cohorts(self, _name, cohort_kind, expected_detail):
+        if cohort_kind == "static":
+            cohort_id = Cohort.objects.create(team=self.team, name="static-cohort", is_static=True).id
+        elif cohort_kind == "dynamic":
+            cohort_id = self._create_behavioral_cohort(None, backfilled=False).id
+        elif cohort_kind == "realtime_unbackfilled":
+            cohort_id = self._create_behavioral_cohort(CohortType.REALTIME, backfilled=False).id
+        else:
+            cohort_id = 999999
+        hog_flow = self._hog_flow_with_condition_filters(
+            "conditional_branch", {"properties": [{"key": "id", "type": "cohort", "value": cohort_id}]}
+        )
+
+        response = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
+
+        assert response.status_code == 400, response.json()
+        assert expected_detail in response.json()["detail"]
+
+    def test_hog_flow_wait_until_condition_rejects_cohort_filters(self):
+        # Cohort support is scoped to conditional_branch: a wait would only notice membership
+        # changes via the polling backstop, so the compile-time rejection must stay in place.
+        cohort = self._create_behavioral_cohort(CohortType.REALTIME, backfilled=True)
+        hog_flow = self._hog_flow_with_condition_filters(
+            "wait_until_condition", {"properties": [{"key": "id", "type": "cohort", "value": cohort.id}]}
+        )
+
+        response = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
+
+        assert response.status_code == 400, response.json()
+        assert "Cohort membership can't be evaluated in real-time filters" in response.json()["detail"]
 
     def test_hog_flow_wait_until_condition_defaults_missing_condition(self):
         # An events-only wait omits 'condition'; the FE always seeds it and StepWaitUntilCondition

--- a/products/workflows/backend/api/test/test_hog_flow.py
+++ b/products/workflows/backend/api/test/test_hog_flow.py
@@ -1254,6 +1254,27 @@ class TestHogFlowAPI(APIBaseTest):
         assert response.status_code == 400, response.json()
         assert "Cohort membership can't be evaluated in real-time filters" in response.json()["detail"]
 
+    @parameterized.expand(
+        [
+            ("expression_only", False),
+            ("mixed_with_structured_cohort", True),
+        ]
+    )
+    @patch("products.workflows.backend.api.hog_flow.feature_enabled_or_false", return_value=True)
+    def test_hog_flow_rejects_hand_authored_incohort_calls(self, _name, include_structured_leaf, _mock_flag):
+        # Hand-authored inCohort() skips cohort eligibility validation, so the compiler rejects it
+        # outright — including alongside a structured cohort leaf that turns cohort support on.
+        cohort = self._create_behavioral_cohort(CohortType.REALTIME, backfilled=True)
+        properties: list[dict[str, Any]] = [{"key": "inCohort(999999)", "type": "hogql"}]
+        if include_structured_leaf:
+            properties.insert(0, {"key": "id", "type": "cohort", "value": cohort.id})
+        hog_flow = self._hog_flow_with_condition_filters("conditional_branch", {"properties": properties})
+
+        response = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
+
+        assert response.status_code == 400, response.json()
+        assert "Can't call inCohort() directly in filters" in response.json()["detail"]
+
     def test_hog_flow_wait_until_condition_rejects_cohort_filters(self):
         cohort = self._create_behavioral_cohort(CohortType.REALTIME, backfilled=True)
         hog_flow = self._hog_flow_with_condition_filters(

--- a/products/workflows/backend/api/test/test_hog_flow.py
+++ b/products/workflows/backend/api/test/test_hog_flow.py
@@ -1141,9 +1141,11 @@ class TestHogFlowAPI(APIBaseTest):
         assert "bytecode" in conditions[0]["filters"], conditions[0]["filters"]
         assert conditions[0]["filters"]["bytecode"] == ["_H", 1, 32, "custom_event", 32, "event", 1, 1, 11]
 
-    def _create_behavioral_cohort(self, cohort_type: Optional[CohortType], backfilled: bool) -> Cohort:
+    def _create_behavioral_cohort(
+        self, cohort_type: Optional[CohortType], backfilled: bool, team: Optional[Team] = None
+    ) -> Cohort:
         cohort_kwargs: dict[str, Any] = {
-            "team": self.team,
+            "team": team or self.team,
             "name": "power-users",
             "filters": {
                 "properties": {
@@ -1219,7 +1221,11 @@ class TestHogFlowAPI(APIBaseTest):
             ("static_cohort", "static", "is a static cohort"),
             ("dynamic_behavioral_cohort", "dynamic", "isn't ready for realtime evaluation"),
             ("realtime_not_backfilled", "realtime_unbackfilled", "isn't ready for realtime evaluation"),
-            ("missing_cohort", "missing", "doesn't exist in this project"),
+            ("missing_cohort", "missing", "doesn't exist in this environment"),
+            # Eligible on its own team, but the runtime reads cohort_membership with the
+            # workflow's team_id, where a sibling environment's cohort has no rows: it would
+            # silently evaluate everyone as a non-member, so validation must reject it.
+            ("sibling_environment_cohort", "sibling_environment", "doesn't exist in this environment"),
         ]
     )
     @patch("products.workflows.backend.api.hog_flow.feature_enabled_or_false", return_value=True)
@@ -1232,6 +1238,9 @@ class TestHogFlowAPI(APIBaseTest):
             cohort_id = self._create_behavioral_cohort(None, backfilled=False).id
         elif cohort_kind == "realtime_unbackfilled":
             cohort_id = self._create_behavioral_cohort(CohortType.REALTIME, backfilled=False).id
+        elif cohort_kind == "sibling_environment":
+            sibling_team = Team.objects.create(organization=self.organization, project=self.project, name="sibling env")
+            cohort_id = self._create_behavioral_cohort(CohortType.REALTIME, backfilled=True, team=sibling_team).id
         else:
             cohort_id = 999999
         hog_flow = self._hog_flow_with_condition_filters(
@@ -1280,6 +1289,39 @@ class TestHogFlowAPI(APIBaseTest):
         assert response.status_code == 400, response.json()
         assert "Cohort membership can't be evaluated in real-time filters" in response.json()["detail"]
 
+    def test_hog_flow_grandfathers_stored_cohort_conditions_after_flag_dial_down(self):
+        # The flag polices new adoption only. An active flow's stored cohort condition must keep
+        # saving after a flag dial-down (or an internal re-save with no request to evaluate the
+        # flag against), while a newly added cohort condition still needs the flag.
+        cohort = self._create_behavioral_cohort(CohortType.REALTIME, backfilled=True)
+        other_cohort = self._create_behavioral_cohort(CohortType.REALTIME, backfilled=True)
+        hog_flow = self._hog_flow_with_condition_filters(
+            "conditional_branch", {"properties": [{"key": "id", "type": "cohort", "value": cohort.id}]}
+        )
+        with patch("products.workflows.backend.api.hog_flow.feature_enabled_or_false", return_value=True):
+            created = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
+        assert created.status_code == 201, created.json()
+        flow_id = created.json()["id"]
+        stored_actions = created.json()["actions"]
+
+        with patch("products.workflows.backend.api.hog_flow.feature_enabled_or_false", return_value=False):
+            resave = self.client.patch(
+                f"/api/projects/{self.team.id}/hog_flows/{flow_id}",
+                {"name": "renamed", "actions": stored_actions},
+            )
+            assert resave.status_code == 200, resave.json()
+
+            edited_actions = deepcopy(stored_actions)
+            edited_actions[1]["config"]["conditions"].append(
+                {"filters": {"properties": [{"key": "id", "type": "cohort", "value": other_cohort.id}]}}
+            )
+            new_adoption = self.client.patch(
+                f"/api/projects/{self.team.id}/hog_flows/{flow_id}",
+                {"actions": edited_actions},
+            )
+            assert new_adoption.status_code == 400, new_adoption.json()
+            assert "Cohort membership can't be evaluated" in new_adoption.json()["detail"]
+
     @parameterized.expand(
         [
             ("expression_only", False),
@@ -1300,6 +1342,41 @@ class TestHogFlowAPI(APIBaseTest):
 
         assert response.status_code == 400, response.json()
         assert "Can't call inCohort() directly" in response.json()["detail"]
+
+    @patch("products.workflows.backend.api.hog_flow.feature_enabled_or_false", return_value=True)
+    def test_hog_flow_rejects_authored_reads_of_the_cohort_ids_global(self, _mock_flag):
+        # An eligible cohort leaf turns cohort support on and makes the runtime inject the
+        # person's real memberships as the `cohort_ids` global. An authored read of that global
+        # (`999999 in cohort_ids`) would then test membership of a cohort the eligibility
+        # validation never cleared, so the compiler must reject it.
+        cohort = self._create_behavioral_cohort(CohortType.REALTIME, backfilled=True)
+        properties: list[dict[str, Any]] = [
+            {"key": "id", "type": "cohort", "value": cohort.id},
+            {"key": "999999 in cohort_ids", "type": "hogql"},
+        ]
+        hog_flow = self._hog_flow_with_condition_filters("conditional_branch", {"properties": properties})
+
+        response = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
+
+        assert response.status_code == 400, response.json()
+        assert "cohort_ids is reserved" in response.json()["detail"]
+
+    @parameterized.expand(
+        [
+            ("filters_is_a_string", "not-a-dict"),
+            ("action_id_not_an_integer", {"actions": [{"id": "not-an-integer"}]}),
+            ("action_entry_not_a_dict", {"actions": ["bogus"]}),
+        ]
+    )
+    @patch("products.workflows.backend.api.hog_flow.feature_enabled_or_false", return_value=True)
+    def test_hog_flow_conditional_branch_malformed_filters_get_a_400(self, _name, filters, _mock_flag):
+        # The cohort-support scan reads raw client filters before DRF validation, so malformed
+        # shapes must fall through to the serializer's structured 400 instead of raising a 500.
+        hog_flow = self._hog_flow_with_condition_filters("conditional_branch", filters)
+
+        response = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
+
+        assert response.status_code == 400, response.json()
 
     @patch("products.workflows.backend.api.hog_flow.feature_enabled_or_false", return_value=True)
     def test_hog_flow_rejects_ineligible_cohorts_inside_referenced_actions(self, _mock_flag):

--- a/products/workflows/backend/api/test/test_hog_flow.py
+++ b/products/workflows/backend/api/test/test_hog_flow.py
@@ -1299,7 +1299,33 @@ class TestHogFlowAPI(APIBaseTest):
         response = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
 
         assert response.status_code == 400, response.json()
-        assert "Can't call inCohort() directly in filters" in response.json()["detail"]
+        assert "Can't call inCohort() directly" in response.json()["detail"]
+
+    @patch("products.workflows.backend.api.hog_flow.feature_enabled_or_false", return_value=True)
+    def test_hog_flow_rejects_ineligible_cohorts_inside_referenced_actions(self, _mock_flag):
+        # action_to_expr inlines a referenced Action's step properties into the compiled
+        # condition, so a cohort hiding there must be eligibility-validated like any other.
+        eligible = self._create_behavioral_cohort(CohortType.REALTIME, backfilled=True)
+        static_cohort = Cohort.objects.create(team=self.team, name="static-in-action", is_static=True)
+        action = Action.objects.create(
+            team=self.team,
+            name="action with cohort step",
+            steps_json=[
+                {"event": "$pageview", "properties": [{"key": "id", "type": "cohort", "value": static_cohort.id}]}
+            ],
+        )
+        hog_flow = self._hog_flow_with_condition_filters(
+            "conditional_branch",
+            {
+                "properties": [{"key": "id", "type": "cohort", "value": eligible.id}],
+                "actions": [{"id": action.id, "type": "actions"}],
+            },
+        )
+
+        response = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
+
+        assert response.status_code == 400, response.json()
+        assert "is a static cohort" in response.json()["detail"]
 
     def test_hog_flow_wait_until_condition_rejects_cohort_filters(self):
         cohort = self._create_behavioral_cohort(CohortType.REALTIME, backfilled=True)

--- a/products/workflows/backend/api/test/test_hog_flow.py
+++ b/products/workflows/backend/api/test/test_hog_flow.py
@@ -1199,7 +1199,8 @@ class TestHogFlowAPI(APIBaseTest):
             ("not_in_operator", "not_in", "notInCohort"),
         ]
     )
-    def test_hog_flow_conditional_branch_cohort_filter_compiles(self, _name, operator, expected_call):
+    @patch("products.workflows.backend.api.hog_flow.feature_enabled_or_false", return_value=True)
+    def test_hog_flow_conditional_branch_cohort_filter_compiles(self, _name, operator, expected_call, _mock_flag):
         cohort = self._create_behavioral_cohort(CohortType.REALTIME, backfilled=True)
         cohort_property: dict[str, Any] = {"key": "id", "type": "cohort", "value": cohort.id}
         if operator:
@@ -1221,7 +1222,10 @@ class TestHogFlowAPI(APIBaseTest):
             ("missing_cohort", "missing", "doesn't exist in this project"),
         ]
     )
-    def test_hog_flow_conditional_branch_rejects_ineligible_cohorts(self, _name, cohort_kind, expected_detail):
+    @patch("products.workflows.backend.api.hog_flow.feature_enabled_or_false", return_value=True)
+    def test_hog_flow_conditional_branch_rejects_ineligible_cohorts(
+        self, _name, cohort_kind, expected_detail, _mock_flag
+    ):
         if cohort_kind == "static":
             cohort_id = Cohort.objects.create(team=self.team, name="static-cohort", is_static=True).id
         elif cohort_kind == "dynamic":
@@ -1238,6 +1242,19 @@ class TestHogFlowAPI(APIBaseTest):
 
         assert response.status_code == 400, response.json()
         assert expected_detail in response.json()["detail"]
+
+    def test_hog_flow_conditional_branch_rejects_cohort_filters_without_flag(self):
+        # Rollout gate: without workflows-cohort-conditions, an eligible cohort still fails
+        # compilation the way it always has, so nothing changes for unflagged teams.
+        cohort = self._create_behavioral_cohort(CohortType.REALTIME, backfilled=True)
+        hog_flow = self._hog_flow_with_condition_filters(
+            "conditional_branch", {"properties": [{"key": "id", "type": "cohort", "value": cohort.id}]}
+        )
+
+        response = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
+
+        assert response.status_code == 400, response.json()
+        assert "Cohort membership can't be evaluated in real-time filters" in response.json()["detail"]
 
     def test_hog_flow_wait_until_condition_rejects_cohort_filters(self):
         # Cohort support is scoped to conditional_branch: a wait would only notice membership

--- a/products/workflows/backend/api/test/test_hog_flow.py
+++ b/products/workflows/backend/api/test/test_hog_flow.py
@@ -1243,6 +1243,32 @@ class TestHogFlowAPI(APIBaseTest):
         assert response.status_code == 400, response.json()
         assert expected_detail in response.json()["detail"]
 
+    @patch("products.workflows.backend.api.hog_flow.feature_enabled_or_false", return_value=True)
+    def test_hog_flow_conditional_branch_validates_cohorts_nested_in_action_filters(self, _mock_flag):
+        # A cohort inside an action filter's own `properties` compiles just like a top-level one, so
+        # it must clear the same eligibility gate. An eligible top-level cohort turns cohort support
+        # on for the whole condition; a static cohort nested in an action entry must still be
+        # rejected rather than silently compiling and routing everyone down the wrong branch.
+        eligible = self._create_behavioral_cohort(CohortType.REALTIME, backfilled=True)
+        static_cohort = Cohort.objects.create(team=self.team, name="static-cohort", is_static=True)
+        action = Action.objects.create(team=self.team, name="Converted", steps_json=[{"event": "converted"}])
+        filters = {
+            "properties": [{"key": "id", "type": "cohort", "value": eligible.id}],
+            "actions": [
+                {
+                    "id": str(action.id),
+                    "type": "actions",
+                    "properties": [{"key": "id", "type": "cohort", "value": static_cohort.id}],
+                }
+            ],
+        }
+        hog_flow = self._hog_flow_with_condition_filters("conditional_branch", filters)
+
+        response = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
+
+        assert response.status_code == 400, response.json()
+        assert "is a static cohort" in response.json()["detail"]
+
     def test_hog_flow_conditional_branch_rejects_cohort_filters_without_flag(self):
         cohort = self._create_behavioral_cohort(CohortType.REALTIME, backfilled=True)
         hog_flow = self._hog_flow_with_condition_filters(

--- a/products/workflows/backend/api/test/test_hog_flow.py
+++ b/products/workflows/backend/api/test/test_hog_flow.py
@@ -1211,7 +1211,7 @@ class TestHogFlowAPI(APIBaseTest):
 
         assert response.status_code == 201, response.json()
         filters = response.json()["actions"][1]["config"]["conditions"][0]["filters"]
-        assert filters["bytecode"] == ["_H", 1, 33, cohort.id, 2, expected_call, 1]
+        assert filters["bytecode"] == ["_H", 1, 33, cohort.id, 32, "cohort_ids", 1, 1, 2, expected_call, 2]
         assert filters["cohort_ids"] == [cohort.id]
 
     @parameterized.expand(

--- a/products/workflows/backend/api/test/test_hog_flow.py
+++ b/products/workflows/backend/api/test/test_hog_flow.py
@@ -1212,7 +1212,7 @@ class TestHogFlowAPI(APIBaseTest):
         assert response.status_code == 201, response.json()
         filters = response.json()["actions"][1]["config"]["conditions"][0]["filters"]
         assert filters["bytecode"] == ["_H", 1, 33, cohort.id, 32, "cohort_ids", 1, 1, 2, expected_call, 2]
-        assert filters["cohort_ids"] == [cohort.id]
+        assert "cohort_ids" not in filters
 
     @parameterized.expand(
         [

--- a/products/workflows/backend/api/test/test_hog_flow.py
+++ b/products/workflows/backend/api/test/test_hog_flow.py
@@ -1244,8 +1244,6 @@ class TestHogFlowAPI(APIBaseTest):
         assert expected_detail in response.json()["detail"]
 
     def test_hog_flow_conditional_branch_rejects_cohort_filters_without_flag(self):
-        # Rollout gate: without workflows-cohort-conditions, an eligible cohort still fails
-        # compilation the way it always has, so nothing changes for unflagged teams.
         cohort = self._create_behavioral_cohort(CohortType.REALTIME, backfilled=True)
         hog_flow = self._hog_flow_with_condition_filters(
             "conditional_branch", {"properties": [{"key": "id", "type": "cohort", "value": cohort.id}]}
@@ -1257,8 +1255,6 @@ class TestHogFlowAPI(APIBaseTest):
         assert "Cohort membership can't be evaluated in real-time filters" in response.json()["detail"]
 
     def test_hog_flow_wait_until_condition_rejects_cohort_filters(self):
-        # Cohort support is scoped to conditional_branch: a wait would only notice membership
-        # changes via the polling backstop, so the compile-time rejection must stay in place.
         cohort = self._create_behavioral_cohort(CohortType.REALTIME, backfilled=True)
         hog_flow = self._hog_flow_with_condition_filters(
             "wait_until_condition", {"properties": [{"key": "id", "type": "cohort", "value": cohort.id}]}


### PR DESCRIPTION
## Problem

Saving a workflow with a cohort filter in a conditional branch fails with a 400: "Cohort membership can't be evaluated in real-time filters". The runtime can now evaluate them (#83799), but the compiler still rejects every cohort reference.

Third layer of stack #83802, on top of #83799.

## Changes

**Compilation.** Conditional branch conditions compile with `cohort_membership_supported`, so a cohort property filter becomes an `inCohort(id, cohort_ids)` / `notInCohort(id, cohort_ids)` call instead of a compile error — the second argument is the membership set the runtime prefetches into globals, passed explicitly because the STL implementations are pure (#83799). Hand-authored `inCohort(...)` calls (e.g. in a HogQL expression filter) are rejected at compile time with a clear 400: they would bypass both the rollout flag and the eligibility check, and an ineligible cohort id silently evaluates everyone as a non-member. Only compiler-generated calls from cohort property filters pass, including when a structured cohort leaf has already turned cohort support on for the condition. Only `conditional_branch` gets this; every other filter surface keeps rejecting cohorts, and `wait_until_condition` keeps its rejection since a parked wait has no membership wake stream and would only ever advance via the 10-minute poll.

**Rollout.** Everything sits behind the `workflows-cohort-conditions` flag (organization-targeted), evaluated only when a condition actually references a cohort — ordinary saves never pay for it. Flag off means cohorts fail compilation exactly as before.

**Eligibility.** Save-time validation uses `Cohort.is_flag_compatible`, the same gate feature flags use: only realtime cohorts whose backfills completed have rows in the membership table. Static, dynamic, unbackfilled, and missing cohorts each get a 400 naming the problem. Validation covers every property tree the compiler actually reaches: top-level properties, each event/action entry's own properties, and cohort properties inside a referenced Action's stored steps (which action_to_expr inlines).

## How did you test this code?

I'm an agent: 8 API tests ran locally and pass — the two compile cases assert the exact two-arg bytecode (pinning the cross-language contract the Node e2e in #83799 asserts from the other side), four ineligibility cases assert their 400s, one pins the flag-off rejection, one pins the wait_until_condition rejection so the carve-out can't silently widen, and two pin the hand-authored inCohort rejection (expression-only and mixed with a structured leaf). The cohorts API bytecode tests (which share the compiler flag for nested cohort references) also pass against the new emission. Repo-wide mypy clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code. Skills followed: improving-drf-endpoints, writing-tests, writing-user-facing-copy, stacking-prs, writing-pr-descriptions. Design notes: emission changed from a one-arg marker call (earlier revision) to the explicit two-arg form when the implementation moved to pure bytecode STL; the shared `posthog/api/cohort.py` path that compiles nested-cohort-reference bytecode with the same flag was verified against the new shape (its consumers resolve nested refs structurally and never execute these calls).
