### PR TITLE
docs(workflows): require the push app_id list to be cached on disk

### DIFF
--- a/docs/internal/push-subscription-registration.md
+++ b/docs/internal/push-subscription-registration.md
@@ -49,6 +49,22 @@ self-hosted deployment.
 Rule 3 is the one that is easy to miss, and without it a project that turns push on never reaches the
 devices it already has.
 
+## The list has to be cached on disk
+
+Registration runs at startup. Remote config resolves asynchronously, so on a cold start the SDK
+usually reaches the point of registering before `/config` has answered. An SDK that only consults the
+freshly fetched list therefore still sends the request it was supposed to skip, and the gate takes
+effect from the second launch onward rather than the first.
+
+So the push slice has to be persisted when it arrives and preloaded on the next start, before the
+first registration attempt. On Android that is the pattern `errorTracking` already uses:
+`processErrorTrackingConfig` writes to `config.cachePreferences`, and `preloadErrorTrackingConfig`
+restores it on launch. iOS mirrors it.
+
+This interacts with rule 1. A cold start with nothing cached is not the same as an absent key: the SDK
+has never heard from this server, so it registers, exactly as rule 1 says. Only a cached empty list
+means "skip".
+
 ## Why rule 3 exists
 
 Both mobile SDKs persist a delivered marker (`deliveredForDistinctId`) alongside the pending


### PR DESCRIPTION
## Problem

An SDK that implements the push registration contract exactly as written still sends the first-launch request it was meant to skip.

- Registration runs at startup. Remote config resolves asynchronously.
- On a cold start the SDK reaches the point of registering before `/config` has answered, so the freshly fetched `push.appIds` is not there yet.
- The gate then takes effect from the second launch onward. For an app opened once a day that is most of the requests the contract was supposed to remove.
- #83148 added the contract doc without this, so the spec @ioannisj implements against is currently missing a requirement.

## Changes

- Adds a section to `docs/internal/push-subscription-registration.md` requiring the push slice to be persisted when it arrives and preloaded before the first registration attempt.
- Points at the pattern already in the Android SDK: `processErrorTrackingConfig` writes to `config.cachePreferences`, `preloadErrorTrackingConfig` restores it on launch.
- Separates "nothing cached yet" from "absent key". Both read as empty, but only the second means the server predates the key, so only a cached empty list means skip.

Docs only. No code changes.

## How did you test this code?

Nothing to test. `hogli ci:preflight --strict` reports 0 changed files that map to a CI failure class.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

This PR is the docs update. It amends `docs/internal/push-subscription-registration.md`, added in #83148.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted). Directed by @dmarchuk, assigned as DRI.

Authored with Claude Code. Skills invoked: `/writing-pr-descriptions`.

I found this while checking whether the SDK side was tractable, by reading how `PostHogRemoteConfig.kt` handles the `errorTracking` key. The caching is not incidental there — it exists so a first launch does not install the default before `/config` responds, which is the same ordering problem push has.

#83148 is already merged, so this goes on a fresh branch rather than reopening it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bbav6vE7Tm24KkdRhZmvNM)_