### PR TITLE
fix(data-imports): stop retrying Framer's broken-code-component error

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/framer/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/framer/source.py
@@ -50,6 +50,11 @@ class FramerSource(SimpleSource[FramerSourceConfig]):
             "Framer API error UNAUTHORIZED": "Framer rejected the API key for this project. Generate a new API key in the project's Site Settings → General and reconnect.",
             "Framer API error INVALID_REQUEST": "The Framer project URL or ID is invalid. Update the source with your project URL (https://framer.com/projects/...) or project ID.",
             "Invalid Framer project URL or ID": "The Framer project URL or ID is invalid. Update the source with your project URL (https://framer.com/projects/...) or project ID.",
+            # Framer's headless loader raises this when a code component the project uses
+            # references a module the headless runtime can't resolve — a defect in the
+            # project's own code components, not a transient server condition, so it fails
+            # identically on every retry until the project is fixed.
+            "ensureComponentsInLoader": "A code component in this Framer project references a module Framer's API can't load. Check the project's code components for missing or broken dependencies, then resync.",
         }
 
     def get_retryable_errors(self) -> set[str]:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/framer/tests/test_framer_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/framer/tests/test_framer_source.py
@@ -87,3 +87,17 @@ class TestFramerSource:
         tables = FramerSource().get_documented_tables()
         assert [table["name"] for table in tables] == list(ENDPOINTS)
         assert all(table["sync_methods"] == ["Full refresh"] for table in tables)
+
+    def test_broken_code_component_is_non_retryable(self) -> None:
+        # Framer's headless loader raises this identically on every retry when a project's
+        # code component references a module the headless runtime can't resolve — a project
+        # config defect, not a transient server condition.
+        observed_error = (
+            "Framer API error METHOD_ERROR: getCollectionItems2: ensureComponentsInLoader: Some modules are missing."
+        )
+        assert any(key in observed_error for key in FramerSource().get_non_retryable_errors())
+
+    def test_pool_exhausted_stays_retryable(self) -> None:
+        observed_error = "Framer API error POOL_EXHAUSTED: busy"
+        assert not any(key in observed_error for key in FramerSource().get_non_retryable_errors())
+        assert any(key in observed_error for key in FramerSource().get_retryable_errors())


### PR DESCRIPTION
## Problem

A Framer source sync fails every time a project's code component references a module Framer's headless API can't load, but PostHog keeps retrying it up to the activity's full retry budget and reports an exception on every attempt. [Error tracking issue](https://us.posthog.com/project/2/error_tracking/01a012e7-b360-7181-b058-a3e9ea79f01e).

The exception is `FramerAPIError: Framer API error METHOD_ERROR: getCollectionItems2: ensureComponentsInLoader: Some modules are missing.`, raised from `FramerClient.call` in [`framer.py`](https://github.com/PostHog/posthog/blob/master/products/warehouse_sources/backend/temporal/data_imports/sources/framer/framer.py#L217-L230) whenever Framer's API returns an application-level error string.

`ensureComponentsInLoader` is Framer's own check that a project's code components can be loaded before serving its data. When it fails, the failure is tied to how the project is configured on Framer's side (a code component that references a missing or broken module), not to a transient server condition, so it recurs identically on every retry.

## Changes

- Add an `ensureComponentsInLoader` entry to `FramerSource.get_non_retryable_errors()`, with a message pointing the user at the project's code components.
- The existing shared classification in `import_data_sync.py` already routes any non-retryable match to `handle_non_retryable_error`, so no pipeline changes are needed.

## How did you test this code?

Added `test_broken_code_component_is_non_retryable` and `test_pool_exhausted_stays_retryable` to `test_framer_source.py`, asserting this error message now matches `get_non_retryable_errors` while a transient `POOL_EXHAUSTED` condition still matches `get_retryable_errors`. Ran the full `test_framer_source.py` suite (11 passed) and `mypy` on the touched files (clean).

Not run: a live sync against a Framer project, since this sandbox has no Framer credentials.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing config or API change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog's error tracking MCP tools (issue details, sampled exception event, and a SQL query against `events` for the `warehouse_sources_*` sync-context properties). No skills were invoked for the investigation itself; `/writing-tests` and `/writing-pr-descriptions` were invoked before writing the test and this description.

Confirmed no open human-authored PR already addresses this (searched by exception type, message phrase, and file path; also checked the data-imports maintainer's open PRs).