### PR TITLE
feat(desktop): plus button starts a task instead of a one-item menu

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelsFab.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelsFab.tsx
@@ -72,40 +72,62 @@ export function ChannelsFab({ channelId }: { channelId?: string }) {
     </DropdownMenuItem>
   );
 
+  // Inside a space on the layout, the menu held one item, so the button is that
+  // item: a click starts the task instead of asking which kind to start.
+  const newTaskOnly = channelsLayout && !!channelId;
+
+  const draftDot = channelsLayout && hasDraft && (
+    <span
+      aria-hidden
+      className="absolute top-0.5 right-0.5 size-2 rounded-full bg-current ring-(--primary) ring-2"
+    />
+  );
+
+  const label = newTaskOnly ? "New task" : "Create";
+
   const trigger = (
     <Button
       variant="primary"
       size="icon-lg"
-      aria-label="Create"
+      aria-label={label}
       className="absolute right-3 bottom-3 z-10 rounded-full"
+      onClick={newTaskOnly ? newTask : undefined}
     >
       <PlusIcon size={20} weight="bold" />
-      {channelsLayout && hasDraft && (
-        <span
-          aria-hidden
-          className="absolute top-0.5 right-0.5 size-2 rounded-full bg-current ring-(--primary) ring-2"
-        />
-      )}
+      {draftDot}
     </Button>
   );
+
+  const tooltip = (
+    <TooltipContent side="top" align="center">
+      {channelsLayout ? (
+        <>
+          {/* The draft dot needs saying out loud, and the button is where
+              the create shortcut is worth advertising. */}
+          {hasDraft ? `${label} — you have a draft` : label}
+          <Kbd className="ml-1.5">{formatHotkey(SHORTCUTS.NEW_TASK)}</Kbd>
+        </>
+      ) : (
+        "Create something new"
+      )}
+    </TooltipContent>
+  );
+
+  if (newTaskOnly) {
+    return (
+      <Tooltip>
+        <TooltipTrigger render={trigger} />
+        {tooltip}
+      </Tooltip>
+    );
+  }
 
   return (
     <>
       <DropdownMenu>
         <Tooltip>
           <TooltipTrigger render={<DropdownMenuTrigger render={trigger} />} />
-          <TooltipContent side="top" align="center">
-            {channelsLayout ? (
-              <>
-                {/* The draft dot needs saying out loud, and the button is where
-                    the create shortcut is worth advertising. */}
-                {hasDraft ? "Create — you have a draft" : "Create"}
-                <Kbd className="ml-1.5">{formatHotkey(SHORTCUTS.NEW_TASK)}</Kbd>
-              </>
-            ) : (
-              "Create something new"
-            )}
-          </TooltipContent>
+          {tooltip}
         </Tooltip>
         <DropdownMenuContent
           align={channelId ? "end" : "center"}

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.tsx
@@ -4,7 +4,6 @@ import {
   CaretDownIcon,
   CaretRightIcon,
   DotsThreeIcon,
-  FileTextIcon,
   LinkIcon,
   PencilSimpleIcon,
   PlusIcon,
@@ -950,8 +949,6 @@ const ChannelSection = memo(
     const isActive = pathname === base || pathname.startsWith(`${base}/`);
     // Lifted so the hover button group stays visible while the menu is open.
     const [menuOpen, setMenuOpen] = useState(false);
-    // Keep the hover actions pinned while the create menu is open.
-    const [newMenuOpen, setNewMenuOpen] = useState(false);
     const { reveal, hoverProps, focusProps } = useOverflowTickerReveal();
     const hasAttention = unreadSessions > 0 || blockedSessions > 0;
     const prefetchSessions = usePrefetchSpaceTasks();
@@ -970,6 +967,15 @@ const ChannelSection = memo(
       confirmDelete,
       isDeleting,
     } = useChannelActions(channel);
+
+    const newTask = () => {
+      track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+        action_type: "new_task_open",
+        surface: "sidebar",
+        channel_id: channel.id,
+      });
+      openTaskInput({ channelId: channel.id });
+    };
 
     // A boolean rather than the value itself, so a keypress re-renders only the
     // two rows whose answer changed. The row's autocomplete value is the space
@@ -1129,55 +1135,30 @@ const ChannelSection = memo(
               </ContextMenuContent>
             </ContextMenu>
           </SpaceHoverCard>
-          {/* Hover actions stay visible while either menu is open. */}
+          {/* Hover actions stay visible while the menu is open. */}
           <div className="absolute top-1 right-1">
             <ButtonGroup>
-              <DropdownMenu open={newMenuOpen} onOpenChange={setNewMenuOpen}>
-                <Tooltip>
-                  <TooltipTrigger
-                    render={
-                      <DropdownMenuTrigger
-                        render={
-                          <Button
-                            variant="outline"
-                            size="icon-xs"
-                            aria-label={`New in ${channel.name}`}
-                            className={cn(
-                              "gap-1 transition-opacity group-hover:border-border",
-                              menuOpen || newMenuOpen
-                                ? "opacity-100"
-                                : "opacity-0 group-hover/chan:opacity-100",
-                            )}
-                          >
-                            <PlusIcon size={12} weight="bold" />
-                          </Button>
-                        }
-                      />
-                    }
-                  />
-                  <TooltipContent side="top">New…</TooltipContent>
-                </Tooltip>
-                <DropdownMenuContent
-                  align="start"
-                  side="bottom"
-                  sideOffset={4}
-                  className="w-auto min-w-fit"
-                >
-                  <DropdownMenuItem
-                    onClick={() => {
-                      track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
-                        action_type: "new_task_open",
-                        surface: "sidebar",
-                        channel_id: channel.id,
-                      });
-                      openTaskInput({ channelId: channel.id });
-                    }}
-                  >
-                    <FileTextIcon size={14} />
-                    New task
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      variant="outline"
+                      size="icon-xs"
+                      aria-label={`New task in ${channel.name}`}
+                      className={cn(
+                        "gap-1 transition-opacity group-hover:border-border",
+                        menuOpen
+                          ? "opacity-100"
+                          : "opacity-0 group-hover/chan:opacity-100",
+                      )}
+                      onClick={newTask}
+                    >
+                      <PlusIcon size={12} weight="bold" />
+                    </Button>
+                  }
+                />
+                <TooltipContent side="top">New task</TooltipContent>
+              </Tooltip>
               <ChannelMenu
                 channelName={channel.name}
                 actions={actions}
