### PR TITLE
chore(replay-vision): clarify digest naming and sampling hint

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -7341,9 +7341,9 @@ snapshots:
     scenes-app-replay-vision--action-editor-alert--light:
         hash: v1.k794b7964.ee28763bea5b87190aa29033f4f606fced20ca3d7801a76ef54cd1c84bf06546.lDUEss5wCkOJco80RWv8QEAYh4cGfSBNZSdzqWTvs3A
     scenes-app-replay-vision--action-editor-digest--dark:
-        hash: v1.k794b7964.f10b2e984137ba89cbce769c4a2e70ee63f688a3f34386a6f26ae54e4ada6603.DHaq-zm_hkjuih8RdvRIpEFDWLt2Cafz2QPu1HU5NJM
+        hash: v1.k794b7964.483244eee8c1dcbfd3d897559b867fe8127151f78ec5b00a6ac4a9a39fa0219f.vyWDN2gFu2CWgMK3DCWigJEkLIIFzi3KCm73GY9bNvo
     scenes-app-replay-vision--action-editor-digest--light:
-        hash: v1.k794b7964.ceb59d1eff8444a358ace1fa1be1fb082601fb8e054df969bd356f436f0c3b24.bTS0nweIvrWSkw-h_Q0Uy3UCKYj0MgUOQD_aMHSj1HY
+        hash: v1.k794b7964.6cd49c6dbbc09c847479d744211d1e8093b6d79abc1592dc53a1fd52494d9550.Or0nHhJzto-v3vL5gegjNruUbQY4SIzTOMG2f54LW-c
     scenes-app-replay-vision--observation-detail--dark:
         hash: v1.k794b7964.d3fbcea617e7a146ed9e9bac43c3dc05e6a4dceff23ae43777f2d3c3e6a1d8d6.li21N7hWkm5OeaU6HoRR0TXOUFynF6dJWT1kQwsLCpc
     scenes-app-replay-vision--observation-detail--light:

