### PR TITLE
fix(navigation): keep submenus open on the diagonal to them

### DIFF
--- a/frontend/src/lib/components/Account/NewAccountMenu.tsx
+++ b/frontend/src/lib/components/Account/NewAccountMenu.tsx
@@ -23,6 +23,7 @@ import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { DropdownMenuSeparator } from 'lib/ui/DropdownMenu/DropdownMenu'
 import { Label } from 'lib/ui/Label/Label'
 import { MenuOpenIndicator } from 'lib/ui/Menus/Menus'
+import { useSubmenuSafeTriangle } from 'lib/ui/Menus/useSubmenuSafeTriangle'
 import { cn } from 'lib/utils/css-classes'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { billingLogic } from 'scenes/billing/billingLogic'
@@ -69,6 +70,8 @@ export function NewAccountMenu({ isLayoutNavCollapsed }: AccountMenuProps): JSX.
     const { guardAvailableFeature } = useValues(upgradeModalLogic)
     const { showCreateProjectModal } = useActions(globalModalsLogic)
     const { showCreateOrganizationModal } = useActions(globalModalsLogic)
+    const projectSubmenu = useSubmenuSafeTriangle()
+    const organizationSubmenu = useSubmenuSafeTriangle()
 
     const projectNameStartsWithEmoji = currentTeam?.name?.match(/^\p{Extended_Pictographic}/u) !== null
     const projectNameWithoutFirstEmoji = projectNameStartsWithEmoji
@@ -169,6 +172,7 @@ export function NewAccountMenu({ isLayoutNavCollapsed }: AccountMenuProps): JSX.
                                     <Menu.SubmenuRoot>
                                         <Menu.SubmenuTrigger
                                             openOnHover={false}
