### PR TITLE
feat(tasks): open the model picker on a Faster/Smarter slider

### DIFF
--- a/products/posthog_ai/frontend/components/composer/ComposerModelEffortPickers.tsx
+++ b/products/posthog_ai/frontend/components/composer/ComposerModelEffortPickers.tsx
@@ -1,12 +1,14 @@
-import { useMemo, useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
 
-import { IconChevronDown } from '@posthog/icons'
+import { IconChevronDown, IconChevronLeft, IconRevert } from '@posthog/icons'
 import {
     Button,
     DropdownMenu,
     DropdownMenuContent,
+    DropdownMenuItem,
     DropdownMenuRadioGroup,
     DropdownMenuRadioItem,
+    DropdownMenuSeparator,
     DropdownMenuSub,
     DropdownMenuSubContent,
     DropdownMenuSubTrigger,
@@ -14,6 +16,7 @@ import {
 } from '@posthog/quill-primitives'
 
 import {
+    getCapabilityLadder,
     getEffortLabel,
     getEffortsForModel,
     getModelLabel,
@@ -27,6 +30,11 @@ import {
     ReasoningEffortEnumApi,
     RuntimeAdapterEnumApi,
 } from 'products/tasks/frontend/generated/api.schemas'
+
+import { ComposerReasoningSlider } from './ComposerReasoningSlider'
+
+// Separates model and effort in a slider stop key; never appears in a model id or an effort.
+const STOP_SEPARATOR = '|'
 
 export interface ComposerModelEffortPickersProps {
     /** Models to offer, and the efforts each supports. Callers pass `modelCatalogueLogic`'s live catalogue. */
@@ -43,15 +51,6 @@ export interface ComposerModelEffortPickersProps {
     lockedRuntimeAdapter?: string | null
 }
 
-/**
- * Controlled, logic-free model + reasoning-effort picker for a composer footer. The caller owns the selection and the
- * side effects of changing it — the run composer wires it to `runInteractionLogic` (held client-side and applied at
- * send time), the new-task composer wires it to the form that seeds the first run.
- *
- * Laid out as one chip opening a Harness → Model → Reasoning cascade, mirroring the desktop app's advanced view so the
- * two surfaces read the same. Every option comes from the passed catalogue; nothing about a specific model is
- * hardcoded here.
- */
 interface PickerSectionProps {
     title: string
     /** Right-aligned summary on the closed row — the value this section currently holds. */
@@ -78,6 +77,16 @@ function PickerSection({ title, current, value, onValueChange, children }: Picke
     )
 }
 
+/**
+ * Controlled, logic-free model + reasoning-effort picker for a composer footer. The caller owns the selection and the
+ * side effects of changing it — the run composer wires it to `runInteractionLogic` (held client-side and applied at
+ * send time), the new-task composer wires it to the form that seeds the first run.
+ *
+ * One chip opens the Faster/Smarter capability slider, whose stops are model + effort pairings from the shared ladder.
+ * Behind Advanced sits the full Harness → Model → Reasoning cascade and a reset row. This mirrors the desktop app's
+ * merged model + reasoning control so the two surfaces read the same. Every option comes from the passed catalogue;
+ * nothing about a specific model is hardcoded here.
+ */
 export function ComposerModelEffortPickers({
     models,
     selectedModel,
@@ -87,10 +96,15 @@ export function ComposerModelEffortPickers({
     lockedRuntimeAdapter,
 }: ComposerModelEffortPickersProps): JSX.Element {
     const [open, setOpen] = useState(false)
+    const [advanced, setAdvanced] = useState(false)
+    // Frozen when the Advanced view is entered rather than derived from the ladder: a model pick that steps off a
+    // notch would otherwise make the Back row flash in and out while the menu is open.
+    const [showBack, setShowBack] = useState(false)
+    const pendingChangeRef = useRef<(() => void) | null>(null)
 
     // The catalogue only changes when the gateway list reloads, so derive the whole tree in one pass — this
     // component re-renders on every keystroke in the composer above it.
-    const { selectedAdapter, modelLabel, effortOptions, adapters, adapterModels } = useMemo(() => {
+    const { selectedAdapter, modelLabel, effortOptions, adapters, adapterModels, ladder } = useMemo(() => {
         const adapter = getRuntimeAdapterForModel(models, selectedModel)
         return {
             selectedAdapter: adapter,
@@ -98,6 +112,7 @@ export function ComposerModelEffortPickers({
             effortOptions: getEffortsForModel(models, selectedModel),
             adapters: listRuntimeAdapters(models),
             adapterModels: modelsForRuntimeAdapter(models, adapter),
+            ladder: getCapabilityLadder(models, adapter),
         }
     }, [models, selectedModel])
 
@@ -110,8 +125,61 @@ export function ComposerModelEffortPickers({
         }
     }
 
+    // A one-rung ladder is no slider, so fall back to the model's plain effort list.
+    const useLadder = ladder.length >= 2
+    const stops = useLadder
+        ? ladder.map((notch) => `${notch.model}${STOP_SEPARATOR}${notch.effort}`)
+        : effortOptions.map((option) => option.value as string)
+    const currentStop = useLadder ? `${selectedModel}${STOP_SEPARATOR}${selectedEffort}` : selectedEffort
+
+    // A combination assembled in Advanced can sit between rungs. Then the menu opens straight on Advanced until
+    // "Reset to default" puts the selection back on a notch.
+    const onNotch = useLadder ? stops.includes(currentStop) : effortOptions.length > 0
+
+    const selectStop = (stop: string): void => {
+        if (!stop.includes(STOP_SEPARATOR)) {
+            onEffortChange(stop as ReasoningEffortEnumApi)
+            return
+        }
+        const [model, effort] = stop.split(STOP_SEPARATOR)
+        // Model first: the caller clamps the effort to the new model on the way through, and this pairing is
+        // already known to be one it supports.
+        if (model !== selectedModel) {
+            onModelChange(model)
+        }
+        if (effort !== selectedEffort) {
+            onEffortChange(effort as ReasoningEffortEnumApi)
+        }
+    }
+
+    // Deferred until the menu has finished closing: applying mid-animation re-renders the list the user is
+    // watching disappear.
+    const selectAndClose = (apply: () => void): void => {
+        pendingChangeRef.current = apply
+        setOpen(false)
+    }
+
     return (
-        <DropdownMenu open={open} onOpenChange={setOpen}>
+        <DropdownMenu
+            open={open}
+            onOpenChange={(nextOpen) => {
+                // Only on the closed-to-open transition: submenu opens re-fire this with true and must not yank
+                // the view back.
+                if (nextOpen && !open) {
+                    setAdvanced(!onNotch)
+                    setShowBack(false)
+                }
+                setOpen(nextOpen)
+            }}
+            onOpenChangeComplete={(isOpen) => {
+                if (!isOpen) {
+                    setAdvanced(false)
+                    setShowBack(false)
+                    pendingChangeRef.current?.()
+                    pendingChangeRef.current = null
+                }
+            }}
+        >
             <DropdownMenuTrigger
                 render={
                     <Button variant="outline" size="sm">
@@ -124,58 +192,97 @@ export function ComposerModelEffortPickers({
                 }
             />
             <DropdownMenuContent className="w-auto min-w-56">
-                {adapters.length > 1 && (
-                    <PickerSection
-                        title="Harness"
-                        current={getRuntimeAdapterLabel(selectedAdapter)}
-                        value={selectedAdapter}
-                        onValueChange={selectAdapter}
-                    >
-                        {adapters.map((adapter) => (
-                            <DropdownMenuRadioItem
-                                key={adapter}
-                                value={adapter}
-                                disabled={!!lockedRuntimeAdapter && adapter !== lockedRuntimeAdapter}
+                {advanced ? (
+                    <>
+                        {showBack && (
+                            <button
+                                type="button"
+                                className="flex w-full items-center gap-1 px-2 py-1.5 text-xs text-muted hover:text-default"
+                                onClick={() => setAdvanced(false)}
                             >
-                                {getRuntimeAdapterLabel(adapter)}
-                            </DropdownMenuRadioItem>
-                        ))}
-                    </PickerSection>
-                )}
+                                <IconChevronLeft className="text-xs" />
+                                Back
+                            </button>
+                        )}
+                        {adapters.length > 1 && (
+                            <PickerSection
+                                title="Harness"
+                                current={getRuntimeAdapterLabel(selectedAdapter)}
+                                value={selectedAdapter}
+                                onValueChange={selectAdapter}
+                            >
+                                {adapters.map((adapter) => (
+                                    <DropdownMenuRadioItem
+                                        key={adapter}
+                                        value={adapter}
+                                        disabled={!!lockedRuntimeAdapter && adapter !== lockedRuntimeAdapter}
+                                    >
+                                        {getRuntimeAdapterLabel(adapter)}
+                                    </DropdownMenuRadioItem>
+                                ))}
+                            </PickerSection>
+                        )}
 
-                <PickerSection
-                    title="Model"
-                    current={modelLabel}
-                    value={selectedModel}
-                    onValueChange={(value) => {
-                        onModelChange(value)
-                        setOpen(false)
-                    }}
-                >
-                    {adapterModels.map((option) => (
-                        <DropdownMenuRadioItem key={option.model} value={option.model}>
-                            {option.display_name}
-                        </DropdownMenuRadioItem>
-                    ))}
-                </PickerSection>
+                        <PickerSection
+                            title="Model"
+                            current={modelLabel}
+                            value={selectedModel}
+                            onValueChange={(value) => {
+                                onModelChange(value)
+                                setOpen(false)
+                            }}
+                        >
+                            {adapterModels.map((option) => (
+                                <DropdownMenuRadioItem key={option.model} value={option.model}>
+                                    {option.display_name}
+                                </DropdownMenuRadioItem>
+                            ))}
+                        </PickerSection>
 
-                {/* A model with no effort control reports no supported efforts — then there's nothing to pick. */}
-                {effortOptions.length > 0 && (
-                    <PickerSection
-                        title="Reasoning"
-                        current={getEffortLabel(selectedEffort)}
-                        value={selectedEffort}
-                        onValueChange={(value) => {
-                            onEffortChange(value as ReasoningEffortEnumApi)
-                            setOpen(false)
+                        {/* A model with no effort control reports no supported efforts — then there's nothing to pick. */}
+                        {effortOptions.length > 0 && (
+                            <PickerSection
+                                title="Reasoning"
+                                current={getEffortLabel(selectedEffort)}
+                                value={selectedEffort}
+                                onValueChange={(value) => {
+                                    onEffortChange(value as ReasoningEffortEnumApi)
+                                    setOpen(false)
+                                }}
+                            >
+                                {effortOptions.map((option) => (
+                                    <DropdownMenuRadioItem key={option.value} value={option.value}>
+                                        {option.label}
+                                    </DropdownMenuRadioItem>
+                                ))}
+                            </PickerSection>
+                        )}
+
+                        {stops.length > 0 && (
+                            <>
+                                <DropdownMenuSeparator />
+                                <DropdownMenuItem
+                                    onClick={() =>
+                                        // The middle notch is the balanced default for the whole ladder.
+                                        selectAndClose(() => selectStop(stops[Math.floor((stops.length - 1) / 2)]))
+                                    }
+                                >
+                                    <IconRevert />
+                                    Reset to default
+                                </DropdownMenuItem>
+                            </>
+                        )}
+                    </>
+                ) : (
+                    <ComposerReasoningSlider
+                        stops={stops}
+                        currentStop={currentStop}
+                        onSelect={selectStop}
+                        onAdvanced={() => {
+                            setShowBack(true)
+                            setAdvanced(true)
                         }}
-                    >
-                        {effortOptions.map((option) => (
-                            <DropdownMenuRadioItem key={option.value} value={option.value}>
-                                {option.label}
-                            </DropdownMenuRadioItem>
-                        ))}
-                    </PickerSection>
+                    />
                 )}
             </DropdownMenuContent>
         </DropdownMenu>

--- a/products/posthog_ai/frontend/components/composer/ComposerReasoningSlider.tsx
+++ b/products/posthog_ai/frontend/components/composer/ComposerReasoningSlider.tsx
@@ -1,0 +1,111 @@
+import { useState } from 'react'
+
+import { IconChevronRight } from '@posthog/icons'
+import { Slider } from '@posthog/quill-primitives'
+
+import { cn } from 'lib/utils/css-classes'
+
+export interface ComposerReasoningSliderProps {
+    /** Stop keys in Faster → Smarter order. */
+    stops: string[]
+    currentStop?: string
+    onSelect: (stop: string) => void
+    onAdvanced: () => void
+}
+
+/**
+ * The Faster/Smarter face of the model picker: an Advanced link above a notched slider whose stops the caller
+ * defines. Mirrors the desktop app's `ReasoningSliderFace` so both surfaces read the same.
+ */
+export function ComposerReasoningSlider({
+    stops,
+    currentStop,
+    onSelect,
+    onAdvanced,
+}: ComposerReasoningSliderProps): JSX.Element {
+    const matchedIndex = stops.indexOf(currentStop ?? '')
+    const activeIndex = matchedIndex >= 0 ? matchedIndex : Math.floor((stops.length - 1) / 2)
+    // Continuous drag position so the thumb tracks the pointer fluidly; outside a drag the thumb derives from the
+    // current selection, so releasing snaps it to the notch the live-applied selection landed on.
+    const [dragPosition, setDragPosition] = useState<number | null>(null)
+    const position = dragPosition ?? activeIndex
+    const nearestIndex = Math.min(stops.length - 1, Math.max(0, Math.round(position)))
+
+    const applyNotch = (notch: number): void => {
+        const stop = stops[notch]
+        if (stop && stop !== currentStop) {
+            onSelect(stop)
+        }
+    }
+
+    const nudge = (delta: number): void => {
+        setDragPosition(null)
+        applyNotch(Math.min(stops.length - 1, Math.max(0, nearestIndex + delta)))
+    }
+
+    return (
+        <div className="flex min-w-[220px] flex-col gap-2 p-2">
+            <button
+                type="button"
+                className="flex items-center gap-1 text-xs text-muted hover:text-default"
+                onClick={onAdvanced}
+            >
+                Advanced
+                <IconChevronRight className="text-xs" />
+            </button>
+            <div className="flex items-center justify-between gap-2 text-xs text-muted">
+                <span>Faster ($)</span>
+                <span>Smarter ($$$)</span>
+            </div>
+            <div
+                className="relative py-1"
+                onKeyDownCapture={(event) => {
+                    if (event.key === 'ArrowLeft' || event.key === 'ArrowDown') {
+                        event.preventDefault()
+                        event.stopPropagation()
+                        nudge(-1)
+                    } else if (event.key === 'ArrowRight' || event.key === 'ArrowUp') {
+                        event.preventDefault()
+                        event.stopPropagation()
+                        nudge(1)
+                    }
+                }}
+            >
+                <Slider
+                    aria-label="Reasoning level"
+                    min={0}
+                    max={stops.length - 1}
+                    step={0.01}
+                    value={[position]}
+                    onValueChange={(next: number | readonly number[]) => {
+                        const raw = Array.isArray(next) ? next[0] : next
+                        if (typeof raw !== 'number') {
+                            return
+                        }
+                        setDragPosition(raw)
+                        // Applied per notch crossing so the trigger pill tracks the drag.
+                        applyNotch(Math.round(raw))
+                    }}
+                    onValueCommitted={(next: number | readonly number[]) => {
+                        const raw = Array.isArray(next) ? next[0] : next
+                        if (typeof raw === 'number') {
+                            applyNotch(Math.min(stops.length - 1, Math.max(0, Math.round(raw))))
+                        }
+                        setDragPosition(null)
+                    }}
+                />
+                <div className="-translate-y-1/2 pointer-events-none absolute inset-x-2 top-1/2 flex justify-between">
+                    {stops.map((stop, stopIndex) => (
+                        <span
+                            key={stop}
+                            className={cn(
+                                'size-1 rounded-full',
+                                stopIndex <= nearestIndex ? 'bg-(--background)/80' : 'bg-(--foreground)/30'
+                            )}
+                        />
+                    ))}
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/products/posthog_ai/frontend/utils/composerModels.test.ts
+++ b/products/posthog_ai/frontend/utils/composerModels.test.ts
@@ -7,7 +7,12 @@ import {
     RuntimeAdapterEnumApi,
 } from 'products/tasks/frontend/generated/api.schemas'
 
-import { buildRunCreateRequest, listRuntimeAdapters, modelsForRuntimeAdapter } from './composerModels'
+import {
+    buildRunCreateRequest,
+    getCapabilityLadder,
+    listRuntimeAdapters,
+    modelsForRuntimeAdapter,
+} from './composerModels'
 import { type PermissionMode } from './composerModes'
 
 describe('composerModels', () => {
@@ -83,6 +88,34 @@ describe('composerModels', () => {
         )
 
         expect((request as ClaudeTaskRunCreateSchemaApi).reasoning_effort).toBeUndefined()
+    })
+
+    // Every rung the Faster/Smarter slider offers has to be sendable. The ladder is a hardcoded progression, so a
+    // model the gateway has retired — or one that no longer takes the paired effort — must drop out of the stops
+    // rather than become a notch whose run the backend rejects.
+    it('keeps only the ladder rungs the catalogue still serves', () => {
+        const catalogue: ModelChoiceApi[] = [
+            {
+                runtime_adapter: 'claude',
+                model: 'claude-sonnet-5',
+                display_name: 'Claude Sonnet 5',
+                supported_efforts: ['low', 'medium'],
+            },
+            {
+                runtime_adapter: 'claude',
+                model: 'claude-opus-5',
+                display_name: 'Claude Opus 5',
+                supported_efforts: ['medium', 'high', 'xhigh'],
+            },
+        ]
+
+        // Dropped: sonnet at `high` (unsupported effort) and fable entirely (absent from the catalogue).
+        expect(getCapabilityLadder(catalogue, RuntimeAdapterEnumApi.Claude)).toEqual([
+            { model: 'claude-sonnet-5', effort: ReasoningEffortEnumApi.Medium },
+            { model: 'claude-opus-5', effort: ReasoningEffortEnumApi.Medium },
+            { model: 'claude-opus-5', effort: ReasoningEffortEnumApi.Xhigh },
+        ])
+        expect(getCapabilityLadder(catalogue, RuntimeAdapterEnumApi.Codex)).toEqual([])
     })
 
     // The picker groups by harness and offers one row per runtime, so both have to come off the catalogue rather

--- a/products/posthog_ai/frontend/utils/composerModels.ts
+++ b/products/posthog_ai/frontend/utils/composerModels.ts
@@ -85,6 +85,45 @@ export function modelsForRuntimeAdapter(
     return catalogue.filter((option) => option.runtime_adapter === runtimeAdapter)
 }
 
+/** One stop on the Faster/Smarter slider: a model paired with the effort it runs at. */
+export interface CapabilityNotch {
+    model: string
+    effort: ReasoningEffortEnumApi
+}
+
+// The curated Faster → Smarter progression per harness, kept in step with the desktop app's ladder in
+// `products/desktop/packages/agent/src/adapters/reasoning-effort.ts` so both surfaces offer the same rungs.
+const CAPABILITY_LADDERS: Record<RuntimeAdapterEnumApi, CapabilityNotch[]> = {
+    [RuntimeAdapterEnumApi.Claude]: [
+        { model: 'claude-sonnet-5', effort: ReasoningEffortEnumApi.Medium },
+        { model: 'claude-sonnet-5', effort: ReasoningEffortEnumApi.High },
+        { model: 'claude-opus-5', effort: ReasoningEffortEnumApi.Medium },
+        { model: 'claude-opus-5', effort: ReasoningEffortEnumApi.Xhigh },
+        { model: 'claude-fable-5', effort: ReasoningEffortEnumApi.Max },
+    ],
+    [RuntimeAdapterEnumApi.Codex]: [
+        { model: 'gpt-5.6-terra', effort: ReasoningEffortEnumApi.Low },
+        { model: 'gpt-5.6-sol', effort: ReasoningEffortEnumApi.Low },
+        { model: 'gpt-5.6-sol', effort: ReasoningEffortEnumApi.Medium },
+        { model: 'gpt-5.6-sol', effort: ReasoningEffortEnumApi.High },
+        { model: 'gpt-5.6-sol', effort: ReasoningEffortEnumApi.Xhigh },
+    ],
+}
+
+/**
+ * The ladder rungs the live catalogue actually serves. A notch naming a model the gateway no longer offers — or an
+ * effort that model no longer accepts — drops out rather than becoming a stop that fails on send. The picker falls
+ * back to its plain effort list when fewer than two rungs survive.
+ */
+export function getCapabilityLadder(
+    catalogue: ModelChoiceApi[],
+    runtimeAdapter: RuntimeAdapterEnumApi
+): CapabilityNotch[] {
+    return (CAPABILITY_LADDERS[runtimeAdapter] ?? []).filter((notch) =>
+        catalogue.some((option) => option.model === notch.model && option.supported_efforts.includes(notch.effort))
+    )
+}
+
 const RUNTIME_ADAPTER_LABELS: Record<RuntimeAdapterEnumApi, string> = {
     [RuntimeAdapterEnumApi.Claude]: 'Claude',
     [RuntimeAdapterEnumApi.Codex]: 'Codex',


### PR DESCRIPTION
## Problem

Setting how much horsepower a task run gets meant walking a Harness → Model → Reasoning cascade — three menus for one intent: how capable, and how expensive. Desktop already answers that with a Faster/Smarter slider.

## Changes

The model pill now opens on the same notched capability slider as desktop. Each notch is a model + effort pairing, so one drag moves both. The full cascade lives behind **Advanced**, with a **Reset to default** row.

Ladder rungs are filtered against the live model catalogue, so a retired model drops out instead of becoming a notch that fails on send.


https://github.com/user-attachments/assets/0e7e1734-c129-477a-9299-b0dde5e7b3c8



## How did you test this code?

`products/posthog_ai/frontend` jest suite + a new `composerModels` case for ladder filtering; frontend typecheck clean. Driven through Storybook (`Scenes-App/Tasks → NewTask`) headlessly — one notch of drag moved the pill from *Claude Sonnet 5 · High* to *Claude Opus 5 · Medium*. 

Manual test

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code; no repo skills invoked. Ported from `products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.tsx` + `ReasoningLevelDropdown.tsx`, with the ladder from `packages/agent/src/adapters/reasoning-effort.ts`.

Two deliberate omissions: desktop's `AnimatedHeight` tween on the view swap (would add `motion` as a new `products/posthog_ai` dependency for a height animation), and the fast-mode toggle (no tasks-side equivalent).
