### PR TITLE
feat(dashboards): add customizable dashboard compaction modes

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardHeader.test.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.test.tsx
@@ -3,6 +3,7 @@ import '@testing-library/jest-dom'
 import { cleanup, render, screen } from '@testing-library/react'
 import { BindLogic } from 'kea'
 
+import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { DashboardEventSource } from 'lib/utils/eventUsageLogic'
 
@@ -73,6 +74,9 @@ describe('DashboardHeader', () => {
         })
         initKeaTests()
         featureFlagLogic.mount()
+        featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.DASHBOARD_CUSTOMIZATION], {
+            [FEATURE_FLAGS.DASHBOARD_CUSTOMIZATION]: true,
+        })
     })
 
     afterEach(() => {
@@ -171,7 +175,7 @@ describe('DashboardHeader', () => {
             dashboardMode: DashboardMode.Edit,
             dashboardModeSource: DashboardEventSource.DashboardFilters,
             canEdit: true,
-            visible: ['dashboard-add-tile'],
+            visible: ['dashboard-add-tile', 'dashboard-edit-layout-customize-dropdown'],
             notVisible: [
                 'dashboard-edit-mode-discard',
                 'dashboard-edit-mode-save',
@@ -185,7 +189,12 @@ describe('DashboardHeader', () => {
             dashboardMode: DashboardMode.Edit,
             dashboardModeSource: DashboardEventSource.SceneCommonButtons,
             canEdit: true,
-            visible: ['dashboard-edit-mode-discard', 'dashboard-edit-mode-save', 'dashboard-add-tile'],
+            visible: [
+                'dashboard-edit-mode-discard',
+                'dashboard-edit-mode-save',
+                'dashboard-edit-layout-customize-dropdown',
+                'dashboard-add-tile',
+            ],
             notVisible: ['dashboard-share-button', 'add-text-tile-to-dashboard', 'dashboard-add-graph-header'],
         },
         {

--- a/frontend/src/scenes/dashboard/DashboardHeaderActions.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeaderActions.tsx
@@ -222,12 +222,35 @@ export function DashboardEditSaveCancelButtons({
 }
 
 export function EditModeActions(): JSX.Element {
-    const { layoutEditMode } = useValues(dashboardLogic)
+    const { layoutEditMode, tiles, dashboardCustomizeMenuOpen } = useValues(dashboardLogic)
+    const { setDashboardCustomizeMenuOpen } = useActions(dashboardLogic)
+    const dashboardCustomizationEnabled = useFeatureFlag('DASHBOARD_CUSTOMIZATION')
 
     return (
         <>
             <DashboardSubscribeButton />
             {layoutEditMode && <DashboardEditSaveCancelButtons />}
+            {dashboardCustomizationEnabled && (
+                <LemonMenu
+                    items={[{ label: () => <DashboardCustomizeMenu /> }]}
+                    closeOnClickInside={false}
+                    placement="bottom-end"
+                    visible={dashboardCustomizeMenuOpen}
+                    onVisibilityChange={setDashboardCustomizeMenuOpen}
+                >
+                    <LemonButton
+                        type="secondary"
+                        data-attr="dashboard-edit-layout-customize-dropdown"
+                        size="small"
+                        icon={<IconGridMasonry fontSize="16" />}
+                        disabledReason={
+                            tiles.length === 0 ? 'Add at least one tile to customize this dashboard' : undefined
+                        }
+                    >
+                        Customize
+                    </LemonButton>
+                </LemonMenu>
+            )}
             <DashboardAddTileButton />
         </>
     )

--- a/frontend/src/scenes/dashboard/DashboardItems.scss
+++ b/frontend/src/scenes/dashboard/DashboardItems.scss
@@ -32,6 +32,22 @@
             content-visibility: visible;
         }
     }
+
+    &.dashboard-tile-spacing-changing {
+        transition: none;
+
+        .react-grid-item {
+            transition: none;
+        }
+    }
+
+    &.dashboard-layout-interaction .react-grid-item {
+        transition: none;
+    }
+
+    &.dashboard-layout-settling .react-grid-item:not(.react-draggable-dragging, .resizing) {
+        transition: transform 180ms ease-out;
+    }
 }
 
 .react-grid-item.cssTransforms {

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -194,7 +194,11 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
 
     const { width, containerRef, mounted } = useContainerWidth()
     const { gridCompactor, handleLayoutChange, interactionInProgress, startInteraction, finishInteraction } =
-        useDashboardLayoutInteraction({ layoutEditMode, updateLayouts })
+        useDashboardLayoutInteraction({
+            layoutEditMode,
+            layoutCompaction: dashboard?.customization?.layout_compaction,
+            updateLayouts,
+        })
 
     // Debounce width changes to the grid. Rapidly crossing the width causes tiles to stay squashed at 1-column
     // width. Debouncing avoids this and reduces unnecessary re-layouts during resize.

--- a/frontend/src/scenes/dashboard/dashboardActivityDescriber.tsx
+++ b/frontend/src/scenes/dashboard/dashboardActivityDescriber.tsx
@@ -2,7 +2,10 @@ import posthog from 'posthog-js'
 import { DashboardFilter, HogQLVariable } from 'src/queries/schema/schema-general'
 
 import { Link } from '@posthog/lemon-ui'
-import { DASHBOARD_TILE_SPACING_LABELS } from '@posthog/products-dashboards/frontend/dashboardCustomization'
+import {
+    DASHBOARD_GRID_COMPACTION_LABELS,
+    DASHBOARD_TILE_SPACING_LABELS,
+} from '@posthog/products-dashboards/frontend/dashboardCustomization'
 
 import {
     ActivityChange,
@@ -161,17 +164,28 @@ const dashboardActionsMapping: Record<
     last_viewed_at: () => null,
     quick_filter_ids: () => null,
     customization: function onChangedCustomization(change) {
-        const customization = change?.after as DashboardType['customization']
-        if (!customization?.tile_spacing) {
-            return null
-        }
-        return {
-            description: [
+        const before = change?.before as DashboardType['customization']
+        const after = change?.after as DashboardType['customization']
+        const description: Description[] = []
+        if (after?.layout_compaction && after.layout_compaction !== before?.layout_compaction) {
+            description.push(
                 <>
-                    changed tile density to <strong>{DASHBOARD_TILE_SPACING_LABELS[customization.tile_spacing]}</strong>
-                </>,
-            ],
+                    changed tile movement to{' '}
+                    <strong>{DASHBOARD_GRID_COMPACTION_LABELS[after.layout_compaction]}</strong>
+                </>
+            )
         }
+        if (after?.tile_spacing && after.tile_spacing !== before?.tile_spacing) {
+            if (description.length > 0) {
+                description.push(' and ')
+            }
+            description.push(
+                <>
+                    changed tile density to <strong>{DASHBOARD_TILE_SPACING_LABELS[after.tile_spacing]}</strong>
+                </>
+            )
+        }
+        return description.length > 0 ? { description } : null
     },
 }
 

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -387,6 +387,7 @@ describe('dashboardLogic', () => {
 
                 expect(api.update).toHaveBeenCalledTimes(1)
                 expect(api.update).toHaveBeenCalledWith(`api/environments/${MOCK_TEAM_ID}/dashboards/5`, {
+                    layout_compaction: 'vertical',
                     grid_spacing: 'relaxed',
                 })
                 expect(reportTileDensityConfigured).toHaveBeenCalledWith('relaxed')
@@ -410,6 +411,64 @@ describe('dashboardLogic', () => {
                 await expectLogic(logic).toFinishAllListeners()
 
                 expect(reportTileDensityConfigured).not.toHaveBeenCalled()
+            } finally {
+                jest.useRealTimers()
+            }
+        })
+
+        it('previews layout compaction immediately and persists only the final choice', async () => {
+            await expectLogic(logic).toFinishAllListeners()
+            ;(api.update as jest.Mock).mockClear()
+            jest.useFakeTimers()
+
+            try {
+                logic.actions.setDashboardGridCompaction('vertical')
+                logic.actions.saveDashboardGridCompaction('vertical')
+                logic.actions.setDashboardGridCompaction('horizontal')
+                logic.actions.saveDashboardGridCompaction('horizontal')
+
+                expect(logic.values.dashboard?.customization?.layout_compaction).toBe('horizontal')
+                expect(api.update).not.toHaveBeenCalled()
+
+                await jest.advanceTimersByTimeAsync(750)
+                await expectLogic(logic).toFinishAllListeners()
+
+                expect(api.update).toHaveBeenCalledTimes(1)
+                expect(api.update).toHaveBeenCalledWith(`api/environments/${MOCK_TEAM_ID}/dashboards/5`, {
+                    layout_compaction: 'horizontal',
+                    grid_spacing: 'standard',
+                })
+            } finally {
+                jest.useRealTimers()
+            }
+        })
+
+        it('persists the latest movement mode after a save is already in flight', async () => {
+            await expectLogic(logic).toFinishAllListeners()
+            let resolveFirstSave: (dashboard: DashboardType<QueryBasedInsightModel>) => void
+            const firstSave = new Promise<DashboardType<QueryBasedInsightModel>>((resolve) => {
+                resolveFirstSave = resolve
+            })
+            ;(api.update as jest.Mock).mockImplementationOnce(() => firstSave)
+            jest.useFakeTimers()
+
+            try {
+                logic.actions.setDashboardGridCompaction('horizontal')
+                logic.actions.saveDashboardGridCompaction('horizontal')
+                await jest.advanceTimersByTimeAsync(750)
+
+                logic.actions.setDashboardGridCompaction('stable')
+                logic.actions.saveDashboardGridCompaction('stable')
+                await jest.advanceTimersByTimeAsync(750)
+
+                resolveFirstSave(logic.values.dashboard!)
+                await jest.advanceTimersByTimeAsync(750)
+                await expectLogic(logic).toFinishAllListeners()
+
+                expect(api.update).toHaveBeenLastCalledWith(`api/environments/${MOCK_TEAM_ID}/dashboards/5`, {
+                    layout_compaction: 'stable',
+                    grid_spacing: 'standard',
+                })
             } finally {
                 jest.useRealTimers()
             }
@@ -1164,6 +1223,64 @@ describe('dashboardLogic', () => {
                 })
                     .toFinishAllListeners()
                     .toMatchValues({ hasUnsavedLayoutChanges: false })
+            })
+        })
+
+        describe('changeDashboardGridCompaction action', () => {
+            let dialogOpenSpy: jest.SpyInstance
+
+            beforeEach(() => {
+                dialogOpenSpy = jest.spyOn(LemonDialog, 'open').mockImplementation(() => {})
+            })
+
+            afterEach(() => {
+                dialogOpenSpy.mockRestore()
+            })
+
+            const moveFirstTile = (): void => {
+                const firstTile = logic.values.dashboard!.tiles[0]
+                const currentLayouts = logic.values.layouts
+                logic.actions.updateLayouts({
+                    ...currentLayouts,
+                    sm: currentLayouts.sm?.map((layout) =>
+                        layout.i === String(firstTile.id) ? { ...layout, x: (layout.x ?? 0) + 1 } : layout
+                    ),
+                })
+            }
+
+            it('changes the movement mode without a prompt when the layout is saved', async () => {
+                await expectLogic(logic, () => {
+                    logic.actions.changeDashboardGridCompaction('horizontal')
+                }).toDispatchActions([
+                    logic.actionCreators.setDashboardGridCompaction('horizontal'),
+                    logic.actionCreators.saveDashboardGridCompaction('horizontal'),
+                ])
+
+                expect(dialogOpenSpy).not.toHaveBeenCalled()
+            })
+
+            it('prompts before changing the movement mode when the layout is unsaved', async () => {
+                await expectLogic(logic).toFinishAllListeners()
+                await expectLogic(logic, moveFirstTile).toFinishAllListeners()
+
+                await expectLogic(logic, () => {
+                    logic.actions.changeDashboardGridCompaction('horizontal')
+                }).toNotHaveDispatchedActions([
+                    logic.actionCreators.setDashboardGridCompaction('horizontal'),
+                    logic.actionCreators.saveDashboardGridCompaction('horizontal'),
+                ])
+
+                expect(dialogOpenSpy).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        title: 'Change tile movement?',
+                        description: 'Changing this setting discards your unsaved tile layout changes.',
+                    })
+                )
+
+                const dialogProps = dialogOpenSpy.mock.calls.at(-1)?.[0]
+                dialogProps?.primaryButton?.onClick?.({} as React.MouseEvent<HTMLButtonElement>)
+
+                await expectLogic(logic).toFinishAllListeners().toMatchValues({ hasUnsavedLayoutChanges: false })
             })
         })
 

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -445,7 +445,9 @@ describe('dashboardLogic', () => {
 
         it('persists the latest movement mode after a save is already in flight', async () => {
             await expectLogic(logic).toFinishAllListeners()
-            let resolveFirstSave: (dashboard: DashboardType<QueryBasedInsightModel>) => void
+            let resolveFirstSave: (dashboard: DashboardType<QueryBasedInsightModel>) => void = () => {
+                throw new Error('First save resolver is unavailable')
+            }
             const firstSave = new Promise<DashboardType<QueryBasedInsightModel>>((resolve) => {
                 resolveFirstSave = resolve
             })

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -32,13 +32,14 @@ import { initKeaTests } from '~/test/init'
 import {
     DashboardMode,
     DashboardPlacement,
-    DashboardGridCompaction,
     DashboardTile,
     DashboardType,
     InsightColor,
     InsightShortId,
     QueryBasedInsightModel,
 } from '~/types'
+
+import { DashboardGridCompaction } from 'products/dashboards/frontend/dashboardCustomization'
 
 import { dashboardResult, insightOnDashboard, tileFromInsight } from './dashboardLogic.testHelpers'
 
@@ -428,7 +429,9 @@ describe('dashboardLogic', () => {
                 logic.actions.setDashboardGridCompaction(DashboardGridCompaction.Horizontal)
                 logic.actions.saveDashboardGridCompaction(DashboardGridCompaction.Horizontal)
 
-                expect(logic.values.dashboard?.customization?.layout_compaction).toBe(DashboardGridCompaction.Horizontal)
+                expect(logic.values.dashboard?.customization?.layout_compaction).toBe(
+                    DashboardGridCompaction.Horizontal
+                )
                 expect(api.update).not.toHaveBeenCalled()
 
                 await jest.advanceTimersByTimeAsync(750)

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -32,6 +32,7 @@ import { initKeaTests } from '~/test/init'
 import {
     DashboardMode,
     DashboardPlacement,
+    DashboardGridCompaction,
     DashboardTile,
     DashboardType,
     InsightColor,
@@ -387,7 +388,7 @@ describe('dashboardLogic', () => {
 
                 expect(api.update).toHaveBeenCalledTimes(1)
                 expect(api.update).toHaveBeenCalledWith(`api/environments/${MOCK_TEAM_ID}/dashboards/5`, {
-                    layout_compaction: 'vertical',
+                    layout_compaction: DashboardGridCompaction.Vertical,
                     grid_spacing: 'relaxed',
                 })
                 expect(reportTileDensityConfigured).toHaveBeenCalledWith('relaxed')
@@ -422,12 +423,12 @@ describe('dashboardLogic', () => {
             jest.useFakeTimers()
 
             try {
-                logic.actions.setDashboardGridCompaction('vertical')
-                logic.actions.saveDashboardGridCompaction('vertical')
-                logic.actions.setDashboardGridCompaction('horizontal')
-                logic.actions.saveDashboardGridCompaction('horizontal')
+                logic.actions.setDashboardGridCompaction(DashboardGridCompaction.Vertical)
+                logic.actions.saveDashboardGridCompaction(DashboardGridCompaction.Vertical)
+                logic.actions.setDashboardGridCompaction(DashboardGridCompaction.Horizontal)
+                logic.actions.saveDashboardGridCompaction(DashboardGridCompaction.Horizontal)
 
-                expect(logic.values.dashboard?.customization?.layout_compaction).toBe('horizontal')
+                expect(logic.values.dashboard?.customization?.layout_compaction).toBe(DashboardGridCompaction.Horizontal)
                 expect(api.update).not.toHaveBeenCalled()
 
                 await jest.advanceTimersByTimeAsync(750)
@@ -435,7 +436,7 @@ describe('dashboardLogic', () => {
 
                 expect(api.update).toHaveBeenCalledTimes(1)
                 expect(api.update).toHaveBeenCalledWith(`api/environments/${MOCK_TEAM_ID}/dashboards/5`, {
-                    layout_compaction: 'horizontal',
+                    layout_compaction: DashboardGridCompaction.Horizontal,
                     grid_spacing: 'standard',
                 })
             } finally {
@@ -455,12 +456,12 @@ describe('dashboardLogic', () => {
             jest.useFakeTimers()
 
             try {
-                logic.actions.setDashboardGridCompaction('horizontal')
-                logic.actions.saveDashboardGridCompaction('horizontal')
+                logic.actions.setDashboardGridCompaction(DashboardGridCompaction.Horizontal)
+                logic.actions.saveDashboardGridCompaction(DashboardGridCompaction.Horizontal)
                 await jest.advanceTimersByTimeAsync(750)
 
-                logic.actions.setDashboardGridCompaction('stable')
-                logic.actions.saveDashboardGridCompaction('stable')
+                logic.actions.setDashboardGridCompaction(DashboardGridCompaction.Stable)
+                logic.actions.saveDashboardGridCompaction(DashboardGridCompaction.Stable)
                 await jest.advanceTimersByTimeAsync(750)
 
                 resolveFirstSave(logic.values.dashboard!)
@@ -468,7 +469,7 @@ describe('dashboardLogic', () => {
                 await expectLogic(logic).toFinishAllListeners()
 
                 expect(api.update).toHaveBeenLastCalledWith(`api/environments/${MOCK_TEAM_ID}/dashboards/5`, {
-                    layout_compaction: 'stable',
+                    layout_compaction: DashboardGridCompaction.Stable,
                     grid_spacing: 'standard',
                 })
             } finally {
@@ -1252,10 +1253,10 @@ describe('dashboardLogic', () => {
 
             it('changes the movement mode without a prompt when the layout is saved', async () => {
                 await expectLogic(logic, () => {
-                    logic.actions.changeDashboardGridCompaction('horizontal')
+                    logic.actions.changeDashboardGridCompaction(DashboardGridCompaction.Horizontal)
                 }).toDispatchActions([
-                    logic.actionCreators.setDashboardGridCompaction('horizontal'),
-                    logic.actionCreators.saveDashboardGridCompaction('horizontal'),
+                    logic.actionCreators.setDashboardGridCompaction(DashboardGridCompaction.Horizontal),
+                    logic.actionCreators.saveDashboardGridCompaction(DashboardGridCompaction.Horizontal),
                 ])
 
                 expect(dialogOpenSpy).not.toHaveBeenCalled()
@@ -1266,10 +1267,10 @@ describe('dashboardLogic', () => {
                 await expectLogic(logic, moveFirstTile).toFinishAllListeners()
 
                 await expectLogic(logic, () => {
-                    logic.actions.changeDashboardGridCompaction('horizontal')
+                    logic.actions.changeDashboardGridCompaction(DashboardGridCompaction.Horizontal)
                 }).toNotHaveDispatchedActions([
-                    logic.actionCreators.setDashboardGridCompaction('horizontal'),
-                    logic.actionCreators.saveDashboardGridCompaction('horizontal'),
+                    logic.actionCreators.setDashboardGridCompaction(DashboardGridCompaction.Horizontal),
+                    logic.actionCreators.saveDashboardGridCompaction(DashboardGridCompaction.Horizontal),
                 ])
 
                 expect(dialogOpenSpy).toHaveBeenCalledWith(

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -19,6 +19,7 @@ import { loaders } from 'kea-loaders'
 import { actionToUrl, beforeUnload, router, urlToAction } from 'kea-router'
 import { CombinedLocation } from 'kea-router/lib/utils'
 import uniqBy from 'lodash.uniqby'
+import posthog from 'posthog-js'
 import { ResponsiveLayouts } from 'react-grid-layout'
 import type { Layout } from 'react-grid-layout'
 
@@ -98,6 +99,7 @@ import {
     DashboardPlacement,
     DashboardTemplateEditorType,
     DashboardTile,
+    DashboardGridCompaction,
     DashboardTileBasicType,
     DashboardTileSpacing,
     DashboardType,
@@ -270,6 +272,7 @@ export interface dashboardLogicValues {
     containerWidth: number | null
     currentLayoutSize: 'sm' | 'xs'
     dashboard: DashboardType<QueryBasedInsightModel> | null
+    dashboardCustomizeMenuOpen: boolean
     dashboardFailedToLoad: boolean
     dashboardLayouts: Record<DashboardTile['id'], DashboardTile['layouts']>
     dashboardLoadData: {
@@ -423,6 +426,9 @@ export interface dashboardLogicActions {
     }
     cancelEditMode: () => {
         value: true
+    }
+    changeDashboardGridCompaction: (layoutCompaction: DashboardGridCompaction) => {
+        layoutCompaction: DashboardGridCompaction
     }
     clearAddWidgetSelectedTypes: () => {
         value: true
@@ -669,6 +675,9 @@ export interface dashboardLogicActions {
             variables?: unknown
         } | null
     }
+    saveDashboardGridCompaction: (layoutCompaction: DashboardGridCompaction) => {
+        layoutCompaction: DashboardGridCompaction
+    }
     saveDashboardTileSpacing: (tileSpacing: DashboardTileSpacing) => {
         tileSpacing: DashboardTileSpacing
     }
@@ -711,6 +720,12 @@ export interface dashboardLogicActions {
     }
     setButtonTileId: (buttonTileId: number | 'new' | null) => {
         buttonTileId: number | 'new' | null
+    }
+    setDashboardCustomizeMenuOpen: (open: boolean) => {
+        open: boolean
+    }
+    setDashboardGridCompaction: (layoutCompaction: DashboardGridCompaction) => {
+        layoutCompaction: DashboardGridCompaction
     }
     setDashboardMode: (
         mode: DashboardMode | null,
@@ -1311,6 +1326,9 @@ export const dashboardLogic = kea<dashboardLogicType>([
         /** Update the dashboard in dashboardsModel with given payload. */
         triggerDashboardUpdate: (payload) => ({ payload }),
         saveDashboardTileSpacing: (tileSpacing: DashboardTileSpacing) => ({ tileSpacing }),
+        saveDashboardGridCompaction: (layoutCompaction: DashboardGridCompaction) => ({ layoutCompaction }),
+        setDashboardCustomizeMenuOpen: (open: boolean) => ({ open }),
+        changeDashboardGridCompaction: (layoutCompaction: DashboardGridCompaction) => ({ layoutCompaction }),
         updateDashboardTags: (tags: string[]) => ({ tags }),
         /** Update page visibility for virtualized rendering. */
         setPageVisibility: (visible: boolean) => ({ visible }),
@@ -1383,6 +1401,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
         setBreakdownColorConfig: (config: BreakdownColorConfig) => ({ config }),
         setDataColorThemeId: (dataColorThemeId: number | null) => ({ dataColorThemeId }),
         setDashboardTileSpacing: (tileSpacing: DashboardTileSpacing) => ({ tileSpacing }),
+        setDashboardGridCompaction: (layoutCompaction: DashboardGridCompaction) => ({ layoutCompaction }),
         setDashboardTileSpacingSaving: (saving: boolean) => ({ saving }),
         restoreTemporaryColorState: (colors: BreakdownColorConfig[], themeId: { themeId: number | null } | null) => ({
             colors,
@@ -1929,6 +1948,13 @@ export const dashboardLogic = kea<dashboardLogicType>([
                               customization: { ...state.customization, tile_spacing: tileSpacing },
                           }
                         : state,
+                setDashboardGridCompaction: (state, { layoutCompaction }) =>
+                    state
+                        ? {
+                              ...state,
+                              customization: { ...state.customization, layout_compaction: layoutCompaction },
+                          }
+                        : state,
                 removeTile: (state, { tile }) => {
                     // Optimistically drop the tile so the grid reflows immediately; the loader rolls back on failure.
                     return {
@@ -2159,6 +2185,13 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     }
                     return false
                 },
+            },
+        ],
+        dashboardCustomizeMenuOpen: [
+            false,
+            {
+                setDashboardCustomizeMenuOpen: (_, { open }) => open,
+                setDashboardMode: () => false,
             },
         ],
         pendingInsertion: [
@@ -3721,7 +3754,10 @@ export const dashboardLogic = kea<dashboardLogicType>([
             try {
                 const dashboard = await api.update<DashboardType<QueryBasedInsightModel>>(
                     `api/environments/${values.currentTeamId}/dashboards/${props.id}`,
-                    { grid_spacing: tileSpacing }
+                    {
+                        grid_spacing: tileSpacing,
+                        layout_compaction: values.dashboard?.customization?.layout_compaction ?? 'vertical',
+                    }
                 )
                 dashboardsModel.actions.updateDashboardSuccess(getQueryBasedDashboard(dashboard))
                 if (tileSpacing !== 'standard') {
@@ -3742,6 +3778,48 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     actions.saveDashboardTileSpacing(pendingTileSpacing)
                 } else {
                     actions.setDashboardTileSpacingSaving(false)
+                }
+            }
+        },
+        saveDashboardGridCompaction: async ({ layoutCompaction }, breakpoint) => {
+            await breakpoint(750)
+
+            if (cache.dashboardGridCompactionSaveInFlight) {
+                cache.pendingDashboardGridCompaction = layoutCompaction
+                return
+            }
+
+            const persistedDashboard = dashboardsModel.values.rawDashboards[props.id]
+            const persistedLayoutCompaction =
+                persistedDashboard && 'customization' in persistedDashboard
+                    ? (persistedDashboard.customization?.layout_compaction ?? 'vertical')
+                    : 'vertical'
+            cache.dashboardGridCompactionSaveInFlight = true
+            try {
+                const dashboard = await api.update<DashboardType<QueryBasedInsightModel>>(
+                    `api/environments/${values.currentTeamId}/dashboards/${props.id}`,
+                    {
+                        layout_compaction: layoutCompaction,
+                        grid_spacing: values.dashboard?.customization?.tile_spacing ?? 'standard',
+                    }
+                )
+                dashboardsModel.actions.updateDashboardSuccess(getQueryBasedDashboard(dashboard))
+            } catch (error) {
+                posthog.captureException(error)
+                if (!cache.pendingDashboardGridCompaction) {
+                    actions.setDashboardGridCompaction(persistedLayoutCompaction)
+                    actions.loadDashboard({ action: DashboardLoadAction.Update })
+                }
+                lemonToast.error("Couldn't update tile movement. Try again.")
+            } finally {
+                cache.dashboardGridCompactionSaveInFlight = false
+                const pendingLayoutCompaction = cache.pendingDashboardGridCompaction as
+                    | DashboardGridCompaction
+                    | undefined
+                cache.pendingDashboardGridCompaction = undefined
+                if (pendingLayoutCompaction) {
+                    actions.setDashboardGridCompaction(pendingLayoutCompaction)
+                    actions.saveDashboardGridCompaction(pendingLayoutCompaction)
                 }
             }
         },
@@ -4228,6 +4306,37 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     onClick: () => {
                         eventUsageLogic.actions.reportDashboardEditModeDiscardPrompt(values.dashboard, 'kept_editing')
                     },
+                },
+            })
+        },
+        changeDashboardGridCompaction: ({ layoutCompaction }) => {
+            const changeCompaction = (discardUnsavedLayoutChanges = false): void => {
+                if (discardUnsavedLayoutChanges) {
+                    const savedSmLayout = Object.entries(values.dashboardLayouts).flatMap(([tileId, layouts]) =>
+                        layouts?.sm ? [{ ...layouts.sm, i: tileId }] : []
+                    )
+                    actions.updateLayouts({ sm: savedSmLayout })
+                }
+                actions.setDashboardGridCompaction(layoutCompaction)
+                actions.saveDashboardGridCompaction(layoutCompaction)
+            }
+
+            if (!values.hasUnsavedLayoutChanges) {
+                changeCompaction()
+                return
+            }
+
+            actions.setDashboardCustomizeMenuOpen(false)
+            LemonDialog.open({
+                title: 'Change tile movement?',
+                description: 'Changing this setting discards your unsaved tile layout changes.',
+                zIndex: '1169',
+                primaryButton: {
+                    children: 'Change mode',
+                    onClick: () => changeCompaction(true),
+                },
+                secondaryButton: {
+                    children: 'Cancel',
                 },
             })
         },

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -3756,7 +3756,8 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     `api/environments/${values.currentTeamId}/dashboards/${props.id}`,
                     {
                         grid_spacing: tileSpacing,
-                        layout_compaction: values.dashboard?.customization?.layout_compaction ?? 'vertical',
+                        layout_compaction:
+                            values.dashboard?.customization?.layout_compaction ?? DashboardGridCompaction.Vertical,
                     }
                 )
                 dashboardsModel.actions.updateDashboardSuccess(getQueryBasedDashboard(dashboard))
@@ -3792,8 +3793,8 @@ export const dashboardLogic = kea<dashboardLogicType>([
             const persistedDashboard = dashboardsModel.values.rawDashboards[props.id]
             const persistedLayoutCompaction =
                 persistedDashboard && 'customization' in persistedDashboard
-                    ? (persistedDashboard.customization?.layout_compaction ?? 'vertical')
-                    : 'vertical'
+                    ? (persistedDashboard.customization?.layout_compaction ?? DashboardGridCompaction.Vertical)
+                    : DashboardGridCompaction.Vertical
             cache.dashboardGridCompactionSaveInFlight = true
             try {
                 const dashboard = await api.update<DashboardType<QueryBasedInsightModel>>(

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -99,7 +99,6 @@ import {
     DashboardPlacement,
     DashboardTemplateEditorType,
     DashboardTile,
-    DashboardGridCompaction,
     DashboardTileBasicType,
     DashboardTileSpacing,
     DashboardType,
@@ -113,6 +112,8 @@ import {
     TextModel,
     TileLayout,
 } from '~/types'
+
+import { DashboardGridCompaction } from 'products/dashboards/frontend/dashboardCustomization'
 
 import type { FeatureFlagsSet } from '../../lib/logic/featureFlagLogic'
 import type { Node } from '../../queries/schema/schema-general'

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -4331,7 +4331,6 @@ export const dashboardLogic = kea<dashboardLogicType>([
             LemonDialog.open({
                 title: 'Change tile movement?',
                 description: 'Changing this setting discards your unsaved tile layout changes.',
-                zIndex: '1169',
                 primaryButton: {
                     children: 'Change mode',
                     onClick: () => changeCompaction(true),

--- a/frontend/src/scenes/dashboard/useDashboardLayoutInteraction.ts
+++ b/frontend/src/scenes/dashboard/useDashboardLayoutInteraction.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useRef } from 'react'
 import type { MutableRefObject } from 'react'
-import { cloneLayoutItem, verticalCompactor } from 'react-grid-layout'
+import { cloneLayoutItem } from 'react-grid-layout'
 import type { Compactor, Layout, LayoutItem } from 'react-grid-layout'
 
 import {
@@ -12,10 +12,16 @@ import type { ResizeNeighbors } from 'scenes/dashboard/dashboardResizeCompactor'
 
 import type { DashboardLayoutSize } from '~/types'
 
+import {
+    getDashboardGridCompactor,
+    resolveFreePlacementCollisions,
+} from 'products/dashboards/frontend/dashboardCustomization'
+
 type InteractionKind = 'drag' | 'resize'
 
 interface UseDashboardLayoutInteractionProps {
     layoutEditMode: boolean
+    layoutCompaction?: string
     updateLayouts: (layouts: Partial<Record<DashboardLayoutSize, Layout>>) => void
 }
 
@@ -29,6 +35,7 @@ interface DashboardLayoutInteraction {
 
 export function useDashboardLayoutInteraction({
     layoutEditMode,
+    layoutCompaction,
     updateLayouts,
 }: UseDashboardLayoutInteractionProps): DashboardLayoutInteraction {
     const interactionInProgress = useRef(false)
@@ -39,26 +46,31 @@ export function useDashboardLayoutInteraction({
     const activeItemId = useRef<string | null>(null)
     const interactionKind = useRef<InteractionKind | null>(null)
 
-    const gridCompactor = useMemo<Compactor>(
-        () => ({
-            ...verticalCompactor,
+    const gridCompactor = useMemo<Compactor>(() => {
+        const selectedCompaction = layoutCompaction ?? 'vertical'
+        const compactor = getDashboardGridCompactor(selectedCompaction)
+
+        return {
+            ...compactor,
             compact: (layout: Layout, cols: number): Layout => {
                 const baseline = baselineLayout.current
                 const activeTileId = activeItemId.current
                 if (!baseline || !activeTileId) {
-                    return verticalCompactor.compact(layout, cols)
+                    return compactor.compact(layout, cols)
                 }
 
                 const restoredLayout = restoreUnmovedItemPositions(layout, baseline, activeTileId, baselineById.current)
+                if (selectedCompaction === 'stable') {
+                    return resolveFreePlacementCollisions(restoredLayout, cols, activeTileId)
+                }
                 const layoutForCompaction =
-                    interactionKind.current === 'resize'
+                    selectedCompaction === 'vertical' && interactionKind.current === 'resize'
                         ? resizeNeighborToFitRow(restoredLayout, baseline, activeTileId, resizeNeighbors.current)
                         : restoredLayout
-                return verticalCompactor.compact(layoutForCompaction, cols)
+                return compactor.compact(layoutForCompaction, cols)
             },
-        }),
-        []
-    )
+        }
+    }, [layoutCompaction])
 
     const handleLayoutChange = useCallback(
         (_: unknown, newLayouts: Partial<Record<DashboardLayoutSize, Layout>>) => {

--- a/frontend/src/scenes/dashboard/useDashboardLayoutInteraction.ts
+++ b/frontend/src/scenes/dashboard/useDashboardLayoutInteraction.ts
@@ -10,10 +10,9 @@ import {
 } from 'scenes/dashboard/dashboardResizeCompactor'
 import type { ResizeNeighbors } from 'scenes/dashboard/dashboardResizeCompactor'
 
-import { DashboardGridCompaction } from '~/types'
 import type { DashboardLayoutSize } from '~/types'
 
-import { getDashboardGridCompactor } from 'products/dashboards/frontend/dashboardCustomization'
+import { DashboardGridCompaction, getDashboardGridCompactor } from 'products/dashboards/frontend/dashboardCustomization'
 
 type InteractionKind = 'drag' | 'resize'
 

--- a/frontend/src/scenes/dashboard/useDashboardLayoutInteraction.ts
+++ b/frontend/src/scenes/dashboard/useDashboardLayoutInteraction.ts
@@ -13,10 +13,7 @@ import type { ResizeNeighbors } from 'scenes/dashboard/dashboardResizeCompactor'
 import { DashboardGridCompaction } from '~/types'
 import type { DashboardLayoutSize } from '~/types'
 
-import {
-    getDashboardGridCompactor,
-    resolveFreePlacementCollisions,
-} from 'products/dashboards/frontend/dashboardCustomization'
+import { getDashboardGridCompactor } from 'products/dashboards/frontend/dashboardCustomization'
 
 type InteractionKind = 'drag' | 'resize'
 
@@ -48,8 +45,7 @@ export function useDashboardLayoutInteraction({
     const interactionKind = useRef<InteractionKind | null>(null)
 
     const gridCompactor = useMemo<Compactor>(() => {
-        const selectedCompaction = layoutCompaction ?? DashboardGridCompaction.Vertical
-        const compactor = getDashboardGridCompactor(selectedCompaction)
+        const compactor = getDashboardGridCompactor(layoutCompaction ?? DashboardGridCompaction.Vertical)
 
         return {
             ...compactor,
@@ -61,14 +57,11 @@ export function useDashboardLayoutInteraction({
                 }
 
                 const restoredLayout = restoreUnmovedItemPositions(layout, baseline, activeTileId, baselineById.current)
-                if (selectedCompaction === DashboardGridCompaction.Stable) {
-                    return resolveFreePlacementCollisions(restoredLayout, cols, activeTileId)
-                }
-                const layoutForCompaction =
-                    selectedCompaction === DashboardGridCompaction.Vertical && interactionKind.current === 'resize'
+                const resizedLayout =
+                    interactionKind.current === 'resize'
                         ? resizeNeighborToFitRow(restoredLayout, baseline, activeTileId, resizeNeighbors.current)
                         : restoredLayout
-                return compactor.compact(layoutForCompaction, cols)
+                return compactor.compactInteraction(cols, activeTileId, restoredLayout, resizedLayout)
             },
         }
     }, [layoutCompaction])

--- a/frontend/src/scenes/dashboard/useDashboardLayoutInteraction.ts
+++ b/frontend/src/scenes/dashboard/useDashboardLayoutInteraction.ts
@@ -10,6 +10,7 @@ import {
 } from 'scenes/dashboard/dashboardResizeCompactor'
 import type { ResizeNeighbors } from 'scenes/dashboard/dashboardResizeCompactor'
 
+import { DashboardGridCompaction } from '~/types'
 import type { DashboardLayoutSize } from '~/types'
 
 import {
@@ -21,7 +22,7 @@ type InteractionKind = 'drag' | 'resize'
 
 interface UseDashboardLayoutInteractionProps {
     layoutEditMode: boolean
-    layoutCompaction?: string
+    layoutCompaction?: DashboardGridCompaction
     updateLayouts: (layouts: Partial<Record<DashboardLayoutSize, Layout>>) => void
 }
 
@@ -47,7 +48,7 @@ export function useDashboardLayoutInteraction({
     const interactionKind = useRef<InteractionKind | null>(null)
 
     const gridCompactor = useMemo<Compactor>(() => {
-        const selectedCompaction = layoutCompaction ?? 'vertical'
+        const selectedCompaction = layoutCompaction ?? DashboardGridCompaction.Vertical
         const compactor = getDashboardGridCompactor(selectedCompaction)
 
         return {
@@ -60,11 +61,11 @@ export function useDashboardLayoutInteraction({
                 }
 
                 const restoredLayout = restoreUnmovedItemPositions(layout, baseline, activeTileId, baselineById.current)
-                if (selectedCompaction === 'stable') {
+                if (selectedCompaction === DashboardGridCompaction.Stable) {
                     return resolveFreePlacementCollisions(restoredLayout, cols, activeTileId)
                 }
                 const layoutForCompaction =
-                    selectedCompaction === 'vertical' && interactionKind.current === 'resize'
+                    selectedCompaction === DashboardGridCompaction.Vertical && interactionKind.current === 'resize'
                         ? resizeNeighborToFitRow(restoredLayout, baseline, activeTileId, resizeNeighbors.current)
                         : restoredLayout
                 return compactor.compact(layoutForCompaction, cols)

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2705,10 +2705,12 @@ export interface DashboardType<T = InsightModel> extends DashboardBasicType {
     quick_filter_ids?: string[] | null
     customization?: {
         tile_spacing?: DashboardTileSpacing
+        layout_compaction?: DashboardGridCompaction
     }
 }
 
 export type DashboardTileSpacing = 'tight' | 'condensed' | 'standard' | 'relaxed' | 'wide'
+export type DashboardGridCompaction = 'vertical' | 'horizontal' | 'stable'
 
 export enum TemplateAvailabilityContext {
     GENERAL = 'general',

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2710,7 +2710,11 @@ export interface DashboardType<T = InsightModel> extends DashboardBasicType {
 }
 
 export type DashboardTileSpacing = 'tight' | 'condensed' | 'standard' | 'relaxed' | 'wide'
-export type DashboardGridCompaction = 'vertical' | 'horizontal' | 'stable'
+export enum DashboardGridCompaction {
+    Vertical = 'vertical',
+    Horizontal = 'horizontal',
+    Stable = 'stable',
+}
 
 export enum TemplateAvailabilityContext {
     GENERAL = 'general',

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -6,6 +6,7 @@ import { ReactNode } from 'react'
 import { LayoutItem } from 'react-grid-layout'
 
 import { LemonTableColumns } from '@posthog/lemon-ui'
+import { LayoutCompactionEnumApi as DashboardGridCompaction } from '@posthog/products-dashboards/frontend/generated/api.schemas'
 
 import { PaginatedResponse } from 'lib/api'
 import { ChartDataset, ChartType, InteractionItem } from 'lib/Chart'
@@ -2710,11 +2711,7 @@ export interface DashboardType<T = InsightModel> extends DashboardBasicType {
 }
 
 export type DashboardTileSpacing = 'tight' | 'condensed' | 'standard' | 'relaxed' | 'wide'
-export enum DashboardGridCompaction {
-    Vertical = 'vertical',
-    Horizontal = 'horizontal',
-    Stable = 'stable',
-}
+export { DashboardGridCompaction }
 
 export enum TemplateAvailabilityContext {
     GENERAL = 'general',

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -6,7 +6,6 @@ import { ReactNode } from 'react'
 import { LayoutItem } from 'react-grid-layout'
 
 import { LemonTableColumns } from '@posthog/lemon-ui'
-import { LayoutCompactionEnumApi as DashboardGridCompaction } from '@posthog/products-dashboards/frontend/generated/api.schemas'
 
 import { PaginatedResponse } from 'lib/api'
 import { ChartDataset, ChartType, InteractionItem } from 'lib/Chart'
@@ -2706,12 +2705,11 @@ export interface DashboardType<T = InsightModel> extends DashboardBasicType {
     quick_filter_ids?: string[] | null
     customization?: {
         tile_spacing?: DashboardTileSpacing
-        layout_compaction?: DashboardGridCompaction
+        layout_compaction?: 'vertical' | 'horizontal' | 'stable'
     }
 }
 
 export type DashboardTileSpacing = 'tight' | 'condensed' | 'standard' | 'relaxed' | 'wide'
-export { DashboardGridCompaction }
 
 export enum TemplateAvailabilityContext {
     GENERAL = 'general',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2870,6 +2870,9 @@ importers:
       react-dom:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
+      react-grid-layout:
+        specifier: ^2.2.4
+        version: 2.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@storybook/react':
         specifier: 'catalog:'
@@ -13490,10 +13493,12 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xterm/xterm@5.5.0':
     resolution: {integrity: sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==}
@@ -13516,6 +13521,7 @@ packages:
   '@zenfs/core@1.11.4':
     resolution: {integrity: sha512-jFihhedKitw1X9rlImtaca4KTs1Xk9awo4GxUemqt2ucE1jLi10lyRfFFbiYXZsFDkuCWGHwEQwv7BeDIEXMbQ==}
     engines: {node: '>= 18'}
+    deprecated: v1 is no longer supported. Please update ZenFS (or whatever ZenFS dependent you depend on).
     hasBin: true
 
   abab@2.0.6:
@@ -14701,6 +14707,7 @@ packages:
   cron-parser@4.8.1:
     resolution: {integrity: sha512-jbokKWGcyU4gl6jAfX97E1gDpY12DJ1cLJZmoDzaAln/shZ+S3KBFBuA2Q6WeUN4gJf/8klnV1EfvhA2lK5IRQ==}
     engines: {node: '>=12.0.0'}
+    deprecated: v4 is no longer maintained, upgrade to v5
 
   cron-parser@5.5.0:
     resolution: {integrity: sha512-oML4lKUXxizYswqmxuOCpgFS8BNUJpIu6k/2HVHyaL8Ynnf3wdf9tkns0yRdJLSIjkJ+b0DXHMZEHGpMwjnPww==}

--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -674,6 +674,54 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
             Dashboard.objects.get(id=copied_id).customization, {"show_legend": False, "tile_spacing": "wide"}
         )
 
+    @parameterized.expand([("horizontal",), ("stable",)])
+    @patch("products.dashboards.backend.api.dashboard.dashboard_customization_enabled", return_value=True)
+    def test_dashboard_layout_compaction_is_saved_and_duplicated(
+        self, layout_compaction: str, _mock_enabled: MagicMock
+    ) -> None:
+        dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dashboard"})
+
+        _, updated = self.dashboard_api.update_dashboard(dashboard_id, {"layout_compaction": layout_compaction})
+        self.assertEqual(updated["customization"], {"layout_compaction": layout_compaction})
+
+        copied_id, copied = self.dashboard_api.create_dashboard({"name": "copy", "use_dashboard": dashboard_id})
+        self.assertEqual(copied["customization"], {"layout_compaction": layout_compaction})
+        self.assertEqual(Dashboard.objects.get(id=copied_id).customization, {"layout_compaction": layout_compaction})
+
+    @patch("products.dashboards.backend.api.dashboard.report_user_action")
+    @patch("products.dashboards.backend.api.dashboard.dashboard_customization_enabled", return_value=True)
+    def test_dashboard_layout_compaction_reports_every_mode_change(
+        self, _mock_enabled: MagicMock, mock_report_user_action: MagicMock
+    ) -> None:
+        dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dashboard"})
+        mock_report_user_action.reset_mock()
+
+        self.dashboard_api.update_dashboard(dashboard_id, {"layout_compaction": "horizontal"})
+        self.dashboard_api.update_dashboard(dashboard_id, {"layout_compaction": "vertical"})
+
+        compaction_calls = [
+            call
+            for call in mock_report_user_action.call_args_list
+            if call.args[1] == "dashboard grid compaction configured"
+        ]
+        self.assertEqual(len(compaction_calls), 2)
+        self.assertEqual(
+            compaction_calls[0].args[2],
+            {
+                "dashboard_id": dashboard_id,
+                "previous_layout_compaction": "vertical",
+                "layout_compaction": "horizontal",
+            },
+        )
+        self.assertEqual(
+            compaction_calls[1].args[2],
+            {
+                "dashboard_id": dashboard_id,
+                "previous_layout_compaction": "horizontal",
+                "layout_compaction": "vertical",
+            },
+        )
+
     @patch("products.dashboards.backend.api.dashboard.dashboard_customization_enabled", return_value=True)
     def test_dashboard_tile_spacing_recovers_from_malformed_customization(self, _mock_enabled: MagicMock):
         dashboard = Dashboard.objects.create(team=self.team, name="dashboard", customization=[])
@@ -696,6 +744,18 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         self.assertEqual(response["attr"], "grid_spacing")
         self.assertEqual(response["detail"], "Tile density isn't available.")
 
+    @patch("products.dashboards.backend.api.dashboard.dashboard_customization_enabled", return_value=False)
+    def test_dashboard_layout_compaction_requires_feature_flag(self, _mock_enabled: MagicMock) -> None:
+        dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dashboard"})
+
+        _, response = self.dashboard_api.update_dashboard(
+            dashboard_id,
+            {"layout_compaction": "horizontal"},
+            expected_status=status.HTTP_400_BAD_REQUEST,
+        )
+        self.assertEqual(response["attr"], "layout_compaction")
+        self.assertEqual(response["detail"], "Tile movement settings aren't available.")
+
     @patch("products.dashboards.backend.api.dashboard.dashboard_customization_enabled", return_value=True)
     def test_dashboard_tile_spacing_requires_a_known_preset(self, _mock_enabled: MagicMock):
         dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dashboard"})
@@ -706,6 +766,17 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
             expected_status=status.HTTP_400_BAD_REQUEST,
         )
         self.assertEqual(response["attr"], "grid_spacing")
+
+    @patch("products.dashboards.backend.api.dashboard.dashboard_customization_enabled", return_value=True)
+    def test_dashboard_layout_compaction_requires_a_known_mode(self, _mock_enabled: MagicMock) -> None:
+        dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dashboard"})
+
+        _, response = self.dashboard_api.update_dashboard(
+            dashboard_id,
+            {"layout_compaction": "none"},
+            expected_status=status.HTTP_400_BAD_REQUEST,
+        )
+        self.assertEqual(response["attr"], "layout_compaction")
 
     @patch("products.product_analytics.backend.presentation.insight.record_dashboard_cache_outcome")
     @patch("posthog.caching.calculate_results.calculate_for_query_based_insight")

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -685,6 +685,7 @@ SPECTACULAR_SETTINGS = {
         "TargetTypeEnum": "products.exports.backend.models.subscription.Subscription.SubscriptionTarget",
         # --- Inline value lists (type-hint enums, no x-spec-enum-id) ---
         "TileSpacingEnum": ["tight", "condensed", "standard", "relaxed", "wide"],
+        "LayoutCompactionEnum": ["vertical", "horizontal", "stable"],
         "PropertyGroupOperator": ["AND", "OR"],
         # `scope`/`state` are generic field names; one shared name for the canvas state scope set.
         "CanvasStateScopeEnum": ["user", "shared"],

--- a/products/batch_exports/backend/tests/api/test_delete.py
+++ b/products/batch_exports/backend/tests/api/test_delete.py
@@ -22,7 +22,6 @@ from products.batch_exports.backend.tests.api.operations import (
     delete_batch_export,
     delete_batch_export_ok,
     get_batch_export,
-    wait_for_workflow_executions,
 )
 
 pytestmark = [
@@ -131,9 +130,12 @@ def test_delete_batch_export_cancels_backfills(
 
     backfill_workflow_id = f"{batch_export_id}-Backfill-{start_at}-{end_at}"
 
-    # In order for the backfill to be cancelable, it needs to be running and requesting backfills.
-    # We check this by waiting for executions scheduled by our BatchExport id to pop up.
-    _ = wait_for_workflow_executions(temporal, query=f'TemporalScheduledById="{batch_export_id}"')
+    workflow = wait_for_workflow_in_status(
+        temporal,
+        workflow_id=backfill_workflow_id,
+        status=temporalio.client.WorkflowExecutionStatus.RUNNING,
+    )
+    assert workflow.status == temporalio.client.WorkflowExecutionStatus.RUNNING
 
     delete_batch_export_ok(client, team.pk, batch_export_id)
 

--- a/products/batch_exports/backend/tests/api/test_delete.py
+++ b/products/batch_exports/backend/tests/api/test_delete.py
@@ -22,6 +22,7 @@ from products.batch_exports.backend.tests.api.operations import (
     delete_batch_export,
     delete_batch_export_ok,
     get_batch_export,
+    wait_for_workflow_executions,
 )
 
 pytestmark = [
@@ -130,12 +131,9 @@ def test_delete_batch_export_cancels_backfills(
 
     backfill_workflow_id = f"{batch_export_id}-Backfill-{start_at}-{end_at}"
 
-    workflow = wait_for_workflow_in_status(
-        temporal,
-        workflow_id=backfill_workflow_id,
-        status=temporalio.client.WorkflowExecutionStatus.RUNNING,
-    )
-    assert workflow.status == temporalio.client.WorkflowExecutionStatus.RUNNING
+    # In order for the backfill to be cancelable, it needs to be running and requesting backfills.
+    # We check this by waiting for executions scheduled by our BatchExport id to pop up.
+    _ = wait_for_workflow_executions(temporal, query=f'TemporalScheduledById="{batch_export_id}"')
 
     delete_batch_export_ok(client, team.pk, batch_export_id)
 

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -116,7 +116,11 @@ from products.dashboards.backend.api.widget_openapi_serializers import (
 )
 from products.dashboards.backend.constants import DASHBOARD_GRID_COLUMN_COUNT, MAX_WIDGETS_BATCH_SIZE
 from products.dashboards.backend.feature_flags import dashboard_customization_enabled, dashboard_widgets_enabled
-from products.dashboards.backend.models.dashboard import DASHBOARD_GRID_SPACING_GAPS, Dashboard
+from products.dashboards.backend.models.dashboard import (
+    DASHBOARD_GRID_COMPACTION_MODES,
+    DASHBOARD_GRID_SPACING_GAPS,
+    Dashboard,
+)
 from products.dashboards.backend.models.dashboard_tile import ButtonTile, DashboardTile, Text
 from products.dashboards.backend.models.dashboard_widget import DashboardWidget
 from products.dashboards.backend.widget_access import (
@@ -165,6 +169,11 @@ from ee.hogai.utils.aio import async_to_sync
 
 def _normalize_dashboard_customization(customization: Any) -> dict[str, Any]:
     return customization.copy() if isinstance(customization, dict) else {}
+
+
+def _effective_layout_compaction(customization: Any) -> str:
+    layout_compaction = _normalize_dashboard_customization(customization).get("layout_compaction")
+    return layout_compaction if layout_compaction in DASHBOARD_GRID_COMPACTION_MODES else "vertical"
 
 
 logger = structlog.get_logger(__name__)
@@ -242,6 +251,7 @@ DASHBOARD_SHARED_FIELDS = [
     "quick_filter_ids",
     "customization",
     "grid_spacing",
+    "layout_compaction",
 ]
 
 
@@ -1179,6 +1189,14 @@ class DashboardCustomizationSerializer(serializers.Serializer):
         required=False,
         help_text="Named tile density preset.",
     )
+    layout_compaction = serializers.ChoiceField(
+        choices=DASHBOARD_GRID_COMPACTION_MODES,
+        required=False,
+        help_text=(
+            "How tiles rearrange after a move or resize. vertical stacks tiles upward, horizontal stacks tiles "
+            "to the left, and stable preserves positions while moving colliding tiles."
+        ),
+    )
 
 
 class DashboardMetadataSerializer(DashboardBasicSerializer):
@@ -1206,6 +1224,15 @@ class DashboardMetadataSerializer(DashboardBasicSerializer):
         write_only=True,
         help_text="Named tile density preset. Use tight, condensed, standard, relaxed, or wide.",
     )
+    layout_compaction = serializers.ChoiceField(
+        choices=DASHBOARD_GRID_COMPACTION_MODES,
+        required=False,
+        write_only=True,
+        help_text=(
+            "How tiles rearrange after a move or resize. vertical stacks tiles upward, horizontal stacks tiles "
+            "to the left, and stable preserves positions while moving colliding tiles."
+        ),
+    )
     persisted_filters = serializers.SerializerMethodField()
     persisted_variables = serializers.SerializerMethodField()
 
@@ -1221,10 +1248,15 @@ class DashboardMetadataSerializer(DashboardBasicSerializer):
 
     @extend_schema_field(DashboardCustomizationSerializer)
     def get_customization(self, dashboard: Dashboard) -> dict[str, str]:
-        tile_spacing = _normalize_dashboard_customization(dashboard.customization).get("tile_spacing")
+        customization = _normalize_dashboard_customization(dashboard.customization)
+        tile_spacing = customization.get("tile_spacing")
+        layout_compaction = customization.get("layout_compaction")
+        result = {}
         if isinstance(tile_spacing, str) and tile_spacing in DASHBOARD_GRID_SPACING_GAPS:
-            return {"tile_spacing": tile_spacing}
-        return {}
+            result["tile_spacing"] = tile_spacing
+        if isinstance(layout_compaction, str) and layout_compaction in DASHBOARD_GRID_COMPACTION_MODES:
+            result["layout_compaction"] = layout_compaction
+        return result
 
     def get_variables(self, dashboard: Dashboard) -> dict | None:
         request = self.context.get("request")
@@ -1494,8 +1526,11 @@ class DashboardSerializer(DashboardMetadataSerializer):
         team_id = self.context["team_id"]
         team = self.context["get_team"]()
         grid_spacing = validated_data.pop("grid_spacing", None)
+        layout_compaction = validated_data.pop("layout_compaction", None)
         if grid_spacing is not None and not dashboard_customization_enabled(team=team, user=request.user):
             raise serializers.ValidationError({"grid_spacing": "Tile density isn't available."})
+        if layout_compaction is not None and not dashboard_customization_enabled(team=team, user=request.user):
+            raise serializers.ValidationError({"layout_compaction": "Tile movement settings aren't available."})
         current_count = Dashboard.objects.filter(team_id=team_id, deleted=False).count()
         check_count_limit(
             team=team,
@@ -1552,6 +1587,11 @@ class DashboardSerializer(DashboardMetadataSerializer):
             validated_data["customization"] = {
                 **validated_data.get("customization", {}),
                 "tile_spacing": grid_spacing,
+            }
+        if layout_compaction is not None:
+            validated_data["customization"] = {
+                **validated_data.get("customization", {}),
+                "layout_compaction": layout_compaction,
             }
 
         dashboard = Dashboard.objects.create(team_id=team_id, filters=filters, **validated_data)
@@ -1741,6 +1781,7 @@ class DashboardSerializer(DashboardMetadataSerializer):
 
     @monitor(feature=Feature.DASHBOARD, endpoint="dashboard", method="PATCH")
     def update(self, instance: Dashboard, validated_data: dict, *args: Any, **kwargs: Any) -> Dashboard:
+        previous_layout_compaction = _effective_layout_compaction(instance.customization)
         can_user_restrict = self.user_permissions.dashboard(instance).can_restrict
         if "restriction_level" in validated_data and not can_user_restrict:
             raise exceptions.PermissionDenied(
@@ -1749,14 +1790,20 @@ class DashboardSerializer(DashboardMetadataSerializer):
 
         validated_data.pop("use_template", None)  # Remove attribute if present
         grid_spacing = validated_data.pop("grid_spacing", None)
+        layout_compaction = validated_data.pop("layout_compaction", None)
         if grid_spacing is not None and not dashboard_customization_enabled(
             team=instance.team, user=cast(User, self.context["request"].user)
         ):
             raise serializers.ValidationError({"grid_spacing": "Tile density isn't available."})
-        if grid_spacing is not None:
+        if layout_compaction is not None and not dashboard_customization_enabled(
+            team=instance.team, user=cast(User, self.context["request"].user)
+        ):
+            raise serializers.ValidationError({"layout_compaction": "Tile movement settings aren't available."})
+        if grid_spacing is not None or layout_compaction is not None:
             validated_data["customization"] = {
                 **_normalize_dashboard_customization(instance.customization),
-                "tile_spacing": grid_spacing,
+                **({"tile_spacing": grid_spacing} if grid_spacing is not None else {}),
+                **({"layout_compaction": layout_compaction} if layout_compaction is not None else {}),
             }
 
         being_undeleted = instance.deleted and "deleted" in validated_data and not validated_data["deleted"]
@@ -1827,6 +1874,18 @@ class DashboardSerializer(DashboardMetadataSerializer):
                 self._deep_duplicate_tiles(instance, existing_tile, user_access_control)
 
         if "request" in self.context:
+            if layout_compaction is not None and layout_compaction != previous_layout_compaction:
+                report_user_action(
+                    user,
+                    "dashboard grid compaction configured",
+                    {
+                        "dashboard_id": instance.id,
+                        "previous_layout_compaction": previous_layout_compaction,
+                        "layout_compaction": layout_compaction,
+                    },
+                    team=instance.team,
+                    request=self.context["request"],
+                )
             if being_deleted:
                 report_user_action(
                     user,

--- a/products/dashboards/backend/models/dashboard.py
+++ b/products/dashboards/backend/models/dashboard.py
@@ -23,6 +23,8 @@ DASHBOARD_GRID_SPACING_GAPS = {
     "wide": 48,
 }
 
+DASHBOARD_GRID_COMPACTION_MODES = ("vertical", "horizontal", "stable")
+
 
 class DashboardManager(RootTeamManager):
     def get_queryset(self):

--- a/products/dashboards/backend/widget_specs/openapi.py
+++ b/products/dashboards/backend/widget_specs/openapi.py
@@ -6,7 +6,7 @@ from drf_spectacular.utils import PolymorphicProxySerializer, extend_schema_fiel
 from pydantic import BaseModel
 from rest_framework import serializers
 
-from products.dashboards.backend.models.dashboard import DASHBOARD_GRID_SPACING_GAPS
+from products.dashboards.backend.models.dashboard import DASHBOARD_GRID_COMPACTION_MODES, DASHBOARD_GRID_SPACING_GAPS
 from products.dashboards.backend.widget_specs.pydantic_openapi import pydantic_config_field, pydantic_stub_serializer
 from products.dashboards.backend.widget_specs.registry import EXPECTED_WIDGET_TYPES, WIDGET_SPECS
 
@@ -307,6 +307,14 @@ class PatchedDashboardOpenApiSerializer(serializers.Serializer):
         choices=tuple(DASHBOARD_GRID_SPACING_GAPS),
         required=False,
         help_text="Named tile density preset. Use tight, condensed, standard, relaxed, or wide.",
+    )
+    layout_compaction = serializers.ChoiceField(
+        choices=DASHBOARD_GRID_COMPACTION_MODES,
+        required=False,
+        help_text=(
+            "How tiles rearrange after a move or resize. vertical stacks tiles upward, horizontal stacks tiles "
+            "to the left, and stable preserves positions while moving colliding tiles."
+        ),
     )
     tiles = DashboardPatchTileOpenApiSerializer(
         many=True,

--- a/products/dashboards/frontend/components/DashboardCustomizeMenu/DashboardCustomizeMenu.tsx
+++ b/products/dashboards/frontend/components/DashboardCustomizeMenu/DashboardCustomizeMenu.tsx
@@ -1,12 +1,15 @@
 import { useActions, useValues } from 'kea'
 
+import { LemonTag } from '@posthog/lemon-ui'
+
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
 import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
 
-import { DashboardTileSpacing } from '~/types'
+import { DashboardGridCompaction, DashboardTileSpacing } from '~/types'
 
-import { DASHBOARD_TILE_SPACING_LABELS } from '../../dashboardCustomization'
+import { DASHBOARD_GRID_COMPACTION_LABELS, DASHBOARD_TILE_SPACING_LABELS } from '../../dashboardCustomization'
+import { DashboardTileMovementPreview } from './DashboardTileMovementPreview'
 
 const TILE_SPACING_OPTIONS: { value: DashboardTileSpacing; label: string }[] = [
     { value: 'tight', label: DASHBOARD_TILE_SPACING_LABELS.tight },
@@ -16,9 +19,47 @@ const TILE_SPACING_OPTIONS: { value: DashboardTileSpacing; label: string }[] = [
     { value: 'wide', label: DASHBOARD_TILE_SPACING_LABELS.wide },
 ]
 
+const GRID_COMPACTION_OPTIONS: {
+    value: DashboardGridCompaction
+    label: JSX.Element
+}[] = [
+    {
+        value: 'vertical',
+        label: (
+            <span className="flex items-center gap-2">
+                <span className="text-xs font-medium">{DASHBOARD_GRID_COMPACTION_LABELS.vertical}</span>
+                <LemonTag type="success">Recommended</LemonTag>
+                <DashboardTileMovementPreview mode="vertical" />
+            </span>
+        ),
+    },
+    {
+        value: 'horizontal',
+        label: (
+            <span className="flex items-center gap-2">
+                <span className="text-xs font-medium">{DASHBOARD_GRID_COMPACTION_LABELS.horizontal}</span>
+                <DashboardTileMovementPreview mode="horizontal" />
+            </span>
+        ),
+    },
+    {
+        value: 'stable',
+        label: (
+            <span className="flex items-center gap-2">
+                <span className="text-xs font-medium">{DASHBOARD_GRID_COMPACTION_LABELS.stable}</span>
+                <DashboardTileMovementPreview mode="stable" />
+            </span>
+        ),
+    },
+]
+
 export function DashboardCustomizeMenu(): JSX.Element | null {
     const { dashboard, canEditDashboard } = useValues(dashboardLogic)
-    const { setDashboardTileSpacing, saveDashboardTileSpacing } = useActions(dashboardLogic)
+    const {
+        changeDashboardGridCompaction,
+        setDashboardTileSpacing,
+        saveDashboardTileSpacing,
+    } = useActions(dashboardLogic)
     const dashboardCustomizationEnabled = useFeatureFlag('DASHBOARD_CUSTOMIZATION')
 
     if (!dashboard || !canEditDashboard || !dashboardCustomizationEnabled) {
@@ -26,6 +67,7 @@ export function DashboardCustomizeMenu(): JSX.Element | null {
     }
 
     const tileSpacing = dashboard.customization?.tile_spacing ?? 'standard'
+    const layoutCompaction = dashboard.customization?.layout_compaction ?? 'vertical'
     const setTileSpacing = (value: DashboardTileSpacing): void => {
         if (value === tileSpacing) {
             return
@@ -34,17 +76,37 @@ export function DashboardCustomizeMenu(): JSX.Element | null {
         saveDashboardTileSpacing(value)
     }
 
+    const setGridCompaction = (value: DashboardGridCompaction): void => {
+        if (value === layoutCompaction) {
+            return
+        }
+        changeDashboardGridCompaction(value)
+    }
+
     return (
-        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 p-2">
-            <span className="text-xs text-muted whitespace-nowrap">Tile density</span>
-            <LemonRadio<DashboardTileSpacing>
-                value={tileSpacing}
-                onChange={setTileSpacing}
-                options={TILE_SPACING_OPTIONS}
-                orientation="horizontal"
-                className="flex-1 flex-wrap gap-x-3 gap-y-1"
-                aria-label="Tile density"
-            />
+        <div className="space-y-2 p-2">
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+                <span className="text-xs text-muted whitespace-nowrap">Tile density</span>
+                <LemonRadio<DashboardTileSpacing>
+                    value={tileSpacing}
+                    onChange={setTileSpacing}
+                    options={TILE_SPACING_OPTIONS}
+                    orientation="horizontal"
+                    className="flex-1 flex-wrap gap-x-3 gap-y-1"
+                    aria-label="Tile density"
+                />
+            </div>
+            <div className="flex gap-x-3 border-t pt-2">
+                <span className="pt-3 text-xs text-muted whitespace-nowrap">When you move a tile</span>
+                <LemonRadio<DashboardGridCompaction>
+                    value={layoutCompaction}
+                    onChange={setGridCompaction}
+                    options={GRID_COMPACTION_OPTIONS}
+                    radioPosition="top"
+                    className="flex-1"
+                    aria-label="How moving a tile rearranges other tiles"
+                />
+            </div>
         </div>
     )
 }

--- a/products/dashboards/frontend/components/DashboardCustomizeMenu/DashboardCustomizeMenu.tsx
+++ b/products/dashboards/frontend/components/DashboardCustomizeMenu/DashboardCustomizeMenu.tsx
@@ -55,11 +55,7 @@ const GRID_COMPACTION_OPTIONS: {
 
 export function DashboardCustomizeMenu(): JSX.Element | null {
     const { dashboard, canEditDashboard } = useValues(dashboardLogic)
-    const {
-        changeDashboardGridCompaction,
-        setDashboardTileSpacing,
-        saveDashboardTileSpacing,
-    } = useActions(dashboardLogic)
+    const { changeDashboardGridCompaction, setDashboardTileSpacing, saveDashboardTileSpacing } = useActions(dashboardLogic)
     const dashboardCustomizationEnabled = useFeatureFlag('DASHBOARD_CUSTOMIZATION')
 
     if (!dashboard || !canEditDashboard || !dashboardCustomizationEnabled) {

--- a/products/dashboards/frontend/components/DashboardCustomizeMenu/DashboardCustomizeMenu.tsx
+++ b/products/dashboards/frontend/components/DashboardCustomizeMenu/DashboardCustomizeMenu.tsx
@@ -24,30 +24,30 @@ const GRID_COMPACTION_OPTIONS: {
     label: JSX.Element
 }[] = [
     {
-        value: 'vertical',
+        value: DashboardGridCompaction.Vertical,
         label: (
             <span className="flex items-center gap-2">
-                <span className="text-xs font-medium">{DASHBOARD_GRID_COMPACTION_LABELS.vertical}</span>
+                <span className="text-xs font-medium">{DASHBOARD_GRID_COMPACTION_LABELS[DashboardGridCompaction.Vertical]}</span>
                 <LemonTag type="success">Recommended</LemonTag>
-                <DashboardTileMovementPreview mode="vertical" />
+                <DashboardTileMovementPreview mode={DashboardGridCompaction.Vertical} />
             </span>
         ),
     },
     {
-        value: 'horizontal',
+        value: DashboardGridCompaction.Horizontal,
         label: (
             <span className="flex items-center gap-2">
-                <span className="text-xs font-medium">{DASHBOARD_GRID_COMPACTION_LABELS.horizontal}</span>
-                <DashboardTileMovementPreview mode="horizontal" />
+                <span className="text-xs font-medium">{DASHBOARD_GRID_COMPACTION_LABELS[DashboardGridCompaction.Horizontal]}</span>
+                <DashboardTileMovementPreview mode={DashboardGridCompaction.Horizontal} />
             </span>
         ),
     },
     {
-        value: 'stable',
+        value: DashboardGridCompaction.Stable,
         label: (
             <span className="flex items-center gap-2">
-                <span className="text-xs font-medium">{DASHBOARD_GRID_COMPACTION_LABELS.stable}</span>
-                <DashboardTileMovementPreview mode="stable" />
+                <span className="text-xs font-medium">{DASHBOARD_GRID_COMPACTION_LABELS[DashboardGridCompaction.Stable]}</span>
+                <DashboardTileMovementPreview mode={DashboardGridCompaction.Stable} />
             </span>
         ),
     },
@@ -63,7 +63,7 @@ export function DashboardCustomizeMenu(): JSX.Element | null {
     }
 
     const tileSpacing = dashboard.customization?.tile_spacing ?? 'standard'
-    const layoutCompaction = dashboard.customization?.layout_compaction ?? 'vertical'
+    const layoutCompaction = dashboard.customization?.layout_compaction ?? DashboardGridCompaction.Vertical
     const setTileSpacing = (value: DashboardTileSpacing): void => {
         if (value === tileSpacing) {
             return

--- a/products/dashboards/frontend/components/DashboardCustomizeMenu/DashboardCustomizeMenu.tsx
+++ b/products/dashboards/frontend/components/DashboardCustomizeMenu/DashboardCustomizeMenu.tsx
@@ -6,9 +6,14 @@ import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
 import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
 
-import { DashboardGridCompaction, DashboardTileSpacing } from '~/types'
+import type { DashboardTileSpacing } from '~/types'
 
-import { DASHBOARD_GRID_COMPACTION_LABELS, DASHBOARD_TILE_SPACING_LABELS } from '../../dashboardCustomization'
+import {
+    DASHBOARD_GRID_COMPACTION_LABELS,
+    DASHBOARD_TILE_SPACING_LABELS,
+    DashboardGridCompaction,
+    type DashboardGridCompaction as DashboardGridCompactionType,
+} from '../../dashboardCustomization'
 import { DashboardTileMovementPreview } from './DashboardTileMovementPreview'
 
 const TILE_SPACING_OPTIONS: { value: DashboardTileSpacing; label: string }[] = [
@@ -20,14 +25,16 @@ const TILE_SPACING_OPTIONS: { value: DashboardTileSpacing; label: string }[] = [
 ]
 
 const GRID_COMPACTION_OPTIONS: {
-    value: DashboardGridCompaction
+    value: DashboardGridCompactionType
     label: JSX.Element
 }[] = [
     {
         value: DashboardGridCompaction.Vertical,
         label: (
             <span className="flex items-center gap-2">
-                <span className="text-xs font-medium">{DASHBOARD_GRID_COMPACTION_LABELS[DashboardGridCompaction.Vertical]}</span>
+                <span className="text-xs font-medium">
+                    {DASHBOARD_GRID_COMPACTION_LABELS[DashboardGridCompaction.Vertical]}
+                </span>
                 <LemonTag type="success">Recommended</LemonTag>
                 <DashboardTileMovementPreview mode={DashboardGridCompaction.Vertical} />
             </span>
@@ -37,7 +44,9 @@ const GRID_COMPACTION_OPTIONS: {
         value: DashboardGridCompaction.Horizontal,
         label: (
             <span className="flex items-center gap-2">
-                <span className="text-xs font-medium">{DASHBOARD_GRID_COMPACTION_LABELS[DashboardGridCompaction.Horizontal]}</span>
+                <span className="text-xs font-medium">
+                    {DASHBOARD_GRID_COMPACTION_LABELS[DashboardGridCompaction.Horizontal]}
+                </span>
                 <DashboardTileMovementPreview mode={DashboardGridCompaction.Horizontal} />
             </span>
         ),
@@ -46,7 +55,9 @@ const GRID_COMPACTION_OPTIONS: {
         value: DashboardGridCompaction.Stable,
         label: (
             <span className="flex items-center gap-2">
-                <span className="text-xs font-medium">{DASHBOARD_GRID_COMPACTION_LABELS[DashboardGridCompaction.Stable]}</span>
+                <span className="text-xs font-medium">
+                    {DASHBOARD_GRID_COMPACTION_LABELS[DashboardGridCompaction.Stable]}
+                </span>
                 <DashboardTileMovementPreview mode={DashboardGridCompaction.Stable} />
             </span>
         ),
@@ -55,7 +66,8 @@ const GRID_COMPACTION_OPTIONS: {
 
 export function DashboardCustomizeMenu(): JSX.Element | null {
     const { dashboard, canEditDashboard } = useValues(dashboardLogic)
-    const { changeDashboardGridCompaction, setDashboardTileSpacing, saveDashboardTileSpacing } = useActions(dashboardLogic)
+    const { changeDashboardGridCompaction, setDashboardTileSpacing, saveDashboardTileSpacing } =
+        useActions(dashboardLogic)
     const dashboardCustomizationEnabled = useFeatureFlag('DASHBOARD_CUSTOMIZATION')
 
     if (!dashboard || !canEditDashboard || !dashboardCustomizationEnabled) {
@@ -72,7 +84,7 @@ export function DashboardCustomizeMenu(): JSX.Element | null {
         saveDashboardTileSpacing(value)
     }
 
-    const setGridCompaction = (value: DashboardGridCompaction): void => {
+    const setGridCompaction = (value: DashboardGridCompactionType): void => {
         if (value === layoutCompaction) {
             return
         }
@@ -94,7 +106,7 @@ export function DashboardCustomizeMenu(): JSX.Element | null {
             </div>
             <div className="flex gap-x-3 border-t pt-2">
                 <span className="pt-3 text-xs text-muted whitespace-nowrap">When you move a tile</span>
-                <LemonRadio<DashboardGridCompaction>
+                <LemonRadio<DashboardGridCompactionType>
                     value={layoutCompaction}
                     onChange={setGridCompaction}
                     options={GRID_COMPACTION_OPTIONS}

--- a/products/dashboards/frontend/components/DashboardCustomizeMenu/DashboardTileMovementPreview.scss
+++ b/products/dashboards/frontend/components/DashboardCustomizeMenu/DashboardTileMovementPreview.scss
@@ -1,0 +1,154 @@
+.dashboard-tile-movement-preview {
+    &__move-up,
+    &__move-up-double,
+    &__move-right,
+    &__move-into-row,
+    &__move-down,
+    &__resize-right {
+        transform-box: fill-box;
+        transform-origin: center;
+    }
+
+    &__move-up {
+        animation: DashboardTileMovementPreview__moveUp 2.5s ease-in-out infinite;
+    }
+
+    &__move-up-double {
+        animation: DashboardTileMovementPreview__moveUpDouble 2.5s ease-in-out infinite;
+    }
+
+    &__move-right {
+        animation: DashboardTileMovementPreview__moveRight 2.5s ease-in-out infinite;
+    }
+
+    &__move-into-row {
+        animation: DashboardTileMovementPreview__moveIntoRow 2.5s ease-in-out infinite;
+    }
+
+    &__move-down {
+        animation: DashboardTileMovementPreview__moveDown 2.5s ease-in-out infinite;
+    }
+
+    &__resize-right {
+        transform-origin: left center;
+        animation: DashboardTileMovementPreview__resizeRight 2.5s ease-in-out infinite;
+    }
+}
+
+@keyframes DashboardTileMovementPreview__moveUp {
+    0%,
+    16.67%,
+    50%,
+    100% {
+        transform: translateY(-16px);
+    }
+
+    30% {
+        transform: translateY(0);
+    }
+}
+
+@keyframes DashboardTileMovementPreview__moveUpDouble {
+    0%,
+    16.67%,
+    50%,
+    100% {
+        transform: translateY(-32px);
+    }
+
+    30% {
+        transform: translateY(0);
+    }
+}
+
+@keyframes DashboardTileMovementPreview__moveRight {
+    0%,
+    16.67%,
+    50%,
+    100% {
+        transform: translateX(15.5px);
+    }
+
+    30% {
+        transform: translateX(0);
+    }
+}
+
+@keyframes DashboardTileMovementPreview__moveIntoRow {
+    0%,
+    16.67%,
+    66.67%,
+    100% {
+        transform: translateY(-16px);
+    }
+
+    30%,
+    56.67% {
+        transform: translateY(0);
+    }
+}
+
+@keyframes DashboardTileMovementPreview__moveDown {
+    0%,
+    16.67%,
+    58.33%,
+    100% {
+        transform: translateY(16px);
+    }
+
+    30%,
+    43.33% {
+        transform: translateY(0);
+    }
+}
+
+@keyframes DashboardTileMovementPreview__resizeRight {
+    0%,
+    16.67%,
+    58.33%,
+    100% {
+        transform: scaleX(2.24);
+    }
+
+    30%,
+    56.67% {
+        transform: scaleX(1);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .dashboard-tile-movement-preview {
+        &__move-up {
+            transform: translateY(-16px);
+        }
+
+        &__move-up-double {
+            transform: translateY(-32px);
+        }
+
+        &__move-right {
+            transform: translateX(15.5px);
+        }
+
+        &__move-into-row {
+            transform: translateY(-16px);
+        }
+
+        &__move-down {
+            transform: translateY(16px);
+        }
+
+        &__resize-right {
+            transform: scaleX(2.24);
+        }
+
+        &__move-up,
+        &__move-up-double,
+        &__move-right,
+        &__move-into-row,
+        &__move-down,
+        &__resize-right {
+            animation: none;
+        }
+    }
+}

--- a/products/dashboards/frontend/components/DashboardCustomizeMenu/DashboardTileMovementPreview.tsx
+++ b/products/dashboards/frontend/components/DashboardCustomizeMenu/DashboardTileMovementPreview.tsx
@@ -1,0 +1,63 @@
+import './DashboardTileMovementPreview.scss'
+
+import type { DashboardGridCompaction } from '~/types'
+
+const GRID_STROKE = 'var(--color-border-primary)'
+const EXISTING_TILE = 'var(--data-color-3)'
+const MOVED_TILE = 'var(--data-color-1)'
+const DISPLACED_TILE = 'var(--data-color-5)'
+
+interface DashboardTileMovementPreviewProps {
+    mode: DashboardGridCompaction
+}
+
+function Tile({ x, y, fill, className }: { x: number; y: number; fill: string; className?: string }): JSX.Element {
+    return <rect className={className} x={x * 15.5 + 3} y={y * 16 + 11} width="12.5" height="13" rx="2" fill={fill} />
+}
+
+function MovementTiles({ mode }: DashboardTileMovementPreviewProps): JSX.Element {
+    if (mode === 'vertical') {
+        return (
+            <>
+                <Tile x={0} y={0} fill={EXISTING_TILE} />
+                <Tile x={0} y={1} fill={EXISTING_TILE} />
+                <Tile x={0} y={2} fill={EXISTING_TILE} />
+                <Tile x={1} y={2} fill={MOVED_TILE} className="dashboard-tile-movement-preview__move-up-double" />
+                <Tile x={2} y={1} fill={DISPLACED_TILE} className="dashboard-tile-movement-preview__move-up" />
+            </>
+        )
+    }
+
+    if (mode === 'horizontal') {
+        return (
+            <>
+                <Tile x={0} y={0} fill={EXISTING_TILE} />
+                <Tile x={1} y={0} fill={DISPLACED_TILE} className="dashboard-tile-movement-preview__move-right" />
+                <Tile x={1} y={1} fill={MOVED_TILE} className="dashboard-tile-movement-preview__move-into-row" />
+            </>
+        )
+    }
+
+    return (
+        <>
+            <Tile x={0} y={0} fill={MOVED_TILE} className="dashboard-tile-movement-preview__resize-right" />
+            <Tile x={1} y={0} fill={DISPLACED_TILE} className="dashboard-tile-movement-preview__move-down" />
+            <Tile x={2} y={1} fill={EXISTING_TILE} />
+        </>
+    )
+}
+
+export function DashboardTileMovementPreview({ mode }: DashboardTileMovementPreviewProps): JSX.Element {
+    return (
+        <svg
+            viewBox="0 0 48 58"
+            className="dashboard-tile-movement-preview mt-0.5 h-12 w-10 shrink-0"
+            fill="none"
+            aria-hidden="true"
+        >
+            <rect x="1" y="9" width="46" height="46" rx="4" fill="var(--color-bg-light)" stroke={GRID_STROKE} />
+            <path d="M16.5 9V55M32 9V55M1 25H47M1 41H47" stroke={GRID_STROKE} strokeWidth="0.75" opacity="0.7" />
+            <MovementTiles mode={mode} />
+        </svg>
+    )
+}

--- a/products/dashboards/frontend/components/DashboardCustomizeMenu/DashboardTileMovementPreview.tsx
+++ b/products/dashboards/frontend/components/DashboardCustomizeMenu/DashboardTileMovementPreview.tsx
@@ -1,6 +1,6 @@
 import './DashboardTileMovementPreview.scss'
 
-import type { DashboardGridCompaction } from '~/types'
+import { DashboardGridCompaction } from '~/types'
 
 const GRID_STROKE = 'var(--color-border-primary)'
 const EXISTING_TILE = 'var(--data-color-3)'
@@ -16,7 +16,7 @@ function Tile({ x, y, fill, className }: { x: number; y: number; fill: string; c
 }
 
 function MovementTiles({ mode }: DashboardTileMovementPreviewProps): JSX.Element {
-    if (mode === 'vertical') {
+    if (mode === DashboardGridCompaction.Vertical) {
         return (
             <>
                 <Tile x={0} y={0} fill={EXISTING_TILE} />
@@ -28,7 +28,7 @@ function MovementTiles({ mode }: DashboardTileMovementPreviewProps): JSX.Element
         )
     }
 
-    if (mode === 'horizontal') {
+    if (mode === DashboardGridCompaction.Horizontal) {
         return (
             <>
                 <Tile x={0} y={0} fill={EXISTING_TILE} />

--- a/products/dashboards/frontend/components/DashboardCustomizeMenu/DashboardTileMovementPreview.tsx
+++ b/products/dashboards/frontend/components/DashboardCustomizeMenu/DashboardTileMovementPreview.tsx
@@ -1,6 +1,6 @@
 import './DashboardTileMovementPreview.scss'
 
-import { DashboardGridCompaction } from '~/types'
+import { DashboardGridCompaction } from '../../dashboardCustomization'
 
 const GRID_STROKE = 'var(--color-border-primary)'
 const EXISTING_TILE = 'var(--data-color-3)'

--- a/products/dashboards/frontend/dashboardCustomization.test.ts
+++ b/products/dashboards/frontend/dashboardCustomization.test.ts
@@ -1,0 +1,33 @@
+import type { Layout } from 'react-grid-layout'
+
+import { resolveFreePlacementCollisions } from './dashboardCustomization'
+
+const geometry = (layout: Layout): Layout => layout.map(({ i, x, y, w, h }) => ({ i, x, y, w, h }))
+
+describe('dashboard grid compactors', () => {
+    it('moves a collision chain below the active tile', () => {
+        const layout = [
+            { i: 'active', x: 0, y: 2, w: 6, h: 4 },
+            { i: 'neighbor', x: 0, y: 4, w: 6, h: 4 },
+            { i: 'next-neighbor', x: 0, y: 8, w: 6, h: 4 },
+        ] as Layout
+
+        expect(geometry(resolveFreePlacementCollisions(layout, 12, 'active'))).toEqual([
+            { i: 'active', x: 0, y: 2, w: 6, h: 4 },
+            { i: 'neighbor', x: 0, y: 6, w: 6, h: 4 },
+            { i: 'next-neighbor', x: 0, y: 10, w: 6, h: 4 },
+        ])
+    })
+
+    it('bounds malformed tile heights before resolving collisions', () => {
+        const layout = [
+            { i: 'active', x: 0, y: 0, w: 6, h: 1_000_000 },
+            { i: 'neighbor', x: 0, y: 5, w: 6, h: 4 },
+        ] as Layout
+
+        expect(geometry(resolveFreePlacementCollisions(layout, 12, 'active'))).toEqual([
+            { i: 'active', x: 0, y: 0, w: 6, h: 100 },
+            { i: 'neighbor', x: 0, y: 100, w: 6, h: 4 },
+        ])
+    })
+})

--- a/products/dashboards/frontend/dashboardCustomization.ts
+++ b/products/dashboards/frontend/dashboardCustomization.ts
@@ -1,4 +1,8 @@
-import type { DashboardTileSpacing } from '~/types'
+import { cloneLayoutItem, horizontalCompactor, noCompactor } from 'react-grid-layout'
+import type { Compactor, Layout, LayoutItem } from 'react-grid-layout'
+import { fastVerticalCompactor } from 'react-grid-layout/extras'
+
+import type { DashboardGridCompaction, DashboardTileSpacing } from '~/types'
 
 export const DASHBOARD_TILE_SPACING_GAPS: Record<DashboardTileSpacing, number> = {
     tight: 8,
@@ -16,6 +20,90 @@ export const DASHBOARD_TILE_SPACING_LABELS: Record<DashboardTileSpacing, string>
     wide: 'Wide',
 }
 
+export const DASHBOARD_GRID_COMPACTION_LABELS: Record<DashboardGridCompaction, string> = {
+    vertical: 'Stack tiles upward',
+    horizontal: 'Stack tiles to the left',
+    stable: 'Free-form placement',
+}
+
+type GridOccupancy = Map<number, Array<LayoutItem | undefined>>
+
+const MAX_FREE_FORM_TILE_HEIGHT_ROWS = 100
+
+function getOccupants(occupancy: GridOccupancy, item: LayoutItem, cols: number): LayoutItem[] {
+    const occupants = new Set<LayoutItem>()
+    const startX = Math.max(0, item.x)
+    const endX = Math.min(cols, item.x + item.w)
+
+    for (let y = item.y; y < item.y + item.h; y++) {
+        const row = occupancy.get(y)
+        for (let x = startX; row && x < endX; x++) {
+            const occupant = row[x]
+            if (occupant) {
+                occupants.add(occupant)
+            }
+        }
+    }
+
+    return [...occupants]
+}
+
+function occupy(occupancy: GridOccupancy, item: LayoutItem, cols: number): void {
+    const startX = Math.max(0, item.x)
+    const endX = Math.min(cols, item.x + item.w)
+
+    for (let y = item.y; y < item.y + item.h; y++) {
+        const row = occupancy.get(y) ?? new Array<LayoutItem | undefined>(cols)
+        for (let x = startX; x < endX; x++) {
+            row[x] = item
+        }
+        occupancy.set(y, row)
+    }
+}
+
+export const freePlacementCompactor: Compactor = noCompactor
+
+export const makeRoomInRowCompactor: Compactor = horizontalCompactor
+
+export function resolveFreePlacementCollisions(layout: Layout, cols: number, activeTileId?: string | null): Layout {
+    const items = layout.map((item) => ({
+        ...cloneLayoutItem(item),
+        h: Math.min(item.h, MAX_FREE_FORM_TILE_HEIGHT_ROWS),
+    }))
+    const activeTile = activeTileId ? items.find((item) => item.i === activeTileId) : undefined
+    const occupancy: GridOccupancy = new Map()
+    for (const item of items) {
+        if (item.static) {
+            occupy(occupancy, item, cols)
+        }
+    }
+    const movableItems = items.filter((item) => !item.static && item.i !== activeTileId)
+
+    for (const item of activeTile && !activeTile.static ? [activeTile, ...movableItems] : movableItems) {
+        let collisions = getOccupants(occupancy, item, cols)
+
+        while (collisions.length > 0) {
+            item.y = Math.max(...collisions.map((collision) => collision.y + collision.h))
+            collisions = getOccupants(occupancy, item, cols)
+        }
+
+        occupy(occupancy, item, cols)
+    }
+
+    return items
+}
+
 export function getDashboardTileSpacingGap(tileSpacing?: string): number {
     return DASHBOARD_TILE_SPACING_GAPS[tileSpacing as DashboardTileSpacing] ?? DASHBOARD_TILE_SPACING_GAPS.standard
+}
+
+export function getDashboardGridCompactor(layoutCompaction?: string): Compactor {
+    switch (layoutCompaction) {
+        case 'horizontal':
+            return makeRoomInRowCompactor
+        case 'stable':
+            return freePlacementCompactor
+        default:
+            return fastVerticalCompactor
+    }
 }

--- a/products/dashboards/frontend/dashboardCustomization.ts
+++ b/products/dashboards/frontend/dashboardCustomization.ts
@@ -2,7 +2,8 @@ import { cloneLayoutItem, horizontalCompactor, noCompactor } from 'react-grid-la
 import type { Compactor, Layout, LayoutItem } from 'react-grid-layout'
 import { fastVerticalCompactor } from 'react-grid-layout/extras'
 
-import type { DashboardGridCompaction, DashboardTileSpacing } from '~/types'
+import { DashboardGridCompaction } from '~/types'
+import type { DashboardTileSpacing } from '~/types'
 
 export const DASHBOARD_TILE_SPACING_GAPS: Record<DashboardTileSpacing, number> = {
     tight: 8,
@@ -21,9 +22,9 @@ export const DASHBOARD_TILE_SPACING_LABELS: Record<DashboardTileSpacing, string>
 }
 
 export const DASHBOARD_GRID_COMPACTION_LABELS: Record<DashboardGridCompaction, string> = {
-    vertical: 'Stack tiles upward',
-    horizontal: 'Stack tiles to the left',
-    stable: 'Free-form placement',
+    [DashboardGridCompaction.Vertical]: 'Stack tiles upward',
+    [DashboardGridCompaction.Horizontal]: 'Stack tiles to the left',
+    [DashboardGridCompaction.Stable]: 'Free-form placement',
 }
 
 type GridOccupancy = Map<number, Array<LayoutItem | undefined>>
@@ -97,11 +98,11 @@ export function getDashboardTileSpacingGap(tileSpacing?: string): number {
     return DASHBOARD_TILE_SPACING_GAPS[tileSpacing as DashboardTileSpacing] ?? DASHBOARD_TILE_SPACING_GAPS.standard
 }
 
-export function getDashboardGridCompactor(layoutCompaction?: string): Compactor {
+export function getDashboardGridCompactor(layoutCompaction?: DashboardGridCompaction): Compactor {
     switch (layoutCompaction) {
-        case 'horizontal':
+        case DashboardGridCompaction.Horizontal:
             return makeRoomInRowCompactor
-        case 'stable':
+        case DashboardGridCompaction.Stable:
             return freePlacementCompactor
         default:
             return fastVerticalCompactor

--- a/products/dashboards/frontend/dashboardCustomization.ts
+++ b/products/dashboards/frontend/dashboardCustomization.ts
@@ -66,6 +66,15 @@ export const freePlacementCompactor: Compactor = noCompactor
 
 export const makeRoomInRowCompactor: Compactor = horizontalCompactor
 
+export interface DashboardGridCompactor extends Compactor {
+    compactInteraction: (
+        cols: number,
+        activeTileId: string,
+        restoredLayout: Layout,
+        resizedLayout: Layout
+    ) => Layout
+}
+
 export function resolveFreePlacementCollisions(layout: Layout, cols: number, activeTileId?: string | null): Layout {
     const items = layout.map((item) => ({
         ...cloneLayoutItem(item),
@@ -98,13 +107,30 @@ export function getDashboardTileSpacingGap(tileSpacing?: string): number {
     return DASHBOARD_TILE_SPACING_GAPS[tileSpacing as DashboardTileSpacing] ?? DASHBOARD_TILE_SPACING_GAPS.standard
 }
 
-export function getDashboardGridCompactor(layoutCompaction?: DashboardGridCompaction): Compactor {
-    switch (layoutCompaction) {
-        case DashboardGridCompaction.Horizontal:
-            return makeRoomInRowCompactor
-        case DashboardGridCompaction.Stable:
-            return freePlacementCompactor
-        default:
-            return fastVerticalCompactor
+export function getDashboardGridCompactor(layoutCompaction?: DashboardGridCompaction): DashboardGridCompactor {
+    const selectedCompaction = layoutCompaction ?? DashboardGridCompaction.Vertical
+    const compactor = (() => {
+        switch (selectedCompaction) {
+            case DashboardGridCompaction.Horizontal:
+                return makeRoomInRowCompactor
+            case DashboardGridCompaction.Stable:
+                return freePlacementCompactor
+            default:
+                return fastVerticalCompactor
+        }
+    })()
+
+    return {
+        ...compactor,
+        compactInteraction: (cols, activeTileId, restoredLayout, resizedLayout): Layout => {
+            switch (selectedCompaction) {
+                case DashboardGridCompaction.Stable:
+                    return resolveFreePlacementCollisions(restoredLayout, cols, activeTileId)
+                case DashboardGridCompaction.Vertical:
+                    return compactor.compact(resizedLayout, cols)
+                default:
+                    return compactor.compact(restoredLayout, cols)
+            }
+        },
     }
 }

--- a/products/dashboards/frontend/dashboardCustomization.ts
+++ b/products/dashboards/frontend/dashboardCustomization.ts
@@ -2,8 +2,15 @@ import { cloneLayoutItem, horizontalCompactor, noCompactor } from 'react-grid-la
 import type { Compactor, Layout, LayoutItem } from 'react-grid-layout'
 import { fastVerticalCompactor } from 'react-grid-layout/extras'
 
-import { DashboardGridCompaction } from '~/types'
 import type { DashboardTileSpacing } from '~/types'
+
+export const DashboardGridCompaction = {
+    Vertical: 'vertical',
+    Horizontal: 'horizontal',
+    Stable: 'stable',
+} as const
+
+export type DashboardGridCompaction = (typeof DashboardGridCompaction)[keyof typeof DashboardGridCompaction]
 
 export const DASHBOARD_TILE_SPACING_GAPS: Record<DashboardTileSpacing, number> = {
     tight: 8,
@@ -67,12 +74,7 @@ export const freePlacementCompactor: Compactor = noCompactor
 export const makeRoomInRowCompactor: Compactor = horizontalCompactor
 
 export interface DashboardGridCompactor extends Compactor {
-    compactInteraction: (
-        cols: number,
-        activeTileId: string,
-        restoredLayout: Layout,
-        resizedLayout: Layout
-    ) => Layout
+    compactInteraction: (cols: number, activeTileId: string, restoredLayout: Layout, resizedLayout: Layout) => Layout
 }
 
 export function resolveFreePlacementCollisions(layout: Layout, cols: number, activeTileId?: string | null): Layout {

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -336,6 +336,19 @@ export const TileSpacingEnumApi = {
     Wide: 'wide',
 } as const
 
+/**
+ * * `vertical` - vertical
+ * * `horizontal` - horizontal
+ * * `stable` - stable
+ */
+export type LayoutCompactionEnumApi = (typeof LayoutCompactionEnumApi)[keyof typeof LayoutCompactionEnumApi]
+
+export const LayoutCompactionEnumApi = {
+    Vertical: 'vertical',
+    Horizontal: 'horizontal',
+    Stable: 'stable',
+} as const
+
 export interface DashboardCustomizationApi {
     /** Named tile density preset.
      *
@@ -345,6 +358,12 @@ export interface DashboardCustomizationApi {
      * * `relaxed` - relaxed
      * * `wide` - wide */
     tile_spacing?: TileSpacingEnumApi
+    /** How tiles rearrange after a move or resize. vertical stacks tiles upward, horizontal stacks tiles to the left, and stable preserves positions while moving colliding tiles.
+     *
+     * * `vertical` - vertical
+     * * `horizontal` - horizontal
+     * * `stable` - stable */
+    layout_compaction?: LayoutCompactionEnumApi
 }
 
 /**
@@ -425,6 +444,12 @@ export interface DashboardApi {
      * * `relaxed` - relaxed
      * * `wide` - wide */
     grid_spacing?: TileSpacingEnumApi
+    /** How tiles rearrange after a move or resize. vertical stacks tiles upward, horizontal stacks tiles to the left, and stable preserves positions while moving colliding tiles.
+     *
+     * * `vertical` - vertical
+     * * `horizontal` - horizontal
+     * * `stable` - stable */
+    layout_compaction?: LayoutCompactionEnumApi
     /** @nullable */
     readonly tiles: readonly DashboardApiTilesItem[] | null
     /** Template key to create the dashboard from a predefined template. */
@@ -1006,6 +1031,12 @@ export interface PatchedPatchedDashboardOpenApiApi {
      * * `relaxed` - relaxed
      * * `wide` - wide */
     grid_spacing?: TileSpacingEnumApi
+    /** How tiles rearrange after a move or resize. vertical stacks tiles upward, horizontal stacks tiles to the left, and stable preserves positions while moving colliding tiles.
+     *
+     * * `vertical` - vertical
+     * * `horizontal` - horizontal
+     * * `stable` - stable */
+    layout_compaction?: LayoutCompactionEnumApi
     /** Dashboard tiles to update. Widget tiles accept nested widget.config patches. */
     tiles?: DashboardPatchTileOpenApiApi[]
     /** Template key to create the dashboard from a predefined template. */

--- a/products/dashboards/frontend/generated/api.zod.ts
+++ b/products/dashboards/frontend/generated/api.zod.ts
@@ -163,6 +163,13 @@ export const DashboardsCreateBody = /* @__PURE__ */ zod
             .describe(
                 'Named tile density preset. Use tight, condensed, standard, relaxed, or wide.\n\n\* `tight` - tight\n\* `condensed` - condensed\n\* `standard` - standard\n\* `relaxed` - relaxed\n\* `wide` - wide'
             ),
+        layout_compaction: zod
+            .enum(['vertical', 'horizontal', 'stable'])
+            .describe('\* `vertical` - vertical\n\* `horizontal` - horizontal\n\* `stable` - stable')
+            .optional()
+            .describe(
+                'How tiles rearrange after a move or resize. vertical stacks tiles upward, horizontal stacks tiles to the left, and stable preserves positions while moving colliding tiles.\n\n\* `vertical` - vertical\n\* `horizontal` - horizontal\n\* `stable` - stable'
+            ),
         use_template: zod
             .string()
             .optional()
@@ -218,6 +225,13 @@ export const DashboardsUpdateBody = /* @__PURE__ */ zod
             .optional()
             .describe(
                 'Named tile density preset. Use tight, condensed, standard, relaxed, or wide.\n\n\* `tight` - tight\n\* `condensed` - condensed\n\* `standard` - standard\n\* `relaxed` - relaxed\n\* `wide` - wide'
+            ),
+        layout_compaction: zod
+            .enum(['vertical', 'horizontal', 'stable'])
+            .describe('\* `vertical` - vertical\n\* `horizontal` - horizontal\n\* `stable` - stable')
+            .optional()
+            .describe(
+                'How tiles rearrange after a move or resize. vertical stacks tiles upward, horizontal stacks tiles to the left, and stable preserves positions while moving colliding tiles.\n\n\* `vertical` - vertical\n\* `horizontal` - horizontal\n\* `stable` - stable'
             ),
         use_template: zod
             .string()
@@ -341,6 +355,13 @@ export const DashboardsPartialUpdateBody = /* @__PURE__ */ zod
             .optional()
             .describe(
                 'Named tile density preset. Use tight, condensed, standard, relaxed, or wide.\n\n\* `tight` - tight\n\* `condensed` - condensed\n\* `standard` - standard\n\* `relaxed` - relaxed\n\* `wide` - wide'
+            ),
+        layout_compaction: zod
+            .enum(['vertical', 'horizontal', 'stable'])
+            .describe('\* `vertical` - vertical\n\* `horizontal` - horizontal\n\* `stable` - stable')
+            .optional()
+            .describe(
+                'How tiles rearrange after a move or resize. vertical stacks tiles upward, horizontal stacks tiles to the left, and stable preserves positions while moving colliding tiles.\n\n\* `vertical` - vertical\n\* `horizontal` - horizontal\n\* `stable` - stable'
             ),
         tiles: zod
             .array(
@@ -3324,6 +3345,13 @@ export const DashboardsCreateFromTemplateJsonCreateBody = /* @__PURE__ */ zod
             .describe(
                 'Named tile density preset. Use tight, condensed, standard, relaxed, or wide.\n\n\* `tight` - tight\n\* `condensed` - condensed\n\* `standard` - standard\n\* `relaxed` - relaxed\n\* `wide` - wide'
             ),
+        layout_compaction: zod
+            .enum(['vertical', 'horizontal', 'stable'])
+            .describe('\* `vertical` - vertical\n\* `horizontal` - horizontal\n\* `stable` - stable')
+            .optional()
+            .describe(
+                'How tiles rearrange after a move or resize. vertical stacks tiles upward, horizontal stacks tiles to the left, and stable preserves positions while moving colliding tiles.\n\n\* `vertical` - vertical\n\* `horizontal` - horizontal\n\* `stable` - stable'
+            ),
         use_template: zod
             .string()
             .optional()
@@ -3375,6 +3403,13 @@ export const DashboardsCreateUnlistedDashboardCreateBody = /* @__PURE__ */ zod
             .optional()
             .describe(
                 'Named tile density preset. Use tight, condensed, standard, relaxed, or wide.\n\n\* `tight` - tight\n\* `condensed` - condensed\n\* `standard` - standard\n\* `relaxed` - relaxed\n\* `wide` - wide'
+            ),
+        layout_compaction: zod
+            .enum(['vertical', 'horizontal', 'stable'])
+            .describe('\* `vertical` - vertical\n\* `horizontal` - horizontal\n\* `stable` - stable')
+            .optional()
+            .describe(
+                'How tiles rearrange after a move or resize. vertical stacks tiles upward, horizontal stacks tiles to the left, and stable preserves positions while moving colliding tiles.\n\n\* `vertical` - vertical\n\* `horizontal` - horizontal\n\* `stable` - stable'
             ),
         use_template: zod
             .string()

--- a/products/dashboards/package.json
+++ b/products/dashboards/package.json
@@ -8,7 +8,8 @@
         "kea": "catalog:",
         "kea-loaders": "catalog:",
         "kea-router": "catalog:",
-        "posthog-js": "catalog:"
+        "posthog-js": "catalog:",
+        "react-grid-layout": "^2.2.4"
     },
     "devDependencies": {
         "@storybook/react": "catalog:",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -19904,6 +19904,20 @@ export namespace Schemas {
       Wide: 'wide',
     } as const;
 
+    /**
+     * * `vertical` - vertical
+     * * `horizontal` - horizontal
+     * * `stable` - stable
+     */
+    export type LayoutCompactionEnum = typeof LayoutCompactionEnum[keyof typeof LayoutCompactionEnum];
+
+
+    export const LayoutCompactionEnum = {
+      Vertical: 'vertical',
+      Horizontal: 'horizontal',
+      Stable: 'stable',
+    } as const;
+
     export interface DashboardCustomization {
       /** Named tile density preset.
        *
@@ -19913,6 +19927,12 @@ export namespace Schemas {
        * * `relaxed` - relaxed
        * * `wide` - wide */
       tile_spacing?: TileSpacingEnum;
+      /** How tiles rearrange after a move or resize. vertical stacks tiles upward, horizontal stacks tiles to the left, and stable preserves positions while moving colliding tiles.
+       *
+       * * `vertical` - vertical
+       * * `horizontal` - horizontal
+       * * `stable` - stable */
+      layout_compaction?: LayoutCompactionEnum;
     }
 
     /**
@@ -19993,6 +20013,12 @@ export namespace Schemas {
        * * `relaxed` - relaxed
        * * `wide` - wide */
       grid_spacing?: TileSpacingEnum;
+      /** How tiles rearrange after a move or resize. vertical stacks tiles upward, horizontal stacks tiles to the left, and stable preserves positions while moving colliding tiles.
+       *
+       * * `vertical` - vertical
+       * * `horizontal` - horizontal
+       * * `stable` - stable */
+      layout_compaction?: LayoutCompactionEnum;
       /** @nullable */
       readonly tiles: readonly DashboardTilesItem[] | null;
       /** Template key to create the dashboard from a predefined template. */
@@ -60777,6 +60803,12 @@ export namespace Schemas {
        * * `relaxed` - relaxed
        * * `wide` - wide */
       grid_spacing?: TileSpacingEnum;
+      /** How tiles rearrange after a move or resize. vertical stacks tiles upward, horizontal stacks tiles to the left, and stable preserves positions while moving colliding tiles.
+       *
+       * * `vertical` - vertical
+       * * `horizontal` - horizontal
+       * * `stable` - stable */
+      layout_compaction?: LayoutCompactionEnum;
       /** Dashboard tiles to update. Widget tiles accept nested widget.config patches. */
       tiles?: DashboardPatchTileOpenApi[];
       /** Template key to create the dashboard from a predefined template. */

--- a/services/mcp/src/generated/dashboards/api.ts
+++ b/services/mcp/src/generated/dashboards/api.ts
@@ -129,6 +129,13 @@ export const DashboardsCreateBody = /* @__PURE__ */ zod
             .describe(
                 'Named tile density preset. Use tight, condensed, standard, relaxed, or wide.\n\n\* `tight` - tight\n\* `condensed` - condensed\n\* `standard` - standard\n\* `relaxed` - relaxed\n\* `wide` - wide'
             ),
+        layout_compaction: zod
+            .enum(['vertical', 'horizontal', 'stable'])
+            .describe('\* `vertical` - vertical\n\* `horizontal` - horizontal\n\* `stable` - stable')
+            .optional()
+            .describe(
+                'How tiles rearrange after a move or resize. vertical stacks tiles upward, horizontal stacks tiles to the left, and stable preserves positions while moving colliding tiles.\n\n\* `vertical` - vertical\n\* `horizontal` - horizontal\n\* `stable` - stable'
+            ),
         use_template: zod
             .string()
             .optional()
@@ -298,6 +305,13 @@ export const DashboardsPartialUpdateBody = /* @__PURE__ */ zod
             .optional()
             .describe(
                 'Named tile density preset. Use tight, condensed, standard, relaxed, or wide.\n\n\* `tight` - tight\n\* `condensed` - condensed\n\* `standard` - standard\n\* `relaxed` - relaxed\n\* `wide` - wide'
+            ),
+        layout_compaction: zod
+            .enum(['vertical', 'horizontal', 'stable'])
+            .describe('\* `vertical` - vertical\n\* `horizontal` - horizontal\n\* `stable` - stable')
+            .optional()
+            .describe(
+                'How tiles rearrange after a move or resize. vertical stacks tiles upward, horizontal stacks tiles to the left, and stable preserves positions while moving colliding tiles.\n\n\* `vertical` - vertical\n\* `horizontal` - horizontal\n\* `stable` - stable'
             ),
         tiles: zod
             .array(

--- a/services/mcp/src/tools/generated/dashboards.ts
+++ b/services/mcp/src/tools/generated/dashboards.ts
@@ -80,6 +80,9 @@ const dashboardCreate = (): ToolBase<typeof DashboardCreateSchema, WithPostHogUr
         if (params.grid_spacing !== undefined) {
             body['grid_spacing'] = params.grid_spacing
         }
+        if (params.layout_compaction !== undefined) {
+            body['layout_compaction'] = params.layout_compaction
+        }
         if (params.use_template !== undefined) {
             body['use_template'] = params.use_template
         }
@@ -478,6 +481,9 @@ const dashboardUpdate = (): ToolBase<typeof DashboardUpdateSchema, WithPostHogUr
         }
         if (params.grid_spacing !== undefined) {
             body['grid_spacing'] = params.grid_spacing
+        }
+        if (params.layout_compaction !== undefined) {
+            body['layout_compaction'] = params.layout_compaction
         }
         if (params.tiles !== undefined) {
             body['tiles'] = params.tiles

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-create.json
@@ -32,6 +32,11 @@
             "description": "Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in enforcement is enabled, API-token callers stop receiving it by default; use `dashboard_tiles` instead.",
             "type": "boolean"
         },
+        "layout_compaction": {
+            "description": "How tiles rearrange after a move or resize. vertical stacks tiles upward, horizontal stacks tiles to the left, and stable preserves positions while moving colliding tiles.\n\n* `vertical` - vertical\n* `horizontal` - horizontal\n* `stable` - stable",
+            "enum": ["vertical", "horizontal", "stable"],
+            "type": "string"
+        },
         "name": {
             "anyOf": [
                 {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-update.json
@@ -66,6 +66,11 @@
             "description": "Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in enforcement is enabled, API-token callers stop receiving it by default; use `dashboard_tiles` instead.",
             "type": "boolean"
         },
+        "layout_compaction": {
+            "description": "How tiles rearrange after a move or resize. vertical stacks tiles upward, horizontal stacks tiles to the left, and stable preserves positions while moving colliding tiles.\n\n* `vertical` - vertical\n* `horizontal` - horizontal\n* `stable` - stable",
+            "enum": ["vertical", "horizontal", "stable"],
+            "type": "string"
+        },
         "name": {
             "anyOf": [
                 {


### PR DESCRIPTION
## Problem

- Dashboard editors can control tile density, but cannot choose how tiles move after a drag or resize.
- Different dashboards need dense upward stacks, left-aligned rows, or layouts that preserve intentional gaps.

## Changes

| Tile movement | Result |
| --- | --- |
| Stack tiles upward | Fills empty space above. Recommended for most dashboards. |
| Stack tiles to the left | Packs tiles toward the left and wraps overflow to a later row. |
| Free-form placement | Preserves positions and gaps. Only colliding tiles move. |

https://github.com/user-attachments/assets/d3a3abe5-c333-467e-96d6-484e9e1281a7



![Dashboard tile movement settings](https://raw.githubusercontent.com/PostHog/pr-assets/ad355d4b49282b88569bf608c203c8a05a9908b2/2026/08/c0c90ce9-c8e0-4e95-b5ef-022a6f5b91d6.png)

- Adds the saved `layout_compaction` dashboard customization behind `dashboard-customization`.
- Keeps vertical stacking for dashboards without a saved setting.
- Uses React Grid Layout compactors for upward, left, and free-form movement.
- Keeps Customize available during dashboard layout and filter editing.
- Closes the tile movement menu before the unsaved-layout confirmation opens.
- Applies the saved movement mode to normal, shared, embedded, exported, duplicated, and template-created dashboards.
- Captures backend configuration events for web, API, and MCP requests.
- Exposes `layout_compaction` through the dashboard API and MCP tools.

## How did you test this code?

- Dashboard API tests cover saved modes, validation, duplication, feature-flag access, and backend adoption events.
- Dashboard logic tests cover mode persistence and optimistic updates.
- MCP schema snapshots cover the renamed `layout_compaction` request field.
- Local project 1 browser smoke checks covered mode persistence, drag collisions, one resize collision, cancellation, and reloads.
- Shared, embedded, exported, and narrow layouts remain untested in the browser.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- None. No matching dashboard customization documentation exists in this repository.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex and PostHog Desktop implemented the change.
- Used `/managing-dashboards`, `/playwright-test`, `/writing-tests`, `/writing-kea-logics`, `/writing-ui-components`, `/writing-user-facing-copy`, and `/writing-pr-descriptions`.
- The feature moved from custom compactors to React Grid Layout compactors.
- Public artifacts contain no customer data or private session material.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
