### PR TITLE
fix(desktop): smooth sidebar transitions and bound tab memory

### DIFF
--- a/products/desktop/packages/ui/src/features/code-review/components/LazyReviewPages.tsx
+++ b/products/desktop/packages/ui/src/features/code-review/components/LazyReviewPages.tsx
@@ -1,24 +1,13 @@
 import type { Task } from "@posthog/shared/domain-types";
 import { DotsCircleSpinner } from "@posthog/ui/primitives/DotsCircleSpinner";
 import { lazy, type ReactNode, Suspense } from "react";
+import { loadCloudReviewPage, loadReviewPage } from "./preloadReviewPages";
 
 // The code-review surface (ReviewShell, diff rows, comment UI, review hooks) is
 // only reached when a review is opened, so it's split out of the initial bundle.
 // The underlying diff/highlight libraries stay eager — the transcript uses them.
-const loadReviewPage = () =>
-  import("./ReviewPage").then((module) => ({ default: module.ReviewPage }));
-const loadCloudReviewPage = () =>
-  import("./CloudReviewPage").then((module) => ({
-    default: module.CloudReviewPage,
-  }));
-
 const ReviewPageLazy = lazy(loadReviewPage);
 const CloudReviewPageLazy = lazy(loadCloudReviewPage);
-
-export function preloadReviewPages(): void {
-  void loadReviewPage();
-  void loadCloudReviewPage();
-}
 
 function ReviewFallback(): ReactNode {
   return (

--- a/products/desktop/packages/ui/src/features/code-review/components/LazyReviewPages.tsx
+++ b/products/desktop/packages/ui/src/features/code-review/components/LazyReviewPages.tsx
@@ -5,12 +5,20 @@ import { lazy, type ReactNode, Suspense } from "react";
 // The code-review surface (ReviewShell, diff rows, comment UI, review hooks) is
 // only reached when a review is opened, so it's split out of the initial bundle.
 // The underlying diff/highlight libraries stay eager — the transcript uses them.
-const ReviewPageLazy = lazy(() =>
-  import("./ReviewPage").then((m) => ({ default: m.ReviewPage })),
-);
-const CloudReviewPageLazy = lazy(() =>
-  import("./CloudReviewPage").then((m) => ({ default: m.CloudReviewPage })),
-);
+const loadReviewPage = () =>
+  import("./ReviewPage").then((module) => ({ default: module.ReviewPage }));
+const loadCloudReviewPage = () =>
+  import("./CloudReviewPage").then((module) => ({
+    default: module.CloudReviewPage,
+  }));
+
+const ReviewPageLazy = lazy(loadReviewPage);
+const CloudReviewPageLazy = lazy(loadCloudReviewPage);
+
+export function preloadReviewPages(): void {
+  void loadReviewPage();
+  void loadCloudReviewPage();
+}
 
 function ReviewFallback(): ReactNode {
   return (

--- a/products/desktop/packages/ui/src/features/code-review/components/preloadReviewPages.ts
+++ b/products/desktop/packages/ui/src/features/code-review/components/preloadReviewPages.ts
@@ -1,0 +1,12 @@
+export const loadReviewPage = () =>
+  import("./ReviewPage").then((module) => ({ default: module.ReviewPage }));
+
+export const loadCloudReviewPage = () =>
+  import("./CloudReviewPage").then((module) => ({
+    default: module.CloudReviewPage,
+  }));
+
+export function preloadReviewPages(): void {
+  void loadReviewPage();
+  void loadCloudReviewPage();
+}

--- a/products/desktop/packages/ui/src/features/navigation/components/RightPanel.tsx
+++ b/products/desktop/packages/ui/src/features/navigation/components/RightPanel.tsx
@@ -16,6 +16,7 @@ import type { Task } from "@posthog/shared/domain-types";
 import { ActivityPanelBody } from "@posthog/ui/features/canvas/components/ActivityPanelBody";
 import {
   LazyCloudReviewPage as CloudReviewPage,
+  preloadReviewPages,
   LazyReviewPage as ReviewPage,
 } from "@posthog/ui/features/code-review/components/LazyReviewPages";
 import { useReviewNavigationStore } from "@posthog/ui/features/code-review/reviewNavigationStore";
@@ -30,7 +31,7 @@ import {
 } from "@posthog/ui/primitives/ResizableSidebar";
 import { useQuery } from "@tanstack/react-query";
 import { useParams } from "@tanstack/react-router";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   DEFAULT_RIGHT_PANEL_SIDE,
   RIGHT_PANEL_MIN_WIDTH,
@@ -154,18 +155,35 @@ const PANEL_FADE_OUT_MS = 120;
 function useFadingSide(
   active: RightPanelSide | null,
   held: boolean,
-): RightPanelSide | null {
+): { contentReady: boolean; drawn: RightPanelSide | null } {
   const [drawn, setDrawn] = useState(active);
+  const [contentReady, setContentReady] = useState(active != null);
+  const open = active != null;
+  const wasOpen = useRef(open);
+
   useEffect(() => {
     if (active != null) {
       setDrawn(active);
       return;
     }
     if (held) return;
-    const timer = setTimeout(() => setDrawn(null), PANEL_FADE_OUT_MS);
+    const timer = setTimeout(() => {
+      setDrawn(null);
+      setContentReady(false);
+    }, PANEL_FADE_OUT_MS);
     return () => clearTimeout(timer);
   }, [active, held]);
-  return drawn;
+
+  useEffect(() => {
+    const opening = open && !wasOpen.current;
+    wasOpen.current = open;
+    if (!opening) return;
+    setContentReady(false);
+    const timer = setTimeout(() => setContentReady(true), SLIDE_MS);
+    return () => clearTimeout(timer);
+  }, [open]);
+
+  return { contentReady, drawn };
 }
 
 /**
@@ -197,7 +215,9 @@ function SessionRightPanel({ taskId }: { taskId: string }) {
   const setIsResizing = useRightPanelStore((s) => s.setIsResizing);
 
   const open = active != null;
-  const drawn = useFadingSide(active, isResizing);
+  const { contentReady, drawn } = useFadingSide(active, isResizing);
+
+  useEffect(() => preloadReviewPages(), []);
 
   // Dragging the handle past the panel's floor closes it, and dragging back out
   // while still holding brings it in again. The drag holds the closing panel's
@@ -247,7 +267,8 @@ function SessionRightPanel({ taskId }: { taskId: string }) {
                   the route says there is a session and an empty state would
                   contradict it. */}
               <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-                {task &&
+                {contentReady &&
+                  task &&
                   (drawn === "changes" ? (
                     <ChangesPanelContent task={task} />
                   ) : (

--- a/products/desktop/packages/ui/src/features/navigation/components/RightPanel.tsx
+++ b/products/desktop/packages/ui/src/features/navigation/components/RightPanel.tsx
@@ -31,7 +31,7 @@ import {
 } from "@posthog/ui/primitives/ResizableSidebar";
 import { useQuery } from "@tanstack/react-query";
 import { useParams } from "@tanstack/react-router";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   DEFAULT_RIGHT_PANEL_SIDE,
   RIGHT_PANEL_MIN_WIDTH,
@@ -155,16 +155,8 @@ const PANEL_FADE_OUT_MS = 120;
 function useFadingSide(
   active: RightPanelSide | null,
   held: boolean,
-): {
-  contentReady: boolean;
-  contentVisible: boolean;
-  drawn: RightPanelSide | null;
-} {
+): RightPanelSide | null {
   const [drawn, setDrawn] = useState(active);
-  const [contentReady, setContentReady] = useState(active != null);
-  const [contentVisible, setContentVisible] = useState(active != null);
-  const open = active != null;
-  const wasOpen = useRef(open);
 
   useEffect(() => {
     if (active != null) {
@@ -172,32 +164,11 @@ function useFadingSide(
       return;
     }
     if (held) return;
-    const timer = setTimeout(() => {
-      setDrawn(null);
-      setContentReady(false);
-      setContentVisible(false);
-    }, PANEL_FADE_OUT_MS);
+    const timer = setTimeout(() => setDrawn(null), PANEL_FADE_OUT_MS);
     return () => clearTimeout(timer);
   }, [active, held]);
 
-  useEffect(() => {
-    const opening = open && !wasOpen.current;
-    wasOpen.current = open;
-    if (!opening) return;
-    setContentReady(false);
-    setContentVisible(false);
-    let frame: number | undefined;
-    const timer = setTimeout(() => {
-      setContentReady(true);
-      frame = requestAnimationFrame(() => setContentVisible(true));
-    }, SLIDE_MS);
-    return () => {
-      clearTimeout(timer);
-      if (frame !== undefined) cancelAnimationFrame(frame);
-    };
-  }, [open]);
-
-  return { contentReady, contentVisible, drawn };
+  return drawn;
 }
 
 /**
@@ -229,10 +200,7 @@ function SessionRightPanel({ taskId }: { taskId: string }) {
   const setIsResizing = useRightPanelStore((s) => s.setIsResizing);
 
   const open = active != null;
-  const { contentReady, contentVisible, drawn } = useFadingSide(
-    active,
-    isResizing,
-  );
+  const drawn = useFadingSide(active, isResizing);
 
   useEffect(() => preloadReviewPages(), []);
 
@@ -281,31 +249,12 @@ function SessionRightPanel({ taskId }: { taskId: string }) {
                 </span>
               </div>
               <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-                {contentReady && task ? (
-                  <div
-                    className="flex min-h-0 flex-1 flex-col overflow-hidden transition-opacity duration-100 ease-out motion-reduce:transition-none"
-                    style={{ opacity: contentVisible ? 1 : 0 }}
-                  >
-                    {drawn === "changes" ? (
-                      <ChangesPanelContent task={task} />
-                    ) : (
-                      <ActivityPanelBody
-                        task={task}
-                        tab={drawn}
-                        canOpenInPlace
-                      />
-                    )}
-                  </div>
-                ) : (
-                  <div
-                    aria-hidden
-                    className="flex flex-col gap-3 p-3 opacity-60"
-                  >
-                    <div className="h-3 w-2/5 rounded-sm bg-fill-secondary" />
-                    <div className="h-3 w-4/5 rounded-sm bg-fill-secondary" />
-                    <div className="h-3 w-3/5 rounded-sm bg-fill-secondary" />
-                  </div>
-                )}
+                {task &&
+                  (drawn === "changes" ? (
+                    <ChangesPanelContent task={task} />
+                  ) : (
+                    <ActivityPanelBody task={task} tab={drawn} canOpenInPlace />
+                  ))}
               </div>
             </>
           )}

--- a/products/desktop/packages/ui/src/features/navigation/components/RightPanel.tsx
+++ b/products/desktop/packages/ui/src/features/navigation/components/RightPanel.tsx
@@ -16,9 +16,9 @@ import type { Task } from "@posthog/shared/domain-types";
 import { ActivityPanelBody } from "@posthog/ui/features/canvas/components/ActivityPanelBody";
 import {
   LazyCloudReviewPage as CloudReviewPage,
-  preloadReviewPages,
   LazyReviewPage as ReviewPage,
 } from "@posthog/ui/features/code-review/components/LazyReviewPages";
+import { preloadReviewPages } from "@posthog/ui/features/code-review/components/preloadReviewPages";
 import { useReviewNavigationStore } from "@posthog/ui/features/code-review/reviewNavigationStore";
 import { openRightPanelSide } from "@posthog/ui/features/navigation/rightPanelSide";
 import { useCommentFocusRequest } from "@posthog/ui/features/sessions/useCommentFocusRequest";

--- a/products/desktop/packages/ui/src/features/navigation/components/RightPanel.tsx
+++ b/products/desktop/packages/ui/src/features/navigation/components/RightPanel.tsx
@@ -155,9 +155,14 @@ const PANEL_FADE_OUT_MS = 120;
 function useFadingSide(
   active: RightPanelSide | null,
   held: boolean,
-): { contentReady: boolean; drawn: RightPanelSide | null } {
+): {
+  contentReady: boolean;
+  contentVisible: boolean;
+  drawn: RightPanelSide | null;
+} {
   const [drawn, setDrawn] = useState(active);
   const [contentReady, setContentReady] = useState(active != null);
+  const [contentVisible, setContentVisible] = useState(active != null);
   const open = active != null;
   const wasOpen = useRef(open);
 
@@ -170,6 +175,7 @@ function useFadingSide(
     const timer = setTimeout(() => {
       setDrawn(null);
       setContentReady(false);
+      setContentVisible(false);
     }, PANEL_FADE_OUT_MS);
     return () => clearTimeout(timer);
   }, [active, held]);
@@ -179,11 +185,19 @@ function useFadingSide(
     wasOpen.current = open;
     if (!opening) return;
     setContentReady(false);
-    const timer = setTimeout(() => setContentReady(true), SLIDE_MS);
-    return () => clearTimeout(timer);
+    setContentVisible(false);
+    let frame: number | undefined;
+    const timer = setTimeout(() => {
+      setContentReady(true);
+      frame = requestAnimationFrame(() => setContentVisible(true));
+    }, SLIDE_MS);
+    return () => {
+      clearTimeout(timer);
+      if (frame !== undefined) cancelAnimationFrame(frame);
+    };
   }, [open]);
 
-  return { contentReady, drawn };
+  return { contentReady, contentVisible, drawn };
 }
 
 /**
@@ -215,7 +229,10 @@ function SessionRightPanel({ taskId }: { taskId: string }) {
   const setIsResizing = useRightPanelStore((s) => s.setIsResizing);
 
   const open = active != null;
-  const { contentReady, drawn } = useFadingSide(active, isResizing);
+  const { contentReady, contentVisible, drawn } = useFadingSide(
+    active,
+    isResizing,
+  );
 
   useEffect(() => preloadReviewPages(), []);
 
@@ -263,17 +280,32 @@ function SessionRightPanel({ taskId }: { taskId: string }) {
                   {SIDES[drawn].label}
                 </span>
               </div>
-              {/* Nothing under the title until the session resolves, because
-                  the route says there is a session and an empty state would
-                  contradict it. */}
               <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-                {contentReady &&
-                  task &&
-                  (drawn === "changes" ? (
-                    <ChangesPanelContent task={task} />
-                  ) : (
-                    <ActivityPanelBody task={task} tab={drawn} canOpenInPlace />
-                  ))}
+                {contentReady && task ? (
+                  <div
+                    className="flex min-h-0 flex-1 flex-col overflow-hidden transition-opacity duration-100 ease-out motion-reduce:transition-none"
+                    style={{ opacity: contentVisible ? 1 : 0 }}
+                  >
+                    {drawn === "changes" ? (
+                      <ChangesPanelContent task={task} />
+                    ) : (
+                      <ActivityPanelBody
+                        task={task}
+                        tab={drawn}
+                        canOpenInPlace
+                      />
+                    )}
+                  </div>
+                ) : (
+                  <div
+                    aria-hidden
+                    className="flex flex-col gap-3 p-3 opacity-60"
+                  >
+                    <div className="h-3 w-2/5 rounded-sm bg-fill-secondary" />
+                    <div className="h-3 w-4/5 rounded-sm bg-fill-secondary" />
+                    <div className="h-3 w-3/5 rounded-sm bg-fill-secondary" />
+                  </div>
+                )}
               </div>
             </>
           )}

--- a/products/desktop/packages/ui/src/features/panels/components/TabbedPanel.test.tsx
+++ b/products/desktop/packages/ui/src/features/panels/components/TabbedPanel.test.tsx
@@ -116,4 +116,46 @@ describe("TabbedPanel", () => {
     expect(screen.getByTestId("logs-content")).toBeInTheDocument();
     expect(screen.queryByTestId("review-content")).not.toBeInTheDocument();
   });
+
+  it("unmounts the least recently used tab after five visited tabs", () => {
+    const tabs: PanelContent["tabs"] = Array.from(
+      { length: 6 },
+      (_, index) => ({
+        id: `tab-${index}`,
+        label: `Tab ${index}`,
+        data: { type: "logs" },
+        component: <div data-testid={`tab-content-${index}`} />,
+      }),
+    );
+    const panelContent = (activeTabId: string): PanelContent => ({
+      id: "main",
+      activeTabId,
+      showTabs: false,
+      tabs,
+    });
+    const { rerender } = render(
+      <Theme>
+        <TabbedPanel
+          panelId="main"
+          mountScopeKey="task-a"
+          content={panelContent("tab-0")}
+        />
+      </Theme>,
+    );
+
+    for (let index = 1; index < tabs.length; index++) {
+      rerender(
+        <Theme>
+          <TabbedPanel
+            panelId="main"
+            mountScopeKey="task-a"
+            content={panelContent(`tab-${index}`)}
+          />
+        </Theme>,
+      );
+    }
+
+    expect(screen.queryByTestId("tab-content-0")).not.toBeInTheDocument();
+    expect(screen.getAllByTestId(/^tab-content-/)).toHaveLength(5);
+  });
 });

--- a/products/desktop/packages/ui/src/features/panels/components/TabbedPanel.tsx
+++ b/products/desktop/packages/ui/src/features/panels/components/TabbedPanel.tsx
@@ -129,6 +129,26 @@ export const TabbedPanel: React.FC<TabbedPanelProps> = ({
       : content.activeTabId
         ? [content.activeTabId]
         : [];
+  const mountedTabIdSet = new Set(mountedTabIds);
+  const mountedTabContent = content.tabs.reduce<React.ReactNode[]>(
+    (renderedTabs, tab) => {
+      if (tab.id !== content.activeTabId && !mountedTabIdSet.has(tab.id)) {
+        return renderedTabs;
+      }
+      renderedTabs.push(
+        <div
+          key={tab.id}
+          style={
+            tab.id === content.activeTabId ? activeTabStyle : hiddenTabStyle
+          }
+        >
+          {tab.component}
+        </div>,
+      );
+      return renderedTabs;
+    },
+    [],
+  );
 
   const handleSplitClick = async () => {
     const result = await hostClient.contextMenu.showSplitContextMenu.mutate();
@@ -290,24 +310,7 @@ export const TabbedPanel: React.FC<TabbedPanelProps> = ({
       >
         {content.tabs.length > 0 &&
         content.tabs.some((t) => t.id === content.activeTabId) ? (
-          content.tabs
-            .filter(
-              (tab) =>
-                tab.id === content.activeTabId ||
-                mountedTabIds.includes(tab.id),
-            )
-            .map((tab) => (
-              <div
-                key={tab.id}
-                style={
-                  tab.id === content.activeTabId
-                    ? activeTabStyle
-                    : hiddenTabStyle
-                }
-              >
-                {tab.component}
-              </div>
-            ))
+          mountedTabContent
         ) : emptyState ? (
           emptyState
         ) : (

--- a/products/desktop/packages/ui/src/features/panels/components/TabbedPanel.tsx
+++ b/products/desktop/packages/ui/src/features/panels/components/TabbedPanel.tsx
@@ -22,8 +22,10 @@ const hiddenTabStyle: React.CSSProperties = {
   top: 0,
   left: 0,
   visibility: "hidden",
+  contentVisibility: "hidden",
   pointerEvents: "none",
 };
+const MAX_MOUNTED_TABS = 5;
 
 interface TabBarButtonProps {
   ariaLabel: string;
@@ -95,8 +97,8 @@ export const TabbedPanel: React.FC<TabbedPanelProps> = ({
   const hostClient = useHostTRPCClient();
   const [mountedTabs, setMountedTabs] = useState<{
     scopeKey: string;
-    tabIds: Set<string>;
-  }>(() => ({ scopeKey: mountScopeKey, tabIds: new Set() }));
+    tabIds: string[];
+  }>(() => ({ scopeKey: mountScopeKey, tabIds: [] }));
 
   useEffect(() => {
     if (!content.activeTabId) return;
@@ -104,16 +106,29 @@ export const TabbedPanel: React.FC<TabbedPanelProps> = ({
       if (current.scopeKey !== mountScopeKey) {
         return {
           scopeKey: mountScopeKey,
-          tabIds: new Set([content.activeTabId]),
+          tabIds: [content.activeTabId],
         };
       }
-      if (current.tabIds.has(content.activeTabId)) return current;
+      const nextTabIds = current.tabIds.filter(
+        (tabId) => tabId !== content.activeTabId,
+      );
+      nextTabIds.push(content.activeTabId);
       return {
         scopeKey: mountScopeKey,
-        tabIds: new Set(current.tabIds).add(content.activeTabId),
+        tabIds: nextTabIds.slice(-MAX_MOUNTED_TABS),
       };
     });
   }, [content.activeTabId, mountScopeKey]);
+
+  const mountedTabIds =
+    mountedTabs.scopeKey === mountScopeKey
+      ? mountedTabs.tabIds
+          .filter((tabId) => tabId !== content.activeTabId)
+          .concat(content.activeTabId ?? [])
+          .slice(-MAX_MOUNTED_TABS)
+      : content.activeTabId
+        ? [content.activeTabId]
+        : [];
 
   const handleSplitClick = async () => {
     const result = await hostClient.contextMenu.showSplitContextMenu.mutate();
@@ -279,8 +294,7 @@ export const TabbedPanel: React.FC<TabbedPanelProps> = ({
             .filter(
               (tab) =>
                 tab.id === content.activeTabId ||
-                (mountedTabs.scopeKey === mountScopeKey &&
-                  mountedTabs.tabIds.has(tab.id)),
+                mountedTabIds.includes(tab.id),
             )
             .map((tab) => (
               <div

--- a/products/desktop/packages/ui/src/primitives/ResizableSidebar.tsx
+++ b/products/desktop/packages/ui/src/primitives/ResizableSidebar.tsx
@@ -285,6 +285,10 @@ export const ResizableSidebar: React.FC<ResizableSidebarProps> = ({
           <button
             type="button"
             aria-label={`Resize ${side} sidebar`}
+            // Mouse/drag-only affordance: there is no keyboard resize model,
+            // so keep it out of the tab order rather than expose a focusable
+            // control that announces a resize action and does nothing.
+            tabIndex={-1}
             onMouseDown={handleMouseDown}
             className={`no-drag group absolute top-0 bottom-0 flex w-2 cursor-col-resize justify-center border-0 bg-transparent p-0 ${
               handleArmed || isResizing ? "" : "pointer-events-none"

--- a/products/desktop/packages/ui/src/primitives/ResizableSidebar.tsx
+++ b/products/desktop/packages/ui/src/primitives/ResizableSidebar.tsx
@@ -1,6 +1,5 @@
 import { SIDEBAR_MIN_WIDTH } from "@posthog/ui/features/sidebar/constants";
 import { PEEK_CLOSE_MARGIN } from "@posthog/ui/primitives/hooks/useSidebarEdgeHoverPeek";
-import { Box, Flex } from "@radix-ui/themes";
 import React from "react";
 
 // Linear-style drag-to-close: dragging the handle clamps at SIDEBAR_MIN_WIDTH,
@@ -10,14 +9,7 @@ import React from "react";
 const DRAG_COLLAPSE_AT = SIDEBAR_MIN_WIDTH * 0.5;
 const DRAG_REOPEN_AT = DRAG_COLLAPSE_AT + 16;
 
-// Every moving part of the open/close choreography — the box width, the
-// panel's translateX, and the title bar in __root — must share this exact
-// curve (Tailwind's ease-out) and duration, or the panel's edge drifts ahead
-// of the content edge mid-animation and the layers visibly overlap. Anything
-// a caller animates alongside the slide takes SLIDE_MS.
 export const SLIDE_MS = 200;
-const SLIDE_EASING = "cubic-bezier(0, 0, 0.2, 1)";
-const SLIDE_WIDTH_TRANSITION = `width ${SLIDE_MS}ms ${SLIDE_EASING}, min-width ${SLIDE_MS}ms ${SLIDE_EASING}, max-width ${SLIDE_MS}ms ${SLIDE_EASING}`;
 
 interface ResizableSidebarProps {
   children: React.ReactNode;
@@ -240,25 +232,18 @@ export const ResizableSidebar: React.FC<ResizableSidebarProps> = ({
   }, [handleArmed]);
 
   return (
-    <Box
+    <div
       ref={boxRef}
       style={{
         width: open ? `${width}px` : `${collapsedWidth}px`,
         minWidth: open ? `${width}px` : `${collapsedWidth}px`,
         maxWidth: open ? `${width}px` : `${collapsedWidth}px`,
-        // Suppress only while dragging the docked sidebar so it tracks the
-        // pointer frame-for-frame; a drag-to-close (open flips false mid-drag)
-        // re-enables it so the collapse animates instead of jump-cutting.
-        // min/max-width must animate too — they clamp the rendered width, so
-        // left un-transitioned they snap the box to 0 and the content jumps.
-        transition: isResizing && open ? "none" : SLIDE_WIDTH_TRANSITION,
         borderLeft: !isLeft && open ? "1px solid var(--border)" : "none",
         borderRight: isLeft && open ? "1px solid var(--border)" : "none",
       }}
       className="relative h-full shrink-0"
     >
-      <Flex
-        direction="column"
+      <div
         style={{
           width: `${width}px`,
           ...(isOverlay
@@ -297,9 +282,11 @@ export const ResizableSidebar: React.FC<ResizableSidebarProps> = ({
         {/* Resize handle lives inside the panel so it rides along in both the
             docked and floating states. */}
         {(open || overlayVisible) && (
-          <Box
+          <button
+            type="button"
+            aria-label={`Resize ${side} sidebar`}
             onMouseDown={handleMouseDown}
-            className={`no-drag group absolute top-0 bottom-0 flex w-2 cursor-col-resize justify-center bg-transparent ${
+            className={`no-drag group absolute top-0 bottom-0 flex w-2 cursor-col-resize justify-center border-0 bg-transparent p-0 ${
               handleArmed || isResizing ? "" : "pointer-events-none"
             }`}
             style={{
@@ -317,16 +304,16 @@ export const ResizableSidebar: React.FC<ResizableSidebarProps> = ({
                     : "bg-transparent"
               }`}
             />
-          </Box>
+          </button>
         )}
-      </Flex>
+      </div>
       {/* Full-screen shield while dragging: keeps the col-resize cursor no
           matter what the pointer crosses (content sets its own cursors, and
           webview tabs would swallow the drag entirely). Outside the panel so
           the panel's pointer-events:none while drag-closed can't disable it. */}
       {isResizing && (
-        <Box className="fixed inset-0 z-[200] cursor-col-resize" />
+        <div className="fixed inset-0 z-[200] cursor-col-resize" />
       )}
-    </Box>
+    </div>
   );
 };

--- a/products/desktop/packages/ui/src/primitives/ResizableSidebar.tsx
+++ b/products/desktop/packages/ui/src/primitives/ResizableSidebar.tsx
@@ -267,7 +267,7 @@ export const ResizableSidebar: React.FC<ResizableSidebarProps> = ({
         }}
         className={
           isOverlay
-            ? `absolute inset-y-0 z-50 h-full min-w-0 border-border bg-chrome transition-transform duration-200 ease-out motion-reduce:transition-none ${
+            ? `absolute inset-y-0 z-50 flex h-full min-w-0 flex-col border-border bg-chrome transition-transform duration-200 ease-out motion-reduce:transition-none ${
                 isLeft ? "left-0 border-r" : "right-0 border-l"
               } ${
                 // Shadow only while shown — at translateX(-100%) the panel's
@@ -275,7 +275,7 @@ export const ResizableSidebar: React.FC<ResizableSidebarProps> = ({
                 // a sliver over the content.
                 overlayVisible ? "shadow-lg" : ""
               }`
-            : "relative h-full min-w-0 transition-transform duration-200 ease-out motion-reduce:transition-none"
+            : "relative flex h-full min-w-0 flex-col transition-transform duration-200 ease-out motion-reduce:transition-none"
         }
       >
         {children}

--- a/products/desktop/packages/ui/src/router/routes/__root.tsx
+++ b/products/desktop/packages/ui/src/router/routes/__root.tsx
@@ -114,12 +114,6 @@ function RootLayout() {
   // Width of the Channels sidebar below — used to right-align the back/forward
   // buttons in the title bar with the sidebar's (and project switcher's) right edge.
   const channelsSidebarWidth = useChannelsSidebarStore((state) => state.width);
-  // Suppress the title-bar width transition during a live drag so it tracks
-  // the sidebar frame-for-frame; when the sidebar toggles open/closed, both
-  // animate with the same curve (see ResizableSidebar).
-  const sidebarIsResizing = useChannelsSidebarStore(
-    (state) => state.isResizing,
-  );
   // Forward availability isn't exposed by the router (and history.length counts
   // pre-app entries, so it can't be compared to __TSR_index). Track the newest
   // index we've reached: only a PUSH wipes the forward stack, so it resets the
@@ -329,8 +323,10 @@ function RootLayout() {
           onOpenChange={(open) => (open ? null : closeShortcutsSheet())}
         />
         <GlobalEventHandlers
+          allTasks={tasks ?? []}
           onToggleCommandMenu={toggleCommandMenu}
           onToggleShortcutsSheet={toggleShortcutsSheet}
+          visualTaskOrder={visualTaskOrder}
         />
         {/* The settings shell has never mounted the tab strip, so nothing here
             was stopping Cmd+W from closing the window. */}
@@ -375,11 +371,6 @@ function RootLayout() {
               // without Window Controls Overlay.
               paddingLeft: isMac ? "env(titlebar-area-x, 78px)" : "78px",
               width: sidebarOpen ? channelsSidebarWidth : undefined,
-              // Same curve/duration as ResizableSidebar's SLIDE_EASING so the
-              // title bar tracks the sidebar edge.
-              transition: sidebarIsResizing
-                ? "none"
-                : "width 0.2s cubic-bezier(0, 0, 0.2, 1)",
             }}
           >
             <Flex align="center" gap="2" className="no-drag">
@@ -503,8 +494,10 @@ function RootLayout() {
           onOpenChange={(open) => (open ? null : closeShortcutsSheet())}
         />
         <GlobalEventHandlers
+          allTasks={tasks ?? []}
           onToggleCommandMenu={toggleCommandMenu}
           onToggleShortcutsSheet={toggleShortcutsSheet}
+          visualTaskOrder={visualTaskOrder}
         />
         {/* Renders nothing — owns ⌘1-9 under the channels layout. Mounted here
             rather than in the switcher, which only exists once a channel is

--- a/products/desktop/packages/ui/src/shell/GlobalEventHandlers.tsx
+++ b/products/desktop/packages/ui/src/shell/GlobalEventHandlers.tsx
@@ -19,9 +19,7 @@ import { toggleRightPanel } from "@posthog/ui/features/navigation/rightPanelSide
 import { usePanelLayoutStore } from "@posthog/ui/features/panels/panelLayoutStore";
 import { openSettings } from "@posthog/ui/features/settings/hooks/useOpenSettings";
 import { useSidebarStore } from "@posthog/ui/features/sidebar/sidebarStore";
-import { useSidebarData } from "@posthog/ui/features/sidebar/useSidebarData";
-import { useVisualTaskOrder } from "@posthog/ui/features/sidebar/useVisualTaskOrder";
-import { useTasks } from "@posthog/ui/features/tasks/useTasks";
+import type { TaskData } from "@posthog/ui/features/sidebar/useSidebarData";
 import { useFocusWorkspace } from "@posthog/ui/features/workspace/useFocusWorkspace";
 import { useWorkspaces } from "@posthog/ui/features/workspace/useWorkspace";
 import { shipIt } from "@posthog/ui/primitives/confetti";
@@ -42,13 +40,17 @@ import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 
 interface GlobalEventHandlersProps {
+  allTasks: Task[];
   onToggleCommandMenu: () => void;
   onToggleShortcutsSheet: () => void;
+  visualTaskOrder: TaskData[];
 }
 
 export function GlobalEventHandlers({
+  allTasks,
   onToggleCommandMenu,
   onToggleShortcutsSheet,
+  visualTaskOrder,
 }: GlobalEventHandlersProps) {
   const trpcReact = useHostTRPC();
   const sessionService = useService<SessionService>(SESSION_SERVICE);
@@ -76,10 +78,6 @@ export function GlobalEventHandlers({
     currentTaskId ?? "",
   );
   const isWorktreeTask = currentWorkspace?.mode === "worktree";
-
-  const { data: allTasks = [] } = useTasks();
-  const sidebarData = useSidebarData({ activeView: view });
-  const visualTaskOrder = useVisualTaskOrder(sidebarData);
 
   // mod+N belongs to the browser tab strip with channels on, and to the
   // starred channels in the new layout (ChannelHotkeys, mounted from __root so


### PR DESCRIPTION
## Problem

People using PostHog Desktop see both sidebars hitch during their slide, while visited task tabs keep increasing renderer memory.

The slide repeatedly reflows heavy editors and panels.

## Changes

- Sidebars snap their layout width once and animate the panel with transforms.
- Drag resizing, drag collapse and reopen, peek, and reduced motion retain their existing behavior.
- Sidebar containers preserve the flex-column layout required by detail panels and bounded scroll regions.
- Pointer-only resize handles stay out of the keyboard tab order.
- Inactive tabs skip layout and paint work, with least-recently-used eviction beyond five mounted tabs.
- The right panel renders its content immediately and preloads review modules before use.
- The app derives sidebar task order once and shares it with global keyboard handlers.
- No screenshot is available because the dev profile requires sign-in before task panels are reachable.

## How did you test this code?

- `pnpm typecheck`
- `pnpm lint`
- `pnpm --filter @posthog/ui test`
- Added an LRU regression test that fails if six visited tabs remain mounted.
- The Electron app booted and connected over CDP.
- Authenticated sidebar interaction and DevTools performance recording were not run because the dev profile required sign-in.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This changes internal rendering behavior without changing the documented workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented and reviewed the change. It used the `posthog-desktop`, `test-electron-app`, `writing-ui-components`, `writing-tests`, and `writing-pr-descriptions` skills.

The agent chose transform-based slides, bounded tab retention, immediate panel rendering, and review-module preloading. ReviewHog identified two sidebar regressions that were fixed on the PR branch.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
