### PR TITLE
feat(desktop): add activity click attribution

### DIFF
--- a/products/desktop/packages/shared/src/analytics-events.ts
+++ b/products/desktop/packages/shared/src/analytics-events.ts
@@ -1,7 +1,7 @@
 // Analytics event types and properties
 
 import type { Adapter } from "./adapter";
-import type { EffortLevel } from "./domain-types";
+import type { EffortLevel, TaskActivityKind } from "./domain-types";
 import type { SourceProduct } from "./inbox-types";
 
 export interface PromptHistoryOpenedProperties {
@@ -951,6 +951,8 @@ export type ChannelsSurface =
   | "activity_panel"
   | "activity";
 
+export type ActivityActorType = "self" | "agent" | "other_user" | "unknown";
+
 export type ChannelActionType =
   | "enter_space"
   | "leave_space"
@@ -1003,6 +1005,9 @@ export interface ChannelActionProperties {
   tab?: string;
   /** Whether the underlying mutation resolved successfully. */
   success?: boolean;
+  activity_kind?: TaskActivityKind;
+  activity_actor_type?: ActivityActorType;
+  was_unread?: boolean;
 }
 
 export type DashboardActionType =

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityView.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityView.test.tsx
@@ -1,4 +1,5 @@
 import type { TaskActivityItem } from "@posthog/core/canvas/taskActivity";
+import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -16,6 +17,7 @@ vi.mock("@posthog/ui/router/navigationBridge", () => ({
 vi.mock("@posthog/ui/shell/analytics", () => ({ track: vi.fn() }));
 
 import { useCommentNavigationStore } from "@posthog/ui/features/sessions/commentNavigationStore";
+import { track } from "@posthog/ui/shell/analytics";
 import { ActivityRow, activityHeadline } from "./ActivityView";
 
 function item(overrides: Partial<TaskActivityItem>): TaskActivityItem {
@@ -36,12 +38,19 @@ function item(overrides: Partial<TaskActivityItem>): TaskActivityItem {
 }
 
 const NO_BLOCKED_TASKS: ReadonlySet<string> = new Set();
+const CURRENT_USER = {
+  id: 1,
+  uuid: "me",
+  email: "me@posthog.com",
+  first_name: "Me",
+};
 
 describe("activityHeadline", () => {
   beforeEach(() => {
     navigation.toChannelTask.mockReset();
     navigation.toChannelDashboard.mockReset();
     navigation.toTaskDetail.mockReset();
+    vi.mocked(track).mockReset();
     useCommentNavigationStore.setState({
       focusByTask: {},
       resolutionsByTarget: {},
@@ -136,6 +145,7 @@ describe("activityHeadline", () => {
         channelId="channel-1"
         onOpen={vi.fn()}
         onMarkRead={vi.fn()}
+        currentUser={CURRENT_USER}
         blockedTaskIds={NO_BLOCKED_TASKS}
       />,
     );
@@ -143,6 +153,15 @@ describe("activityHeadline", () => {
     if (!activityButton) throw new Error("Expected activity row button");
     fireEvent.click(activityButton);
 
+    expect(track).toHaveBeenCalledWith(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+      action_type: "open_task",
+      surface: "activity",
+      channel_id: "channel-1",
+      task_id: "task-1",
+      activity_kind: "mention",
+      activity_actor_type: "other_user",
+      was_unread: true,
+    });
     expect(navigation.toChannelDashboard).toHaveBeenCalledWith(
       "channel-1",
       "canvas-1",

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityView.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityView.tsx
@@ -188,6 +188,15 @@ export function ActivityRow({
     item.activityKind === "awaiting_input" ||
     item.activityKind === "completed" ||
     (item.activityKind === "message" && !item.author);
+  const actorType = isAgentActivity
+    ? "agent"
+    : item.activityKind === "created"
+      ? "self"
+      : !item.author || !currentUser
+        ? "unknown"
+        : item.author.id === currentUser.id
+          ? "self"
+          : "other_user";
   // The one row here that is blocked on you, and the sidebar's session rows
   // already say that in blue. Yellow is everything else the feed carries:
   // something happened that you haven't read.
@@ -204,6 +213,9 @@ export function ActivityRow({
       surface,
       channel_id: channelId ?? undefined,
       task_id: item.taskId,
+      activity_kind: item.activityKind,
+      activity_actor_type: actorType,
+      was_unread: item.isUnread,
     });
     onOpen(item);
     if (item.commentId && item.commentTarget) {


### PR DESCRIPTION
🤖 This pull request was prepared by an automated coding agent.

## Problem

People who open tasks from Activity produce one generic event. Product teams cannot tell whether the update came from an agent or a person.

## Changes

- Add `activity_kind`, `activity_actor_type`, and `was_unread` when someone opens a task from Activity.
- Derive the actor from data already loaded for the Activity row.
- Keep the change inside the desktop client. The task activity API does not change.
- This change has no visible UI effect.

## How did you test this code?

- Extended the existing Activity row test to catch missing attribution properties.
- Ran the focused Activity view test, desktop type checks, and Biome.
- I did not perform manual testing because this change has no visible UI effect.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This only adds properties to an existing internal analytics event.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Pi used local code tools and the PostHog MCP server. Session: `01a01358-97c1-7f3a-be2a-76ea6a6d0f72`.
- Skills: `querying-posthog-data`, `instrument-product-analytics`, `writing-tests`, and `writing-pr-descriptions`.
- The first design changed the API. User feedback led to this desktop-only version.
