### PR TITLE
fix(data-imports): retry transient S3 internal errors while publishing queryable files

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/errors.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/errors.py
@@ -11,6 +11,8 @@ from posthog.temporal.common.errors import NonReportableError
 #   (IMDS/STS blips, dispatch timeouts)
 # - "Please reduce your request rate" is S3's SlowDown throttling response, surfaced by s3fs/aiobotocore
 #   when a bulk operation (e.g. `_purge_s3_prefix`'s list-then-delete) outruns the bucket's request-rate limit
+# - "We encountered an internal error. Please try again." is S3's fixed message for its InternalError
+#   (500) response, surfaced by s3fs/aiobotocore as an OSError once its own request retries are exhausted
 # A retry (of the same idempotent operation) clears these, so they shouldn't be treated the same as a
 # bug in our logic.
 TRANSIENT_OBJECT_STORE_ERRORS = (
@@ -18,6 +20,7 @@ TRANSIENT_OBJECT_STORE_ERRORS = (
     "the credential provider was not enabled",
     "Generic S3 error",
     "Please reduce your request rate",
+    "We encountered an internal error. Please try again.",
 )
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/test/test_delta_errors.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/test/test_delta_errors.py
@@ -27,6 +27,13 @@ class TestIsTransientObjectStoreError:
             ),
             ("unrelated_os_error", OSError("Permission denied: bucket policy forbids this operation"), False),
             (
+                # s3fs wraps a CopyObject/PutObject 5xx as a plain OSError once boto's own retries
+                # are exhausted - S3's fixed InternalError message, not a bug in our code.
+                "s3_internal_error_os_error",
+                OSError("[Errno 121] We encountered an internal error. Please try again."),
+                True,
+            ),
+            (
                 # s3fs/aiobotocore's own credential resolution (distinct from delta-rs's Rust
                 # object_store crate) can raise this bare, unwrapped — same IMDS/STS blip
                 # hitting our own instance-role-authenticated bucket, different client library.

--- a/products/warehouse_sources/backend/temporal/data_imports/tests/test_util.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/tests/test_util.py
@@ -163,6 +163,44 @@ class TestPrepareS3FilesForQuerying:
                     delete_existing=False,
                 )
 
