### PR TITLE
fix(data-imports): reset redis client to none after a failed ping

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/extract.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/extract.py
@@ -60,6 +60,10 @@ async def _get_redis():
         await redis.ping()
     except Exception as e:
         capture_exception(e)
+        # get_async_client only builds a lazy client, so a failed ping means redis is
+        # still unreachable - reset it to None so callers' `if redis_client is None` guard
+        # actually skips the real command instead of raising the same error uncaught.
+        redis = None
 
     yield redis
 

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_extract.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_extract.py
@@ -18,6 +18,7 @@ from products.warehouse_sources.backend.models.oom_event import ExternalDataSche
 from products.warehouse_sources.backend.temporal.data_imports.external_data_job import Any_Source_Errors
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.common.extract import (
     NON_RETRYABLE_ERROR_RETRY_LIMIT,
+    _get_redis,
     handle_corrupted_delta_log,
     handle_non_retryable_error,
     handle_reset_or_full_refresh,
@@ -615,6 +616,30 @@ class TestValidateIncrementalSync:
         # run is retried on every schedule even though only the user can resolve it.
         message = str(MissingPrimaryKeysException())
         assert [key for key in Any_Source_Errors if key in message]
+
+
+class TestGetRedis:
+    @pytest.mark.asyncio
+    async def test_yields_none_when_ping_fails(self):
+        # `handle_non_retryable_error` only takes its Redis-unreachable fast-fail path when the
+        # yielded client is None; otherwise it calls `.incr()` on the broken client, which raises
+        # the same connection error uncaught instead of failing fast as NonRetryableException.
+        # `get_async_client` only builds a lazy client, so a failed ping is the only signal that
+        # the client is unusable - it must reset the client to None rather than yield it as-is.
+        broken_client = AsyncMock(ping=AsyncMock(side_effect=ConnectionError("Connect call failed")))
+
+        with (
+            patch(f"{_EXTRACT_MODULE}.settings") as mock_settings,
+            patch(f"{_EXTRACT_MODULE}.get_async_client", return_value=broken_client),
+            patch(f"{_EXTRACT_MODULE}.capture_exception") as mock_capture,
+        ):
+            mock_settings.DATA_WAREHOUSE_REDIS_HOST = "localhost"
+            mock_settings.DATA_WAREHOUSE_REDIS_PORT = 6379
+
+            async with _get_redis() as redis_client:
+                assert redis_client is None
+
+        mock_capture.assert_called_once()
 
 
 class TestHandleNonRetryableError:


### PR DESCRIPTION
## Problem

A Postgres incremental sync's non-retryable-error handling crashed instead of failing fast whenever Redis was briefly unreachable ([error tracking issue](https://us.posthog.com/project/2/error_tracking/01a0149a-d676-7561-b6e2-2f7adf190216)). One team hit this repeatedly within about 90 seconds, each retry re-raising the same connection error.

## Changes

- `_get_redis()` in the shared data-imports pipeline (`pipelines/common/extract.py`) yielded its Redis client even after `ping()` failed, instead of `None`.
- `handle_non_retryable_error` only takes its Redis-unreachable fast-fail path (`raise NonRetryableException()`) when the yielded client is `None`. With the broken client yielded instead, it went on to call `.incr()`, which raised the same connection error uncaught.
- The uncaught error surfaced as an ordinary retryable activity failure, so Temporal retried the activity instead of stopping, and each retry repeated the same failure and the same captured exception.
- Reset the client to `None` on a failed ping, matching the equivalent helper in `row_tracking.py`, which already does this correctly.

## How did you test this code?

- Added `TestGetRedis::test_yields_none_when_ping_fails`: asserts a failed ping yields `None` rather than the broken client. Verified it fails without the fix and passes with it.
- `TestHandleNonRetryableError` (existing) already covers the fast-fail-vs-retry classification once `_get_redis` behaves correctly.
- Ran `ruff check --fix`, `ruff format`, and `uv run mypy --cache-fine-grained .` on both changed files — all clean.
- Not run: the DB-backed tests elsewhere in the same file (heartbeat/reset/corrupted-log suites) — they need a live Postgres this sandbox doesn't provide, and are unaffected by this change.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None - internal pipeline reliability fix, no user-facing behavior or docs change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error tracking issue via Claude Code. Skills invoked: `investigating-error-issue`, `writing-tests`, `writing-pr-descriptions`. The root cause was found by comparing this helper against its near-identical sibling in `row_tracking.py`, which resets the client to `None` on the same failure path — this one was missing that line.