### PR TITLE
fix(experiments): Handle null multivariate in exposure query runner

### DIFF
--- a/products/experiments/backend/hogql_queries/experiment_exposures_query_runner.py
+++ b/products/experiments/backend/hogql_queries/experiment_exposures_query_runner.py
@@ -92,7 +92,7 @@ class ExperimentExposuresQueryRunner(QueryRunner):
         # the experiment, so they don't belong in the exposure chart. self.query.holdout
         # is still consulted by _calculate_srm for the holdout-adjusted rollout math.
         self.excluded_variants = set(self.experiment.excluded_variants or [])
-        multivariate_data = self.query.feature_flag.get("filters", {}).get("multivariate", {})
+        multivariate_data = (self.query.feature_flag.get("filters") or {}).get("multivariate") or {}
         self.variants = [
             variant.get("key")
             for variant in multivariate_data.get("variants", [])
@@ -190,7 +190,7 @@ class ExperimentExposuresQueryRunner(QueryRunner):
         Compares observed variant distribution against expected (from rollout percentages).
         Returns None if insufficient data.
         """
-        multivariate_data = self.query.feature_flag.get("filters", {}).get("multivariate", {})
+        multivariate_data = (self.query.feature_flag.get("filters") or {}).get("multivariate") or {}
         variants_config = multivariate_data.get("variants", [])
 
         if not variants_config or not total_exposures:
@@ -278,7 +278,7 @@ class ExperimentExposuresQueryRunner(QueryRunner):
         # query (the cache key), so the running/stopped decision matches the cached window.
         if self.window_end_date is not None:
             return None
-        multivariate_data = self.query.feature_flag.get("filters", {}).get("multivariate", {})
+        multivariate_data = (self.query.feature_flag.get("filters") or {}).get("multivariate") or {}
         flag_variants = multivariate_data.get("variants", [])
         exposure_params = get_exposure_config_params_for_builder(
             self.exposure_criteria, self.team, self.experiment.start_date

--- a/products/experiments/backend/hogql_queries/experiment_exposures_query_runner.py
+++ b/products/experiments/backend/hogql_queries/experiment_exposures_query_runner.py
@@ -98,6 +98,15 @@ class ExperimentExposuresQueryRunner(QueryRunner):
             for variant in multivariate_data.get("variants", [])
             if variant.get("key") not in self.excluded_variants
         ]
+        # No variants means the exposure SQL (`variant IN {variants}`) matches nothing.
+        # For a running experiment that's a broken flag (variants stripped out from under
+        # it) — surface it rather than render an empty chart that reads as "no exposures".
+        # Stopped/draft experiments may legitimately keep a flag that was later simplified
+        # to boolean, so they fall through and degrade to an empty result instead.
+        if not multivariate_data.get("variants") and self.experiment.is_running:
+            raise ValidationError(
+                "This experiment's feature flag has no variants. Restore the flag's variants to see exposure data."
+            )
 
         self.date_range = self._get_date_range()
         self.date_range_query = QueryDateRange(

--- a/products/experiments/backend/hogql_queries/test/experiment_query_runner/test_experiment_exposures_query_runner.py
+++ b/products/experiments/backend/hogql_queries/test/experiment_query_runner/test_experiment_exposures_query_runner.py
@@ -42,6 +42,27 @@ class TestExperimentExposuresQueryRunner(ExperimentQueryRunnerBaseTest):
             end_date=datetime(2024, 1, 7),
         )
 
+    def test_handles_null_multivariate_in_flag_filters(self):
+        # Boolean flags serialize filters with "multivariate": null — present but None,
+        # which .get("multivariate", {}) does not guard against.
+        flag_dict = model_to_dict(self.feature_flag)
+        flag_dict["filters"] = {**flag_dict["filters"], "multivariate": None}
+
+        query = ExperimentExposureQuery(
+            kind="ExperimentExposureQuery",
+            experiment_id=self.experiment.id,
+            experiment_name=self.experiment.name,
+            feature_flag=flag_dict,
+            holdout=None,
+            start_date=self.experiment.start_date.isoformat(),
+            end_date=self.experiment.end_date.isoformat(),
+            exposure_criteria=None,
+        )
+
+        runner = ExperimentExposuresQueryRunner(team=self.team, query=query)
+
+        self.assertEqual(runner.variants, [])
+
     @freeze_time("2024-01-07T12:00:00Z")
     def test_exposure_query_resolves_soft_deleted_feature_flag_key(self):
         # Exposure events are captured under the flag's original key.

--- a/products/experiments/backend/hogql_queries/test/experiment_query_runner/test_experiment_exposures_query_runner.py
+++ b/products/experiments/backend/hogql_queries/test/experiment_query_runner/test_experiment_exposures_query_runner.py
@@ -9,6 +9,7 @@ from django.forms.models import model_to_dict
 from django.test import override_settings
 
 from parameterized import parameterized
+from rest_framework.exceptions import ValidationError
 
 from posthog.schema import ActionsNode, ExperimentEventExposureConfig, ExperimentExposureQuery
 
@@ -42,26 +43,37 @@ class TestExperimentExposuresQueryRunner(ExperimentQueryRunnerBaseTest):
             end_date=datetime(2024, 1, 7),
         )
 
-    def test_handles_null_multivariate_in_flag_filters(self):
+    def _null_multivariate_query(self) -> ExperimentExposureQuery:
         # Boolean flags serialize filters with "multivariate": null — present but None,
         # which .get("multivariate", {}) does not guard against.
         flag_dict = model_to_dict(self.feature_flag)
         flag_dict["filters"] = {**flag_dict["filters"], "multivariate": None}
-
-        query = ExperimentExposureQuery(
+        return ExperimentExposureQuery(
             kind="ExperimentExposureQuery",
             experiment_id=self.experiment.id,
             experiment_name=self.experiment.name,
             feature_flag=flag_dict,
             holdout=None,
             start_date=self.experiment.start_date.isoformat(),
-            end_date=self.experiment.end_date.isoformat(),
+            end_date=self.experiment.end_date.isoformat() if self.experiment.end_date else None,
             exposure_criteria=None,
         )
 
-        runner = ExperimentExposuresQueryRunner(team=self.team, query=query)
+    def test_handles_null_multivariate_in_flag_filters(self):
+        # The setUp experiment is stopped: a flag simplified to boolean after the
+        # experiment ended degrades to an empty variants list, not an error.
+        runner = ExperimentExposuresQueryRunner(team=self.team, query=self._null_multivariate_query())
 
         self.assertEqual(runner.variants, [])
+
+    def test_null_multivariate_raises_for_running_experiment(self):
+        self.experiment.end_date = None
+        self.experiment.save()
+
+        with self.assertRaises(ValidationError) as ctx:
+            ExperimentExposuresQueryRunner(team=self.team, query=self._null_multivariate_query())
+
+        self.assertIn("has no variants", str(ctx.exception))
 
     @freeze_time("2024-01-07T12:00:00Z")
     def test_exposure_query_resolves_soft_deleted_feature_flag_key(self):


### PR DESCRIPTION
## Problem
Boolean flags serialize filters with `"multivariate": null`. `.get("multivariate", {})` returns `None` for a present-but-null key, so `ExperimentExposuresQueryRunner` raises `AttributeError: 'NoneType' object has no attribute 'get'` (~36 occurrences/week, [error tracking](https://us.posthog.com/project/2/error_tracking/019ea75a-04f5-7100-bb4a-f41575e95298)). Flags end up in this state when their variants are edited away while an experiment references them (#84317 blocks that for running experiments going forward).

## Changes
- Guard the three `filters`/`multivariate` reads with `or {}`.
- With no variants the exposure SQL (`variant IN {variants}`) matches nothing, so: running experiment → raise a clear `ValidationError` ("This experiment's feature flag has no variants") instead of rendering an empty chart that reads as "no exposures"; draft/stopped experiment → degrade to the empty result, since a flag legitimately simplified after the experiment ended shouldn't break the historical results page.

## How did you test this code?
Regression tests for both paths: stopped experiment with `"multivariate": null` degrades to empty variants, running experiment raises. mypy on the changed file.