### PR TITLE
fix(clerk): return actionable copy when validating a bad Clerk key

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/clerk.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/clerk.py
@@ -7,6 +7,8 @@ from requests import Request, Response
 from requests.exceptions import HTTPError, RequestException
 from structlog.types import FilteringBoundLogger
 
+from posthog.exceptions_capture import capture_exception
+
 from products.warehouse_sources.backend.temporal.data_imports.sources.clerk.settings import (
     CLERK_ENDPOINTS,
     RETIRED_ENDPOINTS,
@@ -224,6 +226,20 @@ def _strip_sensitive_fields(item: dict[str, Any], paths: tuple[str, ...]) -> dic
     return item
 
 
+# Curated copy shared with the sync path's non-retryable-error map in source.py, so a bad key is
+# explained the same way whether it's caught at create time or on a running sync. The previous
+# behaviour forwarded Clerk's raw response body (and requests' exception string) straight to the
+# wizard, which the user can't act on.
+_INVALID_KEY_MESSAGE = (
+    "Your Clerk secret key is invalid or has been revoked. Please update the secret key in your "
+    "Clerk dashboard and reconnect."
+)
+_FORBIDDEN_KEY_MESSAGE = (
+    "Your Clerk secret key does not have permission to access this endpoint. Please check the "
+    "key's permissions in your Clerk dashboard."
+)
+
+
 def validate_credentials(secret_key: str) -> tuple[bool, str | None]:
     """Validate Clerk API credentials by making a test request."""
     url = "https://api.clerk.com/v1/users"
@@ -234,20 +250,21 @@ def validate_credentials(secret_key: str) -> tuple[bool, str | None]:
 
     try:
         response = make_tracked_session().get(url, headers=headers, params={"limit": 1}, timeout=10)
-
-        if response.status_code == 200:
-            return True, None
-
-        try:
-            error_data = response.json()
-            if error_data.get("errors"):
-                return False, error_data["errors"][0].get("message", response.text)
-        except Exception:
-            pass
-
-        return False, response.text
     except RequestException as e:
-        return False, str(e)
+        capture_exception(e)
+        return False, "Couldn't reach Clerk to validate your secret key. Please try again in a moment."
+
+    if response.status_code == 200:
+        return True, None
+    if response.status_code == 401:
+        return False, _INVALID_KEY_MESSAGE
+    if response.status_code == 403:
+        return False, _FORBIDDEN_KEY_MESSAGE
+
+    # Any other status is unexpected for this endpoint; keep the raw detail for us instead of
+    # surfacing it to the user.
+    capture_exception(Exception(f"Unexpected Clerk credential validation response ({response.status_code})"))
+    return False, "Couldn't validate your Clerk secret key. Please check the key and try again."
 
 
 # Clerk error codes meaning "this account has not switched the feature on". Paired with the

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/tests/test_clerk.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/tests/test_clerk.py
@@ -7,7 +7,7 @@ import pytest
 from unittest.mock import MagicMock, patch
 
 from requests import Request, Response
-from requests.exceptions import HTTPError
+from requests.exceptions import HTTPError, RequestException
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.clerk.clerk import (
     ClerkPaginator,
@@ -16,6 +16,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.clerk.cler
     _strip_sensitive_fields,
     clerk_source,
     get_resources,
+    validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.clerk.settings import (
     CLERK_ENDPOINTS,
@@ -559,3 +560,38 @@ class TestClerkRetiredEndpoints:
                 resumable_source_manager=manager,
                 logger=MagicMock(),
             )
+
+
+_VALIDATE_SESSION = "products.warehouse_sources.backend.temporal.data_imports.sources.clerk.clerk.make_tracked_session"
+
+
+class TestClerkValidateCredentials:
+    @pytest.mark.parametrize(
+        ("status_code", "expected_substring"),
+        [
+            (401, "invalid or has been revoked"),
+            (403, "does not have permission"),
+            (500, "Couldn't validate your Clerk secret key"),
+        ],
+    )
+    def test_maps_status_to_curated_message_without_leaking_raw_body(
+        self, status_code: int, expected_substring: str
+    ) -> None:
+        # A regression that forwards Clerk's response body (or errors[0].message) back to the wizard
+        # would surface this sentinel; the curated copy must not.
+        sentinel = "RAW-CLERK-BODY-SENTINEL"
+        response = _make_http_response({"errors": [{"message": sentinel}]}, status_code=status_code)
+        with patch(_VALIDATE_SESSION) as mock_session:
+            mock_session.return_value.get.return_value = response
+            is_valid, message = validate_credentials("sk_test_key")
+        assert is_valid is False
+        assert expected_substring in (message or "")
+        assert sentinel not in (message or "")
+
+    def test_network_error_returns_actionable_message_without_leaking_exception(self) -> None:
+        with patch(_VALIDATE_SESSION) as mock_session:
+            mock_session.return_value.get.side_effect = RequestException("connection reset by peer")
+            is_valid, message = validate_credentials("sk_test_key")
+        assert is_valid is False
+        assert "Couldn't reach Clerk" in (message or "")
+        assert "connection reset by peer" not in (message or "")


### PR DESCRIPTION
## Problem

- A user setting up a Clerk data-warehouse source with a bad secret key saw whatever text Clerk's API returned, forwarded verbatim into the setup agent's error.
- The create/validate path returned the raw response body on any non-200 status, and the raw request-exception string on a network failure. Neither is guaranteed to be actionable.
- Curated 401/403 copy already exists for running syncs, but the validation path never used it, so the two surfaces explained the same bad key differently.

## Changes

- `validate_credentials` now maps the HTTP status to fixed, user-facing copy: 401 to an invalid-or-revoked-key message, 403 to a missing-permission message. The wording matches the sync path's non-retryable-error map.
- Any other status, and network errors, return a generic actionable message. The raw detail goes to error tracking via `capture_exception` instead of to the user.
- No visual change; this is a backend error string only.

## How did you test this code?

- Added `TestClerkValidateCredentials`. It asserts that 401, 403, and an unexpected status return the curated copy and never echo a sentinel planted in the response body, and that a network error returns the reachability message without the exception string. This catches a regression that re-forwards Clerk's raw response to the wizard, which no existing test covered (the source-level test mocks the validation call out entirely).
- Ran the Clerk source test suite locally. Not run: the database-backed API suites, since this change is a pure function with no DB path.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (actually Claude) triaged a batch of data-warehouse source-creation failures and classified each error message. Most were already clear, actionable messages that needed no change. Clerk's validation path was the one that forwarded raw upstream API text, so it is the only fix here.

Skills invoked: `/writing-user-facing-copy`, `/writing-tests`, `/writing-pr-descriptions`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