--- a/products/replay_vision/backend/api/scanners.py
+++ b/products/replay_vision/backend/api/scanners.py
@@ -642,7 +642,7 @@ class ReplayScannerSerializer(TaggedItemSerializerMixin, UserAccessControlSerial
                 self._reraise_unique_name_violation(e)
             self._attempt_set_tags(tags, scanner)
         _refresh_estimate_fail_soft(scanner)
-        # Every scanner starts with a built-in daily digest so the overview has a summary to show.
+        # Every scanner starts with a built-in featured digest so the overview has a summary to show.
         provision_scanner_digest(scanner, user)
         report_user_action(
             user,

--- a/products/replay_vision/backend/api/vision_actions.py
+++ b/products/replay_vision/backend/api/vision_actions.py
@@ -502,7 +502,7 @@ class VisionActionSerializer(serializers.ModelSerializer):
         if name is None:
             return
         # A brand-new digest whose name is exactly the auto-derived one came from the one-click
-        # "Turn on daily digest" button, so create() makes it collision-safe instead of 400-ing.
+        # "Turn on featured digest" button, so create() makes it collision-safe instead of 400-ing.
         # A user-typed name (even on a digest) still gets the explicit duplicate error below.
         if self.instance is None and attrs.get("is_scanner_digest") and self._has_derived_digest_name(attrs):
             return
@@ -590,7 +590,7 @@ class VisionActionSerializer(serializers.ModelSerializer):
         if "vision_action_unique_team_name" in str(error):
             raise serializers.ValidationError({"name": "An action with this name already exists in this team."})
         if "vision_action_unique_scanner_digest" in str(error):
-            raise serializers.ValidationError({"is_scanner_digest": "This scanner already has a daily digest."})
+            raise serializers.ValidationError({"is_scanner_digest": "This scanner already has a featured digest."})
         raise error
 
 

--- a/products/replay_vision/backend/digest.py
+++ b/products/replay_vision/backend/digest.py
@@ -16,7 +16,7 @@ SCANNER_DIGEST_RRULE = "FREQ=DAILY;BYHOUR=8;BYMINUTE=0"
 
 
 def digest_name_for_scanner(scanner: "ReplayScanner") -> str:
-    return f"Daily digest: {scanner.name}"[:255]
+    return f"Featured digest: {scanner.name}"[:255]
 
 
 def unique_digest_name(team_id: int, base: str) -> str:

--- a/products/replay_vision/backend/digest.py
+++ b/products/replay_vision/backend/digest.py
@@ -39,7 +39,7 @@ def unique_digest_name(team_id: int, base: str) -> str:
 
 
 def provision_scanner_digest(scanner: "ReplayScanner", user: "User") -> VisionAction | None:
-    """Create the scanner's built-in daily digest: a summary action with no delivery targets whose
+    """Create the scanner's built-in featured digest: a summary action with no delivery targets whose
     runs surface on the scanner overview. Fail-soft; scanner creation must never fail because digest
     provisioning did."""
     try:

--- a/products/replay_vision/backend/max_tools.py
+++ b/products/replay_vision/backend/max_tools.py
@@ -1228,7 +1228,7 @@ class CreateReplayVisionScannerTool(ReplayVisionGatesMixin, MaxTool):
         resolved_type = scanner_type if scanner_type in VALID_SCANNER_TYPES else ScannerType.MONITOR
         # Through the serializer, not ReplayScanner.objects.create: it owns the sampling-rate floor below
         # which a scanner silently never scans, the unique-name race, the estimate refresh, the built-in
-        # daily digest, and the lifecycle event. A scanner Max makes should be the same object the UI makes.
+        # featured digest, and the lifecycle event. A scanner Max makes should be the same object the UI makes.
         serializer = ReplayScannerSerializer(
             data={
                 "name": name.strip(),

--- a/products/replay_vision/backend/tests/test_api.py
+++ b/products/replay_vision/backend/tests/test_api.py
@@ -1100,7 +1100,7 @@ class TestScannerDigestProvisioning(_VisionAPITestCase):
         resp = self.client.post(self.scanners_url, data=self._CREATE_BODY, format="json")
         self.assertEqual(resp.status_code, 201, resp.json())
         digest = VisionAction.objects.for_team(self.team.id).get(scanner_id=resp.json()["id"], is_scanner_digest=True)
-        self.assertEqual(digest.name, "Daily digest: checkout-monitor")
+        self.assertEqual(digest.name, "Featured digest: checkout-monitor")
         self.assertEqual(digest.trigger_config["rrule"], SCANNER_DIGEST_RRULE)
         self.assertEqual(digest.trigger_config["timezone"], self.team.timezone)
         self.assertEqual(digest.delivery_config, [])

--- a/products/replay_vision/backend/tests/test_vision_actions_api.py
+++ b/products/replay_vision/backend/tests/test_vision_actions_api.py
@@ -278,7 +278,7 @@ class TestVisionActionViewSet(_VisionActionAPITestCase):
     def test_creating_a_digest_dedupes_a_taken_name(self) -> None:
         # The "Turn on daily digest" button derives a fixed name from the scanner. If another action
         # already holds it, the create must succeed with a suffixed name, not 400 on (team, name).
-        taken = f"Daily digest: {self.scanner.name}"
+        taken = f"Featured digest: {self.scanner.name}"
         VisionAction.all_teams.create(
             team=self.team,
             scanner=self.scanner,

--- a/products/replay_vision/backend/tests/test_vision_actions_api.py
+++ b/products/replay_vision/backend/tests/test_vision_actions_api.py
@@ -276,7 +276,7 @@ class TestVisionActionViewSet(_VisionActionAPITestCase):
         self.assertEqual(self._flagged_digest_ids(), [str(current.id)])
 
     def test_creating_a_digest_dedupes_a_taken_name(self) -> None:
-        # The "Turn on daily digest" button derives a fixed name from the scanner. If another action
+        # The "Turn on featured digest" button derives a fixed name from the scanner. If another action
         # already holds it, the create must succeed with a suffixed name, not 400 on (team, name).
         taken = f"Featured digest: {self.scanner.name}"
         VisionAction.all_teams.create(

--- a/products/replay_vision/frontend/replay_scanners/ActionEditorScene.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ActionEditorScene.tsx
@@ -132,8 +132,8 @@ function ScheduleSection(): JSX.Element {
             </div>
 
             <span className="text-xs text-muted">
-                Each run summarizes up to 100 observations since the last digest ran. Busier periods are sampled down
-                to that limit.
+                Each run summarizes up to 100 observations since the last digest ran. Busier periods are sampled down to
+                that limit.
             </span>
 
             <div className="w-32">

--- a/products/replay_vision/frontend/replay_scanners/ActionEditorScene.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ActionEditorScene.tsx
@@ -131,6 +131,11 @@ function ScheduleSection(): JSX.Element {
                 {noDays && <span className="text-xs text-danger">Pick at least one day</span>}
             </div>
 
+            <span className="text-xs text-muted">
+                Each run summarizes up to 100 observations from the period. Busier periods are sampled down to that
+                limit.
+            </span>
+
             <div className="w-32">
                 <label className="text-sm font-semibold">At</label>
                 <LemonInput
@@ -153,11 +158,6 @@ function ScheduleSection(): JSX.Element {
                 <label className="text-sm font-semibold">Timezone</label>
                 <TimezoneSelect value={timezone} onChange={(tz) => setActionFormValue('timezone', tz)} />
             </div>
-
-            <span className="text-xs text-muted">
-                Each run summarizes up to 100 observations from the period. Busier periods are sampled down to that
-                limit.
-            </span>
         </div>
     )
 }

--- a/products/replay_vision/frontend/replay_scanners/ActionEditorScene.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ActionEditorScene.tsx
@@ -132,8 +132,8 @@ function ScheduleSection(): JSX.Element {
             </div>
 
             <span className="text-xs text-muted">
-                Each run summarizes up to 100 observations from the period. Busier periods are sampled down to that
-                limit.
+                Each run summarizes up to 100 observations since the last digest ran. Busier periods are sampled down
+                to that limit.
             </span>
 
             <div className="w-32">

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerDigestCard.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerDigestCard.tsx
@@ -40,7 +40,7 @@ function CardHeader({ meta }: { meta?: React.ReactNode }): JSX.Element {
     )
 }
 
-// The scanner page's hero: the built-in daily digest. Shows the latest summary when one exists,
+// The scanner page's hero: the built-in featured digest. Shows the latest summary when one exists,
 // otherwise the state that gets the user there (turn on / paused / first run pending).
 export function ScannerDigestCard({
     scannerId,
@@ -99,7 +99,7 @@ export function ScannerDigestCard({
                             </DropdownMenuTrigger>
                             <DropdownMenuContent align="end" className="min-w-[220px]">
                                 <DropdownMenuItem onClick={createDigest} data-attr="vision-scanner-digest-create">
-                                    Create a new daily digest
+                                    Create a new featured digest
                                 </DropdownMenuItem>
                                 <DropdownMenuSeparator />
                                 <DropdownMenuGroup>
@@ -126,7 +126,7 @@ export function ScannerDigestCard({
                             disabledReason={editDisabledReason}
                             data-attr="vision-scanner-digest-create"
                         >
-                            Turn on daily digest
+                            Turn on featured digest
                         </LemonButton>
                     )}
                 </div>

--- a/products/replay_vision/frontend/replay_scanners/components/VisionActionsTab.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/VisionActionsTab.tsx
@@ -111,7 +111,7 @@ function VisionActionsTable({
     const { visionActions, visionActionsLoading, togglingIds } = useValues(visionActionsLogic)
     const { toggleActionEnabled, deleteAction } = useActions(visionActionsLogic)
 
-    // The scanner's built-in daily digest is listed here alongside user-created digests and alerts
+    // The scanner's built-in featured digest is listed here alongside user-created digests and alerts
     // (marked with a "Featured digest" chip), so this page is the one place to see and manage every
     // automation on the scanner. It also has its own hero surface on the Observations tab.
     const rows = visionActions

--- a/products/replay_vision/frontend/replay_scanners/components/VisionActionsTab.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/VisionActionsTab.tsx
@@ -112,7 +112,7 @@ function VisionActionsTable({
     const { toggleActionEnabled, deleteAction } = useActions(visionActionsLogic)
 
     // The scanner's built-in daily digest is listed here alongside user-created digests and alerts
-    // (marked with a "Daily digest" chip), so this page is the one place to see and manage every
+    // (marked with a "Featured digest" chip), so this page is the one place to see and manage every
     // automation on the scanner. It also has its own hero surface on the Observations tab.
     const rows = visionActions
 

--- a/products/replay_vision/frontend/replay_scanners/scannerDigestLogic.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/scannerDigestLogic.test.ts
@@ -8,7 +8,7 @@ import { scannerDigestLogic } from './scannerDigestLogic'
 
 const DIGEST = {
     id: 'd1',
-    name: 'Daily digest: my-scanner',
+    name: 'Featured digest: my-scanner',
     scanner: 's1',
     enabled: true,
     is_scanner_digest: true,
@@ -112,7 +112,7 @@ describe('scannerDigestLogic', () => {
             .toDispatchActions(['createDigestSuccess', 'addAction', 'loadLatestRunSuccess'])
             .toFinishAllListeners()
         expect(body).toMatchObject({
-            name: 'Daily digest: my-scanner',
+            name: 'Featured digest: my-scanner',
             scanner: 's1',
             is_scanner_digest: true,
             trigger_config: { rrule: 'FREQ=DAILY;BYHOUR=8;BYMINUTE=0' },

--- a/products/replay_vision/frontend/replay_scanners/scannerDigestLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/scannerDigestLogic.ts
@@ -290,7 +290,7 @@ export const scannerDigestLogic = kea<scannerDigestLogicType>([
                         delivery_config: [],
                     })
                     actions.createDigestSuccess()
-                    lemonToast.success('Daily digest turned on')
+                    lemonToast.success('Featured digest turned on')
                     // Insert the created digest optimistically instead of refetching the list — a refetch
                     // would blank the card (visionActionsLoading true, digest still absent) and flash it.
                     actions.addAction(created)
@@ -299,7 +299,7 @@ export const scannerDigestLogic = kea<scannerDigestLogicType>([
                     actions.loadLatestRunSuccess(null)
                 } catch (error: any) {
                     actions.createDigestFailure()
-                    lemonToast.error(`Couldn't turn on the daily digest${error?.detail ? `: ${error.detail}` : ''}`)
+                    lemonToast.error(`Couldn't turn on the featured digest${error?.detail ? `: ${error.detail}` : ''}`)
                 }
             },
 

--- a/products/replay_vision/frontend/replay_scanners/scannerDigestLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/scannerDigestLogic.ts
@@ -280,7 +280,7 @@ export const scannerDigestLogic = kea<scannerDigestLogicType>([
                     const created = await visionActionsCreate(String(teamId), {
                         // Mirrors the backend provisioning defaults (digest.py) for scanners created before
                         // digests existed, or after the digest was deleted.
-                        name: `Daily digest: ${props.scannerName}`.slice(0, 255),
+                        name: `Featured digest: ${props.scannerName}`.slice(0, 255),
                         scanner: props.scannerId,
                         is_scanner_digest: true,
                         trigger_config: {


### PR DESCRIPTION
## Problem

Two things made the scanner digest read as a daily thing when it isn't:

- The note explaining that each run summarizes up to 100 observations sat at the bottom of the schedule form, under the timezone picker, far from the day picker it qualifies. People setting a weekly cadence miss the limit that decides how much of the week the digest covers.
- The digest created with every scanner was named "Daily digest: <scanner>", and the card that hosts it said "Turn on daily digest". The cadence is editable, so a digest set to run weekly still called itself daily. The scanner overview already tags it "Featured digest", so the name contradicted the chip.

## Changes

- Moved the sampling note directly below the "Runs on" day picker, above "At" and "Timezone".
- Reworded it to "summarizes up to 100 observations since the last digest ran" instead of "from the period".
- New scanners get a digest named "Featured digest: <scanner>". The frontend fallback that recreates a deleted digest uses the same name.
- Renamed the remaining "daily digest" copy on these surfaces: the card button, its toast messages, and the duplicate-digest validation error.
- No migration: existing digests keep their current names.
- Left the serializer `help_text` on `is_scanner_digest` alone so the generated API types stay in sync.

## How did you test this code?

Not manually tested — the sandbox has no app stack. The change is a JSX reorder plus string replacements, with the assertions in `test_api.py`, `test_vision_actions_api.py`, and `scannerDigestLogic.test.ts` updated to the new derived name.

Ran oxfmt 0.57.0 over `products/replay_vision` locally, which is what the first push failed on. CI covers the rest.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Directed from a Slack thread: the schedule hint was easy to miss where it sat, and the "Daily" in the default name was the reason a weekly digest looked wrong. Renaming was chosen over a backfill at the requester's direction, so both naming conventions coexist for existing scanners. The label rename came in a follow-up round once the mismatch with the existing "Featured digest" chip was clear.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C03PB072FMJ/p1786989230713189?thread_ts=1786989230.713189&cid=C03PB072FMJ)*
