### PR TITLE
fix(data-imports): treat pgbouncer's cached login-retry error as transient

### DIFF
--- a/posthog/temporal/common/db_errors.py
+++ b/posthog/temporal/common/db_errors.py
@@ -12,6 +12,11 @@ _TRANSIENT_DB_ERROR_MARKERS = (
     "connection reset by peer",
     "the database system is starting up",
     "the database system is shutting down",
+    # pgbouncer's server_login_retry cooldown: a backend connect attempt failed, so pgbouncer
+    # caches the failure and hands it to every client asking for a connection until the cooldown
+    # (default 15s) elapses and it retries the backend itself. Self-heals without our retry doing
+    # anything special, so it's transient by construction, not a symptom of the underlying cause.
+    "server login has been failing, cached error",
 )
 
 # SQLSTATE class 57P (operator intervention): the server is shutting down or restarting and

--- a/posthog/temporal/common/test_db_errors.py
+++ b/posthog/temporal/common/test_db_errors.py
@@ -1,0 +1,45 @@
+import pytest
+
+from django.db import InterfaceError, OperationalError
+
+from posthog.temporal.common.db_errors import is_transient_db_error
+
+
+class _WithSqlstate(Exception):
+    def __init__(self, sqlstate: str) -> None:
+        super().__init__(sqlstate)
+        self.sqlstate = sqlstate
+
+
+@pytest.mark.parametrize(
+    "error,expected",
+    [
+        (ValueError("query_wait_timeout"), False),
+        (OperationalError("query_wait_timeout"), True),
+        (OperationalError("server closed the connection unexpectedly"), True),
+        (InterfaceError("connection reset by peer"), True),
+        (OperationalError("the database system is starting up"), True),
+        (OperationalError("the database system is shutting down"), True),
+        (
+            OperationalError("server login has been failing, cached error: server conn crashed? (server_login_retry)"),
+            True,
+        ),
+        (OperationalError("connection failed: FATAL: password authentication failed for user"), False),
+        (OperationalError("no such database"), False),
+    ],
+)
+def test_is_transient_db_error_by_message(error: BaseException, expected: bool) -> None:
+    assert is_transient_db_error(error) is expected
+
+
+@pytest.mark.parametrize(
+    "sqlstate,expected",
+    [
+        ("57P03", True),  # cannot_connect_now (server starting up/shutting down)
+        ("3D000", False),  # invalid_catalog_name — persistent misconfiguration
+    ],
+)
+def test_is_transient_db_error_by_sqlstate(sqlstate: str, expected: bool) -> None:
+    error = OperationalError("some driver-specific message")
+    error.__cause__ = _WithSqlstate(sqlstate)
+    assert is_transient_db_error(error) is expected


### PR DESCRIPTION
## Problem

Data warehouse import syncs sometimes fail with `OperationalError: server login has been failing, cached error: ... (server_login_retry)` while fetching the sync's job row from PostHog's own database, tripping a fresh [error tracking issue](https://us.posthog.com/project/2/error_tracking/01a010ae-dd67-7040-a116-bc35003a66de) for a condition nobody can act on.

- The failure happens inside `_get_external_data_job` (`import_data_sync.py`), a plain Django read against PostHog's application database, not the customer's source.
- It hit many unrelated sources, schemas, and teams within the same minute and never recurred, matching a brief pgbouncer backend-connect blip rather than anything source-specific.
- `is_transient_db_error` in `posthog/temporal/common/db_errors.py` already exists to keep exactly this class of self-healing Postgres error out of error tracking, but its marker list didn't cover pgbouncer's `server_login_retry` cooldown message.

## Changes

- Add `server login has been failing, cached error` to `_TRANSIENT_DB_ERROR_MARKERS`. This is pgbouncer's fixed template text for its `server_login_retry` cooldown: a backend connect attempt failed, pgbouncer caches the failure, and hands it to clients until the cooldown elapses and it retries on its own.
- Left the marker list's exclusion of the generic `connection failed:` prefix untouched, so persistent misconfiguration (bad credentials, bad host) still reaches error tracking.

## How did you test this code?

Added `posthog/temporal/common/test_db_errors.py`, a pure-function unit test suite for `is_transient_db_error`:
- Parametrized cases cover the new pgbouncer message, the existing message markers, a non-`OperationalError`/`InterfaceError` input, and two persistent-misconfiguration messages that must keep reaching error tracking.
- Two more cases cover the SQLSTATE-prefix path (transient `57P03` vs. persistent `3D000`).

No prior test file existed for this module. Ran locally: `pytest posthog/temporal/common/test_db_errors.py` (11 passed), `ruff check`/`ruff format --check`, and `mypy` on the changed files.

Not run: an end-to-end Temporal worker test, since reproducing an actual pgbouncer login-retry cooldown needs a real pooler in that failure state.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal error-classification behavior, no user-facing or documented workflow changed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tool: Claude Code, triaging a webhook-delivered PostHog error tracking issue.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- Pulled the issue's stack trace and a sample of `$exception` events via the PostHog MCP error-tracking and SQL tools to confirm the failure originates in shared pipeline code (not a source connector) and to check whether it correlated with one source/schema (it did not).
- Read `posthog/temporal/common/posthog_client.py` and `db_errors.py` to find the existing transient-error allowlist this bug was a gap in, rather than introducing a new suppression mechanism.