### PR TITLE
fix(desktop): make the working session row's spinner legible again

### DIFF
--- a/products/desktop/packages/ui/src/features/sidebar/components/items/TaskStatusDot.test.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/items/TaskStatusDot.test.tsx
@@ -1,0 +1,27 @@
+import { TaskStatusDot } from "@posthog/ui/features/sidebar/components/items/TaskStatusDot";
+import type { TaskDot } from "@posthog/ui/features/sidebar/components/items/taskStatusVocabulary";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+const working: TaskDot = {
+  tone: "yellow",
+  style: "solid",
+  pulse: false,
+  spinner: true,
+  label: "Working",
+};
+
+describe("TaskStatusDot", () => {
+  // The two halves of the same constraint, and the pair is the point: the ring
+  // has to outgrow the dot's box to read as a ring at all, and it has to leave
+  // that box's width alone or every working row's label steps right.
+  it("draws the working ring larger than the column it occupies", () => {
+    render(<TaskStatusDot dot={working} />);
+
+    const mark = screen.getByRole("img", { name: "Working" });
+    const ring = mark.firstElementChild as HTMLElement;
+
+    expect(mark.style.width).toBe("8px");
+    expect(Number.parseFloat(ring.style.width)).toBeGreaterThan(8);
+  });
+});

--- a/products/desktop/packages/ui/src/features/sidebar/components/items/TaskStatusDot.test.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/items/TaskStatusDot.test.tsx
@@ -11,17 +11,39 @@ const working: TaskDot = {
   label: "Working",
 };
 
