### PR TITLE
chore(ci): verify hobby preflight page reports healthy

### DIFF
--- a/bin/hobby-ci.py
+++ b/bin/hobby-ci.py
@@ -433,6 +433,31 @@ runcmd:
         # nosemgrep: python.lang.security.audit.insecure-transport.requests.request-with-http.request-with-http
         base_url = f"http://{self.droplet.ip_address}"
 
+        # The signup wizard gates on these keys from /_preflight, so they must
+        # report true once the stack is healthy (regression test for
+        # https://github.com/PostHog/posthog/issues/57899 and siblings).
+        preflight_required_keys = ["django", "redis", "plugins", "celery", "clickhouse", "kafka", "db", "object_storage"]
+        print("🩺 Checking /_preflight reports healthy...", flush=True)
+        preflight_deadline = time.time() + timeout_seconds
+        last_preflight_detail = ""
+        while time.time() < preflight_deadline:
+            try:
+                preflight_resp = requests.get(f"{base_url}/_preflight", timeout=10)
+                if preflight_resp.status_code == 200:
+                    failing_keys = [key for key in preflight_required_keys if not preflight_resp.json().get(key)]
+                    if not failing_keys:
+                        print("✅ Preflight reports all services healthy", flush=True)
+                        break
+                    last_preflight_detail = f"failing keys: {', '.join(failing_keys)}"
+                else:
+                    last_preflight_detail = f"HTTP {preflight_resp.status_code}"
+            except Exception as e:
+                last_preflight_detail = f"{type(e).__name__}: {e}"
+            print(f"   Preflight not healthy yet ({last_preflight_detail})", flush=True)
+            time.sleep(poll_interval)
+        else:
+            return False, f"Preflight never reported healthy within {timeout_seconds}s ({last_preflight_detail})"
+
         print("📝 Creating test user and fetching API keys via Django shell...", flush=True)
         script_path = os.path.join(os.path.dirname(__file__), "hobby-ci-setup-user.py")
         remote_script = "/tmp/hobby-ci-setup-user.py"
@@ -766,7 +791,7 @@ runcmd:
                 )
                 if query_resp.status_code == 200 and query_resp.json().get("results", []):
                     print(f"✅ Trace found after {attempt} poll(s)", flush=True)
-                    return True, "Events, log, exception issue, session recording, and trace ingested successfully"
+                    return True, "Preflight healthy; events, log, exception issue, session recording, and trace ingested successfully"
                 if query_resp.status_code != 200:
                     print(f"   Poll {attempt}: trace HTTP {query_resp.status_code}", flush=True)
                 else:

--- a/bin/hobby-ci.py
+++ b/bin/hobby-ci.py
@@ -436,13 +436,25 @@ runcmd:
         # The signup wizard gates on these keys from /_preflight, so they must
         # report true once the stack is healthy (regression test for
         # https://github.com/PostHog/posthog/issues/57899 and siblings).
-        preflight_required_keys = ["django", "redis", "plugins", "celery", "clickhouse", "kafka", "db", "object_storage"]
+        preflight_required_keys = [
+            "django",
+            "redis",
+            "plugins",
+            "celery",
+            "clickhouse",
+            "kafka",
+            "db",
+            "object_storage",
+        ]
         print("🩺 Checking /_preflight reports healthy...", flush=True)
         preflight_deadline = time.time() + timeout_seconds
         last_preflight_detail = ""
         while time.time() < preflight_deadline:
             try:
-                preflight_resp = requests.get(f"{base_url}/_preflight", timeout=10)
+                preflight_resp = requests.get(
+                    f"{base_url}/_preflight",  # nosemgrep: python.lang.security.audit.insecure-transport.requests.request-with-http.request-with-http
+                    timeout=10,
+                )
                 if preflight_resp.status_code == 200:
                     failing_keys = [key for key in preflight_required_keys if not preflight_resp.json().get(key)]
                     if not failing_keys:
