### PR TITLE
fix(desktop): pin quill's base-ui to 1.6.0 in the canvas source preview

### DIFF
--- a/products/desktop/packages/core/src/canvas/freeformWhitelist.ts
+++ b/products/desktop/packages/core/src/canvas/freeformWhitelist.ts
@@ -43,7 +43,12 @@ export const FREEFORM_WHITELIST: WhitelistEntry[] = [
   {
     name: "@posthog/quill",
     version: QUILL_VERSION,
-    esm: `${ESM}/@posthog/quill@${QUILL_VERSION}?external=react,react-dom`,
+    // `deps` pins quill's Base UI to the version the canvas builder bundles.
+    // Left floating (quill declares ^1.4.0), esm.sh resolves the newest Base
+    // UI, and its 1.7.0 build emits literal `#prehydration/...` specifiers
+    // that browsers read as URL fragments — the esm.sh homepage comes back as
+    // text/html and the whole quill module graph fails to load.
+    esm: `${ESM}/@posthog/quill@${QUILL_VERSION}?external=react,react-dom&deps=@base-ui/react@1.6.0`,
   },
   // One charting library (the conventional React pick).
   {


### PR DESCRIPTION
## Problem

- Previewing or editing any unbuilt canvas in the desktop app fails with "Failed to fetch dynamically imported module: blob:null/…". Published canvases are unaffected.
- The source preview loads `@posthog/quill` from esm.sh with its Base UI dependency floating on quill's `^1.4.0` range.
- esm.sh now resolves that range to Base UI 1.7.0, whose CDN build emits literal `#prehydration/...` import specifiers.
- Browsers read `#...` as a URL fragment, fetch the esm.sh homepage as text/html, and the whole quill module graph fails. No change on our side triggered this.

## Changes

- The quill import-map entry adds `deps=@base-ui/react@1.6.0`, pinning the preview to the Base UI version the canvas builder bundles into published artifacts.

## How did you test this code?

- Reproduced against esm.sh: the Base UI 1.7.0 build of `slider` carries a literal `#prehydration/slider/thumb` import; the 1.4.0, 1.5.0, and 1.6.0 builds do not.
- Verified the pinned quill URL resolves its whole module graph to Base UI 1.6.0.
- Ran the freeform whitelist unit and contract suites and the core typecheck. Not run: a live desktop render, because this sandbox has no GUI.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The source preview is an internal tier with no documented behavior change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5) diagnosed and fixed this while dogfooding the grid canvas stack: a user hit the blob error on a canvas with a live build, console output pointed at the `#prehydration` module fetch, and curl reproduction narrowed it to the floating Base UI range on esm.sh. Skills invoked: /writing-tests, /writing-pr-descriptions. The same pin ships in the grid canvas stack (#83549); this PR carries it to master since the breakage is live for all source previews today.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*