### PR TITLE
feat(provisioning): store rate limit overrides per endpoint and drop rate_limit_source

### DIFF
--- a/ee/api/agentic_provisioning/ratelimits.py
+++ b/ee/api/agentic_provisioning/ratelimits.py
@@ -42,7 +42,7 @@ from rest_framework.request import Request
 
 from posthog.dataclasses import frozen
 from posthog.models.oauth import OAuthAccessToken, OAuthApplication
-from posthog.models.oauth_provisioning import PartnerTier
+from posthog.models.oauth_provisioning import UNLIMITED_OVERRIDE, PartnerTier
 from posthog.token_bucket import BucketDecision, BucketUnavailable, Budget, consume, refund
 
 from ee.api.agentic_provisioning.analytics import capture_provisioning_event
@@ -93,12 +93,6 @@ DID_NO_WORK_CODES: frozenset[str] = frozenset(
     }
 )
 
-# The endpoints whose per-partner override fields exist on ProvisioningRateLimits
-# today. Endpoints outside this set are tier-derived only until the override
-# storage becomes a per-endpoint dict.
-LEGACY_OVERRIDE_ENDPOINTS: frozenset[str] = frozenset(
-    {"account_requests", "token_exchanges", "resource_creates", "github_grants", "wizard_runs"}
-)
 
 DECISIONS_COUNTER = Counter(
     "provisioning_rate_limit_decisions_total",
@@ -218,12 +212,6 @@ def partner_for_rate_limiting(request: Request) -> OAuthApplication | None:
     return app
 
 
-def _legacy_override(partner: OAuthApplication, endpoint: str) -> int | None:
-    if endpoint not in LEGACY_OVERRIDE_ENDPOINTS:
-        return None
-    return getattr(partner.provisioning.rate_limits, endpoint, None)
-
-
 def resolve_budget(declaration: BudgetDeclaration, partner: OAuthApplication) -> Budget | None:
     """The bucket to charge for this partner, or None when it is unlimited.
 
@@ -233,10 +221,10 @@ def resolve_budget(declaration: BudgetDeclaration, partner: OAuthApplication) ->
     """
     tier = partner.partner_tier
     multiplier = declaration.multipliers[tier]
-    override = _legacy_override(partner, declaration.endpoint)
+    override = partner.provisioning.rate_limits.get(declaration.endpoint)
 
     if override is not None:
-        if override <= 0:
+        if override == UNLIMITED_OVERRIDE:
             return None
         # The override replaces the hourly rate; burst keeps the endpoint's
         # declared burst-to-rate proportion, independent of tier, so an

--- a/ee/api/agentic_provisioning/test/test_provisioning_auth.py
+++ b/ee/api/agentic_provisioning/test/test_provisioning_auth.py
@@ -9,7 +9,6 @@ from parameterized import parameterized
 
 from posthog.api.oauth.cimd import _blocked_key, _cache_key, fetch_and_upsert_cimd_application
 from posthog.models.oauth import OAuthApplication
-from posthog.models.oauth_provisioning import ProvisioningRateLimits
 from posthog.models.personal_api_key import PersonalAPIKey
 from posthog.models.user import User
 
@@ -525,7 +524,7 @@ class TestCimdProvisioningRegistration(ProvisioningTestBase):
                 active=True,
                 can_create_accounts=True,
                 can_provision_resources=True,
-                rate_limits=ProvisioningRateLimits(account_requests=10),
+                rate_limits={"account_requests": 10},
             ),
         )
 

--- a/posthog/admin/admins/oauth_admin.py
+++ b/posthog/admin/admins/oauth_admin.py
@@ -14,7 +14,7 @@ from oauth2_provider.generators import generate_client_id, generate_client_secre
 from oauth2_provider.models import AbstractApplication
 
 from posthog.models.oauth import OAuthApplication, revoke_application_sessions
-from posthog.models.oauth_provisioning import ProvisioningConfig, ProvisioningRateLimits
+from posthog.models.oauth_provisioning import UNLIMITED_OVERRIDE, ProvisioningConfig
 
 # The provisioning config is one JSONB column, but an operator should still get the checkboxes
 # they had when it was a column each: a raw JSON textarea turns a mistyped capability key into
@@ -25,19 +25,40 @@ PROVISIONING_RATE_LIMIT_PREFIX = "provisioning_rate_limit_"
 
 
 def _provisioning_form_fields() -> dict[str, forms.Field]:
-    """One form field per capability, plus one per rate-limit override."""
+    """One form field per capability. Rate-limit override fields are generated
+    per request in ``get_form`` from the endpoint registry."""
     fields: dict[str, forms.Field] = {}
     for name, info in ProvisioningConfig.model_fields.items():
-        if name in ("rate_limits", "rate_limit_source"):
+        if name == "rate_limits":
             continue
         fields[f"{PROVISIONING_FIELD_PREFIX}{name}"] = forms.BooleanField(
             required=False, label=name.replace("_", " "), help_text=info.description or ""
         )
-    for name in ProvisioningRateLimits.model_fields:
-        fields[f"{PROVISIONING_RATE_LIMIT_PREFIX}{name}"] = forms.IntegerField(
-            required=False, min_value=0, label=f"rate limit {name.replace('_', ' ')} (per hour)"
-        )
     return fields
+
+
+def _rate_limit_endpoints() -> list[str]:
+    """Every declared rate-limit endpoint, so a new @rate_limited declaration
+    grows an override field here with no admin change."""
+    # Deferred: budgets register when the provisioning view modules import, and this
+    # admin module loads at django.setup() in every process, where pulling the ee
+    # views in eagerly would bloat startup.
+    from ee.api.agentic_provisioning import views  # noqa: F401, PLC0415
+    from ee.api.agentic_provisioning.ratelimits import registered_budgets  # noqa: PLC0415
+
+    return sorted(registered_budgets())
+
+
+def _rate_limit_form_fields() -> dict[str, forms.Field]:
+    return {
+        f"{PROVISIONING_RATE_LIMIT_PREFIX}{name}": forms.IntegerField(
+            required=False,
+            min_value=UNLIMITED_OVERRIDE,
+            label=f"rate limit {name.replace('_', ' ')} (per hour)",
+            help_text="Blank = tier-derived budget; -1 = unlimited. Outranks the tier, including BLOCKED.",
+        )
+        for name in _rate_limit_endpoints()
+    }
 
 
 PROVISIONING_FORM_FIELD_NAMES = tuple(_provisioning_form_fields())
