### PR TITLE
fix(postgres): treat a blank stored incremental watermark as no watermark

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/partitioned_tables.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/partitioned_tables.py
@@ -392,7 +392,7 @@ def iterate_date_windows(
     ]
 
     cursor_lo: Any = db_incremental_field_last_value
-    if cursor_lo is None:
+    if cursor_lo is None or cursor_lo == "":
         cursor_lo = incremental_type_to_initial_value(incremental_field_type)
     cursor_lo = _ensure_aware(cursor_lo, incremental_field_type)
 
@@ -564,7 +564,10 @@ def build_partition_query(
     if incremental_field is None or incremental_field_type is None:
         raise ValueError("incremental_field and incremental_field_type can't be None")
 
-    if db_incremental_field_last_value is None:
+    # A stored watermark of "" must not become a literal `''` — Postgres rejects casting it
+    # against a numeric/date/etc. column with "invalid input syntax" (see postgres.py's
+    # `_build_query` for the same guard on the non-partitioned path).
+    if db_incremental_field_last_value is None or db_incremental_field_last_value == "":
         db_incremental_field_last_value = incremental_type_to_initial_value(incremental_field_type)
 
     operator = sql.SQL(incremental_type_to_operator(incremental_field_type))
@@ -603,7 +606,7 @@ def iterate_partitions(
 
     # If range-partitioned on the incremental field, skip children whose upper
     # bound is at or below cursor to avoid reading already-synced data.
-    skippable_upper: Any = db_incremental_field_last_value
+    skippable_upper: Any = db_incremental_field_last_value if db_incremental_field_last_value != "" else None
     if incremental_field_type is not None and skippable_upper is not None:
         skippable_upper = _ensure_aware(skippable_upper, incremental_field_type)
     partition_bounds: dict[str, tuple[Any, Any] | None] = {}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
@@ -1992,7 +1992,10 @@ def _build_query(
     if incremental_field_type == IncrementalFieldType.XID:
         raise ValueError(XMIN_AS_INCREMENTAL_FIELD_ERROR)
 
-    if db_incremental_field_last_value is None:
+    # A stored watermark of "" (e.g. a stale/corrupted sync_type_config value) must not become a
+    # literal `''` in the WHERE clause — Postgres rejects casting it against a numeric/date/etc.
+    # column with "invalid input syntax", so treat it the same as no watermark at all.
+    if db_incremental_field_last_value is None or db_incremental_field_last_value == "":
         db_incremental_field_last_value = incremental_type_to_initial_value(incremental_field_type)
 
     # Use the type-aware operator (`>=` for Date) only for single-shot scans. Windowed
@@ -2119,7 +2122,7 @@ def _build_count_query(
     if incremental_field_type == IncrementalFieldType.XID:
         raise ValueError(XMIN_AS_INCREMENTAL_FIELD_ERROR)
 
-    if db_incremental_field_last_value is None:
+    if db_incremental_field_last_value is None or db_incremental_field_last_value == "":
         db_incremental_field_last_value = incremental_type_to_initial_value(incremental_field_type)
 
     operator = sql.SQL(incremental_type_to_operator(incremental_field_type))

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -4605,6 +4605,19 @@ class TestBuildQuery:
         with pytest.raises(ValueError):
             _build_query("public", "events", True, "table", "id", None, None)
 
+    @pytest.mark.parametrize(
+        "field_type",
+        [IncrementalFieldType.Numeric, IncrementalFieldType.Integer],
+    )
+    def test_empty_string_last_value_falls_back_to_initial_value(self, field_type):
+        # Regression: a stored watermark of "" used to become a literal `''` in the WHERE
+        # clause, which Postgres rejects for a numeric/integer column with "invalid input
+        # syntax for type numeric" instead of falling back like a missing (None) watermark.
+        query = _build_query("public", "events", True, "table", "cursor", field_type, "")
+        rendered = self._render(query)
+        assert "''" not in rendered
+        assert '"cursor" > 0' in rendered
+
     def test_sampling_table(self):
         query = _build_query("public", "users", False, "table", None, None, None, add_sampling=True)
         rendered = self._render(query)
@@ -5083,6 +5096,19 @@ class TestBuildPartitionQuery:
         rendered = self._render(query)
         assert f'"cursor" {expected_operator} ' in rendered
 
+    def test_empty_string_last_value_falls_back_to_initial_value(self):
+        query = build_partition_query(
+            "public",
+            "events_2026_01",
+            should_use_incremental_field=True,
+            incremental_field="cursor",
+            incremental_field_type=IncrementalFieldType.Numeric,
+            db_incremental_field_last_value="",
+        )
+        rendered = self._render(query)
+        assert "''" not in rendered
+        assert '"cursor" > 0' in rendered
+
     def test_row_filter_full_refresh(self):
         query = build_partition_query(
             "public",
@@ -5134,6 +5160,12 @@ class TestBuildCountQuery:
         assert "'2024-01-01'" in rendered
         assert "ORDER BY" not in rendered
         assert "FROM (" not in rendered
+
+    def test_empty_string_last_value_falls_back_to_initial_value(self):
+        query = _build_count_query("public", "events", True, "cursor", IncrementalFieldType.Numeric, "")
+        rendered = self._render(query)
+        assert "''" not in rendered
+        assert '"cursor" > 0' in rendered
 
 
 class TestIsPartitionedTable:


### PR DESCRIPTION
## Problem

Postgres data warehouse imports can crash mid-sync with `InvalidTextRepresentation: invalid input syntax for type numeric: ""`, surfaced by [error tracking](https://us.posthog.com/project/2/error_tracking/01a011f4-3aac-7ed2-83ef-0ddb36afdf9f).

- The schema's stored incremental watermark (`incremental_field_last_value`) can end up as an empty string instead of `None` or a real value.
- The Postgres source builds a `WHERE column > <watermark>` clause and only falls back to a type-appropriate initial value when the watermark is `None` — an empty string skips that fallback and becomes a literal `''`.
- Postgres rejects comparing `''` against a numeric (or date/timestamp) column, so the query fails instead of falling back like a genuinely missing watermark would.
- The failure surfaces during the row read (`get_rows` / `fetchmany`) rather than the earlier best-effort row-count query, because that query already swallows and logs errors instead of raising.

## Changes

- Guard the three places under `sources/postgres/` that turn a stored watermark into SQL: `_build_query`, `_build_count_query` (`postgres.py`), and `build_partition_query` (`partitioned_tables.py`). An empty-string watermark now falls back to `incremental_type_to_initial_value(...)`, same as `None`.
- Apply the same guard to the windowed and per-partition iterators (`iterate_date_windows`, `iterate_partitions`) before they compare the watermark against typed partition bounds, so a blank value can't reach a `<`/`<=` comparison against a date or number either.

## How did you test this code?

- Added regression tests for `_build_query`, `_build_count_query`, and `build_partition_query`, each asserting an empty-string watermark falls back to the type's initial value (`0`) instead of an empty literal (`''`). These catch the exact query shape that produced the reported error.
- Ran `products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py`: 610 passed, including the new cases. 56 unrelated tests errored because this sandbox has no live Postgres instance for the DB-backed cases; not caused by this change.
- Ran `ruff check` and `ruff format --check` on the changed files: clean.
- Not run: mypy, and manual reproduction against a live source (no test Postgres instance available here).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal query-building fix, no user-facing or documented behavior changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a production error tracking issue and traced it to a stored `""` incremental watermark reaching a SQL literal comparison against a numeric column. Used the PostHog MCP error-tracking tools to pull the issue and a sample stack trace, then read the Postgres source's query-building code to find every place the watermark reaches a literal or a typed comparison. Invoked `/writing-tests` before adding the regression tests and `/writing-pr-descriptions` before writing this body. No duplicate open PR (human-authored) addresses this; searched by exception type, message, and module path.