### PR TITLE
refactor(clickhouse): share the dictionary lifecycle between deletion jobs

### DIFF
--- a/posthog/dags/clickhouse_cleanup.py
+++ b/posthog/dags/clickhouse_cleanup.py
@@ -33,11 +33,18 @@ from posthog.clickhouse.cleanup_snapshots import (
     CLEANUP_REVIVED_PERSONS_TABLE,
     CLEANUP_SNAPSHOT_TABLES,
 )
-from posthog.clickhouse.client.connection import ClickHouseUser, get_clickhouse_creds
+from posthog.clickhouse.client.connection import ClickHouseCredentials, ClickHouseUser, get_clickhouse_creds
 from posthog.clickhouse.cluster import ClickhouseCluster, LightweightDeleteMutationRunner, MutationWaiter, NodeRole
 from posthog.clickhouse.custom_metrics import MetricsClient
 from posthog.dags.common import JobOwners
 from posthog.dags.common.common import settings_with_log_comment
+from posthog.dags.common.dictionaries import Dictionary
+from posthog.dags.common.staged_dictionary import (
+    StagedDictionary,
+    create_on_every_cluster,
+    load_and_verify_on_every_cluster,
+)
+from posthog.dataclasses import frozen
 from posthog.models.async_deletion.delete_cohorts import sweep_cohort_deletions
 from posthog.models.person.sql import PERSON_DISTINCT_ID2_TABLE, PERSONS_TABLE
 
@@ -314,9 +321,15 @@ class RevivedDistinctIdsTable(SnapshotTable):
         return self.count(client)
 
 
-@dataclass(frozen=True, kw_only=True)
-class SnapshotDictionary:
-    """A cluster-wide dictionary over one run's rows in a worklist, minus anything since revived."""
+@frozen
+class SnapshotDictionary(Dictionary):
+    """A cluster-wide dictionary over one run's rows in a worklist, minus anything since revived.
+
+    The inherited checksum hashes every declared column, which here includes max_version: the
+    delete mutation reads it from each host's local dictionary, so hosts agreeing on keys but
+    not on the version bound would delete different version sets per replica and diverge the
+    table.
+    """
 
     source: SnapshotTable
     # Keys recorded here are anti-joined out of the dictionary, which is how a checkpoint
@@ -334,8 +347,12 @@ class SnapshotDictionary:
         return f"{self.source.table_name}_{self.source.run_id}_dictionary"
 
     @property
-    def qualified_name(self) -> str:
-        return f"{settings.CLICKHOUSE_DATABASE}.{self.name}"
+    def schema(self) -> str:
+        return self.source.dictionary_types
+
+    @property
+    def primary_key(self) -> str:
+        return self.key_columns
 
     @property
     def query(self) -> str:
