### PR TITLE
fix(tasks): keep the sandbox alive while a loop run's turn is in flight

### DIFF
--- a/products/tasks/backend/temporal/process_task/activities/relay_sandbox_events.py
+++ b/products/tasks/backend/temporal/process_task/activities/relay_sandbox_events.py
@@ -119,8 +119,10 @@ async def _relay_sandbox_events(input: RelaySandboxEventsInput, *, finalize_stre
 
     task_run = await TaskRunModel.objects.select_related("task__created_by", "task__team").aget(id=input.run_id)
 
-    # Match the freshness window to the workflow's inactivity timeout for this run
-    # so the heartbeat suppression below never resets a timer it shouldn't.
+    # The workflow's inactivity timeout for this run also drives the heartbeat
+    # freshness guard (floored at the background default while a turn is in
+    # flight; see _background_heartbeat), so the relay never resets a timer for
+    # a run that is genuinely idle.
     origin_product = task_run.task.origin_product
     is_user_origin = not origin_product or origin_product == TaskModel.OriginProduct.USER_CREATED.value
     inactivity_timeout_seconds = resolve_inactivity_timeout(
@@ -289,13 +291,12 @@ async def _background_heartbeat(
         except TimeoutError:
             activity.heartbeat()
             now = time.monotonic()
-            if (
-                workflow_handle is not None
-                and last_event_time is not None
-                and last_event_time[0] > 0
-                and (now - last_event_time[0]) < inactivity_timeout_seconds
-                and (last_workflow_signal is None or (now - last_workflow_signal[0]) >= HEARTBEAT_INTERVAL_SECONDS)
-                and (agent_active is None or agent_active[0])
+            if workflow_handle is not None and _should_signal_workflow_heartbeat(
+                now=now,
+                last_event_time=last_event_time,
+                last_workflow_signal=last_workflow_signal,
+                agent_active=agent_active,
+                inactivity_timeout_seconds=inactivity_timeout_seconds,
             ):
                 if last_workflow_signal is not None:
                     last_workflow_signal[0] = now
@@ -305,6 +306,32 @@ async def _background_heartbeat(
                     )
                 except Exception as e:
                     logger.warning("relay_workflow_heartbeat_signal_failed", error=str(e))
+
+
+def _should_signal_workflow_heartbeat(
+    *,
+    now: float,
+    last_event_time: list[float] | None,
+    last_workflow_signal: list[float] | None,
+    agent_active: list[bool] | None,
+    inactivity_timeout_seconds: float,
+) -> bool:
+    """Gate for the periodic workflow keep-alive signal sent by _background_heartbeat."""
+    if last_event_time is None or last_event_time[0] <= 0:
+        return False
+    if agent_active is not None and not agent_active[0]:
+        return False
+    if last_workflow_signal is not None and (now - last_workflow_signal[0]) < HEARTBEAT_INTERVAL_SECONDS:
+        return False
+    # An in-flight turn can be legitimately quiet for minutes (a long tool call
+    # emits no session events), so a short per-run idle window (loop runs: 2
+    # minutes) must not starve keep-alives mid-turn and let the workflow tear
+    # the sandbox down under the agent. Floor the freshness guard at the
+    # background default; that still bounds how long a turn that hung without
+    # an end_of_turn can pin the sandbox, and the short window keeps applying
+    # to post-turn idleness because agent_active is false there.
+    event_freshness_seconds = max(inactivity_timeout_seconds, INACTIVITY_TIMEOUT_DEFAULT_SECONDS)
+    return (now - last_event_time[0]) < event_freshness_seconds
 
 
 async def _relay_loop(

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_relay_sandbox_events.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_relay_sandbox_events.py
@@ -13,10 +13,12 @@ from parameterized import parameterized
 from temporalio.exceptions import ApplicationError
 
 from products.tasks.backend.models import Task, TaskRun
+from products.tasks.backend.temporal.constants import INACTIVITY_TIMEOUT_DEFAULT_SECONDS
 from products.tasks.backend.temporal.process_task import workflow as process_task_workflow_module
 from products.tasks.backend.temporal.process_task.activities.get_task_processing_context import TaskProcessingContext
 from products.tasks.backend.temporal.process_task.activities.relay_sandbox_events import (
     FINAL_MESSAGE_MAX_CHARS,
+    HEARTBEAT_INTERVAL_SECONDS,
     FinalMessageTracker,
     RelaySandboxEventsInput,
     TaskRunRedisStream,
@@ -29,6 +31,7 @@ from products.tasks.backend.temporal.process_task.activities.relay_sandbox_event
     _mark_sandbox_error_best_effort,
     _persist_final_message,
     _relay_loop,
+    _should_signal_workflow_heartbeat,
     relay_sandbox_events,
 )
 from products.tasks.backend.temporal.process_task.workflow import (
@@ -1068,3 +1071,71 @@ class TestFlushPendingText:
         parts = ["dropped"]
         await _flush_pending_text(None, parts, [0.0])
         assert parts == []
+
+
+class TestShouldSignalWorkflowHeartbeat:
+    @parameterized.expand(
+        [
+            # Loop runs carry a 2-minute idle window; a quiet in-flight turn past that
+            # window must still keep the workflow alive (the mid-turn teardown bug).
+            ("mid_turn_quiet_past_short_run_window", True, 300.0, 120.0, True),
+            # The floor is the background default, not unbounded: a turn that hung
+            # without an end_of_turn stops pinning the sandbox past that window.
+            (
+                "mid_turn_quiet_past_default_window",
+                True,
+                float(INACTIVITY_TIMEOUT_DEFAULT_SECONDS) + 60.0,
+                120.0,
+                False,
+            ),
+            # Idle after end_of_turn: the short loop window applies and the run winds down.
+            ("idle_agent_stale_events", False, 300.0, 120.0, False),
+            ("mid_turn_fresh_events", True, 30.0, 120.0, True),
+            # Runs with a window above the default keep their longer window mid-turn.
+            ("mid_turn_long_window_still_fresh", True, float(INACTIVITY_TIMEOUT_DEFAULT_SECONDS) + 60.0, 3600.0, True),
+        ]
+    )
+    def test_freshness_gating(
+        self,
+        _name: str,
+        agent_active: bool,
+        event_age_seconds: float,
+        inactivity_timeout_seconds: float,
+        expected: bool,
+    ) -> None:
+        now = 100_000.0
+        assert (
+            _should_signal_workflow_heartbeat(
+                now=now,
+                last_event_time=[now - event_age_seconds],
+                last_workflow_signal=[now - HEARTBEAT_INTERVAL_SECONDS - 1.0],
+                agent_active=[agent_active],
+                inactivity_timeout_seconds=inactivity_timeout_seconds,
+            )
+            is expected
+        )
+
+    @parameterized.expand(
+        [
+            ("no_events_yet", [0.0], None, False),
+            ("signaled_within_interval", None, [100_000.0 - 1.0], False),
+        ]
+    )
+    def test_rate_and_bootstrap_gating(
+        self,
+        _name: str,
+        last_event_time: list[float] | None,
+        last_workflow_signal: list[float] | None,
+        expected: bool,
+    ) -> None:
+        now = 100_000.0
+        assert (
+            _should_signal_workflow_heartbeat(
+                now=now,
+                last_event_time=last_event_time if last_event_time is not None else [now - 10.0],
+                last_workflow_signal=last_workflow_signal,
+                agent_active=[True],
+                inactivity_timeout_seconds=120.0,
+            )
+            is expected
+        )


### PR DESCRIPTION
## Problem

- A loop run dies mid-work with "The upstream AI provider failed to process the request" whenever one tool call stays quiet for over 2 minutes.
- Loop runs carry a 2-minute inactivity timeout (`LOOP_RUN_IDLE_TIMEOUT_SECONDS`) so the unattended sandbox is reclaimed promptly after the turn ends.
- The relay measures activity by relayed session events, and a long quiet tool call (for example a curl loop over PR diffs) emits none.
- The keep-alive heartbeat then stops, the workflow's inactivity timer fires, and the workflow tears the sandbox down under the in-flight turn.
- The agent's in-flight prompt rejects with "ACP connection closed", which is reported as an upstream provider failure and terminalizes the run.
- Traced on a production loop run: the agent server was stopped 103 seconds after the last session event, while a bash tool call was still running.

## Changes

- The heartbeat's event-freshness guard now floors at the 30-minute background default while a turn is in flight.
- The 2-minute loop window still applies once the turn ends, because the heartbeat already requires `agent_active` and that flag drops on `end_of_turn`.
- A turn that hangs without an `end_of_turn` still stops pinning the sandbox after the background default window.
- The gating condition moves into `_should_signal_workflow_heartbeat` so it is testable without running the heartbeat loop.
- No workflow definition changes, so no Temporal versioning concerns.

## How did you test this code?

- New parameterized tests over `_should_signal_workflow_heartbeat` guard the regression this fixes: a quiet in-flight turn past the loop's 2-minute window losing its keep-alives. They also pin the hung-turn bound and the idle-after-turn reclaim, which no existing test covered (`_background_heartbeat` was only ever mocked out).
- Ran the full `test_relay_sandbox_events.py` file locally.
- Not run: repo-wide mypy.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude Code (Fable 5) in a local session, directed by @Gilbert09 after diagnosing two recurring loop-run failures from a production run's session log.
- Skills invoked: /writing-tests, /writing-code-comments, /writing-pr-descriptions.
- The companion fix for repo-less loop runs lacking GitHub credentials ships separately.