@@ -1361,8 +1342,6 @@ const PersonalChannelRow = memo(function PersonalChannelRow({
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const { channels } = useChannels();
   const { ensureChannelId, openPersonalChannel } = useOpenPersonalChannel();
-  // The create dropdown mirrors a shared channel row.
-  const [newMenuOpen, setNewMenuOpen] = useState(false);
 
   // Personal channels are provisioned lazily server-side when the channel list
   // is fetched; `undefined` just means the list hasn't loaded it yet.
@@ -1446,43 +1425,22 @@ const PersonalChannelRow = memo(function PersonalChannelRow({
           )}
         </SpaceRowSurface>
         <div className="absolute top-0 right-1">
-          <DropdownMenu open={newMenuOpen} onOpenChange={setNewMenuOpen}>
-            <Tooltip>
-              <TooltipTrigger
-                render={
-                  <DropdownMenuTrigger
-                    render={
-                      <Button
-                        variant="outline"
-                        size="icon-xs"
-                        aria-label={`New in ${PERSONAL_CHANNEL_LABEL}`}
-                        className={cn(
-                          "gap-1 transition-opacity group-hover:border-border",
-                          newMenuOpen
-                            ? "opacity-100"
-                            : "opacity-0 group-hover/chan:opacity-100",
-                        )}
-                      >
-                        <PlusIcon size={12} weight="bold" />
-                      </Button>
-                    }
-                  />
-                }
-              />
-              <TooltipContent side="top">New…</TooltipContent>
-            </Tooltip>
-            <DropdownMenuContent
-              align="start"
-              side="bottom"
-              sideOffset={4}
-              className="w-auto min-w-fit"
-            >
-              <DropdownMenuItem onClick={newTask}>
-                <FileTextIcon size={14} />
-                New task
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  variant="outline"
+                  size="icon-xs"
+                  aria-label={`New task in ${PERSONAL_CHANNEL_LABEL}`}
+                  className="gap-1 opacity-0 transition-opacity group-hover:border-border group-hover/chan:opacity-100"
+                  onClick={newTask}
+                >
+                  <PlusIcon size={12} weight="bold" />
+                </Button>
+              }
+            />
+            <TooltipContent side="top">New task</TooltipContent>
+          </Tooltip>
         </div>
       </Box>
       {expanded && meChannel && (


### PR DESCRIPTION
## Problem

In the desktop app's Spaces sidebar, the hover "+" on a space row didn't create anything. It opened a dropdown whose only entry was "New task", so every new session cost two clicks and a menu that never had a decision in it. The same button on the personal row, and the create FAB while you're inside a space, behaved the same way.

## Changes

- All three plus buttons now start the task on click.
- Tooltips and aria-labels drop the "New…" ellipsis, since nothing opens a follow-up step anymore.
- The FAB keeps its menu where it still has a second option: the space list, and off the spaces layout.

## How did you test this code?

Manually, see 
<img width="2542" height="2806" alt="2026-08-17 14 13 57" src="https://github.com/user-attachments/assets/67fd2a34-082d-4270-8f12-edaa1e2335a7" />


## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested from Slack via the PostHog Slack app. Left unassigned because I couldn't verify the requester's GitHub handle from the thread.

Skills/agents used: the Explore subagent to locate the three call sites. No repo skills were invoked beyond the desktop `AGENTS.md` conventions (quill components, the `…` suffix rule for anything that opens another step, which is why the ellipsis came off the tooltips).

One decision worth flagging: the FAB is shared between the space list and a space, and its menu has two items in the list case. Rather than collapsing it everywhere, it only becomes a direct action in the single-item case.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1786975156742659?thread_ts=1786975156.742659&cid=C09G8Q32R6F)*
