### PR TITLE
feat(desktop): lead a space's list with the create row for its tab

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/AGENTS.md
+++ b/products/desktop/packages/ui/src/features/canvas/AGENTS.md
@@ -178,9 +178,14 @@ changing breadcrumbs, canvas naming, or the canvas generation harness. The root
   inside a space. Autocomplete has no API for setting the highlight, so moving it
   means synthesizing the arrow keys it listens for — and moving *before*
   collapsing, while the rows still exist.
-- One `ChannelsFab` serves both panes: given a `channelId` it creates a task in
-  that channel; from the list, where nothing else offers it, it creates a space
-  instead. Off the layout it keeps its original two-item menu.
+- **Creating follows the pane you're on.** Under the layout the floating
+  `ChannelsFab` serves the list only, where a new space has no other entry
+  point; inside a space it renders nothing, because the list there leads with
+  its own create row (`ChannelCreateRow`) — "New session" on the sessions tab,
+  "New canvas…" on the canvases tab, so the action makes the kind of thing the
+  tab below it shows. That row also carries the ⌘N hint and the unsent-draft
+  badge the FAB used to. Off the layout the FAB keeps its original two-item menu
+  on both panes.
   Archived moves out of the sidebar and into the account menu
   (`ProjectSwitcher`), beside Settings.
 - **Which pane shows is view state, not a route.** `channelPaneStore` holds it,

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelCreateRow.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelCreateRow.tsx
@@ -48,8 +48,8 @@ export function NewSessionRow({
           params: { channelId },
         });
       }}
-      // An unsent draft is the reason to come back to this row, and it is the
-      // only thing left saying you have one now the floating button is gone.
+      // An unsent draft is the reason to come back to this row, and this row is
+      // the only place a space says you have one.
       endContent={
         hasDraft ? (
           <Badge variant="default" title="You have unsubmitted changes">

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelCreateRow.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelCreateRow.tsx
@@ -1,0 +1,102 @@
+import { Plus } from "@phosphor-icons/react";
+import { Badge } from "@posthog/quill";
+import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
+import { NewCanvasDialog } from "@posthog/ui/features/canvas/components/NewCanvasMenu";
+import { trackAndCreateCanvas } from "@posthog/ui/features/canvas/createCanvasAnalytics";
+import { useCanvasTemplates } from "@posthog/ui/features/canvas/hooks/useCanvasTemplates";
+import { useCreateAndOpenDashboard } from "@posthog/ui/features/canvas/hooks/useDashboards";
+import { SHORTCUTS } from "@posthog/ui/features/command/keyboard-shortcuts";
+import { isContentEmpty } from "@posthog/ui/features/message-editor/content";
+import { useDraftStore } from "@posthog/ui/features/message-editor/draftStore";
+import { SidebarKbdHint } from "@posthog/ui/features/sidebar/components/items/SidebarKbdHint";
+import { SidebarItem } from "@posthog/ui/features/sidebar/components/SidebarItem";
+import { track } from "@posthog/ui/shell/analytics";
+import { useNavigate } from "@tanstack/react-router";
+import { useState } from "react";
+
+/**
+ * The create rows that lead a space's list, one per tab: making a thing sits
+ * with the list of those things, so the action follows the tab you're on
+ * instead of floating in a corner over the rows.
+ */
+export function NewSessionRow({
+  channelId,
+  isActive,
+}: {
+  channelId: string;
+  isActive: boolean;
+}) {
+  const navigate = useNavigate();
+  const hasDraft = useDraftStore(
+    (s) => !isContentEmpty(s.drafts["task-input"]),
+  );
+
+  return (
+    <SidebarItem
+      depth={0}
+      icon={<Plus size={16} weight={isActive ? "bold" : "regular"} />}
+      label="New session"
+      isActive={isActive}
+      onClick={() => {
+        track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+          action_type: "new_task_open",
+          surface: "sidebar",
+          channel_id: channelId,
+        });
+        void navigate({
+          to: "/website/$channelId/new",
+          params: { channelId },
+        });
+      }}
+      // An unsent draft is the reason to come back to this row, and it is the
+      // only thing left saying you have one now the floating button is gone.
+      endContent={
+        hasDraft ? (
+          <Badge variant="default" title="You have unsubmitted changes">
+            Draft
+          </Badge>
+        ) : null
+      }
+      // ⌘N inside a space lands on this same route (openTaskInput scopes to
+      // the channel you're in), so the row can claim the key.
+      endHint={<SidebarKbdHint keys={SHORTCUTS.NEW_TASK} />}
+    />
+  );
+}
+
+export function NewCanvasRow({ channelId }: { channelId: string }) {
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const templates = useCanvasTemplates();
+  const createAndOpen = useCreateAndOpenDashboard(channelId);
+  const hasTemplates = templates.length > 0;
+
+  return (
+    <>
+      <SidebarItem
+        depth={0}
+        icon={<Plus size={16} />}
+        // Until templates load there is nothing to pick, so the click creates
+        // the canvas outright — and the label drops the ellipsis with it.
+        label={hasTemplates ? "New canvas…" : "New canvas"}
+        onClick={() => {
+          if (hasTemplates) {
+            setPickerOpen(true);
+            return;
+          }
+          trackAndCreateCanvas(
+            channelId,
+            undefined,
+            "sidebar",
+            () => void createAndOpen(),
+          );
+        }}
+      />
+      <NewCanvasDialog
+        channelId={channelId}
+        surface="sidebar"
+        open={pickerOpen}
+        onOpenChange={setPickerOpen}
+      />
+    </>
+  );
+}

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelSidebar.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelSidebar.test.tsx
@@ -1,4 +1,5 @@
 import type { ChannelItemModel } from "@posthog/core/canvas/channelItems";
