### PR TITLE
fix(data-imports): coerce warehouse column values to JSON-safe scalars

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/person_property_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/person_property_sync.py
@@ -22,6 +22,9 @@ import json
 import asyncio
 import hashlib
 import dataclasses
+from datetime import date, datetime, time
+from decimal import Decimal
+from typing import Any
 
 from django.conf import settings
 
@@ -103,16 +106,36 @@ def bundle_hash(bundle: dict) -> str:
     return hashlib.sha256(json.dumps(bundle, sort_keys=True, default=str).encode("utf-8")).hexdigest()
 
 
+def _json_safe(value: Any) -> Any:
+    """Coerce a warehouse column value into something ``json.dumps`` accepts. Timestamp/date/time
+    columns arrive as datetime objects and numeric columns as Decimal — neither is JSON-serializable,
+    so the Kafka produce (which serializes the intent with plain ``json.dumps``) would raise. Mirrors
+    ``bundle_hash``'s ``default=str`` posture: temporal types get an ISO-8601 string PostHog reads as a
+    DateTime property, decimals become floats, and anything else falls back to ``str``."""
+    if value is None or isinstance(value, (str, bool, int, float)):
+        return value
+    if isinstance(value, (datetime, date, time)):
+        return value.isoformat()
+    if isinstance(value, Decimal):
+        return float(value)
+    if isinstance(value, dict):
+        return {k: _json_safe(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(v) for v in value]
+    return str(value)
+
+
 def build_bundles(rows: list[dict], key_column: str, column_property_map: dict[str, str]) -> list[tuple[str, dict]]:
     """(distinct_id, {person_property: value}) for each row with a non-null key and at least one
     non-null mapped value. Missing columns are simply absent (a misconfigured source degrades to
-    fewer properties rather than erroring)."""
+    fewer properties rather than erroring). Values are coerced to JSON-safe scalars so a timestamp or
+    numeric column doesn't crash the downstream Kafka produce."""
     bundles: list[tuple[str, dict]] = []
     for row in rows:
         key = row.get(key_column)
         if key is None:
             continue
-        bundle = {prop: row[col] for col, prop in column_property_map.items() if row.get(col) is not None}
+        bundle = {prop: _json_safe(row[col]) for col, prop in column_property_map.items() if row.get(col) is not None}
         if bundle:
             bundles.append((str(key), bundle))
     return bundles

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/person_property_sync_test.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/person_property_sync_test.py
@@ -1,4 +1,6 @@
-from datetime import datetime
+import json
+from datetime import date, datetime
+from decimal import Decimal
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -34,6 +36,25 @@ class TestBuildBundles:
         assert pps.build_bundles(rows, "distinct_id", {"plan": "plan_tier", "seats": "seat_count"}) == [
             ("a", {"plan_tier": "pro"})
         ]
+
+    def test_coerces_non_json_scalars_so_the_produce_can_serialize(self):
+        # A timestamp column arrives as a datetime and a numeric column as a Decimal; the Kafka
+        # producer serializes intents with plain json.dumps, so these must be coerced or it crashes.
+        rows = [
+            {
+                "distinct_id": "a",
+                "signed_up": datetime(2026, 1, 2, 3, 4, 5),
+                "born": date(2026, 1, 2),
+                "ltv": Decimal("9.99"),
+            }
+        ]
+        bundles = pps.build_bundles(
+            rows, "distinct_id", {"signed_up": "signed_up_at", "born": "born_on", "ltv": "lifetime_value"}
+        )
+        assert bundles == [
+            ("a", {"signed_up_at": "2026-01-02T03:04:05", "born_on": "2026-01-02", "lifetime_value": 9.99})
+        ]
+        json.dumps(bundles[0][1])  # the produced bundle round-trips without a default handler
 
 
 class TestBundleHash:


### PR DESCRIPTION
## Problem

- A person-property sync or backfill fails whenever a warehouse table maps a timestamp or numeric column onto a person or group property. The property never lands and the run errors out.
- The mapped column value flows unchanged into the update intent produced to Kafka, which serializes with plain `json.dumps`.
- A timestamp column arrives as a `datetime` and a numeric column as a `Decimal` — neither is JSON-serializable — so the produce raises `TypeError: Object of type datetime is not JSON serializable` and fails the whole run.
- Surfaced by error tracking: [issue 01a0117b](https://us.posthog.com/project/2/error_tracking/01a0117b-eb8b-74e2-9093-f15dd3b16e87).

## Changes

- `build_bundles` now coerces each mapped value to a JSON-safe scalar, so both the incremental sync and the full-table backfill are fixed at their shared source.
- Temporal types (`datetime`, `date`, `time`) become ISO-8601 strings, which PostHog reads as a DateTime property; `Decimal` becomes a float; dicts and lists are coerced recursively; anything else falls back to `str`.
- This matches the `default=str` posture `bundle_hash` already used, so a value that hashed fine now also serializes fine.

## How did you test this code?

- Added `TestBuildBundles::test_coerces_non_json_scalars_so_the_produce_can_serialize`: a `datetime`, `date`, and `Decimal` column coerce to serializable values, and the bundle round-trips through `json.dumps` without a default handler. No existing case exercised non-JSON scalars through `build_bundles` — the prior tests used only strings and ints.
- Ran the module's pure-function tests locally; the two `TestStampProvenance` cases need Postgres and did not run in this sandbox.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triaged from an error-tracking webhook by Claude (Claude Code). Traced the stack from the backfill activity through `_produce_intents` to the Kafka client's `json_serializer`, and confirmed both the sync and backfill paths reach the failure through `build_bundles`.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- Chose to fix at `build_bundles` rather than at the produce call so the whole class of non-JSON column types is handled once for both entry points, rather than patching a single value type.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
