### PR TITLE
fix(evals): let a sandboxed eval run locally, and say so when it cannot

### DIFF
--- a/products/posthog_ai/eval_harness/base.py
+++ b/products/posthog_ai/eval_harness/base.py
@@ -15,7 +15,7 @@ from .engines.base import EvalEngine
 from .engines.types import CaseHooks, CaseSpec, ExperimentResult, ExperimentSpec, SpanKind
 from .harness.kernel_sandboxes import reclaim_kernels
 from .log_sink import append_case_scores, build_case_dir, write_case_logs
-from .runner import EvalCaseResult, run_eval_case
+from .runner import AgentNeverRanError, EvalCaseResult, agent_never_ran, run_eval_case
 from .scorers import ExitCodeZero, wrap_scorers
 from .trace_events import emit_evaluation_events, emit_trace_events, emit_trace_root
 
@@ -453,6 +453,12 @@ class _SandboxedEvalRun(_BaseEvalRun):
             )
         except Exception:
             logger.exception("Failed to write local eval logs for '%s'", eval_case.name)
+
+        # After the logs are on disk, so a failed run is still there to read.
+        if agent_never_ran(result.artifacts):
+            raise AgentNeverRanError(
+                f"Eval case '{eval_case.name}' failed before doing any work: {result.artifacts.stderr}"
+            )
 
         return result.artifacts.model_dump() | {
             "last_message": last_message,

--- a/products/posthog_ai/eval_harness/config.py
+++ b/products/posthog_ai/eval_harness/config.py
@@ -93,7 +93,7 @@ class AgentArtifacts(BaseModel):
     """Lint output extracted from agent tool calls."""
 
     tool_call_count: int = 0
-    """Tool calls the agent made. Zero alongside a non-empty ``stderr`` means the run failed before
+    """Tool calls the agent made. Zero alongside a non-zero ``exit_code`` means the run failed before
     it did any work, which the harness treats as an infrastructure error rather than a score."""
 
     duration_seconds: float = 0.0

--- a/products/posthog_ai/eval_harness/config.py
+++ b/products/posthog_ai/eval_harness/config.py
@@ -92,6 +92,10 @@ class AgentArtifacts(BaseModel):
     lint_output: str = ""
     """Lint output extracted from agent tool calls."""
 
+    tool_call_count: int = 0
+    """Tool calls the agent made. Zero alongside a non-empty ``stderr`` means the run failed before
+    it did any work, which the harness treats as an infrastructure error rather than a score."""
+
     duration_seconds: float = 0.0
     """Wall-clock time for the agent run in seconds."""
 

--- a/products/posthog_ai/eval_harness/harness/cli.py
+++ b/products/posthog_ai/eval_harness/harness/cli.py
@@ -7,10 +7,12 @@ from typing import cast, get_args
 
 from .providers import DockerProviderStrategy, ModalProviderStrategy, SandboxProvider
 
-# Bare model ids, no "anthropic/"/"openai/" prefix: the LLM gateway checks the model
-# against a bare-id allowlist with startswith, so the prefixed form is rejected with a
-# 403 and the agent finishes without doing anything — while still scoring exit_code_zero=1.
-DEFAULT_AGENT_MODEL = "claude-opus-4-8"
+# Bare model ids, no "anthropic/"/"openai/" prefix: the LLM gateway checks the model against a
+# bare-id allowlist with startswith, so the prefixed form is rejected with a 403 and the agent
+# finishes without doing anything. `start_llm_gateway` declares this exact id free-tier on the
+# harness's own gateway, and a run that dies at the gate anyway now fails as an error rather than
+# scoring zero on every outcome scorer.
+DEFAULT_AGENT_MODEL = "claude-opus-5"
 DEFAULT_CODEX_AGENT_MODEL = "gpt-5.5"
 
 # Literal mirror of products.tasks' RuntimeAdapter values: this module must stay

--- a/products/posthog_ai/eval_harness/harness/lifecycle.py
+++ b/products/posthog_ai/eval_harness/harness/lifecycle.py
@@ -195,7 +195,7 @@ class SandboxedEvalHarness:
 
         if Infra.LLM_GATEWAY in required:
             assert self._live_server is not None
-            self._stack.callback(start_llm_gateway(self._live_server.url))
+            self._stack.callback(start_llm_gateway(self._live_server.url, self.options.agent_model))
         if Infra.MCP_SERVER in required:
             assert self._live_server is not None
             self._stack.callback(start_mcp_server(self._live_server.url))

--- a/products/posthog_ai/eval_harness/harness/services.py
+++ b/products/posthog_ai/eval_harness/harness/services.py
@@ -22,11 +22,16 @@ logger = logging.getLogger(__name__)
 LONG_LIVED_SUBPROCESSES = LongLivedSubprocessManager()
 
 
-def start_llm_gateway(live_server_url: str) -> Callable[[], None]:
+def start_llm_gateway(live_server_url: str, agent_model: str) -> Callable[[], None]:
     """Start the LLM gateway as a subprocess.
 
     Mirrors ``bin/start-llm-gateway``: runs uvicorn on a non-default port.
     The sandbox's agent-server uses this to proxy LLM calls to Anthropic.
+
+    ``agent_model`` is declared free-tier on this gateway, because the gate it would otherwise hit
+    cannot mean anything here: every case runs as a freshly minted team that has never been billed,
+    so ``check_free_tier_model_access`` sees ``code_usage_billed=False`` and rejects the run's model
+    with a 403 before the agent sends its first message.
     """
     gateway_dir = Path(settings.BASE_DIR) / "services" / "llm-gateway"
     venv_dir = gateway_dir / ".venv"
@@ -60,6 +65,9 @@ def start_llm_gateway(live_server_url: str) -> Callable[[], None]:
         "LLM_GATEWAY_DATABASE_URL": test_db_url,
         "LLM_GATEWAY_DEBUG": "true",
         "LLM_GATEWAY_POSTHOG_HOST": live_server_url,
+        # Only the model this run uses, so the gate still rejects a typo rather than waving through
+        # anything the agent-server happens to ask for.
+        "LLM_GATEWAY_POSTHOG_CODE_FREE_TIER_MODELS": json.dumps([agent_model]),
     }
 
     logger.info("Starting LLM gateway on port %d", LLM_GATEWAY_PORT)

--- a/products/posthog_ai/eval_harness/runner.py
+++ b/products/posthog_ai/eval_harness/runner.py
@@ -36,8 +36,27 @@ WORKFLOW_COMPLETION_GRACE_SECONDS = 60
 WORKFLOW_CANCELLATION_GRACE_SECONDS = 30
 
 
+class AgentNeverRanError(RuntimeError):
+    """The agent failed before it did any work, so the case has no outcome to score.
+
+    Raised so the engine records the case as an error and drops it from the aggregates. Scoring it
+    instead would put a zero on every outcome scorer while ``exit_code_zero`` stayed at one, which
+    reads as a model regression rather than the infrastructure failure it is.
+    """
+
+
 class WorkflowCleanupError(RuntimeError):
     pass
+
+
+def agent_never_ran(artifacts: AgentArtifacts) -> bool:
+    """Did the run fail before the agent did anything at all?
+
+    An agent that errored after making tool calls has a partial outcome worth scoring. One that
+    errored with no tool call behind it produced nothing, so its zeros describe the infrastructure
+    rather than the model.
+    """
+    return bool(artifacts.stderr) and not artifacts.tool_call_count
 
 
 async def _wait_for_workflow_terminal(handle: WorkflowHandle, timeout_seconds: int) -> bool:
@@ -159,6 +178,7 @@ async def run_eval_case(
 def _parse_artifacts_from_log(log_content: str, duration_seconds: float, agent_finished: bool) -> AgentArtifacts:
     """Extract scoring artifacts from JSONL agent logs."""
     tool_outputs: list[dict] = []
+    agent_errors: list[str] = []
     has_error = False
 
     for line in log_content.strip().split("\n"):
@@ -189,6 +209,12 @@ def _parse_artifacts_from_log(log_content: str, duration_seconds: float, agent_f
         session_update = update.get("sessionUpdate")
         if session_update in {"tool_call", "tool_call_update"}:
             tool_outputs.append(update)
+        # The agent-server reports its own failures here, and every `errorType` it emits means the
+        # run failed rather than the model answering badly. Without this the case looks clean:
+        # the workflow still finishes, so `exit_code` stays 0 and only the outcome scorers move.
+        if session_update == "error":
+            has_error = True
+            agent_errors.append(str(update.get("message") or update.get("errorType") or "agent error"))
 
     # Extract git diff, file changes, test results from tool outputs
     git_diff = ""
@@ -240,12 +266,13 @@ def _parse_artifacts_from_log(log_content: str, duration_seconds: float, agent_f
     return AgentArtifacts(
         exit_code=0 if agent_finished and not has_error else 1,
         stdout=agent_output[:10000],
-        stderr="",
+        stderr="\n".join(agent_errors)[:5000],
         git_diff=git_diff,
         files_changed=files_changed,
         test_exit_code=test_exit_code,
         test_output=test_output[:5000],
         lint_exit_code=lint_exit_code,
         lint_output=lint_output[:5000],
+        tool_call_count=len(tool_outputs),
         duration_seconds=duration_seconds,
     )

--- a/products/posthog_ai/eval_harness/runner.py
+++ b/products/posthog_ai/eval_harness/runner.py
@@ -55,8 +55,13 @@ def agent_never_ran(artifacts: AgentArtifacts) -> bool:
     An agent that errored after making tool calls has a partial outcome worth scoring. One that
     errored with no tool call behind it produced nothing, so its zeros describe the infrastructure
     rather than the model.
+
+    Keyed off ``exit_code`` rather than ``stderr`` because both terminal failure channels set a
+    non-zero exit code, but only a ``session/update`` error also fills ``stderr``. A terminal
+    ``_posthog/error`` (the channel a provider 403 lands on) leaves ``stderr`` empty, so a
+    ``stderr`` check would score it instead of excluding it.
     """
-    return bool(artifacts.stderr) and not artifacts.tool_call_count
+    return artifacts.exit_code != 0 and artifacts.tool_call_count == 0
 
 
 async def _wait_for_workflow_terminal(handle: WorkflowHandle, timeout_seconds: int) -> bool:

--- a/products/posthog_ai/eval_harness/test/test_sandboxed_harness.py
+++ b/products/posthog_ai/eval_harness/test/test_sandboxed_harness.py
@@ -14,7 +14,7 @@ import requests
 from parameterized import parameterized
 
 from products.posthog_ai.eval_harness import runner
-from products.posthog_ai.eval_harness.config import SandboxedEvalCase
+from products.posthog_ai.eval_harness.config import AgentArtifacts, SandboxedEvalCase
 from products.posthog_ai.eval_harness.harness.cli import parse_args
 from products.posthog_ai.eval_harness.harness.live_server import EvalLiveServer
 from products.posthog_ai.eval_harness.harness.providers import ModalProviderStrategy, SandboxProviderStrategy
@@ -263,3 +263,33 @@ def test_modal_cleanup_case_terminates_only_the_task_sandboxes(monkeypatch: pyte
 
     sandbox_list.assert_called_once_with(app_id="app-id", tags={"task_id": "task-id"})
     sandbox.terminate.assert_called_once_with()
+
+
+class TestAgentRunFailureDetection:
+    # An agent-server failure reaches the log as a session error, and the workflow still finishes
+    # cleanly afterwards. Miss it and a run where no agent ever spoke reports exit_code_zero=1 with
+    # zeros on every outcome scorer, which reads as a model regression.
+    def test_a_session_error_makes_the_run_a_failure(self) -> None:
+        log = "\n".join(
+            [
+                '{"notification": {"method": "session/update", "params": {"update": '
+                '{"sessionUpdate": "error", "errorType": "agent_error", "message": "403 model_gate"}}}}',
+            ]
+        )
+        artifacts = runner._parse_artifacts_from_log(log, duration_seconds=1.0, agent_finished=True)
+        assert artifacts.exit_code == 1
+        assert "403 model_gate" in artifacts.stderr
+
+    @parameterized.expand(
+        [
+            ("no work behind the error", "403 model_gate", 0, True),
+            ("errored after doing work", "stream terminated", 3, False),
+            ("clean run", "", 2, False),
+            ("clean run with no tool calls", "", 0, False),
+        ]
+    )
+    def test_only_a_run_that_did_nothing_counts_as_infrastructure(
+        self, _name: str, stderr: str, tool_call_count: int, expected: bool
+    ) -> None:
+        artifacts = AgentArtifacts(exit_code=1 if stderr else 0, stderr=stderr, tool_call_count=tool_call_count)
+        assert runner.agent_never_ran(artifacts) is expected

--- a/products/posthog_ai/eval_harness/test/test_sandboxed_harness.py
+++ b/products/posthog_ai/eval_harness/test/test_sandboxed_harness.py
@@ -280,6 +280,16 @@ class TestAgentRunFailureDetection:
         assert artifacts.exit_code == 1
         assert "403 model_gate" in artifacts.stderr
 
+    # A provider 403 lands on the terminal `_posthog/error` channel, which sets the non-zero exit
+    # code but leaves `stderr` empty. Reading `stderr` to spot the infra failure would score this
+    # run at zero on every outcome scorer instead of dropping it from the aggregates.
+    def test_a_terminal_posthog_error_with_no_tool_call_is_infrastructure(self) -> None:
+        log = '{"notification": {"method": "_posthog/error", "params": {"message": "403 model_gate"}}}'
+        artifacts = runner._parse_artifacts_from_log(log, duration_seconds=1.0, agent_finished=True)
+        assert artifacts.exit_code == 1
+        assert artifacts.tool_call_count == 0
+        assert runner.agent_never_ran(artifacts) is True
+
     @parameterized.expand(
         [
             ("no work behind the error", "403 model_gate", 0, True),

--- a/products/posthog_ai/scripts/build_skills.py
+++ b/products/posthog_ai/scripts/build_skills.py
@@ -814,6 +814,11 @@ def _setup_django() -> None:
     — it only needs the Django ORM metadata and model imports to work.
     """
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "posthog.settings")
+    # A build must not depend on reaching the flags endpoint. Rendering a HogQL example walks
+    # `Database.create_for`, which asks posthoganalytics whether a flag is on; that call has no
+    # timeout, so on a machine without egress the build sits in connect() forever with no output
+    # and no error. Opting out makes `feature_enabled` answer locally instead.
+    os.environ.setdefault("OPT_OUT_CAPTURE", "1")
     try:
         import django
 


### PR DESCRIPTION
## Problem

- A local sandboxed eval run reports `PASS` while measuring nothing, and the output says so nowhere.
- The agent never sent a message. The gateway rejected its model with a 403 before the first turn.
- `check_free_tier_model_access` clears a request only when the team is billed or the user is staff. Every eval case runs as a freshly minted team that has never been billed, so no local run can clear it.
- The runner ignores the `session/update` error the agent-server emits for its own failures. `exit_code` stays 0, and the message never reaches the artifacts.
- The scorecard that follows reads as a model regression: every outcome scorer at 0%, `exit_code_zero` at 100%.
- `hogli evals` also cannot start until `hogli build:skills` has run, and that command hangs forever on a machine without egress to the flags endpoint.
- Rendering a HogQL example asks posthoganalytics whether a flag is on. The call has no timeout, so the build sits in `connect()` with no output and no error.

## Changes

- The harness declares the run's model free-tier on the gateway it starts itself. That gateway serves only synthetic eval teams, so a paid-plan gate on it can never gate anything real.
- Only the run's own model is declared, so the gate still rejects a typo instead of accepting whatever the agent-server asks for.
- A `session/update` error now sets `exit_code=1` and puts its message in `stderr`.
- A case that errored with no tool call behind it raises `AgentNeverRanError`. The engine records an error and drops the case from the aggregates.
- A case that errored after making tool calls stays scored. Partial work is a real outcome, not an infrastructure failure.
- `AgentArtifacts` gains `tool_call_count`, which is what separates those two cases.
- `build_skills.py` opts out of capture before `django.setup()`, so a build never depends on reaching the flags endpoint.
- The default agent model is now `claude-opus-5`.

The gate could also be cleared by marking the eval user staff, which is how `is_usage_unlimited` passes in production. That would widen a real entitlement to make a test pass. Declaring one model on a throwaway gateway does not.

> [!NOTE]
> `services/llm-gateway` is unchanged. The gate itself is correct for real callers; only the harness's own instance of it is wrong.

## How did you test this code?

Both claims come from this branch with no environment overrides.

- `hogli build:skills` completes. Before this change it never returned and printed nothing.
- `hogli evals eval_basic` ran 2 suites and 4 cases on `claude-opus-5`, 100% mean, 0 errors, no 403 in the logs. Every case in the same environment previously died at the gate in under a minute.

Tests, and the regression each catches:

- `test_a_session_error_makes_the_run_a_failure` catches the silent pass. Drop the session-error branch and a run where no agent spoke reports `exit_code_zero=1` again.
- `test_only_a_run_that_did_nothing_counts_as_infrastructure` catches the opposite over-reach. Loosen the rule to any error and every partially-failed run disappears from the aggregates.

Not checked: no Modal-provider run, and no CI run of a sandboxed suite.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The behavior changed is internal to the eval harness, and the invariants file already states that a task exception becomes a case error excluded from aggregates.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Opus 5 in Claude Code wrote this. Skills invoked: `/writing-evals`, `/writing-tests`, `/writing-pr-descriptions`.

The failure surfaced while running an unrelated eval suite, which reported `PASS` at 0%. The first reading was that the suite's prompts were wrong. The agent logs showed the 403 instead.

The first fix set `exit_code=1` on a session error and stopped there. That turns a silent pass into a visible failure but still averages a zero into the scorecard for a run that produced no answer, so the case now raises instead.

Public artifact: everything here comes from this repository and from local runs against a test database. No customer material is involved.
