### PR TITLE
fix(data-imports): recognize psycopg's dead-socket message as a transient db error

### DIFF
--- a/posthog/temporal/common/db_errors.py
+++ b/posthog/temporal/common/db_errors.py
@@ -17,6 +17,12 @@ _TRANSIENT_DB_ERROR_MARKERS = (
     # (default 15s) elapses and it retries the backend itself. Self-heals without our retry doing
     # anything special, so it's transient by construction, not a symptom of the underlying cause.
     "server login has been failing, cached error",
+    # psycopg's own message when libpq finds the backend socket already gone (raised as a
+    # ProtocolViolation, SQLSTATE 08P01, which the class-based check above doesn't cover since
+    # 08P01 also covers genuine protocol bugs). Same dead-socket condition as the "closed
+    # unexpectedly" marker above, just detected client-side instead of reported by the server.
+    # Reaches us standalone too, not only wrapped in the cached-login message above.
+    "server conn crashed",
 )
 
 # SQLSTATE class 57P (operator intervention): the server is shutting down or restarting and

--- a/posthog/temporal/common/test_db_errors.py
+++ b/posthog/temporal/common/test_db_errors.py
@@ -24,6 +24,9 @@ class _WithSqlstate(Exception):
             OperationalError("server login has been failing, cached error: server conn crashed? (server_login_retry)"),
             True,
         ),
+        # The dead-socket message on its own, without pgbouncer's cached-login wrapper — the case
+        # the marker above doesn't cover.
+        (OperationalError("server conn crashed?"), True),
         (OperationalError("connection failed: FATAL: password authentication failed for user"), False),
         (OperationalError("no such database"), False),
     ],
@@ -37,6 +40,7 @@ def test_is_transient_db_error_by_message(error: BaseException, expected: bool) 
     [
         ("57P03", True),  # cannot_connect_now (server starting up/shutting down)
         ("3D000", False),  # invalid_catalog_name — persistent misconfiguration
+        ("08P01", False),  # protocol_violation — shared with genuine protocol bugs, so message-only
     ],
 )
 def test_is_transient_db_error_by_sqlstate(sqlstate: str, expected: bool) -> None:


### PR DESCRIPTION
## Problem

A self-healing Postgres blip during a data warehouse sync mints an actionable-looking [error tracking issue](https://us.posthog.com/project/2/error_tracking/01a010ae-bd51-7140-b6c5-f4de27afad9e) that nobody can act on. Temporal retries the activity and the sync completes, so the issue is pure noise over a condition that already fixed itself.

The blip is not specific to one source connector. It happens in the shared activity code every import runs through, so any sync can hit it once its pooled Postgres connection is recycled mid-run.

## Changes

- `is_transient_db_error` now treats psycopg's `server conn crashed` message as transient. The activity interceptor in `posthog_client.py` logs it and leaves the retry to Temporal instead of reporting it.
- The error carries SQLSTATE `08P01` (protocol violation), a class it shares with genuine protocol bugs. The SQLSTATE prefix check cannot separate the two, so the message text is the only reliable signal. The Postgres source connector already keys off this same wording.
- #83875 added a marker for pgbouncer's cached-login form of this error. That marker matches only when pgbouncer wraps the dead socket in its cooldown message. This one also catches the message standalone, which is how it reaches the interceptor here.

## How did you test this code?

Two cases joined the parameterized suites in `posthog/temporal/common/test_db_errors.py`:

| Case | Regression it catches |
| --- | --- |
| `OperationalError("server conn crashed?")` is transient | Deleting the new marker. The case #83875 added stays green without it, because its message also matches the cached-login marker. |
| SQLSTATE `08P01` alone is not transient | Adding `08P01` to `_TRANSIENT_SQLSTATE_PREFIXES`, which would swallow genuine protocol bugs. |

Each row was checked against its own regression. Deleting the marker fails only `[error7-True]`. Adding `08P01` to the prefixes fails only `[08P01-False]`.

Not run: a live sync reproduction. This environment cannot drive an end-to-end Temporal sync.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Found the failure through PostHog's error tracking MCP tools, which confirmed it originates in shared pipeline and activity code rather than in one source connector. Skills invoked: `/writing-pr-descriptions` and `/writing-tests`.

Rebased onto master to resolve a conflict with #83875, a sibling fix that landed in the same tuple and created `test_db_errors.py`, the file this PR had also added. The resolution kept both markers and folded this PR's coverage into the version now on master, dropping seven cases that duplicated it.
