### PR TITLE
chore(devex): build the tasks sandbox images in their own depot project

### DIFF
--- a/.github/workflows/cd-sandbox-base-image.yml
+++ b/.github/workflows/cd-sandbox-base-image.yml
@@ -224,6 +224,7 @@ jobs:
                     id: build
                     uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1.17.0
                     with:
+                        project: vpl2362h0x # tasks-sandbox-images
                         context: . # use local checkout (includes downloaded artifact)
                         file: ./products/tasks/backend/sandbox/images/Dockerfile.sandbox-base
                         buildx-fallback: false # the fallback is so slow it's better to just fail
@@ -238,6 +239,7 @@ jobs:
                     id: build-notebook
                     uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1.17.0
                     with:
+                        project: vpl2362h0x # tasks-sandbox-images
                         context: . # use local checkout (includes downloaded artifact)
                         file: ./products/tasks/backend/sandbox/images/Dockerfile.sandbox-notebook
                         buildx-fallback: false # the fallback is so slow it's better to just fail
@@ -250,6 +252,7 @@ jobs:
                     id: build-streamlit
                     uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1.17.0
                     with:
+                        project: vpl2362h0x # tasks-sandbox-images
                         context: . # use local checkout (includes downloaded artifact)
                         file: ./products/tasks/backend/sandbox/images/Dockerfile.sandbox-streamlit
                         buildx-fallback: false # the fallback is so slow it's better to just fail
@@ -262,6 +265,7 @@ jobs:
                     id: build-pi
                     uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1.17.0
                     with:
+                        project: vpl2362h0x # tasks-sandbox-images
                         context: . # use local checkout (includes downloaded artifact)
                         file: ./products/tasks/backend/sandbox/images/Dockerfile.sandbox-pi
                         buildx-fallback: false # the fallback is so slow it's better to just fail
@@ -275,6 +279,7 @@ jobs:
                     id: build-vm
                     uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1.17.0
                     with:
+                        project: vpl2362h0x # tasks-sandbox-images
                         context: . # use local checkout (includes downloaded artifact)
                         file: ./products/tasks/backend/sandbox/images/Dockerfile.sandbox-vm
                         buildx-fallback: false # the fallback is so slow it's better to just fail


### PR DESCRIPTION
## Problem

The main PostHog product image shares its Depot layer cache and build stats with five unrelated sandbox images.

- The five sandbox builds pass no `project:` to `depot/build-push-action`.
- The action falls back to the repo-root `depot.json`, which is the main posthog project.
- Five images across two architectures share that cache, so they evict layers the product image would reuse.
- Every other image build in this repo already names its own Depot project.

## Changes

- Each of the five build steps now names the `tasks-sandbox-images` project.
- Nothing changes about what gets built, tagged, or pushed.
- The first build in the new project runs on a cold cache, so expect one slow run per image.

> [!WARNING]
> The Depot project needs Trust Relationships set to GitHub Actions, org PostHog, repo posthog, before this merges. Without it every build fails with a Depot auth error. It also needs amd64 and arm64 builders, because all five images are multi-arch. I could not verify either from here.

## How did you test this code?

- `bin/hogli lint:workflows` passes.
- `actionlint` reports two `parallel:` syntax errors on this file. Both are present on master and unrelated to this change.
- Not checked: any actual build in the new project. That needs the project configured first.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude) started from a Depot dashboard observation that sandbox builds were landing in the main posthog project. I confirmed it by mapping every `depot/build-push-action` call site under `.github/workflows` to its `project:` input. Only this workflow and the two that build the product image itself omit it, and for those two the fallback is correct.

Skills invoked: `/stacking-prs`, `/authoring-ci-workflows`, `/writing-code-comments`, `/writing-pr-descriptions`.

Bottom of a two-PR stack. #84063 narrows this workflow's PR trigger.
