### PR TITLE
feat(ingestion): split Kafka batches into event-capped sub-batch chunks

### DIFF
--- a/rust/ingestion-consumer/src/config.rs
+++ b/rust/ingestion-consumer/src/config.rs
@@ -223,12 +223,14 @@ pub struct Config {
     #[envconfig(from = "INGESTION_SUB_BATCH_MAX_EVENTS", default = "0")]
     pub sub_batch_max_events: usize,
 
-    /// Floor on splitting: an open chunk still under this many events is not
-    /// closed just because the next key-group doesn't fit — that group gets a
-    /// chunk of its own and the under-filled one keeps taking later groups.
-    /// Best-effort, not a guarantee: whatever is left at the end of a batch
-    /// ships as one chunk however small. `0` (the default) means no floor;
-    /// values above `INGESTION_SUB_BATCH_MAX_EVENTS` are clamped to it.
+    /// Soft target that suppresses runt chunks: an open chunk still under this
+    /// many events is not closed just because the next key-group doesn't fit —
+    /// that group gets a chunk of its own and the under-filled one keeps taking
+    /// later groups. It is not a lower bound and never holds messages back:
+    /// chunks below it still ship (a batch's tail, a batch smaller than this,
+    /// or the group shipped on its own). Only the max is a real cap. `0` (the
+    /// default) means no target; values above
+    /// `INGESTION_SUB_BATCH_MAX_EVENTS` are clamped to it.
     #[envconfig(from = "INGESTION_SUB_BATCH_MIN_EVENTS", default = "0")]
     pub sub_batch_min_events: usize,
 

--- a/rust/ingestion-consumer/src/config.rs
+++ b/rust/ingestion-consumer/src/config.rs
@@ -211,6 +211,27 @@ pub struct Config {
     #[envconfig(from = "INGESTION_TRANSPORT_MAX_BODY_BYTES", default = "10485760")]
     pub transport_max_body_bytes: usize,
 
+    /// Cap on the number of events in one sub-batch. A Kafka batch's key-groups
+    /// are packed into chunks of at most this many events, each sent as its own
+    /// request, so one batch can be worked by several workers in parallel
+    /// instead of landing on one worker as a single request. A key-group is
+    /// never split, so a single group larger than this stays whole (the
+    /// transport's byte cap still bounds the wire size).
+    ///
+    /// `0` (the default) disables chunking: each worker receives exactly one
+    /// sub-batch per Kafka batch. Enabling is a charts-side, per-lane opt-in.
+    #[envconfig(from = "INGESTION_SUB_BATCH_MAX_EVENTS", default = "0")]
+    pub sub_batch_max_events: usize,
+
+    /// Floor on splitting: an open chunk still under this many events is not
+    /// closed just because the next key-group doesn't fit — that group gets a
+    /// chunk of its own and the under-filled one keeps taking later groups.
+    /// Best-effort, not a guarantee: whatever is left at the end of a batch
+    /// ships as one chunk however small. `0` (the default) means no floor;
+    /// values above `INGESTION_SUB_BATCH_MAX_EVENTS` are clamped to it.
+    #[envconfig(from = "INGESTION_SUB_BATCH_MIN_EVENTS", default = "0")]
+    pub sub_batch_min_events: usize,
+
     /// Shared secret for authenticating with Node.js workers (X-Internal-Api-Secret header)
     #[envconfig(default = "")]
     pub internal_api_secret: String,

--- a/rust/ingestion-consumer/src/config.rs
+++ b/rust/ingestion-consumer/src/config.rs
@@ -211,25 +211,28 @@ pub struct Config {
     #[envconfig(from = "INGESTION_TRANSPORT_MAX_BODY_BYTES", default = "10485760")]
     pub transport_max_body_bytes: usize,
 
-    /// Cap on the number of events in one sub-batch. A Kafka batch's key-groups
-    /// are packed into chunks of at most this many events, each sent as its own
-    /// request, so one batch can be worked by several workers in parallel
-    /// instead of landing on one worker as a single request. A key-group is
-    /// never split, so a single group larger than this stays whole (the
-    /// transport's byte cap still bounds the wire size).
+    /// Cap on the number of events in one sub-batch. A worker's share of a
+    /// Kafka batch is split into requests of at most this many events, so a
+    /// batch that lands concentrated on few workers is worked in parallel
+    /// rather than as one large request each. A key-group is never split, so a
+    /// single group larger than this stays whole (the transport's byte cap
+    /// still bounds the wire size).
+    ///
+    /// A worker whose share is already under the cap still gets one request, so
+    /// this only splits where a batch is actually concentrated.
     ///
     /// `0` (the default) disables chunking: each worker receives exactly one
     /// sub-batch per Kafka batch. Enabling is a charts-side, per-lane opt-in.
     #[envconfig(from = "INGESTION_SUB_BATCH_MAX_EVENTS", default = "0")]
     pub sub_batch_max_events: usize,
 
-    /// Soft target that suppresses runt chunks: an open chunk still under this
+    /// Soft target that suppresses runt requests: a sub-batch still under this
     /// many events is not closed just because the next key-group doesn't fit —
-    /// that group gets a chunk of its own and the under-filled one keeps taking
-    /// later groups. It is not a lower bound and never holds messages back:
-    /// chunks below it still ship (a batch's tail, a batch smaller than this,
-    /// or the group shipped on its own). Only the max is a real cap. `0` (the
-    /// default) means no target; values above
+    /// that group gets a sub-batch of its own and the under-filled one keeps
+    /// taking later groups. It is not a lower bound and never holds messages
+    /// back: sub-batches below it still ship (a worker's tail, a share smaller
+    /// than this, or the group shipped on its own). Only the max is a real cap.
+    /// `0` (the default) means no target; values above
     /// `INGESTION_SUB_BATCH_MAX_EVENTS` are clamped to it.
     #[envconfig(from = "INGESTION_SUB_BATCH_MIN_EVENTS", default = "0")]
     pub sub_batch_min_events: usize,

--- a/rust/ingestion-consumer/src/dispatcher.rs
+++ b/rust/ingestion-consumer/src/dispatcher.rs
@@ -90,9 +90,91 @@ pub struct EagerFlush {
     pub sub_batch: SubBatch,
 }
 
+/// Event-count bands for splitting a batch into several sub-batches ("chunks")
+/// rather than one per worker. A key-group is never split across chunks — that
+/// is what keeps per-key ordering intact — so a group larger than `max_events`
+/// becomes an over-sized chunk of its own.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ChunkConfig {
+    /// Hard cap on events per chunk. `0` disables chunking, giving each worker
+    /// exactly one sub-batch per batch.
+    max_events: usize,
+    /// Best-effort floor: an under-filled chunk stays open instead of closing
+    /// early because the next key-group doesn't fit.
+    min_events: usize,
+}
+
+impl ChunkConfig {
+    /// A `min_events` above `max_events` is clamped — a floor above the cap
+    /// could never be met.
+    pub fn new(max_events: usize, min_events: usize) -> Self {
+        Self {
+            max_events,
+            min_events: min_events.min(max_events),
+        }
+    }
+
+    pub fn disabled() -> Self {
+        Self::new(0, 0)
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.max_events > 0
+    }
+
+    /// Whether a sub-batch holding `open_events` still has room for `events`.
+    fn fits(&self, open_events: usize, events: usize) -> bool {
+        !self.enabled() || open_events + events <= self.max_events
+    }
+}
+
 struct MessageGroup {
     routing_key: String,
     messages: Vec<SerializedKafkaMessage>,
+}
+
+impl MessageGroup {
+    fn message_count(&self) -> usize {
+        self.messages.len()
+    }
+}
+
+/// Pack key-groups into chunks of at most `chunking.max_events` events, keeping
+/// each key-group whole. A chunk still under `min_events` is not closed just
+/// because the next group doesn't fit: that group gets a chunk of its own and
+/// the under-filled one keeps taking later groups. Whatever is left at the end
+/// ships as one chunk, however small.
+fn pack_chunks(groups: Vec<MessageGroup>, chunking: ChunkConfig) -> Vec<Vec<MessageGroup>> {
+    debug_assert!(chunking.enabled(), "packing needs an event cap");
+
+    let mut chunks: Vec<Vec<MessageGroup>> = Vec::new();
+    let mut open: Vec<MessageGroup> = Vec::new();
+    let mut open_events = 0usize;
+
+    for group in groups {
+        let events = group.message_count();
+        if !open.is_empty() && !chunking.fits(open_events, events) {
+            if open_events < chunking.min_events {
+                // Under the floor — ship this group alone rather than splitting
+                // the open chunk early; later groups keep topping it up.
+                chunks.push(vec![group]);
+                continue;
+            }
+            chunks.push(std::mem::take(&mut open));
+            open_events = 0;
+        }
+        open_events += events;
+        open.push(group);
+        if open_events >= chunking.max_events {
+            chunks.push(std::mem::take(&mut open));
+            open_events = 0;
+        }
+    }
+
+    if !open.is_empty() {
+        chunks.push(open);
+    }
+    chunks
 }
 
 struct WorkerSubBatchBuilder {
@@ -102,6 +184,14 @@ struct WorkerSubBatchBuilder {
 }
 
 impl WorkerSubBatchBuilder {
+    fn new() -> Self {
+        Self {
+            messages: Vec::new(),
+            routing_keys: Vec::new(),
+            key_offsets: Vec::new(),
+        }
+    }
+
     fn is_empty(&self) -> bool {
         self.messages.is_empty()
     }
@@ -109,28 +199,8 @@ impl WorkerSubBatchBuilder {
     fn message_count(&self) -> usize {
         self.messages.len()
     }
-}
 
-#[derive(Default)]
-struct WorkerAssignments {
-    by_worker: HashMap<WorkerId, WorkerSubBatchBuilder>,
-}
-
-impl WorkerAssignments {
-    fn new() -> Self {
-        Self::default()
-    }
-
-    fn add_group(&mut self, worker: WorkerId, group: MessageGroup) {
-        let builder = self
-            .by_worker
-            .entry(worker)
-            .or_insert_with(|| WorkerSubBatchBuilder {
-                messages: Vec::new(),
-                routing_keys: Vec::new(),
-                key_offsets: Vec::new(),
-            });
-
+    fn push(&mut self, group: MessageGroup) {
         // Only keyed messages participate in the key-order sentinel: a
         // null-key message lives on an arbitrary partition, so its offset
         // must not advance the key's ACK watermark.
@@ -141,17 +211,89 @@ impl WorkerAssignments {
             .map(|m| m.offset)
             .max()
         {
-            builder.key_offsets.push(KeyOffset {
+            self.key_offsets.push(KeyOffset {
                 routing_key: group.routing_key.clone(),
                 max_offset,
             });
         }
-        builder.messages.extend(group.messages);
-        builder.routing_keys.push(group.routing_key);
+        self.messages.extend(group.messages);
+        self.routing_keys.push(group.routing_key);
+    }
+}
+
+/// The sub-batches a single assignment round produces. With chunking off a
+/// worker gets one sub-batch holding everything routed to it; with it on the
+/// worker's groups are packed into event-capped sub-batches, so one worker may
+/// appear several times.
+struct WorkerAssignments {
+    sub_batches: Vec<(WorkerId, WorkerSubBatchBuilder)>,
+    /// Index into `sub_batches` of the sub-batch each worker is still filling.
+    open: HashMap<WorkerId, usize>,
+    chunking: ChunkConfig,
+}
+
+impl WorkerAssignments {
+    fn new(chunking: ChunkConfig) -> Self {
+        Self {
+            sub_batches: Vec::new(),
+            open: HashMap::new(),
+            chunking,
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.sub_batches.iter().all(|(_, b)| b.is_empty())
+    }
+
+    /// Add a group to the worker's open sub-batch, starting a new one when the
+    /// event cap would be exceeded. The group itself is never split.
+    fn add_group(&mut self, worker: WorkerId, group: MessageGroup) {
+        let events = group.message_count();
+
+        if let Some(idx) = self.open.get(&worker).copied() {
+            let open_events = self.sub_batches[idx].1.message_count();
+            if self.chunking.fits(open_events, events) {
+                self.sub_batches[idx].1.push(group);
+                self.close_if_full(&worker, idx);
+                return;
+            }
+            if open_events < self.chunking.min_events {
+                // Keep the under-filled sub-batch open for later groups and
+                // give this one its own, rather than splitting early.
+                self.push_sub_batch(worker, group, false);
+                return;
+            }
+            self.open.remove(&worker);
+        }
+
+        self.push_sub_batch(worker, group, true);
+    }
+
+    /// Start a sub-batch for `worker` holding `group`. `keep_open` decides
+    /// whether later groups may still be added to it.
+    fn push_sub_batch(&mut self, worker: WorkerId, group: MessageGroup, keep_open: bool) {
+        let mut builder = WorkerSubBatchBuilder::new();
+        builder.push(group);
+        self.sub_batches.push((worker.clone(), builder));
+        if keep_open {
+            let idx = self.sub_batches.len() - 1;
+            self.open.insert(worker.clone(), idx);
+            self.close_if_full(&worker, idx);
+        }
+    }
+
+    /// Stop filling a sub-batch that has reached the cap, so the next group
+    /// starts a fresh one.
+    fn close_if_full(&mut self, worker: &WorkerId, idx: usize) {
+        if self.chunking.enabled()
+            && self.sub_batches[idx].1.message_count() >= self.chunking.max_events
+        {
+            self.open.remove(worker);
+        }
     }
 
     fn sub_batch_infos(&self) -> Vec<SubBatchInfo> {
-        self.by_worker
+        self.sub_batches
             .iter()
             .filter(|(_, builder)| !builder.is_empty())
             .map(|(worker, builder)| SubBatchInfo {
@@ -162,15 +304,17 @@ impl WorkerAssignments {
             .collect()
     }
 
+    /// One entry per sub-batch, so a worker split across chunks appears once
+    /// per chunk. Callers accumulate per worker.
     fn routed_counts(&self) -> impl Iterator<Item = (WorkerId, usize)> + '_ {
-        self.by_worker
+        self.sub_batches
             .iter()
             .filter(|(_, builder)| !builder.is_empty())
             .map(|(worker, builder)| (worker.clone(), builder.message_count()))
     }
 
     fn into_sub_batches(self) -> Vec<SubBatch> {
-        self.by_worker
+        self.sub_batches
             .into_iter()
             .filter(|(_, builder)| !builder.is_empty())
             .map(|(worker, builder)| SubBatch {
@@ -210,6 +354,9 @@ pub struct Dispatcher {
     /// dispatcher's ring slice is derived from its agreed peer index. `None`
     /// (or a not-yet-known peer index) falls back to the full healthy pool.
     aperture: Option<(Arc<PeerTracker>, usize)>,
+    /// Event bands for splitting a batch into several sub-batches per worker.
+    /// Disabled by default — one sub-batch per worker per batch.
+    chunking: ChunkConfig,
     /// Debug event recorder; `None` unless `DEBUG_API_ENABLED`.
     debug_recorder: Option<Arc<DebugRecorder>>,
     /// Channel to the consumer's eager-flush send task. `None` disables eager
@@ -231,6 +378,7 @@ impl Dispatcher {
             router: Mutex::new(Router::new(strategy)),
             key_sentinel: Arc::new(KeyOrderSentinel::new()),
             aperture: None,
+            chunking: ChunkConfig::disabled(),
             debug_recorder: None,
             eager_flush_tx: Mutex::new(None),
         }
@@ -249,6 +397,7 @@ impl Dispatcher {
             router: Mutex::new(Router::with_seed(strategy, seed)),
             key_sentinel: Arc::new(KeyOrderSentinel::new()),
             aperture: None,
+            chunking: ChunkConfig::disabled(),
             debug_recorder: None,
             eager_flush_tx: Mutex::new(None),
         }
@@ -266,6 +415,13 @@ impl Dispatcher {
     /// dispatcher is shared.
     pub fn set_aperture(&mut self, tracker: Arc<PeerTracker>, min_aperture: usize) {
         self.aperture = Some((tracker, min_aperture.max(1)));
+    }
+
+    /// Split each batch into event-capped sub-batches instead of one per
+    /// worker, so a large batch can be worked by several workers in parallel.
+    /// Call before the dispatcher is shared.
+    pub fn set_chunking(&mut self, chunking: ChunkConfig) {
+        self.chunking = chunking;
     }
 
     /// Inject the debug UI recorder. Call before the dispatcher is shared.
@@ -353,7 +509,7 @@ impl Dispatcher {
         let distinct_ids = key_groups.len();
         histogram!("ingestion_consumer_distinct_ids_per_batch").record(distinct_ids as f64);
 
-        let mut assignments = WorkerAssignments::new();
+        let mut assignments = WorkerAssignments::new(self.chunking);
 
         // Candidate workers and their working load for this round. `working_load`
         // starts from each candidate's outstanding load and is bumped as groups
@@ -453,42 +609,61 @@ impl Dispatcher {
         };
         let candidates: &[WorkerId] = narrowed.as_deref().unwrap_or(&healthy);
 
-        for group in unpinned_groups {
+        // With chunking on, the groups are packed into event-capped chunks and
+        // each chunk is routed as a unit, so one batch spreads over several
+        // requests instead of one per worker. With it off every group is routed
+        // on its own, as before.
+        let routing_units = if self.chunking.enabled() {
+            pack_chunks(unpinned_groups, self.chunking)
+        } else {
+            unpinned_groups.into_iter().map(|g| vec![g]).collect()
+        };
+
+        for unit in routing_units {
+            let events: usize = unit.iter().map(MessageGroup::message_count).sum();
             let Some(worker) = router.select(candidates, &working_load) else {
                 // No routable worker right now (e.g. the whole pool is draining
-                // during a deploy overlap). Stash the group so the flush loop
-                // can route it once a worker returns — dropping it would fail
-                // the whole batch and restart the process for a transient
+                // during a deploy overlap). Stash the groups so the flush loop
+                // can route them once a worker returns — dropping them would
+                // fail the whole batch and restart the process for a transient
                 // condition.
                 counter!("ingestion_consumer_dispatcher_unroutable_messages_total")
-                    .increment(group.messages.len() as u64);
-                table.stash.defer(
-                    batch_id,
-                    DeferredGroup {
-                        routing_key: group.routing_key,
-                        messages: group.messages,
-                    },
-                );
-                unroutable_deferred_count += 1;
+                    .increment(events as u64);
+                for group in unit {
+                    table.stash.defer(
+                        batch_id,
+                        DeferredGroup {
+                            routing_key: group.routing_key,
+                            messages: group.messages,
+                        },
+                    );
+                    unroutable_deferred_count += 1;
+                }
                 continue;
             };
 
-            bump_load(&mut working_load, &worker, group.messages.len());
-            table.pins.insert(
-                group.routing_key.clone(),
-                Pin {
-                    worker: worker.clone(),
-                    ref_count: 1,
-                },
-            );
-            self.key_sentinel
-                .note_sent(&group.routing_key, &group.messages);
-            assignments.add_group(worker, group);
+            bump_load(&mut working_load, &worker, events);
+            for group in unit {
+                table.pins.insert(
+                    group.routing_key.clone(),
+                    Pin {
+                        worker: worker.clone(),
+                        ref_count: 1,
+                    },
+                );
+                self.key_sentinel
+                    .note_sent(&group.routing_key, &group.messages);
+                assignments.add_group(worker.clone(), group);
+            }
         }
         drop(router);
 
-        // Add each worker's message volume to its outstanding load.
+        // Add each worker's message volume to its outstanding load. A worker
+        // split across chunks yields one entry per chunk, so the counters see
+        // every sub-batch and the load accumulates over all of them.
+        let mut chunk_count = 0u64;
         for (worker, message_count) in assignments.routed_counts() {
+            chunk_count += 1;
             *table.in_flight.entry(worker.clone()).or_insert(0) += message_count;
             counter!(
                 "ingestion_consumer_dispatcher_sub_batches_assigned_total",
@@ -500,7 +675,9 @@ impl Dispatcher {
                 "worker" => worker.clone(),
             )
             .increment(message_count as u64);
+            histogram!("ingestion_consumer_sub_batch_events").record(message_count as f64);
         }
+        histogram!("ingestion_consumer_chunks_per_batch").record(chunk_count as f64);
 
         if drain_deferred_count > 0 {
             counter!(
@@ -716,7 +893,7 @@ impl Dispatcher {
             .iter()
             .map(|w| (w.clone(), table.in_flight.get(w).copied().unwrap_or(0)))
             .collect();
-        let mut assignments = WorkerAssignments::new();
+        let mut assignments = WorkerAssignments::new(self.chunking);
 
         let mut router = self.router.lock().unwrap();
         for group in groups {
@@ -781,11 +958,12 @@ impl Dispatcher {
                 "worker" => worker.to_string(),
             )
             .increment(message_count as u64);
+            histogram!("ingestion_consumer_sub_batch_events").record(message_count as f64);
         }
         gauge!("ingestion_consumer_dispatcher_pins_total").set(table.pins.len() as f64);
         record_stash_gauges(&table.stash);
 
-        if !assignments.by_worker.is_empty() {
+        if !assignments.is_empty() {
             record_if(&self.debug_recorder, || DebugEventKind::DeferredFlushed {
                 batch_id: batch_id.to_string(),
                 sub_batches: assignments.sub_batch_infos(),
@@ -973,7 +1151,8 @@ impl Dispatcher {
                 }
             }
             self.key_sentinel.note_sent(key, &messages);
-            let mut assignments = WorkerAssignments::new();
+            // One group, so this is a single sub-batch whatever the bands are.
+            let mut assignments = WorkerAssignments::new(self.chunking);
             assignments.add_group(
                 worker.clone(),
                 MessageGroup {
@@ -1267,7 +1446,7 @@ mod tests {
 
     #[test]
     fn test_worker_assignments_merges_groups_for_same_worker() {
-        let mut assignments = WorkerAssignments::new();
+        let mut assignments = WorkerAssignments::new(ChunkConfig::disabled());
 
         assignments.add_group(
             wid(1),
@@ -1315,7 +1494,7 @@ mod tests {
             ..make_msg("tok", "user-1")
         };
 
-        let mut assignments = WorkerAssignments::new();
+        let mut assignments = WorkerAssignments::new(ChunkConfig::disabled());
         assignments.add_group(
             wid(1),
             MessageGroup {
@@ -1329,7 +1508,7 @@ mod tests {
         assert_eq!(sub_batches[0].key_offsets[0].max_offset, 100);
 
         // An all-unkeyed group produces no ACK watermark at all.
-        let mut assignments = WorkerAssignments::new();
+        let mut assignments = WorkerAssignments::new(ChunkConfig::disabled());
         assignments.add_group(
             wid(1),
             MessageGroup {
@@ -1338,6 +1517,258 @@ mod tests {
             },
         );
         assert!(assignments.into_sub_batches()[0].key_offsets.is_empty());
+    }
+
+    // ---- sub-batch chunking ----
+
+    fn group(routing_key: &str, events: usize) -> MessageGroup {
+        MessageGroup {
+            routing_key: routing_key.to_string(),
+            messages: (0..events).map(|_| make_msg("t", routing_key)).collect(),
+        }
+    }
+
+    fn chunk_sizes(chunks: &[Vec<MessageGroup>]) -> Vec<usize> {
+        chunks
+            .iter()
+            .map(|chunk| chunk.iter().map(MessageGroup::message_count).sum())
+            .collect()
+    }
+
+    fn chunked_dispatcher(workers: usize, max_events: usize, min_events: usize) -> Dispatcher {
+        let mut dispatcher = Dispatcher::new(healthy_registry(workers));
+        dispatcher.set_chunking(ChunkConfig::new(max_events, min_events));
+        dispatcher
+    }
+
+    /// Distinct-id of every message in a sub-batch, as routing keys.
+    fn keys_in(sub_batch: &SubBatch) -> Vec<String> {
+        sub_batch
+            .messages
+            .iter()
+            .map(|m| format!("t:{}", m.headers["distinct_id"]))
+            .collect()
+    }
+
+    struct PackCase {
+        name: &'static str,
+        /// Event count of each key-group, in packing order.
+        group_events: &'static [usize],
+        max_events: usize,
+        min_events: usize,
+        /// Expected event count of each produced chunk.
+        expected_chunks: &'static [usize],
+    }
+
+    #[test]
+    fn test_pack_chunks_bands() {
+        let cases = [
+            PackCase {
+                name: "fills to the cap",
+                group_events: &[2, 2, 2, 2],
+                max_events: 4,
+                min_events: 0,
+                expected_chunks: &[4, 4],
+            },
+            PackCase {
+                name: "remainder under the floor still ships",
+                group_events: &[4, 1],
+                max_events: 4,
+                min_events: 3,
+                expected_chunks: &[4, 1],
+            },
+            PackCase {
+                name: "whole batch under the floor is one chunk",
+                group_events: &[1, 1, 1],
+                max_events: 100,
+                min_events: 50,
+                expected_chunks: &[3],
+            },
+            PackCase {
+                name: "a group over the cap stays whole",
+                group_events: &[9, 1],
+                max_events: 4,
+                min_events: 0,
+                expected_chunks: &[9, 1],
+            },
+            PackCase {
+                name: "floor keeps an under-filled chunk open past a heavy group",
+                // Without the floor the 90-event group would close the 30-event
+                // chunk early, emitting a runt request.
+                group_events: &[30, 90, 30, 30],
+                max_events: 100,
+                min_events: 80,
+                expected_chunks: &[90, 90],
+            },
+        ];
+
+        for case in cases {
+            let groups: Vec<MessageGroup> = case
+                .group_events
+                .iter()
+                .enumerate()
+                .map(|(i, events)| group(&format!("k{i}"), *events))
+                .collect();
+
+            let chunks = pack_chunks(groups, ChunkConfig::new(case.max_events, case.min_events));
+
+            assert_eq!(chunk_sizes(&chunks), case.expected_chunks, "{}", case.name);
+        }
+    }
+
+    #[test]
+    fn test_chunk_config_clamps_floor_to_cap() {
+        // A floor above the cap could never be met — it must not make the
+        // packer hold groups back or emit over-cap chunks.
+        let chunking = ChunkConfig::new(4, 100);
+        let groups = vec![group("a", 2), group("b", 2), group("c", 2)];
+
+        assert_eq!(chunk_sizes(&pack_chunks(groups, chunking)), vec![4, 2]);
+    }
+
+    #[test]
+    fn test_chunking_splits_a_batch_into_capped_sub_batches() {
+        // One worker, so every chunk lands on it: the split is the dispatcher's,
+        // not the router's.
+        let dispatcher = chunked_dispatcher(1, 3, 0);
+        let specs: Vec<(&str, &str)> = vec![
+            ("t", "a"),
+            ("t", "b"),
+            ("t", "c"),
+            ("t", "d"),
+            ("t", "e"),
+            ("t", "f"),
+            ("t", "g"),
+        ];
+
+        let sub_batches = dispatcher.assign("b", make_msgs(&specs));
+
+        let mut sizes: Vec<usize> = sub_batches.iter().map(|b| b.messages.len()).collect();
+        sizes.sort_unstable();
+        assert_eq!(sizes, vec![1, 3, 3]);
+        assert!(sub_batches.iter().all(|b| b.worker == wid(0)));
+    }
+
+    #[test]
+    fn test_disabled_chunking_keeps_one_sub_batch_per_worker() {
+        // The default, and the rollout's starting state: a worker receives all
+        // of its share of the batch as a single request.
+        let dispatcher = Dispatcher::new(healthy_registry(2));
+        let specs: Vec<(String, String)> = (0..20)
+            .map(|i| ("t".to_string(), format!("u{i}")))
+            .collect();
+        let specs: Vec<(&str, &str)> = specs
+            .iter()
+            .map(|(t, d)| (t.as_str(), d.as_str()))
+            .collect();
+
+        let sub_batches = dispatcher.assign("b", make_msgs(&specs));
+
+        let workers: std::collections::HashSet<WorkerId> =
+            sub_batches.iter().map(|b| b.worker.clone()).collect();
+        assert_eq!(
+            workers.len(),
+            sub_batches.len(),
+            "no worker may get more than one sub-batch"
+        );
+        assert_eq!(
+            sub_batches.iter().map(|b| b.messages.len()).sum::<usize>(),
+            20
+        );
+    }
+
+    #[test]
+    fn test_chunking_keeps_each_key_in_exactly_one_sub_batch() {
+        // The ordering invariant: a key-group is never split, so all of a
+        // distinct_id's messages ride one chunk to one worker.
+        let dispatcher = chunked_dispatcher(3, 4, 0);
+        let specs: Vec<(&str, &str)> = ["a", "b", "c", "d", "e"]
+            .iter()
+            .flat_map(|d| std::iter::repeat_n(("t", *d), 3))
+            .collect();
+
+        let sub_batches = dispatcher.assign("b", make_msgs(&specs));
+
+        let mut owner: HashMap<String, usize> = HashMap::new();
+        for (index, sub_batch) in sub_batches.iter().enumerate() {
+            assert!(sub_batch.messages.len() <= 4, "sub-batch over the cap");
+            for key in keys_in(sub_batch) {
+                let previous = owner.insert(key.clone(), index);
+                assert!(
+                    previous.is_none_or(|prev| prev == index),
+                    "key {key} split across sub-batches"
+                );
+            }
+        }
+        assert_eq!(owner.len(), 5);
+        assert_eq!(
+            sub_batches.iter().map(|b| b.messages.len()).sum::<usize>(),
+            15
+        );
+    }
+
+    #[test]
+    fn test_chunked_pinned_groups_stay_on_their_pinned_worker() {
+        let dispatcher = chunked_dispatcher(2, 2, 0);
+        let specs: Vec<(&str, &str)> = vec![("t", "a"), ("t", "b"), ("t", "c"), ("t", "d")];
+
+        // First batch pins the four keys; leave it in flight so the pins live.
+        let first = dispatcher.assign("batch-1", make_msgs(&specs));
+        let mut pinned: HashMap<String, WorkerId> = HashMap::new();
+        for sub_batch in &first {
+            for key in keys_in(sub_batch) {
+                pinned.insert(key, sub_batch.worker.clone());
+            }
+        }
+
+        let second = dispatcher.assign("batch-2", make_msgs(&specs));
+
+        for sub_batch in &second {
+            assert!(sub_batch.messages.len() <= 2, "pinned chunk over the cap");
+            for key in keys_in(sub_batch) {
+                assert_eq!(
+                    pinned.get(&key),
+                    Some(&sub_batch.worker),
+                    "key {key} left its pinned worker"
+                );
+            }
+        }
+        assert_eq!(second.iter().map(|b| b.messages.len()).sum::<usize>(), 4);
+    }
+
+    #[test]
+    fn test_chunk_resolution_drains_load_and_pins() {
+        // Commit accounting is per chunk: the batch's messages are spread over
+        // several sub-batches, and resolving each must leave nothing behind.
+        let dispatcher = chunked_dispatcher(1, 3, 0);
+        let specs: Vec<(String, String)> = (0..10)
+            .map(|i| ("t".to_string(), format!("u{i}")))
+            .collect();
+        let specs: Vec<(&str, &str)> = specs
+            .iter()
+            .map(|(t, d)| (t.as_str(), d.as_str()))
+            .collect();
+
+        let sub_batches = dispatcher.assign("b", make_msgs(&specs));
+        assert!(sub_batches.len() > 1, "batch should have been chunked");
+        assert_eq!(
+            sub_batches.iter().map(|b| b.messages.len()).sum::<usize>(),
+            10
+        );
+        assert_eq!(in_flight_of(&dispatcher, &wid(0)), 10);
+
+        for sub_batch in &sub_batches {
+            dispatcher.on_sub_batch_resolved(
+                &sub_batch.worker,
+                sub_batch.messages.len(),
+                &sub_batch.routing_keys,
+                false,
+                false,
+            );
+        }
+
+        assert_eq!(dispatcher.total_in_flight(), 0);
+        assert_eq!(dispatcher.pin_count(), 0);
     }
 
     // ---- basic assignment ----

--- a/rust/ingestion-consumer/src/dispatcher.rs
+++ b/rust/ingestion-consumer/src/dispatcher.rs
@@ -141,45 +141,6 @@ impl MessageGroup {
     }
 }
 
-/// Pack key-groups into chunks of at most `chunking.max_events` events, keeping
-/// each key-group whole. `min_events` only suppresses runt chunks: one still
-/// under it is not closed just because the next group doesn't fit — that group
-/// gets a chunk of its own and the under-filled one keeps taking later groups.
-/// Nothing is held back to reach it, so whatever is left at the end ships as
-/// one chunk however small.
-fn pack_chunks(groups: Vec<MessageGroup>, chunking: ChunkConfig) -> Vec<Vec<MessageGroup>> {
-    debug_assert!(chunking.enabled(), "packing needs an event cap");
-
-    let mut chunks: Vec<Vec<MessageGroup>> = Vec::new();
-    let mut open: Vec<MessageGroup> = Vec::new();
-    let mut open_events = 0usize;
-
-    for group in groups {
-        let events = group.message_count();
-        if !open.is_empty() && !chunking.fits(open_events, events) {
-            if open_events < chunking.min_events {
-                // Under the target — ship this group alone rather than
-                // splitting the open chunk early; later groups top it up.
-                chunks.push(vec![group]);
-                continue;
-            }
-            chunks.push(std::mem::take(&mut open));
-            open_events = 0;
-        }
-        open_events += events;
-        open.push(group);
-        if open_events >= chunking.max_events {
-            chunks.push(std::mem::take(&mut open));
-            open_events = 0;
-        }
-    }
-
-    if !open.is_empty() {
-        chunks.push(open);
-    }
-    chunks
-}
-
 struct WorkerSubBatchBuilder {
     messages: Vec<SerializedKafkaMessage>,
     routing_keys: Vec<String>,
@@ -224,10 +185,15 @@ impl WorkerSubBatchBuilder {
     }
 }
 
-/// The sub-batches a single assignment round produces. With chunking off a
-/// worker gets one sub-batch holding everything routed to it; with it on the
-/// worker's groups are packed into event-capped sub-batches, so one worker may
-/// appear several times.
+/// The sub-batches a single assignment round produces.
+///
+/// Every group — pinned or freshly routed — is added under its target worker,
+/// and each worker has one sub-batch still taking groups. With chunking off
+/// that sub-batch never closes, so the worker gets everything routed to it in
+/// one request. With it on, the sub-batch closes at the cap and the next group
+/// starts another, so one worker may appear several times. Because a worker
+/// keeps only one open sub-batch, its pinned groups and the fresh keys routed
+/// to it in the same batch share a request rather than each getting their own.
 struct WorkerAssignments {
     sub_batches: Vec<(WorkerId, WorkerSubBatchBuilder)>,
     /// Index into `sub_batches` of the sub-batch each worker is still filling.
@@ -614,52 +580,37 @@ impl Dispatcher {
         };
         let candidates: &[WorkerId] = narrowed.as_deref().unwrap_or(&healthy);
 
-        // With chunking on, the groups are packed into event-capped chunks and
-        // each chunk is routed as a unit, so one batch spreads over several
-        // requests instead of one per worker. With it off every group is routed
-        // on its own, as before.
-        let routing_units = if self.chunking.enabled() {
-            pack_chunks(unpinned_groups, self.chunking)
-        } else {
-            unpinned_groups.into_iter().map(|g| vec![g]).collect()
-        };
-
-        for unit in routing_units {
-            let events: usize = unit.iter().map(MessageGroup::message_count).sum();
+        for group in unpinned_groups {
             let Some(worker) = router.select(candidates, &working_load) else {
                 // No routable worker right now (e.g. the whole pool is draining
-                // during a deploy overlap). Stash the groups so the flush loop
-                // can route them once a worker returns — dropping them would
-                // fail the whole batch and restart the process for a transient
+                // during a deploy overlap). Stash the group so the flush loop
+                // can route it once a worker returns — dropping it would fail
+                // the whole batch and restart the process for a transient
                 // condition.
                 counter!("ingestion_consumer_dispatcher_unroutable_messages_total")
-                    .increment(events as u64);
-                for group in unit {
-                    table.stash.defer(
-                        batch_id,
-                        DeferredGroup {
-                            routing_key: group.routing_key,
-                            messages: group.messages,
-                        },
-                    );
-                    unroutable_deferred_count += 1;
-                }
+                    .increment(group.messages.len() as u64);
+                table.stash.defer(
+                    batch_id,
+                    DeferredGroup {
+                        routing_key: group.routing_key,
+                        messages: group.messages,
+                    },
+                );
+                unroutable_deferred_count += 1;
                 continue;
             };
 
-            bump_load(&mut working_load, &worker, events);
-            for group in unit {
-                table.pins.insert(
-                    group.routing_key.clone(),
-                    Pin {
-                        worker: worker.clone(),
-                        ref_count: 1,
-                    },
-                );
-                self.key_sentinel
-                    .note_sent(&group.routing_key, &group.messages);
-                assignments.add_group(worker.clone(), group);
-            }
+            bump_load(&mut working_load, &worker, group.messages.len());
+            table.pins.insert(
+                group.routing_key.clone(),
+                Pin {
+                    worker: worker.clone(),
+                    ref_count: 1,
+                },
+            );
+            self.key_sentinel
+                .note_sent(&group.routing_key, &group.messages);
+            assignments.add_group(worker, group);
         }
         drop(router);
 
@@ -1533,10 +1484,17 @@ mod tests {
         }
     }
 
-    fn chunk_sizes(chunks: &[Vec<MessageGroup>]) -> Vec<usize> {
-        chunks
+    /// Event count of each sub-batch produced by adding `group_events` worth of
+    /// key-groups to one worker.
+    fn packed_sizes(group_events: &[usize], chunking: ChunkConfig) -> Vec<usize> {
+        let mut assignments = WorkerAssignments::new(chunking);
+        for (i, events) in group_events.iter().enumerate() {
+            assignments.add_group(wid(0), group(&format!("k{i}"), *events));
+        }
+        assignments
+            .into_sub_batches()
             .iter()
-            .map(|chunk| chunk.iter().map(MessageGroup::message_count).sum())
+            .map(|sub_batch| sub_batch.messages.len())
             .collect()
     }
 
@@ -1557,78 +1515,98 @@ mod tests {
 
     struct PackCase {
         name: &'static str,
-        /// Event count of each key-group, in packing order.
+        /// Event count of each key-group, in the order they reach the worker.
         group_events: &'static [usize],
         max_events: usize,
         min_events: usize,
-        /// Expected event count of each produced chunk.
-        expected_chunks: &'static [usize],
+        /// Expected event count of each sub-batch the worker ends up with.
+        expected_sub_batches: &'static [usize],
     }
 
     #[test]
-    fn test_pack_chunks_bands() {
+    fn test_sub_batch_packing_bands() {
         let cases = [
+            PackCase {
+                name: "no cap merges everything into one sub-batch",
+                group_events: &[2, 2, 2],
+                max_events: 0,
+                min_events: 0,
+                expected_sub_batches: &[6],
+            },
             PackCase {
                 name: "fills to the cap",
                 group_events: &[2, 2, 2, 2],
                 max_events: 4,
                 min_events: 0,
-                expected_chunks: &[4, 4],
+                expected_sub_batches: &[4, 4],
             },
             PackCase {
-                name: "remainder under the floor still ships",
+                name: "remainder under the target still ships",
                 group_events: &[4, 1],
                 max_events: 4,
                 min_events: 3,
-                expected_chunks: &[4, 1],
+                expected_sub_batches: &[4, 1],
             },
             PackCase {
-                name: "whole batch under the floor is one chunk",
+                name: "whole batch under the target is one sub-batch",
                 group_events: &[1, 1, 1],
                 max_events: 100,
                 min_events: 50,
-                expected_chunks: &[3],
+                expected_sub_batches: &[3],
             },
             PackCase {
                 name: "a group over the cap stays whole",
                 group_events: &[9, 1],
                 max_events: 4,
                 min_events: 0,
-                expected_chunks: &[9, 1],
+                expected_sub_batches: &[9, 1],
             },
             PackCase {
-                name: "floor keeps an under-filled chunk open past a heavy group",
-                // Without the floor the 90-event group would close the 30-event
-                // chunk early, emitting a runt request.
+                name: "target keeps an under-filled sub-batch open past a heavy group",
+                // Without the target the 90-event group would close the
+                // 30-event sub-batch early, emitting a runt request.
                 group_events: &[30, 90, 30, 30],
                 max_events: 100,
                 min_events: 80,
-                expected_chunks: &[90, 90],
+                expected_sub_batches: &[90, 90],
+            },
+            PackCase {
+                name: "a target above the cap is clamped, not stalled",
+                group_events: &[2, 2, 2],
+                max_events: 4,
+                min_events: 100,
+                expected_sub_batches: &[4, 2],
             },
         ];
 
         for case in cases {
-            let groups: Vec<MessageGroup> = case
-                .group_events
-                .iter()
-                .enumerate()
-                .map(|(i, events)| group(&format!("k{i}"), *events))
-                .collect();
+            let sizes = packed_sizes(
+                case.group_events,
+                ChunkConfig::new(case.max_events, case.min_events),
+            );
 
-            let chunks = pack_chunks(groups, ChunkConfig::new(case.max_events, case.min_events));
-
-            assert_eq!(chunk_sizes(&chunks), case.expected_chunks, "{}", case.name);
+            assert_eq!(sizes, case.expected_sub_batches, "{}", case.name);
         }
     }
 
     #[test]
-    fn test_chunk_config_clamps_floor_to_cap() {
-        // A floor above the cap could never be met — it must not make the
-        // packer hold groups back or emit over-cap chunks.
-        let chunking = ChunkConfig::new(4, 100);
-        let groups = vec![group("a", 2), group("b", 2), group("c", 2)];
+    fn test_a_workers_pinned_and_fresh_groups_share_a_sub_batch() {
+        // The reason routing is per group: a worker keeps one open sub-batch,
+        // so a small pinned remainder is topped up by fresh keys routed to the
+        // same worker instead of going out as a request of its own.
+        let dispatcher = chunked_dispatcher(1, 10, 0);
 
-        assert_eq!(chunk_sizes(&pack_chunks(groups, chunking)), vec![4, 2]);
+        // Pin "a" and leave it in flight so the next batch honors the pin.
+        dispatcher.assign("batch-1", make_msgs(&[("t", "a")]));
+
+        let second = dispatcher.assign("batch-2", make_msgs(&[("t", "a"), ("t", "b"), ("t", "c")]));
+
+        assert_eq!(
+            second.len(),
+            1,
+            "the pinned group and the fresh keys must share one request"
+        );
+        assert_eq!(second[0].routing_keys.len(), 3);
     }
 
     #[test]

--- a/rust/ingestion-consumer/src/dispatcher.rs
+++ b/rust/ingestion-consumer/src/dispatcher.rs
@@ -158,8 +158,8 @@ fn pack_chunks(groups: Vec<MessageGroup>, chunking: ChunkConfig) -> Vec<Vec<Mess
         let events = group.message_count();
         if !open.is_empty() && !chunking.fits(open_events, events) {
             if open_events < chunking.min_events {
-                // Under the floor — ship this group alone rather than splitting
-                // the open chunk early; later groups keep topping it up.
+                // Under the target — ship this group alone rather than
+                // splitting the open chunk early; later groups top it up.
                 chunks.push(vec![group]);
                 continue;
             }
@@ -334,7 +334,8 @@ impl WorkerAssignments {
 ///
 /// **Assignment** (`assign`): groups messages by `token:distinct_id`, honors
 /// existing pins for live workers, routes new keys onto a healthy worker via the
-/// configured [`RoutingStrategy`], and returns one `SubBatch` per worker.
+/// configured [`RoutingStrategy`], and returns the `SubBatch`es to send — one
+/// per worker, or several when [`ChunkConfig`] caps their event count.
 ///
 /// **Stickiness**: a routing key stays on the same worker across batches
 /// (ref-counted pin). Pins are dropped when a worker is declared dead (or leaves
@@ -494,8 +495,9 @@ impl Dispatcher {
     ///   group when no worker is routable at all, so a transient full-pool
     ///   outage holds messages instead of failing the batch.
     ///
-    /// Returns one `SubBatch` per worker to send now. Deferred groups stay in
-    /// the stash and are flushed later via [`Dispatcher::flush_deferred`].
+    /// Returns the `SubBatch`es to send now: one per worker, or several per
+    /// worker when [`ChunkConfig`] caps their event count. Deferred groups stay
+    /// in the stash and are flushed later via [`Dispatcher::flush_deferred`].
     pub fn assign(&self, batch_id: &str, messages: Vec<SerializedKafkaMessage>) -> Vec<SubBatch> {
         let mut table = self.pin_table.lock().unwrap();
 

--- a/rust/ingestion-consumer/src/dispatcher.rs
+++ b/rust/ingestion-consumer/src/dispatcher.rs
@@ -90,10 +90,10 @@ pub struct EagerFlush {
     pub sub_batch: SubBatch,
 }
 
-/// Event-count bands for splitting a batch into several sub-batches ("chunks")
-/// rather than one per worker. A key-group is never split across chunks — that
-/// is what keeps per-key ordering intact — so a group larger than `max_events`
-/// becomes an over-sized chunk of its own.
+/// Event-count bands for splitting a worker's share of a batch into several
+/// sub-batches ("chunks") rather than one. A key-group is never split across
+/// chunks — that is what keeps per-key ordering intact — so a group larger than
+/// `max_events` becomes an over-sized chunk of its own.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct ChunkConfig {
     /// Cap on events per chunk, honored except by a single over-sized

--- a/rust/ingestion-consumer/src/dispatcher.rs
+++ b/rust/ingestion-consumer/src/dispatcher.rs
@@ -96,16 +96,18 @@ pub struct EagerFlush {
 /// becomes an over-sized chunk of its own.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct ChunkConfig {
-    /// Hard cap on events per chunk. `0` disables chunking, giving each worker
-    /// exactly one sub-batch per batch.
+    /// Cap on events per chunk, honored except by a single over-sized
+    /// key-group. `0` disables chunking, giving each worker exactly one
+    /// sub-batch per batch.
     max_events: usize,
-    /// Best-effort floor: an under-filled chunk stays open instead of closing
-    /// early because the next key-group doesn't fit.
+    /// Soft target, not a lower bound: an under-filled chunk stays open instead
+    /// of closing early because the next key-group doesn't fit. Chunks below it
+    /// still ship — nothing is ever held back to reach it.
     min_events: usize,
 }
 
 impl ChunkConfig {
-    /// A `min_events` above `max_events` is clamped — a floor above the cap
+    /// A `min_events` above `max_events` is clamped — a target above the cap
     /// could never be met.
     pub fn new(max_events: usize, min_events: usize) -> Self {
         Self {
@@ -140,10 +142,11 @@ impl MessageGroup {
 }
 
 /// Pack key-groups into chunks of at most `chunking.max_events` events, keeping
-/// each key-group whole. A chunk still under `min_events` is not closed just
-/// because the next group doesn't fit: that group gets a chunk of its own and
-/// the under-filled one keeps taking later groups. Whatever is left at the end
-/// ships as one chunk, however small.
+/// each key-group whole. `min_events` only suppresses runt chunks: one still
+/// under it is not closed just because the next group doesn't fit — that group
+/// gets a chunk of its own and the under-filled one keeps taking later groups.
+/// Nothing is held back to reach it, so whatever is left at the end ships as
+/// one chunk however small.
 fn pack_chunks(groups: Vec<MessageGroup>, chunking: ChunkConfig) -> Vec<Vec<MessageGroup>> {
     debug_assert!(chunking.enabled(), "packing needs an event cap");
 

--- a/rust/ingestion-consumer/src/main.rs
+++ b/rust/ingestion-consumer/src/main.rs
@@ -211,11 +211,8 @@ async fn async_main(config: Config) -> Result<()> {
     let mut dispatcher = Dispatcher::with_strategy(Arc::clone(&registry), config.routing_strategy);
     let chunking = ChunkConfig::new(config.sub_batch_max_events, config.sub_batch_min_events);
     if chunking.enabled() {
-        info!(
-            max_events = config.sub_batch_max_events,
-            min_events = config.sub_batch_min_events,
-            "Sub-batch chunking enabled"
-        );
+        // Log the effective bands, so a min clamped down to the max is visible.
+        info!(?chunking, "Sub-batch chunking enabled");
     }
     dispatcher.set_chunking(chunking);
     if let Some(recorder) = &debug_recorder {

--- a/rust/ingestion-consumer/src/main.rs
+++ b/rust/ingestion-consumer/src/main.rs
@@ -24,7 +24,7 @@ use ingestion_consumer::debug_recorder::{DebugLoad, DebugRecorder, DebugState, W
 use ingestion_consumer::discovery::{
     DiscoveryMode, EndpointSliceDiscovery, StaticDiscovery, WorkerDiscovery,
 };
-use ingestion_consumer::dispatcher::Dispatcher;
+use ingestion_consumer::dispatcher::{ChunkConfig, Dispatcher};
 use ingestion_consumer::routing::RoutingStrategy;
 use ingestion_consumer::transport::HttpTransport;
 use ingestion_consumer::worker_registry::{WorkerId, WorkerRegistry, WorkerRegistryConfig};
@@ -209,6 +209,15 @@ async fn async_main(config: Config) -> Result<()> {
         };
 
     let mut dispatcher = Dispatcher::with_strategy(Arc::clone(&registry), config.routing_strategy);
+    let chunking = ChunkConfig::new(config.sub_batch_max_events, config.sub_batch_min_events);
+    if chunking.enabled() {
+        info!(
+            max_events = config.sub_batch_max_events,
+            min_events = config.sub_batch_min_events,
+            "Sub-batch chunking enabled"
+        );
+    }
+    dispatcher.set_chunking(chunking);
     if let Some(recorder) = &debug_recorder {
         dispatcher.set_debug_recorder(Arc::clone(recorder));
     }


### PR DESCRIPTION
## Problem

- A large Kafka batch reaches one processor worker as a single request, so adding processor pods cannot make that batch finish sooner. We see ingestion lag rise while processors sit idle.
- `Dispatcher::assign` merges every key-group destined for a worker into exactly one `SubBatch` per Kafka batch.
- Usable processor concurrency is therefore capped by `consumer_pods × CONSUMER_MAX_BACKGROUND_TASKS × workers-touched`, not by the size of the processor pool.
- The consumer's per-batch completion time is the tail of a few large requests. `scatter` awaits every sub-batch, and in-flight slots free oldest-first.
- The transport's byte cap (`INGESTION_TRANSPORT_MAX_BODY_BYTES`) already splits an over-sized sub-batch, but the pieces go to the same worker. It bounds memory, not parallelism.

## Changes

A worker's share of a batch is now split into requests of at most `INGESTION_SUB_BATCH_MAX_EVENTS` events, instead of always going out as one.

- Routing is untouched. Every key-group is still routed on its own, through the existing strategies (binpack, p2c, aperture), with the same per-group load feedback.
- The split happens after routing, in the per-worker sub-batch builder. A worker keeps one open sub-batch; it closes at the cap and the next group starts another.
- A key-group is never split across sub-batches, so every distinct_id's messages ride one request to one worker. That is what preserves per-key ordering.
- Pinned key-groups still go to their pinned worker, and share a request with the fresh keys routed to that same worker, rather than each getting their own.
- A single key-group larger than the cap stays whole, because keys cannot be split. The transport's byte cap still bounds the wire for that case.
- `INGESTION_SUB_BATCH_MIN_EVENTS` suppresses runt requests. A sub-batch under it is not closed just because the next key-group does not fit; that group gets a sub-batch of its own instead. It is a soft target, not a lower bound, and it never holds messages back.

Both settings default to `0`. With no cap the builder never closes a sub-batch, which reproduces one-per-worker exactly, so enabling this per lane is a charts-side opt-in.

**Why the split comes after routing.** A worker whose share is already under the cap still gets one request, so this only splits where a batch is genuinely concentrated on few workers — which is the case that produced the problem. Splitting before routing would also break up batches already spread thin across a wide pool, adding requests and shrinking each worker's person-batching window without touching more workers. Concentrating a batch onto fewer workers is aperture routing's job, and it stays orthogonal to this.

Metrics:

| Metric | Change |
| --- | --- |
| `ingestion_consumer_sub_batch_events` | New histogram: events per sub-batch |
| `ingestion_consumer_chunks_per_batch` | New histogram: sub-batches per Kafka batch |
| `..._dispatcher_sub_batches_assigned_total` | Now counts one per sub-batch rather than one per worker |
| `..._dispatcher_messages_routed_total` | Unchanged, still sums per worker across all its sub-batches |

Invariants I checked against the code rather than assuming:

- Pin lifecycle is unaffected. A key appears in exactly one sub-batch, so `assign` still takes one ref per key and one resolution releases it. Eviction on resolve and the deferral cascade are untouched.
- Commit accounting is unaffected. `scatter` sums `accepted` over the sub-batches it was given, so `ProcessedBatch.total_accepted` aggregates across them. `defer_failed`, `flush_deferred`, and the stash work on groups, which the split does not change.
- Backpressure semantics are unchanged. The per-worker semaphore now sees more concurrent, smaller requests, which queue on it exactly as sub-batches do today.
- A sub-batch is single-worker by construction: `WorkerAssignments` indexes the open sub-batch by `WorkerId`, and nothing merges builders or moves a group between them.

`flush_deferred` picks up the same cap, so a drain's backlog also flushes as several requests rather than one large one per worker. The eager-release path already sent one group per request.

The routing loops in `assign`, `flush_deferred`, and `release_next_groups` are byte-identical to master apart from one constructor argument. The whole change lives in `WorkerAssignments`.

## How did you test this code?

New tests, and the regression each catches:

- `test_sub_batch_packing_bands`: the builder honors the cap, merges everything when the cap is off, keeps an over-cap key-group whole, ships a remainder under the target, holds an under-filled sub-batch open past a heavy group, and clamps a target above the cap.
- `test_chunking_splits_a_batch_into_capped_sub_batches`: one worker receives several capped requests instead of one large one.
- `test_disabled_chunking_keeps_one_sub_batch_per_worker`: the default reproduces today's behavior, which is what the rollout depends on.
- `test_chunking_keeps_each_key_in_exactly_one_sub_batch`: the ordering invariant. No distinct_id is split across sub-batches.
- `test_chunked_pinned_groups_stay_on_their_pinned_worker`: the split does not let a pinned key move.
- `test_a_workers_pinned_and_fresh_groups_share_a_sub_batch`: a small pinned remainder is topped up by fresh keys rather than going out as its own request.
- `test_chunk_resolution_drains_load_and_pins`: resolving every sub-batch of a batch leaves no in-flight load and no leaked pins.

Ran locally inside flox: `cargo test -p ingestion-consumer --lib`, plus `--test dispatcher_integration_test --test transport_integration_test`. Clippy and rustfmt are clean.

Not run: `tests/e2e_integration_test.rs`. It needs a Kafka broker on `localhost:9092` and this environment has none.

No manual testing against a running consumer.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The two settings are documented on the config fields.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude, in Claude Code) wrote this from a design brief. No repo skills applied to the Rust dispatcher; I invoked `/writing-pr-descriptions` for this body.

Two decisions worth flagging for review:

- The brief described the min as a floor. It is not one, and the code, docs, and config comments say "soft target" instead. It changes exactly one decision, whether an under-filled sub-batch closes when the next group does not fit, and sub-batches below it still ship in three cases: a worker's tail, a share smaller than the target, and the group shipped on its own. Only the max is a real cap. The knob is one branch and easy to drop if reviewers would rather have max alone.
- I extended the split to `flush_deferred` rather than confining it to `assign`. A drain flush has the same one-large-request-per-worker shape, the change is one constructor argument, and it cannot affect ordering because each key is still in one group.

An earlier revision of this branch packed key-groups into chunks *before* routing and routed each chunk as a unit. That left a worker's pinned remainder as a request of its own unless the router happened to send it an unpinned chunk too, and it split batches that were already spread thin. Routing per group and splitting per worker fixes both and removes about 60 lines.

Nothing in this diff draws on material that is not already in this repository.
