### PR TITLE
feat(inbox): remove yourself from reviewers in list

### DIFF
--- a/products/desktop/packages/core/src/inbox/reportArtefacts.ts
+++ b/products/desktop/packages/core/src/inbox/reportArtefacts.ts
@@ -28,15 +28,20 @@ function latestOfType<T extends ReportArtefact>(
   return latest;
 }
 
+export function selectSuggestedReviewersArtefact(
+  artefacts: ReportArtefact[],
+): SuggestedReviewersArtefact | null {
+  return latestOfType<SuggestedReviewersArtefact>(
+    artefacts,
+    "suggested_reviewers",
+  );
+}
+
 export function selectSuggestedReviewers(
   artefacts: ReportArtefact[],
   meUuid?: string,
 ): SuggestedReviewer[] {
-  const artefact = latestOfType<SuggestedReviewersArtefact>(
-    artefacts,
-    "suggested_reviewers",
-  );
-  const reviewers = artefact?.content ?? [];
+  const reviewers = selectSuggestedReviewersArtefact(artefacts)?.content ?? [];
   if (!meUuid) return reviewers;
   const meIndex = reviewers.findIndex((r) => r.user?.uuid === meUuid);
   if (meIndex <= 0) return reviewers;

--- a/products/desktop/packages/ui/src/features/inbox/components/PullRequestCard.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/PullRequestCard.tsx
@@ -129,10 +129,7 @@ export function PullRequestCardView({
       {renderBody(body, inboxCardBodyClassName)}
 
       <InboxCardActions>
-        <SuggestedReviewerAvatarStack
-          reportId={report.id}
-          artefacts={artefacts}
-        />
+        <SuggestedReviewerAvatarStack report={report} artefacts={artefacts} />
         <UiButton
           type="button"
           variant="soft"

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportCard.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportCard.tsx
@@ -244,7 +244,7 @@ export function ReportCardView(props: ReportCardViewProps) {
   ) : (
     <>
       <SuggestedReviewerAvatarStack
-        reportId={report.id}
+        report={report}
         artefacts={props.artefacts}
       />
       <UiButton

--- a/products/desktop/packages/ui/src/features/inbox/components/SuggestedReviewerAvatarStack.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/SuggestedReviewerAvatarStack.test.tsx
@@ -95,6 +95,7 @@ describe("SuggestedReviewerAvatarStack", () => {
       name: "remove me from reviewers",
     });
     expect(!!button).toBe(isClickable);
+    expect(screen.getByText("2 suggested reviewers")).toBeTruthy();
   });
 
   it("removes the current user and tracks the list action", async () => {

--- a/products/desktop/packages/ui/src/features/inbox/components/SuggestedReviewerAvatarStack.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/SuggestedReviewerAvatarStack.test.tsx
@@ -1,0 +1,131 @@
+import type {
+  SignalReport,
+  SignalReportArtefactsResponse,
+  SuggestedReviewer,
+} from "@posthog/shared/types";
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  currentUserUuid: "user-me",
+  mutate: vi.fn(),
+  trackAction: vi.fn(),
+}));
+
+vi.mock("@posthog/ui/features/auth/authClient", () => ({
+  useOptionalAuthenticatedClient: () => ({}),
+}));
+
+vi.mock("@posthog/ui/features/auth/useCurrentUser", () => ({
+  useCurrentUser: () => ({ data: { uuid: mocks.currentUserUuid } }),
+}));
+
+vi.mock("@posthog/ui/features/inbox/hooks/useInboxReports", () => ({
+  useInboxReportArtefacts: () => ({ data: undefined }),
+  useUpdateSuggestedReviewers: () => ({
+    mutate: mocks.mutate,
+    isPending: false,
+  }),
+}));
+
+vi.mock("@posthog/ui/features/inbox/hooks/useReportActionTracker", () => ({
+  useReportActionTracker: () => mocks.trackAction,
+}));
+
+import { SuggestedReviewerAvatarStack } from "./SuggestedReviewerAvatarStack";
+
+function reviewer(login: string, uuid: string): SuggestedReviewer {
+  return {
+    github_login: login,
+    github_name: login,
+    relevant_commits: [],
+    user: {
+      id: 1,
+      uuid,
+      email: `${login}@example.com`,
+      first_name: login,
+      last_name: "",
+    },
+  };
+}
+
+const me = reviewer("alice", "user-me");
+const teammate = reviewer("bob", "user-bob");
+const report = {
+  id: "report-1",
+  title: "Investigate checkout failures",
+  summary: "Checkout failures increased.",
+  status: "ready",
+  total_weight: 1,
+  signal_count: 1,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+  artefact_count: 1,
+  is_suggested_reviewer: true,
+} satisfies SignalReport;
+const artefacts = {
+  count: 1,
+  results: [
+    {
+      id: "reviewers-1",
+      type: "suggested_reviewers",
+      created_at: "2026-01-01T00:00:00Z",
+      content: [me, teammate],
+    },
+  ],
+} satisfies SignalReportArtefactsResponse;
+
+describe("SuggestedReviewerAvatarStack", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.currentUserUuid = "user-me";
+  });
+
+  it.each([
+    ["the current user is assigned", "user-me", true],
+    ["the current user is not assigned", "user-other", false],
+  ])("is clickable when %s", (_case, currentUserUuid, isClickable) => {
+    mocks.currentUserUuid = currentUserUuid;
+    render(
+      <SuggestedReviewerAvatarStack report={report} artefacts={artefacts} />,
+    );
+
+    const button = screen.queryByRole("button", {
+      name: "remove me from reviewers",
+    });
+    expect(!!button).toBe(isClickable);
+  });
+
+  it("removes the current user and tracks the list action", async () => {
+    const onCardClick = vi.fn();
+    const user = userEvent.setup();
+    document.addEventListener("click", onCardClick);
+    render(
+      <SuggestedReviewerAvatarStack report={report} artefacts={artefacts} />,
+    );
+
+    const button = screen.getByRole("button", {
+      name: "remove me from reviewers",
+    });
+    await user.hover(button);
+    expect(await screen.findByText("remove me from reviewers")).toBeTruthy();
+
+    fireEvent.click(button);
+
+    expect(onCardClick).not.toHaveBeenCalled();
+    expect(mocks.mutate).toHaveBeenCalledWith({
+      artefactId: "reviewers-1",
+      content: [{ github_login: "bob" }],
+      optimisticReviewers: [teammate],
+    });
+    expect(mocks.trackAction).toHaveBeenCalledWith(
+      "remove_suggested_reviewer",
+      {
+        suggested_reviewer_login: "alice",
+        suggested_reviewer_uuid: "user-me",
+      },
+    );
+    document.removeEventListener("click", onCardClick);
+  });
+});