@@ -81,39 +102,43 @@ class OAuthApplicationForm(forms.ModelForm):
             if "client_type" in self.fields:
                 self.fields["client_type"].initial = AbstractApplication.CLIENT_CONFIDENTIAL
 
+    def _rate_limit_field_names(self) -> list[str]:
+        return [name for name in self.fields if name.startswith(PROVISIONING_RATE_LIMIT_PREFIX)]
+
     def _load_provisioning_initial(self) -> None:
         config = self.instance.provisioning if self.instance.pk else ProvisioningConfig()
         for name in ProvisioningConfig.model_fields:
-            if name in ("rate_limits", "rate_limit_source"):
+            if name == "rate_limits":
                 continue
             self.fields[f"{PROVISIONING_FIELD_PREFIX}{name}"].initial = getattr(config, name)
-        for name in ProvisioningRateLimits.model_fields:
-            self.fields[f"{PROVISIONING_RATE_LIMIT_PREFIX}{name}"].initial = getattr(config.rate_limits, name)
+        for field_name in self._rate_limit_field_names():
+            endpoint = field_name.removeprefix(PROVISIONING_RATE_LIMIT_PREFIX)
+            self.fields[field_name].initial = config.rate_limits.get(endpoint)
+
+    def clean(self):
+        cleaned = super().clean() or {}
+        for field_name in self._rate_limit_field_names():
+            # 0 is rejected rather than meaning "unlimited": that footgun is why the
+            # unlimited sentinel is -1 (UNLIMITED_OVERRIDE).
+            if cleaned.get(field_name) == 0:
+                self.add_error(field_name, "Enter a positive hourly limit, -1 for unlimited, or leave blank.")
+        return cleaned
 
     def save(self, commit: bool = True):
         instance = super().save(commit=False)
 
-        previous = instance.provisioning
         capabilities = {
             name: self.cleaned_data[f"{PROVISIONING_FIELD_PREFIX}{name}"]
             for name in ProvisioningConfig.model_fields
-            if name not in ("rate_limits", "rate_limit_source")
+            if name != "rate_limits"
         }
-        rate_limits = ProvisioningRateLimits(
-            **{
-                name: self.cleaned_data[f"{PROVISIONING_RATE_LIMIT_PREFIX}{name}"]
-                for name in ProvisioningRateLimits.model_fields
-            }
-        )
-        # An operator typing a limit here outranks the verified/unverified defaults, so record
-        # that. Without it the next CIMD metadata refresh re-tiers the app and overwrites them.
-        # Keyed on the field actually changing in this form rather than on the stored value, so
-        # saving an unrelated field doesn't pin a limit a CIMD refresh set since the form loaded.
-        source = previous.rate_limit_source
-        if f"{PROVISIONING_RATE_LIMIT_PREFIX}account_requests" in self.changed_data:
-            source = "admin"
+        rate_limits = {
+            field_name.removeprefix(PROVISIONING_RATE_LIMIT_PREFIX): value
+            for field_name in self._rate_limit_field_names()
+            if (value := self.cleaned_data.get(field_name)) is not None
+        }
 
-        instance.provisioning = ProvisioningConfig(**capabilities, rate_limits=rate_limits, rate_limit_source=source)
+        instance.provisioning = ProvisioningConfig(**capabilities, rate_limits=rate_limits)
 
         if commit:
             instance.save()
@@ -140,11 +165,7 @@ class ProvisioningCapabilityFilter(admin.SimpleListFilter):
     parameter_name = "provisioning_capability"
 
     def lookups(self, request, model_admin):
-        return [
-            (name, name.replace("_", " "))
-            for name in ProvisioningConfig.model_fields
-            if name not in ("rate_limits", "rate_limit_source")
-        ]
+        return [(name, name.replace("_", " ")) for name in ProvisioningConfig.model_fields if name != "rate_limits"]
 
     def queryset(self, request, queryset):
         capability = self.value()
@@ -271,7 +292,11 @@ class OAuthApplicationAdmin(admin.ModelAdmin):  # nosemgrep: admin-modeladmin-ne
 
     def get_fieldsets(self, request, obj=None):
         if obj:
-            provisioning_fields = ["is_provisioning_partner", *PROVISIONING_FORM_FIELD_NAMES]
+            provisioning_fields = [
+                "is_provisioning_partner",
+                *PROVISIONING_FORM_FIELD_NAMES,
+                *_rate_limit_form_fields(),
+            ]
 
             return (
                 (None, {"fields": ("id", "name", "client_id", "client_type", "auth_brand", "logo_uri")}),
@@ -335,6 +360,11 @@ class OAuthApplicationAdmin(admin.ModelAdmin):  # nosemgrep: admin-modeladmin-ne
             )
 
     def get_form(self, request, obj=None, change=False, **kwargs):
+        # The rate-limit override fields follow the endpoint registry, so they are
+        # declared on a per-request subclass: modelform_factory validates the
+        # fieldset names against the form class, which therefore has to carry them
+        # before super() runs.
+        kwargs["form"] = type("OAuthApplicationAdminForm", (self.form,), dict(_rate_limit_form_fields()))
         form = super().get_form(request, obj, change=change, **kwargs)
 
         if not obj:

--- a/posthog/admin/test_oauth_admin.py
+++ b/posthog/admin/test_oauth_admin.py
@@ -58,10 +58,8 @@ class TestOAuthApplicationAdmin(BaseTest):
         # Unticked boxes stay off rather than picking up a default.
         assert granted.can_start_wizard_runs is False
 
