### PR TITLE
fix(redis): reconnect shared clients after connection loss

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -10065,10 +10065,13 @@ version = "0.32.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "014cc767fefab6a3e798ca45112bccad9c6e0e218fbd49720042716c73cfef44"
 dependencies = [
+ "arc-swap",
+ "backon",
  "bytes",
  "cfg-if",
  "combine",
  "crc16",
+ "futures-channel",
  "futures-sink",
  "futures-util",
  "itoa",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -237,6 +237,7 @@ moka = { version = "0.12.15", features = ["sync", "future"] }
 posthog-rs = { version = "0.23.3", features = ["async-client", "capture-v1"] }
 redis = { version = "0.32.7", features = [
   "tokio-comp",
+  "connection-manager",
   "cluster",
   "cluster-async",
   "tls-rustls",

--- a/rust/common/redis/src/client.rs
+++ b/rust/common/redis/src/client.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use redis::aio::MultiplexedConnection;
+use redis::aio::{ConnectionManager, ConnectionManagerConfig};
 use redis::{AsyncCommands, RedisError};
 use std::time::Duration;
 use tracing::warn;
@@ -14,7 +14,7 @@ const ERR_RAWBYTES_SET: &str =
 
 #[derive(Clone)]
 pub struct RedisClient {
-    connection: MultiplexedConnection,
+    connection: ConnectionManager,
     compression: CompressionConfig,
     format: RedisValueFormat,
 }
@@ -130,9 +130,19 @@ impl RedisClient {
             }
         }
 
-        // Use Redis native timeout configuration
-        // None means no timeout (blocks indefinitely)
-        let mut config = redis::AsyncConnectionConfig::new();
+        // ConnectionManager replaces a dead multiplexed connection. The command
+        // that detects the dropped connection still returns its error, then later
+        // commands wait for and use the replacement connection. A bare
+        // MultiplexedConnection remains broken after Redis restarts or moves to a
+        // new pod, and every later command keeps failing.
+        //
+        // None means no timeout (blocks indefinitely).
+        // Keep construction compatible with the previous single connection
+        // attempt. The manager's retry policy applies to both initial connection
+        // and later reconnections, so zero retries avoids extending constructor
+        // latency by six timeout periods plus exponential backoff. A command after
+        // a failed reconnect can trigger another reconnect attempt.
+        let mut config = ConnectionManagerConfig::new().set_number_of_retries(0);
 
         if let Some(timeout) = response_timeout {
             config = config.set_response_timeout(timeout);
@@ -142,9 +152,7 @@ impl RedisClient {
             config = config.set_connection_timeout(timeout);
         }
 
-        let connection = client
-            .get_multiplexed_async_connection_with_config(&config)
-            .await?;
+        let connection = ConnectionManager::new_with_config(client, config).await?;
 
         Ok(RedisClient {
             connection,
@@ -774,6 +782,17 @@ mod tests {
             assert!(config.enabled);
             assert_eq!(config.threshold, 512);
             assert_eq!(config.level, 0);
+        }
+
+        #[test]
+        fn test_client_uses_connection_manager_for_automatic_reconnects() {
+            fn assert_connection_manager(_: &redis::aio::ConnectionManager) {}
+
+            let assert_client_connection_type = |client: &RedisClient| {
+                assert_connection_manager(&client.connection);
+            };
+
+            let _ = assert_client_connection_type;
         }
 
         #[tokio::test]


### PR DESCRIPTION
## Problem

Rust services using `common-redis` cannot recover after their Redis connection is interrupted. The client retains a dead multiplexed connection, so later commands continue failing after Redis is available again.

## Changes

- Enable redis-rs connection-manager support.
- Replace the bare multiplexed connection with `ConnectionManager`.
- Preserve response timeout behavior and the previous single-attempt constructor behavior by setting reconnect retries to zero. A later command can trigger a fresh reconnect attempt if one fails.
- Document that the command detecting a dropped connection still returns its error; subsequent commands use the replacement connection.
- Add a regression test that requires the reconnecting client type.

## How did you test this code?

- `cargo fmt --all --check`
- `cargo test -p common-redis --lib` (68 passed, 11 ignored)
- `cargo clippy -p common-redis --lib -- -D warnings`
- Sabotage check: restoring `MultiplexedConnection` makes the regression test fail to compile.
- Independent review caught and prompted a fix for ConnectionManager's default six-attempt constructor retry behavior.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This restores expected connection resilience without changing a public interface.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Hermes Agent investigated the failure and implemented the change using systematic debugging, TDD, and independent code review. The change uses redis-rs' built-in `ConnectionManager` rather than adding custom retry state.

The committed code and PR text contain no private operational logs, customer data, or internal identifiers.