+                                            ref={projectSubmenu.triggerRef}
                                             render={
                                                 <ButtonPrimitive
                                                     menuItem
@@ -192,7 +196,10 @@ export function NewAccountMenu({ isLayoutNavCollapsed }: AccountMenuProps): JSX.
                                                 className="z-[var(--z-popover)]"
                                                 collisionPadding={{ top: 50, bottom: 50 }}
                                             >
-                                                <Menu.Popup className="primitive-menu-content w-min max-w-[var(--available-width)]">
+                                                <Menu.Popup
+                                                    ref={projectSubmenu.popupRef}
+                                                    className="primitive-menu-content w-min max-w-[var(--available-width)]"
+                                                >
                                                     {/* We need to add a div here to prevent the keydown event from bubbling up to the menu. */}
                                                     <div onKeyDown={(e) => e.stopPropagation()}>
                                                         <ProjectSwitcher dialog={false} />
@@ -268,6 +275,7 @@ export function NewAccountMenu({ isLayoutNavCollapsed }: AccountMenuProps): JSX.
                                 <Menu.SubmenuRoot>
                                     <Menu.SubmenuTrigger
                                         openOnHover={false}
+                                        ref={organizationSubmenu.triggerRef}
                                         render={
                                             <ButtonPrimitive
                                                 menuItem
@@ -297,7 +305,10 @@ export function NewAccountMenu({ isLayoutNavCollapsed }: AccountMenuProps): JSX.
                                             className="z-[var(--z-popover)]"
                                             collisionPadding={{ top: 50, bottom: 50 }}
                                         >
-                                            <Menu.Popup className="primitive-menu-content w-min max-w-[var(--available-width)]">
+                                            <Menu.Popup
+                                                ref={organizationSubmenu.popupRef}
+                                                className="primitive-menu-content w-min max-w-[var(--available-width)]"
+                                            >
                                                 {/* We need to add a div here to prevent the keydown event from bubbling up to the menu. */}
                                                 <div onKeyDown={(e) => e.stopPropagation()}>
                                                     <OrgSwitcher dialog={false} />

--- a/frontend/src/lib/components/Menus/ThemeMenu.tsx
+++ b/frontend/src/lib/components/Menus/ThemeMenu.tsx
@@ -8,6 +8,7 @@ import { Link } from 'lib/lemon-ui/Link/Link'
 import { themeLogic } from 'lib/logic/themeLogic'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { MenuOpenIndicator } from 'lib/ui/Menus/Menus'
+import { useSubmenuSafeTriangle } from 'lib/ui/Menus/useSubmenuSafeTriangle'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
@@ -17,6 +18,7 @@ export function ThemeMenu(): JSX.Element {
     const { themeMode } = useValues(userLogic)
     const { updateUser } = useActions(userLogic)
     const { customCssEnabled } = useValues(themeLogic)
+    const themeSubmenu = useSubmenuSafeTriangle()
 
     function handleThemeChange(theme: UserTheme): void {
         updateUser({ theme_mode: theme })
@@ -26,6 +28,7 @@ export function ThemeMenu(): JSX.Element {
         <Menu.SubmenuRoot>
             <Menu.SubmenuTrigger
                 openOnHover={false}
+                ref={themeSubmenu.triggerRef}
                 render={
                     <ButtonPrimitive menuItem data-attr="more-menu-theme-button">
                         <IconPalette />
@@ -39,7 +42,7 @@ export function ThemeMenu(): JSX.Element {
             />
             <Menu.Portal>
                 <Menu.Positioner className="z-[var(--z-popover)]" collisionPadding={{ top: 50, bottom: 50 }}>
-                    <Menu.Popup className="primitive-menu-content">
+                    <Menu.Popup ref={themeSubmenu.popupRef} className="primitive-menu-content">
                         <div className="primitive-menu-content-inner flex flex-col gap-px p-1">
                             <Menu.Item
                                 onClick={() => handleThemeChange('light')}

--- a/frontend/src/lib/ui/Menus/safeTriangle.test.ts
+++ b/frontend/src/lib/ui/Menus/safeTriangle.test.ts
@@ -1,0 +1,64 @@
+import { isPointInSafeTriangle, Point, Rect } from './safeTriangle'
+
+describe('safeTriangle', () => {
+    // A submenu sitting to the right of its trigger, the way Base UI places one by default.
+    const submenuOnTheRight: Rect = { left: 200, right: 400, top: 100, bottom: 300 }
+    const anchorLeftOfSubmenu: Point = { x: 100, y: 110 }
+
+    const cases: [string, Point, Point, Rect, boolean][] = [
+        [
+            'keeps a point on the diagonal to the far corner',
+            { x: 150, y: 200 },
+            anchorLeftOfSubmenu,
+            submenuOnTheRight,
+            true,
+        ],
+        [
+            'keeps a point straight ahead of the anchor',
+            { x: 150, y: 110 },
+            anchorLeftOfSubmenu,
+            submenuOnTheRight,
+            true,
+        ],
+        [
+            'drops a point past the diagonal to the far corner',
+            { x: 150, y: 260 },
+            anchorLeftOfSubmenu,
+            submenuOnTheRight,
+            false,
+        ],
+        [
+            'drops a point heading away from the submenu',
+            { x: 150, y: 50 },
+            anchorLeftOfSubmenu,
+            submenuOnTheRight,
+            false,
+        ],
+        ['drops a point behind the anchor', { x: 50, y: 110 }, anchorLeftOfSubmenu, submenuOnTheRight, false],
+        [
+            'keeps a point heading to a submenu on the left',
+            { x: 450, y: 200 },
+            { x: 500, y: 110 },
+            { left: 200, right: 400, top: 100, bottom: 300 },
+            true,
+        ],
+        [
+            'keeps a point heading to a submenu below',
+            { x: 250, y: 250 },
+            { x: 210, y: 50 },
+            { left: 100, right: 400, top: 300, bottom: 500 },
+            true,
+        ],
+        [
+            'drops a point whose anchor faces no edge',
+            { x: 250, y: 250 },
+            { x: 250, y: 200 },
+            { left: 100, right: 400, top: 100, bottom: 300 },
+            false,
+        ],
+    ]
+
+    it.each(cases)('%s', (_name, point, anchor, rect, expected) => {
+        expect(isPointInSafeTriangle(point, anchor, rect)).toBe(expected)
+    })
+})

--- a/frontend/src/lib/ui/Menus/safeTriangle.ts
+++ b/frontend/src/lib/ui/Menus/safeTriangle.ts
@@ -1,0 +1,67 @@
+export interface Point {
+    x: number
+    y: number
+}
+
+/** The parts of a `DOMRect` the safe triangle needs. */
+export interface Rect {
+    left: number
+    right: number
+    top: number
+    bottom: number
+}
+
+/** Widens the target edge, where the triangle is at its narrowest and least forgiving. */
+const EDGE_TOLERANCE_PX = 12
+
+/**
+ * Whether `point` sits in the triangle spanned by `anchor` and the edge of `rect` facing it — the
+ * wedge a pointer travelling from `anchor` towards any part of `rect` stays inside.
+ */
+export function isPointInSafeTriangle(point: Point, anchor: Point, rect: Rect): boolean {
+    const edge = facingEdge(anchor, rect)
+    return edge !== null && isPointInTriangle(point, anchor, edge[0], edge[1])
+}
+
+/** The two corners of the `rect` edge that faces `anchor`, or null when `anchor` faces no edge. */
+function facingEdge(anchor: Point, rect: Rect): [Point, Point] | null {
+    if (anchor.x <= rect.left) {
+        return [
+            { x: rect.left, y: rect.top - EDGE_TOLERANCE_PX },
+            { x: rect.left, y: rect.bottom + EDGE_TOLERANCE_PX },
+        ]
+    }
+    if (anchor.x >= rect.right) {
+        return [
+            { x: rect.right, y: rect.top - EDGE_TOLERANCE_PX },
+            { x: rect.right, y: rect.bottom + EDGE_TOLERANCE_PX },
+        ]
+    }
+    if (anchor.y <= rect.top) {
+        return [
+            { x: rect.left - EDGE_TOLERANCE_PX, y: rect.top },
+            { x: rect.right + EDGE_TOLERANCE_PX, y: rect.top },
+        ]
+    }
+    if (anchor.y >= rect.bottom) {
+        return [
+            { x: rect.left - EDGE_TOLERANCE_PX, y: rect.bottom },
+            { x: rect.right + EDGE_TOLERANCE_PX, y: rect.bottom },
+        ]
+    }
+    return null
+}
+
+function isPointInTriangle(point: Point, a: Point, b: Point, c: Point): boolean {
+    const ab = crossProductSign(point, a, b)
+    const bc = crossProductSign(point, b, c)
+    const ca = crossProductSign(point, c, a)
+    const hasNegative = ab < 0 || bc < 0 || ca < 0
+    const hasPositive = ab > 0 || bc > 0 || ca > 0
+    // A point inside the triangle sits on the same side of all three edges.
+    return !(hasNegative && hasPositive)
+}
+
+function crossProductSign(point: Point, from: Point, to: Point): number {
+    return (point.x - to.x) * (from.y - to.y) - (from.x - to.x) * (point.y - to.y)
+}

--- a/frontend/src/lib/ui/Menus/useSubmenuSafeTriangle.ts
+++ b/frontend/src/lib/ui/Menus/useSubmenuSafeTriangle.ts
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useMemo, useRef } from 'react'
+
+import { isPointInSafeTriangle, Point } from './safeTriangle'
+
+/** A pointer that pauses this long is no longer travelling to the submenu, whatever the wedge says. */
+const MAX_STALL_MS = 200
+
+export interface SubmenuSafeTriangle {
+    /** Attach to `Menu.SubmenuTrigger`. */
+    triggerRef: (element: HTMLElement | null) => void
+    /** Attach to the submenu's `Menu.Popup`. */
+    popupRef: (element: HTMLElement | null) => void
+}
+
+/**
+ * Keeps a submenu open while the pointer travels diagonally from its trigger to the submenu itself.
+ *
+ * Base UI only does this for submenus that open on hover; one that opens on click closes as soon as
+ * the pointer grazes another item of the parent menu, which is most of the diagonal path. Blocking
+ * the mouse move before it reaches those items keeps the path from registering as a hover.
+ */
+export function useSubmenuSafeTriangle(): SubmenuSafeTriangle {
+    const triggerElement = useRef<HTMLElement | null>(null)
+    const popupElement = useRef<HTMLElement | null>(null)
+    const anchor = useRef<{ point: Point; movedAt: number } | null>(null)
+    const detach = useRef<(() => void) | null>(null)
+
+    const handleMouseMove = useCallback((event: MouseEvent): void => {
+        const trigger = triggerElement.current
+        const popup = popupElement.current
+        if (!trigger || !popup) {
+            return
+        }
+
+        const point = { x: event.clientX, y: event.clientY }
+        // Going by the event target rather than the trigger's rect matters on the boundary pixel,
+        // which reads as inside the rect while the move already belongs to the item below.
+        if (trigger.contains(event.target as Node)) {
+            // The last point the pointer held on the trigger is where the wedge starts.
+            anchor.current = { point, movedAt: event.timeStamp }
+            return
+        }
+
+        const from = anchor.current
+        if (!from) {
+            return
+        }
+        if (
+            event.timeStamp - from.movedAt < MAX_STALL_MS &&
+            isPointInSafeTriangle(point, from.point, popup.getBoundingClientRect())
+        ) {
+            from.movedAt = event.timeStamp
+            event.stopPropagation()
+            return
+        }
+        anchor.current = null
+    }, [])
+
+    // Listening on the parent menu rather than the document keeps every other mouse move untouched.
+    const listenOnParentMenu = useCallback((): void => {
+        detach.current?.()
+        detach.current = null
+        anchor.current = null
+
+        const parentMenu = popupElement.current ? triggerElement.current?.closest<HTMLElement>('[role="menu"]') : null
+        if (!parentMenu) {
+            return
+        }
+        parentMenu.addEventListener('mousemove', handleMouseMove, true)
+        detach.current = () => parentMenu.removeEventListener('mousemove', handleMouseMove, true)
+    }, [handleMouseMove])
+
+    useEffect(() => () => detach.current?.(), [])
+
+    return useMemo(
+        () => ({
+            triggerRef: (element: HTMLElement | null): void => {
+                triggerElement.current = element
+                listenOnParentMenu()
+            },
+            popupRef: (element: HTMLElement | null): void => {
+                popupElement.current = element
+                listenOnParentMenu()
+            },
+        }),
+        [listenOnParentMenu]
+    )
+}


### PR DESCRIPTION
## Problem

- Moving the pointer from the "All projects" or "All organizations" row toward the submenu closes it before it can be reached.
- The pointer crosses the items below the trigger on the way, and Base UI closes a submenu the moment another item of the parent menu registers a hover.
- Base UI ships a safe polygon only for submenus that open on hover. These three submenus set `openOnHover={false}`, so they get none.
- Affected surfaces: the account menu's project and organization switchers, and the color theme submenu.

<img width="974" height="684" alt="2026-09-17 12 53 55" src="https://github.com/user-attachments/assets/b239a561-6e7f-48d3-a3ed-23fe834b1f64" />

## Changes

- Add `useSubmenuSafeTriangle`, a hook that keeps a click-opened Base UI submenu open while the pointer travels to it.
- The hook records the point where the pointer left the trigger, then stops the mouse move on the parent menu while the pointer stays in the triangle between that point and the near edge of the submenu.
- Stopping the event, rather than setting `pointer-events: none` on the parent menu, leaves clicks on the parent items working during a traversal.
- A pointer that pauses for more than 200 ms gives up the triangle, so a cursor resting over a sibling item cannot pin the submenu open.
- Wire the hook into both account-menu submenus and the theme submenu, by passing its two refs to `Menu.SubmenuTrigger` and `Menu.Popup`.
- A deliberate move down onto a sibling item still closes the submenu.
- Nothing looks different in a still frame: the change is visible only while the pointer moves.

## How did you test this code?

- `safeTriangle.test.ts` covers the geometry: a sign flip or a wrong edge choice would leave the wedge pointing away from the submenu and silently disable the whole feature. No existing test touches it.
- Drove the real `NewAccountMenu` in Storybook with Playwright, mouse moving in 40 steps from the trigger to the far corner of the submenu, counting open `[role="menu"]` elements.

<details>
<summary>Measured before and after</summary>

| Path | Before | After |
| --- | --- | --- |
| Diagonal to the projects submenu | closed at step 4 of 40 | stayed open |
| Diagonal to the organizations submenu | closed at step 7 of 40 | stayed open |
| Straight down onto a sibling item | closed at step 3 | closed at step 3 |

Also ran the same paths against a standalone Base UI menu, including a slow traversal (120 steps), a sagging path, and a path paused for 600 ms mid-way. The paused path closes, by design.

</details>

- Not run: the Playwright e2e suite and the visual regression suite, which need the full app stack. Neither covers these menus today.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tooling: pi, running Claude. Skills invoked: `/writing-ui-components`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.
- Two alternatives were rejected during the session. Turning on `openOnHover` restores Base UI's own safe polygon, but it also sets `ignoreMouse` on the click handler, so the trigger stops opening on click. Setting `closeDelay` only defers the close, and nothing cancels the timer once the pointer is inside the submenu, so the submenu closes under the pointer.
- The hook keys "the pointer is still on the trigger" off the event target rather than the trigger's rect. On the boundary pixel the rect reads as a hit while the move already belongs to the item below, which broke the first version at slower pointer speeds.
- The stall limit follows Base UI's own safe polygon, which stops protecting a cursor that slows down or stops.
- Nothing in this PR draws on anything outside the repository.
