### PR TITLE
fix(tasks): keep error_type a string when an activity times out

### DIFF
--- a/products/tasks/backend/temporal/process_task/tests/test_failure_error_type.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_failure_error_type.py
@@ -1,0 +1,56 @@
+from unittest import TestCase
+
+import temporalio.exceptions
+from parameterized import parameterized
+
+from products.tasks.backend.temporal.process_task.workflow import _failure_error_type
+
+
+class TestFailureErrorType(TestCase):
+    @parameterized.expand(
+        [
+            (
+                "application_error_type",
+                temporalio.exceptions.ApplicationError("boom", type="SandboxProvisionError"),
+                "SandboxProvisionError",
+            ),
+            (
+                "timeout_start_to_close",
+                temporalio.exceptions.TimeoutError(
+                    "timed out",
+                    type=temporalio.exceptions.TimeoutType.START_TO_CLOSE,
+                    last_heartbeat_details=[],
+                ),
+                "start_to_close",
+            ),
+            (
+                "timeout_heartbeat",
+                temporalio.exceptions.TimeoutError(
+                    "timed out",
+                    type=temporalio.exceptions.TimeoutType.HEARTBEAT,
+                    last_heartbeat_details=[],
+                ),
+                "heartbeat",
+            ),
+            (
+                "timeout_without_type",
+                temporalio.exceptions.TimeoutError("timed out", type=None, last_heartbeat_details=[]),
+                "RuntimeError",
+            ),
+            ("no_cause", None, "RuntimeError"),
+            (
+                "cause_without_type",
+                temporalio.exceptions.CancelledError("cancelled"),
+                "RuntimeError",
+            ),
+            (
+                "application_error_empty_type",
+                temporalio.exceptions.ApplicationError("boom", type=""),
+                "RuntimeError",
+            ),
+        ]
+    )
+    def test_always_returns_a_string(self, _name: str, cause: BaseException | None, expected: str) -> None:
+        result = _failure_error_type(cause, RuntimeError("outer"))
+        assert result == expected
+        assert isinstance(result, str)

--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -128,6 +128,15 @@ def _is_dead_sandbox_failure(error: BaseException) -> bool:
     return isinstance(cause, temporalio.exceptions.ApplicationError) and cause.type in DEAD_SANDBOX_ERROR_TYPES
 
 
+def _failure_error_type(cause: BaseException | None, exc: Exception) -> str:
+    cause_type = getattr(cause, "type", None)
+    if isinstance(cause_type, temporalio.exceptions.TimeoutType):
+        return cause_type.name.lower()
+    if isinstance(cause_type, str) and cause_type:
+        return cause_type
+    return type(exc).__name__
+
+
 def _message_dedupe_key(
     message_id: str,
     actor_user_id: int | None,
@@ -1123,7 +1132,7 @@ class ProcessTaskWorkflow(PostHogWorkflow):
             # the UI show the persisted message, so surface the cause instead.
             cause = e.cause if isinstance(e, temporalio.exceptions.ActivityError) else None
             cause_message = getattr(cause, "message", None) or (str(cause) if cause is not None else None)
-            error_type = getattr(cause, "type", None) or type(e).__name__
+            error_type = _failure_error_type(cause, e)
             error_message = truncate_error_message(cause_message or str(e))
             if self._context:
                 if self._current_progress_step is not None:


### PR DESCRIPTION
## Problem

- A run that fails on an activity timeout is never marked failed, and its workflow retries itself in a loop, provisioning a fresh sandbox each cycle.
- The workflow's failure handler copies the Temporal cause's `type` attribute into `UpdateTaskRunStatusInput.error_type`, declared `Optional[str]`.
- For a timeout cause that attribute is a `TimeoutType` IntEnum, so it serializes as the integer `1`.
- The status-update activity then fails decoding its arguments on every retry (`Failed converting to typing.Optional[str] from 1`), the workflow fails, and Temporal retries the whole workflow.

## Changes

- Extract `_failure_error_type`: timeout causes map to the timeout name (`start_to_close`), string types pass through, everything else falls back to the exception class name.
- The function guarantees a string, so the activity payload always decodes.
- No workflow commands change; only the value passed to an existing activity changes, so in-flight histories replay safely.