-    def test_admin_rate_limit_override_outranks_the_verified_default(self):
-        # A CIMD refresh re-tiers the account-request limit unless the source says an admin set
-        # it, so an override typed here has to record that or the next refresh overwrites it.
-        app = OAuthApplication.objects.create(
+    def _rate_limit_app(self) -> OAuthApplication:
+        return OAuthApplication.objects.create(
             name="Rate Limit App",
             client_id="rate_limit_client_id",
             client_secret="secret",
@@ -71,13 +69,29 @@ class TestOAuthApplicationAdmin(BaseTest):
             algorithm="RS256",
         )
 
+    def test_admin_rate_limit_override_is_stored_per_endpoint(self):
+        app = self._rate_limit_app()
+
         form = self._provisioning_form(app, provisioning_rate_limit_account_requests="250")
         assert form.is_valid(), form.errors
         form.save()
 
         app.refresh_from_db()
-        assert app.provisioning.rate_limits.account_requests == 250
-        assert app.provisioning.rate_limit_source == "admin"
+        assert app.provisioning.rate_limits == {"account_requests": 250}
+
+    def test_admin_rate_limit_zero_is_rejected_and_minus_one_means_unlimited(self):
+        # 0 used to mean unlimited; an operator typing it must get an error, not infinity.
+        app = self._rate_limit_app()
+
+        form = self._provisioning_form(app, provisioning_rate_limit_account_requests="0")
+        assert not form.is_valid()
+        assert "provisioning_rate_limit_account_requests" in form.errors
+
+        form = self._provisioning_form(app, provisioning_rate_limit_account_requests="-1")
+        assert form.is_valid(), form.errors
+        form.save()
+        app.refresh_from_db()
+        assert app.provisioning.rate_limits == {"account_requests": -1}
 
     @parameterized.expand(
         [

--- a/posthog/api/oauth/cimd.py
+++ b/posthog/api/oauth/cimd.py
@@ -707,39 +707,6 @@ def _touch_verification_token(token: CIMDVerificationToken) -> None:
     CIMDVerificationToken.objects.filter(pk=token.pk).update(last_used_at=timezone.now())
 
 
-def _retier_account_requests_limit(app: OAuthApplication, *, verified: bool) -> None:
-    """Move a partner's account-request limit onto the verified or unverified default tier.
-
-    Only our own default tiers move. An explicit admin override (source="admin") stays put, and
-    so does a legacy row with no source recorded, treated conservatively as admin so a value
-    that pre-dates the field is not clobbered.
-
-    Locks and re-reads before deciding, because the caller's copy of the app was loaded before a
-    network fetch of the metadata document. That window is wide enough for an admin to have
-    revoked a capability in it, and merging into a stale blob would write the revoked value back.
-    """
-    with transaction.atomic():
-        current = OAuthApplication.objects.select_for_update().get(pk=app.pk)
-        config = current.provisioning
-        if not current.is_provisioning_partner or config.rate_limit_source not in (
-            "default_unverified",
-            "default_verified",
-        ):
-            return
-        app.update_provisioning(
-            rate_limits=config.rate_limits.model_copy(
-                update={
-                    "account_requests": (
-                        CIMD_PROVISIONING_ACCOUNT_REQUESTS_VERIFIED_RATE_LIMIT
-                        if verified
-                        else CIMD_PROVISIONING_ACCOUNT_REQUESTS_DEFAULT_RATE_LIMIT
-                    )
-                }
-            ),
-            rate_limit_source="default_verified" if verified else "default_unverified",
-        )
-
-
 def _describe_validation_error(error: ValidationError) -> str:
     """Flatten a model ValidationError into one line a partner can act on.
 
@@ -840,13 +807,9 @@ def _update_cimd_application(
     else:
         if verification is not None:
             _touch_verification_token(verification)
-        # Keep the rate-limit tier in step with verification status. Written after the main save
-        # and through its own locked merge, rather than as another field on it, because the whole
-        # provisioning blob has to be rewritten to change one key inside it.
-        if old_org_id is None and new_org_id is not None:
-            _retier_account_requests_limit(app, verified=True)
-        elif old_org_id is not None and new_org_id is None:
-            _retier_account_requests_limit(app, verified=False)
+        # No rate-limit re-tiering on verification flips: the partner tier is derived
+        # from organization_id at request time (OAuthApplication.partner_tier), so
+        # the budgets follow the flip with nothing persisted.
         # Emit a distinct event on org re-linking so a metadata compromise
         # flipping A→B (or A→None, None→A) is visible in analytics, not
         # just buried in the generic refresh event.
@@ -1067,17 +1030,6 @@ def get_application_by_client_id(client_id: str) -> OAuthApplication:
     return OAuthApplication.objects.get(client_id=client_id)
 
 
-# Defaults applied when a CIMD app is opted into provisioning at client_registration. A
-# self-serve partner gets there without manual admin setup, at the same trust level as other
-# PKCE partners. The account-request rate limit is set to a conservative floor so a single
-# self-serve partner cannot burn through bulk user-onboarding calls - admin can raise it
-# per-partner once a partner demonstrates legitimate volume. Verified partners (those who
-# presented a valid `posthog_verification_token`) get a higher default since abuse is
-# traceable to a real PostHog organization.
-CIMD_PROVISIONING_ACCOUNT_REQUESTS_DEFAULT_RATE_LIMIT = 10  # per hour, anonymous CIMD
-CIMD_PROVISIONING_ACCOUNT_REQUESTS_VERIFIED_RATE_LIMIT = 100  # per hour, verified CIMD
-
-
 def _cimd_provisioning_defaults_for(app: OAuthApplication) -> "ProvisioningConfig":
     """The config a CIMD app gets when it registers itself, layered over whatever it already has.
 
@@ -1091,31 +1043,18 @@ def _cimd_provisioning_defaults_for(app: OAuthApplication) -> "ProvisioningConfi
     trust. GitHub grants, wizard runs, deep links and skipped consent are granted by an admin or
     not at all.
 
+    No rate limits are written here: budgets are derived per request from the partner's tier
+    (auth method x verification), so registration and verification change what the partner
+    gets without persisting anything an admin override could collide with.
+
     Layered rather than replacing the config wholesale, so an admin who granted a capability
     before the app first registered does not have it silently dropped here. For the ordinary
     case - a brand new self-registered client - the existing config is empty and the two are
     the same thing.
     """
-    config = app.provisioning
-    changes: dict[str, object] = {"active": True, "can_create_accounts": True, "can_provision_resources": True}
-
-    # Verified partners (those who presented a valid `posthog_verification_token`) get a higher
-    # account-request limit, since abuse is traceable to a real PostHog organization. An admin
-    # override already recorded on the app outranks both tiers.
-    if config.rate_limit_source != "admin":
-        verified = app.organization_id is not None
-        changes["rate_limits"] = config.rate_limits.model_copy(
-            update={
-                "account_requests": (
-                    CIMD_PROVISIONING_ACCOUNT_REQUESTS_VERIFIED_RATE_LIMIT
-                    if verified
-                    else CIMD_PROVISIONING_ACCOUNT_REQUESTS_DEFAULT_RATE_LIMIT
-                )
-            }
-        )
-        changes["rate_limit_source"] = "default_verified" if verified else "default_unverified"
-
-    return config.model_copy(update=changes)
+    return app.provisioning.model_copy(
+        update={"active": True, "can_create_accounts": True, "can_provision_resources": True}
+    )
 
 
 def apply_provisioning_defaults(app: OAuthApplication) -> OAuthApplication:
@@ -1165,7 +1104,7 @@ def apply_provisioning_defaults(app: OAuthApplication) -> OAuthApplication:
             "cimd_url": app.cimd_metadata_url,
             "client_name": app.name,
             "app_id": str(app.pk),
-            "account_requests_rate_limit": app.provisioning.rate_limits.account_requests,
+            "partner_tier": app.partner_tier,
             "is_verified": app.organization_id is not None,
             "organization_id": str(app.organization_id) if app.organization_id else None,
         },

--- a/posthog/api/oauth/test_cimd.py
+++ b/posthog/api/oauth/test_cimd.py
@@ -18,8 +18,6 @@ from parameterized import parameterized
 from rest_framework.test import APIClient
 
 from posthog.api.oauth.cimd import (
-    CIMD_PROVISIONING_ACCOUNT_REQUESTS_DEFAULT_RATE_LIMIT,
-    CIMD_PROVISIONING_ACCOUNT_REQUESTS_VERIFIED_RATE_LIMIT,
     CIMDFetchError,
     CIMDMetadataDocument,
     CIMDValidationError,
@@ -45,6 +43,7 @@ from posthog.models.oauth import (
     TokenEndpointAuthMethod,
     create_cimd_verification_token,
 )
+from posthog.models.oauth_provisioning import PartnerTier
 from posthog.scopes import OAUTH_SCOPES_HIDDEN, PRIVILEGED_SCOPES
 
 VALID_CIMD_URL = "https://app.example.com/.well-known/oauth-client-metadata.json"
@@ -641,10 +640,8 @@ class TestApplyProvisioningDefaults(APIBaseTest):
         self.assertTrue(app.provisioning.active)
         self.assertTrue(app.provisioning.can_create_accounts)
         self.assertTrue(app.provisioning.can_provision_resources)
-        self.assertEqual(
-            app.provisioning.rate_limits.account_requests,
-            CIMD_PROVISIONING_ACCOUNT_REQUESTS_DEFAULT_RATE_LIMIT,
-        )
+        # No limits are persisted at registration: budgets derive from the tier.
+        self.assertEqual(app.provisioning.rate_limits, {})
 
     @parameterized.expand(
         [
@@ -773,7 +770,7 @@ class TestCIMDVerificationToken(APIBaseTest):
         self.assertIsNone(app.organization_id)
 
     @patch("posthog.api.oauth.cimd.requests.Session.get")
-    def test_verified_partner_gets_higher_rate_limit(self, mock_get, _url_mock):
+    def test_verified_partner_derives_the_attested_tier(self, mock_get, _url_mock):
         _, plaintext = create_cimd_verification_token(
             organization=self.organization, label="Verified partner", cimd_url=VALID_CIMD_URL, created_by=self.user
         )
@@ -784,23 +781,19 @@ class TestCIMDVerificationToken(APIBaseTest):
 
         assert app is not None
         self.assertEqual(app.organization_id, self.organization.id)
-        self.assertEqual(
-            app.provisioning.rate_limits.account_requests,
-            CIMD_PROVISIONING_ACCOUNT_REQUESTS_VERIFIED_RATE_LIMIT,
-        )
+        self.assertEqual(app.partner_tier, PartnerTier.PUBLIC_ATTESTED)
+        self.assertEqual(app.provisioning.rate_limits, {})
 
     @patch("posthog.api.oauth.cimd.requests.Session.get")
-    def test_unverified_partner_gets_default_rate_limit(self, mock_get, _url_mock):
+    def test_unverified_partner_derives_the_public_tier(self, mock_get, _url_mock):
         mock_get.return_value = _mock_response(_make_metadata(), headers={})
 
         app = _register_provisioning_partner()
 
         assert app is not None
         self.assertIsNone(app.organization_id)
-        self.assertEqual(
-            app.provisioning.rate_limits.account_requests,
-            CIMD_PROVISIONING_ACCOUNT_REQUESTS_DEFAULT_RATE_LIMIT,
-        )
+        self.assertEqual(app.partner_tier, PartnerTier.PUBLIC)
+        self.assertEqual(app.provisioning.rate_limits, {})
 
     @patch("posthog.api.oauth.cimd.requests.Session.get")
     def test_refresh_unlinks_app_when_token_removed(self, mock_get, _url_mock):
@@ -850,15 +843,12 @@ class TestCIMDVerificationToken(APIBaseTest):
         self.assertIsNone(app.organization_id)
 
     @patch("posthog.api.oauth.cimd.requests.Session.get")
-    def test_refresh_bumps_rate_limit_when_token_added_post_registration(self, mock_get, _url_mock):
+    def test_refresh_moves_the_tier_when_token_added_post_registration(self, mock_get, _url_mock):
         mock_get.return_value = _mock_response(_make_metadata(), headers={})
         _register_provisioning_partner()
         app = OAuthApplication.objects.get(cimd_metadata_url=VALID_CIMD_URL)
         self.assertIsNone(app.organization_id)
-        self.assertEqual(
-            app.provisioning.rate_limits.account_requests,
-            CIMD_PROVISIONING_ACCOUNT_REQUESTS_DEFAULT_RATE_LIMIT,
-        )
+        self.assertEqual(app.partner_tier, PartnerTier.PUBLIC)
 
         _, plaintext = create_cimd_verification_token(
             organization=self.organization,
@@ -872,13 +862,11 @@ class TestCIMDVerificationToken(APIBaseTest):
 
         assert refreshed is not None
         self.assertEqual(refreshed.organization_id, self.organization.id)
-        self.assertEqual(
-            refreshed.provisioning.rate_limits.account_requests,
-            CIMD_PROVISIONING_ACCOUNT_REQUESTS_VERIFIED_RATE_LIMIT,
-        )
+        self.assertEqual(refreshed.partner_tier, PartnerTier.PUBLIC_ATTESTED)
+        self.assertEqual(refreshed.provisioning.rate_limits, {})
 
     @patch("posthog.api.oauth.cimd.requests.Session.get")
-    def test_refresh_drops_rate_limit_when_token_removed(self, mock_get, _url_mock):
+    def test_refresh_moves_the_tier_back_when_token_removed(self, mock_get, _url_mock):
         _, plaintext = create_cimd_verification_token(
             organization=self.organization, label="Rotating partner", cimd_url=VALID_CIMD_URL, created_by=self.user
         )
@@ -886,10 +874,7 @@ class TestCIMDVerificationToken(APIBaseTest):
         _register_provisioning_partner()
         app = OAuthApplication.objects.get(cimd_metadata_url=VALID_CIMD_URL)
         self.assertEqual(app.organization_id, self.organization.id)
-        self.assertEqual(
-            app.provisioning.rate_limits.account_requests,
-            CIMD_PROVISIONING_ACCOUNT_REQUESTS_VERIFIED_RATE_LIMIT,
-        )
+        self.assertEqual(app.partner_tier, PartnerTier.PUBLIC_ATTESTED)
 
         real_cache.delete(_fetch_lock_key(VALID_CIMD_URL))
         mock_get.return_value = _mock_response(_make_metadata(), headers={})
@@ -897,17 +882,13 @@ class TestCIMDVerificationToken(APIBaseTest):
 
         assert refreshed is not None
         self.assertIsNone(refreshed.organization_id)
-        self.assertEqual(
-            refreshed.provisioning.rate_limits.account_requests,
-            CIMD_PROVISIONING_ACCOUNT_REQUESTS_DEFAULT_RATE_LIMIT,
-        )
+        self.assertEqual(refreshed.partner_tier, PartnerTier.PUBLIC)
 
     @patch("posthog.api.oauth.cimd.requests.Session.get")
     def test_refresh_preserves_admin_custom_rate_limit(self, mock_get, _url_mock):
         mock_get.return_value = _mock_response(_make_metadata(), headers={})
         _register_provisioning_partner()
         app = OAuthApplication.objects.get(cimd_metadata_url=VALID_CIMD_URL)
-        app.update_provisioning(rate_limit_source="admin")
         app.update_provisioning_rate_limits(account_requests=250)
         _, plaintext = create_cimd_verification_token(
             organization=self.organization, label="Post-admin-override", cimd_url=VALID_CIMD_URL, created_by=self.user
@@ -918,8 +899,7 @@ class TestCIMDVerificationToken(APIBaseTest):
 
         assert refreshed is not None
         self.assertEqual(refreshed.organization_id, self.organization.id)
-        self.assertEqual(refreshed.provisioning.rate_limits.account_requests, 250)
-        self.assertEqual(refreshed.provisioning.rate_limit_source, "admin")
+        self.assertEqual(refreshed.provisioning.rate_limits, {"account_requests": 250})
 
 
 @patch("posthog.security.url_validation.resolve_host_ips", return_value={ip_address("93.184.216.34")})

--- a/posthog/migrations/1310_provisioning_rate_limit_overrides.py
+++ b/posthog/migrations/1310_provisioning_rate_limit_overrides.py
@@ -1,0 +1,89 @@
+from django.db import migrations
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+BATCH_SIZE = 500
+
+UNLIMITED_OVERRIDE = -1
+
+TIER_SOURCES = ["default_verified", "default_unverified"]
+
+
+def migrate_rate_limit_overrides(apps, schema_editor):
+    """Clear the persisted CIMD tier values so the derived tier applies again.
+
+    Rate limits used to mix two kinds of value in one place: admin overrides and the
+    CIMD verified/unverified tier defaults (10/100), disambiguated by rate_limit_source.
+    Tiers are now derived per request, so a persisted tier value would be read as an
+    admin override and pin the partner to the old number forever. Only those rows are
+    rewritten: rate_limit_source in (default_verified, default_unverified), dropping
+    the account_requests value the tiering wrote. Other keys on those rows stay, since
+    the source tracked account_requests alone.
+
+    Everything else the old shape stored is left alone, because ProvisioningConfig
+    already reads it correctly: the rate_limits validator drops nulls and maps 0 to
+    UNLIMITED_OVERRIDE, and extra="ignore" ignores a leftover rate_limit_source. Those
+    keys are dead weight rather than wrong, and rewriting them would mean touching
+    every row in a table 1274 backfilled in full. They clear themselves the next time
+    anything saves the config.
+    """
+    OAuthApplication = apps.get_model("posthog", "OAuthApplication")
+
+    # Pinned to the alias `migrate` is running on rather than letting the router pick;
+    # see 1274 for why (server-side cursors on default_direct).
+    db_alias = schema_editor.connection.alias
+
+    # Filtered in Postgres, not in Python: 1274 backfilled a config onto all of the
+    # table, so streaming it to find the tier-sourced rows would read millions to write
+    # a handful.
+    candidates = (
+        OAuthApplication.objects.using(db_alias)
+        .filter(_provisioning_config__rate_limit_source__in=TIER_SOURCES)
+        .order_by("pk")
+    )
+
+    cleared_tier_values = []
+    updated = []
+    for app in candidates.iterator(chunk_size=BATCH_SIZE):
+        config = app._provisioning_config or {}
+        raw_limits = config.get("rate_limits") or {}
+
+        limits = {}
+        for key, value in raw_limits.items():
+            if value is None:
+                continue
+            if key == "account_requests":
+                cleared_tier_values.append(str(app.pk))
+                continue
+            limits[key] = UNLIMITED_OVERRIDE if value <= 0 else value
+
+        new_config = {k: v for k, v in config.items() if k != "rate_limit_source"}
+        new_config["rate_limits"] = limits
+
+        app._provisioning_config = new_config
+        updated.append(app)
+        if len(updated) >= BATCH_SIZE:
+            OAuthApplication.objects.using(db_alias).bulk_update(updated, ["_provisioning_config"])
+            updated = []
+
+    if updated:
+        OAuthApplication.objects.using(db_alias).bulk_update(updated, ["_provisioning_config"])
+
+    if cleared_tier_values:
+        logger.info(
+            "provisioning_tier_rate_limits_cleared",
+            application_ids=cleared_tier_values,
+            count=len(cleared_tier_values),
+        )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("posthog", "1309_integration_kind_ext_idx"),
+    ]
+
+    operations = [
+        migrations.RunPython(migrate_rate_limit_overrides, migrations.RunPython.noop, elidable=True),
+    ]

--- a/posthog/migrations/max_migration.txt
+++ b/posthog/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-1309_integration_kind_ext_idx
+1310_provisioning_rate_limit_overrides

--- a/posthog/models/activity_logging/signal_handlers.py
+++ b/posthog/models/activity_logging/signal_handlers.py
@@ -30,6 +30,7 @@ from posthog.models.activity_logging.activity_log import (
     LogActivityEntry,
     bulk_log_activity,
     changes_between,
+    field_name_overrides,
     log_activity,
 )
 from posthog.models.activity_logging.model_activity import get_current_trigger, get_current_user, get_was_impersonated
@@ -494,16 +495,19 @@ def handle_oauth_application_scopes_change(
     else:
         if before_update is None or after_update is None:
             return
-        # `scopes` is an ordered ArrayField but semantically a set (a permission ceiling),
-        # so a pure reorder is not an auditable change.
-        if set(before_update.scopes or []) == set(after_update.scopes or []):
-            return
-        # Only the scope ceiling is audited for OAuth apps; other fields changed in the
-        # same save are deliberately left out of the entry.
+        # Only the scope ceiling and the provisioning config (capabilities and rate-limit
+        # overrides) are audited for OAuth apps; other fields changed in the same save are
+        # deliberately left out of the entry. `scopes` is an ordered ArrayField but
+        # semantically a set (a permission ceiling), so a pure reorder is not auditable.
+        scopes_changed = set(before_update.scopes or []) != set(after_update.scopes or [])
+        # Changes carry the display name, not the column name.
+        provisioning_field = field_name_overrides.get("OAuthApplication", {}).get(
+            "_provisioning_config", "_provisioning_config"
+        )
         changes = [
             change
             for change in changes_between(scope, previous=before_update, current=after_update)
-            if change.field == "scopes"
+            if (change.field == "scopes" and scopes_changed) or change.field == provisioning_field
         ]
         if not changes:
             return

--- a/posthog/models/oauth.py
+++ b/posthog/models/oauth.py
@@ -259,16 +259,18 @@ class OAuthApplication(ModelActivityMixin, AbstractApplication):  # type: ignore
             self.save(update_fields=["_provisioning_config"])
         return self.provisioning
 
-    def update_provisioning_rate_limits(self, **changes: object) -> "ProvisioningConfig":
-        """Apply a partial change to the nested rate limits and persist it.
+    def update_provisioning_rate_limits(self, **changes: int | None) -> "ProvisioningConfig":
+        """Apply a partial change to the per-endpoint rate limit overrides and persist it.
 
-        Nested under the same lock as any other partial change, so the read of the current
-        limits can't be stale by the time it is written back.
+        A value of None removes the endpoint's override (back to the tier-derived
+        budget). Nested under the same lock as any other partial change, so the read
+        of the current limits can't be stale by the time it is written back.
         """
         with transaction.atomic():
             current = OAuthApplication.objects.select_for_update().get(pk=self.pk)
             self._provisioning_config = current._provisioning_config
-            return self.update_provisioning(rate_limits=self.provisioning.rate_limits.model_copy(update=changes))
+            merged = {**self.provisioning.rate_limits, **changes}
+            return self.update_provisioning(rate_limits={k: v for k, v in merged.items() if v is not None})
 
     @property
     def partner_tier(self) -> "PartnerTier":

--- a/posthog/models/oauth_provisioning.py
+++ b/posthog/models/oauth_provisioning.py
@@ -18,9 +18,8 @@ to an operator as a capability that was granted.
 from __future__ import annotations
 
 from enum import StrEnum
-from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class PartnerTier(StrEnum):
@@ -42,21 +41,10 @@ class PartnerTier(StrEnum):
     JWKS_ATTESTED = "jwks_attested"
 
 
-# Records who set the account-request rate limit, so a verification flip doesn't overwrite an
-# explicit admin override. Empty for rows that pre-date the field.
-RateLimitSource = Literal["", "default_unverified", "default_verified", "admin"]
-
-
-class ProvisioningRateLimits(BaseModel):
-    """Per-endpoint hourly overrides. None means "use the endpoint's default"."""
-
-    model_config = ConfigDict(extra="ignore", frozen=True)
-
-    account_requests: int | None = None
-    token_exchanges: int | None = None
-    resource_creates: int | None = None
-    github_grants: int | None = None
-    wizard_runs: int | None = None
+# Admin override value that disables an endpoint's limit outright. Distinct from the
+# BLOCKED tier multiplier (0) on purpose: an operator typing 0 into a form must not
+# accidentally grant infinity, so 0 is rejected at the write paths.
+UNLIMITED_OVERRIDE = -1
 
 
 class ProvisioningConfig(BaseModel):
@@ -94,5 +82,21 @@ class ProvisioningConfig(BaseModel):
     # Grandfathered: only the legacy Stripe app still mints a Personal API Key.
     issues_personal_api_key: bool = False
 
-    rate_limits: ProvisioningRateLimits = Field(default_factory=ProvisioningRateLimits)
-    rate_limit_source: RateLimitSource = ""
+    # Per-endpoint hourly overrides, keyed by rate-limit endpoint name. An absent key
+    # means the tier-derived budget applies; UNLIMITED_OVERRIDE disables the limit.
+    # Every value stored here is admin-authored: the self-serve tiers are derived at
+    # request time and never written, which is what made rate_limit_source obsolete.
+    rate_limits: dict[str, int] = Field(default_factory=dict)
+
+    @field_validator("rate_limits", mode="before")
+    @classmethod
+    def _normalize_rate_limits(cls, value: object) -> dict[str, int]:
+        """Load blobs written by any release: the old fixed-field shape stored null
+        for "no override" and 0 for "unlimited"."""
+        if not isinstance(value, dict):
+            return {}
+        return {
+            str(key): (UNLIMITED_OVERRIDE if int(raw) <= 0 else int(raw))
+            for key, raw in value.items()
+            if raw is not None
+        }

--- a/posthog/models/oauth_provisioning.py
+++ b/posthog/models/oauth_provisioning.py
@@ -95,8 +95,14 @@ class ProvisioningConfig(BaseModel):
         for "no override" and 0 for "unlimited"."""
         if not isinstance(value, dict):
             return {}
-        return {
-            str(key): (UNLIMITED_OVERRIDE if int(raw) <= 0 else int(raw))
-            for key, raw in value.items()
-            if raw is not None
-        }
+        limits: dict[str, int] = {}
+        for key, raw in value.items():
+            try:
+                parsed = int(raw)
+            except (TypeError, ValueError):
+                # Dropped like a null rather than raised: pydantic lets a TypeError out of a
+                # validator, and the config is re-parsed on every read, so one unreadable
+                # value would fail every request for that partner.
+                continue
+            limits[str(key)] = UNLIMITED_OVERRIDE if parsed <= 0 else parsed
+        return limits

--- a/posthog/models/test/test_oauth.py
+++ b/posthog/models/test/test_oauth.py
@@ -655,7 +655,7 @@ class TestCarriesProvisioningConfig(SimpleTestCase):
             ),
             (
                 "quota_recorded",
-                {"is_provisioning_partner": False, "config": ProvisioningConfig(rate_limit_source="admin")},
+                {"is_provisioning_partner": False, "config": ProvisioningConfig(rate_limits={"account_requests": 5})},
                 True,
             ),
         ]

--- a/posthog/models/test/test_oauth.py
+++ b/posthog/models/test/test_oauth.py
@@ -21,7 +21,7 @@ from posthog.models.oauth import (
     revoke_oauth_session,
     revoke_oauth_token_session,
 )
-from posthog.models.oauth_provisioning import ProvisioningConfig
+from posthog.models.oauth_provisioning import UNLIMITED_OVERRIDE, ProvisioningConfig
 
 
 class TestOAuthModels(TestCase):
@@ -666,6 +666,25 @@ class TestCarriesProvisioningConfig(SimpleTestCase):
             _provisioning_config=fields["config"].model_dump(mode="json"),
         )
         assert app.carries_provisioning_config is expected
+
+
+class TestNormalizeRateLimits(SimpleTestCase):
+    @parameterized.expand(
+        [
+            # The old fixed-field shape stored these two for "no override" and "unlimited".
+            ("null_is_no_override", {"account_requests": None}, {}),
+            ("zero_becomes_unlimited", {"account_requests": 0}, {"account_requests": UNLIMITED_OVERRIDE}),
+            ("negative_stays_unlimited", {"account_requests": -1}, {"account_requests": UNLIMITED_OVERRIDE}),
+            ("value_is_kept", {"account_requests": 5}, {"account_requests": 5}),
+            # The config is re-parsed on every read, so a value the validator cannot coerce has
+            # to drop out rather than raise and fail every request for that partner.
+            ("unreadable_value_is_dropped", {"account_requests": {}}, {}),
+            ("unreadable_text_is_dropped", {"account_requests": "many"}, {}),
+            ("readable_value_survives_an_unreadable_sibling", {"a": [], "b": 5}, {"b": 5}),
+        ]
+    )
+    def test_normalize_rate_limits(self, _name: str, stored: dict, expected: dict) -> None:
+        assert ProvisioningConfig(rate_limits=stored).rate_limits == expected
 
 
 class TestNormalizeCimdUrl(SimpleTestCase):

--- a/posthog/test/activity_logging/test_oauth_application_activity_logging.py
+++ b/posthog/test/activity_logging/test_oauth_application_activity_logging.py
@@ -108,6 +108,20 @@ class TestOAuthApplicationActivityLogging(BaseTest):
 
         self.assertEqual(self._scope_logs(application).count(), 0)
 
+    def test_provisioning_config_change_is_logged(self):
+        # Rate-limit overrides and capabilities are admin-authored security state,
+        # so a change must leave an audit trail like a scope-ceiling change does.
+        application = self._create_application(scopes=["insight:read"])
+        self._scope_logs(application).delete()
+
+        application.update_provisioning_rate_limits(account_requests=250)
+
+        log = self._scope_logs(application, "updated").first()
+        assert log is not None
+        assert log.detail is not None
+        fields = [change["field"] for change in log.detail["changes"]]
+        self.assertEqual(fields, ["provisioning config"])
+
     def test_only_scopes_change_appears_when_other_fields_change_in_same_save(self):
         application = self._create_application(scopes=["insight:read"])
         self._scope_logs(application).delete()
@@ -133,11 +147,12 @@ class TestOAuthApplicationActivityLogging(BaseTest):
 
         self.assertEqual(self._scope_logs(application).count(), 0)
 
-    def test_save_with_update_fields_excluding_scopes_logs_nothing(self):
+    def test_save_with_update_fields_excluding_audited_fields_logs_nothing(self):
         application = self._create_application(scopes=["insight:read"])
         self._scope_logs(application).delete()
 
-        application.update_provisioning(active=True)
+        application.name = "Renamed App"
+        application.save(update_fields=["name"])
 
         self.assertEqual(self._scope_logs(application).count(), 0)
 

--- a/posthog/test/test_migration_1310.py
+++ b/posthog/test/test_migration_1310.py
@@ -25,16 +25,24 @@ class ProvisioningRateLimitOverridesMigrationTest(TestMigrations):
                 _provisioning_config=config,
             )
 
-        # Tier-sourced value cleared; the admin value on another endpoint survives.
+        # Tier-sourced: the persisted tier value goes, other keys are normalized while
+        # this row is being written anyway.
         self.tiered = create(
             "tiered",
             {
                 "active": True,
-                "rate_limits": {"account_requests": 100, "resource_creates": 5, "token_exchanges": None},
+                "rate_limits": {
+                    "account_requests": 100,
+                    "resource_creates": 5,
+                    "wizard_runs": 0,
+                    "token_exchanges": None,
+                },
                 "rate_limit_source": "default_verified",
             },
         )
-        # Admin-sourced value kept; legacy 0 becomes the -1 unlimited sentinel.
+        # Not tier-sourced, so the migration leaves it alone. 1274 wrote a config onto
+        # every OAuthApplication, so rewriting these rows would mean rewriting the table;
+        # the read-path validator normalizes them instead.
         self.admin_set = create(
             "admin_set",
             {
@@ -43,18 +51,17 @@ class ProvisioningRateLimitOverridesMigrationTest(TestMigrations):
                 "rate_limit_source": "admin",
             },
         )
-        # Legacy row with no source recorded is treated as admin and kept.
         self.legacy = create("legacy", {"active": True, "rate_limits": {"account_requests": 42}})
         self.untouched = create("untouched", {})
 
-    def test_tier_values_cleared_and_admin_overrides_normalized(self) -> None:
+    def test_only_tier_sourced_rows_are_rewritten(self) -> None:
         tiered = self.OAuthApplication.objects.get(pk=self.tiered.pk)._provisioning_config
-        assert tiered["rate_limits"] == {"resource_creates": 5}
+        assert tiered["rate_limits"] == {"resource_creates": 5, "wizard_runs": -1}
         assert "rate_limit_source" not in tiered
 
         admin_set = self.OAuthApplication.objects.get(pk=self.admin_set.pk)._provisioning_config
-        assert admin_set["rate_limits"] == {"account_requests": 250, "wizard_runs": -1}
-        assert "rate_limit_source" not in admin_set
+        assert admin_set["rate_limits"] == {"account_requests": 250, "wizard_runs": 0}
+        assert admin_set["rate_limit_source"] == "admin"
 
         legacy = self.OAuthApplication.objects.get(pk=self.legacy.pk)._provisioning_config
         assert legacy["rate_limits"] == {"account_requests": 42}

--- a/posthog/test/test_migration_1310.py
+++ b/posthog/test/test_migration_1310.py
@@ -1,0 +1,62 @@
+from typing import Any
+
+from posthog.test.base import TestMigrations
+
+
+class ProvisioningRateLimitOverridesMigrationTest(TestMigrations):
+    migrate_from = "1309_integration_kind_ext_idx"
+    migrate_to = "1310_provisioning_rate_limit_overrides"
+
+    CLASS_DATA_LEVEL_SETUP = False
+
+    def setUpBeforeMigration(self, apps: Any) -> None:
+        OAuthApplication = apps.get_model("posthog", "OAuthApplication")
+        self.OAuthApplication = OAuthApplication
+
+        def create(client_id: str, config: dict) -> Any:
+            return OAuthApplication.objects.create(
+                name=client_id,
+                client_id=client_id,
+                client_secret="",
+                client_type="confidential",
+                authorization_grant_type="authorization-code",
+                redirect_uris="https://example.com/callback",
+                algorithm="RS256",
+                _provisioning_config=config,
+            )
+
+        # Tier-sourced value cleared; the admin value on another endpoint survives.
+        self.tiered = create(
+            "tiered",
+            {
+                "active": True,
+                "rate_limits": {"account_requests": 100, "resource_creates": 5, "token_exchanges": None},
+                "rate_limit_source": "default_verified",
+            },
+        )
+        # Admin-sourced value kept; legacy 0 becomes the -1 unlimited sentinel.
+        self.admin_set = create(
+            "admin_set",
+            {
+                "active": True,
+                "rate_limits": {"account_requests": 250, "wizard_runs": 0},
+                "rate_limit_source": "admin",
+            },
+        )
+        # Legacy row with no source recorded is treated as admin and kept.
+        self.legacy = create("legacy", {"active": True, "rate_limits": {"account_requests": 42}})
+        self.untouched = create("untouched", {})
+
+    def test_tier_values_cleared_and_admin_overrides_normalized(self) -> None:
+        tiered = self.OAuthApplication.objects.get(pk=self.tiered.pk)._provisioning_config
+        assert tiered["rate_limits"] == {"resource_creates": 5}
+        assert "rate_limit_source" not in tiered
+
+        admin_set = self.OAuthApplication.objects.get(pk=self.admin_set.pk)._provisioning_config
+        assert admin_set["rate_limits"] == {"account_requests": 250, "wizard_runs": -1}
+        assert "rate_limit_source" not in admin_set
+
+        legacy = self.OAuthApplication.objects.get(pk=self.legacy.pk)._provisioning_config
+        assert legacy["rate_limits"] == {"account_requests": 42}
+
+        assert self.OAuthApplication.objects.get(pk=self.untouched.pk)._provisioning_config == {}


### PR DESCRIPTION

## Problem

- An operator could only override five hardcoded endpoints; the endpoints added in the tier cutover (token_refreshes, resource_reads, credential_rotations, ...) had no override lever.
- `rate_limit_source` existed to stop CIMD verification flips from clobbering admin overrides. With tiers derived at request time, CIMD no longer persists limits, so the bookkeeping is dead weight.
- The stored `0` meant "unlimited": one digit away from an operator accidentally granting infinity.
- Limit and capability changes wrote no ActivityLog row (`handle_oauth_application_scopes_change` filtered everything but `scopes`).

## Changes

- `ProvisioningConfig.rate_limits` becomes a per-endpoint dict; every stored value is admin-authored by definition. `rate_limit_source` and the fixed-field `ProvisioningRateLimits` model are gone.
- Unlimited is the explicit `UNLIMITED_OVERRIDE` (-1); `0` is rejected at the write paths. A validator loads old blobs (nulls dropped, 0 normalized, unreadable values dropped) so mid-deploy reads stay safe. An unreadable value drops out rather than raising, because the config is re-parsed on every read and one bad value would otherwise fail every request for that partner.
- CIMD stops persisting limits: `_retier_account_requests_limit` and the 10/100 registration defaults are deleted; the registration analytics event reports the derived `partner_tier` instead.
- The Django admin generates one override field per registered endpoint from the `@rate_limited` registry (lazily, keeping the ee views off `django.setup()`), so a new declaration grows an admin field with no admin change. Help text states the semantics; the `changed_data` -> `source="admin"` pin logic is gone.
- Data migration `1310`: clears the tier-sourced `account_requests` values so the derived tier applies again, instead of the persisted 10/100 being read as an admin override forever.
- The migration filters to `rate_limit_source in (default_verified, default_unverified)` in Postgres, so it writes only the affected CIMD partners. `posthog_oauthapplication` holds about 2.6M rows because 1274 backfilled a config onto all of them, and rewriting those to strip dead keys would be thousands of `bulk_update` statements in the deploy path.
- The keys it leaves behind are dead weight rather than wrong: the `rate_limits` validator drops nulls and maps `0` to `-1`, and `extra="ignore"` ignores a leftover `rate_limit_source`. They clear on the next save of that row.
- Overrides now apply to every endpoint (`resolve_budget` reads the dict), and an override still outranks a `BLOCKED` tier cell.
- OAuth app activity logging now includes `_provisioning_config` changes alongside `scopes`, so override and capability edits leave an audit trail.

## How did you test this code?

- Migration test `test_migration_1310.py`: a tier-sourced row loses the tier value and the source key while its other keys normalize, and an admin-sourced row is left byte-for-byte alone. The second assertion is the one that guards the row count.
- Admin tests: override stored per endpoint; `0` rejected with a field error while `-1` persists as unlimited.
- CIMD tests rewritten from persisted-limit assertions to derived-tier assertions (registration, verification added/removed on refresh, admin override surviving refresh).
- New activity-logging test pins that a provisioning-config change writes an ActivityLog row; the update_fields test that used a provisioning save as its non-audited change now uses `name`.
- Full agentic + oauth/cimd/admin suites pass locally; repo-wide `mypy --cache-fine-grained .` clean.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Operator-facing semantics are in the admin help text; posthog.com docs land after the introspection endpoint PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code session directed by Rafael; dropping `rate_limit_source` follows from the user-approved design (derived tiers mean any stored override is admin-authored).
- Skills invoked: `/django-migrations`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.
- The migration clears only `account_requests` for default-sourced rows because the retier logic only ever wrote that key; clearing the whole dict could drop an admin value on another endpoint that coexisted with a default source.


