### PR TITLE
feat(desktop): report active turns from agent health

### DIFF
--- a/products/desktop/packages/agent/src/server/agent-server.test.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.test.ts
@@ -547,6 +547,7 @@ describe("AgentServer HTTP Mode", () => {
         hasSession: true,
         bootMs: expect.any(Number),
         sessionInitMs: expect.any(Number),
+        turnInFlight: false,
       });
     }, 30000);
 

--- a/products/desktop/packages/agent/src/server/agent-server.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.ts
@@ -667,6 +667,9 @@ export class AgentServer {
         hasSession: !!this.session,
         bootMs: this.sessionReadyBootMs,
         sessionInitMs: this.sessionInitMs,
+        turnInFlight:
+          this.activeOwnedTurnCount > 0 ||
+          this.inFlightMessageDeliveries.size > 0,
       });
     });
 

--- a/products/desktop/packages/agent/src/server/pi-agent-server.test.ts
+++ b/products/desktop/packages/agent/src/server/pi-agent-server.test.ts
@@ -22,6 +22,36 @@ function config(overrides: Partial<AgentServerConfig> = {}): AgentServerConfig {
 }
 
 describe("PiAgentServer", () => {
+  it.each([true, false])("reports Pi turn state", async (isStreaming) => {
+    const server = new PiAgentServer(config()) as unknown as {
+      session: unknown;
+      readTurnInFlight(): Promise<boolean | undefined>;
+    };
+    server.session = {
+      runtime: { client: { getState: vi.fn(async () => ({ isStreaming })) } },
+    };
+
+    await expect(server.readTurnInFlight()).resolves.toBe(isStreaming);
+  });
+
+  it("omits Pi turn state when the runtime fails", async () => {
+    const server = new PiAgentServer(config()) as unknown as {
+      session: unknown;
+      readTurnInFlight(): Promise<boolean | undefined>;
+    };
+    server.session = {
+      runtime: {
+        client: {
+          getState: vi.fn(async () => {
+            throw new Error("unavailable");
+          }),
+        },
+      },
+    };
+
+    await expect(server.readTurnInFlight()).resolves.toBeUndefined();
+  });
+
   it("logs session initialization diagnostics when setup fails", async () => {
     const payload = { task_id: "task-1", run_id: "run-1" };
     const server = new PiAgentServer(

--- a/products/desktop/packages/agent/src/server/pi-agent-server.ts
+++ b/products/desktop/packages/agent/src/server/pi-agent-server.ts
@@ -49,6 +49,7 @@ interface PiCloudSession {
 }
 
 const emptySchema = z.object({});
+const TURN_STATE_PROBE_TIMEOUT_MS = 2_000;
 const MAX_PENDING_EVENTS = 1_000;
 const MAX_PENDING_LOG_ENTRIES = 10_000;
 const LOG_FLUSH_ENTRY_COUNT = 100;
@@ -290,12 +291,13 @@ export class PiAgentServer {
   private createApp(): Hono {
     const app = new Hono();
 
-    app.get("/health", (context) =>
+    app.get("/health", async (context) =>
       context.json({
         status: "ok",
         hasSession: this.session !== null,
         bootMs: this.sessionReadyBootMs,
         sessionInitMs: this.sessionInitMs,
+        turnInFlight: await this.readTurnInFlight(),
       }),
     );
 
@@ -720,6 +722,24 @@ export class PiAgentServer {
       params.steer === true,
     );
     return result;
+  }
+
+  private async readTurnInFlight(): Promise<boolean | undefined> {
+    const runtime = this.session?.runtime;
+    if (!runtime) {
+      return false;
+    }
+    try {
+      const state = await Promise.race([
+        runtime.client.getState(),
+        new Promise<null>((resolve) =>
+          setTimeout(() => resolve(null), TURN_STATE_PROBE_TIMEOUT_MS),
+        ),
+      ]);
+      return state === null ? undefined : state.isStreaming;
+    } catch {
+      return undefined;
+    }
   }
 
   private async prepareUserMessage(


### PR DESCRIPTION
## Problem

The task orchestrator cannot distinguish an idle sandbox from an agent working without emitting events.

**Why:** Inactivity cleanup must not discard active work.

## Changes

- Report active turn state from both agent-server health endpoints.
- Bound Pi runtime state probes to two seconds.

## How did you test this code?

Pi server tests and the agent package typecheck pass. The default server suite is blocked by its local git-commit fixture.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Created with Codex using targeted desktop tests.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*