+const idle: TaskDot = {
+  tone: "gray",
+  style: "hollow",
+  pulse: false,
+  label: "All caught up",
+};
+
 describe("TaskStatusDot", () => {
   // The two halves of the same constraint, and the pair is the point: the ring
-  // has to outgrow the dot's box to read as a ring at all, and it has to leave
-  // that box's width alone or every working row's label steps right.
-  it("draws the working ring larger than the column it occupies", () => {
-    render(<TaskStatusDot dot={working} />);
+  // has to outgrow the column to read as a ring at all, and the column has to
+  // stay the plain dot's or every working row's label steps right of its
+  // neighbours'. Measured against a rendered plain dot rather than a hardcoded
+  // 8px, so retuning the vocabulary's sizes moves both marks together.
+  //
+  // jsdom lays nothing out, so this reaches the sizes the component sets and
+  // stops there. Whether the ring is legible at that size, and whether it is
+  // clipped by anything upstream, is not a claim this test makes.
+  it("draws the working ring larger than the column it sits in", () => {
+    render(
+      <>
+        <TaskStatusDot dot={working} />
+        <TaskStatusDot dot={idle} />
+      </>,
+    );
 
+    const column = screen.getByRole("img", { name: "All caught up" }).style
+      .width;
     const mark = screen.getByRole("img", { name: "Working" });
     const ring = mark.firstElementChild as HTMLElement;
 
-    expect(mark.style.width).toBe("8px");
-    expect(Number.parseFloat(ring.style.width)).toBeGreaterThan(8);
+    expect(mark.style.width).toBe(column);
+    expect(Number.parseFloat(ring.style.width)).toBeGreaterThan(
+      Number.parseFloat(column),
+    );
   });
 });

--- a/products/desktop/packages/ui/src/features/sidebar/components/items/TaskStatusDot.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/items/TaskStatusDot.tsx
@@ -20,10 +20,15 @@ import { DotRingSpinner } from "@posthog/ui/primitives/DotRingSpinner";
 import type { ReactElement, ReactNode } from "react";
 
 const DOT_SIZE = 8;
-// Exactly the plain dot's box. Anything larger and a working row's label starts
-// further right than its neighbours' — the icon column has to hold one width or
-// the list stops looking like a list.
-const SPINNER_SIZE = DOT_SIZE;
+// Drawn at the row-icon size the rest of the app spins at, not at the dot's own
+// 8px: eight dots inside an 8px box are 1.6px across, and that reads as a smudge
+// rather than as something turning, which leaves the one row that is working the
+// faintest mark in the list.
+const SPINNER_SIZE = 12;
+// The box the ring is centered in and measured by. It stays the plain dot's, so
+// the icon column holds one width and a working row's label lines up with its
+// neighbours' — the ring's extra width spills evenly into the row's padding.
+const SPINNER_BOX = DOT_SIZE;
 // Enough to still find the dot if you look for it, not enough to count as one of
 // the list's live rows.
 const FAINT_OPACITY = 0.4;
@@ -74,12 +79,20 @@ function dotMark(dot: TaskDot, decorative = false): ReactElement {
     return (
       <span
         {...naming}
-        className="flex shrink-0 items-center justify-center"
+        className="relative flex shrink-0 items-center justify-center"
         // The spinner draws its dots in `currentColor`, so the tone is set
         // here rather than passed down.
-        style={{ color: TONE_ICON_VAR[dot.tone], width: SPINNER_SIZE }}
+        style={{
+          color: TONE_ICON_VAR[dot.tone],
+          width: SPINNER_BOX,
+          height: SPINNER_BOX,
+        }}
       >
-        <DotRingSpinner size={SPINNER_SIZE} />
+        <DotRingSpinner
+          size={SPINNER_SIZE}
+          // Out of flow, so the box measures the dot rather than the ring.
+          className="-translate-x-1/2 -translate-y-1/2 absolute top-1/2 left-1/2"
+        />
       </span>
     );
   }


### PR DESCRIPTION
## Problem

- A session that is working shows the faintest mark in the space's session list, so a running run reads as idle.
- The row's spinner is drawn at the plain dot's 8px box. Its eight dots are 1.6px across at that size.
- At 1x the ring lands about 12 lit pixels. A hollow "all caught up" dot lands about 36, and a solid unread dot about 52.
- The spinner also dips to 0.2 opacity on every animation cycle, and the sidebar's icon slot renders it at 80% opacity.

Affects every surface on the dot vocabulary: a space's session list, the space tree in the channels sidebar, and the row hover card.

<img width="632" height="352" alt="2026-08-18 12 50 25" src="https://github.com/user-attachments/assets/81d078a6-dae7-455b-9af2-5771910321f2" />

<img width="346" height="160" alt="image" src="https://github.com/user-attachments/assets/6fd48e08-c565-4d74-a905-ed8c9a89d6fe" />




## Changes

- `TaskStatusDot` draws the working ring at 12px, the row-icon size used elsewhere in the app.
- The ring sits out of flow inside an 8px box, centered on it, so it overflows evenly into the row's own padding.
- The icon column keeps one width, so a working row's label stays in line with its neighbours'. That constraint is why the ring was sized to 8px in the first place; overflowing the box satisfies both.

Ink measured off a headless-Chromium render of the same markup, at full opacity:

| Mark | Lit pixels at 1x | Lit pixels at 2x |
| --- | --- | --- |
| Solid dot (unread) | 52 | 208 |
| Hollow dot (all caught up) | 36 | 134 |
| Ring at 8px (before) | 12 | 48 |
| Ring at 12px (after) | 32 | 96 |

## How did you test this code?

- Added `TaskStatusDot.test.tsx`, which asserts the working mark keeps the plain dot's 8px box while the ring inside it is wider. It catches both halves of the regression: a ring shrunk back into the box, and a ring that widens the column and steps every working row's label right. No existing test covers the mark's geometry — `ChannelItemRow.test.tsx` covers only the dot's label.
- Verified the test fails when `SPINNER_SIZE` goes back to `DOT_SIZE`.
- Measured the row geometry in headless Chromium against a copy of the rendered markup: the label starts at x=24 with the plain dot and with the 12px ring, and the ring spans x=6 to x=18 in a row whose left padding is 8px.

Not done: no screenshot of the running app, and no manual pass over the app. This sandbox cannot run the Electron host, and the agent cannot view images. The numbers above stand in for that.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Reported from PostHog Desktop with a screenshot of a space's session list next to a streaming session.
- Two candidates were on the table: the row never learns the session is streaming, or the mark is drawn too small to read. Traced `isGenerating` from the session store through `useChannelTaskData` and `useChannelTaskStatus` into `taskDot` — the row and the thread footer read one store field, so a data gap has no mechanism. Measured the rendered mark instead, which is where the signal is lost.
- Skills invoked: `/writing-pr-descriptions`, `/writing-code-comments`, `/writing-tests`, `/writing-user-facing-copy`.
- `hogli ci:preflight` was not run: this sandbox has no Python environment for hogli. Biome and `tsc --noEmit` were run over the desktop UI package instead.
- Tools: pi with Claude, plus headless Chromium (Playwright) for the geometry and ink measurements.
