### PR TITLE
fix(conversations): keep formatting when copying a private note

### DIFF
--- a/frontend/src/lib/utils/copyToClipboard.tsx
+++ b/frontend/src/lib/utils/copyToClipboard.tsx
@@ -4,7 +4,7 @@ import { lemonToast } from '@posthog/lemon-ui'
 export async function copyToClipboard(
     value: string,
     description: string = 'text',
-    { silent = false }: { silent?: boolean } = {}
+    { silent = false, html }: { silent?: boolean; html?: string } = {}
 ): Promise<boolean> {
     if (!navigator.clipboard) {
         lemonToast.warning('Oops! Clipboard capabilities are only available over HTTPS or on localhost')
@@ -18,6 +18,25 @@ export async function copyToClipboard(
         lemonToast.info(`Copied ${description} to clipboard`, {
             icon: <IconCopy />,
         })
+    }
+
+    // Writing both formats lets a paste target that understands HTML keep the formatting, while
+    // plain-text targets still receive `value`. Browser support for `text/html` in a ClipboardItem
+    // is not universal, so a failure here falls through to the plain-text write below rather than
+    // failing the copy.
+    if (html && typeof ClipboardItem !== 'undefined' && navigator.clipboard.write) {
+        try {
+            await navigator.clipboard.write([
+                new ClipboardItem({
+                    'text/html': new Blob([html], { type: 'text/html' }),
+                    'text/plain': new Blob([value], { type: 'text/plain' }),
+                }),
+            ])
+            notifySuccess()
+            return true
+        } catch {
+            // Fall through to the plain-text paths.
+        }
     }
 
     try {

--- a/products/conversations/frontend/components/Chat/Message.tsx
+++ b/products/conversations/frontend/components/Chat/Message.tsx
@@ -17,7 +17,8 @@ import { TZLabel } from 'lib/components/TZLabel'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
 
 import type { AiReplyFeedbackRating, ChatMessage, MessageDeliveryStatus } from '../../types'
-import { SupportMarkdown, SupportRichContentPreview, richContentToHtml } from '../Editor'
+import { SupportMarkdown, SupportRichContentPreview } from '../Editor'
+import { richContentToHtml } from '../Editor/richContentToHtml'
 import { TeamOnlyBadge } from './TeamOnlyBadge'
 
 export interface MessageProps {

--- a/products/conversations/frontend/components/Chat/Message.tsx
+++ b/products/conversations/frontend/components/Chat/Message.tsx
@@ -17,7 +17,7 @@ import { TZLabel } from 'lib/components/TZLabel'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
 
 import type { AiReplyFeedbackRating, ChatMessage, MessageDeliveryStatus } from '../../types'
-import { SupportMarkdown, SupportRichContentPreview } from '../Editor'
+import { SupportMarkdown, SupportRichContentPreview, richContentToHtml } from '../Editor'
 import { TeamOnlyBadge } from './TeamOnlyBadge'
 
 export interface MessageProps {
@@ -61,6 +61,12 @@ export function Message({
             return
         }
         onSubmitAiReplyFeedback(rating)
+    }
+
+    function copyMessage(): void {
+        // Generated on demand rather than per render, since only a copy needs it.
+        const html = richContentToHtml(message.richContent as JSONContent | null)
+        void copyToClipboard(message.content, 'Message', { html: html ?? undefined })
     }
 
     function submitBadFeedbackText(): void {
@@ -151,7 +157,7 @@ export function Message({
                                             size="xsmall"
                                             icon={<IconCopy />}
                                             noPadding
-                                            onClick={() => void copyToClipboard(message.content, 'Message')}
+                                            onClick={copyMessage}
                                         />
                                     </Tooltip>
                                 </div>

--- a/products/conversations/frontend/components/Editor/SupportRichContentPreview.tsx
+++ b/products/conversations/frontend/components/Editor/SupportRichContentPreview.tsx
@@ -1,31 +1,16 @@
 import './SupportEditor.scss'
 
-import { JSONContent, getSchema } from '@tiptap/core'
-import { Node as ProseMirrorNode } from '@tiptap/pm/model'
+import { JSONContent } from '@tiptap/core'
 import { EditorContent } from '@tiptap/react'
 import { useEffect, useMemo } from 'react'
 
 import { useRichContentEditor } from 'lib/components/RichContentEditor'
 import { cn } from 'lib/utils/css-classes'
 
+import { isRenderableRichContent } from './isRenderableRichContent'
 import { SUPPORT_PREVIEW_EXTENSIONS } from './SupportEditor'
 import { SupportMarkdown } from './SupportMarkdown'
 import { useImageLightbox } from './useImageLightbox'
-
-let previewSchema: ReturnType<typeof getSchema> | null = null
-
-function isRenderableRichContent(content: JSONContent | null): content is JSONContent {
-    if (!content) {
-        return false
-    }
-    try {
-        previewSchema = previewSchema ?? getSchema([...SUPPORT_PREVIEW_EXTENSIONS])
-        ProseMirrorNode.fromJSON(previewSchema, content).check()
-        return true
-    } catch {
-        return false
-    }
-}
 
 export interface SupportRichContentPreviewProps {
     content: JSONContent | null

--- a/products/conversations/frontend/components/Editor/index.ts
+++ b/products/conversations/frontend/components/Editor/index.ts
@@ -13,7 +13,5 @@ export type { ImageLightboxProps } from './ImageLightbox'
 export { SupportMarkdown } from './SupportMarkdown'
 export type { SupportMarkdownProps } from './SupportMarkdown'
 
-export { richContentToHtml } from './richContentToHtml'
-
 export { SupportRichContentPreview } from './SupportRichContentPreview'
 export type { SupportRichContentPreviewProps } from './SupportRichContentPreview'

--- a/products/conversations/frontend/components/Editor/index.ts
+++ b/products/conversations/frontend/components/Editor/index.ts
@@ -13,5 +13,7 @@ export type { ImageLightboxProps } from './ImageLightbox'
 export { SupportMarkdown } from './SupportMarkdown'
 export type { SupportMarkdownProps } from './SupportMarkdown'
 
+export { richContentToHtml } from './richContentToHtml'
+
 export { SupportRichContentPreview } from './SupportRichContentPreview'
 export type { SupportRichContentPreviewProps } from './SupportRichContentPreview'

--- a/products/conversations/frontend/components/Editor/isRenderableRichContent.ts
+++ b/products/conversations/frontend/components/Editor/isRenderableRichContent.ts
@@ -1,0 +1,27 @@
+import { JSONContent, getSchema } from '@tiptap/core'
+import { Node as ProseMirrorNode } from '@tiptap/pm/model'
+
+import { SUPPORT_PREVIEW_EXTENSIONS } from './SupportEditor'
+
+let previewSchema: ReturnType<typeof getSchema> | null = null
+
+/**
+ * Whether stored rich content can be rendered against the preview schema.
+ *
+ * The request serializers accept any JSON-serializable shape, so a message can carry known node
+ * types in a structure the schema rejects. Everything that consumes a message's rich content has
+ * to agree on this verdict, otherwise a reader sees the plain-text fallback while another surface
+ * shows something else.
+ */
+export function isRenderableRichContent(content: JSONContent | null | undefined): content is JSONContent {
+    if (!content) {
+        return false
+    }
+    try {
+        previewSchema = previewSchema ?? getSchema([...SUPPORT_PREVIEW_EXTENSIONS])
+        ProseMirrorNode.fromJSON(previewSchema, content).check()
+        return true
+    } catch {
+        return false
+    }
+}

--- a/products/conversations/frontend/components/Editor/richContentToHtml.test.ts
+++ b/products/conversations/frontend/components/Editor/richContentToHtml.test.ts
@@ -1,0 +1,81 @@
+import { JSONContent, getSchema } from '@tiptap/core'
+import { DOMParser as ProseMirrorDOMParser } from '@tiptap/pm/model'
+
+import { richContentToHtml } from './richContentToHtml'
+import { SUPPORT_EXTENSIONS } from './SupportEditor'
+
+// jest.setup.ts stubs this module out, which would make schema construction meaningless here
+jest.unmock('@tiptap/extension-code-block-lowlight')
+
+const paragraph = (...content: JSONContent[]): JSONContent => ({ type: 'paragraph', content })
+const text = (value: string): JSONContent => ({ type: 'text', text: value })
+const listItem = (...content: JSONContent[]): JSONContent => ({ type: 'listItem', content })
+
+/**
+ * What the composer does with a `text/html` paste: ProseMirror parses the HTML against the
+ * editor's own schema. Going through it here is the point of the test, because the bug this
+ * guards against is structure surviving generation but not the paste.
+ */
+function pasteIntoComposer(html: string): JSONContent {
+    const dom = document.createElement('div')
+    dom.innerHTML = html
+    const parser = ProseMirrorDOMParser.fromSchema(getSchema([...SUPPORT_EXTENSIONS]))
+    return parser.parse(dom).toJSON()
+}
+
+/** Node types and text only, so the comparison ignores attrs the schema fills in with defaults. */
+function outline(node: JSONContent): string {
+    if (node.type === 'text') {
+        return node.text ?? ''
+    }
+    if (!node.content) {
+        return `<${node.type}/>`
+    }
+    return `<${node.type}>${node.content.map(outline).join('')}</${node.type}>`
+}
+
+describe('richContentToHtml', () => {
+    // Copying the markdown form instead flattens all of these to a run of plain paragraphs,
+    // because the composer has no markdown paste parser: ProseMirror splits plain text on every
+    // run of newlines, so a blank line and a line break both become one ordinary paragraph
+    // boundary and list markers arrive as literal text.
+    test.each<[string, JSONContent, string]>([
+        [
+            'paragraph breaks',
+            { type: 'doc', content: [paragraph(text('one')), paragraph(text('two'))] },
+            '<doc><paragraph>one</paragraph><paragraph>two</paragraph></doc>',
+        ],
+        [
+            'a deliberate blank line between paragraphs',
+            { type: 'doc', content: [paragraph(text('one')), paragraph(), paragraph(text('two'))] },
+            '<doc><paragraph>one</paragraph><paragraph/><paragraph>two</paragraph></doc>',
+        ],
+        [
+            'hard breaks within a paragraph',
+            { type: 'doc', content: [paragraph(text('one'), { type: 'hardBreak' }, text('two'))] },
+            '<doc><paragraph>one<hardBreak/>two</paragraph></doc>',
+        ],
+        [
+            'list structure',
+            {
+                type: 'doc',
+                content: [
+                    {
+                        type: 'bulletList',
+                        content: [listItem(paragraph(text('one'))), listItem(paragraph(text('two')))],
+                    },
+                ],
+            },
+            '<doc><bulletList><listItem><paragraph>one</paragraph></listItem>' +
+                '<listItem><paragraph>two</paragraph></listItem></bulletList></doc>',
+        ],
+    ])('survives a paste into the composer: %s', (_name, content, expected) => {
+        const html = richContentToHtml(content)
+        expect(html).not.toBeNull()
+        expect(outline(pasteIntoComposer(html as string))).toEqual(expected)
+    })
+
+    it('returns null for content the schema cannot render, so the copy falls back to plain text', () => {
+        expect(richContentToHtml({ type: 'doc', content: [{ type: 'somethingUnknown' }] })).toBeNull()
+    })
+})

--- a/products/conversations/frontend/components/Editor/richContentToHtml.test.ts
+++ b/products/conversations/frontend/components/Editor/richContentToHtml.test.ts
@@ -1,6 +1,8 @@
 import { JSONContent, getSchema } from '@tiptap/core'
 import { DOMParser as ProseMirrorDOMParser } from '@tiptap/pm/model'
 
+import { RichContentNodeType } from 'lib/components/RichContentEditor/types'
+
 import { richContentToHtml } from './richContentToHtml'
 import { SUPPORT_EXTENSIONS } from './SupportEditor'
 
@@ -75,7 +77,28 @@ describe('richContentToHtml', () => {
         expect(outline(pasteIntoComposer(html as string))).toEqual(expected)
     })
 
-    it('returns null for content the schema cannot render, so the copy falls back to plain text', () => {
-        expect(richContentToHtml({ type: 'doc', content: [{ type: 'somethingUnknown' }] })).toBeNull()
+    it('keeps a mention readable outside PostHog and a node inside it', () => {
+        const content: JSONContent = {
+            type: 'doc',
+            content: [paragraph(text('ask '), { type: RichContentNodeType.Mention, attrs: { id: 5 } })],
+        }
+        const html = richContentToHtml(content) as string
+
+        // A mail client renders the text and ignores the tag it does not know
+        expect(html).toContain('@member:5')
+        // The composer restores the node from the tag, and its node view renders the name again
+        expect(outline(pasteIntoComposer(html))).toEqual(
+            `<doc><paragraph>ask <${RichContentNodeType.Mention}/></paragraph></doc>`
+        )
+    })
+
+    // Both of these render as the plain-text form for the reader, so the clipboard has to agree.
+    // `generateHTML` builds the document without checking it, so an invalid structure of known
+    // node types would otherwise serialize to HTML the message never displayed.
+    test.each<[string, JSONContent]>([
+        ['an unknown node type', { type: 'doc', content: [{ type: 'somethingUnknown' }] }],
+        ['known node types in an invalid structure', { type: 'doc', content: [text('bare text under doc')] }],
+    ])('returns null for %s, so the copy falls back to plain text', (_name, content) => {
+        expect(richContentToHtml(content)).toBeNull()
     })
 })

--- a/products/conversations/frontend/components/Editor/richContentToHtml.ts
+++ b/products/conversations/frontend/components/Editor/richContentToHtml.ts
@@ -1,0 +1,30 @@
+import { JSONContent } from '@tiptap/core'
+import { generateHTML } from '@tiptap/html'
+
+import { SUPPORT_PREVIEW_EXTENSIONS } from './SupportEditor'
+
+/**
+ * Render a message's rich content as HTML, for putting on the clipboard alongside the plain-text
+ * markdown form.
+ *
+ * A message's plain-text field is markdown, and nothing that receives a paste parses markdown out
+ * of it. The reply composer is a ProseMirror editor with no markdown paste parser, so pasted text
+ * goes through ProseMirror's default handling, which splits on each run of newlines and makes
+ * every block a plain paragraph. A blank line, a line break, and a list item all end up as the
+ * same ordinary paragraph boundary, and markdown syntax plus the backslash escapes that
+ * `serializeToMarkdown` adds arrive as literal text. HTML is the format both the composer and
+ * mail clients already know how to parse.
+ *
+ * Returns null when the content cannot be rendered against the preview schema, in which case
+ * callers should copy the plain-text form on its own.
+ */
+export function richContentToHtml(content: JSONContent | null | undefined): string | null {
+    if (!content) {
+        return null
+    }
+    try {
+        return generateHTML(content, [...SUPPORT_PREVIEW_EXTENSIONS])
+    } catch {
+        return null
+    }
+}

--- a/products/conversations/frontend/components/Editor/richContentToHtml.ts
+++ b/products/conversations/frontend/components/Editor/richContentToHtml.ts
@@ -1,7 +1,28 @@
-import { JSONContent } from '@tiptap/core'
+import { JSONContent, mergeAttributes } from '@tiptap/core'
 import { generateHTML } from '@tiptap/html'
 
+import { RichContentNodeMention } from 'lib/components/RichContentEditor/RichContentNodeMention'
+import { RichContentNodeType } from 'lib/components/RichContentEditor/types'
+
+import { isRenderableRichContent } from './isRenderableRichContent'
 import { SUPPORT_PREVIEW_EXTENSIONS } from './SupportEditor'
+
+/**
+ * A mention normally shows a member's name through a React node view, which never runs during
+ * plain HTML generation. Without a text child the element serializes empty, so a paste target that
+ * does not know the `ph-mention` tag, such as a mail client, drops the mention and loses a word
+ * from the sentence. The composer parses the node back from the tag and ignores this text, so it
+ * only shows up outside PostHog, where it matches what the markdown form has always carried.
+ */
+const ClipboardMention = RichContentNodeMention.extend({
+    renderHTML({ HTMLAttributes, node }) {
+        return [RichContentNodeType.Mention, mergeAttributes(HTMLAttributes), `@member:${node.attrs.id}`]
+    },
+})
+
+const CLIPBOARD_EXTENSIONS = SUPPORT_PREVIEW_EXTENSIONS.map((extension) =>
+    extension.name === RichContentNodeMention.name ? ClipboardMention : extension
+)
 
 /**
  * Render a message's rich content as HTML, for putting on the clipboard alongside the plain-text
@@ -16,14 +37,16 @@ import { SUPPORT_PREVIEW_EXTENSIONS } from './SupportEditor'
  * mail clients already know how to parse.
  *
  * Returns null when the content cannot be rendered against the preview schema, in which case
- * callers should copy the plain-text form on its own.
+ * callers should copy the plain-text form on its own. That is the same verdict the reader sees,
+ * because `generateHTML` builds the document without checking it against the schema and would
+ * otherwise put content on the clipboard that the message never displayed.
  */
 export function richContentToHtml(content: JSONContent | null | undefined): string | null {
-    if (!content) {
+    if (!isRenderableRichContent(content)) {
         return null
     }
     try {
-        return generateHTML(content, [...SUPPORT_PREVIEW_EXTENSIONS])
+        return generateHTML(content, CLIPBOARD_EXTENSIONS)
     } catch {
         return null
     }


### PR DESCRIPTION
## Problem

- Copying a private note on a support ticket and pasting it into the reply box drops the note's formatting, so the writer re-adds paragraphs and lists by hand.
- The copy button puts only the note's markdown form on the clipboard, as `text/plain`.
- The reply composer is a ProseMirror editor with no markdown paste parser.
- ProseMirror's default plain-text handling splits on each run of newlines and makes every block a plain paragraph. A blank line, a line break and a list item all become the same boundary.
- Bold, italic, links and the backslash escapes the markdown form adds arrive as literal characters.

## Changes

- The copy button writes the note's rich content as `text/html` alongside the plain-text markdown. Paragraphs, blank lines, line breaks, lists and inline formatting now survive the paste, in the composer and in a mail client.
- `copyToClipboard` takes an optional `html` string. A browser that rejects `text/html` in a `ClipboardItem` falls back to the existing plain-text write, so no caller loses a working copy.
- The clipboard flavor renders a mention as `@member:<id>` inside the `ph-mention` element. HTML generation runs outside React, so the node view that shows the member's name never runs, and a mail client would otherwise drop the reference from the sentence. The composer parses the node back from the tag and ignores the text.
- `richContentToHtml` returns null unless the content passes the preview schema check, and the copy then carries markdown alone. `generateHTML` does not check the document it builds, so a note the reader sees as plain text could otherwise reach the clipboard as HTML.
- The preview's schema check moves out of `SupportRichContentPreview` into `isRenderableRichContent`, so the reader and the clipboard share one verdict.
- Copying the rich content is what makes this work. Teaching the composer to parse pasted markdown would fix the composer only, and leave every other paste target flat.
- No screenshot: nothing renders differently. The change is what the clipboard carries.

## How did you test this code?

- New `richContentToHtml.test.ts` renders a note to HTML and parses it back through the composer's own ProseMirror schema, which is what a paste does. The cases are paragraph breaks, a deliberate blank line, a hard break and a bullet list. Each is a shape the markdown copy flattens today, and no existing test covered the copy path.
- One case asserts a mention keeps readable text in the HTML and still parses back as a mention node, which is the regression the clipboard flavor would otherwise introduce for external paste targets.
- Two cases lock in the null return, for an unknown node type and for known node types in a structure the schema rejects. That second one is the divergence between what a reader sees and what the clipboard carries.
- Ran the conversations frontend jest suites locally, all green.
- The frontend typecheck does not run in this sandbox, because the quill workspace packages are unbuilt and 318 errors surface in unrelated products. None of them are in the changed files. The `Frontend typechecking` CI job is the check that covers this.
- Not done: no browser check. The `ClipboardItem` write and per-browser `text/html` support are unverified, because jsdom has no real clipboard. Worth a manual paste into the composer and into a mail client before merge.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written by the PostHog Slack app (Claude Code) from a report in Slack that private notes lose their spacing when copied.
- Skills invoked: `/writing-ui-components`, `/writing-code-comments`, `/writing-tests`, `/writing-pr-descriptions`.
- The first diagnosis was wrong. It assumed the composer collapsed single newlines into whitespace. A local replica of prosemirror-view's plain-text clipboard branch showed the opposite: the paste over-splits into paragraphs, drops deliberate blank lines, and leaves markdown escapes as literal text. The code comments and the test cases were rewritten against that output rather than the assumption.
- The second commit answers review feedback: the mention regression ReviewHog found, and two findings from an unaffiliated bot that hold up independently, the missing schema check and the barrel re-export.
- Public artifact: the diff, the tests and this description carry no material from the originating Slack thread. The test fixtures are invented.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C08S2L0S5MZ/p1787049940093169?thread_ts=1787049940.093169&cid=C08S2L0S5MZ)*
