### PR TITLE
fix(google_analytics): retry transient token-refresh errors during report fetch

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/google_analytics.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/google_analytics.py
@@ -9,6 +9,7 @@ from django.db import OperationalError, close_old_connections
 
 import requests
 import structlog
+from google.auth.exceptions import RefreshError
 from google.auth.transport.requests import AuthorizedSession
 from google.oauth2.credentials import Credentials as OAuthCredentials
 
@@ -165,6 +166,23 @@ def _runreport_backoff_seconds(response: requests.Response, attempt: int) -> flo
     return RUNREPORT_BACKOFF_BASE_SECONDS * (2**attempt)
 
 
+def _is_transient_refresh_error(error: RefreshError) -> bool:
+    """Whether an OAuth token-refresh failure is a transient server-side blip worth retrying.
+
+    `AuthorizedSession` refreshes the access token before the Data API request, so a failing
+    token endpoint raises `RefreshError` from `session.post` before any response object exists —
+    the 5xx handling below never sees it. google-auth flags 500/503/504/408/429 (and JSON
+    `server_error`/`temporarily_unavailable`) as retryable, but omits 502 from its retryable
+    status codes, so a Bad Gateway from the token endpoint surfaces as a `RefreshError(retryable=False)`
+    carrying an HTML error page. Treat those as transient too. Permanent failures (`invalid_grant`,
+    `invalid_scope`) stay non-transient so they bubble up to `get_non_retryable_errors`.
+    """
+    if getattr(error, "retryable", False):
+        return True
+    message = str(error)
+    return "502" in message and "Server Error" in message
+
+
 def _run_report(
     session: AuthorizedSession,
     property_id: str,
@@ -188,7 +206,26 @@ def _run_report(
     url = f"{GA4_API_BASE}/properties/{pid}:runReport"
 
     for attempt in range(RUNREPORT_MAX_RETRIES + 1):
-        response = session.post(url, json=body)
+        try:
+            response = session.post(url, json=body)
+        except RefreshError as e:
+            # A transient 5xx from Google's OAuth token endpoint (notably a 502, which
+            # google-auth doesn't count as retryable) is raised here while AuthorizedSession
+            # refreshes the access token, before any response exists. It clears on its own, so
+            # retry inline like a 5xx; permanent failures (invalid_grant / invalid_scope) bubble
+            # up so `get_non_retryable_errors` can stop the sync.
+            if not _is_transient_refresh_error(e) or attempt == RUNREPORT_MAX_RETRIES:
+                raise
+            wait = RUNREPORT_BACKOFF_BASE_SECONDS * (2**attempt)
+            logger.warning(
+                "GA4 runReport token refresh transient error, backing off",
+                property_id=pid,
+                attempt=attempt,
+                wait_seconds=wait,
+            )
+            time.sleep(wait)
+            continue
+
         if response.ok:
             return response.json()
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/tests/test_google_analytics.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/tests/test_google_analytics.py
@@ -8,6 +8,7 @@ from unittest import mock
 from django.db import OperationalError
 
 import requests
+from google.auth.exceptions import RefreshError
 
 from posthog.models.integration import Integration
 
@@ -28,6 +29,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.google_ana
     _initial_start_date,
     _is_quota_error,
     _is_retryable_server_error,
+    _is_transient_refresh_error,
     _iter_chunks,
     _parse_ga4_date,
     _resolve_window,
@@ -401,6 +403,75 @@ def test_run_report_raises_http_error_for_non_quota_failures(status_code):
     session.post.return_value = _fake_response(status_code)
 
     with pytest.raises(requests.HTTPError):
+        _run_report(
+            session=session,
+            property_id="123",
+            start_date="2026-04-01",
+            end_date="2026-04-30",
+            dimensions=["date"],
+            metrics=["totalUsers"],
+            offset=0,
+        )
+
+    assert session.post.call_count == 1
+
+
+# A Bad Gateway from Google's OAuth token endpoint arrives as an HTML page, not JSON.
+_HTML_502_BODY = (
+    "<!DOCTYPE html>\n<html lang=en>\n  <title>Error 502 (Server Error)!!1</title>\n"
+    "  <p><b>502.</b> That's an error.\n  <p>The server encountered a temporary error "
+    "and could not complete your request."
+)
+
+
+@pytest.mark.parametrize(
+    "error,expected",
+    [
+        # 502 gateway page: google-auth omits 502 from its retryable status codes, but it's transient.
+        (RefreshError(_HTML_502_BODY), True),
+        # google-auth flags 500/503/504/408/429 (and JSON server errors) retryable itself.
+        (RefreshError("temporarily_unavailable: try again later", retryable=True), True),
+        # Revoked/expired refresh token — permanent, must not be retried inline.
+        (RefreshError("invalid_grant: Token has been expired or revoked."), False),
+        (RefreshError("invalid_scope: Bad Request"), False),
+    ],
+)
+def test_is_transient_refresh_error(error, expected):
+    assert _is_transient_refresh_error(error) is expected
+
+
+def test_run_report_retries_transient_token_refresh_error_then_succeeds(monkeypatch):
+    monkeypatch.setattr(ga.time, "sleep", lambda _: None)
+    payload = {"rows": [], "rowCount": 0}
+    session = mock.MagicMock()
+    session.post.side_effect = [
+        # AuthorizedSession raises RefreshError from post() when the token endpoint 502s mid-refresh.
+        RefreshError(_HTML_502_BODY),
+        _fake_response(200, payload),
+    ]
+
+    result = _run_report(
+        session=session,
+        property_id="123",
+        start_date="2026-04-01",
+        end_date="2026-04-30",
+        dimensions=["date"],
+        metrics=["totalUsers"],
+        offset=0,
+    )
+
+    assert result == payload
+    assert session.post.call_count == 2
+
+
+def test_run_report_permanent_token_refresh_error_bubbles_without_retry(monkeypatch):
+    monkeypatch.setattr(ga.time, "sleep", lambda _: None)
+    session = mock.MagicMock()
+    session.post.side_effect = RefreshError("invalid_grant: Token has been expired or revoked.")
+
+    # A revoked/expired refresh token never recovers, so it must bubble on the first attempt
+    # (matching get_non_retryable_errors' "invalid_grant") rather than burning the inline budget.
+    with pytest.raises(RefreshError, match="invalid_grant"):
         _run_report(
             session=session,
             property_id="123",


### PR DESCRIPTION
## Problem

A Google Analytics warehouse sync failed and reported to error tracking when Google's OAuth token endpoint returned a transient 502 Bad Gateway page while refreshing the access token mid-sync ([issue](https://us.posthog.com/project/2/error_tracking/01a01112-c171-7e73-804f-94e53b51168e)).

- `AuthorizedSession.post()` raises `google.auth.exceptions.RefreshError` when a token refresh fails.
- google-auth flags 500/503/504/408/429 as retryable internally, but omits 502.
- The 502 case reached `_run_report` unhandled and crashed the whole import activity instead of retrying.

## Changes

- `_run_report` now catches `RefreshError` from `session.post()` and retries transient cases inline with the same backoff already used for quota/5xx responses.
- A new `_is_transient_refresh_error` helper treats a 502 gateway page, or anything google-auth itself flags `retryable=True`, as transient.
- Permanent failures (`invalid_grant`, `invalid_scope`) still bubble up so `get_non_retryable_errors` can stop the sync and prompt a reconnect.
- Mirrors the existing `_is_transient_refresh_error` pattern already shipped for the Google Search Console source.

## How did you test this code?

Added two cases to `test_run_report_*`: one confirms a transient 502 `RefreshError` is retried and the sync recovers, the other confirms a permanent `invalid_grant` `RefreshError` still bubbles on the first attempt. Neither existing test exercised a `RefreshError` raised from `session.post()` itself.

Ran the full `test_google_analytics.py` suite locally (69 passed) plus `ruff check`/`ruff format` and a repo-wide `mypy` run, all clean. Not run: a live sync against a real Google Analytics property.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude) triaged this from a PostHog error-tracking webhook, confirmed the failing frame lands in `_run_report` (google_analytics.py:191), and found the identical failure mode already fixed in the Google Search Console source. I ported that source's `_is_transient_refresh_error` pattern and added matching regression tests. No skills were invoked beyond investigating the error tracking issue and writing tests/PR descriptions per repo convention.