### PR TITLE
fix(insights): apply series rename immediately

### DIFF
--- a/frontend/src/scenes/insights/filters/ActionFilter/entityFilterLogic.test.ts
+++ b/frontend/src/scenes/insights/filters/ActionFilter/entityFilterLogic.test.ts
@@ -84,6 +84,23 @@ describe('entityFilterLogic', () => {
 
             expect(logic.values.modalVisible).toBe(false)
         })
+
+        it('does not rename another series when the selected series is removed', () => {
+            const selectedFilter = logic.values.localFilters[0]
+            const replacementFilter = {
+                ...logic.values.localFilters[1],
+                order: selectedFilter.order,
+                uuid: 'replacement-uuid',
+            }
+            logic.actions.selectFilter(selectedFilter)
+            logic.actions.showModal()
+            logic.actions.setFilters([replacementFilter])
+
+            logic.actions.renameFilter('Custom event name')
+
+            expect(logic.values.localFilters[0].custom_name).not.toEqual('Custom event name')
+            expect(logic.values.modalVisible).toBe(false)
+        })
     })
 
     describe('modal behavior', () => {

--- a/frontend/src/scenes/insights/filters/ActionFilter/entityFilterLogic.test.ts
+++ b/frontend/src/scenes/insights/filters/ActionFilter/entityFilterLogic.test.ts
@@ -67,12 +67,22 @@ describe('entityFilterLogic', () => {
             )
         })
 
-        it('closes modal after renaming', () => {
-            expectLogic(logic, () => {
-                logic.actions.renameFilter('Custom event name')
-            })
-                .toDispatchActions(['renameFilter', 'hideModal'])
-                .toMatchValues({ modalVisible: false })
+        it('applies the rename and closes the modal without yielding', () => {
+            logic.actions.selectFilter(logic.values.localFilters[0])
+            logic.actions.showModal()
+
+            logic.actions.renameFilter('Custom event name')
+
+            expect(logic.values.localFilters[0].custom_name).toEqual('Custom event name')
+            expect(logic.values.modalVisible).toBe(false)
+        })
+
+        it('closes the modal when no series is selected', () => {
+            logic.actions.showModal()
+
+            logic.actions.renameFilter('Custom event name')
+
+            expect(logic.values.modalVisible).toBe(false)
         })
     })
 

--- a/frontend/src/scenes/insights/filters/ActionFilter/entityFilterLogic.ts
+++ b/frontend/src/scenes/insights/filters/ActionFilter/entityFilterLogic.ts
@@ -478,17 +478,19 @@ export const entityFilterLogic = kea<entityFilterLogicType>([
         renameFilter: ({ custom_name }) => {
             const selectedFilter = values.selectedFilter as LocalFilter | null
             if (selectedFilter) {
-                const indexByUuid = selectedFilter.uuid
+                const index = selectedFilter.uuid
                     ? values.localFilters.findIndex((filter) => filter.uuid === selectedFilter.uuid)
-                    : -1
+                    : selectedFilter.order
 
-                actions.updateFilter({
-                    ...selectedFilter,
-                    index: indexByUuid === -1 ? selectedFilter.order : indexByUuid,
-                    custom_name,
-                } as EntityFilter & {
-                    index: number
-                })
+                if (index !== -1) {
+                    actions.updateFilter({
+                        ...selectedFilter,
+                        index,
+                        custom_name,
+                    } as EntityFilter & {
+                        index: number
+                    })
+                }
             }
             actions.hideModal()
         },

--- a/frontend/src/scenes/insights/filters/ActionFilter/entityFilterLogic.ts
+++ b/frontend/src/scenes/insights/filters/ActionFilter/entityFilterLogic.ts
@@ -475,20 +475,21 @@ export const entityFilterLogic = kea<entityFilterLogicType>([
     }),
 
     listeners(({ actions, values, props }) => ({
-        renameFilter: async ({ custom_name }, breakpoint) => {
-            if (!values.selectedFilter) {
-                return
+        renameFilter: ({ custom_name }) => {
+            const selectedFilter = values.selectedFilter as LocalFilter | null
+            if (selectedFilter) {
+                const indexByUuid = selectedFilter.uuid
+                    ? values.localFilters.findIndex((filter) => filter.uuid === selectedFilter.uuid)
+                    : -1
+
+                actions.updateFilter({
+                    ...selectedFilter,
+                    index: indexByUuid === -1 ? selectedFilter.order : indexByUuid,
+                    custom_name,
+                } as EntityFilter & {
+                    index: number
+                })
             }
-
-            await breakpoint(100)
-
-            actions.updateFilter({
-                ...values.selectedFilter,
-                index: values.selectedFilter?.order,
-                custom_name,
-            } as EntityFilter & {
-                index: number
-            })
             actions.hideModal()
         },
         hideModal: () => {


### PR DESCRIPTION
## Problem

Renaming a funnel step or graph series can leave the chart label unchanged.

The rename listener waits before applying the update. A second action during that delay can discard the new label.

Refs #21390. This supersedes the closed draft #74597.

## Changes

- Apply series renames during the confirm action.
- Resolve the selected series by its stable UUID before using its stored order.
- Close the rename modal even when the selected series is unavailable.
- Add logic coverage for immediate updates and the empty-selection path.
- No screenshot. The visual design is unchanged.

## How did you test this code?

- `hogli test frontend/src/scenes/insights/filters/ActionFilter/entityFilterLogic.test.ts`
- `pnpm --filter=@posthog/frontend fix`
- `pnpm --filter=@posthog/frontend typescript:check`
- `hogli ci:preflight --fix`
- Manual browser testing was not run.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation change. This restores the existing rename behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Created with Codex. Skills: `/writing-tests`, `/writing-pr-descriptions`, and the GitHub publishing skill.

A private support report triggered the investigation. The diff contains generic code and invented test labels.