### PR TITLE
fix(dashboards): reload tiles when an insight rename lands before they are in state

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -2528,10 +2528,23 @@ describe('dashboardLogic', () => {
                 insightsModel.actions.renameInsightSuccess({
                     ...insight800(),
                     short_id: 'not_already_on_the_dashboard' as InsightShortId,
+                    dashboard_tiles: [{ id: 1, dashboard_id: 9 }],
                 })
             })
                 .toFinishAllListeners()
                 .toDispatchActions(['loadDashboard'])
+        })
+
+        it('does not reload when an external rename targets a different dashboard only', async () => {
+            const loadDashboardSpy = jest.spyOn(logic.actions, 'loadDashboard')
+            await expectLogic(logic, () => {
+                insightsModel.actions.renameInsightSuccess({
+                    ...insight800(),
+                    short_id: 'not_already_on_the_dashboard' as InsightShortId,
+                    dashboard_tiles: [{ id: 1, dashboard_id: 10 }],
+                })
+            }).toFinishAllListeners()
+            expect(loadDashboardSpy).not.toHaveBeenCalled()
         })
     })
 

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -2522,6 +2522,17 @@ describe('dashboardLogic', () => {
                 .toFinishAllListeners()
                 .toDispatchActions(['loadDashboard'])
         })
+
+        it('reloads when an external rename lands before the tile is in state', async () => {
+            await expectLogic(logic, () => {
+                insightsModel.actions.renameInsightSuccess({
+                    ...insight800(),
+                    short_id: 'not_already_on_the_dashboard' as InsightShortId,
+                })
+            })
+                .toFinishAllListeners()
+                .toDispatchActions(['loadDashboard'])
+        })
     })
 
     describe('text tiles', () => {

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -3387,6 +3387,15 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 actions.loadDashboard({ action: DashboardLoadAction.Update })
             }
         },
+        [insightsModel.actionTypes.renameInsightSuccess]: ({ item }: { item: QueryBasedInsightModel }) => {
+            const tileIndex = values.tiles.findIndex((t) => !!t.insight && t.insight.short_id === item.short_id)
+
+            if (tileIndex === -1) {
+                // the rename landed before this dashboard had the tile in state, so the reducer
+                // could not patch it and the tile would show the stale name forever - reload instead
+                actions.loadDashboard({ action: DashboardLoadAction.Update })
+            }
+        },
         duplicateTile: () => {
             cache.widgetTileIdsBeforeDuplicate = new Set(values.widgetTiles.map((tile) => tile.id))
         },

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -3388,6 +3388,12 @@ export const dashboardLogic = kea<dashboardLogicType>([
             }
         },
         [insightsModel.actionTypes.renameInsightSuccess]: ({ item }: { item: QueryBasedInsightModel }) => {
+            const targetDashboards = (item.dashboard_tiles || []).map((tile) => tile.dashboard_id)
+            if (!targetDashboards.includes(props.id)) {
+                // this update is not for this dashboard
+                return
+            }
+
             const tileIndex = values.tiles.findIndex((t) => !!t.insight && t.insight.short_id === item.short_id)
 
             if (tileIndex === -1) {


### PR DESCRIPTION
Robot:

## Problem

The E2E test `dashboards.spec.ts > Inline editing insight title via compact card popover` flaked once in 40+ runs ([log](https://github.com/PostHog/posthog/actions/runs/32075114112/job/95527181495)): the "Insight updated" toast appeared, but the card title kept the old name for the whole 40s timeout - and again on the retry.

Tracing the update path shows an app-side race, not a test bug:

1. The popover title edit calls `insightsModel.actions.updateInsightDirect`, which PATCHes and then fires `renameInsightSuccess` + toast.
2. `dashboardLogic` syncs its tiles from `renameInsightSuccess` in a **reducer** that only patches a tile already present in state. There is no fallback.
3. When the rename lands while a freshly created dashboard's tiles are not loaded yet (exactly this test's setup on a busy 4-worker runner), the patch silently no-ops. Nothing ever refetches, so the card shows the stale name forever - while the server has the new name, which is why the "reload and verify" step would still pass.

The sibling path proves the intended resilience: `updateDashboardInsight` already handles "insight not in current tiles" by dispatching `loadDashboard` ([dashboardLogic.tsx](https://github.com/PostHog/posthog/blob/master/frontend/src/scenes/dashboard/dashboardLogic.tsx)). The rename path simply lacked the mirror.

## Changes

- `frontend/src/scenes/dashboard/dashboardLogic.tsx`: listener fallback mirroring `updateDashboardInsight` - on `renameInsightSuccess`, if the insight is not in the current tiles, reload the dashboard (`DashboardLoadAction.Update`). Like the sibling listener it is scoped by `item.dashboard_tiles` membership, so a rename cannot fan out a reload into unrelated mounted dashboard logics (review finding on the first revision).
- `frontend/src/scenes/dashboard/dashboardLogic.test.ts`: jest tests pinning both halves of the behavior: reload when the rename lands before the tile is in state (and this dashboard is a member), and no reload when the payload targets other dashboards only - asserted with an action spy because the negative-dispatch form trips on unrelated `loadDashboard` noise in the same window.
- No playwright changes: the spec was already asserting the right user-visible behaviour (toast then card updates, then persists across reload). The flaky part was the app, so the fix is in the logic and the e2e spec continues to guard it unchanged.

## How did you test this code?

- Fallback verified by spying: `loadDashboard` fires exactly when the tile is missing from state, and does not fire when the insight belongs to other dashboards only.
- Full `dashboardLogic.test.ts` suite passes locally: 111 passed, 1 skipped, 0 failed.
- A negative-form test (assert no reload when tile present) was deliberately dropped after debugging: kea-test-utils' negative assertion trips on unrelated `loadDashboard`-family dispatches (auto-refresh) in the same window, so it guards noise not behaviour.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Diagnosed from the CI run's error-context artifact, verified the reducer/listener asymmetry by reading `dashboardLogic`, and confirmed the listener semantics with a throwaway instrumentation test before writing the real one. No customer data involved.
