### PR TITLE
fix(docker): install posthog-owners non-editable in llm-analytics image

### DIFF
--- a/Dockerfile.llm-analytics
+++ b/Dockerfile.llm-analytics
@@ -44,9 +44,12 @@ RUN --mount=type=cache,id=uv-libxmlsec1.2.37-2,target=/root/.cache/uv \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     --mount=type=bind,source=tools/hogli,target=tools/hogli \
     # uv sync validates workspace membership even with --no-dev, so every
-    # workspace member must be present in the build context.
+    # workspace member must be present in the build context. tools/owners is also a real install
+    # source here: posthog-owners is a runtime dependency (stamphog's digest reads owners.yaml
+    # through it, and posthog/urls.py imports that chain unconditionally), and --no-editable copies
+    # it into the venv so the image never depends on this bind mount's path surviving.
     --mount=type=bind,source=tools/owners,target=tools/owners \
-    uv sync --locked --no-dev --no-install-project --group sentiment --no-binary-package lxml --no-binary-package xmlsec
+    uv sync --locked --no-dev --no-editable --no-install-project --group sentiment --no-binary-package lxml --no-binary-package xmlsec
 
 # Copy project files
 COPY manage.py manage.py
@@ -62,6 +65,13 @@ ENV PATH=/python-runtime/bin:$PATH \
     PYTHONPATH=/python-runtime \
     POSTHOG_SENTIMENT_MODEL_CACHE=/opt/posthog-sentiment-model \
     TIKTOKEN_CACHE_DIR=/code/.tiktoken_cache
+
+# posthog-owners is installed from a bind mount that does not survive into the image, so a missing
+# --no-editable above leaves an editable install pointing at /code/tools/owners and every Django
+# entrypoint dies on `import posthog_owners` at runtime instead of here. The root Dockerfile asserts
+# the same invariant with `test -d tools/owners/posthog_owners`; this image never copies that source
+# tree, so assert importability instead of presence.
+RUN python -c "import posthog_owners"
 
 # Pre-warm the tiktoken BPE encoding cache into the image so runtime token counting reads the
 # blobs from disk instead of fetching them from OpenAI's blob host on first use, which fails under


### PR DESCRIPTION
## Problem

`temporal-worker-llm-analytics` on dev wedged this morning and paged Critical (`ArgoCD Deployment failed on dev`). The `migration-check-sync-*` PreSync hook crashes in a loop on Django startup:

```
File "django/core/checks/urls.py", line 136, in check_custom_error_handlers
  handler = resolver.resolve_error_handler(status_code)
File "django/urls/resolvers.py", line 732, in resolve_error_handler
ModuleNotFoundError: No module named 'posthog_owners'
```

It never signals migrations complete, exceeds `activeDeadlineSeconds`, and Argo never leaves `OutOfSync`. The worker `Deployment` is sync-wave 2, so it never received the new image and sits **Healthy on the old one** (`c30d2736…`) — dev is frozen on older code, not running the new build. "Healthy" here means "un-updated", not "rolled out".

## Root cause

`posthog-owners` is a uv **workspace member** (`[tool.uv.workspace] members = ["tools/hogli", "tools/owners"]`), so `uv.lock` records it as `editable = "tools/owners"`.

#83631 promoted it from dev tooling to a **main runtime dependency** and added `--no-editable` to the root `Dockerfile` — but did not touch this file. That commit (`9141de2`) changed exactly `pyproject.toml` and `Dockerfile`:

```
-    # Distributed owners.yaml resolver — installed so hogli's owners:* commands and
-    # the pr-approval gate can `import posthog_owners` from the main venv.
+    # Distributed owners.yaml resolver. A runtime dependency, not just tooling: stamphog's digest
     "posthog-owners",
```

It is a runtime dependency because stamphog's digest reads a repo's team → Slack channel registry through it. That import is reachable from `posthog/urls.py` at module level, in six hops — verified by a static import walk over the tree, no conditionals or `TYPE_CHECKING` guards anywhere on the path:

