### PR TITLE
fix: Properly persist recently searched queries in logs search

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/recentTaxonomicFiltersLogic.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/recentTaxonomicFiltersLogic.test.ts
@@ -1,5 +1,5 @@
 import { initKeaTests } from '~/test/init'
-import { PersonPropertyFilter, PropertyFilterType, PropertyOperator } from '~/types'
+import { LogPropertyFilter, PersonPropertyFilter, PropertyFilterType, PropertyOperator } from '~/types'
 
 import {
     MAX_RECENT_FILTERS,
@@ -529,6 +529,61 @@ describe('recentTaxonomicFiltersLogic', () => {
             expect(emailRecords[1].propertyFilter).toMatchObject(complete)
             // Oldest event was evicted to make room for the selectingKeyOnly entry that followed the complete one.
             expect(filters.find((f) => f.value === 'event-0')).toBeUndefined()
+        })
+    })
+
+    describe('logs message search', () => {
+        // The Logs query bar builds the property filter itself and records it, and taxonomicFilterLogic
+        // separately records the same selection without a value. Both write under groupType Logs / value
+        // 'message' — the key, since the Logs group's getValue returns option.key — so they collide on the
+        // same record, and the guards above keep the complete one whichever order they land in.
+        const messageContainsFoobar: LogPropertyFilter = {
+            key: 'message',
+            value: 'foobar',
+            operator: PropertyOperator.IContains,
+            type: PropertyFilterType.Log,
+        }
+
+        it('keeps the searched value when the value-less record follows the complete one', () => {
+            logic.actions.recordRecentFilter({
+                groupType: TaxonomicFilterGroupType.Logs,
+                groupName: 'Logs',
+                value: 'message',
+                item: { name: 'Search log message for "foobar"' },
+                propertyFilter: messageContainsFoobar,
+            })
+            logic.actions.recordRecentFilter({
+                groupType: TaxonomicFilterGroupType.Logs,
+                groupName: 'Logs',
+                value: 'message',
+                item: { name: 'Search log message for "foobar"' },
+            })
+
+            expect(logic.values.recentFilters).toHaveLength(1)
+            expect(logic.values.recentFilterItems).toHaveLength(1)
+            // Re-selecting this from "Recent" restores `message contains foobar`, not a bare `message`.
+            expect((logic.values.recentFilterItems[0] as any)._recentContext.propertyFilter).toMatchObject(
+                messageContainsFoobar
+            )
+        })
+
+        it('keeps one entry per searched term rather than collapsing onto the message key', () => {
+            logic.actions.recordRecentFilter({
+                groupType: TaxonomicFilterGroupType.Logs,
+                groupName: 'Logs',
+                value: 'message',
+                item: { name: 'Search log message for "foobar"' },
+                propertyFilter: messageContainsFoobar,
+            })
+            logic.actions.recordRecentFilter({
+                groupType: TaxonomicFilterGroupType.Logs,
+                groupName: 'Logs',
+                value: 'message',
+                item: { name: 'Search log message for "baz"' },
+                propertyFilter: { ...messageContainsFoobar, value: 'baz' },
+            })
+
+            expect(logic.values.recentFilters.map((f) => f.propertyFilter?.value)).toEqual(['baz', 'foobar'])
         })
     })
 })

