### PR TITLE
chore(otel): tag RedisCluster spans with connection attributes

### DIFF
--- a/posthog/otel_instrumentation.py
+++ b/posthog/otel_instrumentation.py
@@ -48,6 +48,45 @@ def _otel_django_response_hook(span: Span, request: HttpRequest, response: HttpR
     span.update_name("HTTP" if http_method == "_OTHER" else f"{http_method} {route}")
 
 
+def _otel_redis_request_hook(span: Span, instance: object, args: tuple[object, ...], kwargs: dict[str, object]) -> None:
+    """Tag cluster-client spans with the connection attributes the instrumentor leaves off.
+
+    opentelemetry-instrumentation-redis reads `db.system` and `net.peer.*` off
+    `client.connection_pool.connection_kwargs`, and returns early for any client that has no
+    `connection_pool`. `redis.cluster.RedisCluster` keeps per-node pools under `nodes_manager`
+    instead, so its spans arrive carrying a command name and nothing else, which hides them from
+    every query that selects Redis spans by `db.system` or groups them by host.
+
+    A command's shard is chosen inside `execute_command`, after this hook runs, so `net.peer.name`
+    is a node from the client's own topology: it identifies the cluster, not the hop that served
+    the command. `db.redis.cluster` marks that distinction.
+    """
+    # This runs inside the traced Redis call, and the instrumentor does not guard hook calls, so a
+    # raise here would fail the command itself. An unfamiliar client shape degrades to an untagged
+    # span instead, which is the behavior without this hook.
+    try:
+        if not span or not span.is_recording() or hasattr(instance, "connection_pool"):
+            return
+
+        startup_nodes = getattr(getattr(instance, "nodes_manager", None), "startup_nodes", None)
+        if not startup_nodes:
+            return
+
+        span.set_attribute("db.system", "redis")
+        span.set_attribute("db.redis.cluster", True)
+        span.set_attribute("net.transport", "ip_tcp")
+
+        node = next(iter(startup_nodes.values()), None)
+        host = getattr(node, "host", None)
+        port = getattr(node, "port", None)
+        if host:
+            span.set_attribute("net.peer.name", host)
+        if port:
+            span.set_attribute("net.peer.port", port)
+    except Exception:
+        logger.debug("otel_redis_request_hook_failed", exc_info=True)
+
+
 def initialize_otel():
     # App tracing targets a real OTLP collector (dev/prod). In tests, booting the app
     # (e.g. posthog/test/test_asgi_lifespan.py imports posthog.asgi) would otherwise arm a
@@ -165,7 +204,7 @@ def instrument_celery(provider: trace.TracerProvider):
 
 def instrument_redis(provider: trace.TracerProvider):
     try:
-        RedisInstrumentor().instrument(tracer_provider=provider)
+        RedisInstrumentor().instrument(tracer_provider=provider, request_hook=_otel_redis_request_hook)
         logger.info("otel_instrumentation_attempt", instrumentor="RedisInstrumentor", status="success")
     except Exception as e:
         logger.exception("otel_instrumentation_attempt", instrumentor="RedisInstrumentor", status="error", exc_info=e)

--- a/posthog/otel_instrumentation.py
+++ b/posthog/otel_instrumentation.py
@@ -2,6 +2,7 @@ import os
 import atexit
 import typing
 import logging
+from collections.abc import Sequence
 
 from django.http import HttpRequest, HttpResponse
 
@@ -48,7 +49,7 @@ def _otel_django_response_hook(span: Span, request: HttpRequest, response: HttpR
     span.update_name("HTTP" if http_method == "_OTHER" else f"{http_method} {route}")
 
 
-def _otel_redis_request_hook(span: Span, instance: object, args: tuple[object, ...], kwargs: dict[str, object]) -> None:
+def _otel_redis_request_hook(span: Span, instance: object, args: Sequence[object], kwargs: dict[str, object]) -> None:
     """Tag cluster-client spans with the connection attributes the instrumentor leaves off.
 
     opentelemetry-instrumentation-redis reads `db.system` and `net.peer.*` off

--- a/posthog/test/test_otel_instrumentation.py
+++ b/posthog/test/test_otel_instrumentation.py
@@ -2,6 +2,7 @@
 import os
 import logging
 from types import SimpleNamespace
+from typing import NoReturn
 
 from unittest import mock
 
@@ -11,6 +12,7 @@ from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.util.types import AttributeValue
 from parameterized import parameterized
 
 from posthog.otel_instrumentation import (
@@ -386,7 +388,7 @@ class TestOtelInstrumentation(SimpleTestCase):
 
 
 class TestOtelRedisRequestHook(SimpleTestCase):
-    def _span_attributes_after_hook(self, instance: object) -> dict:
+    def _span_attributes_after_hook(self, instance: object) -> dict[str, AttributeValue]:
         exporter = InMemorySpanExporter()
         provider = TracerProvider()
         provider.add_span_processor(SimpleSpanProcessor(exporter))
@@ -396,7 +398,7 @@ class TestOtelRedisRequestHook(SimpleTestCase):
 
         return dict(exporter.get_finished_spans()[0].attributes or {})
 
-    def test_cluster_client_command_is_attributed_to_a_backend(self):
+    def test_cluster_client_command_is_attributed_to_a_backend(self) -> None:
         node = SimpleNamespace(host="cache.example.com", port=6379)
         instance = SimpleNamespace(nodes_manager=SimpleNamespace(startup_nodes={"cache.example.com:6379": node}))
 
@@ -411,15 +413,15 @@ class TestOtelRedisRequestHook(SimpleTestCase):
             },
         )
 
-    def test_pooled_client_command_is_left_to_the_instrumentor(self):
+    def test_pooled_client_command_is_left_to_the_instrumentor(self) -> None:
         instance = SimpleNamespace(connection_pool=SimpleNamespace(connection_kwargs={"host": "cache.example.com"}))
 
         self.assertEqual(self._span_attributes_after_hook(instance), {})
 
-    def test_client_that_cannot_be_inspected_still_runs_its_command(self):
+    def test_client_that_cannot_be_inspected_still_runs_its_command(self) -> None:
         class ClientWithoutTopology:
             @property
-            def nodes_manager(self):
+            def nodes_manager(self) -> NoReturn:
                 raise RuntimeError("topology unavailable")
 
         self.assertEqual(self._span_attributes_after_hook(ClientWithoutTopology()), {})

--- a/posthog/test/test_otel_instrumentation.py
+++ b/posthog/test/test_otel_instrumentation.py
@@ -1,15 +1,24 @@
 # posthog/test/test_otel_instrumentation.py
 import os
 import logging
+from types import SimpleNamespace
 
 from unittest import mock
 
 from django.test import SimpleTestCase
 
 from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from parameterized import parameterized
 
-from posthog.otel_instrumentation import _otel_django_request_hook, _otel_django_response_hook, initialize_otel
+from posthog.otel_instrumentation import (
+    _otel_django_request_hook,
+    _otel_django_response_hook,
+    _otel_redis_request_hook,
+    initialize_otel,
+)
 
 
 class TestOtelInstrumentation(SimpleTestCase):
@@ -132,7 +141,9 @@ class TestOtelInstrumentation(SimpleTestCase):
 
         # Assert RedisInstrumentor call
         mock_redis_instrumentor_cls.assert_called_once_with()
-        mock_redis_instrumentor_instance.instrument.assert_called_once_with(tracer_provider=mock_provider_instance)
+        mock_redis_instrumentor_instance.instrument.assert_called_once_with(
+            tracer_provider=mock_provider_instance, request_hook=_otel_redis_request_hook
+        )
 
         # Assert PsycopgInstrumentor call
         mock_psycopg_instrumentor_cls.assert_called_once_with()
@@ -372,3 +383,43 @@ class TestOtelInstrumentation(SimpleTestCase):
         # Assert AIOKafkaInstrumentor call
         mock_aio_kafka_instrumentor_cls.assert_called_once_with()
         mock_aio_kafka_instrumentor_instance.instrument.assert_called_once_with(tracer_provider=mock_provider_instance)
+
+
+class TestOtelRedisRequestHook(SimpleTestCase):
+    def _span_attributes_after_hook(self, instance: object) -> dict:
+        exporter = InMemorySpanExporter()
+        provider = TracerProvider()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+        with provider.get_tracer(__name__).start_as_current_span("GET") as span:
+            _otel_redis_request_hook(span, instance, ("GET", "some-key"), {})
+
+        return dict(exporter.get_finished_spans()[0].attributes or {})
+
+    def test_cluster_client_command_is_attributed_to_a_backend(self):
+        node = SimpleNamespace(host="cache.example.com", port=6379)
+        instance = SimpleNamespace(nodes_manager=SimpleNamespace(startup_nodes={"cache.example.com:6379": node}))
+
+        self.assertEqual(
+            self._span_attributes_after_hook(instance),
+            {
+                "db.system": "redis",
+                "db.redis.cluster": True,
+                "net.transport": "ip_tcp",
+                "net.peer.name": "cache.example.com",
+                "net.peer.port": 6379,
+            },
+        )
+
+    def test_pooled_client_command_is_left_to_the_instrumentor(self):
+        instance = SimpleNamespace(connection_pool=SimpleNamespace(connection_kwargs={"host": "cache.example.com"}))
+
+        self.assertEqual(self._span_attributes_after_hook(instance), {})
+
+    def test_client_that_cannot_be_inspected_still_runs_its_command(self):
+        class ClientWithoutTopology:
+            @property
+            def nodes_manager(self):
+                raise RuntimeError("topology unavailable")
+
+        self.assertEqual(self._span_attributes_after_hook(ClientWithoutTopology()), {})


### PR DESCRIPTION
## Problem

An engineer measuring Redis latency cannot see the insight query result cache at all: its spans carry a command name and no backend.

- `caches["query_cache"]` uses `redis.cluster.RedisCluster` when `QUERY_CACHE_REDIS_CLUSTER_URL` is set.
- `opentelemetry-instrumentation-redis` reads `db.system` and `net.peer.*` off `client.connection_pool.connection_kwargs`.
- `RedisCluster` keeps per-node pools under `nodes_manager`, so that lookup returns early and tags nothing.
- Every query that filters Redis spans by `db.system`, or groups them by host, drops these commands without an error.

## Changes

- `_otel_redis_request_hook` sets `db.system`, `net.transport` and `net.peer.*` on spans from clients the instrumentor skips.
- `net.peer.name` is a node from the client's topology, not the shard that served the command.
- `db.redis.cluster` marks that distinction, because `execute_command` picks the shard after the hook runs.
- The hook sits on the global `RedisInstrumentor` rather than at the `RedisCluster.from_url` seam, so it also covers cluster clients added later.

> [!NOTE]
> The instrumentor calls request hooks unguarded, so a raise inside one would fail the Redis command being traced. The hook swallows every exception and degrades to an untagged span.

## How did you test this code?

- Three cases on the hook in `posthog/test/test_otel_instrumentation.py`, plus the existing `initialize_otel` assertion updated to require the hook.
- The cluster case fails when the hook body is stubbed out, so it catches a silent regression back to untagged spans.
- The uninspectable-client case guards the worst failure mode: a raise in the hook breaking every Redis command in the process.
- No manual verification. This sandbox has no Redis cluster, so the untagged-span behavior comes from reading trace data and the pinned instrumentation source, not from a local reproduction.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Internal instrumentation only, with no documented behavior change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by the PostHog Slack app (Claude Code) during a cache latency investigation that could not attribute cached-query Redis time to a backend.
- Skills invoked: `/exploring-apm-traces`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.
- The first plan was to instrument an apparently untraced client. Reading the pinned `opentelemetry-instrumentation-redis` showed it already wraps `RedisCluster.execute_command`, so the change narrowed to filling in the connection attributes that wrapper leaves off.
- Nothing in this diff, its tests, or this description carries material from the agent session. The test fixtures use `cache.example.com` and were written from the list of attributes the hook sets.
