### PR TITLE
fix(tasks): name the gate that rejects a follow-up rebind

### DIFF
--- a/products/tasks/backend/temporal/process_task/activities/send_followup_to_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/send_followup_to_sandbox.py
@@ -3,7 +3,8 @@ import time
 import threading
 import contextvars
 from dataclasses import dataclass
-from typing import Any
+from enum import StrEnum
+from typing import Any, NoReturn
 
 import structlog
 from temporalio import activity
@@ -57,6 +58,20 @@ from products.tasks.backend.temporal.process_task.utils import (
 from ee.hogai.sandbox import STOP_REASON_END_TURN, TURN_COMPLETE_METHOD
 
 logger = structlog.get_logger(__name__)
+
+
+class SandboxRebindFailure(StrEnum):
+    """Why a credential rebind could not be confirmed, so a failed run names the gate
+    that rejected it rather than reporting one message for every cause."""
+
+    TOKEN_MINT_FAILED = "token_mint_failed"
+    NO_CONFIGS_ON_TRANSITION = "no_configs_on_transition"
+    REFRESH_SESSION_FAILED = "refresh_session_failed"
+    NO_SANDBOX_HANDLE = "no_sandbox_handle"
+    CREDENTIAL_LOCK_UNAVAILABLE = "credential_lock_unavailable"
+    LOGOUT_ERRORED = "logout_errored"
+    LOGOUT_UNCONFIRMED = "logout_unconfirmed"
+
 
 REFRESH_RETRY_DELAY_SECONDS = 0.5
 
@@ -124,6 +139,20 @@ def _current_attempt() -> int:
         return 1
 
 
+def _fail_rebind_closed(
+    run_id: str, event: str, reason: SandboxRebindFailure, actor_user: Any, message: str
+) -> NoReturn:
+    """Log and raise for a rebind that could not be confirmed. Both gates report the
+    same way, so the reason reaches the log and the reply from one place."""
+    logger.warning(
+        event,
+        run_id=run_id,
+        reason=reason,
+        actor_user_id=actor_user.id if actor_user is not None else None,
+    )
+    raise RuntimeError(f"send_followup failed: {message} ({reason})")
+
+
 def _is_duplicate_delivery(result_data: dict[str, Any] | None) -> bool:
     if not isinstance(result_data, dict):
         return False
@@ -175,7 +204,6 @@ def _deliver_followup(input: SendFollowupToSandboxInput) -> str | None:
             actor_user_id=input.actor_user_id,
             run_state_actor_user_id=(task_run.state or {}).get("slack_actor_user_id"),
             task_created_by_id=task_run.task.created_by_id,
-            interaction_origin=(state or {}).get("interaction_origin"),
         )
         _write_error_and_complete(input.run_id, error_msg, run_uses_dedicated_stream(task_run.state))
         raise RuntimeError(f"send_followup failed: {error_msg}")
@@ -219,44 +247,35 @@ def _deliver_followup(input: SendFollowupToSandboxInput) -> str | None:
     # fail closed rather than run the turn under the previous actor's creds.
     # A steer joins the active turn, so it cannot interrupt that turn with a
     # session refresh.
