### PR TITLE
fix(tasks): grant repo-less loop runs read-only github access

### DIFF
--- a/products/tasks/backend/logic/services/loop_runs.py
+++ b/products/tasks/backend/logic/services/loop_runs.py
@@ -744,6 +744,12 @@ def _create_loop_task_and_run(loop: Loop, trigger: LoopTrigger | None, trigger_c
     # regular task's sandbox_environment_id flows through Task._build_task.
     if loop.sandbox_environment_id is not None:
         extra_state["sandbox_environment_id"] = str(loop.sandbox_environment_id)
+    # A repo-less loop still needs `gh` for evidence gathering (PR digests, commit
+    # history), so provisioning mints the team-scoped read-only GitHub token for it
+    # (see get_readonly_github_token; a team with no usable integration skips the
+    # mint). Repo-pinned loops get the repository integration's token instead.
+    if not loop.repositories:
+        extra_state["github_read_access"] = True
     # Reclaim the sandbox promptly once the agent goes idle — a loop run is unattended,
     # so nothing sends a follow-up. CI-watching loops keep the default window so the
     # sandbox survives the orchestrator's CI follow-up cadence.

--- a/products/tasks/backend/tests/test_loop_runs.py
+++ b/products/tasks/backend/tests/test_loop_runs.py
@@ -482,6 +482,30 @@ class TestFireLoopCreatesRun(LoopRunsTestCase):
 
     @parameterized.expand(
         [
+            ("repo_less_loop_gets_read_only_github", False, True),
+            ("repo_pinned_loop_uses_repository_integration", True, False),
+        ]
+    )
+    def test_fire_grants_github_read_access_only_to_repo_less_loops(self, _name, pin_repository, expected_flag):
+        repositories = []
+        if pin_repository:
+            integration = Integration.objects.create(team=self.team, kind="github", integration_id="12345", config={})
+            repositories = [{"github_integration_id": integration.id, "full_name": "acme/repo"}]
+        loop = self.create_loop(repositories=repositories)
+        trigger = self.create_trigger(loop)
+
+        result = fire_loop(loop, trigger, f"fire-{_name}", "rendered context")
+
+        self.assertTrue(result.created)
+        assert result.task_run_id is not None
+        task_run = TaskRun.objects.get(id=result.task_run_id)
+        if expected_flag:
+            self.assertIs(task_run.state["github_read_access"], True)
+        else:
+            self.assertNotIn("github_read_access", task_run.state)
+
+    @parameterized.expand(
+        [
             ("claude_default_resolves_to_sonnet_5", "claude", "", None, "claude-sonnet-5", None),
             ("codex_default_resolves_to_gpt5", "codex", "", None, "gpt-5", None),
             ("supported_effort_on_default_model_is_kept", "claude", "", "high", "claude-sonnet-5", "high"),


### PR DESCRIPTION
## Problem

- A loop with no pinned repository always starts its sandbox with an unauthenticated `gh` and no `GITHUB_TOKEN`/`GH_TOKEN`.
- Digest-style loops (summarize PRs, watch commits across repos) hit this on every fire and stop with "GitHub CLI is not authenticated".
- Provisioning only mints the team-scoped read-only GitHub token when the run state carries `github_read_access`, and loop fires never set it.

## Changes

- `_create_loop_task_and_run` sets `github_read_access: true` on runs of loops with no repositories.
- Provisioning then mints the existing downscoped read-only installation token (contents, metadata, and pull_requests read).
- Teams with no usable GitHub integration are unaffected: `get_readonly_github_token` returns None and the run proceeds without a token, as before.
- Repo-pinned loops are unchanged; they keep the repository integration's token.

## How did you test this code?

- New parameterized test in `test_loop_runs.py`: a repo-less fire sets the flag and a repo-pinned fire does not. It catches the flag being dropped (`gh` silently unauthenticated again) and the inverse over-grant; no existing test asserted either.
- Ran the full `test_loop_runs.py` file locally.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude Code (Fable 5) in a local session, directed by @Gilbert09 after diagnosing two recurring loop-run failures from a production run's session log.
- Skills invoked: /writing-tests, /writing-code-comments, /writing-pr-descriptions.
- The companion fix for the loop idle timeout tearing down a sandbox mid-turn is #83860.