--- a/products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsFilterBar.test.ts
+++ b/products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsFilterBar.test.ts
@@ -1,0 +1,99 @@
+import { recentTaxonomicFiltersLogic } from 'lib/components/TaxonomicFilter/recentTaxonomicFiltersLogic'
+import { TaxonomicFilterGroup, TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+
+import { initKeaTests } from '~/test/init'
+import { PropertyFilterType, PropertyOperator } from '~/types'
+
+import { addLogsValueFilter } from './LogsFilterBar'
+
+// The Logs group's getValue returns option.key, so `value` is 'message' while the searched-for text
+// lives on item.value. See buildTaxonomicGroups' localItemsSearch for the Logs group.
+const LOGS_GROUP = { name: 'Logs', type: TaxonomicFilterGroupType.Logs } as TaxonomicFilterGroup
+const messageSearchItem = (query: string): Record<string, any> => ({
+    key: 'message',
+    name: `Search log message for "${query}"`,
+    value: query,
+    propertyFilterType: 'log',
+})
+
+describe('addLogsValueFilter', () => {
+    let logic: ReturnType<typeof recentTaxonomicFiltersLogic.build>
+
+    beforeEach(() => {
+        localStorage.clear()
+        initKeaTests()
+        logic = recentTaxonomicFiltersLogic.build()
+        logic.mount()
+    })
+
+    afterEach(() => {
+        logic.unmount()
+    })
+
+    it('builds a contains filter for the searched text', () => {
+        expect(addLogsValueFilter(LOGS_GROUP, 'message', messageSearchItem('foobar'), [])).toEqual([
+            {
+                key: 'message',
+                value: 'foobar',
+                operator: PropertyOperator.IContains,
+                type: PropertyFilterType.Log,
+            },
+        ])
+    })
+
+    it('appends to existing filters rather than replacing them', () => {
+        const existing = [{ key: 'severity_level', value: 'error', type: PropertyFilterType.Log }] as any
+        expect(addLogsValueFilter(LOGS_GROUP, 'message', messageSearchItem('foobar'), existing)).toHaveLength(2)
+    })
+
+    // The regression: without recording the complete filter here, the only record of this selection is
+    // taxonomicFilterLogic's, which drops the value — so re-selecting from "Recent" yields `message`
+    // with nothing to match on.
+    it('records the searched value to recents so re-selecting it restores the filter', () => {
+        addLogsValueFilter(LOGS_GROUP, 'message', messageSearchItem('foobar'), [])
+
+        expect(logic.values.recentFilters).toHaveLength(1)
+        expect(logic.values.recentFilters[0].propertyFilter).toMatchObject({
+            key: 'message',
+            value: 'foobar',
+            operator: PropertyOperator.IContains,
+            type: PropertyFilterType.Log,
+        })
+    })
+
+    // Recents are expanded into a bare-key row plus a full-filter row, and the bare row inherits this name
+    // while dropping the value. Naming it after the search phrase produced the reported bug: a row reading
+    // `Search log message for "foobar"` that applied an empty `message` filter when clicked.
+    it('names the recent after the key so the bare-key row does not promise a value', () => {
+        addLogsValueFilter(LOGS_GROUP, 'message', messageSearchItem('foobar'), [])
+
+        expect(logic.values.recentFilters[0].item).toEqual({ name: 'message' })
+    })
+
+    // What taxonomicFilterLogic writes for the same selection: same group and value, but a stripped item and
+    // no propertyFilter. Whichever order the two writes land in, the reducer keeps the complete one — so the
+    // outcome does not depend on the ordering between our synchronous write and its deferred one.
+    const recordValueLessWrite = (): void =>
+        logic.actions.recordRecentFilter({
+            groupType: TaxonomicFilterGroupType.Logs,
+            groupName: 'Logs',
+            value: 'message',
+            item: { name: 'message' },
+        })
+
+    it("survives taxonomicFilterLogic's value-less record landing after ours", () => {
+        addLogsValueFilter(LOGS_GROUP, 'message', messageSearchItem('foobar'), [])
+        recordValueLessWrite()
+
+        expect(logic.values.recentFilters).toHaveLength(1)
+        expect(logic.values.recentFilters[0].propertyFilter).toMatchObject({ value: 'foobar' })
+    })
+
+    it("survives taxonomicFilterLogic's value-less record landing before ours", () => {
+        recordValueLessWrite()
+        addLogsValueFilter(LOGS_GROUP, 'message', messageSearchItem('foobar'), [])
+
+        expect(logic.values.recentFilters).toHaveLength(1)
+        expect(logic.values.recentFilters[0].propertyFilter).toMatchObject({ value: 'foobar' })
+    })
+})

--- a/products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsFilterBar.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsFilterBar.tsx
@@ -5,14 +5,21 @@ import { IconRefresh } from '@posthog/icons'
 import { LemonButton, LemonDropdown } from '@posthog/lemon-ui'
 
 import { InfiniteSelectResults } from 'lib/components/TaxonomicFilter/InfiniteSelectResults'
+import { recentTaxonomicFiltersLogic } from 'lib/components/TaxonomicFilter/recentTaxonomicFiltersLogic'
 import { TaxonomicFilterSearchInput } from 'lib/components/TaxonomicFilter/TaxonomicFilter'
 import { taxonomicFilterLogic } from 'lib/components/TaxonomicFilter/taxonomicFilterLogic'
-import { TaxonomicFilterGroupType, TaxonomicFilterLogicProps } from 'lib/components/TaxonomicFilter/types'
+import {
+    TaxonomicFilterGroup,
+    TaxonomicFilterGroupType,
+    TaxonomicFilterLogicProps,
+    TaxonomicFilterValue,
+} from 'lib/components/TaxonomicFilter/types'
 import UniversalFilters from 'lib/components/UniversalFilters/UniversalFilters'
 import { universalFiltersLogic } from 'lib/components/UniversalFilters/universalFiltersLogic'
 import { isUniversalGroupFilterLike } from 'lib/components/UniversalFilters/utils'
 import { dayjs } from 'lib/dayjs'
 import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
+import { teamLogic } from 'scenes/teamLogic'
 
 import {
     AnyPropertyFilter,
@@ -93,6 +100,52 @@ export const LogsFilterGroup = ({ children }: { children: React.ReactNode }): JS
     )
 }
 