-    mcp_rebind_failure = (
-        None
-        if input.steer
-        else _refresh_sandbox_mcp(
+    if not input.steer:
+        mcp_failure = _refresh_sandbox_mcp(
             task_run,
             input.posthog_mcp_scopes,
             auth_token,
             actor_user=actor_user,
             state=state,
         )
-    )
-    if mcp_rebind_failure:
-        logger.warning(
-            "send_followup_mcp_rebind_failed",
-            run_id=input.run_id,
-            reason=mcp_rebind_failure,
-            actor_user_id=actor_user.id if actor_user is not None else None,
-            attempt=_current_attempt(),
-        )
-        error_msg = f"Could not rebind sandbox MCP credentials for the follow-up actor ({mcp_rebind_failure})"
-        raise RuntimeError(f"send_followup failed: {error_msg}")
+        if mcp_failure is not None:
+            _fail_rebind_closed(
+                input.run_id,
+                "send_followup_mcp_rebind_failed",
+                mcp_failure,
+                actor_user,
+                "Could not rebind sandbox MCP credentials for the follow-up actor",
+            )
 
     # Bind the sandbox's GitHub credentials to this actor: rebind if they have
     # access, otherwise log out so the previous actor's identity can't be used.
     # Fail closed only if we can't even clear the prior credentials.
-    github_rebind_failure = _refresh_sandbox_github(task_run, actor_user, state)
-    if github_rebind_failure:
-        logger.warning(
+    github_failure = _refresh_sandbox_github(task_run, actor_user, state)
+    if github_failure is not None:
+        _fail_rebind_closed(
+            input.run_id,
             "send_followup_github_rebind_failed",
-            run_id=input.run_id,
-            reason=github_rebind_failure,
-            actor_user_id=actor_user.id if actor_user is not None else None,
-            attempt=_current_attempt(),
+            github_failure,
+            actor_user,
+            "Could not rebind or clear sandbox GitHub credentials for the follow-up actor",
         )
-        error_msg = (
-            f"Could not rebind or clear sandbox GitHub credentials for the follow-up actor ({github_rebind_failure})"
-        )
-        raise RuntimeError(f"send_followup failed: {error_msg}")
     artifacts = None
     artifact_ids = input.artifact_ids or []
     if artifact_ids:
@@ -361,7 +380,7 @@ def _refresh_sandbox_mcp(
     *,
     actor_user: Any,
     state: dict[str, Any] | None,
-) -> str | None:
+) -> SandboxRebindFailure | None:
     """Rebind the sandbox's MCP session to this message's actor.
 
     Returns ``None`` when the session is safe to use (unchanged actor or a
@@ -406,7 +425,9 @@ def _refresh_sandbox_mcp(
             user_id=actor_user.id,
             exc_info=True,
         )
-        return "token_mint_failed"  # rebind unconfirmed → fail closed (unknown binding may hide a live session)
+        return (
+            SandboxRebindFailure.TOKEN_MINT_FAILED
+        )  # rebind unconfirmed → fail closed (unknown binding may hide a live session)
 
     mcp_configs = get_sandbox_ph_mcp_configs(
         token=access_token,
@@ -448,7 +469,7 @@ def _refresh_sandbox_mcp(
                 previous_user_id=bound_user_id,
                 user_id=actor_user.id,
             )
-            return "no_configs_on_transition"
+            return SandboxRebindFailure.NO_CONFIGS_ON_TRANSITION
         # No recorded prior actor and no MCP configs to establish a session:
         # there is nothing to leak, so let the turn run rather than block the
         # agent just because MCP is unavailable. Record the binding so a later
@@ -497,7 +518,9 @@ def _refresh_sandbox_mcp(
         previous_user_id=bound_user_id,
         server_count=len(mcp_servers),
     )
-    return "refresh_session_failed"  # rebind never confirmed → fail closed (unknown binding may hide a live session)
+    return (
+        SandboxRebindFailure.REFRESH_SESSION_FAILED
+    )  # rebind never confirmed → fail closed (unknown binding may hide a live session)
 
 
 def _resolve_live_sandbox(state: dict[str, Any] | None) -> Any:
@@ -525,7 +548,9 @@ def _resolve_live_sandbox(state: dict[str, Any] | None) -> Any:
         return None
 
 
-def _refresh_sandbox_github(task_run: TaskRun, actor_user: Any, state: dict[str, Any] | None) -> str | None:
+def _refresh_sandbox_github(
+    task_run: TaskRun, actor_user: Any, state: dict[str, Any] | None
+) -> SandboxRebindFailure | None:
     """Bind the sandbox's in-place GitHub credentials to this message's actor.
 
     Runs on every turn, for every actor: re-inject the acting user's token if they
@@ -578,7 +603,7 @@ def _refresh_sandbox_github(task_run: TaskRun, actor_user: Any, state: dict[str,
             user_id=actor_user.id,
             sandbox_id=(state or {}).get("sandbox_id"),
         )
-        return "no_sandbox_handle"
+        return SandboxRebindFailure.NO_SANDBOX_HANDLE
 
     repository = task.repository
     token: str | None = None
@@ -623,7 +648,7 @@ def _refresh_sandbox_github(task_run: TaskRun, actor_user: Any, state: dict[str,
                 user_id=actor_user.id,
                 sandbox_id=sandbox.id,
             )
-            return "credential_lock_unavailable"
+            return SandboxRebindFailure.CREDENTIAL_LOCK_UNAVAILABLE
 
         if token:
             applied = False
@@ -654,7 +679,7 @@ def _refresh_sandbox_github(task_run: TaskRun, actor_user: Any, state: dict[str,
             cleared = clear_github_credentials_from_sandbox(sandbox, repository)
         except Exception:
             logger.warning("refresh_github_logout_errored", run_id=run_id, user_id=actor_user.id, exc_info=True)
-            return "logout_errored"
+            return SandboxRebindFailure.LOGOUT_ERRORED
         if cleared:
             # Still record the actor: the marker tells owner-scoped refreshes that this sandbox is
             # bound away from the run owner, and clearing it would let the scheduled refresh inject
@@ -664,7 +689,7 @@ def _refresh_sandbox_github(task_run: TaskRun, actor_user: Any, state: dict[str,
             logger.info("refresh_github_logged_out", run_id=run_id, user_id=actor_user.id)
             return None
         logger.warning("refresh_github_logout_failed", run_id=run_id, user_id=actor_user.id, had_token=bool(token))
-        return "logout_unconfirmed"
+        return SandboxRebindFailure.LOGOUT_UNCONFIRMED
 
 
 def _get_stop_reason(result_data: dict[str, Any] | None) -> str:

--- a/products/tasks/backend/temporal/process_task/activities/send_followup_to_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/send_followup_to_sandbox.py
@@ -169,6 +169,14 @@ def _deliver_followup(input: SendFollowupToSandboxInput) -> str | None:
     actor_user = get_task_run_credential_user(task_run.task, state)
     if is_slack_interaction_state(state) and actor_user is None:
         error_msg = "Slack actor unavailable for this run"
+        logger.warning(
+            "send_followup_slack_actor_unavailable",
+            run_id=input.run_id,
+            actor_user_id=input.actor_user_id,
+            run_state_actor_user_id=(task_run.state or {}).get("slack_actor_user_id"),
+            task_created_by_id=task_run.task.created_by_id,
+            interaction_origin=(state or {}).get("interaction_origin"),
+        )
         _write_error_and_complete(input.run_id, error_msg, run_uses_dedicated_stream(task_run.state))
         raise RuntimeError(f"send_followup failed: {error_msg}")
 
@@ -211,21 +219,43 @@ def _deliver_followup(input: SendFollowupToSandboxInput) -> str | None:
     # fail closed rather than run the turn under the previous actor's creds.
     # A steer joins the active turn, so it cannot interrupt that turn with a
     # session refresh.
-    if not input.steer and not _refresh_sandbox_mcp(
-        task_run,
-        input.posthog_mcp_scopes,
-        auth_token,
-        actor_user=actor_user,
-        state=state,
-    ):
-        error_msg = "Could not rebind sandbox MCP credentials for the follow-up actor"
+    mcp_rebind_failure = (
+        None
+        if input.steer
+        else _refresh_sandbox_mcp(
+            task_run,
+            input.posthog_mcp_scopes,
+            auth_token,
+            actor_user=actor_user,
+            state=state,
+        )
+    )
+    if mcp_rebind_failure:
+        logger.warning(
+            "send_followup_mcp_rebind_failed",
+            run_id=input.run_id,
+            reason=mcp_rebind_failure,
+            actor_user_id=actor_user.id if actor_user is not None else None,
+            attempt=_current_attempt(),
+        )
+        error_msg = f"Could not rebind sandbox MCP credentials for the follow-up actor ({mcp_rebind_failure})"
         raise RuntimeError(f"send_followup failed: {error_msg}")
 
     # Bind the sandbox's GitHub credentials to this actor: rebind if they have
     # access, otherwise log out so the previous actor's identity can't be used.
     # Fail closed only if we can't even clear the prior credentials.
-    if not _refresh_sandbox_github(task_run, actor_user, state):
-        error_msg = "Could not rebind or clear sandbox GitHub credentials for the follow-up actor"
+    github_rebind_failure = _refresh_sandbox_github(task_run, actor_user, state)
+    if github_rebind_failure:
+        logger.warning(
+            "send_followup_github_rebind_failed",
+            run_id=input.run_id,
+            reason=github_rebind_failure,
+            actor_user_id=actor_user.id if actor_user is not None else None,
+            attempt=_current_attempt(),
+        )
+        error_msg = (
+            f"Could not rebind or clear sandbox GitHub credentials for the follow-up actor ({github_rebind_failure})"
+        )
         raise RuntimeError(f"send_followup failed: {error_msg}")
     artifacts = None
     artifact_ids = input.artifact_ids or []
@@ -331,13 +361,14 @@ def _refresh_sandbox_mcp(
     *,
     actor_user: Any,
     state: dict[str, Any] | None,
-) -> bool:
+) -> str | None:
     """Rebind the sandbox's MCP session to this message's actor.
 
-    Returns ``True`` when the session is safe to use (unchanged actor or a
-    successful rebind) and ``False`` when a rebind could not be confirmed — the
-    caller then fails the follow-up closed. A rebind is unconfirmed whenever the
-    mint or refresh fails and the binding is not known to be this actor's,
+    Returns ``None`` when the session is safe to use (unchanged actor or a
+    successful rebind) and a short reason code when a rebind could not be
+    confirmed — the caller then fails the follow-up closed and surfaces the code,
+    so a failed run says which gate rejected it. A rebind is unconfirmed whenever
+    the mint or refresh fails and the binding is not known to be this actor's,
     including an *unknown* binding: the marker self-expires at half the token
     lifetime, so an absent marker can mean the previous actor's session is still
     live, not that the sandbox is fresh. Retries the refresh once before giving
@@ -347,14 +378,14 @@ def _refresh_sandbox_mcp(
     if actor_user is None:
         # Without a credential user the mint is guaranteed to fail; skip
         # quietly rather than warn on every message.
-        return True
+        return None
 
     scope = sandbox_identity_scope(run_id, state)
     bound_user_id = get_sandbox_mcp_session_user(scope)
     is_built_in_agent_task = task_run.task.mcp_builtin_agent_key is not None
     if bound_user_id == actor_user.id and not is_built_in_agent_task:
         logger.info("refresh_mcp_skipped_within_interval", run_id=run_id, user_id=actor_user.id)
-        return True
+        return None
     is_transition = bound_user_id is not None and bound_user_id != actor_user.id
     if is_transition:
         logger.info(
@@ -367,8 +398,15 @@ def _refresh_sandbox_mcp(
     try:
         access_token = create_oauth_access_token_for_run(task_run.task, state, scopes=scopes)
     except Exception as e:
-        logger.warning("refresh_mcp_token_mint_failed", run_id=run_id, error=str(e))
-        return False  # rebind unconfirmed → fail closed (unknown binding may hide a live session)
+        logger.warning(
+            "refresh_mcp_token_mint_failed",
+            run_id=run_id,
+            error=str(e),
+            error_type=type(e).__name__,
+            user_id=actor_user.id,
+            exc_info=True,
+        )
+        return "token_mint_failed"  # rebind unconfirmed → fail closed (unknown binding may hide a live session)
 
     mcp_configs = get_sandbox_ph_mcp_configs(
         token=access_token,
@@ -404,17 +442,20 @@ def _refresh_sandbox_mcp(
             # configs, so an empty-list refresh (a no-op on the agent-server)
             # can neither rebind it nor tear it down. Fail closed rather than run
             # the turn against the previous actor's retained session.
-            logger.info(
-                "refresh_mcp_no_configs_on_transition_fail_closed", run_id=run_id, previous_user_id=bound_user_id
+            logger.warning(
+                "refresh_mcp_no_configs_on_transition_fail_closed",
+                run_id=run_id,
+                previous_user_id=bound_user_id,
+                user_id=actor_user.id,
             )
-            return False
+            return "no_configs_on_transition"
         # No recorded prior actor and no MCP configs to establish a session:
         # there is nothing to leak, so let the turn run rather than block the
         # agent just because MCP is unavailable. Record the binding so a later
         # actor transition is still detected.
         mark_sandbox_mcp_session(scope, actor_user.id)
         logger.info("refresh_mcp_skipped_no_configs", run_id=run_id)
-        return True
+        return None
 
     mcp_servers = [config.to_dict() for config in mcp_configs]
 
@@ -427,7 +468,7 @@ def _refresh_sandbox_mcp(
     if result.success:
         mark_sandbox_mcp_session(scope, actor_user.id)
         logger.info("refresh_mcp_delivered", run_id=run_id, attempts=1)
-        return True
+        return None
 
     logger.info(
         "refresh_mcp_retrying",
@@ -445,15 +486,18 @@ def _refresh_sandbox_mcp(
     if retry.success:
         mark_sandbox_mcp_session(scope, actor_user.id)
         logger.info("refresh_mcp_delivered", run_id=run_id, attempts=2)
-        return True
+        return None
 
     logger.warning(
         "refresh_mcp_failed",
         run_id=run_id,
         error=retry.error,
         status_code=retry.status_code,
+        user_id=actor_user.id,
+        previous_user_id=bound_user_id,
+        server_count=len(mcp_servers),
     )
-    return False  # rebind never confirmed → fail closed (unknown binding may hide a live session)
+    return "refresh_session_failed"  # rebind never confirmed → fail closed (unknown binding may hide a live session)
 
 
 def _resolve_live_sandbox(state: dict[str, Any] | None) -> Any:
@@ -481,7 +525,7 @@ def _resolve_live_sandbox(state: dict[str, Any] | None) -> Any:
         return None
 
 
-def _refresh_sandbox_github(task_run: TaskRun, actor_user: Any, state: dict[str, Any] | None) -> bool:
+def _refresh_sandbox_github(task_run: TaskRun, actor_user: Any, state: dict[str, Any] | None) -> str | None:
     """Bind the sandbox's in-place GitHub credentials to this message's actor.
 
     Runs on every turn, for every actor: re-inject the acting user's token if they
@@ -495,14 +539,15 @@ def _refresh_sandbox_github(task_run: TaskRun, actor_user: Any, state: dict[str,
     enforces the transition boundary; the periodic credential-refresh loop
     keeps a continuous actor's token rotated between transitions.
 
-    Returns ``True`` when the sandbox safely reflects this actor (rebound, logged
-    out, or nothing to do) and ``False`` when we could neither rebind nor even
-    clear. That is fail-closed for everyone, including an actor who revoked their
-    own connection: deleting a `UserIntegration` does not revoke the token GitHub
-    already issued, so an unconfirmed clear can leave it usable in the sandbox.
+    Returns ``None`` when the sandbox safely reflects this actor (rebound, logged
+    out, or nothing to do) and a short reason code when we could neither rebind nor
+    even clear — the caller surfaces the code so a failed run says which gate
+    rejected it. That is fail-closed for everyone, including an actor who revoked
+    their own connection: deleting a `UserIntegration` does not revoke the token
+    GitHub already issued, so an unconfirmed clear can leave it usable in the sandbox.
     """
     if actor_user is None:
-        return True
+        return None
 
     run_id = str(task_run.id)
     task = task_run.task
@@ -515,7 +560,7 @@ def _refresh_sandbox_github(task_run: TaskRun, actor_user: Any, state: dict[str,
 
     scope = sandbox_identity_scope(run_id, state)
     if get_pr_authorship_mode(task, state) != PrAuthorshipMode.USER:
-        return True
+        return None
 
     # Re-established every turn rather than skipped when the actor is unchanged: they can connect
     # or disconnect their GitHub between any two messages, and the sandbox can lose its token to a
@@ -527,8 +572,13 @@ def _refresh_sandbox_github(task_run: TaskRun, actor_user: Any, state: dict[str,
         # would run it under the prior actor's retained credentials. A missing handle (dead
         # sandbox, or a transient control-plane lookup failure) is not proof the sandbox is
         # safe, so fail closed rather than deliver without a confirmed rebind or clear.
-        logger.info("refresh_github_no_sandbox_handle_fail_closed", run_id=run_id, user_id=actor_user.id)
-        return False
+        logger.warning(
+            "refresh_github_no_sandbox_handle_fail_closed",
+            run_id=run_id,
+            user_id=actor_user.id,
+            sandbox_id=(state or {}).get("sandbox_id"),
+        )
+        return "no_sandbox_handle"
 
     repository = task.repository
     token: str | None = None
@@ -567,21 +617,32 @@ def _refresh_sandbox_github(task_run: TaskRun, actor_user: Any, state: dict[str,
     # owner writers acquire the same lock and re-check the marker this block advances.
     with sandbox_credential_lock(sandbox.id) as acquired:
         if not acquired:
-            logger.warning("refresh_github_lock_unavailable_fail_closed", run_id=run_id, user_id=actor_user.id)
-            return False
+            logger.warning(
+                "refresh_github_lock_unavailable_fail_closed",
+                run_id=run_id,
+                user_id=actor_user.id,
+                sandbox_id=sandbox.id,
+            )
+            return "credential_lock_unavailable"
 
         if token:
             applied = False
             try:
                 applied = apply_github_credentials_to_sandbox(sandbox, repository, token)
             except Exception:
-                logger.warning("refresh_github_apply_failed", run_id=run_id, exc_info=True)
+                logger.warning(
+                    "refresh_github_apply_failed",
+                    run_id=run_id,
+                    user_id=actor_user.id,
+                    repository=repository,
+                    exc_info=True,
+                )
             if applied:
                 # Record the new actor only on a fully-confirmed rebind. A partial write leaves one
                 # credential location on the prior actor's token, so fall through to logout instead.
                 mark_sandbox_github_identity(scope, actor_user.id)
                 logger.info("refresh_github_rebound", run_id=run_id, user_id=actor_user.id)
-                return True
+                return None
             logger.warning("refresh_github_apply_incomplete", run_id=run_id, user_id=actor_user.id)
 
         # No usable rebind (no token, or the rebind write could not be confirmed): log the sandbox
@@ -592,8 +653,8 @@ def _refresh_sandbox_github(task_run: TaskRun, actor_user: Any, state: dict[str,
         try:
             cleared = clear_github_credentials_from_sandbox(sandbox, repository)
         except Exception:
-            logger.warning("refresh_github_logout_failed", run_id=run_id, user_id=actor_user.id, exc_info=True)
-            return False
+            logger.warning("refresh_github_logout_errored", run_id=run_id, user_id=actor_user.id, exc_info=True)
+            return "logout_errored"
         if cleared:
             # Still record the actor: the marker tells owner-scoped refreshes that this sandbox is
             # bound away from the run owner, and clearing it would let the scheduled refresh inject
@@ -601,9 +662,9 @@ def _refresh_sandbox_github(task_run: TaskRun, actor_user: Any, state: dict[str,
             # re-establishes — so a reconnect is still picked up.
             mark_sandbox_github_identity(scope, actor_user.id)
             logger.info("refresh_github_logged_out", run_id=run_id, user_id=actor_user.id)
-            return True
-        logger.warning("refresh_github_logout_failed", run_id=run_id, user_id=actor_user.id)
-        return False
+            return None
+        logger.warning("refresh_github_logout_failed", run_id=run_id, user_id=actor_user.id, had_token=bool(token))
+        return "logout_unconfirmed"
 
 
 def _get_stop_reason(result_data: dict[str, Any] | None) -> str:

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_send_followup_to_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_send_followup_to_sandbox.py
@@ -66,7 +66,11 @@ class TestSendFollowupToSandbox(BaseTest):
         event = json.loads(payload)
         self.assertEqual(event["notification"]["params"]["stopReason"], "max_tokens")
 
-    @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox._refresh_sandbox_mcp")
+    # A bare mock would return a truthy value, which now reads as a rebind failure.
+    @patch(
+        "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox._refresh_sandbox_mcp",
+        return_value=None,
+    )
     @patch(
         "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_tasks_stream_redis_sync"
     )

--- a/products/tasks/backend/temporal/process_task/tests/test_send_followup_to_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_send_followup_to_sandbox.py
@@ -249,9 +249,9 @@ class TestRefreshSandboxMcp:
         mark_sandbox_mcp_session("run-1", 99)
 
         actor = MagicMock(id=42)
-        safe = _refresh_sandbox_mcp(_make_task_run_mock(), "read_only", None, actor_user=actor, state=None)
+        failure = _refresh_sandbox_mcp(_make_task_run_mock(), "read_only", None, actor_user=actor, state=None)
 
-        assert safe is False
+        assert failure == "refresh_session_failed"
         assert get_sandbox_mcp_session_user("run-1") == 99
 
     def test_unknown_binding_refresh_failure_fails_closed(
@@ -267,9 +267,9 @@ class TestRefreshSandboxMcp:
         mock_send_refresh.return_value = CommandResult(success=False, status_code=502, error="down")
 
         actor = MagicMock(id=42)
-        safe = _refresh_sandbox_mcp(_make_task_run_mock(), "read_only", None, actor_user=actor, state=None)
+        failure = _refresh_sandbox_mcp(_make_task_run_mock(), "read_only", None, actor_user=actor, state=None)
 
-        assert safe is False
+        assert failure == "refresh_session_failed"
 
 
 @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.send_refresh_session")
@@ -369,9 +369,9 @@ class TestSessionIdentityGate:
         mark_sandbox_mcp_session("run-1", 99)
 
         actor = MagicMock(id=42)
-        safe = _refresh_sandbox_mcp(_make_task_run_mock(), "read_only", None, actor_user=actor, state=None)
+        failure = _refresh_sandbox_mcp(_make_task_run_mock(), "read_only", None, actor_user=actor, state=None)
 
-        assert safe is False  # fail closed: prior session may still be live
+        assert failure == "no_configs_on_transition"  # fail closed: prior session may still be live
         mock_send_refresh.assert_not_called()
         assert get_sandbox_mcp_session_user("run-1") == 99  # binding unchanged
 
@@ -386,9 +386,9 @@ class TestSessionIdentityGate:
         mock_user_configs.return_value = []
 
         actor = MagicMock(id=42)
-        safe = _refresh_sandbox_mcp(_make_task_run_mock(), "read_only", None, actor_user=actor, state=None)
+        failure = _refresh_sandbox_mcp(_make_task_run_mock(), "read_only", None, actor_user=actor, state=None)
 
-        assert safe is True
+        assert failure is None
         mock_send_refresh.assert_not_called()
         assert get_sandbox_mcp_session_user("run-1") == 42  # binding recorded
 
@@ -418,7 +418,7 @@ class TestSandboxGithubIdentityGate:
         mock_apply.return_value = True
         mark_sandbox_github_identity("run-1", 42)
 
-        assert _refresh_sandbox_github(_make_task_run_mock(), MagicMock(id=42), None) is True
+        assert _refresh_sandbox_github(_make_task_run_mock(), MagicMock(id=42), None) is None
         mock_apply.assert_called_once()
         assert mock_apply.call_args.args[2] == "ghu_token"
         mock_clear.assert_not_called()
@@ -434,7 +434,7 @@ class TestSandboxGithubIdentityGate:
         mock_clear.return_value = True
         mark_sandbox_github_identity("run-1", 42)
 
-        assert _refresh_sandbox_github(_make_task_run_mock(), MagicMock(id=42), None) is True
+        assert _refresh_sandbox_github(_make_task_run_mock(), MagicMock(id=42), None) is None
         mock_clear.assert_called_once()
         mock_apply.assert_not_called()
 
@@ -450,7 +450,7 @@ class TestSandboxGithubIdentityGate:
         mock_clear.return_value = False
         mark_sandbox_github_identity("run-1", 42)
 
-        assert _refresh_sandbox_github(_make_task_run_mock(), MagicMock(id=42), None) is False
+        assert _refresh_sandbox_github(_make_task_run_mock(), MagicMock(id=42), None) == "logout_unconfirmed"
 
     def test_a_transition_that_cannot_clear_still_fails_closed(
         self, mock_authorship, mock_resolve, mock_get_token, mock_apply, mock_clear, mock_upgrade
@@ -462,7 +462,7 @@ class TestSandboxGithubIdentityGate:
         mock_clear.return_value = False
         mark_sandbox_github_identity("run-1", 99)
 
-        assert _refresh_sandbox_github(_make_task_run_mock(), MagicMock(id=42), None) is False
+        assert _refresh_sandbox_github(_make_task_run_mock(), MagicMock(id=42), None) == "logout_unconfirmed"
 
     def test_reconnecting_after_a_logout_rebinds_the_actor(
         self, mock_authorship, mock_resolve, mock_get_token, mock_apply, mock_clear, mock_upgrade
@@ -475,13 +475,13 @@ class TestSandboxGithubIdentityGate:
         mock_get_token.return_value = None
         mark_sandbox_github_identity("run-1", 42)
 
-        assert _refresh_sandbox_github(_make_task_run_mock(), MagicMock(id=42), None) is True
+        assert _refresh_sandbox_github(_make_task_run_mock(), MagicMock(id=42), None) is None
         assert get_sandbox_github_identity_user("run-1") == 42
 
         mock_get_token.return_value = "ghu_reconnected"
         mock_apply.return_value = True
 
-        assert _refresh_sandbox_github(_make_task_run_mock(), MagicMock(id=42), None) is True
+        assert _refresh_sandbox_github(_make_task_run_mock(), MagicMock(id=42), None) is None
         mock_apply.assert_called_once()
         assert mock_apply.call_args.args[2] == "ghu_reconnected"
 
@@ -493,7 +493,7 @@ class TestSandboxGithubIdentityGate:
         mock_authorship.return_value = PrAuthorshipMode.BOT
         mark_sandbox_github_identity("run-1", 99)
 
-        assert _refresh_sandbox_github(_make_task_run_mock(), MagicMock(id=42), None) is True
+        assert _refresh_sandbox_github(_make_task_run_mock(), MagicMock(id=42), None) is None
         mock_get_token.assert_not_called()
         mock_apply.assert_not_called()
         mock_clear.assert_not_called()
@@ -507,7 +507,7 @@ class TestSandboxGithubIdentityGate:
         mock_apply.return_value = True
         mark_sandbox_github_identity("run-1", 99)
 
-        assert _refresh_sandbox_github(_make_task_run_mock(), MagicMock(id=42), None) is True
+        assert _refresh_sandbox_github(_make_task_run_mock(), MagicMock(id=42), None) is None
         mock_apply.assert_called_once()
         assert mock_apply.call_args.args[2] == "ghu_newtoken"
         mock_clear.assert_not_called()
@@ -522,7 +522,7 @@ class TestSandboxGithubIdentityGate:
         mock_clear.return_value = True
         mark_sandbox_github_identity("run-1", 99)
 
-        assert _refresh_sandbox_github(_make_task_run_mock(), MagicMock(id=42), None) is True
+        assert _refresh_sandbox_github(_make_task_run_mock(), MagicMock(id=42), None) is None
         mock_apply.assert_not_called()
         mock_clear.assert_called_once()
         # Still marked: owner-scoped refreshes read this to know the sandbox is bound away from the
@@ -539,7 +539,7 @@ class TestSandboxGithubIdentityGate:
         mock_clear.return_value = True
         mark_sandbox_github_identity("run-1", 99)
 
-        assert _refresh_sandbox_github(_make_task_run_mock(), MagicMock(id=42), None) is True
+        assert _refresh_sandbox_github(_make_task_run_mock(), MagicMock(id=42), None) is None
         mock_apply.assert_called_once()
         mock_clear.assert_called_once()  # fell through to logout so no stale creds remain
 
@@ -556,7 +556,7 @@ class TestSandboxGithubIdentityGate:
         mock_clear.return_value = True
         mark_sandbox_github_identity("run-1", 99)
 
-        assert _refresh_sandbox_github(_make_task_run_mock(), MagicMock(id=42), None) is True
+        assert _refresh_sandbox_github(_make_task_run_mock(), MagicMock(id=42), None) is None
         mock_apply.assert_called_once()
         mock_clear.assert_called_once()
         # Still marked: owner-scoped refreshes read this to know the sandbox is bound away from the
@@ -573,7 +573,7 @@ class TestSandboxGithubIdentityGate:
         mock_resolve.return_value = None
         mark_sandbox_github_identity("run-1", 99)
 
-        assert _refresh_sandbox_github(_make_task_run_mock(), MagicMock(id=42), None) is False
+        assert _refresh_sandbox_github(_make_task_run_mock(), MagicMock(id=42), None) == "no_sandbox_handle"
         mock_get_token.assert_not_called()
         mock_apply.assert_not_called()
         mock_clear.assert_not_called()
@@ -590,7 +590,7 @@ class TestSandboxGithubIdentityGate:
         mock_clear.return_value = False
         mark_sandbox_github_identity("run-1", 99)
 
-        assert _refresh_sandbox_github(_make_task_run_mock(), MagicMock(id=42), None) is False
+        assert _refresh_sandbox_github(_make_task_run_mock(), MagicMock(id=42), None) == "logout_unconfirmed"
         assert get_sandbox_github_identity_user("run-1") == 99  # binding unchanged
 
     def test_logout_exception_fails_closed(
@@ -604,7 +604,7 @@ class TestSandboxGithubIdentityGate:
         mock_clear.side_effect = RuntimeError("sandbox stopped")
         mark_sandbox_github_identity("run-1", 99)
 
-        assert _refresh_sandbox_github(_make_task_run_mock(), MagicMock(id=42), None) is False
+        assert _refresh_sandbox_github(_make_task_run_mock(), MagicMock(id=42), None) == "logout_errored"
         assert get_sandbox_github_identity_user("run-1") == 99  # binding unchanged
 
     def test_credential_unavailable_logs_out(
@@ -620,7 +620,7 @@ class TestSandboxGithubIdentityGate:
         mock_clear.return_value = True
         mark_sandbox_github_identity("run-1", 99)
 
-        assert _refresh_sandbox_github(_make_task_run_mock(), MagicMock(id=42), None) is True
+        assert _refresh_sandbox_github(_make_task_run_mock(), MagicMock(id=42), None) is None
         mock_apply.assert_not_called()
         mock_clear.assert_called_once()
         # Still marked: owner-scoped refreshes read this to know the sandbox is bound away from the
@@ -643,12 +643,13 @@ class TestSendFollowupActivityRefreshOrdering:
                 "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.create_sandbox_connection_token"
             ) as mock_conn_token,
             patch(
-                "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox._refresh_sandbox_mcp"
+                "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox._refresh_sandbox_mcp",
+                return_value=None,
             ) as mock_refresh,
             patch(
                 "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox._refresh_sandbox_github",
-                return_value=True,
-            ),
+                return_value=None,
+            ) as mock_refresh_github,
             patch(
                 "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.send_user_message"
             ) as mock_user_msg,
@@ -668,6 +669,7 @@ class TestSendFollowupActivityRefreshOrdering:
                 "task_run": task_run,
                 "task_run_cls": mock_task_run_cls,
                 "refresh": mock_refresh,
+                "refresh_github": mock_refresh_github,
                 "user_msg": mock_user_msg,
                 "conn_token": mock_conn_token,
             }
@@ -677,7 +679,7 @@ class TestSendFollowupActivityRefreshOrdering:
 
         def _record_refresh(*a, **kw):
             call_order.append("refresh")
-            return True  # refresh confirmed the session is safe; gate lets the turn proceed
+            return None  # refresh confirmed the session is safe; gate lets the turn proceed
 
         def _record_user_msg(*a, **kw):
             call_order.append("user_message")
@@ -689,6 +691,20 @@ class TestSendFollowupActivityRefreshOrdering:
         send_followup_to_sandbox(SendFollowupToSandboxInput(run_id="run-1", message="hi", posthog_mcp_scopes="full"))
 
         assert call_order == ["refresh", "user_message"]
+
+    @pytest.mark.parametrize(
+        "gate,reason",
+        [("refresh", "refresh_session_failed"), ("refresh_github", "logout_unconfirmed")],
+    )
+    def test_gate_rejection_names_its_reason_in_the_failure(self, _patches, gate, reason):
+        # A fail-closed follow-up raises without delivering, so the reason the gate
+        # gave is the only account of why the run stopped.
+        _patches[gate].return_value = reason
+
+        with pytest.raises(RuntimeError, match=reason):
+            send_followup_to_sandbox(SendFollowupToSandboxInput(run_id="run-1", message="hi"))
+
+        _patches["user_msg"].assert_not_called()
 
     def test_scopes_flow_from_input_to_refresh(self, _patches):
         _patches["user_msg"].return_value = CommandResult(success=True, status_code=200)
@@ -784,11 +800,12 @@ class TestSendFollowupTurnTimeout:
                 "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.create_sandbox_connection_token"
             ) as mock_conn_token,
             patch(
-                "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox._refresh_sandbox_mcp"
+                "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox._refresh_sandbox_mcp",
+                return_value=None,
             ),
             patch(
                 "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox._refresh_sandbox_github",
-                return_value=True,
+                return_value=None,
             ),
             patch(
                 "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.send_user_message"

--- a/products/tasks/backend/temporal/process_task/tests/test_send_followup_to_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_send_followup_to_sandbox.py
@@ -12,6 +12,7 @@ from products.tasks.backend.temporal.process_task.activities.send_followup_to_sa
     REFRESH_RETRY_DELAY_SECONDS,
     SEND_FOLLOWUP_MAX_ATTEMPTS,
     STEER_DECLINED_OUTCOME,
+    SandboxRebindFailure,
     SendFollowupToSandboxInput,
     _refresh_sandbox_github,
     _refresh_sandbox_mcp,
@@ -251,7 +252,7 @@ class TestRefreshSandboxMcp:
         actor = MagicMock(id=42)
         failure = _refresh_sandbox_mcp(_make_task_run_mock(), "read_only", None, actor_user=actor, state=None)
 
-        assert failure == "refresh_session_failed"
+        assert failure == SandboxRebindFailure.REFRESH_SESSION_FAILED
         assert get_sandbox_mcp_session_user("run-1") == 99
 
     def test_unknown_binding_refresh_failure_fails_closed(
@@ -269,7 +270,7 @@ class TestRefreshSandboxMcp:
         actor = MagicMock(id=42)
         failure = _refresh_sandbox_mcp(_make_task_run_mock(), "read_only", None, actor_user=actor, state=None)
 
-        assert failure == "refresh_session_failed"
+        assert failure == SandboxRebindFailure.REFRESH_SESSION_FAILED
 
 
 @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.send_refresh_session")
@@ -371,7 +372,7 @@ class TestSessionIdentityGate:
         actor = MagicMock(id=42)
         failure = _refresh_sandbox_mcp(_make_task_run_mock(), "read_only", None, actor_user=actor, state=None)
 
-        assert failure == "no_configs_on_transition"  # fail closed: prior session may still be live
+        assert failure == SandboxRebindFailure.NO_CONFIGS_ON_TRANSITION  # fail closed: prior session may still be live
         mock_send_refresh.assert_not_called()
         assert get_sandbox_mcp_session_user("run-1") == 99  # binding unchanged
 
@@ -450,7 +451,10 @@ class TestSandboxGithubIdentityGate:
         mock_clear.return_value = False
         mark_sandbox_github_identity("run-1", 42)
 
-        assert _refresh_sandbox_github(_make_task_run_mock(), MagicMock(id=42), None) == "logout_unconfirmed"
+        assert (
+            _refresh_sandbox_github(_make_task_run_mock(), MagicMock(id=42), None)
+            == SandboxRebindFailure.LOGOUT_UNCONFIRMED
+        )
 
     def test_a_transition_that_cannot_clear_still_fails_closed(
         self, mock_authorship, mock_resolve, mock_get_token, mock_apply, mock_clear, mock_upgrade
@@ -462,7 +466,10 @@ class TestSandboxGithubIdentityGate:
         mock_clear.return_value = False
         mark_sandbox_github_identity("run-1", 99)
 
-        assert _refresh_sandbox_github(_make_task_run_mock(), MagicMock(id=42), None) == "logout_unconfirmed"
+        assert (
+            _refresh_sandbox_github(_make_task_run_mock(), MagicMock(id=42), None)
+            == SandboxRebindFailure.LOGOUT_UNCONFIRMED
+        )
 
     def test_reconnecting_after_a_logout_rebinds_the_actor(
         self, mock_authorship, mock_resolve, mock_get_token, mock_apply, mock_clear, mock_upgrade
@@ -573,7 +580,10 @@ class TestSandboxGithubIdentityGate:
         mock_resolve.return_value = None
         mark_sandbox_github_identity("run-1", 99)
 
-        assert _refresh_sandbox_github(_make_task_run_mock(), MagicMock(id=42), None) == "no_sandbox_handle"
+        assert (
+            _refresh_sandbox_github(_make_task_run_mock(), MagicMock(id=42), None)
+            == SandboxRebindFailure.NO_SANDBOX_HANDLE
+        )
         mock_get_token.assert_not_called()
         mock_apply.assert_not_called()
         mock_clear.assert_not_called()
@@ -590,7 +600,10 @@ class TestSandboxGithubIdentityGate:
         mock_clear.return_value = False
         mark_sandbox_github_identity("run-1", 99)
 
-        assert _refresh_sandbox_github(_make_task_run_mock(), MagicMock(id=42), None) == "logout_unconfirmed"
+        assert (
+            _refresh_sandbox_github(_make_task_run_mock(), MagicMock(id=42), None)
+            == SandboxRebindFailure.LOGOUT_UNCONFIRMED
+        )
         assert get_sandbox_github_identity_user("run-1") == 99  # binding unchanged
 
     def test_logout_exception_fails_closed(
@@ -604,7 +617,10 @@ class TestSandboxGithubIdentityGate:
         mock_clear.side_effect = RuntimeError("sandbox stopped")
         mark_sandbox_github_identity("run-1", 99)
 
-        assert _refresh_sandbox_github(_make_task_run_mock(), MagicMock(id=42), None) == "logout_errored"
+        assert (
+            _refresh_sandbox_github(_make_task_run_mock(), MagicMock(id=42), None)
+            == SandboxRebindFailure.LOGOUT_ERRORED
+        )
         assert get_sandbox_github_identity_user("run-1") == 99  # binding unchanged
 
     def test_credential_unavailable_logs_out(


### PR DESCRIPTION
## Problem

A rejected Slack follow-up said only "Could not rebind sandbox MCP credentials for the follow-up actor". Both rebind gates fail closed for several distinct reasons, and every one produced that same sentence.

## Changes

- Both gates return a typed reason (`SandboxRebindFailure`) instead of a bool, so the error and the log name which gate rejected the run.
- Two fail-closed paths move from `info` to `warning`.
- The two different GitHub logout failures stop sharing one log key.
- No control flow change: everything that failed closed still does.

## How did you test this code?

Both `test_send_followup_to_sandbox.py` suites pass locally. Existing cases now assert the specific reason, so a gate wired to the wrong code fails the suite. No manual run against a live sandbox.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5). Packaged from uncommitted work in a worktree, rebased onto master, then cleaned up with `/simplify`.

Reviewer call: the reason code reaches the user-facing Slack error. Keeping it to the logs is the alternative.
