### PR TITLE
fix(data-imports): stop leaking a broken redis client from _get_redis

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/extract.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/extract.py
@@ -60,6 +60,10 @@ async def _get_redis():
         await redis.ping()
     except Exception as e:
         capture_exception(e)
+        # get_async_client only builds a lazy client, so a failed ping means redis is
+        # still unreachable - reset it to None so callers' `if redis_client is None` guard
+        # actually skips the real command instead of raising the same error uncaught.
+        redis = None
 
     yield redis
 

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_extract.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_extract.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from asgiref.sync import async_to_sync
 from parameterized import parameterized
+from redis import exceptions as redis_exceptions
 
 from posthog.temporal.common.errors import NonReportableError
 
@@ -18,6 +19,7 @@ from products.warehouse_sources.backend.models.oom_event import ExternalDataSche
 from products.warehouse_sources.backend.temporal.data_imports.external_data_job import Any_Source_Errors
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.common.extract import (
     NON_RETRYABLE_ERROR_RETRY_LIMIT,
+    _get_redis,
     handle_corrupted_delta_log,
     handle_non_retryable_error,
     handle_reset_or_full_refresh,
@@ -615,6 +617,27 @@ class TestValidateIncrementalSync:
         # run is retried on every schedule even though only the user can resolve it.
         message = str(MissingPrimaryKeysException())
         assert [key for key in Any_Source_Errors if key in message]
+
+
+class TestGetRedis:
+    @pytest.mark.asyncio
+    async def test_yields_none_when_ping_fails(self):
+        # get_async_client only builds a lazy client, so a broken connection doesn't surface
+        # until the first real command (here, the ping). If the except branch reports the
+        # failure but forgets to reset the client to None, callers that gate real Redis
+        # commands on `redis_client is None` (e.g. handle_non_retryable_error) go ahead and
+        # issue one anyway, letting the same connection error escape uncaught.
+        broken_client = AsyncMock()
+        broken_client.ping.side_effect = redis_exceptions.ConnectionError("Connection refused")
+
+        with (
+            patch(f"{_EXTRACT_MODULE}.get_async_client", return_value=broken_client),
+            patch(f"{_EXTRACT_MODULE}.capture_exception") as mock_capture,
+        ):
+            async with _get_redis() as redis_client:
+                assert redis_client is None
+
+        mock_capture.assert_called_once()
 
 
 class TestHandleNonRetryableError:


### PR DESCRIPTION
## Problem

A Postgres sync with a config that fails to parse (for example, a stored
credential that can no longer be decrypted) crashes with an unrelated Redis
`ConnectionError` instead of giving up cleanly, spamming error tracking with
a misleading issue ([issue](https://us.posthog.com/project/2/error_tracking/01a0149a-d701-7a92-8eb9-f05dd3b13b53)).

## Changes

- `handle_non_retryable_error` calls `_get_redis()` to track retry attempts, and treats a `None` client as "Redis is unavailable, give up without retrying".
- `_get_redis()` builds the client, then calls `ping()` inside a `try`. When `ping()` raises, the `except` block reports the error but never resets the client back to `None`.
- The still-broken client reaches `handle_non_retryable_error`, which calls `redis_client.incr(...)` on it. That call fails with the same connection error, this time uncaught, and it escapes to error tracking with the original error masked as its cause.
- Resets the client to `None` on a failed ping, matching the already-correct sibling `_get_redis()` in `row_tracking.py`.

## How did you test this code?

- Added `TestGetRedis` in `test_extract.py`: mocks a client whose `ping()` raises `ConnectionError` and asserts `_get_redis()` yields `None`. Confirmed it fails on the pre-fix code and passes after.
- Ran the file's non-database tests locally (25 passed); the remaining cases in the file need a live Postgres this sandbox doesn't have, unrelated to this change.
- Not run: a live sync against a broken Redis, since this sandbox has no Redis or Temporal worker to reproduce the full activity path.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None - internal pipeline reliability fix, no user-facing behavior or docs change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error tracking issue via Claude Code. Skills invoked: `investigating-error-issue`, `writing-tests`, `writing-pr-descriptions`. The root cause was found by tracing the exception's chained stack (an `UndecryptedConfigError` from config parsing, immediately followed by a Redis `ConnectionError` from inside the non-retryable-error handler) and confirmed against the sibling `_get_redis()` in `row_tracking.py`, whose comment already documents this exact hazard.
