### PR TITLE
feat(flags): derive persisted flags from full rollout

### DIFF
--- a/posthog/api/sharing.py
+++ b/posthog/api/sharing.py
@@ -13,6 +13,7 @@ from django.views.decorators.clickjacking import xframe_options_exempt
 
 import jwt
 import structlog
+import posthoganalytics
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_field
 from pydantic import BaseModel
@@ -74,6 +75,7 @@ from products.exports.backend.models.exported_asset import (
     asset_for_token,
     get_content_response,
 )
+from products.feature_flags.backend.persisted_flags import get_dynamic_persisted_feature_flags
 from products.notebooks.backend.facade.content import extract_inline_query_nodes, filter_notebook_content_for_sharing
 from products.notebooks.backend.models import Notebook
 from products.notebooks.backend.presentation.views.notebook import NotebookSerializer
@@ -318,7 +320,9 @@ def build_shared_app_context(team: Team, request: Request) -> dict[str, Any]:
         "suggested_users_with_access": None,
         "commit_sha": get_git_commit_short(),
         "livestream_host": settings.LIVESTREAM_HOST,
-        "persisted_feature_flags": settings.PERSISTED_FEATURE_FLAGS,
+        "persisted_feature_flags": get_dynamic_persisted_feature_flags(
+            posthoganalytics.feature_flag_definitions(), settings.PERSISTED_FEATURE_FLAGS
+        ),
         "anonymous": True,
     }
 

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -60,6 +60,8 @@ from posthog.metrics import KLUDGES_COUNTER
 from posthog.redis import get_client
 from posthog.security.url_validation import has_ambiguous_authority
 
+from products.feature_flags.backend.persisted_flags import get_dynamic_persisted_feature_flags
+
 tracer = trace.get_tracer(__name__)
 
 # Cardinality is bounded: render_template is only called with the literal template