+import type { CanvasTemplateSummary } from "@posthog/core/canvas/templateSchemas";
 import { Theme } from "@radix-ui/themes";
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -9,6 +10,8 @@ const mocks = vi.hoisted(() => ({
   isLoading: false,
   channelMissing: false,
   open: vi.fn(),
+  templates: [] as CanvasTemplateSummary[],
+  createCanvas: vi.fn(),
 }));
 
 vi.mock("@posthog/ui/features/canvas/hooks/useChannelItems", () => ({
@@ -40,10 +43,10 @@ vi.mock("@posthog/ui/shell/analytics", () => ({ track: vi.fn() }));
 // The canvases tab's create row reaches for the template list and the create
 // mutation, both of which come over tRPC.
 vi.mock("@posthog/ui/features/canvas/hooks/useCanvasTemplates", () => ({
-  useCanvasTemplates: () => [],
+  useCanvasTemplates: () => mocks.templates,
 }));
 vi.mock("@posthog/ui/features/canvas/hooks/useDashboards", () => ({
-  useCreateAndOpenDashboard: () => vi.fn(),
+  useCreateAndOpenDashboard: () => mocks.createCanvas,
 }));
 
 // The row menu's spaces list reaches for a QueryClient the unit test has no
@@ -116,6 +119,8 @@ describe("ChannelSidebar", () => {
     mocks.items = [];
     mocks.isLoading = false;
     mocks.channelMissing = false;
+    mocks.templates = [];
+    mocks.createCanvas.mockClear();
   });
 
   it.each([
@@ -274,6 +279,28 @@ describe("ChannelSidebar", () => {
     await user.click(screen.getByRole("tab", { name: "Canvases" }));
 
     expect(listed()).toEqual(["New canvas", "Signup funnel canvas"]);
+  });
+
+  // The ellipsis on the label promises a step in between, so the row must not
+  // create an untemplated canvas behind it.
+  it("asks which template a new canvas starts from", async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    mocks.templates = [
+      {
+        id: "freeform",
+        name: "Freeform",
+        description: "Start from a blank canvas",
+        builtIn: true,
+        suggestions: [],
+      },
+    ];
+    renderSidebar();
+
+    await user.click(screen.getByRole("tab", { name: "Canvases" }));
+    await user.click(screen.getByText("New canvas…"));
+
+    expect(await screen.findByText("Choose a template")).toBeInTheDocument();
+    expect(mocks.createCanvas).not.toHaveBeenCalled();
   });
 
   it("shows one kind at a time, and drops the run filters with the sessions", async () => {

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelSidebar.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelSidebar.test.tsx
@@ -36,6 +36,15 @@ vi.mock("@posthog/ui/features/canvas/components/ChannelBackRow", () => ({
 vi.mock("@posthog/ui/features/canvas/components/ChannelsFab", () => ({
   ChannelsFab: () => null,
 }));
+vi.mock("@posthog/ui/shell/analytics", () => ({ track: vi.fn() }));
+// The canvases tab's create row reaches for the template list and the create
+// mutation, both of which come over tRPC.
+vi.mock("@posthog/ui/features/canvas/hooks/useCanvasTemplates", () => ({
+  useCanvasTemplates: () => [],
+}));
+vi.mock("@posthog/ui/features/canvas/hooks/useDashboards", () => ({
+  useCreateAndOpenDashboard: () => vi.fn(),
+}));
 
 // The row menu's spaces list reaches for a QueryClient the unit test has no
 // stack for. Stubbed at the module boundary, as WebsiteLayout.test.tsx does for
@@ -237,6 +246,34 @@ describe("ChannelSidebar", () => {
       "aria-selected",
       "true",
     );
+  });
+
+  // The floating create button is gone inside a space, so this row is the only
+  // create affordance the pane has — and it has to make what the tab lists.
+  it("leads the list with the create action for the tab you're on", async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    mocks.items = [
+      item(),
+      item({
+        key: "canvas:c1",
+        kind: "canvas",
+        id: "c1",
+        title: "Signup funnel canvas",
+      }),
+    ];
+    const listed = () =>
+      screen
+        .getAllByText(
+          /^(New session|New canvas|Investigate signup drop-off|Signup funnel canvas)$/,
+        )
+        .map((el) => el.textContent);
+    renderSidebar();
+
+    expect(listed()).toEqual(["New session", "Investigate signup drop-off"]);
+
+    await user.click(screen.getByRole("tab", { name: "Canvases" }));
+
+    expect(listed()).toEqual(["New canvas", "Signup funnel canvas"]);
   });
 
   it("shows one kind at a time, and drops the run filters with the sessions", async () => {

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelSidebar.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelSidebar.tsx
@@ -37,6 +37,10 @@ import {
 import { LOOPS_FLAG } from "@posthog/shared";
 import type { Task } from "@posthog/shared/domain-types";
 import { ChannelBackRow } from "@posthog/ui/features/canvas/components/ChannelBackRow";
+import {
+  NewCanvasRow,
+  NewSessionRow,
+} from "@posthog/ui/features/canvas/components/ChannelCreateRow";
 import { ChannelFilterMenu } from "@posthog/ui/features/canvas/components/ChannelFilterMenu";
 import { ChannelItemRow } from "@posthog/ui/features/canvas/components/ChannelItemRow";
 import { ChannelsFab } from "@posthog/ui/features/canvas/components/ChannelsFab";
@@ -49,11 +53,9 @@ import { useChannelItems } from "@posthog/ui/features/canvas/hooks/useChannelIte
 import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
 import { useChannelTasksRunState } from "@posthog/ui/features/canvas/hooks/useChannelTasksRunState";
 import { useLocalDayStart } from "@posthog/ui/features/canvas/hooks/useLocalDayStart";
-import { SHORTCUTS } from "@posthog/ui/features/command/keyboard-shortcuts";
 import { useCommandCenterStore } from "@posthog/ui/features/command-center/commandCenterStore";
 import { placeTaskInCommandCenter } from "@posthog/ui/features/command-center/placeTaskInCommandCenter";
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
-import { SidebarKbdHint } from "@posthog/ui/features/sidebar/components/items/SidebarKbdHint";
 import { MarqueeOverlay } from "@posthog/ui/features/sidebar/components/MarqueeOverlay";
 import { SidebarBulkActionFooter } from "@posthog/ui/features/sidebar/components/SidebarBulkActionFooter";
 import { SidebarItem } from "@posthog/ui/features/sidebar/components/SidebarItem";
@@ -522,22 +524,6 @@ export function ChannelSidebar({ channelId }: { channelId: string }) {
       <ChannelBackRow channelId={channelId} />
 
       <div className="flex flex-col gap-px px-2 pt-2">
-        {/* Starting a session is what you came here to do, so it leads the
-            pane's list of places rather than hiding behind one of them. */}
-        <SidebarItem
-          depth={0}
-          label="New session"
-          isActive={pathname === `${base}/new`}
-          onClick={() =>
-            void navigate({
-              to: "/website/$channelId/new",
-              params: { channelId },
-            })
-          }
-          // ⌘N inside a space lands on this same route (openTaskInput scopes to
-          // the channel you're in), so the row can claim the key.
-          endHint={<SidebarKbdHint keys={SHORTCUTS.NEW_TASK} />}
-        />
         {sectionRow(
           "home",
           base,
@@ -600,6 +586,20 @@ export function ChannelSidebar({ channelId }: { channelId: string }) {
               showRunFilters={tab === "task"}
               filtersActive={filtersActive}
             />
+          </div>
+        )}
+        {/* Above the scroll container, not in it: creating is what the tab you
+            just chose is for, so it can't scroll away with the rows. */}
+        {showHeader && (
+          <div className="px-2 pt-1">
+            {tab === "canvas" ? (
+              <NewCanvasRow channelId={channelId} />
+            ) : (
+              <NewSessionRow
+                channelId={channelId}
+                isActive={pathname === `${base}/new`}
+              />
+            )}
           </div>
         )}
         <div

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelsFab.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelsFab.test.tsx
@@ -1,0 +1,58 @@
+import { Theme } from "@radix-ui/themes";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ channelsLayout: true }));
+
+vi.mock("@posthog/ui/features/canvas/hooks/useChannelsLayout", () => ({
+  useChannelsLayout: () => mocks.channelsLayout,
+}));
+vi.mock("@tanstack/react-router", () => ({
+  useRouterState: () => "/website",
+}));
+vi.mock("@posthog/ui/shell/analytics", () => ({ track: vi.fn() }));
+// Its form reaches for the channel and repository query stacks this file has none of.
+vi.mock("@posthog/ui/features/canvas/components/CreateChannelModal", () => ({
+  CreateChannelModal: () => null,
+}));
+
+import { ChannelsFab } from "./ChannelsFab";
+
+describe("ChannelsFab", () => {
+  it.each([
+    {
+      what: "the channel list, where a new space has no other entry point",
+      channelId: undefined,
+      shown: true,
+    },
+    {
+      what: "inside a space, where the list leads with its own create row",
+      channelId: "channel-1",
+      shown: false,
+    },
+  ])("under the layout it floats over $what", ({ channelId, shown }) => {
+    mocks.channelsLayout = true;
+
+    render(
+      <Theme>
+        <ChannelsFab channelId={channelId} />
+      </Theme>,
+    );
+
+    expect(screen.queryAllByRole("button", { name: "Create" })).toHaveLength(
+      shown ? 1 : 0,
+    );
+  });
+
+  it("keeps its button inside a channel off the layout", () => {
+    mocks.channelsLayout = false;
+
+    render(
+      <Theme>
+        <ChannelsFab channelId="channel-1" />
+      </Theme>,
+    );
+
+    expect(screen.getByRole("button", { name: "Create" })).toBeInTheDocument();
+  });
+});

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelsFab.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelsFab.tsx
@@ -34,9 +34,10 @@ import { useState } from "react";
  * The create affordance for the Channels space, floated over the bottom-right
  * of whichever sidebar pane is showing.
  *
- * The same button on both panes, so "create" is always the same corner: given a
- * channel it creates inside it (task, canvas); from the list it creates a
- * channel, which has no other entry point.
+ * Under the layout it serves the channel list only, where creating a channel
+ * has no other entry point — inside a space the list leads with its own create
+ * row instead. Off the layout it keeps its original two-item menu on both
+ * panes.
  */
 export function ChannelsFab({ channelId }: { channelId?: string }) {
   const channelsLayout = useChannelsLayout();
@@ -49,6 +50,10 @@ export function ChannelsFab({ channelId }: { channelId?: string }) {
   const inChannels = useRouterState({
     select: (s) => s.location.pathname.startsWith("/website"),
   });
+
+  // Inside a space the list's own create row does this job, in the tab of the
+  // thing it makes, so a second create floating over those rows is one too many.
+  if (channelsLayout && channelId) return null;
 
   const newTask = () => {
     track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
@@ -72,10 +77,6 @@ export function ChannelsFab({ channelId }: { channelId?: string }) {
     </DropdownMenuItem>
   );
 
-  // Inside a space on the layout, the menu held one item, so the button is that
-  // item: a click starts the task instead of asking which kind to start.
-  const newTaskOnly = channelsLayout && !!channelId;
-
   const draftDot = channelsLayout && hasDraft && (
     <span
       aria-hidden
@@ -83,15 +84,12 @@ export function ChannelsFab({ channelId }: { channelId?: string }) {
     />
   );
 
-  const label = newTaskOnly ? "New task" : "Create";
-
   const trigger = (
     <Button
       variant="primary"
       size="icon-lg"
-      aria-label={label}
+      aria-label="Create"
       className="absolute right-3 bottom-3 z-10 rounded-full"
-      onClick={newTaskOnly ? newTask : undefined}
     >
       <PlusIcon size={20} weight="bold" />
       {draftDot}
@@ -104,7 +102,7 @@ export function ChannelsFab({ channelId }: { channelId?: string }) {
         <>
           {/* The draft dot needs saying out loud, and the button is where
               the create shortcut is worth advertising. */}
-          {hasDraft ? `${label} — you have a draft` : label}
+          {hasDraft ? "Create — you have a draft" : "Create"}
           <Kbd className="ml-1.5">{formatHotkey(SHORTCUTS.NEW_TASK)}</Kbd>
         </>
       ) : (
@@ -112,15 +110,6 @@ export function ChannelsFab({ channelId }: { channelId?: string }) {
       )}
     </TooltipContent>
   );
-
-  if (newTaskOnly) {
-    return (
-      <Tooltip>
-        <TooltipTrigger render={trigger} />
-        {tooltip}
-      </Tooltip>
-    );
-  }
 
   return (
     <>
@@ -141,9 +130,10 @@ export function ChannelsFab({ channelId }: { channelId?: string }) {
             <FileTextIcon size={14} className="text-gray-9" />
             New task
           </DropdownMenuItem>
-          {/* Inside a space the menu is about filling that space; making
-              another one belongs to the list this button also serves. */}
-          {channelsLayout && !channelId && (
+          {/* Under the layout this button only serves the list, where a new
+              space has no other entry point — but starting a session is the
+              commoner errand, so it stays above the separator. */}
+          {channelsLayout && (
             <>
               <DropdownMenuSeparator />
               {newChannelItem}

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelsFab.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelsFab.tsx
@@ -102,7 +102,7 @@ export function ChannelsFab({ channelId }: { channelId?: string }) {
         <>
           {/* The draft dot needs saying out loud, and the button is where
               the create shortcut is worth advertising. */}
-          {hasDraft ? "Create — you have a draft" : "Create"}
+          {hasDraft ? "Create. You have a draft" : "Create"}
           <Kbd className="ml-1.5">{formatHotkey(SHORTCUTS.NEW_TASK)}</Kbd>
         </>
       ) : (

--- a/products/desktop/packages/ui/src/features/canvas/createCanvasAnalytics.ts
+++ b/products/desktop/packages/ui/src/features/canvas/createCanvasAnalytics.ts
@@ -2,7 +2,7 @@ import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { track } from "@posthog/ui/shell/analytics";
 
 // Where a canvas create was triggered from, for analytics.
-export type CreateSurface = "dashboards_grid";
+export type CreateSurface = "dashboards_grid" | "sidebar";
 
 // Fire the "create" DASHBOARD_ACTION, then create and open the canvas.
 export function trackAndCreateCanvas<T>(


### PR DESCRIPTION
## Problem

- Inside a space the sidebar's floating create button offered one item, "New task", and covered the last rows of the list it sat on.
- Making a canvas had no entry point in that pane, so the create affordance did not match the two tabs below it.
- "New session" sat with the nav rows above the tabs, away from the list it fills.

## Changes

- The list leads with a create row that makes what the tab shows: "New session" on Sessions, "New canvas…" on Canvases.
- The floating button renders nothing inside a space. It still serves the channel list, where creating a space has no other entry point, and it is unchanged off the channels layout.
- The create row sits above the scroll container, so it stays in place while the rows scroll under it.
- "New canvas…" opens the template picker. Before templates load the click creates the canvas outright, and the label drops the ellipsis.
- The row carries the ⌘N hint and the unsent-draft badge the button used to, so the nav row above the tabs gives up its duplicate "New session".
- Canvas creates from this row report the `sidebar` surface; session creates keep the `new_task_open` event the button fired.
- The tooltip on the remaining button loses its em dash, per `/writing-user-facing-copy`.

No screenshot: `hogli pr:upload-image` is not installed in this sandbox.

## How did you test this code?

- `ChannelSidebar.test.tsx` asserts the create row leads the list and swaps with the tab. It catches a row that lists sessions to create while the canvases tab is showing, and one that sorts below the first item.
- `ChannelsFab.test.tsx` asserts the button is absent inside a space under the layout, and present on the list and off the layout. It catches a second create floating over the rows.
- Not run: the desktop app itself, which needs an authenticated PostHog. The pane's arrangement was checked by rendering a throwaway Storybook story built from the same primitives and reading row geometry with Playwright: the create row aligns with the list rows and sits between the tabs and the first row.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`packages/ui/src/features/canvas/AGENTS.md` now records where each pane's create affordance lives.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written by pi, driven by @adamleithp, who pointed at `ChannelsFab.tsx:76` and asked for the in-space button to go away in favor of a tab-first create.
- Skills invoked: `/writing-pr-descriptions`, `/writing-user-facing-copy`, `/writing-code-comments`.
- Decision worth a look: the nav "New session" row was removed rather than kept, because leaving it puts two identical rows three lines apart. Restoring it is a one-block revert in `ChannelSidebar.tsx` if the duplicate is wanted.