+    async def test_retries_transient_s3_internal_error_during_copy(self):
+        # S3's CopyObject can return its own InternalError after boto's own request retries are
+        # already exhausted, which s3fs surfaces as a bare OSError. Regression for that surfacing
+        # straight through the activity instead of retrying the (idempotent) copy batch.
+        transient_error = OSError("[Errno 121] We encountered an internal error. Please try again.")
+        cp_file = AsyncMock(side_effect=[transient_error, None])
+        s3 = _fake_s3(_cp_file=cp_file)
+
+        with (
+            patch.object(util_module, "aget_s3_client", return_value=_FakeS3CM(s3)),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            await prepare_s3_files_for_querying(
+                folder_path="job",
+                table_name="my_table",
+                file_uris=["s3://bucket/job/my_table/part-0.parquet"],
+                delete_existing=False,
+            )
+
+        assert cp_file.await_count == 2
+
+    async def test_propagates_non_transient_os_error_without_retry(self):
+        # A genuine OSError that isn't a recognized transient S3 blip must surface immediately -
+        # otherwise a real bug would burn through the retry budget before being reported.
+        cp_file = AsyncMock(side_effect=OSError("Permission denied: bucket policy forbids this operation"))
+        s3 = _fake_s3(_cp_file=cp_file)
+
+        with patch.object(util_module, "aget_s3_client", return_value=_FakeS3CM(s3)):
+            with pytest.raises(OSError):
+                await prepare_s3_files_for_querying(
+                    folder_path="job",
+                    table_name="my_table",
+                    file_uris=["s3://bucket/job/my_table/part-0.parquet"],
+                    delete_existing=False,
+                )
+
+        assert cp_file.await_count == 1
+
     async def test_tolerates_job_folder_missing_on_first_materialization(self):
         # A brand new table/model has no prior content in S3, so listing the job folder to
         # find old timestamped query folders to clean up raises FileNotFoundError (s3fs's

--- a/products/warehouse_sources/backend/temporal/data_imports/util.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/util.py
@@ -202,6 +202,10 @@ async def prepare_s3_files_for_querying(
                 # S3's SlowDown rate limiting on the destination prefix.
                 await s3._cp_file(file, f"{s3_path_for_querying}/{file_name}")
 
+        from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.errors import (  # noqa: PLC0415 — keeps the heavy deltalake dep off this module's top-level import path
+            is_transient_object_store_error,
+        )
+
         attempt = 0
         while True:
             attempt += 1
@@ -223,6 +227,18 @@ async def prepare_s3_files_for_querying(
                 )
                 await asyncio.sleep(2**attempt)
                 file_uris = await refresh_file_uris()
+            except OSError as e:
+                # s3fs wraps a CopyObject/PutObject 5xx (e.g. S3's InternalError, already retried to
+                # exhaustion at the boto layer) as a plain OSError. That's a blip on S3's side, not a
+                # bug here - retry the whole (idempotent) copy batch with backoff before giving up.
+                if attempt >= _COPY_FILES_MAX_ATTEMPTS or not is_transient_object_store_error(e):
+                    raise
+                await _log(
+                    f"Transient S3 error while copying files (attempt {attempt}/{_COPY_FILES_MAX_ATTEMPTS}), "
+                    f"retrying: {e}",
+                    level="error",
+                )
+                await asyncio.sleep(2**attempt)
 
         # Delete existing files after copying new ones
         if delete_existing and files_to_delete:


### PR DESCRIPTION
## Problem

A warehouse sync's whole import activity fails when S3 returns a transient internal error while copying files into the queryable folder, forcing a full retry of the import instead of just the copy. Seen in [error tracking](https://us.posthog.com/project/2/error_tracking/01a011f3-47dd-7812-bfc7-7457cd1de751), raised from `prepare_s3_files_for_querying` during a sync's post-load step.

S3's `CopyObject` can return its own `InternalError` response after boto's own request retries are already exhausted. `s3fs` surfaces that as a bare `OSError`, which propagates straight through the pipeline as an unhandled failure.

## Changes

- `prepare_s3_files_for_querying`'s copy loop (`util.py`) now also retries on `is_transient_object_store_error`, with the same backoff and attempt budget as its existing vanished-source-file retry.
- Added S3's `InternalError` message to the shared `TRANSIENT_OBJECT_STORE_ERRORS` classifier, so other callers of `is_transient_object_store_error` (delta maintenance, extract/load) recognize this error as transient too.
- A genuine, non-transient `OSError` still surfaces immediately - only the recognized S3 blip gets retried.

## How did you test this code?

- Added `test_retries_transient_s3_internal_error_during_copy` to `TestPrepareS3FilesForQuerying`, regressing this exact failure: a transient `OSError` on the first copy attempt now succeeds on retry instead of failing the activity.
- Added `test_propagates_non_transient_os_error_without_retry` to guard against over-broad classification masking a real bug.
- Added a parameterized case to `TestIsTransientObjectStoreError` for the new needle.
- Ran the affected test files (`test_util.py`, `test_delta_errors.py`): 49 passed.
- Ran `ruff check`/`ruff format` and `mypy` on the changed files: clean. Not run: the full-repo `mypy` pass (still running in this sandbox when this PR was opened) - CI runs it as part of the required checks.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None - internal pipeline reliability fix, no user-facing or documented behavior changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged via PostHog error tracking (issue linked above) and fixed by Claude Code, working from the exception's stack trace and the existing transient-object-store-error classifier already used by delta maintenance code in the same product. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`. No open human-authored PR addressed this failure.