### PR TITLE
chore(desktop): drop root-conventions section from skill

### DIFF
--- a/.agents/skills/posthog-desktop/SKILL.md
+++ b/.agents/skills/posthog-desktop/SKILL.md
@@ -62,15 +62,6 @@ Commands (from `products/desktop/`): `pnpm install`, `pnpm dev`, `pnpm build`, `
 Never run root-level `pnpm install` expecting it to cover desktop, and never let a desktop
 dependency change alter the root lockfile — the root install must stay byte-identical.
 
-## What still applies from the root
-
-- Conventional commits and PR titles; `scope` of `desktop` (e.g. `fix(desktop/$feature): ...`).
-- `.github/pull_request_template.md` structure, including the Agent context section.
-- Public-repo copy safety: no customer names, internal incidents, or Slack quotes.
-- Merging: desktop PRs merge like any other monorepo PR, through the Trunk merge queue (use
-  `/merging-prs`). Never `gh pr merge`; the branch ruleset blocks it.
-- `hogli ci:preflight` on push (pre-push hook) still runs repo-wide.
-
 ## Cross-boundary: the Django API
 
 `packages/api-client/` calls monorepo endpoints — tasks (`/api/projects/:id/tasks/...`),


### PR DESCRIPTION
## Problem

The posthog-desktop skill carried a "What still applies from the root" section that repeated rules from root CLAUDE.md (PR titles, PR template, merge queue, preflight). Claude already reads root CLAUDE.md alongside the skill, so there is no need to duplicate the information. The copy also drifted: its `fix(desktop/$feature)` title example contradicts the root single-word-scope convention.

## Changes

Removed the section from `.agents/skills/posthog-desktop/SKILL.md`.

## How did you test this code?

Docs-only change, nothing to run.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

N/A

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5). Skills invoked: /writing-pr-descriptions.
