### PR TITLE
fix(data-imports): stop reporting transient app-db blips from table-statistics activity

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/compute_table_statistics.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/compute_table_statistics.py
@@ -30,6 +30,7 @@ from posthog.exceptions_capture import capture_exception
 from posthog.models import Team
 from posthog.sync import database_sync_to_async
 from posthog.temporal.common.base import PostHogWorkflow
+from posthog.temporal.common.db_errors import is_transient_db_error
 from posthog.temporal.common.errors import NonReportableError
 from posthog.temporal.common.heartbeat import LivenessHeartbeater as Heartbeater
 
@@ -285,7 +286,14 @@ async def compute_table_statistics_activity(inputs: ComputeTableStatisticsInputs
             # get_delta_table already re-raises known-transient object-store blips as
             # NonReportableError (see DeltaTableRef._capture_unless_transient) and intentionally
             # skips reporting them itself — don't undo that here.
-            if not isinstance(e, NonReportableError):
+            #
+            # The activity interceptor (posthog/temporal/common/posthog_client.py) already skips
+            # reporting a transient app-DB blip (e.g. a PgBouncer query_wait_timeout hit while
+            # resolving the Team/ExternalDataSchema/ExternalDataJob rows above) via
+            # is_transient_db_error — but only for exceptions that reach it unreported. The
+            # unconditional capture_exception call below would report it first, so apply the same
+            # classifier here to avoid double-reporting a condition nobody can act on.
+            if not isinstance(e, NonReportableError) and not is_transient_db_error(e):
                 capture_exception(e)
             try:
                 posthoganalytics.capture(

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_compute_table_statistics.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_compute_table_statistics.py
@@ -6,7 +6,7 @@ from decimal import Decimal
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from django.db import connection
+from django.db import InterfaceError, OperationalError, connection
 from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 
@@ -332,6 +332,25 @@ class TestComputeTableStatisticsActivity:
         ):
             inputs = ComputeTableStatisticsInputs(team_id=1, schema_id=uuid.uuid4())
             with pytest.raises(TransientObjectStoreError):
+                await ActivityEnvironment().run(compute_table_statistics_activity, inputs)
+        mock_capture.assert_not_called()
+
+    @pytest.mark.parametrize("error_cls", [OperationalError, InterfaceError])
+    async def test_activity_does_not_report_transient_app_db_error(self, error_cls: type[Exception]) -> None:
+        # compute_table_statistics_sync's Team/ExternalDataSchema/ExternalDataJob lookups run against
+        # PostHog's own app DB through a connection pooler. A pooler blip under load (e.g. PgBouncer's
+        # query_wait_timeout) surfaces as a Django OperationalError/InterfaceError that the activity
+        # interceptor (posthog_client.py) already knows to keep out of error tracking via
+        # is_transient_db_error — but only if nothing reports it first. This activity's own except
+        # block must defer to that same classifier instead of unconditionally calling
+        # capture_exception, or it reports the blip before the interceptor ever gets a say. It must
+        # still fail the activity so Temporal retries it.
+        with (
+            patch.object(comp, "compute_table_statistics_sync", side_effect=error_cls("query_wait_timeout")),
+            patch.object(comp, "capture_exception") as mock_capture,
+        ):
+            inputs = ComputeTableStatisticsInputs(team_id=1, schema_id=uuid.uuid4())
+            with pytest.raises(error_cls, match="query_wait_timeout"):
                 await ActivityEnvironment().run(compute_table_statistics_activity, inputs)
         mock_capture.assert_not_called()
 


### PR DESCRIPTION
## Problem

The warehouse table-statistics activity mints a fresh [error tracking issue](https://us.posthog.com/project/2/error_tracking/01a010af-545d-7210-935c-63cc1fbcad7a) whenever a PgBouncer connection-pool blip hits its own app-DB reads (Team, schema, job rows), even though the failure is transient and self-recovering.

- The failure surfaces as `OperationalError`/`ProtocolViolation` (`query_wait_timeout`, a cached `server_login_retry` login failure) while resolving `Team.objects.get(...)` and related lookups in `compute_table_statistics_sync`.
- It hit unrelated events within seconds of each other and never recurred, matching a shared pooler blip rather than anything source-specific.
- The Temporal activity interceptor (`posthog/temporal/common/posthog_client.py`) already keeps this exact failure class out of error tracking via `is_transient_db_error`, but only for exceptions that reach it unreported.

## Changes

- `compute_table_statistics_activity`'s own except block calls `capture_exception` unconditionally before the exception ever reaches the interceptor, so the interceptor's classifier never gets a chance to suppress it.
- Skip that local report when `is_transient_db_error(e)` is true, deferring the reporting decision to the same classifier the interceptor already uses.
- The activity still raises, so Temporal retries it per its existing retry policy — only the duplicate/early report is removed.

## How did you test this code?

Added two parametrized cases to `TestComputeTableStatisticsActivity` (`OperationalError`, `InterfaceError`), asserting `capture_exception` is skipped while the original exception still propagates for Temporal to retry. No existing test covered this activity's transient-app-DB-error handling.

Ran locally: `pytest products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_compute_table_statistics.py` (27 passed), `ruff check`/`ruff format --check`, and `uv run mypy --cache-fine-grained .` repo-wide.

Not run: an end-to-end Temporal worker test, since reproducing an actual PgBouncer pool blip needs a real pooler in that failure state.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal error-classification behavior, no user-facing or documented workflow changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code, triaging a webhook-delivered PostHog error tracking issue.
- Skills invoked: `/investigating-error-issue`, `/writing-tests`, `/writing-pr-descriptions`.
- Pulled the issue's stack trace, sample `$exception` events, and `warehouse_sources_*` sync-context properties via the PostHog MCP error-tracking and SQL tools; the context properties were unset on the sampled events, and the failure traced to a shared app-DB read in `compute_table_statistics.py`, not a source connector.
- Checked for a duplicate fix first: the repo maintainer has three open PRs on this same failure class ([#83875](https://github.com/PostHog/posthog/pull/83875), [#83876](https://github.com/PostHog/posthog/pull/83876), [#83877](https://github.com/PostHog/posthog/pull/83877)). All extend the shared `is_transient_db_error` marker list or a different call site's reporting branch; none touch `compute_table_statistics.py`'s own eager `capture_exception` call, so this is a distinct, complementary fix rather than a duplicate.