### PR TITLE
feat(desktop): show session cost next to the context ring

### DIFF
--- a/products/desktop/packages/ui/src/features/sessions/components/ContextUsageIndicator.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ContextUsageIndicator.test.tsx
@@ -1,6 +1,6 @@
 import type { ContextUsage } from "@posthog/ui/features/sessions/hooks/useContextUsage";
 import { Theme } from "@radix-ui/themes";
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ContextUsageIndicator } from "./ContextUsageIndicator";
 
@@ -34,9 +34,9 @@ describe("ContextUsageIndicator", () => {
     expect(container.querySelector("button")).toBeNull();
   });
 
-  // The ring carries no text, so the accessible name is the only way the
+  // The ring carries no text, so the accessible name is the only way the token
   // numbers reach a reader — including the "/0 · 0%" an unknown window must
-  // never claim, and the cost the flag is supposed to surface.
+  // never claim. Cost is deliberately absent: it renders as visible text.
   it.each([
     ["a known window", {}, false, "Context usage: 25%"],
     [
@@ -49,7 +49,7 @@ describe("ContextUsageIndicator", () => {
       "cost enabled",
       { cost: { amount: 0.42, currency: "USD" } },
       true,
-      "Context usage: 25% · $0.42",
+      "Context usage: 25%",
     ],
   ])("names itself for %s", (_case, overrides, costEnabled, expected) => {
     flagState.enabled = costEnabled;
@@ -63,6 +63,31 @@ describe("ContextUsageIndicator", () => {
     expect(container.querySelector("button")?.getAttribute("aria-label")).toBe(
       expected,
     );
+  });
+
+  it("shows the cost as visible text beside the ring", () => {
+    flagState.enabled = true;
+    render(
+      <Theme>
+        <ContextUsageIndicator
+          usage={usage({ cost: { amount: 0.42, currency: "USD" } })}
+        />
+      </Theme>,
+    );
+    // Previously the figure lived only in the aria-label and the popover, so
+    // spend was invisible until you opened it.
+    expect(screen.getByText("$0.42")).toBeInTheDocument();
+  });
+
+  it("renders no cost text when the harness reports none", () => {
+    flagState.enabled = true;
+    render(
+      <Theme>
+        <ContextUsageIndicator usage={usage({ cost: null })} />
+      </Theme>,
+    );
+    // Null means "not reported" (codex), not "free" — $0.00 would misstate it.
+    expect(screen.queryByText(/\$/)).not.toBeInTheDocument();
   });
 
   it("renders a finite stroke offset at 0% (no NaN/Infinity)", () => {

--- a/products/desktop/packages/ui/src/features/sessions/components/ContextUsageIndicator.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ContextUsageIndicator.tsx
@@ -12,6 +12,7 @@ import {
   getOverallUsageColor,
 } from "@posthog/ui/features/sessions/contextColors";
 import type { ContextUsage } from "@posthog/ui/features/sessions/hooks/useContextUsage";
+import { Flex, Text } from "@radix-ui/themes";
 import { ContextBreakdownPopover } from "./ContextBreakdownPopover";
 
 const CIRCLE_SIZE = 20;
@@ -34,64 +35,74 @@ export function ContextUsageIndicator({ usage }: ContextUsageIndicatorProps) {
   const hasSize = size > 0;
   const strokeDashoffset = CIRCUMFERENCE - (percentage / 100) * CIRCUMFERENCE;
   const color = getOverallUsageColor(percentage);
+  // A null cost means the harness never reported one (codex), not that the
+  // session was free, so there is nothing honest to render for it.
   const showCost = costEnabled && cost !== null;
   return (
-    <Popover>
-      <PopoverTrigger
-        render={
-          <Button
-            type="button"
-            variant="default"
-            size="icon-sm"
-            aria-label={
-              hasSize
-                ? `Context usage: ${percentage}%` +
-                  (showCost ? ` · ${formatCostUsd(cost.amount)}` : "")
-                : `Context usage: ${formatTokensCompact(used)} tokens` +
-                  (showCost ? ` · ${formatCostUsd(cost.amount)}` : "")
-            }
-          >
-            {/* viewBox, not width/height: quill sizes a button's svg down to
-                its icon slot, which would crop an unscaled drawing. */}
-            <svg
-              viewBox={`0 0 ${CIRCLE_SIZE} ${CIRCLE_SIZE}`}
-              className="-rotate-90 size-4 shrink-0"
-              role="img"
-              aria-hidden="true"
+    <Flex align="center" gap="1">
+      <Popover>
+        <PopoverTrigger
+          render={
+            <Button
+              type="button"
+              variant="default"
+              size="icon-sm"
+              // The ring carries no text, so the token figures reach a reader
+              // only through the accessible name. Cost is excluded: it renders
+              // as real text alongside, and would otherwise be read twice.
+              aria-label={
+                hasSize
+                  ? `Context usage: ${percentage}%`
+                  : `Context usage: ${formatTokensCompact(used)} tokens`
+              }
             >
-              <circle
-                cx={CIRCLE_SIZE / 2}
-                cy={CIRCLE_SIZE / 2}
-                r={RADIUS}
-                fill="none"
-                stroke="var(--border)"
-                strokeWidth={STROKE_WIDTH}
-              />
-              <circle
-                cx={CIRCLE_SIZE / 2}
-                cy={CIRCLE_SIZE / 2}
-                r={RADIUS}
-                fill="none"
-                stroke={color}
-                strokeWidth={STROKE_WIDTH}
-                strokeDasharray={CIRCUMFERENCE}
-                strokeDashoffset={strokeDashoffset}
-                strokeLinecap="round"
-              />
-            </svg>
-          </Button>
-        }
-      />
-      {/* quill's popup is a fixed 18rem; the token figures sit on their own
-          line and would spill out of it. */}
-      <PopoverContent
-        side="top"
-        align="end"
-        sideOffset={6}
-        className="w-auto min-w-[280px] gap-3"
-      >
-        <ContextBreakdownPopover usage={usage} showCost={showCost} />
-      </PopoverContent>
-    </Popover>
+              {/* viewBox, not width/height: quill sizes a button's svg down to
+                  its icon slot, which would crop an unscaled drawing. */}
+              <svg
+                viewBox={`0 0 ${CIRCLE_SIZE} ${CIRCLE_SIZE}`}
+                className="-rotate-90 size-4 shrink-0"
+                role="img"
+                aria-hidden="true"
+              >
+                <circle
+                  cx={CIRCLE_SIZE / 2}
+                  cy={CIRCLE_SIZE / 2}
+                  r={RADIUS}
+                  fill="none"
+                  stroke="var(--border)"
+                  strokeWidth={STROKE_WIDTH}
+                />
+                <circle
+                  cx={CIRCLE_SIZE / 2}
+                  cy={CIRCLE_SIZE / 2}
+                  r={RADIUS}
+                  fill="none"
+                  stroke={color}
+                  strokeWidth={STROKE_WIDTH}
+                  strokeDasharray={CIRCUMFERENCE}
+                  strokeDashoffset={strokeDashoffset}
+                  strokeLinecap="round"
+                />
+              </svg>
+            </Button>
+          }
+        />
+        {/* quill's popup is a fixed 18rem; the token figures sit on their own
+            line and would spill out of it. */}
+        <PopoverContent
+          side="top"
+          align="end"
+          sideOffset={6}
+          className="w-auto min-w-[280px] gap-3"
+        >
+          <ContextBreakdownPopover usage={usage} showCost={showCost} />
+        </PopoverContent>
+      </Popover>
+      {showCost && cost && (
+        <Text className="select-none font-medium text-[13px] text-gray-11 tabular-nums">
+          {formatCostUsd(cost.amount)}
+        </Text>
+      )}
+    </Flex>
   );
 }


### PR DESCRIPTION
## Problem

You can't see what a session is costing you without clicking. The context usage indicator in the composer toolbar is an icon-only button, so the estimated spend lives in the ring's `aria-label` and inside the popover — nowhere a sighted user actually looks.

## Changes

- The cost renders as visible text beside the ring: `◔ $0.42`.
- Cost drops out of the button's `aria-label`, since it's now real text and would otherwise be announced twice. The token/percentage figures stay there — the ring still carries no text of its own.
- Unchanged: the `posthog-code-task-cost` gate (dev builds bypass it), and the popover's labelled "Estimated cost" row.

A null cost still renders nothing rather than `$0.00`. `ContextUsage.cost` is null both before the first turn settles and permanently for harnesses that don't report cost, and the type can't tell those apart — `$0.00` would read as "this session is free" on every codex session.

Worth knowing: the figure advances once per settled turn, not continuously. The Claude SDK only reports `total_cost_usd` on the terminal `result` message, so it holds still during a long turn.

## How did you test this code?

Automated only — I did not run the desktop app, so the rendered result is unverified visually and there's no screenshot.

`pnpm --filter @posthog/ui exec vitest run ContextUsageIndicator ContextBreakdownPopover` — 13 passing. Biome clean on both changed files.

Two new tests, each catching something the existing suite couldn't: the cost is rendered as text (the old suite only ever asserted the `aria-label`, so deleting the visible figure would have gone unnoticed), and a null cost renders no `$` at all (guards the codex "$0.00 means free" misread).

`pnpm --filter @posthog/ui typecheck` reports 167 errors, all pre-existing `Cannot find module '@posthog/agent/*'` from unbuilt workspace dists in my sandbox — none in the changed file.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Opus 4.5 via PostHog Desktop. No repo skills were invoked.

The session started against the archived `PostHog/code` repo, where this component still used Radix `Popover` and rendered the cost appended to a visible token label — so the first version of this change merely restyled an already-visible figure. Once pointed at `products/desktop/`, the quill-migrated component turned out to be icon-only with no visible figure at all, which is the actual gap this PR closes; the earlier work was discarded rather than ported.

Two judgment calls a reviewer may want to overturn: dropping cost from the `aria-label` (the alternative is duplicate announcement), and leaving the toolbar's `opacity-50`-until-hover dim alone — undimming just the cost means moving the dim onto each sibling, which is a wider refactor than this PR wants.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
