### PR TITLE
feat(ingestion): add ingestion_api_events_in_flight gauge

### DIFF
--- a/nodejs/src/servers/ingestion-api-server.test.ts
+++ b/nodejs/src/servers/ingestion-api-server.test.ts
@@ -1,3 +1,5 @@
+import { Gauge, register } from 'prom-client'
+
 import { GROUPS_OUTPUT } from '~/common/outputs'
 import { GroupFlushResult } from '~/ingestion/common/groups/group-store.interface'
 
@@ -28,9 +30,16 @@ describe('IngestionApiServer', () => {
         }
     }
 
-    function handle(res: ReturnType<typeof makeRes>): Promise<void> {
-        const req = { body: { batch_id: 'b1', messages: [makeMessage()] } }
+    function handle(res: ReturnType<typeof makeRes>, messageCount = 1): Promise<void> {
+        const messages = Array.from({ length: messageCount }, makeMessage)
+        const req = { body: { batch_id: 'b1', messages } }
         return (server as any).handleIngestRequest(req, res)
+    }
+
+    async function eventsInFlight(): Promise<number> {
+        const gauge = register.getSingleMetric('ingestion_api_events_in_flight') as Gauge<string>
+        const { values } = await gauge.get()
+        return values[0]?.value ?? 0
     }
 
     function isHealthy(): { status: string } {
@@ -45,6 +54,8 @@ describe('IngestionApiServer', () => {
         ;(server as any).hogTransformer = { processInvocationResults: jest.fn().mockResolvedValue(undefined) }
         // stop() would call process.exit; stub it so the test only observes that it was invoked.
         stopSpy = jest.spyOn(server, 'stop').mockResolvedValue(undefined)
+        // The gauge is a module-level singleton shared across tests in this file.
+        register.getSingleMetric('ingestion_api_events_in_flight')?.reset()
     })
 
     it('reports healthy before any failure', () => {
@@ -89,6 +100,53 @@ describe('IngestionApiServer', () => {
         expect(res.body()).toMatchObject({ status: 'ok', accepted: 1 })
         expect(isHealthy().status).toBe('ok')
         expect(stopSpy).not.toHaveBeenCalled()
+    })
+
+    describe('events in flight gauge', () => {
+        it('counts events rather than batches while a batch is in flight', async () => {
+            let observed = 0
+            pipeline.feed.mockResolvedValue({ ok: true })
+            // next() runs while the batch occupies its slot, so this samples the peak.
+            pipeline.next.mockImplementation(async () => {
+                observed = await eventsInFlight()
+                return null
+            })
+
+            await handle(makeRes(), 3)
+
+            expect(observed).toBe(3)
+        })
+
+        // A leaked increment would make the gauge climb forever and, since this
+        // drives processor autoscaling, scale the fleet out on phantom load.
+        it.each([
+            {
+                outcome: 'success',
+                arrange: () => {
+                    pipeline.feed.mockResolvedValue({ ok: true })
+                    pipeline.next.mockResolvedValue(null)
+                },
+            },
+            {
+                outcome: 'capacity rejection',
+                arrange: () => {
+                    pipeline.feed.mockResolvedValue({ ok: false, kind: 'at_capacity', reason: 'at capacity' })
+                },
+            },
+            {
+                outcome: 'pipeline crash',
+                arrange: () => {
+                    pipeline.feed.mockResolvedValue({ ok: true })
+                    pipeline.next.mockRejectedValue(new Error('pipeline poisoned'))
+                },
+            },
+        ])('returns to zero after a $outcome', async ({ arrange }) => {
+            arrange()
+
+            await handle(makeRes(), 5)
+
+            expect(await eventsInFlight()).toBe(0)
+        })
     })
 
     describe('cleanup', () => {

--- a/nodejs/src/servers/ingestion-api-server.test.ts
+++ b/nodejs/src/servers/ingestion-api-server.test.ts
@@ -103,18 +103,120 @@ describe('IngestionApiServer', () => {
     })
 
     describe('events in flight gauge', () => {
-        it('counts events rather than batches while a batch is in flight', async () => {
-            let observed = 0
+        type Gate = { resolve: () => void; reject: (error: Error) => void }
+
+        // One gate per in-flight batch. The handler calls next() exactly once
+        // (the mock resolves to null, ending its drain loop), so holding that
+        // promise open holds the batch in flight and lets a test decide the
+        // order batches finish in.
+        let gates: Gate[]
+
+        beforeEach(() => {
+            gates = []
+        })
+
+        function gateBatches(): void {
             pipeline.feed.mockResolvedValue({ ok: true })
-            // next() runs while the batch occupies its slot, so this samples the peak.
-            pipeline.next.mockImplementation(async () => {
-                observed = await eventsInFlight()
-                return null
-            })
+            pipeline.next.mockImplementation(
+                () =>
+                    new Promise<null>((resolve, reject) => {
+                        gates.push({ resolve: () => resolve(null), reject })
+                    })
+            )
+        }
 
-            await handle(makeRes(), 3)
+        // Let pending callbacks run so a started request reaches next() before
+        // the test reads the gauge.
+        function flush(): Promise<void> {
+            return new Promise((resolve) => setImmediate(resolve))
+        }
 
-            expect(observed).toBe(3)
+        // Starts a batch and returns its completion promise. Deliberately not
+        // async: an async wrapper's promise would adopt this one, so awaiting
+        // the helper would wait for the batch to finish instead of starting it.
+        // Callers `await flush()` once the batches they want in flight are up.
+        function start(messageCount: number): Promise<void> {
+            return handle(makeRes(), messageCount)
+        }
+
+        it('sums events across concurrent batches of different sizes', async () => {
+            gateBatches()
+
+            const small = start(5)
+            const medium = start(100)
+            const large = start(1000)
+            await flush()
+
+            // 3 if it counted batches; the sum is the point of the metric.
+            expect(await eventsInFlight()).toBe(1105)
+
+            gates.forEach((gate) => gate.resolve())
+            await Promise.all([small, medium, large])
+            expect(await eventsInFlight()).toBe(0)
+        })
+
+        it('releases exactly the finished batch, leaving the others in flight', async () => {
+            gateBatches()
+
+            const first = start(100)
+            const second = start(5)
+            const third = start(20)
+            await flush()
+            expect(await eventsInFlight()).toBe(125)
+
+            // Finish out of order: a decrement keyed to the wrong request would
+            // subtract someone else's count and drift the gauge.
+            gates[1].resolve()
+            await second
+            expect(await eventsInFlight()).toBe(120)
+
+            gates[2].resolve()
+            await third
+            expect(await eventsInFlight()).toBe(100)
+
+            gates[0].resolve()
+            await first
+            expect(await eventsInFlight()).toBe(0)
+        })
+
+        it('leaves in-flight batches untouched when another is rejected at capacity', async () => {
+            gateBatches()
+            const accepted = start(100)
+            await flush()
+
+            pipeline.feed.mockResolvedValueOnce({ ok: false, kind: 'at_capacity', reason: 'at capacity' })
+            const rejectedRes = makeRes()
+            await handle(rejectedRes, 50)
+
+            expect(rejectedRes.statusCode()).toBe(503)
+            expect(await eventsInFlight()).toBe(100)
+
+            gates[0].resolve()
+            await accepted
+            expect(await eventsInFlight()).toBe(0)
+        })
+
+        it('releases a crashed batch while a concurrent batch stays in flight', async () => {
+            gateBatches()
+            const crashing = start(100)
+            const surviving = start(7)
+            await flush()
+
+            gates[0].reject(new Error('pipeline poisoned'))
+            await crashing
+            expect(await eventsInFlight()).toBe(7)
+
+            gates[1].resolve()
+            await surviving
+            expect(await eventsInFlight()).toBe(0)
+        })
+
+        it('does not count a batch rejected as empty', async () => {
+            const res = makeRes()
+            await handle(res, 0)
+
+            expect(res.statusCode()).toBe(400)
+            expect(await eventsInFlight()).toBe(0)
         })
 
         // A leaked increment would make the gauge climb forever and, since this

--- a/nodejs/src/servers/ingestion-api-server.ts
+++ b/nodejs/src/servers/ingestion-api-server.ts
@@ -149,6 +149,16 @@ const batchesInFlight = new Gauge({
     help: 'Number of accepted batches currently being processed by the ingestion API (concurrent batches)',
 })
 
+// Companion to `batchesInFlight`, and the one to autoscale on: batch sizes vary
+// several-fold with consumer batching and routing, so a batch count says little
+// about how much work a pod is holding. Events in flight is invariant to how the
+// consumer slices a batch, which keeps a scaling target stable across dispatcher
+// tuning changes.
+const eventsInFlight = new Gauge({
+    name: 'ingestion_api_events_in_flight',
+    help: 'Number of events in accepted batches currently being processed by the ingestion API',
+})
+
 /**
  * Ingestion API server that exposes the ingestion pipeline as an HTTP endpoint.
  *
@@ -471,9 +481,10 @@ export class IngestionApiServer implements NodeServer {
 
         const startTime = Date.now()
 
-        // Tracks whether this batch was accepted, so the `finally` only
-        // decrements the in-flight gauge for batches that incremented it.
-        let inFlight = false
+        // Event count of this batch once accepted, or null while it is not.
+        // Holding the count (rather than a bool) makes the `finally` decrement
+        // exactly what was incremented, even if `messages` is out of scope.
+        let inFlight: number | null = null
 
         try {
             const messages: Message[] = serializedMessages.map(deserializeKafkaMessage)
@@ -517,7 +528,8 @@ export class IngestionApiServer implements NodeServer {
             // Batch accepted into the pipeline — it now occupies a concurrent
             // slot until processing completes below.
             batchesInFlight.inc()
-            inFlight = true
+            eventsInFlight.inc(messages.length)
+            inFlight = messages.length
 
             // The pipeline handles its own side effects (scheduling them on
             // the promise scheduler), so draining results is all that's left
@@ -555,8 +567,9 @@ export class IngestionApiServer implements NodeServer {
             }
             res.status(500).json({ batch_id, status: 'error', accepted: 0, error: error.message })
         } finally {
-            if (inFlight) {
+            if (inFlight !== null) {
                 batchesInFlight.dec()
+                eventsInFlight.dec(inFlight)
             }
         }
     }


### PR DESCRIPTION
## Problem

- Processor pods can only be autoscaled on how many *batches* they hold, and a batch is not a fixed amount of work.
- On the overflow lane a consumer batch currently averages 1646 events but is capped at 5000, so a worker's share swings roughly 3× with load alone. A single unsplittable key-group can be larger still.
- `ingestion_api_batches_in_flight` therefore tracks request count, not load. Scaling on it means scaling on how the consumer happened to slice its traffic.
- Nothing on either side exports events in progress. The Rust consumer keeps an exact per-worker count in `PinTable.in_flight`, but that is one consumer's view of its own sends, not what a processor is holding.

## Changes

- Add `ingestion_api_events_in_flight`, incremented by the batch's event count when the pipeline accepts it and decremented on every exit path, alongside the existing batch gauge.
- Track the accepted count in the handler instead of a boolean, so the decrement is exactly what was incremented.

The gauge is a level, so summing it across pods gives the fleet's in-progress work, and dividing by pod count gives the per-pod average an HPA can target. It is invariant to how the consumer slices a batch, so a target set against it survives dispatcher tuning changes that would invalidate a batch-count target.

> [!NOTE]
> The in-flight window is narrower than `ingestion_api_batch_processing_duration_ms`: `startTime` is taken at handler entry, while the gauges only start counting once `feed()` accepts the batch. Deserialization and the feed call sit inside the duration but outside the gauge. Worth knowing when calibrating a target — on overflow the two bases currently disagree by about 3×, and the gauge is the one that reflects occupancy.

## How did you test this code?

Added to the existing `IngestionApiServer` suite:

- `counts events rather than batches while a batch is in flight` — samples the gauge from inside the `next()` mock, which runs while the batch holds its slot, and asserts a 3-message batch reads 3 rather than 1. Catches the gauge being wired to batch count.
- `returns to zero after a $outcome`, parameterized over success, capacity rejection, and pipeline crash — catches a leaked increment. That regression matters more than usual here: a gauge that only climbs would scale the processor fleet out on phantom load.

`pnpm jest src/servers/ingestion-api-server.test.ts` passes (9 tests). No manual testing against a running processor.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude, in Claude Code) wrote this. Skills invoked: `/writing-pr-descriptions`.

This came out of investigating why the overflow lane shows ingestion lag while processors sit idle. Measured on prod-us: processors average 0.67 batches in flight against a capacity of 8, roughly 8% utilization, with capacity rejections at ~0.1/s. The lane's median partition lag is ~1.2s but one partition sits about 68 minutes behind. Chunking consumer batches into smaller sub-batches was explored first and dropped — it reshapes traffic to fit a batch-count limiter rather than fixing the accounting, and it cannot help an unsplittable key-group at all.

A charts PR follows, targeting an average of 500 in-flight events per pod for the overflow processors, keeping the concurrent-batch autoscaler as a safety valve.

Nothing in this diff draws on material that is not already in this repository.
