### PR TITLE
chore(skills): warn that bots push onto stacked PR branches

### DIFF
--- a/.agents/skills/stacking-prs/SKILL.md
+++ b/.agents/skills/stacking-prs/SKILL.md
@@ -64,6 +64,7 @@ gh stack sync --prune    # also delete local branches for merged PRs
 - `gh stack view --short` shows status (`--json` for scripting); a `⚠` means that layer needs a rebase, which blocks merging. `gh stack checkout <stack-number|PR|URL>` pulls down and tracks a stack you don't have locally, including a teammate's.
 - `gh stack modify` interactively reorders, folds, drops, or renames layers. `gh stack unstack` removes the stack on GitHub (`--local` to only drop local tracking).
 - Batch work before syncing. Each sync force-pushes and re-runs a full CI matrix for every rebased layer, so sync when you need the rebase, not to track master.
+- Layer branches move without you: ReviewHog and other bots push fix commits straight onto PR branches. `gh stack sync` fetches first and pushes with `--force-with-lease`, so it refuses when a branch moved; treat that refusal as "someone committed here, go read it", not "retry". Before any manual `git push` or rebase of a layer, `git fetch origin` and fast-forward onto the remote head. Never plain force-push a layer branch.
 - The `ci:preflight` pre-push hook runs on these pushes like any other; never bypass it.
 
 ## Merging


### PR DESCRIPTION
## Problem

- Someone syncing a stack can find a layer branch moved on origin, because ReviewHog pushes fix commits straight onto PR branches. `/stacking-prs` doesn't mention this, so a `--force-with-lease` refusal reads like a transient error to retry rather than commits to go read.

## Changes

- One bullet under "Iterate and keep in sync": bots push onto layer branches; a sync refusal means go read the new commits; fetch and fast-forward before any manual push or rebase; never plain force-push a layer.

## How did you test this code?

Docs only. Not run.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

This is the docs update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Fable 5). Prompted by ReviewHog pushing three commits onto a stacked layer while I was working on it in another session.
- Skills invoked: /stacking-prs, /writing-pr-descriptions.