+/**
+ * Handles selecting a taxonomic item that carries its own value — notably the Logs group's free-text
+ * `Search log message for "…"` item, whose value lives on `item.value` rather than in the `value`
+ * argument (the Logs group's `getValue` returns the key, `message`).
+ *
+ * Besides building the filter, this records the *complete* filter to recents itself. taxonomicFilterLogic
+ * records the selection too, but it strips the item down to `{ name }` and only carries a propertyFilter
+ * through for items that already came from recents — so its record would drop the searched-for value, and
+ * re-selecting the entry from "Recent" would yield a bare `message` with nothing to match on.
+ *
+ * We mirror its groupType/value exactly so both writes collide on one record rather than leaving a duplicate
+ * value-less entry behind. Which of the two lands first doesn't matter: recordRecentFilter ignores a
+ * value-less write when a complete record already exists, and replaces an existing value-less record when a
+ * complete one arrives.
+ */
+export function addLogsValueFilter(
+    taxonomicGroup: TaxonomicFilterGroup,
+    value: TaxonomicFilterValue,
+    item: any,
+    currentValues: UniversalFiltersGroup['values']
+): UniversalFiltersGroup['values'] {
+    const newPropertyFilter = {
+        key: item.key,
+        value: item.value,
+        operator: PropertyOperator.IContains,
+        type: item.propertyFilterType,
+    } as AnyPropertyFilter
+
+    if (recentTaxonomicFiltersLogic.isMounted()) {
+        recentTaxonomicFiltersLogic.actions.recordRecentFilter({
+            groupType: taxonomicGroup.type,
+            groupName: taxonomicGroup.name,
+            value,
+            // Store the key, not `item.name`. Recents are expanded for display into a bare-key row plus a
+            // full-filter row, and the bare row inherits this name while dropping the value — so naming it
+            // `Search log message for "foobar"` would render a row promising a value it can't apply.
+            // `message` reads correctly for both rows, matching how property recents are named elsewhere.
+            item: { name: item.key },
+            teamId: teamLogic.findMounted()?.values.currentTeamId ?? undefined,
+            propertyFilter: newPropertyFilter,
+        })
+    }
+
+    return [...currentValues, newPropertyFilter]
+}
+
 export const LogsFilterSearch = (): JSX.Element => {
     const [visible, setVisible] = useState<boolean>(false)
     const { utcDateRange, filters: logsFilters, queryFilterGroup } = useValues(logsViewerFiltersLogic)
@@ -122,15 +175,7 @@ export const LogsFilterSearch = (): JSX.Element => {
                 return
             }
 
-            const newValues = [...filterGroup.values]
-            const newPropertyFilter = {
-                key: item.key,
-                value: item.value,
-                operator: PropertyOperator.IContains,
-                type: item.propertyFilterType,
-            } as AnyPropertyFilter
-            newValues.push(newPropertyFilter)
-            setGroupValues(newValues)
+            setGroupValues(addLogsValueFilter(taxonomicGroup, value, item, filterGroup.values))
             setVisible(false)
         },
         onEnter: onClose,


### PR DESCRIPTION
<!-- This has to stand on its own: a reader who opens no files should still know why the PR is necessary and what it does. Length tracks the change, so a small diff gets a few bullets rather than a full-length body, and a section you have nothing for gets one line or "None". -->

## Problem

When clicking on a suggestion from recent searches like "Search log message for ___" the actual filter value is not saved properly (what's persisted is the column-only portion) so the generated/applied filter has an empty predicate. This happens during the persistence action not on the rendering/filter application action.

<!-- Who are we building for, what are their needs, why is this important? -->
<!-- First line: what is different for a person, and who they are. A fix says what breaks; a feature says what someone can now do; a chore says who is blocked. The code path goes underneath. -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->
<!-- Don't recite pass counts for suites CI runs; the checks report those with more authority. Link the evidence instead (run, permalink, error tracking issue), and say what you did not check. Long transcripts go in a <details> block. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

Test in local hogli instance and also update tests.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
     - Public artifact: nothing in this PR — code, fixtures and sample data, comments, commit messages, or this description — carries material from the agent session that isn't already public. If the work drew on a customer conversation, ticket, or log, say so here and state that the committed data is invented. Renaming people, hosts, and identifiers does not clear real material; see AGENTS.md "Public open source repo guidance".
-->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way: what changed across the session. The reason the shipped design beats the obvious alternative goes in Changes instead, where a reviewer will actually see it.
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session — that applies to every part of this PR, not just this section.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Stack instead of stuffing: if the diff holds two or more separable steps (migration then behavior, rename then rewrite), open a stack rather than one big PR. See AGENTS.md, "Stacked PRs" and /stacking-prs.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- Shape and style: invoke the `/writing-pr-descriptions` skill before writing this body. In short: lead with the effect a person sees rather than the code path behind it, make the body stand alone for a reader who opens no files, size it to the change, link evidence rather than asserting what CI already reports, then hold what's left to one fact per bullet in under 25 words. A body that got longer as bullets was not cut.
-->
