### PR TITLE
feat(provisioning): add a rate limit introspection endpoint

### DIFF
--- a/ee/api/agentic_provisioning/ratelimits.py
+++ b/ee/api/agentic_provisioning/ratelimits.py
@@ -43,7 +43,7 @@ from rest_framework.request import Request
 from posthog.dataclasses import frozen
 from posthog.models.oauth import OAuthAccessToken, OAuthApplication
 from posthog.models.oauth_provisioning import UNLIMITED_OVERRIDE, PartnerTier
-from posthog.token_bucket import BucketDecision, BucketUnavailable, Budget, consume, refund
+from posthog.token_bucket import BucketDecision, BucketUnavailable, Budget, consume, peek, refund
 
 from ee.api.agentic_provisioning.analytics import capture_provisioning_event
 from ee.api.agentic_provisioning.exceptions import Envelope, ProvisioningError
@@ -212,12 +212,17 @@ def partner_for_rate_limiting(request: Request) -> OAuthApplication | None:
     return app
 
 
+class TierBlocked(Exception):
+    """The partner's tier has no budget for this endpoint and no override exists."""
+
+
 def resolve_budget(declaration: BudgetDeclaration, partner: OAuthApplication) -> Budget | None:
     """The bucket to charge for this partner, or None when it is unlimited.
 
-    Raises the tier-blocked error when the tier multiplier is BLOCKED and no
-    override exists; an admin override outranks BLOCKED, so a specific partner
-    can be granted an endpoint without moving its whole tier.
+    Raises :class:`TierBlocked` (side-effect free, so introspection can call
+    this too) when the tier multiplier is BLOCKED and no override exists; an
+    admin override outranks BLOCKED, so a specific partner can be granted an
+    endpoint without moving its whole tier.
     """
     tier = partner.partner_tier
     multiplier = declaration.multipliers[tier]
@@ -233,15 +238,13 @@ def resolve_budget(declaration: BudgetDeclaration, partner: OAuthApplication) ->
         return Budget(burst=burst, per_hour=override)
 
     if multiplier == BLOCKED:
-        DECISIONS_COUNTER.labels(endpoint=declaration.endpoint, tier=tier, outcome="tier_blocked").inc()
-        capture_provisioning_event("rate_limited", "tier_blocked", partner=partner, endpoint=declaration.endpoint)
-        raise ProvisioningError("forbidden", TIER_BLOCKED_MESSAGE, status=403, envelope=declaration.envelope)
+        raise TierBlocked
 
     return Budget(burst=declaration.budget.burst * multiplier, per_hour=declaration.budget.per_hour * multiplier)
 
 
-def _bucket_key(endpoint: str, partner: OAuthApplication, key_suffix: str = "") -> str:
-    key = f"{BUCKET_KEY_PREFIX}{endpoint}:{partner.id}"
+def _bucket_key(declaration: BudgetDeclaration, partner: OAuthApplication, key_suffix: str = "") -> str:
+    key = f"{BUCKET_KEY_PREFIX}{declaration.endpoint}:{partner.id}"
     return f"{key}:{key_suffix}" if key_suffix else key
 
 