@@ -791,7 +803,10 @@ runcmd:
                 )
                 if query_resp.status_code == 200 and query_resp.json().get("results", []):
                     print(f"✅ Trace found after {attempt} poll(s)", flush=True)
-                    return True, "Preflight healthy; events, log, exception issue, session recording, and trace ingested successfully"
+                    return (
+                        True,
+                        "Preflight healthy; events, log, exception issue, session recording, and trace ingested successfully",
+                    )
                 if query_resp.status_code != 200:
                     print(f"   Poll {attempt}: trace HTTP {query_resp.status_code}", flush=True)
                 else:

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -207,7 +207,11 @@ services:
             OBJECT_STORAGE_ENABLED: true
             CDP_REDIS_HOST: redis7
             CDP_REDIS_PORT: 6379
+            LOGS_REDIS_HOST: redis7
+            LOGS_REDIS_PORT: 6379
             LOGS_REDIS_TLS: 'false'
+            TRACES_REDIS_HOST: redis7
+            TRACES_REDIS_PORT: 6379
             TRACES_REDIS_TLS: 'false'
             # Every CDP process dual-writes to Valkey and refuses to start without a host.
             CDP_VALKEY_HOST: valkey


### PR DESCRIPTION
Robot:

## Problem

Two linked gaps, exposed one by the other:

1. The hobby CI smoke test proves events, logs, traces, session recordings, and exceptions round-trip on a deployed droplet - but it never calls `/_preflight`. The signup wizard gates on that endpoint, so a stack whose services are broken can still pass CI while every new hobby user is blocked at the wizard. Reported repeatedly: #57899, #58151, #57184.
2. On hobby, `/ _preflight` really does report `plugins: false` even when containers look fine. The smoke check added here caught itself failing: the hobby `plugins` service crash-loops because its `logs-redis` points at `127.0.0.1`. PR #82259 set `LOGS_REDIS_TLS`/`TRACES_REDIS_TLS` false for hobby but did not set `LOGS_REDIS_HOST`/`TRACES_REDIS_HOST`, which default to `127.0.0.1` in the Docker image. The container restarts forever under `restart: on-failure`, so `docker ps` looks mostly fine while the process dies over and over. Same mechanism the dirty-dozen report documents (#53405 issue 7). CI reproduces it because the hobby test falls back to `posthog-node:latest` for PRs that do not touch `nodejs/`, and users deploy the same class of image.

## Changes

- `bin/hobby-ci.py`: at the start of `smoke_test_ingestion`, poll `GET /_preflight` and require the wizard-gated health keys (`django`, `redis`, `plugins`, `celery`, `clickhouse`, `kafka`, `db`, `object_storage`) to be `true`. On timeout, fail with the keys still failing. The check runs only after the container stability window, so slow-boot false negatives are already gated out.
- `docker-compose.hobby.yml`: give the `plugins` service `LOGS_REDIS_HOST: redis7`, `LOGS_REDIS_PORT: 6379`, `TRACES_REDIS_HOST: redis7`, `TRACES_REDIS_PORT: 6379` so combined-mode plugin server images (including `posthog-node:latest`) connect to the bundled Redis instead of crash-looping.

## How did you test this code?

- First CI run on this PR proved the new check works: it failed with `plugins` red for the full run ([log](https://github.com/PostHog/posthog/actions/runs/32062519622/job/95491324629#step:11:44)).
- The downloaded droplet logs show the root cause: `plugins-1` constructing `LogsIngestionConsumer`, hitting `ECONNREFUSED 127.0.0.1:6379`, quitting, restarting.
- The preflight key set comes from the wizard's own gating list in `frontend/src/lib/logic/preflightLogic.tsx`; the compose fix mirrors the dedicated `ingestion-logs` / `ingestion-traces` services in `docker-compose.base.yml`.
- `python3 -m py_compile`, `ruff check`, and a YAML parse of the compose file pass.
- The full round trip re-runs in this PR's CI.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Assessed the gap from issues #57899 / #58151 / #57184, added the preflight assertion, then diagnosed the resulting CI failure from the droplet logs and fixed the hobby compose env. No customer data involved.
