### PR TITLE
feat(experiments): Group the settings tab into sections

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentsSettings.tsx
+++ b/frontend/src/scenes/experiments/ExperimentsSettings.tsx
@@ -18,6 +18,42 @@ import { FlagCleanupRepository } from 'scenes/settings/environment/FlagCleanupRe
 
 import { DefaultMinimumDetectableEffect } from './DefaultMinimumDetectableEffect'
 
+function SettingsSection({
+    title,
+    description,
+    children,
+}: {
+    title: string
+    description?: string
+    children: React.ReactNode
+}): JSX.Element {
+    return (
+        <div>
+            <h2 className="text-base font-semibold mb-0">{title}</h2>
+            {description && <p className="text-secondary mt-1 mb-0">{description}</p>}
+            <div className="space-y-4 mt-4">{children}</div>
+        </div>
+    )
+}
+
+function SettingsItem({
+    label,
+    description,
+    children,
+}: {
+    label?: string
+    description: string
+    children: React.ReactNode
+}): JSX.Element {
+    return (
+        <div>
+            {label && <LemonLabel>{label}</LemonLabel>}
+            <p className="text-secondary text-sm mt-1">{description}</p>
+            {children}
+        </div>
+    )
+}
+
 /**
  * although this works fine for now, if we keep adding more settings we need to refactor this to use the
  * <Settings /> component. That will require we create a new section for experiments on the SettingsMap.
@@ -37,89 +73,73 @@ export function ExperimentsSettings(): JSX.Element {
 
     return (
         <div className="space-y-8">
-            <div>
-                <LemonLabel className="text-base">Default statistical method</LemonLabel>
-                <p className="text-secondary mt-2">
-                    Choose the default statistical method for experiment analysis. This setting applies to all new
-                    experiments in this environment and can be overridden per experiment.
-                </p>
-                <DefaultExperimentStatsMethod />
-            </div>
-            <div>
-                <LemonLabel className="text-base">Default confidence level</LemonLabel>
-                <p className="text-secondary mt-2">
-                    Higher confidence level reduces false positives but requires more data. Can be overridden per
-                    experiment.
-                </p>
-                <DefaultExperimentConfidenceLevel />
-            </div>
-            <div>
-                <LemonLabel className="text-base">Default minimum detectable effect</LemonLabel>
-                <p className="text-secondary mt-2">
-                    The smallest effect size you want to detect with statistical significance. Lower values require more
-                    data and longer run times. Can be overridden per experiment.
-                </p>
-                <DefaultMinimumDetectableEffect />
-            </div>
-            <div>
-                <LemonLabel className="text-base">Daily recalculation time</LemonLabel>
-                <p className="text-secondary mt-2">
-                    Select the time of day when experiment metrics should be recalculated. This time is in your
-                    project's timezone.
-                </p>
-                <ExperimentRecalculationTime />
-            </div>
-            <div>
-                <LemonLabel className="text-base">Default conversion window filter</LemonLabel>
-                <p className="text-secondary mt-2">
-                    When enabled, new experiments exclude participants whose conversion or retention window hasn't
-                    elapsed yet. Can be overridden per experiment.
-                </p>
-                <DefaultOnlyCountMaturedUsers />
-            </div>
-            <div>
-                <LemonLabel className="text-base">Default CUPED variance reduction</LemonLabel>
-                <p className="text-secondary mt-2">
-                    When enabled, experiments will use CUPED variance reduction. CUPED uses pre-experiment data to
-                    detect significant effects faster on supported metrics. Can be overridden per experiment.
-                </p>
+            <SettingsSection
+                title="Statistical analysis"
+                description="Defaults for new experiments in this environment. Each setting can be overridden per experiment."
+            >
+                <SettingsItem label="Statistical method" description="The statistical method used to analyze results.">
+                    <DefaultExperimentStatsMethod />
+                </SettingsItem>
+                <SettingsItem
+                    label="Confidence level"
+                    description="Higher confidence levels reduce false positives but require more data."
+                >
+                    <DefaultExperimentConfidenceLevel />
+                </SettingsItem>
+                <SettingsItem
+                    label="Minimum detectable effect"
+                    description="The smallest effect size you want to detect with statistical significance. Lower values require more data and longer run times."
+                >
+                    <DefaultMinimumDetectableEffect />
+                </SettingsItem>
+                <SettingsItem
+                    label="Conversion window"
+                    description="When enabled, new experiments exclude participants whose conversion or retention window hasn't elapsed yet."
+                >
+                    <DefaultOnlyCountMaturedUsers />
+                </SettingsItem>
+            </SettingsSection>
+            <SettingsSection
+                title="CUPED variance reduction"
+                description="CUPED uses pre-experiment data to detect significant effects faster on supported metrics. Can be overridden per experiment."
+            >
                 <DefaultCupedEnabled />
-            </div>
-            <div>
-                <LemonLabel className="text-base">Default CUPED lookback window</LemonLabel>
-                <p className="text-secondary mt-2">
-                    Number of days before the experiment start to use as the pre-experiment window. Must be between{' '}
-                    {MIN_LOOKBACK_DAYS} and {MAX_LOOKBACK_DAYS} days. Can be overridden per experiment.
-                </p>
-                <DefaultCupedLookbackDays />
-            </div>
-            <div>
-                <LemonLabel className="text-base">Default sequential testing</LemonLabel>
-                <p className="text-secondary mt-2">
-                    When enabled, frequentist experiments will use sequential testing by default, producing always-valid
-                    p-values that are robust to peeking. Confidence intervals are wider in exchange. Only applies to the
-                    frequentist statistical method. Can be overridden per experiment.
-                </p>
+                <SettingsItem
+                    label="Lookback window"
+                    description={`Number of days before the experiment start to use as the pre-experiment window. Must be between ${MIN_LOOKBACK_DAYS} and ${MAX_LOOKBACK_DAYS} days.`}
+                >
+                    <DefaultCupedLookbackDays />
+                </SettingsItem>
+            </SettingsSection>
+            <SettingsSection
+                title="Sequential testing"
+                description="Sequential testing produces always-valid p-values that are robust to peeking. Confidence intervals are wider in exchange. Only applies to the frequentist statistical method. Can be overridden per experiment."
+            >
                 <DefaultSequentialTestingEnabled />
-            </div>
-            <div>
-                <LemonLabel className="text-base">Default sequential testing tuning parameter</LemonLabel>
-                <p className="text-secondary mt-2">
-                    Roughly the sample size at which the always-valid confidence sequence is tightest. Set close to the
-                    expected total sample size of new experiments to minimize the width penalty. Can be overridden per
-                    experiment.
-                </p>
-                <DefaultSequentialTuningParameter />
-            </div>
+                <SettingsItem
+                    label="Tuning parameter"
+                    description="Roughly the sample size at which the always-valid confidence sequence is tightest. Set close to the expected total sample size of new experiments to minimize the width penalty."
+                >
+                    <DefaultSequentialTuningParameter />
+                </SettingsItem>
+            </SettingsSection>
+            <SettingsSection title="Recalculation">
+                <SettingsItem
+                    label="Daily recalculation time"
+                    description="The time of day when experiment metrics are recalculated, in your project's timezone."
+                >
+                    <ExperimentRecalculationTime />
+                </SettingsItem>
+            </SettingsSection>
             {cleanupPrAvailable && (
-                <div>
-                    <LemonLabel className="text-base">Default repository for flag cleanup PRs</LemonLabel>
-                    <p className="text-secondary mt-2">
-                        Used when an experiment doesn't have its own repository. Must be connected to this project's
-                        GitHub integration.
-                    </p>
-                    <FlagCleanupRepository />
-                </div>
+                <SettingsSection title="Flag cleanup">
+                    <SettingsItem
+                        label="Default repository for flag cleanup PRs"
+                        description="Used when an experiment doesn't have its own repository. Must be connected to this project's GitHub integration."
+                    >
+                        <FlagCleanupRepository />
+                    </SettingsItem>
+                </SettingsSection>
             )}
         </div>
     )


### PR DESCRIPTION
## Problem

The experiment Settings tab is a flat list of nine top-level items. Related settings (CUPED enable + lookback window, sequential testing enable + tuning parameter) read as unrelated, and every title repeats "Default".

## Changes

Grouped the tab into sections: Statistical analysis, CUPED variance reduction, Sequential testing, Recalculation, and Flag cleanup (flag-gated). Repeated context ("applies to new experiments", "can be overridden per experiment") moved from item descriptions into section descriptions.

Before:

![experiments-settings-before](https://raw.githubusercontent.com/PostHog/pr-assets/1f89ff24be3feb683acd674ec2e201657f53379a/2026/08/30a6c2d5-048a-4385-89d8-3313c04e12a3.png)

After:

![experiments-settings-after](https://raw.githubusercontent.com/PostHog/pr-assets/6cf33b9a89673a5ed0aef2bec819a37f4084454d/2026/08/5e3a2b6a-8404-4253-af85-04b5ab097bcf.png)

## How did you test this code?

Rendered the tab in the local app before and after the change (screenshots above). Layout-only regroup of existing setting components, no behavior change, no automated tests added.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code in a worktree. Skills invoked: /wt, /writing-user-facing-copy, run-posthog (screenshot verification). Checkbox settings keep their own labels instead of getting a redundant sub-heading, so "Enable CUPED by default" sits directly under the CUPED section.