@@ -563,7 +565,9 @@ def _build_template_context(
     context["js_url"] = get_js_url(request)
 
     posthog_app_context: dict[str, Any] = {
-        "persisted_feature_flags": settings.PERSISTED_FEATURE_FLAGS,
+        "persisted_feature_flags": get_dynamic_persisted_feature_flags(
+            posthoganalytics.feature_flag_definitions(), settings.PERSISTED_FEATURE_FLAGS
+        ),
         "anonymous": not request.user or not request.user.is_authenticated,
     }
 

--- a/products/feature_flags/backend/persisted_flags.py
+++ b/products/feature_flags/backend/persisted_flags.py
@@ -1,0 +1,46 @@
+from collections.abc import Iterable
+from typing import Any
+
+FlagDefinition = dict[str, Any]
+
+
+def is_unconditionally_fully_rolled_out(flag: FlagDefinition) -> bool:
+    if not flag.get("active", False) or flag.get("deleted", False):
+        return False
+
+    filters = flag.get("filters") or {}
+
+    multivariate = filters.get("multivariate") or {}
+    if multivariate.get("variants"):
+        return False
+    if filters.get("holdout"):
+        return False
+    if filters.get("super_groups"):
+        return False
+    if filters.get("aggregation_group_type_index") is not None:
+        return False
+
+    groups = filters.get("groups") or []
+    if len(groups) != 1:
+        return False
+
+    group = groups[0]
+    if group.get("properties"):
+        return False
+    if group.get("variant"):
+        return False
+
+    rollout_percentage = group.get("rollout_percentage")
+    return rollout_percentage is None or rollout_percentage == 100
+
+
+def get_dynamic_persisted_feature_flags(
+    definitions: list[FlagDefinition] | None,
+    static_keys: Iterable[str] = (),
+) -> list[str]:
+    keys = set(static_keys)
+    for flag in definitions or []:
+        key = flag.get("key")
+        if key and is_unconditionally_fully_rolled_out(flag):
+            keys.add(key)
+    return sorted(keys)

--- a/products/feature_flags/backend/test/test_persisted_flags.py
+++ b/products/feature_flags/backend/test/test_persisted_flags.py
@@ -1,0 +1,107 @@
+from django.test import SimpleTestCase
+
+from parameterized import parameterized
+
+from products.feature_flags.backend.persisted_flags import (
+    get_dynamic_persisted_feature_flags,
+    is_unconditionally_fully_rolled_out,
+)
+
+
+def _flag(filters: dict, active: bool = True, deleted: bool = False) -> dict:
+    return {"key": "flag", "active": active, "deleted": deleted, "filters": filters}
+
+
+class TestIsUnconditionallyFullyRolledOut(SimpleTestCase):
+    @parameterized.expand(
+        [
+            ("explicit_100", _flag({"groups": [{"properties": [], "rollout_percentage": 100}]}), True),
+            ("implicit_100", _flag({"groups": [{"properties": []}]}), True),
+            ("empty_groups", _flag({"groups": []}), False),
+            ("no_filters", _flag({}), False),
+            ("partial_rollout", _flag({"groups": [{"properties": [], "rollout_percentage": 50}]}), False),
+            (
+                "has_properties",
+                _flag({"groups": [{"properties": [{"key": "email"}], "rollout_percentage": 100}]}),
+                False,
+            ),
+            (
+                "multiple_groups",
+                _flag(
+                    {
+                        "groups": [
+                            {"properties": [], "rollout_percentage": 100},
+                            {"properties": [], "rollout_percentage": 100},
+                        ]
+                    }
+                ),
+                False,
+            ),
+            (
+                "multivariate",
+                _flag(
+                    {
+                        "groups": [{"properties": [], "rollout_percentage": 100}],
+                        "multivariate": {"variants": [{"key": "a", "rollout_percentage": 100}]},
+                    }
+                ),
+                False,
+            ),
+            (
+                "holdout",
+                _flag({"groups": [{"properties": [], "rollout_percentage": 100}], "holdout": {"id": "x"}}),
+                False,
+            ),
+            (
+                "super_groups",
+                _flag(
+                    {"groups": [{"properties": [], "rollout_percentage": 100}], "super_groups": [{"properties": []}]}
+                ),
+                False,
+            ),
+            (
+                "group_aggregation",
+                _flag({"groups": [{"properties": [], "rollout_percentage": 100}], "aggregation_group_type_index": 0}),
+                False,
+            ),
+            (
+                "variant_override",
+                _flag({"groups": [{"properties": [], "rollout_percentage": 100, "variant": "test"}]}),
+                False,
+            ),
+            ("inactive", _flag({"groups": [{"properties": [], "rollout_percentage": 100}]}, active=False), False),
+            ("deleted", _flag({"groups": [{"properties": [], "rollout_percentage": 100}]}, deleted=True), False),
+        ]
+    )
+    def test_predicate(self, _name: str, flag: dict, expected: bool) -> None:
+        self.assertEqual(is_unconditionally_fully_rolled_out(flag), expected)
+
+
+class TestGetDynamicPersistedFeatureFlags(SimpleTestCase):
+    def test_merges_dynamic_with_static_deduped_and_sorted(self) -> None:
+        definitions = [
+            {
+                "key": "rolled-out",
+                "active": True,
+                "deleted": False,
+                "filters": {"groups": [{"rollout_percentage": 100}]},
+            },
+            {"key": "partial", "active": True, "deleted": False, "filters": {"groups": [{"rollout_percentage": 10}]}},
+            {
+                "key": "static-and-rolled-out",
+                "active": True,
+                "deleted": False,
+                "filters": {"groups": [{"rollout_percentage": 100}]},
+            },
+        ]
+        result = get_dynamic_persisted_feature_flags(definitions, ["static-only", "static-and-rolled-out"])
+        self.assertEqual(result, ["rolled-out", "static-and-rolled-out", "static-only"])
+
+    def test_none_definitions_returns_static_only(self) -> None:
+        self.assertEqual(get_dynamic_persisted_feature_flags(None, ["a", "b"]), ["a", "b"])
+
+    def test_no_static_keys(self) -> None:
+        definitions = [
+            {"key": "on", "active": True, "deleted": False, "filters": {"groups": [{"rollout_percentage": 100}]}}
+        ]
+        self.assertEqual(get_dynamic_persisted_feature_flags(definitions), ["on"])


### PR DESCRIPTION
## Problem

- The frontend treats a feature flag as off until posthog-js loads its value, so a flag rolled out to 100% still shows the old UI on first paint, and whenever the SDK fails to load, or for when the flags requests is adblocked
- The only server-set default baseline the frontend reads is `persisted_feature_flags`, but it is a static env list (`PERSISTED_FEATURE_FLAGS`) built for hobby installs, so nothing keeps it in step with rollout state.

## Changes

- The server now adds every unconditionally rolled-out flag to `persisted_feature_flags` on each render, so a fully rolled-out flag defaults on in the frontend with no code change.
- A flag counts as unconditionally rolled out only when it is active, non-deleted, and has exactly one release group with no properties and 100% (or unset) rollout.
- That predicate rejects holdouts, super-condition groups, group aggregation, multivariate variants, and per-condition variant overrides, so a qualifying flag really does evaluate true for everyone.
- The set is read from the flag definitions already loaded in-process (`posthoganalytics.feature_flag_definitions()`), so there is no new database query, network call, task, or scheduler.
- Static `PERSISTED_FEATURE_FLAGS` keys are still honored; the dynamic set is a union with them.
- Applied to both the main app context (`posthog/utils.py`) and shared or embedded views (`posthog/api/sharing.py`).
- The predicate is deliberately stricter than the existing `FeatureFlagStatusChecker`: an empty `{"groups": []}` is not treated as default-on, because that legacy shape evaluates ambiguously and the baseline stays conservative.

## How did you test this code?

- Added `products/feature_flags/backend/test/test_persisted_flags.py`. The predicate cases pin each rejection branch (holdout, super_groups, group aggregation, multivariate, properties, multiple groups, variant override, inactive, deleted, partial rollout); dropping any single check turns exactly one case red.
- The merge cases cover the static union, the definitions-not-loaded fallback, and the no-static path. No existing test exercised this logic.
- Ran `uv run mypy --cache-fine-grained .` (CI's command): clean.
- Not run: browser verification of the frontend default flip. The change is covered only through the unit tests; the server-rendered bootstrap path is unchanged.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing docs describe `persisted_feature_flags`; the env var `PERSISTED_FEATURE_FLAGS` keeps its existing behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code (PostHog Desktop), directed by @frankh.
- Skills invoked: `/writing-tests` (gated the predicate test) and `/writing-pr-descriptions` (this body).
- The session first scoped a frontend-only `FEATURE_FLAG_DEFAULTS` map, then a periodic Celery task. Both were dropped in favor of computing the set at request time from the in-process SDK definitions, which removes the team-resolution and cross-region-mirror problems and adds no infrastructure.
- The empty-groups exclusion is a deliberate divergence from `FeatureFlagStatusChecker` and is locked in by the `empty_groups` and `no_filters` test cases.
