### PR TITLE
fix(cymbal): match the SDK asset host for suspicious frames

### DIFF
--- a/rust/cymbal/src/core/types/langs/js.rs
+++ b/rust/cymbal/src/core/types/langs/js.rs
@@ -180,9 +180,20 @@ impl RawJSFrame {
     }
 
     pub fn is_suspicious(&self) -> bool {
-        self.source_url
-            .as_ref()
-            .is_some_and(|s| s.contains("posthog.com/static/"))
+        // posthog-js is served from a regional asset CDN whose host is
+        // `{region}-assets.i.posthog.com` (the `assets` target in the SDK's request router).
+        // Matching that host rather than a `posthog.com/static/` substring keeps PostHog's own
+        // app bundles out of the count: they are served from hosts like
+        // `app-static-prod.posthog.com` under the same `/static/` path, so a substring match
+        // marks every error in the PostHog app itself as an SDK exception.
+        const SDK_ASSET_HOST_SUFFIX: &str = "-assets.i.posthog.com";
+
+        let Ok(url) = self.source_url() else {
+            return false;
+        };
+
+        url.host_str()
+            .is_some_and(|host| host.ends_with(SDK_ASSET_HOST_SUFFIX))
     }
 }
 
@@ -372,5 +383,49 @@ mod test {
             frame.source_url().unwrap(),
             "http://example.com/path/to/file.js".parse().unwrap()
         );
+    }
+
+    fn frame_from(source_url: Option<&str>) -> super::RawJSFrame {
+        super::RawJSFrame {
+            location: None,
+            source_url: source_url.map(str::to_string),
+            fn_name: "main".to_string(),
+            chunk_id: None,
+            meta: Default::default(),
+        }
+    }
+
+    #[test]
+    fn only_the_sdk_asset_cdn_is_suspicious() {
+        let cases = [
+            ("https://us-assets.i.posthog.com/static/array.js", true),
+            ("https://eu-assets.i.posthog.com/static/recorder.js", true),
+            // Frame filenames often carry a trailing `:line:column`, so this has to match after
+            // the same parsing the resolution path does, not on the raw string.
+            ("https://us-assets.i.posthog.com/static/array.js:1:2", true),
+            (
+                "https://app-static-prod.posthog.com/static/chunk-ABC12345.js",
+                false,
+            ),
+            (
+                "https://app-static.eu.posthog.com/static/chunk-DEF67890.js",
+                false,
+            ),
+            // The legacy host served both the app and the pre-CDN snippet, so a frame here
+            // cannot be attributed to the SDK.
+            ("https://app.posthog.com/static/array.js", false),
+            ("https://example.com/static/bundle.js", false),
+            ("/static/relative.js", false),
+        ];
+
+        for (source_url, expected) in cases {
+            assert_eq!(
+                frame_from(Some(source_url)).is_suspicious(),
+                expected,
+                "{source_url}"
+            );
+        }
+
+        assert!(!frame_from(None).is_suspicious());
     }
 }


### PR DESCRIPTION
## Problem

- On-call reads `cymbal_suspicious_frames_detected{frame_type="raw"}` as "the PostHog SDK is throwing exceptions". It also counts errors thrown by the PostHog app itself.
- `is_suspicious()` matches any source URL containing the substring `posthog.com/static/`.
- The PostHog app serves its bundles from hosts such as `app-static-prod.posthog.com`, under `/static/`, so every frame in an app error matches.
- The SDK is served from `{region}-assets.i.posthog.com/static/`, a much narrower target.

## Changes

- `is_suspicious()` now matches the host suffix `-assets.i.posthog.com`.
- The check reads the host from `source_url()`, so it survives the trailing `:line:column` that frame filenames carry.
- Frames on the legacy `app.posthog.com` host stop counting. That host served both the app and the pre-CDN snippet, so a frame there cannot be attributed to the SDK.
- `frame_type="resolved"` is unchanged. Matching `posthog-js@` in the sourcemap source path already means SDK code.

> [!NOTE]
> This narrows the metric a long way, so the `CymbalSuspiciousFramesElevated` threshold in charts wants a second look. Follow-up, not in this PR.

## How did you test this code?

- Added `only_the_sdk_asset_cdn_is_suspicious` in `js.rs`, a table over the host shapes that appear on real JS frames.
- The regression it catches: widening the match back to a path substring, which re-counts PostHog app bundles as SDK frames. No existing test covered `is_suspicious`.
- Ran locally: `cargo test -p cymbal --lib`, `cargo clippy -p cymbal --all-targets`, `cargo fmt --check`, `hogli ci:preflight`.
- Not run: the integration tests under `rust/cymbal/tests/`, which need a database.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Opus 5) wrote this while I investigated a firing alert. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`, `/query-clickhouse-via-metabase`, `/posthog-repos`.
- I (actually Claude) checked which hosts appear on real JS frames before picking the matcher. That is where the legacy-host and EU-app cases in the test came from.
- Considered matching the host plus a `/static/` path prefix. Dropped the path check, because everything on the asset CDN is PostHog-authored JS, and the extra condition only adds a silent-failure mode if the SDK ever moves off `/static/`.
- Public artifact: the hostnames are PostHog's own public CDN hosts. The chunk filenames in the test are invented, not copied from the production frames I read.