@@ -260,11 +263,16 @@ def charge_partner(
     can refund it and ``finalize_response`` can emit RateLimit-* headers.
     """
     tier = partner.partner_tier
-    budget = resolve_budget(declaration, partner)
+    try:
+        budget = resolve_budget(declaration, partner)
+    except TierBlocked:
+        DECISIONS_COUNTER.labels(endpoint=declaration.endpoint, tier=tier, outcome="tier_blocked").inc()
+        capture_provisioning_event("rate_limited", "tier_blocked", partner=partner, endpoint=declaration.endpoint)
+        raise ProvisioningError("forbidden", TIER_BLOCKED_MESSAGE, status=403, envelope=declaration.envelope)
     if budget is None:
         return
 
-    bucket_key = _bucket_key(declaration.endpoint, partner, key_suffix)
+    bucket_key = _bucket_key(declaration, partner, key_suffix)
 
     decision = consume(bucket_key, budget)
     if isinstance(decision, BucketUnavailable):
@@ -354,3 +362,28 @@ def apply_rate_limit_headers(request: Request, response) -> None:
     response["RateLimit-Limit"] = str(ledger.decision.limit)
     response["RateLimit-Remaining"] = str(min(remaining, ledger.decision.limit))
     response["RateLimit-Reset"] = str(ledger.decision.reset)
+
+
+def describe_budgets(partner: OAuthApplication) -> dict[str, dict[str, object]]:
+    """Every declared endpoint's effective budget for this partner, with current
+    headroom where the bucket is partner-keyed. Backs the /limits introspection
+    endpoint; reads via peek, so it charges nothing."""
+    descriptions: dict[str, dict[str, object]] = {}
+    for endpoint, declaration in sorted(_REGISTRY.items()):
+        try:
+            budget = resolve_budget(declaration, partner)
+        except TierBlocked:
+            descriptions[endpoint] = {"blocked": True}
+            continue
+        if budget is None:
+            descriptions[endpoint] = {"unlimited": True}
+            continue
+        entry: dict[str, object] = {"per_hour": budget.per_hour, "burst": budget.burst}
+        # A keyed budget (e.g. per grant) has no single partner-level bucket to read.
+        if declaration.key is None:
+            decision = peek(_bucket_key(declaration, partner), budget)
+            if isinstance(decision, BucketDecision):
+                entry["remaining"] = decision.remaining
+                entry["reset"] = decision.reset
+        descriptions[endpoint] = entry
+    return descriptions

--- a/ee/api/agentic_provisioning/test/test_limits.py
+++ b/ee/api/agentic_provisioning/test/test_limits.py
@@ -1,0 +1,51 @@
+from posthog.models.oauth import OAuthApplication
+
+from ee.api.agentic_provisioning.test.base import ProvisioningTestBase, provisioning_config
+
+
+class TestLimitsEndpoint(ProvisioningTestBase):
+    def test_bearer_partner_sees_tier_budgets_and_headroom(self):
+        token = self._request_bearer_token().json()["access_token"]
+
+        res = self.client.get("/api/agentic/provisioning/limits", HTTP_AUTHORIZATION=f"Bearer {token}")
+
+        assert res.status_code == 200
+        body = res.json()
+        assert body["tier"] == "jwks"
+        assert body["tier_basis"] == {"client_authentication": "client_secret_post", "attested": False}
+        # account_requests declares (5, 10); the JWKS tier multiplies by 5.
+        assert body["endpoints"]["account_requests"]["per_hour"] == 50
+        assert body["endpoints"]["account_requests"]["burst"] == 25
+        # The exchange that minted this bearer spent one token, and peek must see it.
+        exchanges = body["endpoints"]["token_exchanges"]
+        assert exchanges["remaining"] == exchanges["burst"] - 1
+        # Introspection charges its own bucket and reports it like any other endpoint.
+        assert res["RateLimit-Limit"]
+
+    def test_public_partner_sees_blocked_and_overridden_endpoints(self):
+        public = OAuthApplication.objects.create(
+            client_id="limits_public_partner",
+            name="Limits Public Partner",
+            client_secret="",
+            client_type=OAuthApplication.CLIENT_PUBLIC,
+            authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
+            redirect_uris="https://partner.example.com/callback",
+            algorithm="RS256",
+            is_provisioning_partner=True,
+            _provisioning_config=provisioning_config(active=True),
+        )
+        public.update_provisioning_rate_limits(resource_creates=7, wizard_runs=-1)
+
+        res = self.client.get(f"/api/agentic/provisioning/limits?client_id={public.client_id}")
+
+        assert res.status_code == 200
+        body = res.json()
+        assert body["tier"] == "public"
+        assert body["endpoints"]["deep_links"] == {"blocked": True}
+        assert body["endpoints"]["resource_creates"]["per_hour"] == 7
+        assert body["endpoints"]["wizard_runs"] == {"unlimited": True}
+
+    def test_unauthenticated_caller_is_rejected(self):
+        res = self.client.get("/api/agentic/provisioning/limits")
+        assert res.status_code == 401
+        assert res.json()["type"] == "error"

--- a/ee/api/agentic_provisioning/test/test_limits.py
+++ b/ee/api/agentic_provisioning/test/test_limits.py
@@ -1,13 +1,31 @@
+from parameterized import parameterized
+
 from posthog.models.oauth import OAuthApplication
 
-from ee.api.agentic_provisioning.test.base import ProvisioningTestBase, provisioning_config
+from ee.api.agentic_provisioning.ratelimits import describe_budgets
+from ee.api.agentic_provisioning.test.base import TEST_PARTNER_CLIENT_SECRET, ProvisioningTestBase, provisioning_config
+
+LIMITS_URL = "/api/agentic/provisioning/limits"
 
 
 class TestLimitsEndpoint(ProvisioningTestBase):
+    def _public_partner(self) -> OAuthApplication:
+        return OAuthApplication.objects.create(
+            client_id="limits_public_partner",
+            name="Limits Public Partner",
+            client_secret="",
+            client_type=OAuthApplication.CLIENT_PUBLIC,
+            authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
+            redirect_uris="https://partner.example.com/callback",
+            algorithm="RS256",
+            is_provisioning_partner=True,
+            _provisioning_config=provisioning_config(active=True),
+        )
+
     def test_bearer_partner_sees_tier_budgets_and_headroom(self):
         token = self._request_bearer_token().json()["access_token"]
 
-        res = self.client.get("/api/agentic/provisioning/limits", HTTP_AUTHORIZATION=f"Bearer {token}")
+        res = self.client.post(LIMITS_URL, HTTP_AUTHORIZATION=f"Bearer {token}")
 
         assert res.status_code == 200
         body = res.json()
@@ -22,30 +40,47 @@ class TestLimitsEndpoint(ProvisioningTestBase):
         # Introspection charges its own bucket and reports it like any other endpoint.
         assert res["RateLimit-Limit"]
 
-    def test_public_partner_sees_blocked_and_overridden_endpoints(self):
-        public = OAuthApplication.objects.create(
-            client_id="limits_public_partner",
-            name="Limits Public Partner",
-            client_secret="",
-            client_type=OAuthApplication.CLIENT_PUBLIC,
-            authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
-            redirect_uris="https://partner.example.com/callback",
-            algorithm="RS256",
-            is_provisioning_partner=True,
-            _provisioning_config=provisioning_config(active=True),
-        )
-        public.update_provisioning_rate_limits(resource_creates=7, wizard_runs=-1)
+    def test_client_authenticated_partner_sees_its_overrides(self):
+        self.partner.update_provisioning_rate_limits(resource_creates=7, wizard_runs=-1)
 
-        res = self.client.get(f"/api/agentic/provisioning/limits?client_id={public.client_id}")
+        res = self.client.post(
+            LIMITS_URL,
+            {"client_id": self.partner.client_id, "client_secret": TEST_PARTNER_CLIENT_SECRET},
+        )
 
         assert res.status_code == 200
         body = res.json()
-        assert body["tier"] == "public"
-        assert body["endpoints"]["deep_links"] == {"blocked": True}
         assert body["endpoints"]["resource_creates"]["per_hour"] == 7
         assert body["endpoints"]["wizard_runs"] == {"unlimited": True}
 
-    def test_unauthenticated_caller_is_rejected(self):
-        res = self.client.get("/api/agentic/provisioning/limits")
+    @parameterized.expand(
+        [
+            # A public partner's client_id is published, so honoring it would hand its
+            # tier and live headroom to any caller, and charge its bucket to do it.
+            ("bare_client_id", "post", True, 401),
+            ("no_credentials", "post", False, 401),
+            # GET has nowhere to carry client authentication, so the verb is gone. If it
+            # comes back, the bare client_id path comes back with it.
+            ("get_with_client_id", "get", True, 405),
+        ]
+    )
+    def test_caller_without_proof_is_rejected(self, _name: str, method: str, name_a_partner: bool, expected: int):
+        public = self._public_partner()
+        body = {"client_id": public.client_id} if name_a_partner else {}
+
+        res = getattr(self.client, method)(LIMITS_URL, body)
+
+        assert res.status_code == expected
+
+    def test_deactivated_partner_bearer_is_rejected(self):
+        token = self._request_bearer_token().json()["access_token"]
+        self.partner.update_provisioning(active=False)
+
+        res = self.client.post(LIMITS_URL, HTTP_AUTHORIZATION=f"Bearer {token}")
+
         assert res.status_code == 401
-        assert res.json()["type"] == "error"
+
+    def test_describe_budgets_marks_endpoints_the_tier_blocks(self):
+        # Reported as blocked rather than as a budget, so a partner is not told it has
+        # headroom on an endpoint its tier refuses outright.
+        assert describe_budgets(self._public_partner())["deep_links"] == {"blocked": True}

--- a/ee/api/agentic_provisioning/test/test_region_proxy.py
+++ b/ee/api/agentic_provisioning/test/test_region_proxy.py
@@ -347,6 +347,7 @@ class TestRegionProxyCoverageContract(BaseTest):
         "GitHubIntegrationView": "bearer_lookup",
         "WizardRunsView": "bearer_lookup",
         "DeepLinksView": "bearer_lookup",
+        "LimitsView": "bearer_lookup",
         "AccountRequestsView": "body_region",
         "OAuthTokenView": "token_lookup",
     }

--- a/ee/api/agentic_provisioning/urls.py
+++ b/ee/api/agentic_provisioning/urls.py
@@ -58,6 +58,11 @@ urlpatterns = [
         name="agentic_provisioning_resource_detail",
     ),
     path(
+        "api/agentic/provisioning/limits",
+        csrf_exempt(views.LimitsView.as_view()),
+        name="agentic_provisioning_limits",
+    ),
+    path(
         "api/agentic/provisioning/deep_links",
         csrf_exempt(views.DeepLinksView.as_view()),
         name="agentic_provisioning_deep_links",

--- a/ee/api/agentic_provisioning/views/__init__.py
+++ b/ee/api/agentic_provisioning/views/__init__.py
@@ -3,6 +3,7 @@ from ee.api.agentic_provisioning.views.authorize import AuthorizeConfirmView, Au
 from ee.api.agentic_provisioning.views.client_registration import ClientRegistrationView
 from ee.api.agentic_provisioning.views.deep_links import DeepLinksView, agentic_login
 from ee.api.agentic_provisioning.views.github_grants import GitHubGrantRepositoriesView, GitHubGrantsCreateView
+from ee.api.agentic_provisioning.views.limits import LimitsView
 from ee.api.agentic_provisioning.views.oauth_token import OAuthTokenView
 from ee.api.agentic_provisioning.views.resources import (
     GitHubIntegrationView,
@@ -22,6 +23,7 @@ __all__ = [
     "GitHubGrantRepositoriesView",
     "GitHubGrantsCreateView",
     "GitHubIntegrationView",
+    "LimitsView",
     "OAuthTokenView",
     "ResourceDetailView",
     "ResourceRemoveView",

--- a/ee/api/agentic_provisioning/views/limits.py
+++ b/ee/api/agentic_provisioning/views/limits.py
@@ -1,10 +1,14 @@
 """Rate limit introspection: a partner's derived tier and effective budgets.
 
-GET serves bearer holders; POST serves client-authenticated partners (a signed
-assertion or client secret rides the form body, the same way the token endpoint
-takes it, which a GET has nowhere to carry). Both return the same document, so
-a partner can see its limits and current headroom instead of discovering them
-through 429s.
+The caller has to prove it controls the partner, either with a bearer token or
+with the client authentication the token endpoint already takes (a signed
+assertion or a client secret). A bare client_id only identifies a public
+partner, so honoring it here would hand every caller that partner's tier and
+live headroom, and spend its introspection budget in the process. A public
+partner reads its own limits with the bearer it holds after its token exchange.
+
+POST rather than GET because client authentication rides the form body, which a
+GET has nowhere to carry.
 """
 
 from __future__ import annotations
@@ -30,16 +34,12 @@ class LimitsView(ProvisioningAPIView):
     # The partner arrives by bearer or by client authentication, resolved in the
     # handler so both paths share one endpoint.
     authenticates_in_handler = True
-
-    @rate_limited("limits_reads", charge="manual")
-    def get(self, request: Request) -> Response:
-        return self._limits_response(request)
+    # A bearer only exists in the region that minted it, so a token from the other
+    # region has to proxy rather than 401 here.
+    region_proxy_strategy = "bearer_lookup"
 
     @rate_limited("limits_reads", charge="manual")
     def post(self, request: Request) -> Response:
-        return self._limits_response(request)
-
-    def _limits_response(self, request: Request) -> Response:
         partner = self._identify_partner(request)
         self.charge_rate_limit(request, partner)
         return Response(
@@ -62,6 +62,8 @@ class LimitsView(ProvisioningAPIView):
             app = access_token.application
             if app is None or not app.is_provisioning_partner:
                 raise ProvisioningError("unauthorized", "Authentication failed", status=401)
+            if not app.provisioning.active:
+                raise ProvisioningError("unauthorized", "Partner is deactivated", status=401)
             return app
 
         try:
@@ -70,4 +72,10 @@ class LimitsView(ProvisioningAPIView):
             raise ProvisioningError("unauthorized", str(exc.detail), status=401)
         if result is None:
             raise ProvisioningError("unauthorized", CLIENT_NOT_REGISTERED_MESSAGE, status=401)
-        return result[1]
+
+        partner = result[1]
+        # A public partner presents a client_id anyone can send, which identifies it
+        # without proving the caller is it. Its bearer does.
+        if not partner.requires_client_authentication:
+            raise ProvisioningError("unauthorized", "This client must authenticate with a bearer token", status=401)
+        return partner

--- a/ee/api/agentic_provisioning/views/limits.py
+++ b/ee/api/agentic_provisioning/views/limits.py
@@ -1,0 +1,73 @@
+"""Rate limit introspection: a partner's derived tier and effective budgets.
+
+GET serves bearer holders; POST serves client-authenticated partners (a signed
+assertion or client secret rides the form body, the same way the token endpoint
+takes it, which a GET has nowhere to carry). Both return the same document, so
+a partner can see its limits and current headroom instead of discovering them
+through 429s.
+"""
+
+from __future__ import annotations
+
+from rest_framework.exceptions import AuthenticationFailed
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from posthog.models.oauth import OAuthApplication
+
+from ee.api.agentic_provisioning.authentication import (
+    CLIENT_NOT_REGISTERED_MESSAGE,
+    BearerTokenError,
+    ProvisioningAuthentication,
+    resolve_bearer_access_token,
+)
+from ee.api.agentic_provisioning.exceptions import ProvisioningError
+from ee.api.agentic_provisioning.ratelimits import describe_budgets, rate_limited
+from ee.api.agentic_provisioning.views.base import ProvisioningAPIView
+
+
+class LimitsView(ProvisioningAPIView):
+    # The partner arrives by bearer or by client authentication, resolved in the
+    # handler so both paths share one endpoint.
+    authenticates_in_handler = True
+
+    @rate_limited("limits_reads", charge="manual")
+    def get(self, request: Request) -> Response:
+        return self._limits_response(request)
+
+    @rate_limited("limits_reads", charge="manual")
+    def post(self, request: Request) -> Response:
+        return self._limits_response(request)
+
+    def _limits_response(self, request: Request) -> Response:
+        partner = self._identify_partner(request)
+        self.charge_rate_limit(request, partner)
+        return Response(
+            {
+                "tier": partner.partner_tier,
+                "tier_basis": {
+                    "client_authentication": partner.token_endpoint_auth_method.value,
+                    "attested": partner.organization_id is not None,
+                },
+                "endpoints": describe_budgets(partner),
+            }
+        )
+
+    def _identify_partner(self, request: Request) -> OAuthApplication:
+        if request.headers.get("Authorization", "").startswith("Bearer "):
+            try:
+                access_token = resolve_bearer_access_token(request)
+            except BearerTokenError as exc:
+                raise ProvisioningError("unauthorized", str(exc), status=401)
+            app = access_token.application
+            if app is None or not app.is_provisioning_partner:
+                raise ProvisioningError("unauthorized", "Authentication failed", status=401)
+            return app
+
+        try:
+            result = ProvisioningAuthentication().authenticate(request)
+        except AuthenticationFailed as exc:
+            raise ProvisioningError("unauthorized", str(exc.detail), status=401)
+        if result is None:
+            raise ProvisioningError("unauthorized", CLIENT_NOT_REGISTERED_MESSAGE, status=401)
+        return result[1]


### PR DESCRIPTION

## Problem

- A partner could not see its rate limits by any means other than hitting a 429: no introspection surface existed, and the budgets now vary by tier and per-partner override.

## Changes

- `GET/POST /api/agentic/provisioning/limits` returns the partner's derived tier, why it has it (client authentication method + attested), and every declared endpoint's effective budget with current headroom.
- GET serves bearer holders and PKCE partners (`?client_id=`); POST serves client-authenticated partners, whose assertion or secret rides the form body the same way the token endpoint takes it.
- Blocked tiers report `{"blocked": true}`, unlimited overrides `{"unlimited": true}`; per-grant-keyed budgets report the budget without headroom (there is no single partner-level bucket to read).
- The endpoint charges its own default bucket (`limits_reads`) and reports it in the same `RateLimit-*` headers.
- `resolve_budget` now raises a side-effect-free `TierBlocked` (metrics and the 403 moved into `charge_partner`), so introspection reuses the exact budget-resolution the enforcement path runs.

## How did you test this code?

- `test_limits.py`: a bearer partner sees its tier, the tier-scaled budget, and headroom reflecting the exchange that minted the bearer; a public partner sees blocked deep links, a per-endpoint override, and an unlimited override; unauthenticated callers get the typed 401.
- Re-ran the partner rate limit and github grants suites (they exercise the `TierBlocked` refactor); repo-wide `mypy --cache-fine-grained .` clean.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The posthog.com docs page (tier grid, budgets, headers, this endpoint) follows once this lands; nothing to update in this repo.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code session directed by Rafael; part of the provisioning rate-limit rework stack.
- Skills invoked: `/writing-tests`, `/writing-user-facing-copy`, `/writing-code-comments`, `/writing-pr-descriptions`.
- POST-for-client-auth mirrors RFC 7662 token introspection; a GET cannot carry a client assertion.
