### PR TITLE
feat(experiments): Add delete action to the shared metric form

### DIFF
--- a/frontend/src/scenes/experiments/SharedMetrics/SharedMetric.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/SharedMetric.tsx
@@ -7,6 +7,7 @@ import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { SceneMenuBarFileItems } from 'lib/components/Scenes/SceneMenuBarFileItems'
 import { SceneTags } from 'lib/components/Scenes/SceneTags'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
+import { More } from 'lib/lemon-ui/LemonButton/More'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { SceneExport } from 'scenes/sceneTypes'
 import { teamLogic } from 'scenes/teamLogic'
@@ -43,6 +44,24 @@ export const scene: SceneExport<SharedMetricLogicProps> = {
         sharedMetricId: id === 'new' ? null : parseInt(id),
         action: action || (id === 'new' ? 'create' : 'update'),
     }),
+}
+
+function openDeleteSharedMetricDialog(onDelete: () => void): void {
+    LemonDialog.open({
+        title: 'Delete this metric?',
+        content: <div className="text-sm text-secondary">This action cannot be undone.</div>,
+        primaryButton: {
+            children: 'Delete',
+            type: 'primary',
+            onClick: onDelete,
+            size: 'small',
+        },
+        secondaryButton: {
+            children: 'Cancel',
+            type: 'tertiary',
+            size: 'small',
+        },
+    })
 }
 
 export function SharedMetric(): JSX.Element {
@@ -128,27 +147,7 @@ export function SharedMetric(): JSX.Element {
                                     variant="destructive"
                                     opensFloatingUi
                                     disabled={!!disabledReason}
-                                    onClick={() => {
-                                        LemonDialog.open({
-                                            title: 'Delete this metric?',
-                                            content: (
-                                                <div className="text-sm text-secondary">
-                                                    This action cannot be undone.
-                                                </div>
-                                            ),
-                                            primaryButton: {
-                                                children: 'Delete',
-                                                type: 'primary',
-                                                onClick: () => deleteSharedMetric(),
-                                                size: 'small',
-                                            },
-                                            secondaryButton: {
-                                                children: 'Cancel',
-                                                type: 'tertiary',
-                                                size: 'small',
-                                            },
-                                        })
-                                    }}
+                                    onClick={() => openDeleteSharedMetricDialog(deleteSharedMetric)}
                                     data-attr="shared-metric-menubar-delete"
                                 >
                                     <IconTrash />
@@ -187,25 +186,7 @@ export function SharedMetric(): JSX.Element {
                             <ButtonPrimitive
                                 variant="danger"
                                 menuItem
-                                onClick={() => {
-                                    LemonDialog.open({
-                                        title: 'Delete this metric?',
-                                        content: (
-                                            <div className="text-sm text-secondary">This action cannot be undone.</div>
-                                        ),
-                                        primaryButton: {
-                                            children: 'Delete',
-                                            type: 'primary',
-                                            onClick: () => deleteSharedMetric(),
-                                            size: 'small',
-                                        },
-                                        secondaryButton: {
-                                            children: 'Cancel',
-                                            type: 'tertiary',
-                                            size: 'small',
-                                        },
-                                    })
-                                }}
+                                onClick={() => openDeleteSharedMetricDialog(deleteSharedMetric)}
                             >
                                 <IconTrash /> Delete
                             </ButtonPrimitive>
@@ -236,27 +217,51 @@ export function SharedMetric(): JSX.Element {
                     key: ExperimentsTabs.SharedMetrics,
                 }}
                 actions={
-                    <AccessControlAction
-                        resourceType={AccessControlResourceType.ExperimentSavedMetric}
-                        minAccessLevel={AccessControlLevel.Editor}
-                        userAccessLevel={sharedMetric.user_access_level}
-                    >
-                        <LemonButton
-                            disabledReason={sharedMetric.name ? undefined : 'You must give your metric a name'}
-                            size="small"
-                            type="primary"
-                            onClick={() => {
-                                if (['create', 'duplicate'].includes(action)) {
-                                    createSharedMetric()
-                                    return
+                    <>
+                        {action === 'update' && (
+                            <More
+                                overlay={
+                                    <AccessControlAction
+                                        resourceType={AccessControlResourceType.ExperimentSavedMetric}
+                                        minAccessLevel={AccessControlLevel.Editor}
+                                        userAccessLevel={sharedMetric.user_access_level}
+                                    >
+                                        <LemonButton
+                                            fullWidth
+                                            size="small"
+                                            icon={<IconTrash />}
+                                            status="danger"
+                                            data-attr="shared-metric-delete"
+                                            onClick={() => openDeleteSharedMetricDialog(deleteSharedMetric)}
+                                        >
+                                            Delete
+                                        </LemonButton>
+                                    </AccessControlAction>
                                 }
-
-                                updateSharedMetric()
-                            }}
+                            />
+                        )}
+                        <AccessControlAction
+                            resourceType={AccessControlResourceType.ExperimentSavedMetric}
+                            minAccessLevel={AccessControlLevel.Editor}
+                            userAccessLevel={sharedMetric.user_access_level}
                         >
-                            Save
-                        </LemonButton>
-                    </AccessControlAction>
+                            <LemonButton
+                                disabledReason={sharedMetric.name ? undefined : 'You must give your metric a name'}
+                                size="small"
+                                type="primary"
+                                onClick={() => {
+                                    if (['create', 'duplicate'].includes(action)) {
+                                        createSharedMetric()
+                                        return
+                                    }
+
+                                    updateSharedMetric()
+                                }}
+                            >
+                                Save
+                            </LemonButton>
+                        </AccessControlAction>
+                    </>
                 }
             />
 
@@ -278,32 +283,6 @@ export function SharedMetric(): JSX.Element {
                 <LegacySharedFunnelsMetricForm />
             )}
             <div className="flex justify-between">
-                {/* {action === 'update' && (
-                    <LemonButton
-                        size="medium"
-                        type="primary"
-                        status="danger"
-                        onClick={() => {
-                            LemonDialog.open({
-                                title: 'Delete this metric?',
-                                content: <div className="text-sm text-secondary">This action cannot be undone.</div>,
-                                primaryButton: {
-                                    children: 'Delete',
-                                    type: 'primary',
-                                    onClick: () => deleteSharedMetric(),
-                                    size: 'small',
-                                },
-                                secondaryButton: {
-                                    children: 'Cancel',
-                                    type: 'tertiary',
-                                    size: 'small',
-                                },
-                            })
-                        }}
-                    >
-                        Delete
-                    </LemonButton>
-                )} */}
                 <AccessControlAction
                     resourceType={AccessControlResourceType.ExperimentSavedMetric}
                     minAccessLevel={AccessControlLevel.Editor}


### PR DESCRIPTION
## Problem

The only way to delete a shared metric is the ellipsis menu on the shared metrics list. The form itself has no visible delete action (one exists in the scene panel and behind the SCENE_MENU_BAR flag, but nothing on the form).

## Changes

Added an ellipsis menu next to the Save button on the shared metric form (edit mode only) with a Delete action behind the existing confirmation dialog. Extracted the dialog config, duplicated in three places, into a single helper and removed a commented-out delete button.

## How did you test this code?

oxlint and oxfmt on the changed file. No logic changes, reuses the existing deleteSharedMetric action already covered by the list view.