### PR TITLE
feat(signals): emit signals_autostart_skipped on every auto-start skip

### DIFF
--- a/products/signals/backend/auto_start.py
+++ b/products/signals/backend/auto_start.py
@@ -335,6 +335,38 @@ def _capture_billing_exempted(*, team: Team, report_id: str, reason: str, task_i
         logger.exception("Failed to capture signals_pr_billing_exempted", report_id=report_id)
 
 
+async def _acapture_autostart_skipped(
+    *,
+    team_id: int,
+    report_id: str,
+    reason: str,
+    team: Team | None = None,
+    actionability: str | None = None,
+    priority: str | None = None,
+) -> None:
+    """`signals_autostart_skipped` records every skipped auto-start evaluation with a stable
+    reason slug, so ready-reports-that-never-start is queryable per org instead of log-only."""
+    try:
+        if team is None:
+            team = await Team.objects.select_related("organization").aget(pk=team_id)
+        posthoganalytics.capture(
+            event="signals_autostart_skipped",
+            distinct_id=str(team.organization.id),
+            properties={
+                "team_id": team_id,
+                "organization_id": str(team.organization.id),
+                "report_id": report_id,
+                "reason": reason,
+                "actionability": actionability,
+                "priority": priority,
+            },
+            groups=groups(team.organization, team),
+        )
+    except Exception:
+        # Analytics must never break auto-start.
+        logger.exception("Failed to capture signals_autostart_skipped", report_id=report_id)
+
+
 def _create_implementation_task_if_absent(
     *,
     team_id: int,
@@ -629,20 +661,29 @@ async def maybe_autostart_implementation_task(
             report_id=report_id, team_id=team_id, product=SIGNALS_PRODUCT, type=TASK_RUN_TYPE_IMPLEMENTATION
         )
     )
-    skip_reason: str | None = None
+    # Each skip pairs the existing log wording with a stable event reason slug; the slugs feed
+    # the `signals_autostart_skipped` event, so don't reword them without checking consumers.
+    skip: tuple[str, str] | None = None  # (log reason, event reason slug)
     if task_exists:
-        skip_reason = "implementation task already exists"
+        skip = ("implementation task already exists", "task_exists")
     elif actionability.actionability != ActionabilityChoice.IMMEDIATELY_ACTIONABLE:
-        skip_reason = f"not immediately actionable: {actionability.actionability.value}"
+        skip = (f"not immediately actionable: {actionability.actionability.value}", "not_immediately_actionable")
     elif actionability.already_addressed:
-        skip_reason = "report already addressed"
+        skip = ("report already addressed", "already_addressed")
     elif priority is None:
-        skip_reason = "no priority assessment"
-    if skip_reason is not None:
-        logger.info("self-driving auto-start skipped", report_id=report_id, team_id=team_id, reason=skip_reason)
+        skip = ("no priority assessment", "no_priority")
+    if skip is not None:
+        logger.info("self-driving auto-start skipped", report_id=report_id, team_id=team_id, reason=skip[0])
+        await _acapture_autostart_skipped(
+            team_id=team_id,
+            report_id=report_id,
+            reason=skip[1],
+            actionability=actionability.actionability.value,
+            priority=priority.priority.value if priority else None,
+        )
         return
 
-    assert priority is not None  # narrowed by the `priority is None` skip_reason guard above
+    assert priority is not None  # narrowed by the `priority is None` skip guard above
 
     team_config = await SignalTeamConfig.objects.filter(team_id=team_id).afirst()
     if team_config and team_config.autostart_enabled is False:
@@ -654,6 +695,13 @@ async def maybe_autostart_implementation_task(
             report_id=report_id,
             team_id=team_id,
             reason="autostart disabled for team",
+        )
+        await _acapture_autostart_skipped(
+            team_id=team_id,
+            report_id=report_id,
+            reason="autostart_disabled",
+            actionability=actionability.actionability.value,
+            priority=priority.priority.value,
         )
         return
     team_default_priority = Priority(team_config.default_autostart_priority) if team_config else Priority.P4
@@ -672,6 +720,14 @@ async def maybe_autostart_implementation_task(
             report_id=report_id,
             team_id=team_id,
             reason="org over self-driving credits quota",
+        )
+        await _acapture_autostart_skipped(
+            team_id=team_id,
+            report_id=report_id,
+            reason="quota_enforced",
+            team=team,
+            actionability=actionability.actionability.value,
+            priority=priority.priority.value,
         )
         return
 
@@ -696,6 +752,14 @@ async def maybe_autostart_implementation_task(
             report_id=report_id,
             team_id=team_id,
             reason="no autostart runner: no reviewer met threshold, and no enabling member for a report at/above the team autostart priority",
+        )
+        await _acapture_autostart_skipped(
+            team_id=team_id,
+            report_id=report_id,
+            reason="no_runner",
+            team=team,
+            actionability=actionability.actionability.value,
+            priority=priority.priority.value,
         )
         return
 
@@ -725,6 +789,14 @@ async def maybe_autostart_implementation_task(
     if not created:
         # Another evaluation won the race and already created the implementation task.
         logger.info("self-driving auto-start skipped", report_id=report_id, team_id=team_id, reason="lost create race")
+        await _acapture_autostart_skipped(
+            team_id=team_id,
+            report_id=report_id,
+            reason="lost_create_race",
+            team=team,
+            actionability=actionability.actionability.value,
+            priority=priority.priority.value,
+        )
         return
 
 

--- a/products/signals/backend/test/test_auto_start.py
+++ b/products/signals/backend/test/test_auto_start.py
@@ -541,6 +541,7 @@ async def test_already_addressed_report_does_not_autostart(already_addressed):
     with (
         patch.object(tasks_facade, "create_and_run_task", side_effect=_fake_create_and_run_task) as mock_create,
         patch("products.signals.backend.auto_start.resolve_agent_runtime", return_value=pinned),
+        patch("products.signals.backend.auto_start.posthoganalytics.capture") as mock_capture,
     ):
         await maybe_autostart_implementation_task(
             team_id=team.id,
@@ -558,6 +559,16 @@ async def test_already_addressed_report_does_not_autostart(already_addressed):
         )
 
     assert mock_create.call_count == (0 if already_addressed else 1)
+    skip_events = [c for c in mock_capture.call_args_list if c.kwargs.get("event") == "signals_autostart_skipped"]
+    if already_addressed:
+        assert len(skip_events) == 1
+        props = skip_events[0].kwargs["properties"]
+        assert props["reason"] == "already_addressed"
+        assert props["report_id"] == str(report.id)
+        # Org attribution ($group_0) is what lets the stall analysis join skip events to orgs.
+        assert "organization" in skip_events[0].kwargs["groups"]
+    else:
+        assert skip_events == []
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

- Self-Driving reports that are ready but never get an implementation task stall without a queryable reason.
- Only the quota gate emits an event today (`signal_report_quota_paused`). Every other skip branch in auto-start writes a server log only.
- Log-only reasons cannot join to `$group_0`, so nobody can ask which orgs stall at this stage, or why.

## Changes

- `maybe_autostart_implementation_task` now emits a `signals_autostart_skipped` event on every skip branch.
- The event is org-attributed via `groups`, and carries `team_id`, `report_id`, `actionability`, and `priority`.
- Reasons are stable slugs. Each slug marks a different org segment for ICP analysis:
  - `quota_enforced`: the org used its full self-driving credits quota. A strong fit signal and an expansion candidate.
  - `autostart_disabled`: a deliberate opt-out. The org wants reports, not autonomous tasks.
  - `no_runner`: setup friction. The org fits, but no member with a connected GitHub identity met the threshold.
  - `not_immediately_actionable` / `no_priority`: the research output was not actionable for this org's data. A product boundary marker.
  - `already_addressed`: the team fixed the issue before Self-Driving did.
  - `task_exists` / `lost_create_race`: dedup noise. Exclude these from stall analysis.
- Aggregate by distinct org, not by event count. Auto-start re-evaluates each research cycle, so one stalled org emits many events.
- The capture helper fetches the team lazily inside its own try/except. Early skip branches keep their failure behavior.
- Capture failures are swallowed, matching `_capture_billing_exempted`. Analytics never breaks auto-start.
- Log wording is unchanged. The re-eval entry point keeps its three log-only pre-checks, which fire on artefact edits only.

> [!NOTE]
> An enforced quota skip now emits two events: `signal_report_quota_paused` and `signals_autostart_skipped`. Count quota pauses from one of them, not both.

## How did you test this code?

- Extended `test_already_addressed_report_does_not_autostart`. It now fails if the skip event disappears, loses its reason slug, or loses org attribution. No existing test asserted any capture on a skip path.
- Ran `hogli test products/signals/backend/test/test_auto_start.py` locally: 36 passed.
- Not run: repo-wide mypy. CI runs it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Internal telemetry event.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code session implementing the instrumentation phase of a Self-Driving ICP research plan. The skip reasons were the one funnel stage visible only in logs.
- A follow-up session corrected the Problem claim (the quota skip was already captured) and added the ICP meaning of each reason slug.
- Skills invoked: /writing-tests, /writing-code-comments, /writing-pr-descriptions.
- No customer data or session-specific material is in the diff. Reason slugs and property names were written fresh from the code.