```
posthog.urls
 -> products.stamphog.backend.facade.webhooks
   -> products.stamphog.backend.presentation.webhooks
     -> products.stamphog.backend.facade.tasks
       -> products.stamphog.backend.tasks.digest
         -> products.stamphog.backend.logic.channel_resolution
           -> posthog_owners.resolver
```

So `uv sync --no-dev` now installs `posthog-owners` in this image too. But this image only **bind-mounts** `tools/owners` (added in #68872 purely to satisfy uv's workspace validation) and never `COPY`s it. The editable install resolves to `/code/tools/owners`, a path that does not exist at runtime — so the build succeeds and then every Django entrypoint in the image dies on `import posthog_owners`.

The root `Dockerfile` already handles this at line 207:

```
uv sync --locked --no-dev --no-editable --no-install-project …
```

This image's line was the same call — modulo its `--group sentiment` — but missing `--no-editable`.

## Fix

- Add `--no-editable` to this image's `uv sync`, mirroring the root Dockerfile's flag and comment. It copies the package into the venv, so the image no longer depends on a build-time bind mount's path surviving.
- Assert importability at build time, so the next drift between these two files fails the build instead of a deploy.

Deliberately **not** adding `COPY tools/owners`. The root image copies that source tree so stamphog can ship the resolver into its sandbox at runtime (`_ship_owners_package` reads it from disk), but stamphog runs on `stamphog-task-queue` and this image serves `llm-analytics-task-queue`, so that path never executes here. Copying it would also leave the install editable — i.e. keep the runtime path dependency that broke us. For the same reason the build guard asserts importability rather than mirroring root's `test -d tools/owners/posthog_owners` presence check.

Also deliberately not making the stamphog import chain lazy. #83631 made `posthog-owners` a runtime dependency on purpose, and a lazy import fixes nothing structurally — the next runtime import added to `posthog/urls.py` breaks this image again.

## Why this keeps happening

Second time for this image, same class and same wedged hook:

- 2026-07-14 — `ModuleNotFoundError: No module named 'common.alerting'`, fixed by 2883d5f8 (#70654) — a missing `COPY`.
- 2026-08-18 — this one — a missing `--no-editable`.

Both were **dormant then triggered**: the PR that introduces the breakage doesn't rebuild this image; an unrelated later commit matching the path filter does. Today's trigger was `6c8c5ccc` ("fix(aio): render all otel genai part types"), ~12h after #83631 landed. The standing hazard is that `Dockerfile` and `Dockerfile.llm-analytics` are two halves of one contract kept in step by hand, with nothing failing when they drift. The build guard here closes that for `posthog_owners` specifically; a general fix is out of scope for this PR.

## Blast radius

Dev only. prod-us is `Synced`/`Healthy` because it is still pinned to `c30d2736…` (I did not check prod-eu), but both regions build from this same Dockerfile and would fail identically on promotion to any build after #83631.

## Testing

Not built locally — this image bakes ONNX sentiment models and the full ML dependency set. The flag combination is proven by the root Dockerfile, which pins the same uv version (`0.11.14`, verified identical in both files) against the same `uv.lock` and uses `--no-editable` today.

The new `RUN python -c "import posthog_owners"` is the real gate: without `--no-editable` the editable install points at a non-existent path, so this fails at build time in CI rather than at deploy time. Its own dependencies are satisfied — `posthog_owners/__init__.py` re-exports from `.matcher`/`.resolver`, whose only third-party need is `pyyaml`, a main dependency.

I also checked that no sibling image has the same defect: only the root `Dockerfile` and this one run the workspace `uv sync`, and both now carry the flag. `services/llm-gateway/Dockerfile` also runs `uv sync --locked --no-dev`, but against its own `pyproject.toml`/`uv.lock` and is not a member of this workspace, so it is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
