### PR TITLE
feat(dashboards): add layout undo shortcuts

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardItems.test.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.test.tsx
@@ -165,6 +165,10 @@ const mockedUseValues = useValues as jest.Mock
 const mockedUseActions = useActions as jest.Mock
 const mockedUseAsyncActions = useAsyncActions as jest.Mock
 const mockRemoveTile = jest.fn()
+const mockUndoLayoutChange = jest.fn()
+const mockRedoLayoutChange = jest.fn()
+const layoutToUndo = { sm: [{ i: '1', x: 0, y: 0, w: 6, h: 5 }] }
+const layoutToRedo = { sm: [{ i: '1', x: 1, y: 0, w: 6, h: 5 }] }
 
 describe('DashboardItems', () => {
     beforeEach(() => {
@@ -198,6 +202,8 @@ describe('DashboardItems', () => {
                     dataColorThemeId: null,
                     canEditDashboard: true,
                     layoutZoom: 0.75,
+                    undoLayout: layoutToUndo,
+                    redoLayout: layoutToRedo,
                 }
             }
 
@@ -225,6 +231,8 @@ describe('DashboardItems', () => {
                     copyToDashboard: jest.fn(),
                     setTileOverride: jest.fn(),
                     setDashboardMode: jest.fn(),
+                    undoLayoutChange: mockUndoLayoutChange,
+                    redoLayoutChange: mockRedoLayoutChange,
                 }
             }
 
@@ -263,6 +271,18 @@ describe('DashboardItems', () => {
     it('matches snapshot in edit mode with layout zoom enabled', () => {
         const { container } = render(<DashboardItems />)
         expect(container.firstChild).toMatchSnapshot()
+    })
+
+    it.each([
+        [{ key: 'z', ctrlKey: true }, mockUndoLayoutChange, layoutToUndo],
+        [{ key: 'z', ctrlKey: true, shiftKey: true }, mockRedoLayoutChange, layoutToRedo],
+        [{ key: 'y', ctrlKey: true }, mockRedoLayoutChange, layoutToRedo],
+    ])('applies layout history for keyboard shortcut %o', (event, action, layout) => {
+        render(<DashboardItems />)
+
+        fireEvent.keyDown(document.body, event)
+
+        expect(action).toHaveBeenCalledWith(layout)
     })
 
     it('shows widget tiles on public dashboards', () => {

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -13,6 +13,7 @@ import { getDashboardWidgetFetchDisplayError } from '@posthog/products-dashboard
 import { ApiError } from 'lib/api'
 import { InsightCard } from 'lib/components/Cards/InsightCard'
 import { EditModeEdge, useResizeHandleScrollbarPassThrough } from 'lib/components/Cards/InsightCard/EditModeEdgeOverlay'
+import { useKeyboardHotkeys } from 'lib/hooks/useKeyboardHotkeys'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonMenuItems } from 'lib/lemon-ui/LemonMenu'
 import { DashboardEventSource, eventUsageLogic } from 'lib/utils/eventUsageLogic'
@@ -98,6 +99,8 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
         widgetResultsByTileId,
         widgetRefreshStatus,
         scrollToBottomSignal,
+        undoLayout,
+        redoLayout,
     } = useValues(dashboardLogic)
     const { layoutZoom = 1 } = useValues(dashboardLogic)
     const {
@@ -117,6 +120,8 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
         setDashboardMode,
         setAddWidgetModalOpen,
         setPendingInsertion,
+        undoLayoutChange,
+        redoLayoutChange,
     } = useActions(dashboardLogic)
     const { showAddInsightToDashboardModal } = useActions(addInsightToDashboardLogic)
     const { updateWidgetTile } = useAsyncActions(dashboardLogic)
@@ -239,6 +244,38 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
 
     const isLayoutZoomToggled = layoutEditMode && layoutZoom !== 1
 
+    useKeyboardHotkeys(
+        {
+            z: {
+                willHandleEvent: true,
+                disabled: !layoutEditMode || (!undoLayout && !redoLayout),
+                action: (event) => {
+                    if (!event.metaKey && !event.ctrlKey) {
+                        return
+                    }
+                    event.preventDefault()
+                    if (event.shiftKey) {
+                        redoLayoutChange(redoLayout)
+                    } else {
+                        undoLayoutChange(undoLayout)
+                    }
+                },
+            },
+            y: {
+                willHandleEvent: true,
+                disabled: !layoutEditMode || !redoLayout,
+                action: (event) => {
+                    if (!event.metaKey && !event.ctrlKey) {
+                        return
+                    }
+                    event.preventDefault()
+                    redoLayoutChange(redoLayout)
+                },
+            },
+        },
+        [layoutEditMode, undoLayout, redoLayout, undoLayoutChange, redoLayoutChange]
+    )
+
     const effectiveZoom = layoutEditMode ? layoutZoom : 1
     const rowHeight = BASE_ROW_HEIGHT * effectiveZoom
     const spacingFactor = effectiveZoom < 1 ? 0.9 : 1
@@ -357,15 +394,15 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
                 pendingLayouts.current = newLayouts
                 return
             }
-            updateLayouts(newLayouts)
+            updateLayouts(newLayouts, layouts)
         },
-        [layoutEditMode, updateLayouts]
+        [layoutEditMode, layouts, updateLayouts]
     )
 
     const flushPendingLayouts = useCallback(() => {
         interactionInProgress.current = false
         if (pendingLayouts.current) {
-            updateLayouts(pendingLayouts.current)
+            updateLayouts(pendingLayouts.current, layouts)
             pendingLayouts.current = null
         }
         // Remeasure once the gesture settles, since height updates were suppressed during it.
@@ -375,7 +412,7 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
             }
         })
         // oxlint-disable-next-line react-hooks/exhaustive-deps -- ref reads inside requestAnimationFrame aren't valid deps
-    }, [updateLayouts])
+    }, [layouts, updateLayouts])
 
     const handleWidthChange = useCallback(
         (containerWidth: number, _: unknown, newCols: number) => {

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -410,6 +410,35 @@ describe('dashboardLogic', () => {
             )
         })
 
+        it('undoes and redoes completed layout changes', async () => {
+            await expectLogic(logic).toFinishAllListeners()
+
+            const initialLayouts = logic.values.layouts
+            const firstTile = logic.values.dashboard!.tiles[0]
+            const movedLayouts = {
+                ...initialLayouts,
+                sm: initialLayouts.sm?.map((layout) =>
+                    layout.i === String(firstTile.id) ? { ...layout, x: layout.x + 1 } : layout
+                ),
+            }
+
+            await expectLogic(logic, () => {
+                logic.actions.updateLayouts(movedLayouts, initialLayouts)
+            }).toFinishAllListeners()
+
+            await expectLogic(logic, () => {
+                logic.actions.undoLayoutChange(logic.values.undoLayout)
+            })
+                .toFinishAllListeners()
+                .toMatchValues({ layouts: initialLayouts, redoLayout: movedLayouts })
+
+            await expectLogic(logic, () => {
+                logic.actions.redoLayoutChange(logic.values.redoLayout)
+            })
+                .toFinishAllListeners()
+                .toMatchValues({ layouts: movedLayouts, undoLayout: initialLayouts })
+        })
+
         it('saving after filter change calls api', async () => {
             await expectLogic(logic).toFinishAllListeners()
 

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -1130,8 +1130,8 @@ export interface dashboardLogicMeta {
             layouts: Partial<Record<DashboardLayoutSize, Layout>>,
             sizeKey: DashboardLayoutSize | undefined
         ) => Layout | undefined
-        undoLayout: (layoutHistory: any) => ResponsiveLayouts | null
-        redoLayout: (layoutHistory: any) => ResponsiveLayouts | null
+        undoLayout: (layoutHistory: LayoutHistory) => ResponsiveLayouts | null
+        redoLayout: (layoutHistory: LayoutHistory) => ResponsiveLayouts | null
         layoutForItem: (layout: Layout | undefined) => Record<string, TileLayout>
         refreshMetrics: (
             refreshStatus: Record<string, RefreshStatus>,

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -199,6 +199,31 @@ export interface PendingInsertion {
     w: number | null
 }
 
+interface LayoutHistory {
+    layouts: ResponsiveLayouts[]
+    position: number
+}
+
+function cloneLayouts(layouts: ResponsiveLayouts): ResponsiveLayouts {
+    return Object.fromEntries(
+        Object.entries(layouts).map(([size, layout]) => [size, layout?.map((item) => ({ ...item }))])
+    ) as ResponsiveLayouts
+}
+
+function updateDashboardTileLayouts(
+    dashboard: DashboardType<QueryBasedInsightModel> | null,
+    layouts: ResponsiveLayouts
+): DashboardType<QueryBasedInsightModel> {
+    const itemLayouts = layoutsByTile(layouts)
+    return {
+        ...dashboard,
+        tiles: dashboard?.tiles?.map((tile) => ({
+            ...tile,
+            layouts: itemLayouts[tile.id]?.sm ? { sm: itemLayouts[tile.id].sm } : {},
+        })),
+    } as DashboardType<QueryBasedInsightModel>
+}
+
 const tileLayoutsFromDashboard = (
     dashboard: DashboardType<QueryBasedInsightModel> | null | undefined
 ): Record<number, DashboardTile['layouts']> => {
@@ -315,6 +340,7 @@ export interface dashboardLogicValues {
     layout: Layout | undefined
     layoutEditMode: boolean
     layoutForItem: Record<string, TileLayout>
+    layoutHistory: LayoutHistory
     layoutZoom: number
     layouts: Partial<Record<DashboardLayoutSize, Layout>>
     loadLayoutFromServerOnPreview: boolean
@@ -327,6 +353,7 @@ export interface dashboardLogicValues {
     pendingInsertion: PendingInsertion | null
     placement: DashboardPlacement
     projectTreeRef: ProjectTreeRef
+    redoLayout: ResponsiveLayouts | null
     refreshMetrics: {
         completed: number
         total: number
@@ -352,6 +379,7 @@ export interface dashboardLogicValues {
     textTileId: number | 'new' | null
     textTiles: DashboardTile<QueryBasedInsightModel<Node<Record<string, any>>>>[]
     tiles: DashboardTile<QueryBasedInsightModel<Node<Record<string, any>>>>[]
+    undoLayout: ResponsiveLayouts | null
     urlFilters: DashboardFilter
     urlSearchParamsAtEditModeEntry: {
         filters?: unknown
@@ -592,6 +620,9 @@ export interface dashboardLogicActions {
         order: number
         tile: any
     }
+    redoLayoutChange: (layouts: ResponsiveLayouts | null) => {
+        layouts: Partial<Record<string, Layout>> | null
+    }
     refreshDashboardItem: (payload: { tile: DashboardTile<QueryBasedInsightModel> }) => {
         tile: DashboardTile<QueryBasedInsightModel<Node<Record<string, any>>>>
     }
@@ -640,6 +671,7 @@ export interface dashboardLogicActions {
     resetInterval: () => {
         value: true
     }
+    resetLayoutHistory: () => boolean
     resetUrlFilters: () => boolean
     resetUrlVariables: () => {
         value: true
@@ -874,6 +906,9 @@ export interface dashboardLogicActions {
     triggerDashboardUpdate: (payload: any) => {
         payload: any
     }
+    undoLayoutChange: (layouts: ResponsiveLayouts | null) => {
+        layouts: Partial<Record<string, Layout>> | null
+    }
     updateContainerWidth: (
         containerWidth: number,
         columns: number
@@ -887,8 +922,12 @@ export interface dashboardLogicActions {
     updateDashboardTags: (tags: string[]) => {
         tags: string[]
     }
-    updateLayouts: (layouts: ResponsiveLayouts) => {
+    updateLayouts: (
+        layouts: ResponsiveLayouts,
+        previousLayouts?: ResponsiveLayouts
+    ) => {
         layouts: Partial<Record<string, Layout>>
+        previousLayouts: Partial<Record<string, Layout>> | undefined
     }
     updateTileColor: (
         tileId: number,
@@ -1091,6 +1130,8 @@ export interface dashboardLogicMeta {
             layouts: Partial<Record<DashboardLayoutSize, Layout>>,
             sizeKey: DashboardLayoutSize | undefined
         ) => Layout | undefined
+        undoLayout: (layoutHistory: any) => ResponsiveLayouts | null
+        redoLayout: (layoutHistory: any) => ResponsiveLayouts | null
         layoutForItem: (layout: Layout | undefined) => Record<string, TileLayout>
         refreshMetrics: (
             refreshStatus: Record<string, RefreshStatus>,
@@ -1308,6 +1349,9 @@ export const dashboardLogic = kea<dashboardLogicType>([
         cancelEditMode: true,
         /** Make it easier to handle organizing the layout when theres lots of tiles by zooming out */
         setLayoutZoom: (layoutZoom: number) => ({ layoutZoom }),
+        undoLayoutChange: (layouts: ResponsiveLayouts | null) => ({ layouts }),
+        redoLayoutChange: (layouts: ResponsiveLayouts | null) => ({ layouts }),
+        resetLayoutHistory: () => true,
         /** Optimistic pin/unpin toggle. */
         togglePinned: true,
         /** Open/close the Terraform export modal. */
@@ -1316,7 +1360,10 @@ export const dashboardLogic = kea<dashboardLogicType>([
         /**
          * Dashboard layout & tiles.
          */
-        updateLayouts: (layouts: ResponsiveLayouts) => ({ layouts }),
+        updateLayouts: (layouts: ResponsiveLayouts, previousLayouts?: ResponsiveLayouts) => ({
+            layouts,
+            previousLayouts,
+        }),
         setPendingInsertion: (pendingInsertion: PendingInsertion | null) => ({ pendingInsertion }),
         applyPendingInsertion: true,
         updateContainerWidth: (containerWidth: number, columns: number) => ({ containerWidth, columns }),
@@ -1878,23 +1925,43 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 updateContainerWidth: (state: number, { columns }: { columns: number }) => (columns === 1 ? 1 : state),
             },
         ],
+        layoutHistory: [
+            { layouts: [], position: -1 } as LayoutHistory,
+            {
+                updateLayouts: (state, { layouts, previousLayouts }) => {
+                    if (!previousLayouts || equal(layouts, previousLayouts)) {
+                        return state
+                    }
+
+                    const history = state.layouts.slice(0, state.position + 1)
+                    const entries = history.length ? history : [cloneLayouts(previousLayouts)]
+                    if (equal(entries[entries.length - 1], layouts)) {
+                        return state
+                    }
+
+                    return { layouts: [...entries, cloneLayouts(layouts)], position: entries.length }
+                },
+                undoLayoutChange: (state, { layouts }) =>
+                    layouts && state.position > 0 ? { ...state, position: state.position - 1 } : state,
+                redoLayoutChange: (state, { layouts }) =>
+                    layouts && state.position < state.layouts.length - 1
+                        ? { ...state, position: state.position + 1 }
+                        : state,
+                resetLayoutHistory: () => ({ layouts: [], position: -1 }),
+            },
+        ],
         dashboard: [
             null as DashboardType<QueryBasedInsightModel> | null,
             {
                 dashboardNotFound: () => null,
                 setAccessDeniedToDashboard: () => null,
                 updateLayouts: (state, { layouts }) => {
-                    const itemLayouts = layoutsByTile(layouts)
-
-                    // Only persist sm layouts; xs layouts are derived on the fly
-                    return {
-                        ...state,
-                        tiles: state?.tiles?.map((tile) => ({
-                            ...tile,
-                            layouts: itemLayouts[tile.id]?.sm ? { sm: itemLayouts[tile.id].sm } : {},
-                        })),
-                    } as DashboardType<QueryBasedInsightModel>
+                    return updateDashboardTileLayouts(state, layouts)
                 },
+                undoLayoutChange: (state, { layouts }) =>
+                    layouts ? updateDashboardTileLayouts(state, layouts) : state,
+                redoLayoutChange: (state, { layouts }) =>
+                    layouts ? updateDashboardTileLayouts(state, layouts) : state,
                 setTileProperty: (state, { tileId, properties }) => {
                     return {
                         ...state,
@@ -2875,6 +2942,18 @@ export const dashboardLogic = kea<dashboardLogicType>([
             (s) => [s.layouts, s.sizeKey],
             (layouts: ResponsiveLayouts, sizeKey: DashboardLayoutSize | undefined) =>
                 sizeKey ? layouts[sizeKey] : undefined,
+        ],
+        undoLayout: [
+            (s) => [s.layoutHistory],
+            (layoutHistory: LayoutHistory): ResponsiveLayouts | null =>
+                layoutHistory.position > 0 ? layoutHistory.layouts[layoutHistory.position - 1] : null,
+        ],
+        redoLayout: [
+            (s) => [s.layoutHistory],
+            (layoutHistory: LayoutHistory): ResponsiveLayouts | null =>
+                layoutHistory.position < layoutHistory.layouts.length - 1
+                    ? layoutHistory.layouts[layoutHistory.position + 1]
+                    : null,
         ],
         layoutForItem: [
             (s) => [s.layout],
@@ -4028,6 +4107,10 @@ export const dashboardLogic = kea<dashboardLogicType>([
             })
         },
         setDashboardMode: async ({ mode, source }) => {
+            if (mode !== DashboardMode.Edit || isLayoutEditEventSource(source)) {
+                actions.resetLayoutHistory()
+            }
+
             if (
                 mode === DashboardMode.Edit &&
                 values.urlSearchParamsAtEditModeEntry === null &&


### PR DESCRIPTION
## Problem

- Dashboard editors cannot reverse accidental drag or resize adjustments during a layout session.
- **Why:** Standard shortcuts keep layout edits quick without discarding every pending change.

## Changes

- Add layout history for completed drag and resize changes in dashboard edit mode.
- Support Cmd/Ctrl+Z, Cmd/Ctrl+Shift+Z, and Ctrl/Cmd+Y.
- No visual change. The update adds keyboard behavior only.

## How did you test this code?

- Dashboard logic coverage restores a moved layout, then reapplies it.
- Dashboard item coverage maps each supported shortcut to the correct history action.
- Not run: browser QA.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- No docs update. This change adds standard keyboard behavior to an existing workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Codex.
- Skills invoked: `/writing-kea-logics`, `/writing-tests`, and `/writing-pr-descriptions`.
- No external session material appears in this PR.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*