### PR TITLE
feat(desktop): give the composer send button instant feedback

### DIFF
--- a/products/desktop/packages/ui/src/features/message-editor/components/PromptInput.test.tsx
+++ b/products/desktop/packages/ui/src/features/message-editor/components/PromptInput.test.tsx
@@ -70,11 +70,22 @@ vi.mock("./SlotMachineSubmit", () => ({
 }));
 
 vi.mock("@posthog/quill", () => ({
+  // Mirrors quill's Button: `loading` swaps the label for a spinner and blocks
+  // activation.
   Button: ({
     children,
+    loading,
+    disabled,
     ...props
-  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
-    <button type="button" {...props}>
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    loading?: boolean;
+  }) => (
+    <button
+      type="button"
+      disabled={disabled || loading}
+      aria-busy={loading || undefined}
+      {...props}
+    >
       {children}
     </button>
   ),
@@ -135,6 +146,30 @@ describe("PromptInput submit/stop affordance", () => {
 
     const send = screen.getByRole("button", { name: "Send message" });
     expect(send).toBeDisabled();
+  });
+
+  it("marks Send busy on click, before the surface reports anything", async () => {
+    const user = userEvent.setup();
+    // Surfaces flip their own busy flags only after a round trip, so a send
+    // that never resolves must still register as pressed.
+    const onSubmitClick = vi.fn();
+
+    renderInput({ onSubmitClick });
+
+    const send = screen.getByRole("button", { name: "Send message" });
+    await user.click(send);
+
+    expect(onSubmitClick).toHaveBeenCalledOnce();
+    expect(send).toHaveAttribute("aria-busy", "true");
+    expect(send).toBeDisabled();
+  });
+
+  it("keeps Send busy while the surface is both loading and untypeable", () => {
+    // The new-task composer's whole task creation looks like this.
+    renderInput({ disabled: true, isLoading: true });
+
+    const send = screen.getByRole("button", { name: "Send message" });
+    expect(send).toHaveAttribute("aria-busy", "true");
   });
 });
 

--- a/products/desktop/packages/ui/src/features/message-editor/components/PromptInput.tsx
+++ b/products/desktop/packages/ui/src/features/message-editor/components/PromptInput.tsx
@@ -36,6 +36,11 @@ import { SlotMachineSubmit } from "./SlotMachineSubmit";
 
 export type { EditorHandle };
 
+// How long the send button holds its own busy state when the surface never
+// reports one — long enough to register as a press, short enough that a send
+// the surface silently refuses doesn't strand the spinner.
+const SUBMIT_PRESS_FEEDBACK_MS = 800;
+
 export interface PromptInputProps {
   sessionId: string;
   placeholder?: string;
@@ -381,13 +386,35 @@ export const PromptInput = forwardRef<EditorHandle, PromptInputProps>(
       e.stopPropagation();
     }, []);
 
+    // Instant press feedback. Every surface that owns this composer flips its
+    // own busy flags only after a round trip (a usage pre-flight, a worktree
+    // probe, the send itself), so without this the button sits inert on click.
+    const [pressedSubmit, setPressedSubmit] = useState(false);
+    const surfaceBusy = disabled || isLoading || submitDisabledExternal;
+
     const doSubmit = useCallback(() => {
+      setPressedSubmit(true);
       if (onSubmitClick) {
         onSubmitClick();
       } else {
         submit();
       }
     }, [onSubmitClick, submit]);
+
+    // Hand over as soon as the surface reports busy itself, so the two states
+    // never fight over the button.
+    useEffect(() => {
+      if (!pressedSubmit) return;
+      if (surfaceBusy) {
+        setPressedSubmit(false);
+        return;
+      }
+      const timer = setTimeout(
+        () => setPressedSubmit(false),
+        SUBMIT_PRESS_FEEDBACK_MS,
+      );
+      return () => clearTimeout(timer);
+    }, [pressedSubmit, surfaceBusy]);
 
     const handleSubmitClick = (e: React.MouseEvent) => {
       e.stopPropagation();
@@ -399,9 +426,15 @@ export const PromptInput = forwardRef<EditorHandle, PromptInputProps>(
     // that is not running, a compacting Pi session), and the editor cannot be
     // typed into, so a live send button only invites a click that misfires.
     const submitBlocked = disabled || submitDisabledExternal || isEmpty;
-    const submitTooltip =
-      submitTooltipOverride ??
-      (submitBlocked ? "Enter a message" : "Send message");
+    // A surface that is loading *and* locked out of typing is working on the
+    // send itself, so the button keeps spinning until it lands. A surface that
+    // is loading but still typeable is mid-turn and accepting queued messages,
+    // where send has to stay live.
+    const submitBusy = pressedSubmit || (disabled && isLoading);
+    const submitTooltip = submitBusy
+      ? "Sending"
+      : (submitTooltipOverride ??
+        (submitBlocked ? "Enter a message" : "Send message"));
 
     // Stop takes priority over everything: you cancel a run, you don't gamble
     // on it. With slot machine mode on, the send affordance moves out to the
@@ -428,7 +461,8 @@ export const PromptInput = forwardRef<EditorHandle, PromptInputProps>(
           variant="primary"
           size="icon"
           onClick={handleSubmitClick}
-          disabled={submitBlocked}
+          disabled={submitBlocked || submitBusy}
+          loading={submitBusy}
           aria-label="Send message"
           className="rounded-xs"
           {...(tourTarget && { "data-tour": `${tourTarget}-submit` })}
@@ -564,7 +598,7 @@ export const PromptInput = forwardRef<EditorHandle, PromptInputProps>(
         </InputGroup>
         {slotMachineMode && !inStopMode && (
           <SlotMachineSubmit
-            disabled={submitBlocked}
+            disabled={submitBlocked || submitBusy}
             onSubmit={doSubmit}
             tourTarget={tourTarget}
           />

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -25,6 +25,7 @@ import {
   useTaskRepositoryDraftStore,
 } from "@posthog/ui/features/canvas/stores/taskRepositoryDraftStore";
 import { openSettings } from "@posthog/ui/features/settings/hooks/useOpenSettings";
+import { NEW_TASK_COMPOSER_EXIT_MS } from "@posthog/ui/features/task-detail/newTaskComposerTransition";
 import type { TaskInputReportAssociation } from "@posthog/ui/features/task-detail/stores/taskInputPrefillStore";
 import { useTaskInputPrefillStore } from "@posthog/ui/features/task-detail/stores/taskInputPrefillStore";
 import { navigateToInbox } from "@posthog/ui/router/navigationBridge";
@@ -1256,22 +1257,41 @@ export function TaskInput({
         <Box className="relative h-full min-w-0 flex-1">
           <Flex height="100%" className="relative px-4">
             <DotPatternBackground className="h-[100.333%]" />
-            <div
-              style={{
-                // Raise the input when the suggestion cards are shown so the longer
-                // list below it isn't squished against the bottom of the viewport.
-                // Note: this is NOT tied to `editorIsEmpty` — the input keeps its
-                // position as the user types so the box doesn't jump down when the
-                // suggestions fade out (and back in when the prompt is cleared).
-                top: suggestions && suggestions.length > 0 ? "38%" : "50%",
-                transform: "translate(-50%, -50%)",
+            <motion.div
+              // Framer owns the transform so the submit slide can animate; `x`
+              // stands in for the horizontal half of the old translate.
+              style={{ x: "-50%" }}
+              initial={false}
+              animate={{
+                // On submit the composer travels to the bottom of the page,
+                // meeting the chat's own composer so the swap reads as one
+                // continuous movement rather than a cut.
+                // Otherwise: raise the input when the suggestion cards are shown
+                // so the longer list below it isn't squished against the bottom
+                // of the viewport. Note: this is NOT tied to `editorIsEmpty` —
+                // the input keeps its position as the user types so the box
+                // doesn't jump down when the suggestions fade out (and back in
+                // when the prompt is cleared).
+                top: isCreatingTask
+                  ? "100%"
+                  : suggestions && suggestions.length > 0
+                    ? "38%"
+                    : "50%",
+                y: isCreatingTask ? "-100%" : "-50%",
+                marginTop: isCreatingTask ? -12 : 0,
+              }}
+              transition={{
+                duration: NEW_TASK_COMPOSER_EXIT_MS / 1000,
+                ease: [0.22, 1, 0.36, 1],
               }}
               className="absolute left-1/2 z-1 flex w-[calc(100%-2rem)] max-w-[600px] flex-col gap-2"
             >
               <Flex
                 gap="2"
                 align="center"
-                className="absolute bottom-full left-0 mb-1 min-w-0 gap-1"
+                className={`absolute bottom-full left-0 mb-1 min-w-0 gap-1 transition-opacity duration-200 ${
+                  isCreatingTask ? "pointer-events-none opacity-0" : ""
+                }`}
               >
                 {spaceSelector?.({ disabled: isCreatingTask })}
                 <WorkspaceModeSelect
@@ -1575,7 +1595,11 @@ export function TaskInput({
                     </div>
                   )}
               </Flex>
-              <div className="absolute top-full right-0 left-0 z-10">
+              <div
+                className={`absolute top-full right-0 left-0 z-10 transition-opacity duration-200 ${
+                  isCreatingTask ? "pointer-events-none opacity-0" : ""
+                }`}
+              >
                 {suggestions ? (
                   <AnimatePresence>
                     {suggestions.length > 0 && editorIsEmpty && (
@@ -1641,7 +1665,7 @@ export function TaskInput({
                   />
                 )}
               </div>
-            </div>
+            </motion.div>
           </Flex>
         </Box>
       </Flex>

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -25,7 +25,7 @@ import {
   useTaskRepositoryDraftStore,
 } from "@posthog/ui/features/canvas/stores/taskRepositoryDraftStore";
 import { openSettings } from "@posthog/ui/features/settings/hooks/useOpenSettings";
-import { NEW_TASK_COMPOSER_EXIT_MS } from "@posthog/ui/features/task-detail/newTaskComposerTransition";
+import { NEW_TASK_COMPOSER_FADE_MS } from "@posthog/ui/features/task-detail/newTaskComposerTransition";
 import type { TaskInputReportAssociation } from "@posthog/ui/features/task-detail/stores/taskInputPrefillStore";
 import { useTaskInputPrefillStore } from "@posthog/ui/features/task-detail/stores/taskInputPrefillStore";
 import { navigateToInbox } from "@posthog/ui/router/navigationBridge";
@@ -976,6 +976,7 @@ export function TaskInput({
 
   const {
     isCreatingTask,
+    isExitingComposer,
     canSubmit,
     handleSubmit,
     additionalDirectories,
@@ -1257,41 +1258,30 @@ export function TaskInput({
         <Box className="relative h-full min-w-0 flex-1">
           <Flex height="100%" className="relative px-4">
             <DotPatternBackground className="h-[100.333%]" />
-            <motion.div
-              // Framer owns the transform so the submit slide can animate; `x`
-              // stands in for the horizontal half of the old translate.
-              style={{ x: "-50%" }}
-              initial={false}
-              animate={{
-                // On submit the composer travels to the bottom of the page,
-                // meeting the chat's own composer so the swap reads as one
-                // continuous movement rather than a cut.
-                // Otherwise: raise the input when the suggestion cards are shown
-                // so the longer list below it isn't squished against the bottom
-                // of the viewport. Note: this is NOT tied to `editorIsEmpty` —
-                // the input keeps its position as the user types so the box
-                // doesn't jump down when the suggestions fade out (and back in
-                // when the prompt is cleared).
-                top: isCreatingTask
-                  ? "100%"
-                  : suggestions && suggestions.length > 0
-                    ? "38%"
-                    : "50%",
-                y: isCreatingTask ? "-100%" : "-50%",
-                marginTop: isCreatingTask ? -12 : 0,
+            <div
+              style={{
+                // Raise the input when the suggestion cards are shown so the longer
+                // list below it isn't squished against the bottom of the viewport.
+                // Note: this is NOT tied to `editorIsEmpty` — the input keeps its
+                // position as the user types so the box doesn't jump down when the
+                // suggestions fade out (and back in when the prompt is cleared).
+                top: suggestions && suggestions.length > 0 ? "38%" : "50%",
+                transform: "translate(-50%, -50%)",
+                // Once the task is on its way, the whole composer fades out and
+                // the pending chat fades in over it.
+                opacity: isExitingComposer ? 0 : 1,
+                transitionProperty: "opacity",
+                transitionDuration: `${NEW_TASK_COMPOSER_FADE_MS}ms`,
+                transitionTimingFunction: "ease-out",
               }}
-              transition={{
-                duration: NEW_TASK_COMPOSER_EXIT_MS / 1000,
-                ease: [0.22, 1, 0.36, 1],
-              }}
-              className="absolute left-1/2 z-1 flex w-[calc(100%-2rem)] max-w-[600px] flex-col gap-2"
+              className={`absolute left-1/2 z-1 flex w-[calc(100%-2rem)] max-w-[600px] flex-col gap-2 ${
+                isExitingComposer ? "pointer-events-none" : ""
+              }`}
             >
               <Flex
                 gap="2"
                 align="center"
-                className={`absolute bottom-full left-0 mb-1 min-w-0 gap-1 transition-opacity duration-200 ${
-                  isCreatingTask ? "pointer-events-none opacity-0" : ""
-                }`}
+                className="absolute bottom-full left-0 mb-1 min-w-0 gap-1"
               >
                 {spaceSelector?.({ disabled: isCreatingTask })}
                 <WorkspaceModeSelect
@@ -1595,11 +1585,7 @@ export function TaskInput({
                     </div>
                   )}
               </Flex>
-              <div
-                className={`absolute top-full right-0 left-0 z-10 transition-opacity duration-200 ${
-                  isCreatingTask ? "pointer-events-none opacity-0" : ""
-                }`}
-              >
+              <div className="absolute top-full right-0 left-0 z-10">
                 {suggestions ? (
                   <AnimatePresence>
                     {suggestions.length > 0 && editorIsEmpty && (
@@ -1665,7 +1651,7 @@ export function TaskInput({
                   />
                 )}
               </div>
-            </motion.div>
+            </div>
           </Flex>
         </Box>
       </Flex>

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskPendingView.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskPendingView.tsx
@@ -1,4 +1,5 @@
-import { Box } from "@radix-ui/themes";
+import { NEW_TASK_COMPOSER_FADE_MS } from "@posthog/ui/features/task-detail/newTaskComposerTransition";
+import { motion } from "framer-motion";
 import { usePendingTaskPrompt } from "../../../shell/pendingTaskPromptStore";
 import { PendingChatView } from "../../sessions/components/PendingChatView";
 
@@ -10,11 +11,21 @@ export function TaskPendingView({ pendingTaskKey }: TaskPendingViewProps) {
   const pending = usePendingTaskPrompt(pendingTaskKey);
 
   return (
-    <Box className="relative h-full w-full bg-background">
+    // Picks up where the new-task composer's fade-out left off, so submitting
+    // reads as one phase handing over to the next.
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{
+        duration: NEW_TASK_COMPOSER_FADE_MS / 1000,
+        ease: "easeOut",
+      }}
+      className="relative h-full w-full bg-background"
+    >
       <PendingChatView
         promptText={pending?.promptText ?? ""}
         attachments={pending?.attachments}
       />
-    </Box>
+    </motion.div>
   );
 }

--- a/products/desktop/packages/ui/src/features/task-detail/hooks/useTaskCreation.ts
+++ b/products/desktop/packages/ui/src/features/task-detail/hooks/useTaskCreation.ts
@@ -23,6 +23,7 @@ import type { ExecutionMode, Task } from "@posthog/shared/domain-types";
 import { useTaskChannels } from "@posthog/ui/features/canvas/hooks/useTaskChannels";
 import { useTaskRepositoryDraftStore } from "@posthog/ui/features/canvas/stores/taskRepositoryDraftStore";
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
+import { waitForComposerExit } from "@posthog/ui/features/task-detail/newTaskComposerTransition";
 import { useTaskInputPrefillStore } from "@posthog/ui/features/task-detail/stores/taskInputPrefillStore";
 import { navigateToTaskPending } from "@posthog/ui/router/navigationBridge";
 import { openTask, openTaskInput } from "@posthog/ui/router/useOpenTask";
@@ -259,6 +260,7 @@ export function useTaskCreation({
 
       // Held for the whole submit, pre-flight awaits included, so a second
       // Enter lands after `canSubmitBase` has already gone false.
+      const submitStartedAt = Date.now();
       setIsCreatingTask(true);
 
       try {
@@ -343,6 +345,9 @@ export function useTaskCreation({
               label: a.label,
             })),
           });
+          // Let the composer land at the bottom of the page before the chat
+          // replaces it, so the two views read as one movement.
+          await waitForComposerExit(submitStartedAt);
           navigateToTaskPending(pendingTaskKey);
           if (!contentOverride) {
             editor.clear();

--- a/products/desktop/packages/ui/src/features/task-detail/hooks/useTaskCreation.ts
+++ b/products/desktop/packages/ui/src/features/task-detail/hooks/useTaskCreation.ts
@@ -116,6 +116,8 @@ interface UseTaskCreationOptions {
 
 interface UseTaskCreationReturn {
   isCreatingTask: boolean;
+  /** The task is on its way; the composer fades out before the chat replaces it. */
+  isExitingComposer: boolean;
   canSubmit: boolean;
   handleSubmit: (contentOverride?: EditorContent) => Promise<boolean>;
   additionalDirectories: string[];
@@ -203,6 +205,7 @@ export function useTaskCreation({
   onTaskCreatedEffect,
 }: UseTaskCreationOptions): UseTaskCreationReturn {
   const [isCreatingTask, setIsCreatingTask] = useState(false);
+  const [isExitingComposer, setIsExitingComposer] = useState(false);
   const hostClient = useHostTRPCClient();
   const trpc = useHostTRPC();
   const queryClient = useQueryClient();
@@ -260,7 +263,6 @@ export function useTaskCreation({
 
       // Held for the whole submit, pre-flight awaits included, so a second
       // Enter lands after `canSubmitBase` has already gone false.
-      const submitStartedAt = Date.now();
       setIsCreatingTask(true);
 
       try {
@@ -345,9 +347,10 @@ export function useTaskCreation({
               label: a.label,
             })),
           });
-          // Let the composer land at the bottom of the page before the chat
-          // replaces it, so the two views read as one movement.
-          await waitForComposerExit(submitStartedAt);
+          // Fade the composer out before the chat fades in, so the phases
+          // hand over instead of cutting.
+          setIsExitingComposer(true);
+          await waitForComposerExit();
           navigateToTaskPending(pendingTaskKey);
           if (!contentOverride) {
             editor.clear();
@@ -559,6 +562,7 @@ export function useTaskCreation({
         }
       } finally {
         setIsCreatingTask(false);
+        setIsExitingComposer(false);
       }
     },
     [
@@ -608,6 +612,7 @@ export function useTaskCreation({
 
   return {
     isCreatingTask,
+    isExitingComposer,
     canSubmit,
     handleSubmit,
     additionalDirectories,

--- a/products/desktop/packages/ui/src/features/task-detail/newTaskComposerTransition.ts
+++ b/products/desktop/packages/ui/src/features/task-detail/newTaskComposerTransition.ts
@@ -1,0 +1,16 @@
+/**
+ * How long the new-task composer takes to slide from the middle of the page
+ * down to where the chat's composer sits, once a task has been submitted.
+ */
+export const NEW_TASK_COMPOSER_EXIT_MS = 220;
+
+/**
+ * Resolves once that slide has had its full window, counted from the moment
+ * the submit started. Pre-flight work spent inside the window costs nothing
+ * extra, so a slow submit never gets slower than it already was.
+ */
+export function waitForComposerExit(submitStartedAt: number): Promise<void> {
+  const remaining = NEW_TASK_COMPOSER_EXIT_MS - (Date.now() - submitStartedAt);
+  if (remaining <= 0) return Promise.resolve();
+  return new Promise((resolve) => setTimeout(resolve, remaining));
+}

--- a/products/desktop/packages/ui/src/features/task-detail/newTaskComposerTransition.ts
+++ b/products/desktop/packages/ui/src/features/task-detail/newTaskComposerTransition.ts
@@ -1,16 +1,12 @@
 /**
- * How long the new-task composer takes to slide from the middle of the page
- * down to where the chat's composer sits, once a task has been submitted.
+ * How long the new-task composer takes to fade out once its task has been
+ * submitted, and how long the pending chat takes to fade back in over it.
  */
-export const NEW_TASK_COMPOSER_EXIT_MS = 220;
+export const NEW_TASK_COMPOSER_FADE_MS = 160;
 
-/**
- * Resolves once that slide has had its full window, counted from the moment
- * the submit started. Pre-flight work spent inside the window costs nothing
- * extra, so a slow submit never gets slower than it already was.
- */
-export function waitForComposerExit(submitStartedAt: number): Promise<void> {
-  const remaining = NEW_TASK_COMPOSER_EXIT_MS - (Date.now() - submitStartedAt);
-  if (remaining <= 0) return Promise.resolve();
-  return new Promise((resolve) => setTimeout(resolve, remaining));
+/** Resolves once the composer's fade-out has had its full window. */
+export function waitForComposerExit(): Promise<void> {
+  return new Promise((resolve) =>
+    setTimeout(resolve, NEW_TASK_COMPOSER_FADE_MS),
+  );
 }


### PR DESCRIPTION
## Problem

Clicking send on the desktop composer looks like nothing happened. The button stays idle until the surface behind it reports its own loading state, and that only arrives after a round trip: a cloud usage pre-flight, a worktree probe, or the send itself.

On the new task page the composer then disappears and the pending chat replaces it in one frame.

<img width="1494" height="338" alt="2026-08-18 14 34 47" src="https://github.com/user-attachments/assets/d5b39171-9b7f-4b76-b2e8-5733a2157aea" />



## Changes

- The send button shows a spinner and stops taking clicks the moment it is pressed.
- It hands that state over as soon as the surface reports busy, and drops it after 800 ms if the surface never does.
- A surface that is loading but still typeable keeps send live. That is the mid-turn queue and steer path, where a message has to be sendable while the agent works.
- The new task composer fades out over 160 ms once the task is filed and the pending view is about to open.
- The pending chat view fades in over the same 160 ms.
- Task creation waits out the fade before it navigates, so the two views hand over instead of cutting.
- `newTaskComposerTransition.ts` holds the one duration both sides read.
- `TaskPendingView` drops its Radix `Box` for the animated container, per the Radix ban in the desktop guide.

No screenshot: the change is a spinner and a cross-fade, which a still frame does not carry.

## How did you test this code?

`PromptInput.test.tsx` gains two cases:

- A click marks send busy while the surface reports nothing at all. Guards the dead click this PR fixes.
- A surface that is both loading and untypeable keeps send busy. Guards the new task page path.

The existing queue and steer case already guards the opposite direction.

Not checked: the cross-fade in the running app. Neither the Electron app nor Storybook runs in this environment, so the fade timing is unverified by eye.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude, from a request pointing at the send button in `PromptInput.tsx`.

Skills invoked: `/writing-pr-descriptions`.

The first design spun the button whenever the surface reported loading. An existing test caught that: it disables send on the mid-turn queue and steer path, where sending has to stay possible. The shipped rule requires the surface to be loading and untypeable together.

An earlier revision slid the composer from the middle of the page to the bottom on submit, to meet the chat's composer. The slide is gone; the cross-fade replaces it, and the button spinner now carries the wait on its own.
