### PR TITLE
chore(devex): skip sandbox image builds on skills-only and fork PRs

### DIFF
--- a/.github/workflows/cd-sandbox-base-image.yml
+++ b/.github/workflows/cd-sandbox-base-image.yml
@@ -4,12 +4,16 @@ on:
     push:
         branches:
             - master
-    # paths mirror the changes job's dorny filter, which still gates push events.
+    # Narrower than the changes job's dorny filter, which also gates push events.
+    # A skills edit changes a COPY payload rather than a build instruction, so it
+    # cannot break the image build, and the :sha image a PR build pushes is never
+    # pulled by anything. `ci-agent-skills.yml` already builds the same skills on
+    # the same PR. Master keeps rebuilding on skills changes through the filter
+    # below, so the :master image production resolves still gets current skills.
     pull_request:
         paths:
             - '.github/workflows/cd-sandbox-base-image.yml'
             - 'products/tasks/backend/sandbox/images/**'
-            - 'products/*/skills/**'
             - 'products/posthog_ai/scripts/**'
             # The notebook image bakes this package and stamps its content hash.
             - 'products/notebooks/backend/sandbox/kernel/**'
@@ -40,7 +44,9 @@ jobs:
               id: filter
               with:
                   token: ${{ steps.app-token.outputs.token || github.token }}
-                  # Keep in sync with the trigger-level pull_request paths above.
+                  # Wider than the trigger-level pull_request paths above, because
+                  # this also gates push events, where a skills change does have to
+                  # rebuild the image that :master serves.
                   filters: |
                       sandbox_image:
                         - '.github/workflows/cd-sandbox-base-image.yml'

--- a/.github/workflows/cd-sandbox-base-image.yml
+++ b/.github/workflows/cd-sandbox-base-image.yml
@@ -24,7 +24,13 @@ jobs:
     changes:
         runs-on: ubuntu-24.04
         timeout-minutes: 5
