### PR TITLE
feat(dashboards): add inline insertion experiment tracking

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -179,6 +179,7 @@ export const FEATURE_FLAGS = {
     // UX flags, used to control the UX of the app
     CMD_K_NAV_EXPERIMENT: 'cmd-k-nav-experiment', // owner: @rafaeelaudibert #team-platform-ux multivariate=control,search-bar,footer-hint,tools-row,footer-callout - surfaces the Cmd+K command menu more prominently in the left nav: search-bar = full-width search field below the nav header, footer-hint = extra Search row in the nav footer, tools-row = Search row after the Tools item in the Project section, footer-callout = dismissible callout card in the nav ad slot for users a few days after signup
     CREATE_BUTTON_NAV_EXPERIMENT: 'create-button-nav-experiment', // owner: #team-platform-ux multivariate=control,test — adds a Create dropdown to the top of the Browse tab in the left nav
+    DASHBOARD_INLINE_TILE_INSERTION_EXPERIMENT: 'dashboard-inline-tile-insertion-experiment', // owner: #team-analytics-platform multivariate=control,test — tests whether inline dashboard insertion increases completed tile additions
     FEATURE_FLAG_DISABLE_AND_ARCHIVE_EXPERIMENT: 'feature-flag-disable-and-archive-experiment', // owner: #team-feature-flags multivariate=control,test, adds a destructive "Disable and archive" option alongside "Disable only" in the disable-flag confirmation dialog, control keeps the plain disable confirmation
     INBOX_SELF_DRIVING_EMPTY_STATE: 'inbox-self-driving-empty-state',
     STARRED_REORDER: 'starred-reorder', // owner: #team-platform-ux, drag-and-drop reorder of starred shortcuts in the side panel

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -887,13 +887,17 @@ export interface eventUsageLogicActions {
     }
     reportDashboardTileInsertedInline: (
         tileType: DashboardAddTileType,
+        dashboardId: number,
+        tileId: number,
         column: number,
         row: number,
         fullWidth: boolean
     ) => {
         column: number
+        dashboardId: number
         fullWidth: boolean
         row: number
+        tileId: number
         tileType: DashboardAddTileType
     }
     reportDashboardTileRefreshed: (
@@ -2476,10 +2480,12 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         reportCreatedDashboardFromModal: true,
         reportDashboardTileInsertedInline: (
             tileType: DashboardAddTileType,
+            dashboardId: number,
+            tileId: number,
             column: number,
             row: number,
             fullWidth: boolean
-        ) => ({ tileType, column, row, fullWidth }),
+        ) => ({ tileType, dashboardId, tileId, column, row, fullWidth }),
         /** Dashboard created via PostHog web app from a template (new dashboard modal / template chooser). */
         reportWebDashboardCreatedFromTemplate: (payload: {
             dashboard_id: number
@@ -3595,9 +3601,11 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         reportCreatedDashboardFromModal: async () => {
             posthog.capture('created new dashboard from modal')
         },
-        reportDashboardTileInsertedInline: async ({ tileType, column, row, fullWidth }) => {
+        reportDashboardTileInsertedInline: async ({ tileType, dashboardId, tileId, column, row, fullWidth }) => {
             posthog.capture('dashboard tile inserted inline', {
                 tile_type: tileType,
+                dashboard_id: dashboardId,
+                tile_id: tileId,
                 column,
                 row,
                 full_width: fullWidth,

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -659,6 +659,13 @@ export interface eventUsageLogicActions {
         journeyName: string
         stepCount: number
     }
+    reportDashboardAddMenuOpened: (
+        source: 'header' | 'inline',
+        dashboardId: number
+    ) => {
+        dashboardId: number
+        source: 'header' | 'inline'
+    }
     reportDashboardBreakdownColorsSaved: (
         dashboard: DashboardType<QueryBasedInsightModel> | null,
         manualCount: number,
@@ -2478,6 +2485,7 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         reportCustomChannelTypeRulesUpdated: (numRules: number) => ({ numRules }),
         reportPropertySelectOpened: true,
         reportCreatedDashboardFromModal: true,
+        reportDashboardAddMenuOpened: (source: 'header' | 'inline', dashboardId: number) => ({ source, dashboardId }),
         reportDashboardTileInsertedInline: (
             tileType: DashboardAddTileType,
             dashboardId: number,
@@ -3600,6 +3608,9 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         },
         reportCreatedDashboardFromModal: async () => {
             posthog.capture('created new dashboard from modal')
+        },
+        reportDashboardAddMenuOpened: async ({ source, dashboardId }) => {
+            posthog.capture('dashboard add menu opened', { source, dashboard_id: dashboardId })
         },
         reportDashboardTileInsertedInline: async ({ tileType, dashboardId, tileId, column, row, fullWidth }) => {
             posthog.capture('dashboard tile inserted inline', {

--- a/frontend/src/scenes/dashboard/DashboardHeaderActions.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeaderActions.tsx
@@ -10,7 +10,7 @@ import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonMenu, LemonMenuItem, LemonMenuItems } from 'lib/lemon-ui/LemonMenu'
 import { getAccessControlDisabledReason } from 'lib/utils/accessControlUtils'
-import { DashboardEventSource } from 'lib/utils/eventUsageLogic'
+import { DashboardEventSource, eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { MaxTool } from 'scenes/max/MaxTool'
 import { Scene } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
@@ -83,6 +83,7 @@ export function DashboardAddTileButton(): JSX.Element | null {
     const { loadDashboard, setAddWidgetModalOpen, setPendingInsertion, openAddInsightModal } =
         useActions(dashboardLogic)
     const { push } = useActions(router)
+    const { reportDashboardAddMenuOpened } = useActions(eventUsageLogic)
 
     if (!dashboard) {
         return null
@@ -123,6 +124,11 @@ export function DashboardAddTileButton(): JSX.Element | null {
                         // Adding from the header appends at the bottom; drop any stale inline-insertion target.
                         onBeforeSelect: () => setPendingInsertion(null),
                     })}
+                    onVisibilityChange={(visible) => {
+                        if (visible) {
+                            reportDashboardAddMenuOpened('header', dashboard.id)
+                        }
+                    }}
                 >
                     <LemonButton type="primary" data-attr="dashboard-add-tile" size="small" icon={<IconPlusSmall />}>
                         Add

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -709,7 +709,11 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
                             isMobileView={isMobileView}
                             disabled={resizingTileId !== null}
                             getMenuItems={getInsertMenuItems}
-                            onMenuOpen={() => reportDashboardAddMenuOpened('inline', dashboard.id)}
+                            onMenuOpen={() => {
+                                if (dashboard?.id) {
+                                    reportDashboardAddMenuOpened('inline', dashboard.id)
+                                }
+                            }}
                         />
                     )}
                 </div>

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -121,7 +121,7 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
     const { showAddInsightToDashboardModal } = useActions(addInsightToDashboardLogic)
     const { updateWidgetTile } = useAsyncActions(dashboardLogic)
     const { renameInsight } = useActions(insightsModel)
-    const { reportDashboardTileRepositioned } = useActions(eventUsageLogic)
+    const { reportDashboardAddMenuOpened, reportDashboardTileRepositioned } = useActions(eventUsageLogic)
     const { push } = useActions(router)
     const { data: surveyLinkedInsights, loading: surveyLinkedInsightsLoading } = useSurveyLinkedInsights({})
 
@@ -709,6 +709,7 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
                             isMobileView={isMobileView}
                             disabled={resizingTileId !== null}
                             getMenuItems={getInsertMenuItems}
+                            onMenuOpen={() => reportDashboardAddMenuOpened('inline', dashboard.id)}
                         />
                     )}
                 </div>

--- a/frontend/src/scenes/dashboard/InsertTileOverlay.tsx
+++ b/frontend/src/scenes/dashboard/InsertTileOverlay.tsx
@@ -20,6 +20,7 @@ interface InsertTileOverlayProps {
     isMobileView: boolean
     disabled?: boolean
     getMenuItems: (targetX: number, targetY: number, targetW?: number) => LemonMenuItems
+    onMenuOpen: () => void
 }
 
 export function InsertTileOverlay({
@@ -33,6 +34,7 @@ export function InsertTileOverlay({
     isMobileView,
     disabled,
     getMenuItems,
+    onMenuOpen,
 }: InsertTileOverlayProps): JSX.Element | null {
     const containerRef = useRef<HTMLDivElement>(null)
     const [tileRects, setTileRects] = useState<TileRect[]>([])
@@ -115,6 +117,7 @@ export function InsertTileOverlay({
                     segments={boundary.segments}
                     zones={boundary.zones}
                     getMenuItems={getMenuItems}
+                    onMenuOpen={onMenuOpen}
                 />
             ))}
         </div>
@@ -141,6 +144,7 @@ function InsertionStrip({
     segments,
     zones,
     getMenuItems,
+    onMenuOpen,
 }: {
     lineY: number
     gridRow: number
@@ -149,6 +153,7 @@ function InsertionStrip({
     segments: LineSegment[]
     zones: InsertZone[]
     getMenuItems: (targetX: number, targetY: number, targetW?: number) => LemonMenuItems
+    onMenuOpen: () => void
 }): JSX.Element {
     const stripRef = useRef<HTMLDivElement>(null)
     const buttonRef = useRef<HTMLDivElement>(null)
@@ -235,7 +240,15 @@ function InsertionStrip({
                     revealClass
                 )}
             >
-                <LemonMenu items={menuItems} onVisibilityChange={setMenuOpen}>
+                <LemonMenu
+                    items={menuItems}
+                    onVisibilityChange={(visible) => {
+                        setMenuOpen(visible)
+                        if (visible) {
+                            onMenuOpen()
+                        }
+                    }}
+                >
                     <LemonButton
                         size="xsmall"
                         type="primary"

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -329,9 +329,9 @@ describe('dashboardLogic', () => {
             ['test', true],
         ])('uses the %s variant', async (variant, expectedEnabled) => {
             const experimentFlag = FEATURE_FLAGS.DASHBOARD_INLINE_TILE_INSERTION_EXPERIMENT
-            featureFlagLogic.actions.setFeatureFlags([experimentFlag], { [experimentFlag]: variant })
-
-            await expectLogic(logic).toMatchValues({ inlineTileInsertionEnabled: expectedEnabled })
+            await expectLogic(logic, () => {
+                featureFlagLogic.actions.setFeatureFlags([experimentFlag], { [experimentFlag]: variant })
+            }).toMatchValues({ inlineTileInsertionEnabled: expectedEnabled })
         })
     })
 

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -324,6 +324,11 @@ describe('dashboardLogic', () => {
     })
 
     describe('inline tile insertion experiment', () => {
+        beforeEach(() => {
+            logic = dashboardLogic({ id: 5 })
+            logic.mount()
+        })
+
         it.each([
             ['control', false],
             ['test', true],

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -323,6 +323,18 @@ describe('dashboardLogic', () => {
         })
     })
 
+    describe('inline tile insertion experiment', () => {
+        it.each([
+            ['control', false],
+            ['test', true],
+        ])('uses the %s variant', async (variant, expectedEnabled) => {
+            const experimentFlag = FEATURE_FLAGS.DASHBOARD_INLINE_TILE_INSERTION_EXPERIMENT
+            featureFlagLogic.actions.setFeatureFlags([experimentFlag], { [experimentFlag]: variant })
+
+            await expectLogic(logic).toMatchValues({ inlineTileInsertionEnabled: expectedEnabled })
+        })
+    })
+
     describe('tile layouts', () => {
         beforeEach(() => {
             logic = dashboardLogic({ id: 5 })

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -2704,8 +2704,16 @@ export const dashboardLogic = kea<dashboardLogicType>([
         ],
         inlineTileInsertionEnabled: [
             (s) => [s.featureFlags],
-            (featureFlags: import('lib/logic/featureFlagLogic').FeatureFlagsSet): boolean =>
-                !!featureFlags[FEATURE_FLAGS.DASHBOARD_INLINE_TILE_INSERTION],
+            (featureFlags: import('lib/logic/featureFlagLogic').FeatureFlagsSet): boolean => {
+                const experimentVariant = featureFlags[FEATURE_FLAGS.DASHBOARD_INLINE_TILE_INSERTION_EXPERIMENT]
+                if (experimentVariant === 'control') {
+                    return false
+                }
+                if (experimentVariant === 'test') {
+                    return true
+                }
+                return !!featureFlags[FEATURE_FLAGS.DASHBOARD_INLINE_TILE_INSERTION]
+            },
         ],
         insightTiles: [
             (s) => [s.tiles],
@@ -3312,7 +3320,14 @@ export const dashboardLogic = kea<dashboardLogicType>([
                   : newTile.widget
                     ? 'widget'
                     : 'insight'
-            eventUsageLogic.actions.reportDashboardTileInsertedInline(insertedTileType, slot.x, slot.y, slot.w != null)
+            eventUsageLogic.actions.reportDashboardTileInsertedInline(
+                insertedTileType,
+                props.id,
+                newTile.id,
+                slot.x,
+                slot.y,
+                slot.w != null
+            )
 
             // In edit mode the change is saved with the rest of the edit session.
             if (values.layoutEditMode) {


### PR DESCRIPTION
## Problem

- Dashboard editors cannot compare use of inline Add with use of header Add.
- The experiment needs a frontend metric for both controls.

## Changes

- Capture each successful opening of the header or inline Add menu.
- Record the control source and dashboard ID on the same event.
- Keep the existing inline insertion completion event as a secondary metric.

```mermaid
flowchart LR
    A[Dashboard editor] --> B{Experiment variant}
    B -->|control| C[Header Add menu]
    B -->|test| D[Header or inline Add menu]
    C --> E[Menu-open event]
    D --> E
```

- The visual experience changes only after the draft experiment launches.

## How did you test this code?

- The dashboard logic test covers the control and test variants.
- The frontend formatter and feature-flag validation ran during commit.
- Not run: a browser workflow for either Add menu.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- No docs update. This change adds internal experiment instrumentation.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex created the draft experiment and implemented frontend menu-open tracking.
- Skills used: `/creating-experiments`, `/configuring-experiment-rollout`, `/configuring-experiment-analytics`, `/writing-kea-logics`, `/writing-tests`, and `/writing-pr-descriptions`.
- The draft experiment uses menu opens as its primary metric.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*