### PR TITLE
fix(decagon): stop reporting exhausted read-timeout retries as tracked exceptions

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/decagon/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/decagon/source.py
@@ -86,6 +86,17 @@ You can find your API key on the **Developer** page of the [Decagon dashboard](h
             ),
         }
 
+    def get_retryable_errors(self) -> set[str]:
+        # `fetch_page` (decagon.py) already retries `DecagonRetryableError` (429/5xx),
+        # `requests.ReadTimeout`, and `requests.ConnectionError` with backoff; if that budget
+        # still exhausts, Temporal retries the whole activity, so the failure is transient and
+        # self-recovering. Match the host rather than the per-endpoint path, so a timeout or
+        # dropped connection on any Decagon endpoint is covered.
+        return {
+            "HTTPSConnectionPool(host='api.decagon.ai', port=443)",
+            "Decagon API error (retryable)",
+        }
+
     def get_schemas(
         self,
         config: DecagonSourceConfig,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/decagon/tests/test_decagon_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/decagon/tests/test_decagon_source.py
@@ -7,6 +7,7 @@ from parameterized import parameterized
 
 from posthog.schema import ReleaseStatus, SourceFieldInputConfig, SourceFieldInputConfigType
 
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import error_message_matches
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from products.warehouse_sources.backend.temporal.data_imports.sources.decagon.decagon import DecagonResumeConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.decagon.settings import ENDPOINTS
@@ -114,6 +115,26 @@ class TestDecagonSource:
         errors = self.source.get_non_retryable_errors()
         assert "401 Client Error: Unauthorized" in errors
         assert "403 Client Error: Forbidden" in errors
+
+    @parameterized.expand(
+        [
+            (
+                "connection_error_wrapping_read_timeout",
+                "HTTPSConnectionPool(host='api.decagon.ai', port=443): Max retries exceeded with url: "
+                "/conversation/export (Caused by ReadTimeoutError(\"HTTPSConnectionPool(host='api.decagon.ai', "
+                'port=443): Read timed out. (read timeout=60)"))',
+            ),
+            (
+                "exhausted_retryable_status",
+                "Decagon API error (retryable): status=503, url=https://api.decagon.ai/tag/all",
+            ),
+        ]
+    )
+    def test_retryable_errors_cover_exhausted_transient_failures(self, _name: str, error_msg: str) -> None:
+        # fetch_page already retries these with backoff; once that budget exhausts they must
+        # stay classified as retryable (self-recovering via Temporal) rather than tracked
+        # exception noise.
+        assert error_message_matches(error_msg, self.source.get_retryable_errors())
 
     @mock.patch(
         "products.warehouse_sources.backend.temporal.data_imports.sources.decagon.source.validate_decagon_credentials"


### PR DESCRIPTION
## Problem

A Decagon sync that hits a slow or dropped connection to the vendor API gets reported to error tracking as a hard failure, even though the connector already retried it and Temporal recovers on the next activity attempt. [Error tracking issue](https://us.posthog.com/project/2/error_tracking/01a01493-10d5-7ab0-ae96-dbc16e793dc6).

`fetch_page` in `decagon.py` already retries connection resets, read timeouts, and 429/5xx responses with backoff. Once that budget is exhausted, `DecagonSource` had no `get_retryable_errors()` override, so the exception fell through to the generic path that logs it as an exception and surfaces it in error tracking as noise, instead of the quieter path other sources use for the same self-recovering case.

## Changes

- Add `get_retryable_errors()` to `DecagonSource`, matching the connection/timeout and exhausted-429/5xx message shapes `fetch_page` already retries internally.
- Once `fetch_page`'s own retry budget is exhausted, the failure now logs as a warning and re-raises for Temporal's activity-level retry, instead of being reported as a tracked exception.
- Mirrors the pattern already used by Gladly, Close, Customer.io, UptimeRobot, and Intercom for errors their own connectors already retry.

Retry/backoff timing and `get_non_retryable_errors()` (401/403) are unchanged — this only reclassifies how an already-retried, already-self-recovering failure is logged once its retry budget is exhausted.

## How did you test this code?

Added `test_retryable_errors_cover_exhausted_transient_failures`, covering the connection-error-wrapping-a-read-timeout message and the exhausted-429/5xx message. Ran the full `test_decagon_source.py` suite locally (11 passed).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing or API behavior changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog error tracking MCP tools (issue details, event stack trace) to confirm the failure originates in `products/warehouse_sources/backend/temporal/data_imports/sources/decagon/decagon.py`, then read the sibling sources' `get_retryable_errors()` implementations for the established pattern before applying it to Decagon.