-        if: github.repository_owner == 'PostHog'
+        # A fork PR runs in the base repo, so `repository_owner` does not exclude it,
+        # but its read-only GITHUB_TOKEN cannot push to ghcr.io. Skipping here leaves
+        # `sandbox_image` unset so both build jobs skip too, which keeps a fork off
+        # the skills build it would only pay for to fail at the push.
+        if: |
+            github.repository_owner == 'PostHog' &&
+            (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         name: Determine if sandbox image needs to be built
         permissions:
             contents: read
@@ -60,7 +66,8 @@ jobs:
         needs: changes
         name: Build agent skills from source
         if: |
-            github.repository_owner == 'PostHog' && (
+            github.repository_owner == 'PostHog' &&
+            (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && (
                 needs.changes.outputs.sandbox_image == 'true' ||
                 github.event_name == 'workflow_dispatch' ||
                 contains(github.event.pull_request.labels.*.name, 'build-tasks-sandbox-image')
@@ -174,7 +181,8 @@ jobs:
         needs: [changes, build_skills]
         name: Build and push Tasks Sandbox container image
         if: |
-            github.repository_owner == 'PostHog' && (
+            github.repository_owner == 'PostHog' &&
+            (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && (
                 needs.changes.outputs.sandbox_image == 'true' ||
                 github.event_name == 'workflow_dispatch' ||
                 contains(github.event.pull_request.labels.*.name, 'build-tasks-sandbox-image')


### PR DESCRIPTION
## Problem

This workflow runs five sandbox image builds in two cases where they cannot help anyone.

**Skills-only PRs.** Anyone editing a product skill waits on builds their change does not need.

- `products/*/skills/**` became a trigger path when dynamic skill installation landed.
- It is now one of the most frequently touched paths in the repo.
- Each run also stands up postgres, redis, rust and django migrations to render the skills first.
- PR builds outnumber master builds here by more than an order of magnitude.
- The `:sha` image a PR build pushes to ghcr is never pulled, because production resolves `:master` to a digest.

**Fork PRs.** An outside contributor gets a red check they have no way to fix.

- A fork PR runs in the base repo, so the existing `repository_owner` guard does not exclude it.
- The fork's `GITHUB_TOKEN` is read-only, so the push to ghcr.io always fails.
- The last seven fork runs of this workflow all failed at that step, after paying the full skills build. [Run 31849161079](https://github.com/PostHog/posthog/actions/runs/31849161079) is one.

## Changes

- Drop `products/*/skills/**` from the trigger-level `pull_request.paths`.
- Keep it in the `changes` job's dorny filter, which gates push events, so master still rebuilds the image `:master` serves.
- Keep `products/posthog_ai/scripts/**` on the PR trigger, because the renderer can break the image build and it moves rarely.
- Guard the `changes` job and both build jobs on the PR head being same-repo.

| Event | Before | After |
| --- | --- | --- |
| Skills edit on a PR | five image builds plus the skills build | no run |
| Skills edit on master | five image builds | unchanged |
| Dockerfile edit on a fork PR | five image builds, red at the push | all jobs skip |
| Dockerfile edit on a PR | five image builds | unchanged |

No validation is lost on the skills side. A skills edit changes a `COPY` payload rather than a build instruction, so it cannot break the image build, and `ci-agent-skills.yml` already runs the same `hogli build:skills` on the same PR.

Gating `push:` would not have fixed the fork case. The pi and vm images build `FROM ghcr.io/posthog/posthog-sandbox-base:${{ github.sha }}`, so a base that builds without pushing moves the failure one step later. AGENTS.md calls for skipping a secret-injecting build on forks outright, so all three jobs carry the guard. The roll-up check stays green, because it accepts a skipped `changes` and exits 0 when both build jobs skipped.

> [!WARNING]
> The `build-tasks-sandbox-image` label no longer starts a run on a skills-only PR, because no trigger path matches and a label does not dispatch a run on its own. Use `workflow_dispatch` on the branch to build an image for a skills change.

> [!NOTE]
> Separate and pre-existing, for whoever owns the sandbox images and the skills build. The dorny filter on push cannot see everything that changes rendered skills. `hogli build:skills` renders Jinja templates against `posthog/schema.py`, `posthog/hogql/functions/*` and Pydantic models loaded by dotted path, so a change to any of those alters skill content without touching a skills path. `ci-agent-skills.yml` refuses to filter master pushes for this reason and says so in its header comment. This PR neither worsens that nor fixes it. The durable fix is to stop baking skills into the image and consume the `agent-skills-v*` release that workflow already publishes.

## How did you test this code?

- `bin/hogli lint:workflows` passes, and `hogli ci:preflight` passed in strict mode on the push.
- The sandbox image build ran green on this branch, so the same-repo path is unaffected by the guard.
- Confirmed `on.push` carries no `paths:` block, so the trigger change is scoped to pull requests.
- Not checked: the fork path itself. A same-repo PR cannot exercise it, so the guard is verified by reading the expression, not by a run.
- Not checked: a master push running or skipping the build with this filter in place.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude) sized the skills half from the workflow's run history and the `engineering_analytics_job_costs` view, then traced what the images actually consume from `products/*/skills/`. The finding that makes that trade safe is that only `Dockerfile.sandbox-base` carries the skills `COPY`. The notebook and streamlit images never had skills at all, so today they rebuild on every skills change for no reason.

The fork half came from a Copilot review comment on #84062. I confirmed it against the workflow's fork run history rather than taking it on trust, and it turned out to be live rather than theoretical.

I also checked whether skills could move to a runtime install instead. They cannot, at least not from inside the sandbox: the enforced egress allowlist in `products/tasks/backend/logic/services/agentsh.py` covers PostHog and Anthropic hosts only, so a restricted sandbox cannot reach GitHub releases. A Modal image layer stays viable, which is what the note above points at.

Skills invoked: `/stacking-prs`, `/authoring-ci-workflows`, `/writing-code-comments`, `/writing-pr-descriptions`, `/babysit-pr`.

Top of a two-PR stack on #84062. Origin context: the shared Depot project was first raised during review of #47568 in February.