@@ -350,70 +367,20 @@ class SnapshotDictionary:
             GROUP BY {self.key_columns}
         """
 
-    def create(self, client: Client, shards: int, max_execution_time: int, max_memory_usage: int) -> None:
+    @property
+    def credentials(self) -> ClickHouseCredentials:
         # The source reads as the low-privilege dict_reader user, which falls back to the default
-        # user's credentials where dict_reader is not provisioned. Credentials are query parameters
-        # so they stay out of the traced statement.
-        creds = get_clickhouse_creds(ClickHouseUser.DICT_READER)
-        client.execute(
-            f"""
-            CREATE DICTIONARY IF NOT EXISTS {self.qualified_name} ({self.source.dictionary_types})
-            PRIMARY KEY {self.key_columns}
-            SOURCE(CLICKHOUSE(DB %(database)s USER %(user)s PASSWORD %(password)s QUERY %(query)s))
-            LAYOUT(COMPLEX_KEY_HASHED(SHARDS {shards}))
-            LIFETIME(0)
-            SETTINGS(max_execution_time={max_execution_time}, max_memory_usage={max_memory_usage})
-            """,
-            {
-                "database": settings.CLICKHOUSE_DATABASE,
-                "user": creds.user,
-                "password": creds.password,
-                "query": self.query,
-            },
+        # user's credentials where dict_reader is not provisioned.
+        return get_clickhouse_creds(ClickHouseUser.DICT_READER)
+
+    def staged(self) -> StagedDictionary:
+        # A staged copy is a static object. The revival checkpoints exclude keys by reloading this
+        # dictionary so its source query re-runs against the live exclusion table, and a reload
+        # of a staged copy on another cluster would keep every revived key in the delete set.
+        # The sweep only mutates replicated tables on the cluster in hand, so it never needs one.
+        raise NotImplementedError(
+            f"{self.name} cannot be staged: its contents change during the run, and a staged copy would not"
         )
-
-    def drop(self, client: Client) -> None:
-        client.execute(f"DROP DICTIONARY IF EXISTS {self.qualified_name} SYNC")
-
-    def is_loaded(self, client: Client) -> bool:
-        results = client.execute(
-            "SELECT status, last_exception FROM system.dictionaries WHERE database = %(database)s AND name = %(name)s",
-            {"database": settings.CLICKHOUSE_DATABASE, "name": self.name},
-        )
-        if not results:
-            raise Exception(f"{self.qualified_name} does not exist")
-        [[status, last_exception]] = results
-        if status == "LOADED":
-            return True
-        if status in {"LOADING", "FAILED_AND_RELOADING", "LOADED_AND_RELOADING"}:
-            return False
-        if status == "FAILED":
-            raise Exception(f"{self.qualified_name} failed to load: {last_exception}")
-        raise Exception(f"{self.qualified_name} in unexpected status: {status}")
-
-    def load(self, client: Client, timeout_seconds: int) -> int:
-        client.execute(f"SYSTEM RELOAD DICTIONARY {self.qualified_name}")
-
-        # The reload is asynchronous, so the mutation would read a half-populated dictionary
-        # without this wait. A dictionary wedged in LOADING would otherwise hold the run open
-        # forever, and a weekly job nobody is watching is exactly where that goes unnoticed.
-        deadline = time.monotonic() + timeout_seconds
-        while not self.is_loaded(client):
-            if time.monotonic() > deadline:
-                raise Exception(f"{self.qualified_name} still not loaded after {timeout_seconds}s")
-            time.sleep(5.0)
-
-        return self.checksum(client)
-
-    def checksum(self, client: Client) -> int:
-        # XOR is order independent, so hosts that hold the same entries agree regardless of read
-        # order. max_version is hashed along with the keys because the delete mutation reads it
-        # from each host's local dictionary: hosts agreeing on keys but not on the version bound
-        # would delete different version sets per replica and diverge the table.
-        [[checksum]] = client.execute(
-            f"SELECT groupBitXor(cityHash64({self.key_columns}, max_version)) FROM {self.qualified_name}"
-        )
-        return checksum
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -469,36 +436,32 @@ class CleanupRun:
 
     @property
     def persons_dictionary(self) -> SnapshotDictionary:
-        return SnapshotDictionary(source=self.persons, excluded=self.revived)
+        return SnapshotDictionary(source=self.persons, excluded=self.revived, load_timeout=self.dictionary_load_timeout)
 
     @property
     def orphaned_dictionary(self) -> SnapshotDictionary:
-        return SnapshotDictionary(source=self.orphaned, excluded=self.revived_distinct_ids)
-
-
-def _load_and_verify(cluster: ClickhouseCluster, dictionary: SnapshotDictionary, timeout_seconds: int) -> None:
-    """Load on every host and require them to agree.
-
-    The delete predicate probes whichever host runs the mutation, so hosts holding different key
-    sets would delete different rows. Every load goes through here, including the reloads a
-    checkpoint issues after recording a revival.
-    """
-    checksums = cluster.map_all_hosts(partial(dictionary.load, timeout_seconds=timeout_seconds), concurrency=1).result()
-    assert len(set(checksums.values())) == 1, f"{dictionary.name} differs across hosts: {checksums}"
+        return SnapshotDictionary(
+            source=self.orphaned, excluded=self.revived_distinct_ids, load_timeout=self.dictionary_load_timeout
+        )
 
 
 def _create_dictionary(
-    cluster: ClickhouseCluster, dictionary: SnapshotDictionary, run: CleanupRun
+    context: dagster.OpExecutionContext,
+    cluster: ClickhouseCluster,
+    dictionary: SnapshotDictionary,
+    run: CleanupRun,
 ) -> SnapshotDictionary:
-    cluster.map_all_hosts(
-        partial(
-            dictionary.create,
-            shards=run.shards,
-            max_execution_time=run.max_execution_time,
-            max_memory_usage=run.max_memory_usage,
-        )
-    ).result()
-    _load_and_verify(cluster, dictionary, run.dictionary_load_timeout)
+    # Only the cluster in hand: the sweep's tables are replicated there and nowhere else, and
+    # SnapshotDictionary refuses staging, so a second cluster would fail here rather than diverge.
+    create_on_every_cluster(
+        context,
+        [cluster],
+        dictionary,
+        shards=run.shards,
+        max_execution_time=run.max_execution_time,
+        max_memory_usage=run.max_memory_usage,
+    )
+    load_and_verify_on_every_cluster([cluster], dictionary)
     return dictionary
 
 
@@ -554,13 +517,13 @@ def snapshot_orphaned_distinct_ids(
     run: CleanupRun,
 ) -> CleanupRun:
     """Resolve which distinct ids belong to the snapshotted persons, or tombstoned themselves."""
-    _create_dictionary(cluster, run.persons_dictionary, run)
+    _create_dictionary(context, cluster, run.persons_dictionary, run)
 
     cluster.any_host_by_role(
         partial(run.orphaned.populate, persons_dictionary=run.persons_dictionary), NodeRole.DATA
     ).result()
     cluster.map_all_hosts(run.orphaned.sync_replica).result()
-    _create_dictionary(cluster, run.orphaned_dictionary, run)
+    _create_dictionary(context, cluster, run.orphaned_dictionary, run)
 
     count = cluster.any_host_by_role(run.orphaned.distinct_key_count, NodeRole.DATA).result()
     context.add_output_metadata({"orphaned_distinct_ids": dagster.MetadataValue.int(count)})
@@ -629,7 +592,7 @@ def recheck_revived_persons(name: str) -> dagster.OpDefinition:
             revived_ids,
         )
         for dictionary in (run.persons_dictionary, run.orphaned_dictionary):
-            _load_and_verify(cluster, dictionary, run.dictionary_load_timeout)
+            load_and_verify_on_every_cluster([cluster], dictionary)
         return run
 
     return checkpoint

--- a/posthog/dags/common/dictionaries.py
+++ b/posthog/dags/common/dictionaries.py
@@ -1,0 +1,167 @@
+"""One ClickHouse dictionary definition, created on every host and loaded until they all agree.
+
+Every dictionary-driven deletion job builds the same thing: a dictionary over a small worklist
+table, created on each host, loaded, and checksummed so every host is proven to hold the same
+rows before a mutation joins it. Subclasses supply the identity (name, columns, key, source
+query, credentials); this base owns the lifecycle so there is one implementation of create,
+load-with-deadline, checksum and drop.
+
+Staging across clusters (``staged``) is declared here because ``staged_dictionary`` needs it on
+every dictionary it can carry. A subclass whose contents change during a run must refuse it: a
+staged copy is a static object, so a reload on the far cluster would not see the change.
+"""
+
+import abc
+import time
+
+from django.conf import settings
+
+from clickhouse_driver.client import Client
+
+from posthog.clickhouse.client.connection import ClickHouseCredentials, ClickHouseUser, get_clickhouse_creds
+from posthog.dags.common.staged_dictionary import StagedDictionary
+from posthog.dataclasses import frozen
+
+# A dictionary wedged in LOADING would otherwise hold a run open forever and silently: a run that
+# hangs raises no failure alert, while one that times out does.
+DEFAULT_DICTIONARY_LOAD_TIMEOUT: float = 1800.0
+
+
+@frozen
+class Dictionary(abc.ABC):
+    load_timeout: float = DEFAULT_DICTIONARY_LOAD_TIMEOUT
+
+    @property
+    @abc.abstractmethod
+    def name(self) -> str:
+        """Unqualified dictionary name; the subclass owns the naming scheme."""
+
+    @property
+    @abc.abstractmethod
+    def schema(self) -> str:
+        """Column declarations, e.g. ``team_id Int64, key String``."""
+
+    @property
+    @abc.abstractmethod
+    def primary_key(self) -> str:
+        """Comma-separated key columns."""
+
+    @property
+    @abc.abstractmethod
+    def query(self) -> str:
+        """The SELECT the dictionary source runs against ClickHouse."""
+
+    @abc.abstractmethod
+    def staged(self) -> StagedDictionary:
+        """Where this dictionary's rows go so another cluster can load them; see StagedDictionary.
+
+        Keyed by the dictionary's own name, never by anything per-run. A dictionary outlives the
+        run that created it, and CREATE ... IF NOT EXISTS keys on that same name, so a per-run key
+        would leave the earlier definition pointing at an object no later run writes.
+        """
+
+    @property
+    def credentials(self) -> ClickHouseCredentials:
+        """Credentials the dictionary source reads as.
+
+        Defaults to the default user. Override only when the role's SELECT grants on the source
+        tables are known to exist in every environment; grants live in infra, not this repo.
+        """
+        return get_clickhouse_creds(ClickHouseUser.DEFAULT)
+
+    @property
+    def qualified_name(self) -> str:
+        return f"{settings.CLICKHOUSE_DATABASE}.{self.name}"
+
+    def create(
+        self,
+        client: Client,
+        shards: int,
+        max_execution_time: int,
+        max_memory_usage: int,
+        query: str | None = None,
+    ) -> None:
+        """``query`` overrides the SOURCE query, for a host that cannot see the source table."""
+        # Credentials are query parameters so they stay out of the traced statement.
+        creds = self.credentials
+        client.execute(
+            f"""
+            CREATE DICTIONARY IF NOT EXISTS {self.qualified_name} ({self.schema})
+            PRIMARY KEY {self.primary_key}
+            SOURCE(CLICKHOUSE(DB %(database)s USER %(user)s PASSWORD %(password)s QUERY %(query)s))
+            LAYOUT(COMPLEX_KEY_HASHED(SHARDS {shards}))
+            LIFETIME(0)
+            SETTINGS(max_execution_time={max_execution_time}, max_memory_usage={max_memory_usage})
+            """,
+            {
+                "database": settings.CLICKHOUSE_DATABASE,
+                "user": creds.user,
+                "password": creds.password,
+                "query": query or self.query,
+            },
+        )
+
+    def recreate(
+        self,
+        client: Client,
+        shards: int,
+        max_execution_time: int,
+        max_memory_usage: int,
+        query: str | None = None,
+    ) -> None:
+        """Replace the dictionary, so no definition an earlier run left behind can survive.
+
+        CREATE ... IF NOT EXISTS keeps the existing source, which is right where that source is the
+        replicated table and wrong where it is a staged object whose query can change between
+        deploys.
+        """
+        self.drop(client)
+        self.create(client, shards, max_execution_time, max_memory_usage, query)
+
+    def exists(self, client: Client) -> bool:
+        [[count]] = client.execute(
+            "SELECT count() FROM system.dictionaries WHERE database = %(database)s AND name = %(name)s",
+            {"database": settings.CLICKHOUSE_DATABASE, "name": self.name},
+        )
+        return count > 0
+
+    def drop(self, client: Client) -> None:
+        client.execute(f"DROP DICTIONARY IF EXISTS {self.qualified_name} SYNC")
+
+    def is_loaded(self, client: Client) -> bool:
+        results = client.execute(
+            "SELECT status, last_exception FROM system.dictionaries WHERE database = %(database)s AND name = %(name)s",
+            {"database": settings.CLICKHOUSE_DATABASE, "name": self.name},
+        )
+        if not results:
+            raise Exception(f"{self.qualified_name} does not exist")
+        [[status, last_exception]] = results
+        if status == "LOADED":
+            return True
+        if status in {"LOADING", "FAILED_AND_RELOADING", "LOADED_AND_RELOADING"}:
+            return False
+        if status == "FAILED":
+            raise Exception(f"{self.qualified_name} failed to load: {last_exception}")
+        raise Exception(f"{self.qualified_name} in unexpected status: {status}")
+
+    def load(self, client: Client) -> int:
+        """Reload on this host, wait for it to finish within ``load_timeout``, and return the checksum."""
+        client.execute(f"SYSTEM RELOAD DICTIONARY {self.qualified_name}")
+
+        # The reload is asynchronous, so a consumer would read a half-populated dictionary
+        # without this wait.
+        deadline = time.monotonic() + self.load_timeout
+        while not self.is_loaded(client):
+            if time.monotonic() > deadline:
+                raise Exception(f"{self.qualified_name} still not loaded after {self.load_timeout:.0f}s")
+            time.sleep(5.0)
+
+        return self.checksum(client)
+
+    def checksum(self, client: Client) -> int:
+        # XOR of per-row hashes is order independent, so hosts holding the same entries agree
+        # regardless of read order and no sort is needed. cityHash64(*) covers every declared
+        # column, attributes included: a consumer reads attributes from whichever host it lands
+        # on, so hosts must agree on more than the key set.
+        [[checksum]] = client.execute(f"SELECT groupBitXor(cityHash64(*)) FROM {self.qualified_name}")
+        return checksum

--- a/posthog/dags/deletes.py
+++ b/posthog/dags/deletes.py
@@ -1,5 +1,4 @@
 import abc
-import time
 import uuid
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -27,6 +26,7 @@ from posthog.clickhouse.cluster import (
 )
 from posthog.clickhouse.plugin_log_entries import PLUGIN_LOG_ENTRIES_TABLE
 from posthog.dags.common import JobOwners
+from posthog.dags.common.dictionaries import Dictionary
 from posthog.dags.common.staged_dictionary import (
     StagedDictionary,
     create_on_every_cluster,
@@ -72,6 +72,12 @@ class DeleteConfig(dagster.Config):
     max_memory_usage: int = pydantic.Field(
         default=0,
         description="The maximum amount of memory to use for the dictionary, or 0 to use an unlimited amount.",
+    )
+    dictionary_load_timeout: int = pydantic.Field(
+        default=1800,
+        description="The maximum number of seconds to wait for a dictionary to finish loading on a host before "
+        "failing the run. A dictionary wedged in LOADING would otherwise hold the run open forever without "
+        "raising any failure alert.",
     )
     verification_max_execution_time: int = pydantic.Field(
         default=300,
@@ -254,109 +260,20 @@ class AdhocEventDeletesTable(Table):
 
 
 @frozen
-class Dictionary(abc.ABC):
-    source: Table
+class PendingDeletesDictionary(Dictionary):
+    source: PendingDeletesTable
 
     @property
     def name(self) -> str:
         return f"{self.source.table_name}_dictionary"
 
     @property
-    def qualified_name(self):
-        return f"{settings.CLICKHOUSE_DATABASE}.{self.name}"
+    def schema(self) -> str:
+        return "team_id Int64, deletion_type UInt8, key String, created_at DateTime"
 
     @property
-    @abc.abstractmethod
-    def query(self) -> str:
-        raise NotImplementedError()
-
-    @abc.abstractmethod
-    def create(
-        self,
-        client: Client,
-        shards: int,
-        max_execution_time: int,
-        max_memory_usage: int,
-        query: str | None = None,
-    ) -> None:
-        """``query`` overrides the SOURCE query, for a host that cannot see the source table."""
-        raise NotImplementedError()
-
-    @abc.abstractmethod
-    def staged(self) -> StagedDictionary:
-        """Where this dictionary's rows go so another cluster can load them; see StagedDictionary.
-
-        Keyed by the dictionary's own name, never by anything per-run. A dictionary outlives the
-        run that created it, and CREATE ... IF NOT EXISTS keys on that same name, so a per-run key
-        would leave the earlier definition pointing at an object no later run writes.
-        """
-        raise NotImplementedError()
-
-    def recreate(
-        self,
-        client: Client,
-        shards: int,
-        max_execution_time: int,
-        max_memory_usage: int,
-        query: str | None = None,
-    ) -> None:
-        """Replace the dictionary, so no definition an earlier run left behind can survive.
-
-        CREATE ... IF NOT EXISTS keeps the existing source, which is right where that source is the
-        replicated table and wrong where it is a staged object whose query can change between
-        deploys.
-        """
-        self.drop(client)
-        self.create(client, shards, max_execution_time, max_memory_usage, query)
-
-    def exists(self, client: Client) -> bool:
-        results = client.execute(
-            "SELECT count() FROM system.dictionaries WHERE database = %(database)s AND name = %(name)s",
-            {"database": settings.CLICKHOUSE_DATABASE, "name": self.name},
-        )
-        [[count]] = results
-        return count > 0
-
-    def drop(self, client: Client) -> None:
-        client.execute(f"DROP DICTIONARY IF EXISTS {self.qualified_name} SYNC")
-
-    def __is_loaded(self, client: Client) -> bool:
-        results = client.execute(
-            "SELECT status, last_exception FROM system.dictionaries WHERE database = %(database)s AND name = %(name)s",
-            {"database": settings.CLICKHOUSE_DATABASE, "name": self.name},
-        )
-        if not results:
-            raise Exception("dictionary does not exist")
-        else:
-            [[status, last_exception]] = results
-            if status == "LOADED":
-                return True
-            elif status in {"LOADING", "FAILED_AND_RELOADING", "LOADED_AND_RELOADING"}:
-                return False
-            elif status == "FAILED":
-                raise Exception(f"failed to load: {last_exception}")
-            else:
-                raise Exception(f"unexpected status: {status}")
-
-    def load(self, client: Client):
-        # TODO: this should probably not reload if the dictionary is already loaded
-        client.execute(f"SYSTEM RELOAD DICTIONARY {self.qualified_name}")
-
-        # reload is async, so we need to wait for the dictionary to actually be loaded
-        # TODO: this should probably throw on unexpected reloads
-        while not self.__is_loaded(client):
-            time.sleep(5.0)
-
-        return self.checksum(client)
-
-    @abc.abstractmethod
-    def checksum(self, client: Client) -> int:
-        raise NotImplementedError()
-
-
-@frozen
-class PendingDeletesDictionary(Dictionary):
-    source: PendingDeletesTable
+    def primary_key(self) -> str:
+        return "team_id, deletion_type, key"
 
     @property
     def query(self) -> str:
@@ -366,53 +283,25 @@ class PendingDeletesDictionary(Dictionary):
         return StagedDictionary(
             key=f"{self.name}.parquet",
             columns="team_id, deletion_type, key, created_at",
-            structure="team_id Int64, deletion_type UInt8, key String, created_at DateTime",
+            structure=self.schema,
         )
-
-    def create(
-        self,
-        client: Client,
-        shards: int,
-        max_execution_time: int,
-        max_memory_usage: int,
-        query: str | None = None,
-    ) -> None:
-        client.execute(
-            f"""
-            CREATE DICTIONARY IF NOT EXISTS {self.qualified_name} (
-                team_id Int64,
-                deletion_type UInt8,
-                key String,
-                created_at DateTime,
-            )
-            PRIMARY KEY team_id, deletion_type, key
-            SOURCE(CLICKHOUSE(DB %(database)s USER %(user)s PASSWORD %(password)s QUERY %(query)s))
-            LAYOUT(COMPLEX_KEY_HASHED(SHARDS {shards}))
-            LIFETIME(0)
-            SETTINGS(max_execution_time={max_execution_time}, max_memory_usage={max_memory_usage})
-            """,
-            {
-                "database": settings.CLICKHOUSE_DATABASE,
-                "user": settings.CLICKHOUSE_USER,
-                "password": settings.CLICKHOUSE_PASSWORD,
-                "query": query or self.query,
-            },
-        )
-
-    def checksum(self, client: Client) -> int:
-        results = client.execute(
-            f"""
-            SELECT groupBitXor(row_checksum) AS table_checksum
-            FROM (SELECT cityHash64(*) AS row_checksum FROM {self.qualified_name} ORDER BY team_id, key)
-            """
-        )
-        [[checksum]] = results
-        return checksum
 
 
 @frozen
 class AdhocEventDeletesDictionary(Dictionary):
     source: AdhocEventDeletesTable
+
+    @property
+    def name(self) -> str:
+        return f"{self.source.table_name}_dictionary"
+
+    @property
+    def schema(self) -> str:
+        return "team_id Int64, uuid UUID, created_at DateTime64(6, 'UTC')"
+
+    @property
+    def primary_key(self) -> str:
+        return "team_id, uuid"
 
     @property
     def query(self) -> str:
@@ -422,47 +311,8 @@ class AdhocEventDeletesDictionary(Dictionary):
         return StagedDictionary(
             key=f"{self.name}.parquet",
             columns="team_id, uuid, created_at",
-            structure="team_id Int64, uuid UUID, created_at DateTime64(6, 'UTC')",
+            structure=self.schema,
         )
-
-    def create(
-        self,
-        client: Client,
-        shards: int,
-        max_execution_time: int,
-        max_memory_usage: int,
-        query: str | None = None,
-    ) -> None:
-        client.execute(
-            f"""
-            CREATE DICTIONARY IF NOT EXISTS {self.qualified_name} (
-                team_id Int64,
-                uuid UUID,
-                created_at DateTime64(6, 'UTC')
-            )
-            PRIMARY KEY team_id, uuid
-            SOURCE(CLICKHOUSE(DB %(database)s USER %(user)s PASSWORD %(password)s QUERY %(query)s))
-            LAYOUT(COMPLEX_KEY_HASHED(SHARDS {shards}))
-            LIFETIME(0)
-            SETTINGS(max_execution_time={max_execution_time}, max_memory_usage={max_memory_usage})
-            """,
-            {
-                "database": settings.CLICKHOUSE_DATABASE,
-                "user": settings.CLICKHOUSE_USER,
-                "password": settings.CLICKHOUSE_PASSWORD,
-                "query": query or self.query,
-            },
-        )
-
-    def checksum(self, client: Client) -> int:
-        results = client.execute(
-            f"""
-            SELECT groupBitXor(row_checksum) AS table_checksum
-            FROM (SELECT cityHash64(*) AS row_checksum FROM {self.qualified_name} ORDER BY team_id, uuid)
-            """
-        )
-        [[checksum]] = results
-        return checksum
 
 
 @dagster.op
@@ -564,6 +414,7 @@ def create_deletes_dict(
 
     del_dict = PendingDeletesDictionary(
         source=load_pending_deletions,
+        load_timeout=config.dictionary_load_timeout,
     )
 
     create_on_every_cluster(
@@ -595,6 +446,7 @@ def create_adhoc_event_deletes_dict(
 
     del_dict = AdhocEventDeletesDictionary(
         source=adhoc_event_deletions,
+        load_timeout=config.dictionary_load_timeout,
     )
 
     create_on_every_cluster(

--- a/posthog/dags/tests/test_clickhouse_cleanup.py
+++ b/posthog/dags/tests/test_clickhouse_cleanup.py
@@ -667,7 +667,7 @@ def test_a_retried_snapshot_populate_cannot_skew_the_dictionary(cluster: Clickho
     )
     try:
         cluster.map_all_hosts(partial(dictionary.create, shards=1, max_execution_time=0, max_memory_usage=0)).result()
-        cluster.map_all_hosts(partial(dictionary.load, timeout_seconds=60), concurrency=1).result()
+        cluster.map_all_hosts(dictionary.load, concurrency=1).result()
         rows = cluster.any_host(
             lambda client: client.execute(f"SELECT person_id, max_version FROM {dictionary.qualified_name}")
         ).result()

--- a/posthog/dags/tests/test_common_dictionaries.py
+++ b/posthog/dags/tests/test_common_dictionaries.py
@@ -1,0 +1,185 @@
+import itertools
+from collections.abc import Iterable
+from datetime import datetime
+from typing import Any, cast
+
+import pytest
+
+from clickhouse_driver.client import Client
+
+from posthog.clickhouse.client.connection import ClickHouseCredentials, ClickHouseUser
+from posthog.dags import clickhouse_cleanup
+from posthog.dags.common import dictionaries
+from posthog.dags.common.dictionaries import Dictionary
+from posthog.dags.common.staged_dictionary import StagedDictionary
+from posthog.dags.deletes import (
+    AdhocEventDeletesDictionary,
+    AdhocEventDeletesTable,
+    PendingDeletesDictionary,
+    PendingDeletesTable,
+)
+from posthog.dataclasses import frozen
+
+
+@frozen
+class _StubDictionary(Dictionary):
+    @property
+    def name(self) -> str:
+        return "stub_dictionary"
+
+    @property
+    def schema(self) -> str:
+        return "team_id Int64, key String"
+
+    @property
+    def primary_key(self) -> str:
+        return "team_id, key"
+
+    @property
+    def query(self) -> str:
+        return "SELECT team_id, key FROM stub_source"
+
+    def staged(self) -> StagedDictionary:
+        return StagedDictionary(key="stub.parquet", columns="team_id, key", structure=self.schema)
+
+
+class _ScriptedClient:
+    """Answers dictionary-status polls from a script and records every statement."""
+
+    def __init__(self, statuses: Iterable[tuple[str, str] | None] = (), checksum: int = 0) -> None:
+        self.statuses = iter(statuses)
+        self.checksum = checksum
+        self.executed: list[tuple[str, dict[str, Any] | None]] = []
+
+    def execute(self, query: str, params: dict[str, Any] | None = None) -> list[list[Any]]:
+        self.executed.append((query, params))
+        if "system.dictionaries" in query:
+            status = next(self.statuses)
+            return [] if status is None else [list(status)]
+        if "groupBitXor" in query:
+            return [[self.checksum]]
+        return []
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.now += seconds
+
+
+@pytest.fixture
+def clock(monkeypatch: pytest.MonkeyPatch) -> _Clock:
+    clock = _Clock()
+    monkeypatch.setattr(dictionaries.time, "monotonic", clock.monotonic)
+    monkeypatch.setattr(dictionaries.time, "sleep", clock.sleep)
+    return clock
+
+
+def test_load_returns_the_checksum_once_loaded(clock: _Clock) -> None:
+    client = _ScriptedClient(statuses=[("LOADING", ""), ("LOADED", "")], checksum=42)
+    assert _StubDictionary(load_timeout=600).load(cast(Client, client)) == 42
+
+
+def test_load_fails_instead_of_waiting_forever_on_a_wedged_dictionary(clock: _Clock) -> None:
+    client = _ScriptedClient(statuses=itertools.repeat(("LOADING", "")))
+    with pytest.raises(Exception, match="still not loaded after 600"):
+        _StubDictionary(load_timeout=600).load(cast(Client, client))
+
+
+@pytest.mark.parametrize(
+    "status,match",
+    [
+        (("FAILED", "grant missing"), "failed to load: grant missing"),
+        (("MYSTERY", ""), "unexpected status: MYSTERY"),
+        (None, "does not exist"),
+    ],
+)
+def test_load_surfaces_terminal_statuses(clock: _Clock, status: tuple[str, str] | None, match: str) -> None:
+    client = _ScriptedClient(statuses=[status])
+    with pytest.raises(Exception, match=match):
+        _StubDictionary().load(cast(Client, client))
+
+
+def test_checksum_covers_every_column_without_sorting() -> None:
+    # groupBitXor is order independent, so a sort would only cost time and memory on a
+    # dictionary holding tens of millions of rows per host.
+    client = _ScriptedClient(checksum=7)
+    assert _StubDictionary().checksum(cast(Client, client)) == 7
+    [(query, _)] = client.executed
+    assert "groupBitXor(cityHash64(*))" in query
+    assert "ORDER BY" not in query
+
+
+def _pending_deletes_dictionary() -> PendingDeletesDictionary:
+    return PendingDeletesDictionary(source=PendingDeletesTable(timestamp=datetime(2026, 1, 1)))
+
+
+def _adhoc_event_deletes_dictionary() -> AdhocEventDeletesDictionary:
+    return AdhocEventDeletesDictionary(source=AdhocEventDeletesTable())
+
+
+def _snapshot_dictionary() -> clickhouse_cleanup.SnapshotDictionary:
+    return clickhouse_cleanup.SnapshotDictionary(
+        source=clickhouse_cleanup.DeletedPersonsTable(run_id="run_1"),
+        excluded=clickhouse_cleanup.RevivedPersonsTable(run_id="run_1"),
+    )
+
+
+@pytest.mark.parametrize(
+    "make_dictionary,expected_user",
+    [
+        (_pending_deletes_dictionary, "app_default"),
+        (_adhoc_event_deletes_dictionary, "app_default"),
+        (_snapshot_dictionary, "reader"),
+    ],
+)
+def test_create_reads_the_source_as_each_callers_credentials(
+    monkeypatch: pytest.MonkeyPatch, make_dictionary: Any, expected_user: str
+) -> None:
+    # The GDPR job's dictionaries must keep reading as the default user until dict_reader's
+    # SELECT grants on its per-run tables are proven in every environment; the sweep already
+    # reads as dict_reader. A shared-lifecycle change that flips either breaks a weekly prod job.
+    creds = {
+        ClickHouseUser.DEFAULT: ClickHouseCredentials(user="app_default", password="p1"),
+        ClickHouseUser.DICT_READER: ClickHouseCredentials(user="reader", password="p2"),
+    }
+    monkeypatch.setattr(dictionaries, "get_clickhouse_creds", creds.__getitem__)
+    monkeypatch.setattr(clickhouse_cleanup, "get_clickhouse_creds", creds.__getitem__)
+
+    client = _ScriptedClient()
+    make_dictionary().create(cast(Client, client), shards=1, max_execution_time=0, max_memory_usage=0)
+
+    [(query, params)] = client.executed
+    assert "CREATE DICTIONARY" in query
+    assert params is not None and params["user"] == expected_user
+
+
+def test_create_can_read_a_staged_object_instead_of_the_source() -> None:
+    # create_on_every_cluster hands the far cluster the staged query; the source query must not
+    # leak through or that cluster reads a table it cannot see.
+    client = _ScriptedClient()
+    dictionary = _pending_deletes_dictionary()
+    dictionary.create(cast(Client, client), shards=1, max_execution_time=0, max_memory_usage=0, query="SELECT 1")
+    [(_, params)] = client.executed
+    assert params is not None and params["query"] == "SELECT 1"
+
+
+@pytest.mark.parametrize("make_dictionary", [_pending_deletes_dictionary, _adhoc_event_deletes_dictionary])
+def test_deletes_job_dictionaries_stage_under_their_own_name(make_dictionary: Any) -> None:
+    dictionary = make_dictionary()
+    staged = dictionary.staged()
+    assert staged.key == f"{dictionary.name}.parquet"
+    assert staged.structure == dictionary.schema
+
+
+def test_sweep_dictionaries_refuse_staging() -> None:
+    # A staged copy is static; the sweep's checkpoints exclude revived keys by reloading, so a
+    # staged copy on another cluster would keep deleting persons that came back to life. Failing
+    # at create time is the safe outcome if the person tables ever gain a second placement.
+    with pytest.raises(NotImplementedError, match="cannot be staged"):
+        _snapshot_dictionary().staged()


### PR DESCRIPTION
## Problem

`deletes_job` and the cleanup sweep (#80017) each carried a private copy of the cluster-dictionary lifecycle: create, load, checksum, drop. Review on #80009 asked for one implementation (https://github.com/PostHog/posthog/pull/80009#issuecomment-5317047456).

Since then #89842 added `posthog/dags/common/staged_dictionary.py`, which stages a dictionary's rows through S3 for clusters that share no Keeper, and made `deletes.py`'s `Dictionary` the thing it stages. This PR builds on that rather than beside it.

## Changes

- Moves the `Dictionary` base out of `deletes.py` into `posthog/dags/common/dictionaries.py`. `PendingDeletesDictionary` and `AdhocEventDeletesDictionary` become thin subclasses (name, schema, key, query, `staged()`); their duplicated `create` and `checksum` bodies go away.
- The sweep's `SnapshotDictionary` extends the same base and goes through `create_on_every_cluster` / `load_and_verify_on_every_cluster`, so both jobs share one lifecycle and one verification gate.
- **Load deadline.** `Dictionary.load` now fails after `load_timeout` (default 1800s; `DeleteConfig.dictionary_load_timeout` for `deletes_job`, `CleanupConfig.dictionary_load_timeout` for the sweep). The old loop waited forever, and a dictionary wedged in `LOADING` would hold a weekly run open with no failure alert.
- **Cheaper checksum.** `groupBitXor(cityHash64(*))` is order independent, so the `ORDER BY` inside the old subquery only cost time and memory. It is gone; the value is identical.
- **The sweep's dictionaries refuse staging.** `SnapshotDictionary.staged()` raises. Its revival checkpoints exclude keys by reloading, which re-runs the source query against the live exclusion table; a static staged copy on another cluster would keep every revived key in the delete set. The sweep only mutates replicated tables on the cluster in hand and passes exactly `[cluster]` to the helpers, so a second placement would fail loudly at create time rather than diverge.
- `credentials` is a property on the base: `deletes_job` keeps the default user, the sweep keeps `dict_reader`.

## How did you test this code?

- `posthog/dags/tests/test_common_dictionaries.py`: load returns the checksum once `LOADED`; a wedged dictionary fails at the deadline; `FAILED`/unknown/missing statuses raise; checksum hashes every column with no sort; `create` binds each caller's credentials and honors the staged `query` override; `deletes_job` dictionaries stage under their own name; the sweep's refuse staging.
- `test_deletes.py`, `test_staged_dictionary.py`, `test_clickhouse_cleanup.py`, `posthog/models/async_deletion`: 72 passed locally against ClickHouse. `mypy --cache-fine-grained .` clean.

**Stack order (rebuilt 2026-08-27):** #80943 → #80009 → #80017 → #83981 land first and are inert (no schedule, `dry_run` defaults true) so the sweep can be smoke-tested by hand; #82729 then enables the trigger; #80015 retires Celery last, after the smoke run.

## 🤖 Agent context

- Authored with Claude Code in an interactive session, responding to review feedback on #80009. Reworked 2026-08-28 to build on `staged_dictionary.py` after #89842 landed; touches code from that PR, so its author is a natural reviewer.
- Session decision: the reviewer also suggested folding the sweep into `deletes_job`; we kept separate jobs and serialize them with a sensor in the next layer of this stack, to keep the GDPR job's failure domain separate from the cleanup sweep's.
