### PR TITLE
feat(desktop): add annotated plan review

### DIFF
--- a/products/desktop/packages/ui/src/features/permissions/PlanApprovalSelector.test.tsx
+++ b/products/desktop/packages/ui/src/features/permissions/PlanApprovalSelector.test.tsx
@@ -11,6 +11,7 @@ import {
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { PlanApprovalSelector } from "./PlanApprovalSelector";
+import { usePlanReviewStore } from "./planReview";
 import type { PermissionToolCall } from "./types";
 
 const AUTO: PermissionOption = {
@@ -60,6 +61,7 @@ describe("PlanApprovalSelector", () => {
   beforeEach(() => {
     // Reset the remembered choice so tests don't leak through persistence.
     useSettingsStore.setState({ lastPlanApprovalMode: null });
+    usePlanReviewStore.getState().clear("plan-1");
   });
 
   it.each([
@@ -198,6 +200,33 @@ describe("PlanApprovalSelector", () => {
       "reject_with_feedback",
       "please use hooks",
     );
+  });
+
+  it("submits section comments as structured rejection feedback", async () => {
+    const user = userEvent.setup();
+    usePlanReviewStore.getState().addComment("plan-1", {
+      sectionId: "api",
+      sectionTitle: "Update the API",
+      sectionContent: "## Update the API\nChange the endpoint.",
+      text: "Keep the existing endpoint.",
+    });
+    const { onSelect } = renderSelector([DEFAULT_MODE, REJECT]);
+
+    await user.click(screen.getByText("2."));
+    await user.type(
+      screen.getByPlaceholderText(/review comment/i),
+      "also document the migration{Enter}",
+    );
+
+    expect(onSelect).toHaveBeenCalledWith(
+      "reject_with_feedback",
+      expect.stringContaining('Section "Update the API"'),
+    );
+    expect(onSelect).toHaveBeenCalledWith(
+      "reject_with_feedback",
+      expect.stringContaining("also document the migration"),
+    );
+    expect(usePlanReviewStore.getState().comments["plan-1"]).toBeUndefined();
   });
 
   it("does not reject on empty feedback (Enter is a no-op, exactly as before)", async () => {

--- a/products/desktop/packages/ui/src/features/permissions/PlanApprovalSelector.test.tsx
+++ b/products/desktop/packages/ui/src/features/permissions/PlanApprovalSelector.test.tsx
@@ -59,7 +59,6 @@ function renderSelector(options: PermissionOption[]) {
 
 describe("PlanApprovalSelector", () => {
   beforeEach(() => {
-    // Reset the remembered choice so tests don't leak through persistence.
     useSettingsStore.setState({ lastPlanApprovalMode: null });
     usePlanReviewStore.getState().clear("plan-1");
   });

--- a/products/desktop/packages/ui/src/features/permissions/PlanApprovalSelector.tsx
+++ b/products/desktop/packages/ui/src/features/permissions/PlanApprovalSelector.tsx
@@ -13,6 +13,7 @@ import {
 } from "@posthog/ui/primitives/ActionSelector";
 import { Box, Flex, Text } from "@radix-ui/themes";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { buildPlanReviewFeedback, usePlanReviewStore } from "./planReview";
 import { type BasePermissionProps, toSelectorOptions } from "./types";
 
 const TITLE = "Implementation Plan";
@@ -88,6 +89,13 @@ export function PlanApprovalSelector({
     setExplicitMode(undefined);
   }
   const selectedMode = explicitMode ?? initialMode;
+  const reviewComments = usePlanReviewStore(
+    (state) => state.comments[toolCall.toolCallId] ?? [],
+  );
+  const clearReview = usePlanReviewStore((state) => state.clear);
+  const activeReviewComments = reviewComments.filter(
+    (comment) => !comment.stale,
+  );
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
   const [feedback, setFeedback] = useState("");
@@ -140,6 +148,7 @@ export function PlanApprovalSelector({
     if (!selectedMode) return;
     // Remember this choice so the next plan approval pre-selects it.
     setLastApprovalMode(selectedMode as ExecutionMode);
+    clearReview(toolCall.toolCallId);
     onSelect(selectedMode);
   };
 
@@ -147,8 +156,13 @@ export function PlanApprovalSelector({
     const text = feedback.trim();
     // Exactly as before: reject requires feedback text; empty Enter is a no-op
     // (use Esc to dismiss the request without feedback).
-    if (!rejectOption || !text) return;
-    onSelect(rejectOption.optionId, text);
+    if (!rejectOption || (!text && activeReviewComments.length === 0)) return;
+    const reviewFeedback =
+      activeReviewComments.length > 0
+        ? buildPlanReviewFeedback(activeReviewComments, text)
+        : text;
+    onSelect(rejectOption.optionId, reviewFeedback);
+    clearReview(toolCall.toolCallId);
   };
 
   const moveSelection = (delta: number) => {
@@ -303,7 +317,11 @@ export function PlanApprovalSelector({
                   <Box className="min-w-0 flex-1 leading-4">
                     <InlineEditableText
                       value={feedback}
-                      placeholder="Type here to tell the agent what to do differently"
+                      placeholder={
+                        activeReviewComments.length > 0
+                          ? `${activeReviewComments.length} review comment${activeReviewComments.length === 1 ? "" : "s"} ready. Add more feedback if needed.`
+                          : "Type here to tell the agent what to do differently"
+                      }
                       active={rejectSelected}
                       onChange={setFeedback}
                       onNavigateUp={() => selectRow(0)}

--- a/products/desktop/packages/ui/src/features/permissions/PlanApprovalSelector.tsx
+++ b/products/desktop/packages/ui/src/features/permissions/PlanApprovalSelector.tsx
@@ -79,19 +79,14 @@ export function PlanApprovalSelector({
   // Only the user's own pick lives in state; everything else derives from
   // `initialMode` so it tracks `lastApprovalMode` live instead of freezing it
   // at mount — derive it, don't duplicate it.
-  const [explicitMode, setExplicitMode] = useState<string | undefined>(
-    undefined,
-  );
-  // This component can survive to a later approval request without
-  // remounting, so a pick made for the previous request must not leak into
-  // (and potentially not exist in) this one. Reset during render rather than
-  // in an effect: it takes effect before this render paints instead of one
-  // render later, avoiding a flash of the stale mode.
-  const lastToolCallIdRef = useRef(toolCall.toolCallId);
-  if (lastToolCallIdRef.current !== toolCall.toolCallId) {
-    lastToolCallIdRef.current = toolCall.toolCallId;
-    setExplicitMode(undefined);
-  }
+  const [explicitSelection, setExplicitSelection] = useState<{
+    toolCallId: string;
+    mode: string;
+  }>();
+  const explicitMode =
+    explicitSelection?.toolCallId === toolCall.toolCallId
+      ? explicitSelection.mode
+      : undefined;
   const selectedMode = explicitMode ?? initialMode;
   const reviewComments = usePlanReviewStore(
     (state) => state.comments[toolCall.toolCallId] ?? [],
@@ -322,7 +317,12 @@ export function PlanApprovalSelector({
                   <Box onClick={(e) => e.stopPropagation()}>
                     <ModeSelector
                       modeOption={modeConfigOption}
-                      onChange={(value) => setExplicitMode(value)}
+                      onChange={(mode) =>
+                        setExplicitSelection({
+                          toolCallId: toolCall.toolCallId,
+                          mode,
+                        })
+                      }
                       allowBypassPermissions
                     />
                   </Box>

--- a/products/desktop/packages/ui/src/features/permissions/PlanApprovalSelector.tsx
+++ b/products/desktop/packages/ui/src/features/permissions/PlanApprovalSelector.tsx
@@ -24,10 +24,14 @@ function isElementInDifferentCell(
   containerRef: React.RefObject<HTMLDivElement | null>,
 ): boolean {
   const el = document.activeElement;
-  if (!(el instanceof HTMLElement)) return false;
+  if (!(el instanceof HTMLElement)) {
+    return false;
+  }
   const activeCell = el.closest("[data-grid-cell]");
   const ownCell = containerRef.current?.closest("[data-grid-cell]");
-  if (activeCell && ownCell && activeCell !== ownCell) return true;
+  if (activeCell && ownCell && activeCell !== ownCell) {
+    return true;
+  }
   const isInteractive =
     el.tagName === "INPUT" ||
     el.tagName === "TEXTAREA" ||
@@ -96,6 +100,13 @@ export function PlanApprovalSelector({
   const activeReviewComments = reviewComments.filter(
     (comment) => !comment.stale,
   );
+  const activeReviewCommentCount = activeReviewComments.length;
+  const reviewCommentNoun =
+    activeReviewCommentCount === 1 ? "comment" : "comments";
+  const feedbackPlaceholder =
+    activeReviewCommentCount > 0
+      ? `${activeReviewCommentCount} review ${reviewCommentNoun} ready. Add more feedback if needed.`
+      : "Type here to tell the agent what to do differently";
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
   const [feedback, setFeedback] = useState("");
@@ -141,12 +152,15 @@ export function PlanApprovalSelector({
   const selectRow = (index: number) => {
     setHoveredIndex(null);
     setSelectedIndex(index);
-    if (index !== rejectIndex) containerRef.current?.focus();
+    if (index !== rejectIndex) {
+      containerRef.current?.focus();
+    }
   };
 
   const approve = () => {
-    if (!selectedMode) return;
-    // Remember this choice so the next plan approval pre-selects it.
+    if (!selectedMode) {
+      return;
+    }
     setLastApprovalMode(selectedMode as ExecutionMode);
     clearReview(toolCall.toolCallId);
     onSelect(selectedMode);
@@ -154,13 +168,18 @@ export function PlanApprovalSelector({
 
   const submitReject = () => {
     const text = feedback.trim();
-    // Exactly as before: reject requires feedback text; empty Enter is a no-op
-    // (use Esc to dismiss the request without feedback).
-    if (!rejectOption || (!text && activeReviewComments.length === 0)) return;
-    const reviewFeedback =
-      activeReviewComments.length > 0
-        ? buildPlanReviewFeedback(activeReviewComments, text)
-        : text;
+    if (!rejectOption) {
+      return;
+    }
+    if (!text && activeReviewCommentCount === 0) {
+      return;
+    }
+
+    let reviewFeedback = text;
+    if (activeReviewCommentCount > 0) {
+      reviewFeedback = buildPlanReviewFeedback(activeReviewComments, text);
+    }
+
     onSelect(rejectOption.optionId, reviewFeedback);
     clearReview(toolCall.toolCallId);
   };
@@ -170,9 +189,13 @@ export function PlanApprovalSelector({
   };
 
   const handleContainerKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
-    if (e.nativeEvent.isComposing || e.keyCode === 229) return;
+    if (e.nativeEvent.isComposing || e.keyCode === 229) {
+      return;
+    }
     // The reject textarea owns the keyboard while it's the selected row.
-    if (rejectSelected) return;
+    if (rejectSelected) {
+      return;
+    }
     switch (e.key) {
       case "ArrowUp":
         e.preventDefault();
@@ -196,8 +219,11 @@ export function PlanApprovalSelector({
           const idx = Number.parseInt(e.key, 10) - 1;
           if (idx < rowCount) {
             e.preventDefault();
-            if (idx === 0) approve();
-            else selectRow(idx);
+            if (idx === 0) {
+              approve();
+            } else {
+              selectRow(idx);
+            }
           }
         }
     }
@@ -255,7 +281,9 @@ export function PlanApprovalSelector({
       tabIndex={0}
       onKeyDown={handleContainerKeyDown}
       onClick={(e) => {
-        if (e.target === containerRef.current) containerRef.current?.focus();
+        if (e.target === containerRef.current) {
+          containerRef.current?.focus();
+        }
       }}
       p="3"
       className="rounded-(--radius-3) border border-(--gray-6) bg-(--gray-1) outline-none"
@@ -317,11 +345,7 @@ export function PlanApprovalSelector({
                   <Box className="min-w-0 flex-1 leading-4">
                     <InlineEditableText
                       value={feedback}
-                      placeholder={
-                        activeReviewComments.length > 0
-                          ? `${activeReviewComments.length} review comment${activeReviewComments.length === 1 ? "" : "s"} ready. Add more feedback if needed.`
-                          : "Type here to tell the agent what to do differently"
-                      }
+                      placeholder={feedbackPlaceholder}
                       active={rejectSelected}
                       onChange={setFeedback}
                       onNavigateUp={() => selectRow(0)}

--- a/products/desktop/packages/ui/src/features/permissions/PlanContent.tsx
+++ b/products/desktop/packages/ui/src/features/permissions/PlanContent.tsx
@@ -8,22 +8,40 @@ import {
 } from "@phosphor-icons/react";
 import { Tooltip } from "@posthog/ui/primitives/Tooltip";
 import { Box, Flex, IconButton, Text } from "@radix-ui/themes";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { PlanSectionComment } from "./PlanSectionComment";
+import { splitPlanSections, usePlanReviewStore } from "./planReview";
 
 const planScrollPosition = new Map<string, number>();
 
 interface PlanContentProps {
   id: string;
   plan: string;
+  reviewable?: boolean;
 }
 
-export function PlanContent({ id, plan }: PlanContentProps) {
+export function PlanContent({
+  id,
+  plan,
+  reviewable = false,
+}: PlanContentProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [openSectionId, setOpenSectionId] = useState<string | null>(null);
+  const [editingCommentId, setEditingCommentId] = useState<string | null>(null);
+  const sections = useMemo(() => splitPlanSections(plan), [plan]);
+  const comments = usePlanReviewStore((state) => state.comments[id] ?? []);
+  const addComment = usePlanReviewStore((state) => state.addComment);
+  const updateComment = usePlanReviewStore((state) => state.updateComment);
+  const removeComment = usePlanReviewStore((state) => state.removeComment);
+
+  useEffect(() => {
+    if (reviewable) usePlanReviewStore.getState().reconcile(id, sections);
+  }, [id, reviewable, sections]);
 
   const handleCopy = async () => {
     try {
@@ -66,9 +84,153 @@ export function PlanContent({ id, plan }: PlanContentProps) {
     return () => window.removeEventListener("keydown", handler);
   }, [isFullscreen]);
 
-  const markdown = (
-    <ReactMarkdown remarkPlugins={[remarkGfm]}>{plan}</ReactMarkdown>
+  const markdown = sections.map((section) => {
+    const sectionComments = comments.filter(
+      (comment) => comment.sectionId === section.id,
+    );
+    const isCommentOpen = openSectionId === section.id;
+
+    return (
+      <section
+        key={section.id}
+        id={`${id}-${section.id}`}
+        data-plan-section={section.id}
+        className="group/plan-section scroll-mt-4"
+      >
+        <div className="flex items-start gap-2">
+          <div className="min-w-0 flex-1">
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>
+              {section.content}
+            </ReactMarkdown>
+          </div>
+          {reviewable && (
+            <button
+              type="button"
+              className="mt-1 shrink-0 rounded-sm px-1.5 py-0.5 text-[11px] text-gray-10 opacity-0 transition-opacity hover:bg-gray-3 hover:text-gray-12 focus:opacity-100 group-hover/plan-section:opacity-100"
+              onClick={() => {
+                setEditingCommentId(null);
+                setOpenSectionId(isCommentOpen ? null : section.id);
+              }}
+              aria-label={`Comment on ${section.title}`}
+              data-attr="plan-section-comment"
+            >
+              Comment
+            </button>
+          )}
+        </div>
+
+        {sectionComments.map((comment) => (
+          <div
+            key={comment.id}
+            className={`mt-2 rounded-md border px-2.5 py-2 text-[13px] ${comment.stale ? "border-orange-6 bg-orange-2" : "border-gray-6 bg-gray-2"}`}
+          >
+            {comment.stale && (
+              <Text as="div" size="1" color="orange" className="mb-1">
+                This comment refers to an earlier version of the plan.
+              </Text>
+            )}
+            {editingCommentId === comment.id ? (
+              <PlanSectionComment
+                initialText={comment.text}
+                onDismiss={() => setEditingCommentId(null)}
+                onSubmit={(text) => {
+                  updateComment(id, comment.id, text, section);
+                  setEditingCommentId(null);
+                }}
+              />
+            ) : (
+              <>
+                <Text as="div" className="whitespace-pre-wrap text-gray-12">
+                  {comment.text}
+                </Text>
+                {reviewable && (
+                  <Flex gap="2" className="mt-1">
+                    <button
+                      type="button"
+                      className="text-[11px] text-gray-10 hover:text-gray-12"
+                      onClick={() => setEditingCommentId(comment.id)}
+                    >
+                      Edit
+                    </button>
+                    <button
+                      type="button"
+                      className="text-[11px] text-gray-10 hover:text-gray-12"
+                      onClick={() => removeComment(id, comment.id)}
+                    >
+                      Remove
+                    </button>
+                  </Flex>
+                )}
+              </>
+            )}
+          </div>
+        ))}
+
+        {reviewable && isCommentOpen && (
+          <PlanSectionComment
+            onDismiss={() => setOpenSectionId(null)}
+            onSubmit={(text) => {
+              addComment(id, {
+                sectionId: section.id,
+                sectionTitle: section.title,
+                sectionContent: section.content,
+                text,
+              });
+              setOpenSectionId(null);
+            }}
+          />
+        )}
+      </section>
+    );
+  });
+  const missingComments = comments.filter(
+    (comment) =>
+      comment.stale &&
+      !sections.some((section) => section.id === comment.sectionId),
   );
+  if (missingComments.length > 0) {
+    markdown.push(
+      <div key="stale-plan-comments" className="mt-3">
+        <Text as="div" size="1" color="orange" className="mb-1">
+          Review comments from an earlier plan version
+        </Text>
+        {missingComments.map((comment) => (
+          <div
+            key={comment.id}
+            className="mt-2 rounded-md border border-orange-6 bg-orange-2 px-2.5 py-2 text-[13px]"
+          >
+            {editingCommentId === comment.id ? (
+              <PlanSectionComment
+                initialText={comment.text}
+                onDismiss={() => setEditingCommentId(null)}
+                onSubmit={(text) => {
+                  updateComment(id, comment.id, text);
+                  setEditingCommentId(null);
+                }}
+              />
+            ) : (
+              <>
+                <Text as="div" className="text-gray-12">
+                  {comment.text}
+                </Text>
+                {reviewable && (
+                  <Flex gap="2" className="mt-1">
+                    <button
+                      type="button"
+                      className="text-[11px] text-gray-10 hover:text-gray-12"
+                      onClick={() => removeComment(id, comment.id)}
+                    >
+                      Remove
+                    </button>
+                  </Flex>
+                )}
+              </>
+            )}
+          </div>
+        ))}
+      </div>,
+    );
+  }
 
   if (isFullscreen) {
     const portalTarget = document.getElementById("fullscreen-portal");

--- a/products/desktop/packages/ui/src/features/permissions/PlanContent.tsx
+++ b/products/desktop/packages/ui/src/features/permissions/PlanContent.tsx
@@ -12,6 +12,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { PlanReviewCommentCard } from "./PlanReviewCommentCard";
 import { PlanSectionComment } from "./PlanSectionComment";
 import { splitPlanSections, usePlanReviewStore } from "./planReview";
 
@@ -32,7 +33,6 @@ export function PlanContent({
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [copied, setCopied] = useState(false);
   const [openSectionId, setOpenSectionId] = useState<string | null>(null);
-  const [editingCommentId, setEditingCommentId] = useState<string | null>(null);
   const sections = useMemo(() => splitPlanSections(plan), [plan]);
   const comments = usePlanReviewStore((state) => state.comments[id] ?? []);
   const addComment = usePlanReviewStore((state) => state.addComment);
@@ -40,7 +40,9 @@ export function PlanContent({
   const removeComment = usePlanReviewStore((state) => state.removeComment);
 
   useEffect(() => {
-    if (reviewable) usePlanReviewStore.getState().reconcile(id, sections);
+    if (reviewable) {
+      usePlanReviewStore.getState().reconcile(id, sections);
+    }
   }, [id, reviewable, sections]);
 
   const handleCopy = async () => {
@@ -55,7 +57,9 @@ export function PlanContent({
 
   useEffect(() => {
     const el = scrollRef.current;
-    if (!el) return;
+    if (!el) {
+      return;
+    }
 
     const position = planScrollPosition.get(id);
     if (position !== undefined) {
@@ -74,7 +78,9 @@ export function PlanContent({
   }, [id]);
 
   useEffect(() => {
-    if (!isFullscreen) return;
+    if (!isFullscreen) {
+      return;
+    }
     const handler = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
         setIsFullscreen(false);
@@ -108,7 +114,6 @@ export function PlanContent({
               type="button"
               className="mt-1 shrink-0 rounded-sm px-1.5 py-0.5 text-[11px] text-gray-10 opacity-0 transition-opacity hover:bg-gray-3 hover:text-gray-12 focus:opacity-100 group-hover/plan-section:opacity-100"
               onClick={() => {
-                setEditingCommentId(null);
                 setOpenSectionId(isCommentOpen ? null : section.id);
               }}
               aria-label={`Comment on ${section.title}`}
@@ -120,50 +125,14 @@ export function PlanContent({
         </div>
 
         {sectionComments.map((comment) => (
-          <div
+          <PlanReviewCommentCard
             key={comment.id}
-            className={`mt-2 rounded-md border px-2.5 py-2 text-[13px] ${comment.stale ? "border-orange-6 bg-orange-2" : "border-gray-6 bg-gray-2"}`}
-          >
-            {comment.stale && (
-              <Text as="div" size="1" color="orange" className="mb-1">
-                This comment refers to an earlier version of the plan.
-              </Text>
-            )}
-            {editingCommentId === comment.id ? (
-              <PlanSectionComment
-                initialText={comment.text}
-                onDismiss={() => setEditingCommentId(null)}
-                onSubmit={(text) => {
-                  updateComment(id, comment.id, text, section);
-                  setEditingCommentId(null);
-                }}
-              />
-            ) : (
-              <>
-                <Text as="div" className="whitespace-pre-wrap text-gray-12">
-                  {comment.text}
-                </Text>
-                {reviewable && (
-                  <Flex gap="2" className="mt-1">
-                    <button
-                      type="button"
-                      className="text-[11px] text-gray-10 hover:text-gray-12"
-                      onClick={() => setEditingCommentId(comment.id)}
-                    >
-                      Edit
-                    </button>
-                    <button
-                      type="button"
-                      className="text-[11px] text-gray-10 hover:text-gray-12"
-                      onClick={() => removeComment(id, comment.id)}
-                    >
-                      Remove
-                    </button>
-                  </Flex>
-                )}
-              </>
-            )}
-          </div>
+            comment={comment}
+            reviewable={reviewable}
+            canEdit
+            onUpdate={(text) => updateComment(id, comment.id, text, section)}
+            onRemove={() => removeComment(id, comment.id)}
+          />
         ))}
 
         {reviewable && isCommentOpen && (
@@ -195,38 +164,13 @@ export function PlanContent({
           Review comments from an earlier plan version
         </Text>
         {missingComments.map((comment) => (
-          <div
+          <PlanReviewCommentCard
             key={comment.id}
-            className="mt-2 rounded-md border border-orange-6 bg-orange-2 px-2.5 py-2 text-[13px]"
-          >
-            {editingCommentId === comment.id ? (
-              <PlanSectionComment
-                initialText={comment.text}
-                onDismiss={() => setEditingCommentId(null)}
-                onSubmit={(text) => {
-                  updateComment(id, comment.id, text);
-                  setEditingCommentId(null);
-                }}
-              />
-            ) : (
-              <>
-                <Text as="div" className="text-gray-12">
-                  {comment.text}
-                </Text>
-                {reviewable && (
-                  <Flex gap="2" className="mt-1">
-                    <button
-                      type="button"
-                      className="text-[11px] text-gray-10 hover:text-gray-12"
-                      onClick={() => removeComment(id, comment.id)}
-                    >
-                      Remove
-                    </button>
-                  </Flex>
-                )}
-              </>
-            )}
-          </div>
+            comment={comment}
+            reviewable={reviewable}
+            canEdit={false}
+            onRemove={() => removeComment(id, comment.id)}
+          />
         ))}
       </div>,
     );

--- a/products/desktop/packages/ui/src/features/permissions/PlanReviewCommentCard.tsx
+++ b/products/desktop/packages/ui/src/features/permissions/PlanReviewCommentCard.tsx
@@ -1,4 +1,4 @@
-import { Flex, Text } from "@radix-ui/themes";
+import { Text } from "@posthog/quill";
 import { useState } from "react";
 import { PlanSectionComment } from "./PlanSectionComment";
 import type { PlanReviewComment } from "./planReview";
@@ -45,15 +45,13 @@ export function PlanReviewCommentCard({
       className={`mt-2 rounded-md border px-2.5 py-2 text-[13px] ${colorClasses}`}
     >
       {comment.stale && (
-        <Text as="div" size="1" color="orange" className="mb-1">
+        <Text size="xs" className="mb-1 text-orange-11">
           This comment refers to an earlier version of the plan.
         </Text>
       )}
-      <Text as="div" className="whitespace-pre-wrap text-gray-12">
-        {comment.text}
-      </Text>
+      <Text className="whitespace-pre-wrap text-gray-12">{comment.text}</Text>
       {reviewable && (
-        <Flex gap="2" className="mt-1">
+        <div className="mt-1 flex gap-2">
           {canEdit && (
             <button
               type="button"
@@ -70,7 +68,7 @@ export function PlanReviewCommentCard({
           >
             Remove
           </button>
-        </Flex>
+        </div>
       )}
     </div>
   );

--- a/products/desktop/packages/ui/src/features/permissions/PlanReviewCommentCard.tsx
+++ b/products/desktop/packages/ui/src/features/permissions/PlanReviewCommentCard.tsx
@@ -1,0 +1,77 @@
+import { Flex, Text } from "@radix-ui/themes";
+import { useState } from "react";
+import { PlanSectionComment } from "./PlanSectionComment";
+import type { PlanReviewComment } from "./planReview";
+
+interface PlanReviewCommentCardProps {
+  comment: PlanReviewComment;
+  reviewable: boolean;
+  canEdit: boolean;
+  onUpdate?: (text: string) => void;
+  onRemove: () => void;
+}
+
+export function PlanReviewCommentCard({
+  comment,
+  reviewable,
+  canEdit,
+  onUpdate,
+  onRemove,
+}: PlanReviewCommentCardProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const colorClasses = comment.stale
+    ? "border-orange-6 bg-orange-2"
+    : "border-gray-6 bg-gray-2";
+
+  if (isEditing) {
+    return (
+      <div className={`mt-2 rounded-md border px-2.5 py-2 ${colorClasses}`}>
+        <PlanSectionComment
+          initialText={comment.text}
+          onDismiss={() => setIsEditing(false)}
+          onSubmit={(text) => {
+            if (onUpdate) {
+              onUpdate(text);
+            }
+            setIsEditing(false);
+          }}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`mt-2 rounded-md border px-2.5 py-2 text-[13px] ${colorClasses}`}
+    >
+      {comment.stale && (
+        <Text as="div" size="1" color="orange" className="mb-1">
+          This comment refers to an earlier version of the plan.
+        </Text>
+      )}
+      <Text as="div" className="whitespace-pre-wrap text-gray-12">
+        {comment.text}
+      </Text>
+      {reviewable && (
+        <Flex gap="2" className="mt-1">
+          {canEdit && (
+            <button
+              type="button"
+              className="text-[11px] text-gray-10 hover:text-gray-12"
+              onClick={() => setIsEditing(true)}
+            >
+              Edit
+            </button>
+          )}
+          <button
+            type="button"
+            className="text-[11px] text-gray-10 hover:text-gray-12"
+            onClick={onRemove}
+          >
+            Remove
+          </button>
+        </Flex>
+      )}
+    </div>
+  );
+}

--- a/products/desktop/packages/ui/src/features/permissions/PlanSectionComment.stories.tsx
+++ b/products/desktop/packages/ui/src/features/permissions/PlanSectionComment.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { PlanSectionComment } from "./PlanSectionComment";
+
+const meta: Meta<typeof PlanSectionComment> = {
+  title: "Components/Permissions/PlanSectionComment",
+  component: PlanSectionComment,
+  parameters: { layout: "padded" },
+  args: {
+    onSubmit: () => undefined,
+    onDismiss: () => undefined,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof PlanSectionComment>;
+
+export const Empty: Story = {};
+
+export const Editing: Story = {
+  args: { initialText: "Keep this step compatible with the existing API." },
+};

--- a/products/desktop/packages/ui/src/features/permissions/PlanSectionComment.tsx
+++ b/products/desktop/packages/ui/src/features/permissions/PlanSectionComment.tsx
@@ -1,0 +1,76 @@
+import { ArrowUp, Trash } from "@phosphor-icons/react";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupTextarea,
+} from "@posthog/quill";
+import { useEffect, useRef, useState } from "react";
+
+interface PlanSectionCommentProps {
+  initialText?: string;
+  onSubmit: (text: string) => void;
+  onDismiss: () => void;
+}
+
+export function PlanSectionComment({
+  initialText,
+  onSubmit,
+  onDismiss,
+}: PlanSectionCommentProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const [text, setText] = useState(initialText ?? "");
+
+  useEffect(() => {
+    textareaRef.current?.focus();
+  }, []);
+
+  const submit = () => {
+    const value = text.trim();
+    if (value) onSubmit(value);
+  };
+
+  return (
+    <div className="mt-2">
+      <InputGroup>
+        <InputGroupTextarea
+          ref={textareaRef}
+          value={text}
+          placeholder="Describe what should change"
+          onChange={(event) => setText(event.currentTarget.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Escape") {
+              event.preventDefault();
+              onDismiss();
+            }
+            if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+              event.preventDefault();
+              submit();
+            }
+          }}
+          className="min-h-[48px] resize-none text-[13px]"
+        />
+        <InputGroupAddon align="block-end">
+          <InputGroupButton
+            size="icon-sm"
+            variant="default"
+            onClick={onDismiss}
+            aria-label="Discard comment"
+          >
+            <Trash size={14} />
+          </InputGroupButton>
+          <InputGroupButton
+            className="ml-auto"
+            size="icon-sm"
+            variant="primary"
+            onClick={submit}
+            disabled={!text.trim()}
+            aria-label="Add comment"
+          >
+            <ArrowUp size={14} weight="bold" />
+          </InputGroupButton>
+        </InputGroupAddon>
+      </InputGroup>
+    </div>
+  );
+}

--- a/products/desktop/packages/ui/src/features/permissions/PlanSectionComment.tsx
+++ b/products/desktop/packages/ui/src/features/permissions/PlanSectionComment.tsx
@@ -27,7 +27,9 @@ export function PlanSectionComment({
 
   const submit = () => {
     const value = text.trim();
-    if (value) onSubmit(value);
+    if (value) {
+      onSubmit(value);
+    }
   };
 
   return (

--- a/products/desktop/packages/ui/src/features/permissions/planReview.test.ts
+++ b/products/desktop/packages/ui/src/features/permissions/planReview.test.ts
@@ -34,6 +34,41 @@ describe("plan review", () => {
     ]);
   });
 
+  it("includes content before the first section", () => {
+    expect(
+      splitPlanSections(
+        "Review every step before approval.\n\n## Update the API\nChange the endpoint.",
+      ),
+    ).toEqual([
+      {
+        id: "update-the-api",
+        title: "Update the API",
+        content:
+          "Review every step before approval.\n\n## Update the API\nChange the endpoint.",
+      },
+    ]);
+  });
+
+  it("ignores section markers inside fenced code blocks", () => {
+    expect(
+      splitPlanSections(
+        "## Update the docs\n\n```md\n# Example heading\n1. Example step\n```\n\n## Run tests",
+      ),
+    ).toEqual([
+      {
+        id: "update-the-docs",
+        title: "Update the docs",
+        content:
+          "## Update the docs\n\n```md\n# Example heading\n1. Example step\n```",
+      },
+      {
+        id: "run-tests",
+        title: "Run tests",
+        content: "## Run tests",
+      },
+    ]);
+  });
+
   it("marks a comment stale when its section changes", () => {
     const section = splitPlanSections(
       "## Update the API\nChange the endpoint.",

--- a/products/desktop/packages/ui/src/features/permissions/planReview.test.ts
+++ b/products/desktop/packages/ui/src/features/permissions/planReview.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  buildPlanReviewFeedback,
+  splitPlanSections,
+  usePlanReviewStore,
+} from "./planReview";
+
+describe("plan review", () => {
+  beforeEach(() => {
+    usePlanReviewStore.getState().clear("test-plan");
+  });
+
+  it("creates stable sections for headings and numbered steps", () => {
+    expect(
+      splitPlanSections(
+        "# Plan\n\n## Update the API\nChange the endpoint.\n\n## Update the UI\nChange the form.",
+      ),
+    ).toEqual([
+      {
+        id: "plan",
+        title: "Plan",
+        content: "# Plan",
+      },
+      {
+        id: "update-the-api",
+        title: "Update the API",
+        content: "## Update the API\nChange the endpoint.",
+      },
+      {
+        id: "update-the-ui",
+        title: "Update the UI",
+        content: "## Update the UI\nChange the form.",
+      },
+    ]);
+  });
+
+  it("marks a comment stale when its section changes", () => {
+    const section = splitPlanSections(
+      "## Update the API\nChange the endpoint.",
+    )[0];
+    usePlanReviewStore.getState().addComment("test-plan", {
+      sectionId: section.id,
+      sectionTitle: section.title,
+      sectionContent: section.content,
+      text: "Use the generated client.",
+    });
+
+    usePlanReviewStore
+      .getState()
+      .reconcile("test-plan", [
+        { ...section, content: "## Update the API\nUse a different endpoint." },
+      ]);
+
+    expect(usePlanReviewStore.getState().comments["test-plan"]?.[0].stale).toBe(
+      true,
+    );
+  });
+
+  it("formats multiple comments with section context and extra feedback", () => {
+    const feedback = buildPlanReviewFeedback(
+      [
+        {
+          id: "comment-1",
+          sectionId: "api",
+          sectionTitle: "Update the API",
+          sectionContent: "## Update the API\nChange the endpoint.",
+          text: "Keep the existing endpoint.",
+          createdAt: 1,
+          stale: false,
+        },
+      ],
+      "Explain the migration impact.",
+    );
+
+    expect(feedback).toContain('Section "Update the API"');
+    expect(feedback).toContain("Keep the existing endpoint.");
+    expect(feedback).toContain("Explain the migration impact.");
+  });
+});

--- a/products/desktop/packages/ui/src/features/permissions/planReview.ts
+++ b/products/desktop/packages/ui/src/features/permissions/planReview.ts
@@ -1,0 +1,182 @@
+import { create } from "zustand";
+
+export interface PlanSection {
+  id: string;
+  title: string;
+  content: string;
+}
+
+export interface PlanReviewComment {
+  id: string;
+  sectionId: string;
+  sectionTitle: string;
+  sectionContent: string;
+  text: string;
+  createdAt: number;
+  stale: boolean;
+}
+
+function slugify(value: string): string {
+  const slug = value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+  return slug || "plan-section";
+}
+
+function uniqueId(value: string, seen: Set<string>): string {
+  const base = slugify(value);
+  let id = base;
+  let suffix = 2;
+  while (seen.has(id)) {
+    id = `${base}-${suffix}`;
+    suffix += 1;
+  }
+  seen.add(id);
+  return id;
+}
+
+export function splitPlanSections(plan: string): PlanSection[] {
+  const lines = plan.split("\n");
+  const starts = lines
+    .map((line, index) => ({ line, index }))
+    .filter(({ line }) => /^(#{1,6})\s+\S/.test(line));
+
+  if (starts.length === 0) {
+    const stepStarts = lines
+      .map((line, index) => ({ line, index }))
+      .filter(({ line }) => /^\s*\d+[.)]\s+\S/.test(line));
+    if (stepStarts.length > 0) {
+      starts.push(...stepStarts.map(({ line, index }) => ({ line, index })));
+    }
+  }
+
+  if (starts.length === 0) {
+    return [{ id: "plan", title: "Plan", content: plan }];
+  }
+
+  const seen = new Set<string>();
+  return starts.map(({ line, index }, startIndex) => {
+    const nextIndex = starts[startIndex + 1]?.index ?? lines.length;
+    const title = line.replace(/^\s*(?:#{1,6}\s+|\d+[.)]\s+)/, "").trim();
+    return {
+      id: uniqueId(title, seen),
+      title: title || "Plan section",
+      content: lines.slice(index, nextIndex).join("\n").trim(),
+    };
+  });
+}
+
+export function buildPlanReviewFeedback(
+  comments: PlanReviewComment[],
+  additionalFeedback?: string,
+): string {
+  const activeComments = comments.filter((comment) => !comment.stale);
+  const sections = activeComments
+    .map(
+      (comment) =>
+        `- Section "${comment.sectionTitle}":\n  Context: ${comment.sectionContent}\n  Feedback: ${comment.text}`,
+    )
+    .join("\n\n");
+  const feedback = additionalFeedback?.trim();
+
+  return [
+    "Please revise the implementation plan using this review feedback:",
+    sections,
+    feedback ? `Additional feedback:\n${feedback}` : "",
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+}
+
+interface PlanReviewState {
+  comments: Record<string, PlanReviewComment[]>;
+  addComment: (
+    planId: string,
+    comment: Omit<PlanReviewComment, "id" | "createdAt" | "stale">,
+  ) => void;
+  updateComment: (
+    planId: string,
+    commentId: string,
+    text: string,
+    section?: PlanSection,
+  ) => void;
+  removeComment: (planId: string, commentId: string) => void;
+  reconcile: (planId: string, sections: PlanSection[]) => void;
+  clear: (planId: string) => void;
+}
+
+export const usePlanReviewStore = create<PlanReviewState>()((set) => ({
+  comments: {},
+  addComment: (planId, comment) =>
+    set((state) => ({
+      comments: {
+        ...state.comments,
+        [planId]: [
+          ...(state.comments[planId] ?? []),
+          {
+            ...comment,
+            id: crypto.randomUUID(),
+            createdAt: Date.now(),
+            stale: false,
+          },
+        ],
+      },
+    })),
+  updateComment: (planId, commentId, text, section) =>
+    set((state) => ({
+      comments: {
+        ...state.comments,
+        [planId]: (state.comments[planId] ?? []).map((comment) =>
+          comment.id === commentId
+            ? {
+                ...comment,
+                text,
+                ...(section
+                  ? {
+                      sectionId: section.id,
+                      sectionTitle: section.title,
+                      sectionContent: section.content,
+                      stale: false,
+                    }
+                  : {}),
+              }
+            : comment,
+        ),
+      },
+    })),
+  removeComment: (planId, commentId) =>
+    set((state) => ({
+      comments: {
+        ...state.comments,
+        [planId]: (state.comments[planId] ?? []).filter(
+          (comment) => comment.id !== commentId,
+        ),
+      },
+    })),
+  reconcile: (planId, sections) =>
+    set((state) => {
+      const existing = state.comments[planId];
+      if (!existing) return state;
+      const sectionMap = new Map(
+        sections.map((section) => [section.id, section]),
+      );
+      const next = existing.map((comment) => {
+        const section = sectionMap.get(comment.sectionId);
+        return {
+          ...comment,
+          stale:
+            !section ||
+            section.content !== comment.sectionContent ||
+            section.title !== comment.sectionTitle,
+        };
+      });
+      return { comments: { ...state.comments, [planId]: next } };
+    }),
+  clear: (planId) =>
+    set((state) => {
+      const comments = { ...state.comments };
+      delete comments[planId];
+      return { comments };
+    }),
+}));

--- a/products/desktop/packages/ui/src/features/permissions/planReview.ts
+++ b/products/desktop/packages/ui/src/features/permissions/planReview.ts
@@ -38,17 +38,36 @@ function uniqueId(value: string, seen: Set<string>): string {
 
 export function splitPlanSections(plan: string): PlanSection[] {
   const lines = plan.split("\n");
-  const headingStarts = lines
-    .map((line, index) => ({ line, index }))
-    .filter(({ line }) => /^(#{1,6})\s+\S/.test(line));
-  let starts = headingStarts;
+  const headingStarts: Array<{ line: string; index: number }> = [];
+  const stepStarts: Array<{ line: string; index: number }> = [];
+  let fence: "`" | "~" | undefined;
 
-  if (starts.length === 0) {
-    starts = lines
-      .map((line, index) => ({ line, index }))
-      .filter(({ line }) => /^\s*\d+[.)]\s+\S/.test(line));
+  for (const [index, line] of lines.entries()) {
+    const fenceMatch = line.match(/^\s{0,3}(`{3,}|~{3,})/);
+    if (fenceMatch) {
+      const marker = fenceMatch[1][0] as "`" | "~";
+      if (!fence) {
+        fence = marker;
+      } else if (fence === marker) {
+        fence = undefined;
+      }
+      continue;
+    }
+
+    if (fence) {
+      continue;
+    }
+
+    if (/^(#{1,6})\s+\S/.test(line)) {
+      headingStarts.push({ line, index });
+    }
+
+    if (/^\s*\d+[.)]\s+\S/.test(line)) {
+      stepStarts.push({ line, index });
+    }
   }
 
+  const starts = headingStarts.length > 0 ? headingStarts : stepStarts;
   if (starts.length === 0) {
     return [{ id: "plan", title: "Plan", content: plan }];
   }
@@ -56,11 +75,12 @@ export function splitPlanSections(plan: string): PlanSection[] {
   const seen = new Set<string>();
   return starts.map(({ line, index }, startIndex) => {
     const nextIndex = starts[startIndex + 1]?.index ?? lines.length;
+    const contentStartIndex = startIndex === 0 ? 0 : index;
     const title = line.replace(/^\s*(?:#{1,6}\s+|\d+[.)]\s+)/, "").trim();
     return {
       id: uniqueId(title, seen),
       title: title || "Plan section",
-      content: lines.slice(index, nextIndex).join("\n").trim(),
+      content: lines.slice(contentStartIndex, nextIndex).join("\n").trim(),
     };
   });
 }

--- a/products/desktop/packages/ui/src/features/permissions/planReview.ts
+++ b/products/desktop/packages/ui/src/features/permissions/planReview.ts
@@ -38,17 +38,15 @@ function uniqueId(value: string, seen: Set<string>): string {
 
 export function splitPlanSections(plan: string): PlanSection[] {
   const lines = plan.split("\n");
-  const starts = lines
+  const headingStarts = lines
     .map((line, index) => ({ line, index }))
     .filter(({ line }) => /^(#{1,6})\s+\S/.test(line));
+  let starts = headingStarts;
 
   if (starts.length === 0) {
-    const stepStarts = lines
+    starts = lines
       .map((line, index) => ({ line, index }))
       .filter(({ line }) => /^\s*\d+[.)]\s+\S/.test(line));
-    if (stepStarts.length > 0) {
-      starts.push(...stepStarts.map(({ line, index }) => ({ line, index })));
-    }
   }
 
   if (starts.length === 0) {
@@ -127,22 +125,24 @@ export const usePlanReviewStore = create<PlanReviewState>()((set) => ({
     set((state) => ({
       comments: {
         ...state.comments,
-        [planId]: (state.comments[planId] ?? []).map((comment) =>
-          comment.id === commentId
-            ? {
-                ...comment,
-                text,
-                ...(section
-                  ? {
-                      sectionId: section.id,
-                      sectionTitle: section.title,
-                      sectionContent: section.content,
-                      stale: false,
-                    }
-                  : {}),
-              }
-            : comment,
-        ),
+        [planId]: (state.comments[planId] ?? []).map((comment) => {
+          if (comment.id !== commentId) {
+            return comment;
+          }
+
+          const updatedComment = { ...comment, text };
+          if (!section) {
+            return updatedComment;
+          }
+
+          return {
+            ...updatedComment,
+            sectionId: section.id,
+            sectionTitle: section.title,
+            sectionContent: section.content,
+            stale: false,
+          };
+        }),
       },
     })),
   removeComment: (planId, commentId) =>
@@ -157,20 +157,26 @@ export const usePlanReviewStore = create<PlanReviewState>()((set) => ({
   reconcile: (planId, sections) =>
     set((state) => {
       const existing = state.comments[planId];
-      if (!existing) return state;
+      if (!existing) {
+        return state;
+      }
+
       const sectionMap = new Map(
         sections.map((section) => [section.id, section]),
       );
       const next = existing.map((comment) => {
         const section = sectionMap.get(comment.sectionId);
+        const sectionChanged =
+          !section ||
+          section.content !== comment.sectionContent ||
+          section.title !== comment.sectionTitle;
+
         return {
           ...comment,
-          stale:
-            !section ||
-            section.content !== comment.sectionContent ||
-            section.title !== comment.sectionTitle,
+          stale: sectionChanged,
         };
       });
+
       return { comments: { ...state.comments, [planId]: next } };
     }),
   clear: (planId) =>

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/PlanApprovalView.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/PlanApprovalView.tsx
@@ -68,7 +68,7 @@ export function PlanApprovalView({
               <ModelSelector taskId={taskId} />
             </Flex>
           )}
-          <PlanContent id={toolCall.toolCallId} plan={planText} />
+          <PlanContent id={toolCall.toolCallId} plan={planText} reviewable />
         </>
       )}
 


### PR DESCRIPTION
## Problem

People reviewing agent plans can read and approve or reject them, but cannot attach feedback to individual plan sections.

## Changes

- Add section-level comments to the inline plan review surface.
- Collect comments and submit them as one revision request through the existing approval flow.
- Mark comments stale when a streamed plan revision changes their section.
- Reuse the current Codex and Claude plan handoff protocol.

## How did you test this code?

- Added coverage for section parsing, stale comments, structured feedback, and approval integration.
- Verified that multiple comments and additional feedback produce one revision request.
- No manual visual testing was performed.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs update needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Codex using `/posthog-desktop`, `/writing-ui-components`, `/writing-user-facing-copy`, `/writing-tests`, and `/writing-pr-descriptions`. The design keeps review state in the desktop UI and preserves the existing adapter protocol.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
