### PR TITLE
fix(github): treat a 422 on the topics endpoint as a benign zero-row skip

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/github/github.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/github/github.py
@@ -5,7 +5,7 @@ import dataclasses
 from collections.abc import AsyncIterator, Callable, Iterator
 from datetime import UTC, date, datetime, timedelta
 from typing import Any, Literal, Optional
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlsplit
 
 import pyarrow as pa
 import requests
@@ -299,6 +299,12 @@ def _is_repository_too_large_for_code_frequency(response: requests.Response) -> 
     except (ValueError, TypeError):
         message = response.text or ""
     return isinstance(message, str) and "fewer than 10000 commits" in message.lower()
+
+
+def _is_topics_endpoint(page_url: str) -> bool:
+    """The repository topics endpoint (/repos/{owner}/{repo}/topics). Matched on the URL path so a
+    repository literally named `topics`, or a query string, can't be mistaken for it."""
+    return urlsplit(page_url).path.endswith("/topics")
 
 
 def _as_utc(dt: datetime) -> datetime:
@@ -869,6 +875,15 @@ def _fetch_page(
 
     if _is_repository_too_large_for_code_frequency(response):
         raise GithubRepositoryTooLargeError()
+
+    # GitHub answers 422 on /repos/{owner}/{repo}/topics for some repositories rather than an empty
+    # {"names": []} body. Topics are optional repository metadata, so one repository's 422 there
+    # must not fail its whole schema the way a generic 422 does — sync zero rows, the same benign
+    # skip as a switched-off feature. A genuinely broken connection still fails loudly on the
+    # repository's other tables (401/403/404), so skipping topics here cannot hide it.
+    if response.status_code == 422 and _is_topics_endpoint(page_url):
+        logger.info(f"Github: topics not available for this repository, syncing zero rows: url={page_url}")
+        raise GithubResourceUnavailableError(_github_error_message(response))
 
     # An org-scoped endpoint 404s when the repo owner is a user (no org) or the token lacks org
     # access. Signal it so the caller syncs zero rows rather than failing the schema — a benign skip

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_fetch_page.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_fetch_page.py
@@ -131,6 +131,17 @@ def test_fetch_page_reraises_other_422_errors():
             github._fetch_page("https://api.github.com/repos/o/r/stats/code_frequency", {}, mock.Mock())
 
 
+def test_fetch_page_treats_topics_422_as_resource_unavailable():
+    # GitHub 422s the topics endpoint for some repositories; it's optional metadata, so the caller
+    # must sync zero rows rather than crash and fail the schema over a raw 422.
+    session = mock.Mock()
+    session.request.return_value = _unprocessable_response("Validation failed")
+
+    with mock.patch.object(github, "make_tracked_session", return_value=session):
+        with pytest.raises(github.GithubResourceUnavailableError):
+            github._fetch_page("https://api.github.com/repos/o/r/topics?per_page=100", {}, mock.Mock())
+
+
 def test_fetch_page_retries_chunked_encoding_error():
     session = mock.Mock()
     session.request.side_effect = [requests.exceptions.ChunkedEncodingError("Connection broken"), _ok_response()]


### PR DESCRIPTION
## Problem

- A GitHub source's topics table fails its sync with a raw "422 Client Error: Unprocessable Entity" and imports nothing, across a wide spread of repositories.
- GitHub answers 422 on `/repos/{owner}/{repo}/topics` for some repositories instead of an empty `{"names": []}` body.
- `_fetch_page` has no handler for that 422, so it falls through to `raise_for_status()` and fails the whole topics schema with the raw driver message.

## Changes

- `_fetch_page` now raises `GithubResourceUnavailableError` on a 422 from the topics endpoint, so the sync writes zero rows instead of failing.
- Matched on the URL path, so only the topics endpoint is affected. Every other endpoint's 422 stays fatal, as the existing test asserts.
- Topics are optional repository metadata, so a per-repository 422 there must not fail the schema. A genuinely broken connection still fails loudly on the repository's other tables (401/403/404), so this skip cannot hide it.

> [!NOTE]
> The exact reason GitHub returns 422 here is not in the recorded failures, but the spread across many unrelated teams points to a per-repository condition rather than a malformed request PostHog sends (which would fail every topics sync, not a subset).

## How did you test this code?

- Added `test_fetch_page_treats_topics_422_as_resource_unavailable`: a 422 on the topics URL raises `GithubResourceUnavailableError`. No existing test covered the topics endpoint's 422; this guards against the raw-422-crash regression.
- Ran the GitHub fetch-page unit tests locally.
- Not run: a live GitHub sync, since this sandbox cannot reach GitHub.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code, triaging a batch of data-warehouse sync failure classes.
- Skills invoked: `/writing-code-comments`, `/writing-tests`, `/writing-pr-descriptions`.
- Decision: chose a benign zero-row skip (matching the existing empty-repository, disabled-feature, and too-large-code-frequency patterns) over failing the schema, scoped to the topics endpoint so other 422s stay fatal.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
