### PR TITLE
fix(desktop): keep the turn open when steered work outlasts the grace

### DIFF
--- a/products/desktop/packages/agent/src/adapters/claude/claude-agent.streamed-text.test.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/claude-agent.streamed-text.test.ts
@@ -401,6 +401,50 @@ describe("ClaudeAcpAgent.prompt — streamed assistant text wiring", () => {
     ]);
   });
 
+  it("keeps the turn open when the steered work outlasts the delivery grace", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    try {
+      const { agent } = makeAgent();
+      const sessionId = "s-steer-slow-work";
+      const { query, input } = installFakeSession(agent, sessionId);
+
+      const promptPromise = agent.prompt({
+        sessionId,
+        prompt: [{ type: "text", text: "use orange" }],
+      });
+      let promptSettled = false;
+      void promptPromise.then(() => {
+        promptSettled = true;
+      });
+      await tick();
+      await echoUserMessage(query, input);
+
+      const steerPromise = agent.prompt({
+        sessionId,
+        prompt: [{ type: "text", text: "use green instead" }],
+        _meta: { steer: true },
+      });
+      await tick();
+
+      await send(query, resultSuccess(sessionId));
+      await echoUserMessage(query, input);
+      await send(query, assistantMessage(sessionId, "msg_green", "GREEN"));
+      await expect(steerPromise).resolves.toMatchObject({
+        _meta: { steer: true },
+      });
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(promptSettled).toBe(false);
+
+      await send(query, resultSuccess(sessionId));
+      await expect(promptPromise).resolves.toMatchObject({
+        stopReason: "end_turn",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("declines a steer the turn ends without acting on", async () => {
     const { agent } = makeAgent();
     const sessionId = "s-steer-unacted";

--- a/products/desktop/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/claude-agent.ts
@@ -223,6 +223,14 @@ function confirmConsumedSteers(turn: Turn): void {
       turn.pendingSteers.delete(uuid);
     }
   }
+  if (turn.pendingSteers.size > 0) {
+    return;
+  }
+  if (turn.steerTimer) {
+    clearTimeout(turn.steerTimer);
+    turn.steerTimer = undefined;
+  }
+  turn.deferredResult = undefined;
 }
 
 /** Report every steer left on a finishing turn as undelivered so callers redeliver it. */

--- a/products/desktop/packages/ui/src/features/pi-sessions/PiSessionView.tsx
+++ b/products/desktop/packages/ui/src/features/pi-sessions/PiSessionView.tsx
@@ -329,13 +329,7 @@ function usePiSubmit(
       );
       void controller
         .submit(taskId, message, isStreaming, messagingMode, pendingConfig)
-        .then((result) => {
-          if (result === "steer") {
-            toast.info("Steering waits for a safe boundary", {
-              description:
-                "Pi will apply it at the next safe boundary. The run stays active until then.",
-            });
-          }
+        .then(() => {
           onSuccess(action);
         })
         .catch((error) => {

--- a/products/desktop/packages/ui/src/features/sessions/hooks/useSessionCallbacks.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/hooks/useSessionCallbacks.test.tsx
@@ -193,16 +193,18 @@ describe("useSessionCallbacks.handleSendPrompt", () => {
     expect(toastError).toHaveBeenCalledWith("fetch failed");
   });
 
-  it("uses the post-send compaction state for the steering notice", async () => {
+  it("forwards the steer intent from the messaging mode", async () => {
     messagingMode.value = "steer";
-    sessionService.sendPrompt.mockImplementation(async () => {
-      sessionState.isCompacting = true;
-    });
+    sessionService.sendPrompt.mockResolvedValue({ stopReason: "steered" });
 
     const { result } = renderCallbacks(sessionState as unknown as AgentSession);
     await result.current.handleSendPrompt("change direction");
 
-    expect(toastInfo).not.toHaveBeenCalled();
+    expect(sessionService.sendPrompt).toHaveBeenCalledWith(
+      TASK,
+      "change direction",
+      { steer: true },
+    );
   });
 });
 

--- a/products/desktop/packages/ui/src/features/sessions/hooks/useSessionCallbacks.ts
+++ b/products/desktop/packages/ui/src/features/sessions/hooks/useSessionCallbacks.ts
@@ -13,7 +13,6 @@ import {
 } from "@posthog/core/sessions/sessionService";
 import { useService } from "@posthog/di/react";
 import { useHostTRPCClient } from "@posthog/host-router/react";
-import { sessionSupportsNativeSteer } from "@posthog/shared";
 import type { Task } from "@posthog/shared/domain-types";
 import {
   resolveLocalSkillPrompt,
@@ -138,20 +137,6 @@ export function useSessionCallbacks({
         await sessionService.sendPrompt(taskId, promptText ?? text, {
           steer: messagingMode === "steer",
         });
-
-        const sentSession = sessionStoreSetters.getSessionByTaskId(taskId);
-        if (
-          messagingMode === "steer" &&
-          sentSession?.isPromptPending &&
-          !sentSession.isCompacting &&
-          sentSession.adapter === "claude" &&
-          sessionSupportsNativeSteer(sentSession)
-        ) {
-          toast.info("Steering waits for a safe boundary", {
-            description:
-              "It will apply at the next safe boundary. The current command may keep running until then.",
-          });
-        }
 
         const view = getAppViewSnapshot();
         const isViewingTask =


### PR DESCRIPTION
## Problem

Steering a cloud task mid-run could make it look finished while it was still working, then never finish at all. The user got a "task finished" notification minutes early, the UI stayed on the run, and the run sat in `in_progress` with no error and no completion

## Changes

`confirmConsumedSteers` now clears the grace timer and drops the withheld result once no unconsumed steers remain. The turn stays open until the SDK's next terminal result, which is the one that reflects the steered work.


