### PR TITLE
feat(tasks): record chart kind and display on chart render events

### DIFF
--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -2916,7 +2916,8 @@ class TaskRunLivingArtifactViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewS
         def capture_render(*, failure_reason: str | None = None, export_asset_id: int | None = None) -> None:
             # The insight node under the InsightVizNode wrapper; empty on the saved-insight path,
             # and on a malformed query that never got past validation.
-            source = query.get("source") if isinstance(query, dict) and isinstance(query.get("source"), dict) else {}
+            raw_source = query.get("source") if isinstance(query, dict) else None
+            source: dict = raw_source if isinstance(raw_source, dict) else {}
             posthoganalytics.capture(
                 distinct_id=str(getattr(request.user, "distinct_id", None) or self.team.uuid),
                 event="task_chart_render_failed" if failure_reason else "task_chart_render_succeeded",

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -2914,8 +2914,6 @@ class TaskRunLivingArtifactViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewS
         started = perf_counter()
 
         def capture_render(*, failure_reason: str | None = None, export_asset_id: int | None = None) -> None:
-            # The insight node under the InsightVizNode wrapper; empty on the saved-insight path,
-            # and on a malformed query that never got past validation.
             raw_source = query.get("source") if isinstance(query, dict) else None
             source: dict = raw_source if isinstance(raw_source, dict) else {}
             posthoganalytics.capture(
@@ -2926,8 +2924,6 @@ class TaskRunLivingArtifactViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewS
                     "run_id": run_id,
                     "source": "query" if query is not None else "insight",
                     "insight_id": request.validated_data.get("insight_id"),
-                    # Which chart got made, not just that one did. The display type lives on
-                    # whichever <kind>Filter the source carries, so pick it up wherever it sits.
                     "query_kind": source.get("kind"),
                     "display": next(
                         (f["display"] for f in source.values() if isinstance(f, dict) and f.get("display")), None

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -2914,6 +2914,9 @@ class TaskRunLivingArtifactViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewS
         started = perf_counter()
 
         def capture_render(*, failure_reason: str | None = None, export_asset_id: int | None = None) -> None:
+            # The insight node under the InsightVizNode wrapper; empty on the saved-insight path,
+            # and on a malformed query that never got past validation.
+            source = query.get("source") if isinstance(query, dict) and isinstance(query.get("source"), dict) else {}
             posthoganalytics.capture(
                 distinct_id=str(getattr(request.user, "distinct_id", None) or self.team.uuid),
                 event="task_chart_render_failed" if failure_reason else "task_chart_render_succeeded",
@@ -2921,6 +2924,13 @@ class TaskRunLivingArtifactViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewS
                     "task_id": task_id,
                     "run_id": run_id,
                     "source": "query" if query is not None else "insight",
+                    "insight_id": request.validated_data.get("insight_id"),
+                    # Which chart got made, not just that one did. The display type lives on
+                    # whichever <kind>Filter the source carries, so pick it up wherever it sits.
+                    "query_kind": source.get("kind"),
+                    "display": next(
+                        (f["display"] for f in source.values() if isinstance(f, dict) and f.get("display")), None
+                    ),
                     "duration_ms": round((perf_counter() - started) * 1000, 2),
                     "failure_reason": failure_reason,
                     "export_asset_id": export_asset_id,


### PR DESCRIPTION
## Problem

Anyone asking "what kinds of charts is the Slack bot actually producing?" can't answer it from analytics today. `task_chart_render_succeeded` records only whether the chart came from an ad-hoc query or a saved insight — not trends vs funnel vs retention, and not the display type. Delivery is already covered by `task_chart_slack_delivered`, so the gap is only on the render side.

## Changes

- `task_chart_render_succeeded` / `task_chart_render_failed` now carry `query_kind` (`TrendsQuery`, `FunnelsQuery`, …), `display` (the chart display type), and `insight_id`.
- The display type is read from the first `<kind>Filter` on the query source that defines one, so no per-kind mapping has to be kept in sync as query types are added.
- Both properties are null on the saved-insight path and on queries that fail validation before a source exists; `insight_id` covers the former.

## How did you test this code?

Not manually tested — this is an analytics property addition on an existing capture, and I (the agent) had no dev stack running. Ruff check and format pass on the changed file. No test added: there is no existing coverage of these events to extend, and a test asserting three property values on a mocked capture wouldn't catch a regression worth the fixture.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (PostHog Desktop cloud task). The ask was to check whether the Slack bot chart work emits any analytics at all; it does (`task_chart_render_*`, `task_chart_slack_delivered`, and a `task_chart_slack_delivery_failed` path that has not fired yet), but the render event couldn't answer the "what sorts of charts" half of the question, so this closes that gap.

Considered adding the same properties to the delivery event and skipped it — `export_asset_id` already joins delivery back to its render.

Skills invoked: none of the repo skills applied cleanly here (no serializer, viewset contract, or migration change); I read `.agents/skills/writing-pr-descriptions/SKILL.md` and the PR template before writing this body.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