--- a/products/desktop/packages/ui/src/features/inbox/components/SuggestedReviewerAvatarStack.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/SuggestedReviewerAvatarStack.tsx
@@ -63,9 +63,11 @@ export function SuggestedReviewerAvatarStack({
   );
   const visible = reviewers.slice(0, MAX_VISIBLE);
   const overflow = reviewers.length - visible.length;
+  const reviewerCountLabel = `${reviewers.length} suggested reviewer${reviewers.length === 1 ? "" : "s"}`;
 
   const avatarStack = (
     <span className="-space-x-1.5 flex items-center">
+      <span className="sr-only">{reviewerCountLabel}</span>
       {visible.map((reviewer) => (
         <SuggestedReviewerAvatar
           key={reviewer.github_login}

--- a/products/desktop/packages/ui/src/features/inbox/components/SuggestedReviewerAvatarStack.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/SuggestedReviewerAvatarStack.tsx
@@ -1,63 +1,143 @@
 import {
-  extractSuggestedReviewers,
   suggestedReviewerDisplayName,
+  toSuggestedReviewerWriteContent,
 } from "@posthog/core/inbox/artefacts";
-import type { SignalReportArtefactsResponse } from "@posthog/shared/types";
+import { selectSuggestedReviewersArtefact } from "@posthog/core/inbox/reportArtefacts";
+import {
+  Button,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@posthog/quill";
+import type {
+  SignalReport,
+  SignalReportArtefactsResponse,
+} from "@posthog/shared/types";
+import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
+import { useCurrentUser } from "@posthog/ui/features/auth/useCurrentUser";
 import { SuggestedReviewerAvatar } from "@posthog/ui/features/inbox/components/utils/SuggestedReviewerAvatar";
-import { useInboxReportArtefacts } from "@posthog/ui/features/inbox/hooks/useInboxReports";
-import { Flex, Tooltip } from "@radix-ui/themes";
+import {
+  useInboxReportArtefacts,
+  useUpdateSuggestedReviewers,
+} from "@posthog/ui/features/inbox/hooks/useInboxReports";
+import { useReportActionTracker } from "@posthog/ui/features/inbox/hooks/useReportActionTracker";
 
 const MAX_VISIBLE = 4;
+// Keep this stable because autocapture insights and UI tests can depend on it.
+const REMOVE_SELF_DATA_ATTR = "inbox-remove-self-from-reviewers";
+const REMOVE_SELF_TOOLTIP = "remove me from reviewers";
 
 interface SuggestedReviewerAvatarStackProps {
-  reportId: string;
+  report: SignalReport;
   artefacts?: SignalReportArtefactsResponse | null;
 }
 
 export function SuggestedReviewerAvatarStack({
-  reportId,
+  report,
   artefacts,
 }: SuggestedReviewerAvatarStackProps) {
-  const { data } = useInboxReportArtefacts(reportId, {
+  const client = useOptionalAuthenticatedClient();
+  const { data: currentUser } = useCurrentUser({ client, enabled: !!client });
+  const { data } = useInboxReportArtefacts(report.id, {
     enabled: artefacts === undefined,
     staleTime: 5 * 60 * 1000,
     refetchOnWindowFocus: false,
   });
-  const reviewers = extractSuggestedReviewers(
-    artefacts?.results ?? data?.results,
-  ).filter((reviewer) => reviewer.github_login);
+  const { mutate: updateReviewers, isPending } = useUpdateSuggestedReviewers(
+    report.id,
+  );
+  const fireAction = useReportActionTracker(report, "list_row");
+  const reviewerArtefact = selectSuggestedReviewersArtefact(
+    artefacts?.results ?? data?.results ?? [],
+  );
+  const reviewers = (reviewerArtefact?.content ?? []).filter(
+    (reviewer) => reviewer.github_login,
+  );
   if (reviewers.length === 0) {
     return null;
   }
 
+  const currentReviewer = reviewers.find(
+    (reviewer) => reviewer.user?.uuid === currentUser?.uuid,
+  );
   const visible = reviewers.slice(0, MAX_VISIBLE);
   const overflow = reviewers.length - visible.length;
 
+  const avatarStack = (
+    <span className="-space-x-1.5 flex items-center">
+      {visible.map((reviewer) => (
+        <SuggestedReviewerAvatar
+          key={reviewer.github_login}
+          githubLogin={reviewer.github_login}
+          size="sm"
+          className="ring-(--color-panel-solid) ring-2"
+        />
+      ))}
+      {overflow > 0 ? (
+        <span className="inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-(--gray-3) px-1 font-semibold text-[9px] text-gray-11 leading-none ring-(--color-panel-solid) ring-2">
+          +{overflow}
+        </span>
+      ) : null}
+    </span>
+  );
+
+  if (!currentReviewer || !reviewerArtefact) {
+    const reviewerNames = visible
+      .map((reviewer) => suggestedReviewerDisplayName(reviewer))
+      .join(", ");
+    return (
+      <TooltipProvider delay={300}>
+        <Tooltip>
+          <TooltipTrigger render={<span className="shrink-0" />}>
+            {avatarStack}
+          </TooltipTrigger>
+          <TooltipContent>{reviewerNames}</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+  }
+
+  const removeSelf = () => {
+    const nextReviewers = reviewerArtefact.content.filter(
+      (reviewer) => reviewer.user?.uuid !== currentUser?.uuid,
+    );
+    fireAction("remove_suggested_reviewer", {
+      suggested_reviewer_login: currentReviewer.github_login,
+      suggested_reviewer_uuid: currentReviewer.user?.uuid,
+    });
+    updateReviewers({
+      artefactId: reviewerArtefact.id,
+      content: toSuggestedReviewerWriteContent(nextReviewers),
+      optimisticReviewers: nextReviewers,
+    });
+  };
+
   return (
-    <Flex
-      align="center"
-      className="shrink-0"
-      aria-label={`${reviewers.length} suggested reviewer${reviewers.length === 1 ? "" : "s"}`}
-    >
-      <Flex align="center" className="-space-x-1.5">
-        {visible.map((reviewer) => {
-          const name = suggestedReviewerDisplayName(reviewer);
-          return (
-            <Tooltip key={reviewer.github_login} content={name}>
-              <SuggestedReviewerAvatar
-                githubLogin={reviewer.github_login}
-                size="sm"
-                className="ring-(--color-panel-solid) ring-2"
-              />
-            </Tooltip>
-          );
-        })}
-        {overflow > 0 ? (
-          <span className="inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-(--gray-3) px-1 font-semibold text-[9px] text-gray-11 leading-none ring-(--color-panel-solid) ring-2">
-            +{overflow}
-          </span>
-        ) : null}
-      </Flex>
-    </Flex>
+    <TooltipProvider delay={300}>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <Button
+              type="button"
+              variant="link-muted"
+              size="xs"
+              className="h-auto p-0 no-underline hover:no-underline"
+              aria-label={REMOVE_SELF_TOOLTIP}
+              data-attr={REMOVE_SELF_DATA_ATTR}
+              loading={isPending}
+              onClick={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                removeSelf();
+              }}
+            />
+          }
+        >
+          {avatarStack}
+        </TooltipTrigger>
+        <TooltipContent>{REMOVE_SELF_TOOLTIP}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useInboxReports.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useInboxReports.test.tsx
@@ -111,6 +111,24 @@ describe("useUpdateSuggestedReviewers", () => {
     expect(latest.content.map((r) => r.github_login)).toEqual(["octocat"]);
   });
 
+  it("invalidates report lists after updating reviewers", async () => {
+    mockUpdateArtefact.mockResolvedValue(artefact([reviewer("octocat")]));
+    const { result, queryClient } = renderUpdateHook();
+
+    const listKey = reportKeys.list({ suggested_reviewers: "user-me" });
+    queryClient.setQueryData(listKey, { results: [], count: 0 });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        artefactId: ARTEFACT_ID,
+        content: [{ github_login: "octocat" }],
+        optimisticReviewers: [reviewer("octocat")],
+      });
+    });
+
+    expect(queryClient.getQueryState(listKey)?.isInvalidated).toBe(true);
+  });
+
   it("rolls back the cache when the request fails", async () => {
     const failure = new Error("boom");
     mockUpdateArtefact.mockRejectedValue(failure);

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useInboxReports.ts
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useInboxReports.ts
@@ -236,7 +236,7 @@ interface UpdateSuggestedReviewersVariables {
  * Edits a report's suggested reviewers. The server appends a new `suggested_reviewers` status
  * artefact (latest-wins), so the work-log keeps the full history of changes. We optimistically
  * append a synthetic latest row — mirroring the server — so the detail pane reflects the change
- * instantly (immediate apply); the refetch on settle reconciles it with the real row.
+ * instantly (immediate apply); the refetch on settle reconciles the report and artefact caches.
  */
 export function useUpdateSuggestedReviewers(reportId: string) {
   const queryClient = useQueryClient();
@@ -283,9 +283,8 @@ export function useUpdateSuggestedReviewers(reportId: string) {
         }
         toast.error(error.message || "Failed to update suggested reviewers");
       },
-      onSettled: () => {
-        queryClient.invalidateQueries({ queryKey });
-      },
+      onSettled: () =>
+        queryClient.invalidateQueries({ queryKey: reportKeys.all }),
     },
   );
 }


### PR DESCRIPTION
## Problem

🤖 Robot: Inbox reviewers must open a report before they can remove themselves. The visible list action only offers archive.

## Changes

- Clicking the reviewer avatars now removes the signed-in reviewer from report and pull request list cards.
- The action works in the shared Inbox UI for desktop and web.
- The request disables the avatar button until it finishes.
- The For you list refreshes after the reviewer update succeeds.
- Read-only reviewer stacks keep their reviewer count available to screen readers.
- The existing `Inbox report action` custom event records `remove_suggested_reviewer` with the `list_row` surface.

![inbox-reviewer-stack](https://raw.githubusercontent.com/PostHog/pr-assets/38e33a8d7d424af382d36ae7c0c65437b95db916/2026/08/285ac464-8138-4030-ac86-c414dce044fa.png)

## How did you test this code?

- The component test guards self-only clicks, the reviewer update, click isolation, the tooltip, analytics, and the screen-reader label.
- The hook test guards the report-list refresh after reviewer updates.
- The full `@posthog/core` and `@posthog/ui` test suites passed before the final accessibility-only commit.
- The focused Inbox tests and UI TypeScript check pass on the final SHA.
- The desktop and web host TypeScript checks pass.
- The Storybook build passes. Headless Chromium rendered the pull request card without page errors.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This change uses the existing reviewer action and API.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Pi completed the code changes and checks.
- Skills invoked: `/writing-ui-components`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-code-comments`, `/writing-pr-descriptions`, `instrument-product-analytics`, `skills-store`, `working-with-skills`, `pr-shepherd`, `qa-swarm`, `review-triage`, `ci-shepherd`, and `paul-pair`.
- The quality loop fixed a stale For you list and restored the reviewer stack's accessible name.
- The change reuses the Inbox event family instead of adding a separate event name.
- The test data and screenshot use invented report content.
