### PR TITLE
feat(desktop): show github approval as a server-backed state and track connect abandonment

### DIFF
--- a/products/desktop/packages/api-client/src/posthog-client.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.ts
@@ -356,6 +356,18 @@ export interface UserGitHubIntegration {
   created_at?: string;
 }
 
+/** A personal GitHub App install awaiting (or granted) org-owner approval — the
+ * durable server-side counterpart to the in-flight connect spinner. See
+ * `GitHubInstallRequest` on the backend. */
+export interface GitHubInstallRequest {
+  id: string;
+  github_login: string;
+  status: "pending" | "approved";
+  installation_id?: string | null;
+  requested_at: string;
+  resolved_at?: string | null;
+}
+
 export interface LlmSkillCreatedBy {
   id?: number;
   email?: string | null;
@@ -1749,6 +1761,27 @@ export class PostHogAPIClient {
 
     const data = (await response.json()) as {
       results?: UserGitHubIntegration[];
+    };
+    return data.results ?? [];
+  }
+
+  async getGithubInstallRequests(): Promise<GitHubInstallRequest[]> {
+    const urlPath = `/api/users/@me/integrations/github/install_requests/`;
+    const url = new URL(`${this.api.baseUrl}${urlPath}`);
+    const response = await this.api.fetcher.fetch({
+      method: "get",
+      url,
+      path: urlPath,
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch GitHub install requests: ${response.statusText}`,
+      );
+    }
+
+    const data = (await response.json()) as {
+      results?: GitHubInstallRequest[];
     };
     return data.results ?? [];
   }

--- a/products/desktop/packages/api-client/src/posthog-client.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.ts
@@ -356,8 +356,8 @@ export interface UserGitHubIntegration {
   created_at?: string;
 }
 
-/** A personal GitHub App install awaiting (or granted) org-owner approval — the
- * durable server-side counterpart to the in-flight connect spinner. See
+/** A personal GitHub App install awaiting (or granted) org-owner approval; the
+ * durable server-side counterpart to the in-flight connect spinner. Mirrors
  * `GitHubInstallRequest` on the backend. */
 export interface GitHubInstallRequest {
   id: string;

--- a/products/desktop/packages/api-client/src/posthog-client.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.ts
@@ -362,7 +362,9 @@ export interface UserGitHubIntegration {
 export interface GitHubInstallRequest {
   id: string;
   github_login: string;
-  status: "pending" | "approved";
+  /** `unidentified` means the requester could not be resolved, so approval can
+   *  never be detected and the user has to restart the connect flow. */
+  status: "pending" | "approved" | "unidentified";
   installation_id?: string | null;
   requested_at: string;
   resolved_at?: string | null;

--- a/products/desktop/packages/core/src/integrations/connectErrors.test.ts
+++ b/products/desktop/packages/core/src/integrations/connectErrors.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { describeGithubConnectError } from "./connectErrors";
+import {
+  describeGithubConnectError,
+  isGithubConnectPendingApproval,
+} from "./connectErrors";
 
 describe("describeGithubConnectError", () => {
   it("returns an empty string for no error", () => {
@@ -16,5 +19,16 @@ describe("describeGithubConnectError", () => {
     expect(
       describeGithubConnectError({ message: "raw message", code: "unknown" }),
     ).toBe("raw message");
+  });
+});
+
+describe("isGithubConnectPendingApproval", () => {
+  it.each([
+    ["github_install_pending", true],
+    ["access_denied", false],
+    [null, false],
+    [undefined, false],
+  ])("code %s -> %s", (code, expected) => {
+    expect(isGithubConnectPendingApproval(code)).toBe(expected);
   });
 });

--- a/products/desktop/packages/core/src/integrations/connectErrors.ts
+++ b/products/desktop/packages/core/src/integrations/connectErrors.ts
@@ -31,7 +31,19 @@ export const GITHUB_CONNECT_ERROR_MESSAGES: Record<string, string> = {
     "Couldn't get an access token from GitHub. Please retry.",
   integration_create_failed:
     "Couldn't save the GitHub connection. Please retry.",
+  github_install_pending:
+    "PostHog needs approval from a GitHub org owner. We sent the request. Until it's approved, your tasks run on your machine. Once it's approved, connect again.",
 };
+
+export const GITHUB_CONNECT_PENDING_APPROVAL_CODE = "github_install_pending";
+
+/** Travels on the error channel but is not a failure: the connect can still
+ * succeed once an org owner approves, so callers render it as informational. */
+export function isGithubConnectPendingApproval(
+  code: string | null | undefined,
+): boolean {
+  return code === GITHUB_CONNECT_PENDING_APPROVAL_CODE;
+}
 
 export function describeGithubConnectError(
   error: GithubConnectError | null,

--- a/products/desktop/packages/core/src/integrations/connectMachine.test.ts
+++ b/products/desktop/packages/core/src/integrations/connectMachine.test.ts
@@ -77,6 +77,7 @@ describe("invalidation keys", () => {
       ["integrations", "list"],
       ["user-github-integrations"],
       ["github_login"],
+      ["github-install-requests"],
     ]);
   });
 

--- a/products/desktop/packages/core/src/integrations/connectMachine.ts
+++ b/products/desktop/packages/core/src/integrations/connectMachine.ts
@@ -1,3 +1,5 @@
+import { githubInstallRequestKeys } from "./repositoryKeys";
+
 export type ConnectState = "idle" | "connecting" | "timed-out" | "error";
 
 export interface ConnectError {
@@ -76,7 +78,7 @@ export function githubInvalidationKeys(
   keys.push(["integrations", "list"]);
   keys.push(["user-github-integrations"]);
   keys.push(["github_login"]);
-  keys.push(["github-install-requests"]);
+  keys.push([...githubInstallRequestKeys.all]);
   return keys;
 }
 

--- a/products/desktop/packages/core/src/integrations/connectMachine.ts
+++ b/products/desktop/packages/core/src/integrations/connectMachine.ts
@@ -76,6 +76,7 @@ export function githubInvalidationKeys(
   keys.push(["integrations", "list"]);
   keys.push(["user-github-integrations"]);
   keys.push(["github_login"]);
+  keys.push(["github-install-requests"]);
   return keys;
 }
 

--- a/products/desktop/packages/core/src/integrations/repositoryKeys.ts
+++ b/products/desktop/packages/core/src/integrations/repositoryKeys.ts
@@ -64,6 +64,13 @@ export const userGithubIntegrationKeys = {
     ] as const,
 };
 
+// Matches the literal key `githubInvalidationKeys` in connectMachine.ts pushes after a
+// successful connect, so a fresh connect invalidates the pending/approved request list too.
+export const githubInstallRequestKeys = {
+  all: ["github-install-requests"] as const,
+  list: () => [...githubInstallRequestKeys.all, "list"] as const,
+};
+
 export interface RepositoryRefetchKey {
   queryKey: ReadonlyArray<unknown>;
   exact: boolean;

--- a/products/desktop/packages/core/src/integrations/repositoryKeys.ts
+++ b/products/desktop/packages/core/src/integrations/repositoryKeys.ts
@@ -64,8 +64,6 @@ export const userGithubIntegrationKeys = {
     ] as const,
 };
 
-// Matches the literal key `githubInvalidationKeys` in connectMachine.ts pushes after a
-// successful connect, so a fresh connect invalidates the pending/approved request list too.
 export const githubInstallRequestKeys = {
   all: ["github-install-requests"] as const,
   list: () => [...githubInstallRequestKeys.all, "list"] as const,

--- a/products/desktop/packages/core/src/onboarding/githubConnectPanel.test.ts
+++ b/products/desktop/packages/core/src/onboarding/githubConnectPanel.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from "vitest";
 import { GITHUB_CONNECT_TIMEOUT_MESSAGE } from "../integrations/connectErrors";
 import {
+  buildConnectAbandonedProps,
   buildConnectFailedProps,
   buildConnectFailureFingerprint,
   buildInstallationSettingsUrl,
   deriveAlternativeConnectedProjects,
   deriveConnectButtonState,
+  deriveGithubApprovalState,
   getGithubPanelMessage,
   isAnyIntegrationStale,
   resolveSelectedProjectId,
@@ -173,6 +175,28 @@ describe("buildConnectFailedProps", () => {
   });
 });
 
+describe("buildConnectAbandonedProps", () => {
+  it("carries the flow type and rounds the elapsed seconds", () => {
+    expect(
+      buildConnectAbandonedProps({
+        flowType: "user_new",
+        startedAtMs: 1_000,
+        nowMs: 1_000 + 12_400,
+      }),
+    ).toEqual({ flow_type: "user_new", seconds_since_started: 12 });
+  });
+
+  it("never reports a negative duration", () => {
+    expect(
+      buildConnectAbandonedProps({
+        flowType: "team_existing",
+        startedAtMs: 10_000,
+        nowMs: 1_000,
+      }),
+    ).toEqual({ flow_type: "team_existing", seconds_since_started: 0 });
+  });
+});
+
 describe("deriveConnectButtonState", () => {
   it("is a fresh connect when idle", () => {
     expect(
@@ -202,5 +226,54 @@ describe("deriveConnectButtonState", () => {
         timedOut: true,
       }),
     ).toEqual({ isRetry: true, shouldReset: false, label: "Retry connection" });
+  });
+});
+
+describe("deriveGithubApprovalState", () => {
+  it.each([
+    [
+      "this attempt just came back pending",
+      "github_install_pending",
+      [],
+      false,
+      "awaiting",
+    ],
+    [
+      "a pending request row exists server-side",
+      null,
+      [{ status: "pending" }],
+      false,
+      "awaiting",
+    ],
+    [
+      "an approved request exists but no integration is linked yet",
+      null,
+      [{ status: "approved" }],
+      false,
+      "approved",
+    ],
+    [
+      "an existing integration wins over a stale approved row",
+      null,
+      [{ status: "approved" }],
+      true,
+      "none",
+    ],
+    [
+      "an existing integration wins over a stale pending row",
+      null,
+      [{ status: "pending" }],
+      true,
+      "none",
+    ],
+    ["nothing pending or approved", null, [], false, "none"],
+  ] as const)("%s", (_label, errorCode, requests, hasIntegration, expected) => {
+    expect(
+      deriveGithubApprovalState({
+        errorCode,
+        requests: [...requests],
+        hasIntegration,
+      }),
+    ).toBe(expected);
   });
 });

--- a/products/desktop/packages/core/src/onboarding/githubConnectPanel.ts
+++ b/products/desktop/packages/core/src/onboarding/githubConnectPanel.ts
@@ -144,7 +144,7 @@ export function deriveConnectButtonState(inputs: {
 export type GithubApprovalState = "none" | "awaiting" | "approved";
 
 export interface GithubInstallRequestSummary {
-  status: "pending" | "approved";
+  status: "pending" | "approved" | "unidentified";
 }
 
 export interface DeriveGithubApprovalStateInputs {

--- a/products/desktop/packages/core/src/onboarding/githubConnectPanel.ts
+++ b/products/desktop/packages/core/src/onboarding/githubConnectPanel.ts
@@ -1,4 +1,8 @@
-import { GITHUB_CONNECT_TIMEOUT_MESSAGE } from "../integrations/connectErrors";
+import type { OnboardingGithubConnectFlow } from "@posthog/shared/analytics-events";
+import {
+  GITHUB_CONNECT_TIMEOUT_MESSAGE,
+  isGithubConnectPendingApproval,
+} from "../integrations/connectErrors";
 import { POSTHOG_GITHUB_APP_URL } from "../integrations/githubApp";
 
 export interface GithubPanelMessageOptions {
@@ -94,6 +98,29 @@ export function buildConnectFailedProps(
   };
 }
 
+export interface ConnectAbandonedInputs {
+  flowType: OnboardingGithubConnectFlow;
+  startedAtMs: number;
+  nowMs: number;
+}
+
+export interface ConnectAbandonedProps {
+  flow_type: OnboardingGithubConnectFlow;
+  seconds_since_started: number;
+}
+
+export function buildConnectAbandonedProps(
+  inputs: ConnectAbandonedInputs,
+): ConnectAbandonedProps {
+  return {
+    flow_type: inputs.flowType,
+    seconds_since_started: Math.max(
+      0,
+      Math.round((inputs.nowMs - inputs.startedAtMs) / 1000),
+    ),
+  };
+}
+
 export interface ConnectButtonState {
   isRetry: boolean;
   shouldReset: boolean;
@@ -112,4 +139,35 @@ export function deriveConnectButtonState(inputs: {
       ? "Try again"
       : "Connect GitHub";
   return { isRetry, shouldReset: inputs.hasConnectError, label };
+}
+
+export type GithubApprovalState = "none" | "awaiting" | "approved";
+
+export interface GithubInstallRequestSummary {
+  status: "pending" | "approved";
+}
+
+export interface DeriveGithubApprovalStateInputs {
+  errorCode: string | null | undefined;
+  requests: GithubInstallRequestSummary[];
+  hasIntegration: boolean;
+}
+
+/** Reads the durable server-side "awaiting org owner approval" state (see
+ * `GitHubInstallRequest` on the backend), plus the in-flight callback error so the
+ * panel shows the wait immediately after the redirect, before the request list
+ * has had a chance to refetch. An existing integration always wins: once linked,
+ * any leftover request rows are stale history, not current state. */
+export function deriveGithubApprovalState(
+  inputs: DeriveGithubApprovalStateInputs,
+): GithubApprovalState {
+  if (inputs.hasIntegration) return "none";
+  if (isGithubConnectPendingApproval(inputs.errorCode)) return "awaiting";
+  if (inputs.requests.some((request) => request.status === "pending")) {
+    return "awaiting";
+  }
+  if (inputs.requests.some((request) => request.status === "approved")) {
+    return "approved";
+  }
+  return "none";
 }

--- a/products/desktop/packages/shared/src/analytics-events.ts
+++ b/products/desktop/packages/shared/src/analytics-events.ts
@@ -548,6 +548,15 @@ export interface OnboardingGithubConnectFailedProperties {
   error_type?: string;
 }
 
+export interface OnboardingGithubConnectPendingAdminProperties {
+  flow_type: OnboardingGithubConnectFlow;
+}
+
+export interface OnboardingGithubConnectAbandonedProperties {
+  flow_type: OnboardingGithubConnectFlow;
+  seconds_since_started: number;
+}
+
 export interface OnboardingAbandonedProperties {
   last_step_id: OnboardingStepId;
   duration_seconds: number;
@@ -1421,6 +1430,9 @@ export const ANALYTICS_EVENTS = {
   ONBOARDING_FOLDER_SELECTED: "Onboarding folder selected",
   ONBOARDING_GITHUB_CONNECT_STARTED: "Onboarding github connect started",
   ONBOARDING_GITHUB_CONNECT_FAILED: "Onboarding github connect failed",
+  ONBOARDING_GITHUB_CONNECT_PENDING_ADMIN:
+    "Onboarding github connect pending admin",
+  ONBOARDING_GITHUB_CONNECT_ABANDONED: "Onboarding github connect abandoned",
   ONBOARDING_GITHUB_CONNECTED: "Onboarding github connected",
   ONBOARDING_CLI_CHECK_COMPLETED: "Onboarding cli check completed",
   ONBOARDING_CLI_RUN_COMPLETED: "Onboarding cli run completed",
@@ -1604,6 +1616,8 @@ export type EventPropertyMap = {
   [ANALYTICS_EVENTS.ONBOARDING_FOLDER_SELECTED]: OnboardingFolderSelectedProperties;
   [ANALYTICS_EVENTS.ONBOARDING_GITHUB_CONNECT_STARTED]: OnboardingGithubConnectStartedProperties;
   [ANALYTICS_EVENTS.ONBOARDING_GITHUB_CONNECT_FAILED]: OnboardingGithubConnectFailedProperties;
+  [ANALYTICS_EVENTS.ONBOARDING_GITHUB_CONNECT_PENDING_ADMIN]: OnboardingGithubConnectPendingAdminProperties;
+  [ANALYTICS_EVENTS.ONBOARDING_GITHUB_CONNECT_ABANDONED]: OnboardingGithubConnectAbandonedProperties;
   [ANALYTICS_EVENTS.ONBOARDING_GITHUB_CONNECTED]: never;
   [ANALYTICS_EVENTS.ONBOARDING_CLI_CHECK_COMPLETED]: OnboardingCliCheckCompletedProperties;
   [ANALYTICS_EVENTS.ONBOARDING_CLI_RUN_COMPLETED]: OnboardingCliRunCompletedProperties;

--- a/products/desktop/packages/ui/src/features/integrations/GithubApprovalNotice.tsx
+++ b/products/desktop/packages/ui/src/features/integrations/GithubApprovalNotice.tsx
@@ -1,0 +1,37 @@
+import { CheckCircle, Clock } from "@phosphor-icons/react";
+import { cn } from "@posthog/quill";
+
+export function GithubApprovalNotice({
+  state,
+  className,
+}: {
+  state: "awaiting" | "approved";
+  className?: string;
+}) {
+  if (state === "awaiting") {
+    return (
+      <div className={cn("flex flex-col gap-1", className)}>
+        <div className="flex items-center gap-2 font-medium text-(--gray-12) text-sm">
+          <Clock size={16} className="text-(--amber-11)" />
+          Waiting for a GitHub org owner to approve
+        </div>
+        <span className="text-(--gray-11) text-sm">
+          Cloud runs will not be available until your integration is approved.
+          In the meantime, you can run tasks on your local machine.
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-2 font-medium text-(--gray-12) text-sm",
+        className,
+      )}
+    >
+      <CheckCircle size={16} weight="fill" className="text-(--green-9)" />
+      Your GitHub org owner approved the request
+    </div>
+  );
+}

--- a/products/desktop/packages/ui/src/features/integrations/useIntegrations.ts
+++ b/products/desktop/packages/ui/src/features/integrations/useIntegrations.ts
@@ -25,6 +25,7 @@ import {
 } from "@posthog/core/integrations/repositories";
 import type { RepositoriesService } from "@posthog/core/integrations/repositoriesService";
 import {
+  githubInstallRequestKeys,
   integrationKeys,
   type RepositoryRefetchKey,
   userGithubIntegrationKeys,
@@ -110,6 +111,23 @@ function useAllGithubRepositories(githubIntegrations: Integration[]) {
 export function useUserGithubIntegrations() {
   return useAuthenticatedQuery(userGithubIntegrationKeys.list(), (client) =>
     client.getGithubUserIntegrations(),
+  );
+}
+
+/** The durable "awaiting org owner approval" state (see `GitHubInstallRequest` on the
+ * backend) — polled only while a request is still pending, since an approved or empty
+ * list never changes again on its own. */
+export function useGithubInstallRequests() {
+  return useAuthenticatedQuery(
+    githubInstallRequestKeys.list(),
+    (client) => client.getGithubInstallRequests(),
+    {
+      refetchInterval: (query) =>
+        (query.state.data ?? []).some((request) => request.status === "pending")
+          ? 30_000
+          : false,
+      refetchOnWindowFocus: true,
+    },
   );
 }
 

--- a/products/desktop/packages/ui/src/features/integrations/useIntegrations.ts
+++ b/products/desktop/packages/ui/src/features/integrations/useIntegrations.ts
@@ -114,9 +114,7 @@ export function useUserGithubIntegrations() {
   );
 }
 
-/** The durable "awaiting org owner approval" state (see `GitHubInstallRequest` on the
- * backend) — polled only while a request is still pending, since an approved or empty
- * list never changes again on its own. */
+// Polls only while pending; an approved or empty list never changes on its own.
 export function useGithubInstallRequests() {
   return useAuthenticatedQuery(
     githubInstallRequestKeys.list(),

--- a/products/desktop/packages/ui/src/features/onboarding/components/GitHubConnectPanel.tsx
+++ b/products/desktop/packages/ui/src/features/onboarding/components/GitHubConnectPanel.tsx
@@ -158,8 +158,6 @@ export function GitHubConnectPanel() {
     const fingerprint = buildConnectFailureFingerprint(failureInputs);
     if (!connectService.shouldReportFailure(fingerprint)) return;
     if (isPendingApproval) {
-      // The pending marker itself is written in useConnectStateMachine; only
-      // the onboarding-scoped event lives here.
       track(ANALYTICS_EVENTS.ONBOARDING_GITHUB_CONNECT_PENDING_ADMIN, {
         flow_type: flowType,
       });

--- a/products/desktop/packages/ui/src/features/onboarding/components/GitHubConnectPanel.tsx
+++ b/products/desktop/packages/ui/src/features/onboarding/components/GitHubConnectPanel.tsx
@@ -2,7 +2,6 @@ import {
   ArrowSquareOut,
   ArrowsClockwise,
   CheckCircle,
-  Clock,
   GearSix,
   GithubLogo,
   Plus,
@@ -27,6 +26,7 @@ import { Button as QuillButton } from "@posthog/quill";
 import type { OnboardingGithubConnectFlow } from "@posthog/shared/analytics-events";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
+import { GithubApprovalNotice } from "@posthog/ui/features/integrations/GithubApprovalNotice";
 import { useGithubDisconnect } from "@posthog/ui/features/integrations/useGithubDisconnect";
 import {
   describeGithubConnectError,
@@ -323,26 +323,9 @@ export function GitHubConnectPanel() {
                   .
                 </Text>
               ) : isAwaitingApproval ? (
-                <div className="flex flex-col gap-1 pt-3">
-                  <div className="flex items-center gap-2 font-medium text-(--gray-12) text-sm">
-                    <Clock size={16} className="text-(--amber-11)" />
-                    Waiting for a GitHub org owner to approve
-                  </div>
-                  <span className="text-(--gray-11) text-sm">
-                    Cloud runs will not be available until your integration is
-                    approved. In the meantime, you can run tasks on your local
-                    machine.
-                  </span>
-                </div>
+                <GithubApprovalNotice state="awaiting" className="pt-3" />
               ) : isApprovedNotLinked ? (
-                <div className="flex items-center gap-2 pt-3 font-medium text-(--gray-12) text-sm">
-                  <CheckCircle
-                    size={16}
-                    weight="fill"
-                    className="text-(--green-9)"
-                  />
-                  Your GitHub org owner approved the request
-                </div>
+                <GithubApprovalNotice state="approved" className="pt-3" />
               ) : (
                 <Text
                   className={

--- a/products/desktop/packages/ui/src/features/onboarding/components/GitHubConnectPanel.tsx
+++ b/products/desktop/packages/ui/src/features/onboarding/components/GitHubConnectPanel.tsx
@@ -2,16 +2,20 @@ import {
   ArrowSquareOut,
   ArrowsClockwise,
   CheckCircle,
+  Clock,
   GearSix,
   GithubLogo,
   Plus,
 } from "@phosphor-icons/react";
+import { isGithubConnectPendingApproval } from "@posthog/core/integrations/connectErrors";
 import {
+  buildConnectAbandonedProps,
   buildConnectFailedProps,
   buildConnectFailureFingerprint,
   buildInstallationSettingsUrl,
   deriveAlternativeConnectedProjects,
   deriveConnectButtonState,
+  deriveGithubApprovalState,
   getGithubPanelMessage,
   isAnyIntegrationStale,
   resolveSelectedProjectId,
@@ -19,6 +23,7 @@ import {
 import type { GithubConnectService } from "@posthog/core/onboarding/githubConnectService";
 import { GITHUB_CONNECT_SERVICE } from "@posthog/core/onboarding/identifiers";
 import { useService } from "@posthog/di/react";
+import { Button as QuillButton } from "@posthog/quill";
 import type { OnboardingGithubConnectFlow } from "@posthog/shared/analytics-events";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
@@ -28,6 +33,7 @@ import {
   useGithubConnect,
 } from "@posthog/ui/features/integrations/useGithubUserConnect";
 import {
+  useGithubInstallRequests,
   useUserGithubIntegrations,
   useUserRepositoryIntegration,
 } from "@posthog/ui/features/integrations/useIntegrations";
@@ -48,7 +54,7 @@ import {
   Text,
 } from "@radix-ui/themes";
 import { useQueryClient } from "@tanstack/react-query";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 export function GitHubConnectPanel() {
   const queryClient = useQueryClient();
@@ -75,6 +81,13 @@ export function GitHubConnectPanel() {
     [projects, selectedProjectId],
   );
 
+  // Armed on connect start, cleared on any terminal outcome, so an unmount in
+  // between is reported as an abandoned connect.
+  const inFlightConnectRef = useRef<{
+    flowType: OnboardingGithubConnectFlow;
+    startedAtMs: number;
+  } | null>(null);
+
   const {
     error: connectError,
     isConnecting,
@@ -85,11 +98,17 @@ export function GitHubConnectPanel() {
   } = useGithubConnect({
     projectId: selectedProjectId,
     projectHasTeamIntegration: selectedProject?.hasGithubIntegration ?? null,
-    onConnected: () => track(ANALYTICS_EVENTS.ONBOARDING_GITHUB_CONNECTED),
+    onConnected: () => {
+      inFlightConnectRef.current = null;
+      track(ANALYTICS_EVENTS.ONBOARDING_GITHUB_CONNECTED);
+    },
   });
   const canTakeAction = !isConnecting && !timedOut && !hasConnectError;
+  const isPendingApproval = isGithubConnectPendingApproval(connectError?.code);
 
-  const initiateConnect = (
+  // Every path that begins a connect, including reconnect, must go through
+  // this, or its "started" event has no abandoned counterpart.
+  const markConnectStarted = (
     flowType: OnboardingGithubConnectFlow,
     isRetry = false,
   ) => {
@@ -97,8 +116,31 @@ export function GitHubConnectPanel() {
       flow_type: flowType,
       is_retry: isRetry,
     });
+    inFlightConnectRef.current = { flowType, startedAtMs: Date.now() };
+  };
+
+  const initiateConnect = (
+    flowType: OnboardingGithubConnectFlow,
+    isRetry = false,
+  ) => {
+    markConnectStarted(flowType, isRetry);
     void handleConnectGitHub();
   };
+
+  useEffect(() => {
+    return () => {
+      const inFlight = inFlightConnectRef.current;
+      if (!inFlight) return;
+      track(
+        ANALYTICS_EVENTS.ONBOARDING_GITHUB_CONNECT_ABANDONED,
+        buildConnectAbandonedProps({
+          flowType: inFlight.flowType,
+          startedAtMs: inFlight.startedAtMs,
+          nowMs: Date.now(),
+        }),
+      );
+    };
+  }, []);
 
   const connectService = useService<GithubConnectService>(
     GITHUB_CONNECT_SERVICE,
@@ -109,13 +151,31 @@ export function GitHubConnectPanel() {
       timedOut,
       errorCode: connectError?.code,
     };
+    // Any terminal outcome ends the in-flight attempt, even one the dedupe below
+    // decides not to report again.
+    const flowType = inFlightConnectRef.current?.flowType ?? "user_new";
+    inFlightConnectRef.current = null;
     const fingerprint = buildConnectFailureFingerprint(failureInputs);
     if (!connectService.shouldReportFailure(fingerprint)) return;
+    if (isPendingApproval) {
+      // The pending marker itself is written in useConnectStateMachine; only
+      // the onboarding-scoped event lives here.
+      track(ANALYTICS_EVENTS.ONBOARDING_GITHUB_CONNECT_PENDING_ADMIN, {
+        flow_type: flowType,
+      });
+      return;
+    }
     track(
       ANALYTICS_EVENTS.ONBOARDING_GITHUB_CONNECT_FAILED,
       buildConnectFailedProps(failureInputs),
     );
-  }, [hasConnectError, timedOut, connectError, connectService]);
+  }, [
+    hasConnectError,
+    timedOut,
+    connectError,
+    connectService,
+    isPendingApproval,
+  ]);
 
   const defaultPanelMessage = getGithubPanelMessage({
     hasConnectError,
@@ -129,6 +189,14 @@ export function GitHubConnectPanel() {
     isLoading: githubUserIntegrationsLoading,
   } = useUserGithubIntegrations();
   const hasGitIntegration = githubUserIntegrations.length > 0;
+  const { data: githubInstallRequests = [] } = useGithubInstallRequests();
+  const approvalState = deriveGithubApprovalState({
+    errorCode: connectError?.code,
+    requests: githubInstallRequests,
+    hasIntegration: hasGitIntegration,
+  });
+  const isAwaitingApproval = approvalState === "awaiting";
+  const isApprovedNotLinked = approvalState === "approved";
   const { failedInstallationIds, reposByInstallationId } =
     useUserRepositoryIntegration();
   const anyIntegrationStale = isAnyIntegrationStale(
@@ -256,6 +324,25 @@ export function GitHubConnectPanel() {
                   )}
                   .
                 </Text>
+              ) : isAwaitingApproval ? (
+                <div className="flex flex-col gap-1 pt-3">
+                  <div className="flex items-center gap-2 font-medium text-(--gray-12) text-sm">
+                    <Clock size={16} className="text-(--amber-11)" />
+                    Waiting for a GitHub org owner to approve
+                  </div>
+                  <span className="text-(--gray-11) text-sm">
+                    Tasks run on your machine until then. You can keep going.
+                  </span>
+                </div>
+              ) : isApprovedNotLinked ? (
+                <div className="flex items-center gap-2 pt-3 font-medium text-(--gray-12) text-sm">
+                  <CheckCircle
+                    size={16}
+                    weight="fill"
+                    className="text-(--green-9)"
+                  />
+                  Your GitHub org owner approved the request
+                </div>
               ) : (
                 <Text
                   className={
@@ -322,10 +409,7 @@ export function GitHubConnectPanel() {
                             !isReconnecting
                           }
                           onClick={async () => {
-                            track(
-                              ANALYTICS_EVENTS.ONBOARDING_GITHUB_CONNECT_STARTED,
-                              { flow_type: "user_new", is_retry: true },
-                            );
+                            markConnectStarted("user_new", true);
                             setReconnectingInstallationId(installationId);
                             try {
                               await reconnect(
@@ -400,6 +484,17 @@ export function GitHubConnectPanel() {
                 </Button>
               </Flex>
             </Flex>
+          ) : isAwaitingApproval ? null : isApprovedNotLinked ? (
+            <QuillButton
+              variant="primary"
+              size="sm"
+              className="self-start"
+              loading={isConnecting}
+              onClick={() => initiateConnect("user_new")}
+            >
+              Connect GitHub
+              <ArrowSquareOut size={12} />
+            </QuillButton>
           ) : !isLoading && !githubUserIntegrationsLoading ? (
             selectedProject?.hasGithubIntegration && canTakeAction ? (
               <Button

--- a/products/desktop/packages/ui/src/features/onboarding/components/GitHubConnectPanel.tsx
+++ b/products/desktop/packages/ui/src/features/onboarding/components/GitHubConnectPanel.tsx
@@ -402,6 +402,11 @@ export function GitHubConnectPanel() {
                                 installationId,
                                 handleConnectGitHub,
                               );
+                            } catch {
+                              // The pre-connect disconnect failed, so no
+                              // connect flow ever started; a later unmount
+                              // must not report this as user abandonment.
+                              inFlightConnectRef.current = null;
                             } finally {
                               setReconnectingInstallationId(null);
                             }

--- a/products/desktop/packages/ui/src/features/onboarding/components/GitHubConnectPanel.tsx
+++ b/products/desktop/packages/ui/src/features/onboarding/components/GitHubConnectPanel.tsx
@@ -151,11 +151,14 @@ export function GitHubConnectPanel() {
       timedOut,
       errorCode: connectError?.code,
     };
-    // Any terminal outcome ends the in-flight attempt, even one the dedupe below
-    // decides not to report again.
-    const flowType = inFlightConnectRef.current?.flowType ?? "user_new";
-    inFlightConnectRef.current = null;
     const fingerprint = buildConnectFailureFingerprint(failureInputs);
+    const flowType = inFlightConnectRef.current?.flowType ?? "user_new";
+    // Clear the marker only on a terminal outcome — even a deduped one. A
+    // non-terminal re-run (a retry moving error/timeout back to connecting)
+    // must leave it intact so a later unmount still records the abandonment.
+    if (fingerprint !== null) {
+      inFlightConnectRef.current = null;
+    }
     if (!connectService.shouldReportFailure(fingerprint)) return;
     if (isPendingApproval) {
       track(ANALYTICS_EVENTS.ONBOARDING_GITHUB_CONNECT_PENDING_ADMIN, {

--- a/products/desktop/packages/ui/src/features/onboarding/components/GitHubConnectPanel.tsx
+++ b/products/desktop/packages/ui/src/features/onboarding/components/GitHubConnectPanel.tsx
@@ -329,7 +329,9 @@ export function GitHubConnectPanel() {
                     Waiting for a GitHub org owner to approve
                   </div>
                   <span className="text-(--gray-11) text-sm">
-                    Tasks run on your machine until then. You can keep going.
+                    Cloud runs will not be available until your integration is
+                    approved. In the meantime, you can run tasks on your local
+                    machine.
                   </span>
                 </div>
               ) : isApprovedNotLinked ? (

--- a/products/desktop/packages/ui/src/features/settings/sections/GitHubSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/GitHubSettings.tsx
@@ -8,16 +8,19 @@ import {
   WarningIcon,
 } from "@phosphor-icons/react";
 import type { UserGitHubIntegration } from "@posthog/api-client/posthog-client";
+import { deriveGithubApprovalState } from "@posthog/core/onboarding/githubConnectPanel";
 import { githubInstallationSettingsUrl } from "@posthog/core/settings/githubRepoSummary";
 import { formatRelativeTimeLong } from "@posthog/shared";
 import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
+import { GithubApprovalNotice } from "@posthog/ui/features/integrations/GithubApprovalNotice";
 import {
   describeGithubConnectError,
   invalidateGithubQueries,
   useGithubUserConnect,
 } from "@posthog/ui/features/integrations/useGithubUserConnect";
 import {
+  useGithubInstallRequests,
   useUserGithubIntegrations,
   useUserRepositoryIntegration,
 } from "@posthog/ui/features/integrations/useIntegrations";
@@ -54,6 +57,13 @@ export function GitHubSettings() {
   } = useGithubUserConnect({ projectId });
   const canConnect = projectId != null && cloudRegion != null && !isConnecting;
 
+  const { data: installRequests = [] } = useGithubInstallRequests();
+  const approvalState = deriveGithubApprovalState({
+    errorCode: error?.code,
+    requests: installRequests,
+    hasIntegration: integrations.length > 0,
+  });
+
   const handleConnect = () => {
     if (hasConnectError) reset();
     void connect();
@@ -83,11 +93,13 @@ export function GitHubSettings() {
         </Button>
       </Flex>
 
-      {hasConnectError && (
+      {approvalState !== "none" ? (
+        <GithubApprovalNotice state={approvalState} />
+      ) : hasConnectError ? (
         <Text className="text-(--red-11) text-[13px]">
           {describeGithubConnectError(error)}
         </Text>
-      )}
+      ) : null}
 
       <Flex direction="column" className="border-(--gray-5) border-t">
         {isLoading ? (


### PR DESCRIPTION
## Problem

we don't handle the github integration "pending approval" case in the app

## Changes

checks for pending github integrations from the server, and shows a UI that communicates the pending status

for both onboarding & settings

this UI is probably not final ... just getting the system ready by updating the existing pages for now

<img width="3024" height="1732" alt="gh-panel-B-awaiting" src="https://github.com/user-attachments/assets/aa09975d-998a-4d00-932d-18f30d81e7db" />
<img width="3024" height="1732" alt="gh-panel-C-approved" src="https://github.com/user-attachments/assets/7b9ee728-e22a-40e5-9b8c-2906e2dfe906" />
<img width="2016" height="1732" alt="gh-settings-approved" src="https://github.com/user-attachments/assets/71cc8f41-aea5-4a71-9cef-27452a0b971b" />
<img width="2016" height="1732" alt="gh-settings-awaiting" src="https://github.com/user-attachments/assets/e0e3be3b-7b45-4ce1-99c9-8a3c363a1e21" />


## How did you test this code?

agent-driven tests over CDP

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Fable 5) directed by the assignee; implementation delegated to Sonnet subagents across several passes and reviewed between them.
- Skills invoked: /writing-tests, /writing-user-facing-copy, /writing-pr-descriptions, /stacking-prs, /deslop, /remove-dumb-comments.
- Decisions: earlier iterations kept a client-side pending marker with identity scoping, hydration deferral, and a server refetch guard, plus a "next tasks run in the cloud" celebration and an automatic cloud default flip. All of that was removed once the wait became server state; the in-flight state machine and the passive wait are now separate concerns, and the default run mode is left alone.
