### PR TITLE
feat(experiments): show metric type as a tag in the shared metrics list

### DIFF
--- a/frontend/src/scenes/experiments/Metrics/SharedMetricDetailsModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/SharedMetricDetailsModal.tsx
@@ -13,7 +13,8 @@ import { MetricEventDetails } from '../ExperimentForm/MetricsPanel/MetricEventDe
 import { MetricGoal } from '../ExperimentForm/MetricsPanel/MetricGoal'
 import { MetricOutlierHandling } from '../ExperimentForm/MetricsPanel/MetricOutlierHandling'
 import { MetricStepOrder } from '../ExperimentForm/MetricsPanel/MetricStepOrder'
-import { getDefaultMetricTitle, getMetricTag } from '../MetricsView/shared/utils'
+import { MetricTypeTag } from '../MetricsView/shared/MetricTypeTag'
+import { getDefaultMetricTitle } from '../MetricsView/shared/utils'
 import { MetricContext } from './experimentMetricModalLogic'
 import { sharedMetricDetailsModalLogic } from './sharedMetricDetailsModalLogic'
 
@@ -40,9 +41,7 @@ function MetricSummary({ metric }: { metric: ExperimentMetric }): JSX.Element | 
                     </div>
                     <MetricEventDetails metric={metric} />
                     <div className="flex items-center mt-2 gap-1">
-                        <LemonTag type="muted" size="small">
-                            {getMetricTag(metric)}
-                        </LemonTag>
+                        <MetricTypeTag metric={metric} />
                         <LemonTag type="option" size="small">
                             Shared metric
                         </LemonTag>

--- a/frontend/src/scenes/experiments/MetricsView/shared/MetricHeader.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/shared/MetricHeader.tsx
@@ -28,7 +28,7 @@ import type { Experiment } from '~/types'
 
 import { MetricRetryDetails } from './MetricRetryState'
 import { MetricTitle } from './MetricTitle'
-import { getMetricTag } from './utils'
+import { MetricTypeTag } from './MetricTypeTag'
 
 const MAX_BREAKDOWNS = 3
 
@@ -363,9 +363,7 @@ export const MetricHeader = ({
                                 Recalculating
                             </LemonTag>
                         ))}
-                    <LemonTag type="muted" size="small">
-                        {getMetricTag(metric)}
-                    </LemonTag>
+                    <MetricTypeTag metric={metric} />
                     {isMetricThresholdCueVisible(metric) && (
                         <Tooltip
                             title={`Reports the percentage of users whose value reaches or exceeds ${metric.threshold}.`}

--- a/frontend/src/scenes/experiments/MetricsView/shared/MetricTypeTag.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/shared/MetricTypeTag.tsx
@@ -1,0 +1,17 @@
+import { LemonTag } from '@posthog/lemon-ui'
+
+import type { ExperimentFunnelsQuery, ExperimentMetric, ExperimentTrendsQuery } from '~/queries/schema/schema-general'
+
+import { getMetricTag } from './utils'
+
+export function MetricTypeTag({
+    metric,
+}: {
+    metric: ExperimentMetric | ExperimentTrendsQuery | ExperimentFunnelsQuery
+}): JSX.Element {
+    return (
+        <LemonTag type="muted" size="small">
+            {getMetricTag(metric)}
+        </LemonTag>
+    )
+}

--- a/frontend/src/scenes/experiments/SharedMetrics/SharedMetrics.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/SharedMetrics.tsx
@@ -23,8 +23,9 @@ import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
 import { tagsModel } from '~/models/tagsModel'
-import { NodeKind } from '~/queries/schema/schema-general'
+import type { ExperimentFunnelsQuery, ExperimentMetric, ExperimentTrendsQuery } from '~/queries/schema/schema-general'
 
+import { MetricTypeTag } from '../MetricsView/shared/MetricTypeTag'
 import { isLegacySharedMetric } from '../utils'
 import { InlineTagEditor } from './InlineTagEditor'
 import { SharedMetric } from './sharedMetricLogic'
@@ -93,12 +94,11 @@ export function SharedMetrics(): JSX.Element {
         {
             title: 'Type',
             key: 'type',
-            render: (_, metric: SharedMetric) => {
-                if (metric.query.kind === NodeKind.ExperimentMetric) {
-                    return metric.query.metric_type
-                }
-                return metric.query.kind === NodeKind.ExperimentTrendsQuery ? 'Trend' : 'Funnel'
-            },
+            render: (_, metric: SharedMetric) => (
+                <MetricTypeTag
+                    metric={metric.query as ExperimentMetric | ExperimentTrendsQuery | ExperimentFunnelsQuery}
+                />
+            ),
         },
         createdByColumn<SharedMetric>() as LemonTableColumn<SharedMetric, keyof SharedMetric | undefined>,
         createdAtColumn<SharedMetric>() as LemonTableColumn<SharedMetric, keyof SharedMetric | undefined>,


### PR DESCRIPTION
## Problem

The shared metrics list shows the metric type as raw text, while the experiment view shows it as a tag.

## Changes

- Added a reusable `MetricTypeTag` component.
- The shared metrics list type column now renders it, matching the metric rows in the experiment view.
- Swapped the two existing hand-rolled instances (`MetricHeader`, `SharedMetricDetailsModal`) to the shared component.

## How did you test this code?

Lint and format pass. Rendering-only change, no logic changed; not manually verified in the app.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. Straightforward refactor: extracted the existing tag pattern into a component and reused it in the list.
