### PR TITLE
feat(desktop): give the session header the space list's status dot

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/AGENTS.md
+++ b/products/desktop/packages/ui/src/features/canvas/AGENTS.md
@@ -133,6 +133,9 @@ changing breadcrumbs, canvas naming, or the canvas generation harness. The root
   this window has the session, otherwise the closing prose a cloud run persists
   to `latest_run.output.final_message`.
   Neither costs a request.
+- **The open session's header wears the same marks under bluebird.** `TaskHeaderMark` / `TaskHeaderBadges` (task-detail) draw `taskDot` and `taskBadges` around the title, from `useTaskStatusInput` — the row hook's task-shaped half, which `useChannelTaskStatus` now delegates to.
+  Off the flag the header keeps its workspace-mode glyph, and the PR lookup is skipped with it.
+  So the cloud glyph goes: it said where the run lives and nothing about whether the run wants anything, and in this vocabulary cloud is silent — running there is the default, so only the local exception earns a badge.
 - **The card's badges are buttons where they point somewhere; the row's never are.** A row is a `<button>`, so its badges stay spans — the card isn't, so a badge carrying a `url` opens it externally and is underlined, dotted, to say so.
   `taskBadges` sets the url on the PR badges, and on the origin badge for Slack — the one origin that hands back a place to go (`slack_thread_url` off the run's state), rather than just naming itself.
   A PR's url reaches the badge by two routes: a cloud run's `pr_url`, or the one the host cached against the task, which `getTaskPrStatus` returns alongside the state so a local PR is clickable too.

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useChannelTaskStatus.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useChannelTaskStatus.ts
@@ -1,33 +1,35 @@
 import type { ChannelItemModel } from "@posthog/core/canvas/channelItems";
+import type { Task } from "@posthog/shared/domain-types";
 import { useChannelTaskData } from "@posthog/ui/features/canvas/hooks/useChannelTaskData";
 import type { TaskStatusInput } from "@posthog/ui/features/sidebar/components/items/taskStatusVocabulary";
 import { useTaskPrStatus } from "@posthog/ui/features/sidebar/useTaskPrStatus";
 import { useWorkspace } from "@posthog/ui/features/workspace/useWorkspace";
 
+export interface TaskStatusOptions {
+  /**
+   * Whether to resolve the PR's state. It is a query per row into the host,
+   * where it hits git (and GitHub), so a list that only glances at its rows —
+   * the space tree in the sidebar — leaves it off and shows the rest. The
+   * PR's existence still comes through `prUrl`, which costs nothing.
+   */
+  withPrStatus?: boolean;
+}
+
 /**
- * The state behind a channel row's status dot and badges, or `null` for a canvas
- * (which has no run to report).
+ * The state behind a session's status dot and badges, or `null` for anything
+ * with no run to report (a canvas row, a session whose data hasn't landed).
  *
- * Assembled per row, the same way the Code sidebar's `TaskRow` does it, because
- * that's the only place the inputs exist together: the derived flags come from
- * renderer state (live session, workspace, viewed timestamps) and the PR state
- * from a per-task query, so none of it can be baked into the item list in core.
- * Keeping the composition in a hook rather than in the row leaves the row a
- * component that renders, and gives tests one module to stub.
+ * Assembled per surface, the same way the Code sidebar's `TaskRow` does it,
+ * because that's the only place the inputs exist together: the derived flags
+ * come from renderer state (live session, workspace, viewed timestamps) and the
+ * PR state from a per-task query, so none of it can be baked into the item list
+ * in core. Keeping the composition in a hook rather than in the row leaves the
+ * row a component that renders, and gives tests one module to stub.
  */
-export function useChannelTaskStatus(
-  item: ChannelItemModel,
-  options?: {
-    /**
-     * Whether to resolve the PR's state. It is a query per row into the host,
-     * where it hits git (and GitHub), so a list that only glances at its rows —
-     * the space tree in the sidebar — leaves it off and shows the rest. The
-     * PR's existence still comes through `prUrl`, which costs nothing.
-     */
-    withPrStatus?: boolean;
-  },
+export function useTaskStatusInput(
+  task: Task | undefined,
+  options?: TaskStatusOptions,
 ): TaskStatusInput | null {
-  const task = item.task ?? undefined;
   const taskData = useChannelTaskData(task);
   const workspace = useWorkspace(task?.id);
   const { prState, hasDiff, prUrl } = useTaskPrStatus({
@@ -59,4 +61,15 @@ export function useChannelTaskStatus(
     // has no cloud url, so the one the host cached against the task stands in.
     prUrl: taskData.cloudPrUrl ?? prUrl,
   };
+}
+
+/**
+ * The same state for a channel row, which holds the whole task on the item so a
+ * row doesn't have to look it up again.
+ */
+export function useChannelTaskStatus(
+  item: ChannelItemModel,
+  options?: TaskStatusOptions,
+): TaskStatusInput | null {
+  return useTaskStatusInput(item.task ?? undefined, options);
 }

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskDetail.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskDetail.tsx
@@ -38,7 +38,7 @@ import { useWorkspaceEvents } from "../../workspace/useWorkspaceEvents";
 import { HeaderTitleEditor } from "../HeaderTitleEditor";
 import { useTaskData } from "../hooks/useTaskData";
 import { CustomImageBadge } from "./CustomImageBadge";
-import { WorkspaceModeBadge } from "./WorkspaceModeBadge";
+import { TaskHeaderBadges, TaskHeaderMark } from "./TaskHeaderStatus";
 
 const MIN_REVIEW_WIDTH = 300;
 const log = logger.scope("task-detail");
@@ -204,7 +204,8 @@ export function TaskDetail({
           channelId={channelId}
           leafIcon={
             <span className="flex items-center gap-1.5">
-              <WorkspaceModeBadge
+              <TaskHeaderMark
+                task={task}
                 mode={workspaceMode}
                 checkoutPath={effectiveRepoPath}
               />
@@ -214,7 +215,12 @@ export function TaskDetail({
           leafLabel={task.title}
           editScopeKey={taskId}
           onRename={handleTitleEditSubmit}
-          leafTrailing={trailing}
+          leafTrailing={
+            <span className="flex shrink-0 items-center gap-1">
+              <TaskHeaderBadges task={task} />
+              {trailing}
+            </span>
+          }
         />
       ) : (
         <Flex align="center" justify="between" gap="2" width="100%">
@@ -226,7 +232,8 @@ export function TaskDetail({
             />
           ) : (
             <Flex align="center" gap="2" minWidth="0">
-              <WorkspaceModeBadge
+              <TaskHeaderMark
+                task={task}
                 mode={workspaceMode}
                 checkoutPath={effectiveRepoPath}
               />
@@ -240,6 +247,7 @@ export function TaskDetail({
                   {task.title}
                 </Text>
               </Tooltip>
+              <TaskHeaderBadges task={task} />
             </Flex>
           )}
           {trailing}

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskHeaderStatus.test.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskHeaderStatus.test.tsx
@@ -1,0 +1,83 @@
+import type { Task } from "@posthog/shared/domain-types";
+import type { TaskStatusInput } from "@posthog/ui/features/sidebar/components/items/taskStatusVocabulary";
+import { Theme } from "@radix-ui/themes";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The status comes from live session/workspace state and a per-task tRPC query,
+// none of which a unit test has. Stubbed at the module boundary, as
+// ChannelItemRow.test.tsx does for the same reason.
+const mocks = vi.hoisted(() => ({
+  bluebird: true,
+  status: null as TaskStatusInput | null,
+}));
+vi.mock("@posthog/ui/features/feature-flags/useBluebirdFlag", () => ({
+  useBluebirdFlag: () => mocks.bluebird,
+}));
+vi.mock("@posthog/ui/features/canvas/hooks/useChannelTaskStatus", () => ({
+  useTaskStatusInput: () => mocks.status,
+}));
+
+import { TaskHeaderBadges, TaskHeaderMark } from "./TaskHeaderStatus";
+
+const task = { id: "task-1" } as Task;
+
+function renderMark() {
+  return render(
+    <Theme>
+      <TaskHeaderMark task={task} mode="cloud" />
+    </Theme>,
+  );
+}
+
+describe("TaskHeaderStatus", () => {
+  beforeEach(() => {
+    mocks.bluebird = true;
+    mocks.status = { workspaceMode: "cloud" };
+  });
+
+  it.each([
+    ["needs your input", { needsPermission: true }, "Needs your input"],
+    ["a settled session", {}, "All caught up"],
+  ])(
+    "names the state under project-bluebird for %s",
+    (_case, status: TaskStatusInput, label) => {
+      mocks.status = { workspaceMode: "cloud", ...status };
+      renderMark();
+
+      expect(screen.getByRole("img", { name: label })).toBeInTheDocument();
+    },
+  );
+
+  it("keeps the workspace-mode glyph when project-bluebird is off", () => {
+    mocks.bluebird = false;
+    const { container } = renderMark();
+
+    // The mode glyph carries its name in a tooltip rather than a role, so the
+    // dot's absence is what says the old header is still drawn.
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+    expect(container.querySelector("svg")).toBeInTheDocument();
+  });
+
+  it("moves where the session runs into a badge, so cloud stays silent", () => {
+    mocks.status = { workspaceMode: "local" };
+    const { rerender } = render(
+      <Theme>
+        <TaskHeaderBadges task={task} />
+      </Theme>,
+    );
+
+    expect(screen.getByRole("img", { name: "Local" })).toBeInTheDocument();
+
+    mocks.status = { workspaceMode: "cloud" };
+    rerender(
+      <Theme>
+        <TaskHeaderBadges task={task} />
+      </Theme>,
+    );
+
+    expect(
+      screen.queryByRole("img", { name: "Local" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskHeaderStatus.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskHeaderStatus.tsx
@@ -1,0 +1,89 @@
+import type { WorkspaceMode } from "@posthog/shared";
+import type { Task } from "@posthog/shared/domain-types";
+import { useTaskStatusInput } from "@posthog/ui/features/canvas/hooks/useChannelTaskStatus";
+import { useBluebirdFlag } from "@posthog/ui/features/feature-flags/useBluebirdFlag";
+import {
+  TaskBadgeStack,
+  TaskStatusDot,
+  TaskStatusTooltips,
+} from "@posthog/ui/features/sidebar/components/items/TaskStatusDot";
+import {
+  type TaskStatusInput,
+  taskDot,
+} from "@posthog/ui/features/sidebar/components/items/taskStatusVocabulary";
+import { WorkspaceModeBadge } from "@posthog/ui/features/task-detail/components/WorkspaceModeBadge";
+import type { ReactNode } from "react";
+
+/**
+ * The session's state for the window header, or `null` where the header keeps
+ * its old workspace-mode glyph — outside project-bluebird, and before the
+ * task's state has landed.
+ */
+function useHeaderStatus(task: Task): TaskStatusInput | null {
+  const bluebird = useBluebirdFlag();
+  // The PR lookup is the one part that reaches the host, so it goes no further
+  // than the surface that draws it.
+  const status = useTaskStatusInput(task, { withPrStatus: bluebird });
+  return bluebird ? status : null;
+}
+
+/**
+ * The header's marks are the space list's, so a session reads the same open in
+ * front of you as it does in the list you opened it from. `no-drag` because the
+ * header is a window drag region, and a mark whose tooltip never opens is a
+ * mark that says nothing.
+ */
+function HeaderMarks({ children }: { children: ReactNode }) {
+  return (
+    <TaskStatusTooltips>
+      <span className="no-drag flex shrink-0 items-center">{children}</span>
+    </TaskStatusTooltips>
+  );
+}
+
+/**
+ * The mark before the session's title in the window header: its state dot,
+ * whose tooltip names the state in the same words the space list uses.
+ *
+ * It replaces the cloud / laptop / worktree glyph, which said where the run
+ * lives and nothing about whether it wants anything from you. Where the run
+ * lives moves to {@link TaskHeaderBadges}, and in that vocabulary the cloud is
+ * silent: running there is what a session does by default, so only the local
+ * exception earns a badge.
+ */
+export function TaskHeaderMark({
+  task,
+  mode,
+  checkoutPath,
+}: {
+  task: Task;
+  mode?: WorkspaceMode;
+  /** Directory the task runs in, for the workspace-mode glyph's tooltip. */
+  checkoutPath?: string | null;
+}) {
+  const status = useHeaderStatus(task);
+  if (!status) {
+    return <WorkspaceModeBadge mode={mode} checkoutPath={checkoutPath} />;
+  }
+  return (
+    <HeaderMarks>
+      <TaskStatusDot dot={taskDot(status)} />
+    </HeaderMarks>
+  );
+}
+
+/**
+ * The identity badges that ride after the title — where the session came from,
+ * whether it runs on this machine, what came out of it — drawn exactly as a
+ * space row draws them. Nothing at all when there is nothing to say, rather
+ * than an empty group whose padding still moves the title's neighbours.
+ */
+export function TaskHeaderBadges({ task }: { task: Task }) {
+  const status = useHeaderStatus(task);
+  if (!status) return null;
+  return (
+    <HeaderMarks>
+      <TaskBadgeStack status={status} pinned={status.isPinned} />
+    </HeaderMarks>
+  );
+}


### PR DESCRIPTION
## Problem

- A session opened inside a space leads its header with a cloud icon. The icon says where the run happens, not whether the run needs you.
- The space list you opened that session from already answers the useful question with a state dot, so the two surfaces disagree.

## Changes

- Under `project-bluebird`, the header leads with the space list's state dot (`taskDot`). Its tooltip names the state: "Needs your input", "Working", "Unread", "All caught up".
- The identity badges (`taskBadges`) ride after the title: where the session came from, whether it runs on this machine, and what came out of it.
- Cloud loses its glyph on purpose. In this vocabulary running in the cloud is the default, so only a local run earns a badge.
- With the flag off, the header keeps the workspace-mode glyph, and skips the per-task PR lookup that feeds the badges.
- `useChannelTaskStatus` now delegates to `useTaskStatusInput`, which takes a task instead of a channel row. Both surfaces derive the state one way.

No screenshot: the marks were rendered headless, but this environment could not display the captured image back. The check below is what stands in for it.

## How did you test this code?

- New unit tests in `TaskHeaderStatus.test.tsx` cover the flag contract: the dot names the state when `project-bluebird` is on, the workspace-mode glyph stays when it is off, and a local session gets the badge that cloud does not.
- Rendered the header marks in a headless Storybook page from a temporary story, which is not part of this PR, and measured the DOM. The dot draws 8px at the leaf position, solid blue for needs-input, the spinner for working, and the PR badge sits after the title.
- Not done: no run in the Electron app, and no visual review of the pixels.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`packages/ui/src/features/canvas/AGENTS.md` gains the bullet for the header wearing the row vocabulary.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written by an agent in a PostHog cloud task, from a request to replace the header's cloud icon with the interactive dot and its vocabulary behind the space flag.
- Skills invoked: `/writing-pr-descriptions`, `/writing-simplified-technical-english`.
- The header could have taken the dot alone. The badges came with it because the cloud icon was the header's only mark for where a session runs, and dropping both would have lost that fact rather than moved it.
