### PR TITLE
fix(postgres): map UUID columns to Arrow string when absent from schema

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/arrow_utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/arrow_utils.py
@@ -864,6 +864,11 @@ def _python_type_to_pyarrow_type(type_: type, value: Any):
     if issubclass(type_, datetime.time) and isinstance(value, datetime.time):
         return pa.time64("us")
 
+    # UUID values are stringified later in `_process_batch`; declare the field as string here so a
+    # UUID column absent from the provided schema doesn't crash while its field is being appended.
+    if issubclass(type_, uuid.UUID):
+        return pa.string()
+
     raise ValueError(f"Python type {type_} has no pyarrow mapping")
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test/test_utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test/test_utils.py
@@ -60,6 +60,17 @@ def test_table_from_py_list_uuid():
     )
 
 
+def test_table_from_py_list_schema_missing_uuid_column():
+    # A UUID column present in the batch but absent from the provided schema has its Arrow field
+    # inferred by `_python_type_to_pyarrow_type`, which must map UUID to string rather than raising.
+    uuid_ = uuid.uuid4()
+    schema = pa.schema(cast(Any, [pa.field("id", pa.int64())]))
+    table = table_from_py_list([{"id": 1, "uid": uuid_}], schema)
+
+    assert table.schema.field("uid").type == pa.string()
+    assert table.column("uid").to_pylist() == [str(uuid_)]
+
+
 def test_table_from_py_list_inconsistent_list():
     table = table_from_py_list([{"column": "hello"}, {"column": ["hi"]}])
 


### PR DESCRIPTION
## Problem

A Postgres data-warehouse import crashes when a `uuid`-typed column is present in a batch but absent from the read's provided Arrow schema — for example a newly added column, or one that was dropped from the discovered schema between setup and the streaming read.

`_process_batch` appends an Arrow field for such a column via `_python_type_to_pyarrow_type`, which had no mapping for `uuid.UUID` and raised:

```
ValueError: Python type <class 'uuid.UUID'> has no pyarrow mapping
```

The existing "Convert UUIDs to strings" block further down `_process_batch` never gets a chance to run, because the exception is raised while the field is still being appended.

Error-tracking issue: https://us.posthog.com/project/2/error_tracking/01a0111f-ce71-7e60-b5cc-26b3bf455bfa

Call path: `postgres.get_rows` → `table_from_iterator` → `_process_batch` → `_python_type_to_pyarrow_type` (`arrow_utils.py`).

## Changes

- Map `uuid.UUID` to `pa.string()` in `_python_type_to_pyarrow_type`. This is consistent with how UUID column values are already stringified later in `_process_batch`, so the field type and its values agree. Other type mappings are untouched.

This is a fixable bug (our conversion was incomplete), not a user/upstream error, so it is fixed in the shared Arrow helper where the crash originates rather than added to `NonRetryableErrors`.

## How did you test this code?

- Added `test_table_from_py_list_schema_missing_uuid_column`, mirroring the existing `test_table_from_py_list_schema_missing_temporal_column`: a UUID column present in the batch but absent from the provided schema must produce a `string` column rather than raising.
- Verified the patched `_python_type_to_pyarrow_type` in isolation: it maps `uuid.UUID` → `pa.string()`, the exact schema-append call that previously crashed now succeeds, and the other mappings (int, date, …) are unchanged.
- I (the agent) could not run the full pytest suite in this environment (no warehouse-sources dependency stack); the new and existing tests run in CI.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by an automated error-tracking triage agent (Claude Code). It confirmed the issue in PostHog error tracking, traced the stack from the Postgres source's `get_rows` into the shared Arrow conversion helper, and scoped the fix to the single missing type mapping plus a regression test. No customer data is included; the reproduction is synthetic.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
