### PR TITLE
fix(tasks): make recent-activity sort follow real activity

### DIFF
--- a/products/desktop/packages/core/src/canvas/channelItems.test.ts
+++ b/products/desktop/packages/core/src/canvas/channelItems.test.ts
@@ -1,5 +1,6 @@
 import type { Task, UserBasic } from "@posthog/shared/domain-types";
 import { describe, expect, it } from "vitest";
+import type { TaskTimestamp } from "../sidebar/buildSidebarData";
 import {
   buildChannelItems,
   type ChannelItemFilters,
@@ -76,6 +77,45 @@ describe("buildChannelItems", () => {
       ],
     });
     expect(items.map((i) => i.key)).toEqual(["task:new", "canvas:old"]);
+  });
+
+  // `updated_at` alone only moves on the coarse events the server bumps a task on, so a session
+  // whose run is working — or whose activity this device saw before the next poll — has to be able
+  // to outrank a task with a newer `updated_at` and nothing happening.
+  it.each<{
+    term: string;
+    mover: Task;
+    facts: Readonly<Record<string, TaskTimestamp>>;
+  }>([
+    {
+      term: "the latest run's own update",
+      mover: task({
+        id: "mover",
+        updated_at: new Date(1_000).toISOString(),
+        latest_run: {
+          updated_at: new Date(9_000).toISOString(),
+        } as Task["latest_run"],
+      }),
+      facts: {},
+    },
+    {
+      term: "this device's local activity mark",
+      mover: task({ id: "mover", updated_at: new Date(1_000).toISOString() }),
+      facts: { mover: { lastViewedAt: null, lastActivityAt: 9_000 } },
+    },
+  ])("orders a session by $term", ({ mover, facts }) => {
+    const items = build({
+      feedTasks: [
+        task({ id: "stale", updated_at: new Date(5_000).toISOString() }),
+        mover,
+      ],
+      sessionFacts: {
+        needsInputTaskIds: NONE,
+        viewedTimestamps: facts,
+        workspaceModeByTaskId: new Map(),
+      },
+    });
+    expect(items.map((i) => i.id)).toEqual(["mover", "stale"]);
   });
 
   it("drops archived tasks but keeps canvases", () => {
@@ -172,6 +212,15 @@ describe("buildChannelItems", () => {
         task({ id: "asking" }),
         task({ id: "unread" }),
         task({ id: "quiet" }),
+        // A working run reorders the list but says nothing about what you've read: the yellow dot
+        // still answers to the task's own `updated_at`, which here predates the last look.
+        task({
+          id: "running",
+          updated_at: new Date(500).toISOString(),
+          latest_run: {
+            updated_at: new Date(9_000).toISOString(),
+          } as Task["latest_run"],
+        }),
       ],
       sessionFacts: {
         needsInputTaskIds: new Set(["asking"]),
@@ -179,14 +228,20 @@ describe("buildChannelItems", () => {
         // never opened has no timestamp and is not unread.
         viewedTimestamps: {
           unread: { lastViewedAt: 1_000, lastActivityAt: null },
+          running: { lastViewedAt: 1_000, lastActivityAt: null },
         },
         workspaceModeByTaskId: new Map(),
       },
     });
-    expect(items.map((i) => [i.id, i.needsInput, i.unread])).toEqual([
+    expect(
+      items
+        .map((i) => [i.id, i.needsInput, i.unread])
+        .sort((a, b) => String(a[0]).localeCompare(String(b[0]))),
+    ).toEqual([
       ["asking", true, false],
-      ["unread", false, true],
       ["quiet", false, false],
+      ["running", false, false],
+      ["unread", false, true],
     ]);
   });
 

--- a/products/desktop/packages/core/src/canvas/channelItems.ts
+++ b/products/desktop/packages/core/src/canvas/channelItems.ts
@@ -8,7 +8,12 @@ import type {
   TaskRunStatus,
   UserBasic,
 } from "@posthog/shared/domain-types";
-import { isTaskUnread, type TaskTimestamp } from "../sidebar/buildSidebarData";
+import {
+  isTaskUnread,
+  type TaskTimestamp,
+  taskLastActivityAt,
+} from "../sidebar/buildSidebarData";
+import { runActivityTimestamp } from "../tasks/taskActivity";
 import type { DashboardRecord } from "./dashboardSchemas";
 
 /** Where a session runs. `worktree` is a local checkout, so it reads as local. */
@@ -19,6 +24,7 @@ export interface ChannelItemModel {
   kind: "task" | "canvas";
   id: string;
   title: string;
+  /** When it last moved, for the recent-activity sort. See `channelItemTimestamp`. */
   ts: number;
   /** When it was first made, for the created-first sort. */
   createdAt: number;
@@ -112,6 +118,26 @@ function sourceOf(task: Task): string | null {
   return origin && origin !== SELF_ORIGIN ? origin : null;
 }
 
+/**
+ * When a session last moved, from everything one client can see: the backend's `updated_at` (which
+ * the server bumps on the discrete events — a run starting or finishing, a turn completing, a
+ * thread message), its latest run's own timestamps (which keep moving between those events), and
+ * this device's local activity mark (which runs ahead of the 5s feed poll).
+ *
+ * `|| 0` on the first term because `taskLastActivityAt` parses with `new Date`, which yields NaN
+ * for an unparseable string — and a NaN `ts` both breaks the sort comparison and produces a
+ * garbage day header in `groupChannelItems`.
+ */
+function channelItemTimestamp(
+  task: Task,
+  timestamp: TaskTimestamp | undefined,
+): number {
+  return Math.max(
+    taskLastActivityAt(task.updated_at, timestamp) || 0,
+    runActivityTimestamp(task.latest_run),
+  );
+}
+
 export function buildChannelItems({
   dashboards,
   feedTasks,
@@ -156,7 +182,10 @@ export function buildChannelItems({
             kind: "task" as const,
             id: task.id,
             title: task.title || "Untitled task",
-            ts: Date.parse(task.updated_at) || 0,
+            ts: channelItemTimestamp(
+              task,
+              sessionFacts.viewedTimestamps[task.id],
+            ),
             createdAt: Date.parse(task.created_at) || 0,
             pinned: pinnedTaskIds.has(task.id),
             rawStatus: task.latest_run?.status ?? null,

--- a/products/desktop/packages/core/src/tasks/taskActivity.test.ts
+++ b/products/desktop/packages/core/src/tasks/taskActivity.test.ts
@@ -1,6 +1,10 @@
 import type { Task } from "@posthog/shared/domain-types";
 import { describe, expect, it } from "vitest";
-import { filterAndSortTasks, taskActivityTimestamp } from "./taskActivity";
+import {
+  filterAndSortTasks,
+  runActivityTimestamp,
+  taskActivityTimestamp,
+} from "./taskActivity";
 
 function makeTask(overrides: Partial<Task> = {}): Task {
   return {
@@ -50,6 +54,42 @@ describe("taskActivityTimestamp", () => {
     expect(taskActivityTimestamp(task, "updated")).toBe(
       new Date("2026-01-04T00:00:00Z").getTime(),
     );
+  });
+});
+
+describe("runActivityTimestamp", () => {
+  it.each([
+    {
+      what: "the terminal time when it is later than the run's own update",
+      run: {
+        updated_at: "2026-01-02T00:00:00Z",
+        completed_at: "2026-01-04T00:00:00Z",
+      },
+      expected: new Date("2026-01-04T00:00:00Z").getTime(),
+    },
+    {
+      what: "the run's update when it is the later of the two",
+      run: {
+        updated_at: "2026-01-05T00:00:00Z",
+        completed_at: "2026-01-04T00:00:00Z",
+      },
+      expected: new Date("2026-01-05T00:00:00Z").getTime(),
+    },
+    // Callers feed this straight into a Math.max, where a single NaN would swallow every other
+    // term — so a run without timestamps, or with unusable ones, has to read as zero.
+    { what: "zero for a task that never ran", run: null, expected: 0 },
+    {
+      what: "zero for a summary run that carries no timestamps",
+      run: {},
+      expected: 0,
+    },
+    {
+      what: "zero for an unparseable timestamp",
+      run: { updated_at: "whenever" },
+      expected: 0,
+    },
+  ])("returns $what", ({ run, expected }) => {
+    expect(runActivityTimestamp(run)).toBe(expected);
   });
 });
 

--- a/products/desktop/packages/core/src/tasks/taskActivity.ts
+++ b/products/desktop/packages/core/src/tasks/taskActivity.ts
@@ -12,6 +12,29 @@ export interface TaskActivityInput {
   latest_run?: { updated_at: string };
 }
 
+/**
+ * The newest timestamp a run carries, or 0 for a task that has never run.
+ *
+ * `completed_at` is in the max because runs written by older servers persisted the terminal time
+ * without their own `updated_at`, so they finish with a `completed_at` that is later. `created_at`
+ * is deliberately absent: `auto_now` sets `updated_at` on insert, so it can never exceed it.
+ *
+ * A structural parameter type because `/tasks/summaries/` returns a run with only `status` and
+ * `environment` — a caller on that endpoint gets 0 here rather than a wrong claim.
+ */
+export function runActivityTimestamp(
+  run:
+    | { updated_at?: string | null; completed_at?: string | null }
+    | null
+    | undefined,
+): number {
+  if (!run) return 0;
+  return Math.max(
+    Date.parse(run.updated_at ?? "") || 0,
+    Date.parse(run.completed_at ?? "") || 0,
+  );
+}
+
 export function taskActivityTimestamp(
   task: Pick<TaskActivityInput, "created_at" | "updated_at" | "latest_run">,
   sortMode: TaskActivitySortMode,

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useTaskThread.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useTaskThread.ts
@@ -6,6 +6,7 @@ import { useService } from "@posthog/di/react";
 import type { TaskThreadMessage } from "@posthog/shared/domain-types";
 import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
 import { useMarkTaskActivityRead } from "@posthog/ui/features/canvas/hooks/useMarkTaskActivityRead";
+import { useTaskViewed } from "@posthog/ui/features/sidebar/useTaskViewed";
 import { useAuthenticatedQuery } from "@posthog/ui/hooks/useAuthenticatedQuery";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useRef } from "react";
@@ -76,13 +77,20 @@ export function useTaskThread(
 export function usePostTaskThreadMessage(taskId: string | undefined) {
   const client = useOptionalAuthenticatedClient();
   const queryClient = useQueryClient();
+  const { markAsViewed } = useTaskViewed();
   const mutation = useMutation({
     mutationFn: async (content: string) => {
       if (!client || !taskId) throw new Error("Not authenticated");
       return client.createTaskThreadMessage(taskId, content);
     },
-    onSuccess: () =>
-      queryClient.invalidateQueries({ queryKey: taskThreadQueryKey(taskId) }),
+    onSuccess: () => {
+      // Your own message counts as activity on the task, and the server has no actor to compare
+      // it against — so without this the row you just posted in comes back unread.
+      if (taskId) markAsViewed(taskId);
+      return queryClient.invalidateQueries({
+        queryKey: taskThreadQueryKey(taskId),
+      });
+    },
   });
   return { postMessage: mutation.mutateAsync, isPosting: mutation.isPending };
 }
@@ -91,13 +99,18 @@ export function usePostTaskThreadMessageToAgent(taskId: string | undefined) {
   const client = useOptionalAuthenticatedClient();
   const queryClient = useQueryClient();
   const service = useService<TaskThreadService>(TASK_THREAD_SERVICE);
+  const { markAsViewed } = useTaskViewed();
   const mutation = useMutation({
     mutationFn: async (content: string) => {
       if (!client || !taskId) throw new Error("Not authenticated");
       return service.postMessageToAgent(client, taskId, content);
     },
-    onSuccess: () =>
-      queryClient.invalidateQueries({ queryKey: taskThreadQueryKey(taskId) }),
+    onSuccess: () => {
+      if (taskId) markAsViewed(taskId);
+      return queryClient.invalidateQueries({
+        queryKey: taskThreadQueryKey(taskId),
+      });
+    },
   });
   return {
     postMessageToAgent: mutation.mutateAsync,

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -2617,6 +2617,9 @@ def update_task_run(
         handle_loop_run_terminal(run)
 
     if new_status in _TERMINAL_TASK_RUN_STATUSES and old_status != new_status:
+        # The transition, not the PATCH: a run's own state merges land here many times while it
+        # works, and bumping the task on each one would write the task row on every progress tick.
+        Task.bump_activity(task_id=run.task_id, team_id=run.team_id, at=run.completed_at)
         if new_status == TaskRun.Status.FAILED:
             observe_agent_turn_failed(run)
             # This PATCH performed the DB transition, so it owns the task_run_failed
@@ -6868,6 +6871,9 @@ def list_mentions(
 
 def project_thread_message_activity(message: TaskThreadMessage) -> None:
     """Project a new thread message onto the feed of everyone it concerns."""
+    # Above the loop, and above the recipient set: a task's order in a list is task-scoped, so it
+    # has to move even for a message that reaches nobody's feed.
+    Task.bump_activity(task_id=message.task_id, team_id=message.team_id, at=message.created_at)
     recipient_ids = {recipient_id for recipient_id in (message.author_id, message.task.created_by_id) if recipient_id}
     for recipient_id in recipient_ids:
         TaskActivity.record(
@@ -6889,6 +6895,8 @@ def project_awaiting_input_activity(task_run: "TaskRun") -> None:
     the same row. Deliberately outside the push feature flag and its Redis cooldown — the
     in-app feed should update even where the mobile push is off.
     """
+    awaiting_at = django_timezone.now()
+    Task.bump_activity(task_id=task_run.task_id, team_id=task_run.task.team_id, at=awaiting_at)
     creator_id = task_run.task.created_by_id
     if creator_id is None:
         return
@@ -6897,11 +6905,15 @@ def project_awaiting_input_activity(task_run: "TaskRun") -> None:
         user_id=creator_id,
         task_id=task_run.task_id,
         kind=TaskActivity.Kind.AWAITING_INPUT,
-        activity_at=django_timezone.now(),
+        activity_at=awaiting_at,
     )
 
 
 def project_completed_activity(task_run: "TaskRun") -> None:
+    completed_at = task_run.completed_at or django_timezone.now()
+    # Also reached per finished turn (``notify_task_run_turn_completed``), which is what keeps an
+    # interactive session at the top of a recent-activity list between its start and its end.
+    Task.bump_activity(task_id=task_run.task_id, team_id=task_run.task.team_id, at=completed_at)
     creator_id = task_run.task.created_by_id
     if creator_id is None:
         return
@@ -6910,7 +6922,7 @@ def project_completed_activity(task_run: "TaskRun") -> None:
         user_id=creator_id,
         task_id=task_run.task_id,
         kind=TaskActivity.Kind.COMPLETED,
-        activity_at=task_run.completed_at or django_timezone.now(),
+        activity_at=completed_at,
     )
 
 

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -22,7 +22,9 @@ from django.contrib.postgres.fields import ArrayField
 from django.contrib.postgres.indexes import GinIndex
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError, connection, models, transaction
+from django.db.models import F, Value
 from django.db.models.fields.json import KeyTransform
+from django.db.models.functions import Greatest
 from django.utils import timezone as django_timezone
 
 import structlog
@@ -497,6 +499,7 @@ class Task(DeletedMetaFields, models.Model):
             state=state,
             branch=branch,
         )
+        Task.bump_activity(task_id=self.id, team_id=self.team_id, at=task_run.created_at)
         task_run.publish_stream_state_event()
         observe_task_run_created(task_run)
         self.capture_event(
@@ -518,6 +521,33 @@ class Task(DeletedMetaFields, models.Model):
             },
         )
         return task_run
+
+    @classmethod
+    def bump_activity(cls, *, task_id: str | uuid.UUID, team_id: int, at: datetime | None = None) -> None:
+        """Move ``updated_at`` forward for a real timeline event on this task.
+
+        ``updated_at`` is what every task list orders "recent activity" by, but ``auto_now`` only
+        fires on an explicit ``save()`` — so without this the column sits near ``created_at`` and
+        the ordering collapses to creation order. Call it where an event a reader would notice
+        happens: a run starting or terminalizing, a turn completing, a thread message landing.
+        Not on every run state merge — that would put a row write on each progress tick, and the
+        desktop client already folds ``latest_run.updated_at`` into its own ordering.
+
+        ``.update()`` rather than ``save()``: callers hold no task instance, and it must not
+        clobber a concurrent field write. That also means ``auto_now`` (a ``pre_save`` hook) does
+        not fire, hence the explicit value.
+
+        ``Greatest`` because events arrive out of order — a retried Temporal activity replaying a
+        terminal transition, the janitor finalizing a run whose ``completed_at`` is old, a thread
+        message carrying its own ``created_at``. The same newest-wins rule ``TaskActivity.record``
+        enforces in SQL; a late event reordering a list backwards is worse than not reordering it.
+        """
+        cls.objects.filter(id=task_id, team_id=team_id).update(
+            updated_at=Greatest(
+                F("updated_at"),
+                Value(at or django_timezone.now(), output_field=models.DateTimeField()),
+            )
+        )
 
     @property
     def slack_notified_pr_url(self) -> str | None:
@@ -2406,7 +2436,7 @@ class TaskRun(models.Model):
         """
         self.status = self.Status.COMPLETED
         self.completed_at = django_timezone.now()
-        self.save(update_fields=["status", "completed_at"])
+        self.save(update_fields=["status", "completed_at", "updated_at"])
         self.publish_stream_state_event()
         self.capture_event(
             "task_run_completed",
@@ -2437,7 +2467,7 @@ class TaskRun(models.Model):
         self.status = self.Status.FAILED
         self.error_message = error
         self.completed_at = django_timezone.now()
-        self.save(update_fields=["status", "error_message", "completed_at"])
+        self.save(update_fields=["status", "error_message", "completed_at", "updated_at"])
         self.publish_stream_state_event()
         self.capture_event(
             "task_run_failed",

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_update_task_run_status.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_update_task_run_status.py
@@ -1,11 +1,15 @@
+from datetime import timedelta
+
 import pytest
 from unittest.mock import patch
+
+from django.utils import timezone
 
 from asgiref.sync import async_to_sync
 from temporalio.exceptions import ApplicationError
 from temporalio.testing import ActivityEnvironment
 
-from products.tasks.backend.models import Loop, TaskRun
+from products.tasks.backend.models import Loop, Task, TaskRun
 from products.tasks.backend.temporal.process_task.activities.update_task_run_status import (
     SANDBOX_GONE_STATE_KEY,
     TIMED_OUT_WALL_CLOCK_STATE_KEY,
@@ -233,6 +237,25 @@ class TestUpdateTaskRunStatusActivity:
 
         completed = [c for c in mock_capture.call_args_list if c.kwargs.get("event") == "task_run_completed"]
         assert len(completed) == 1
+
+    @pytest.mark.django_db(transaction=True)
+    def test_terminal_transition_bumps_task_activity(self, activity_environment, test_task_run):
+        # This is the only path that terminalizes a cloud run — `mark_completed` is reached by the
+        # janitor sweeps alone — so nothing else would move the task in a recent-activity list.
+        task = test_task_run.task
+        stale = timezone.now() - timedelta(hours=1)
+        Task.objects.filter(pk=task.pk).update(updated_at=stale)
+
+        input_data = UpdateTaskRunStatusInput(run_id=str(test_task_run.id), status=TaskRun.Status.COMPLETED)
+        async_to_sync(activity_environment.run)(update_task_run_status, input_data)
+
+        bumped = Task.objects.get(pk=task.pk).updated_at
+        assert bumped > stale
+
+        # A retried activity sees the row already terminal and must not re-bump: a run that
+        # finished once should not keep climbing the list on every replay.
+        async_to_sync(activity_environment.run)(update_task_run_status, input_data)
+        assert Task.objects.get(pk=task.pk).updated_at == bumped
 
     @pytest.mark.django_db(transaction=True)
     def test_terminal_retry_completes_loop_bookkeeping_exactly_once(self, activity_environment, test_task_run):

--- a/products/tasks/backend/temporal/process_task/activities/update_task_run_status.py
+++ b/products/tasks/backend/temporal/process_task/activities/update_task_run_status.py
@@ -11,7 +11,7 @@ from posthog.temporal.common.utils import asyncify
 
 from products.tasks.backend.error_telemetry import truncate_error_message
 from products.tasks.backend.metrics import observe_wizard_run_unbound
-from products.tasks.backend.models import TaskRun
+from products.tasks.backend.models import Task, TaskRun
 from products.tasks.backend.temporal.metrics import record_run_token_usage
 from products.tasks.backend.temporal.observability import log_with_activity_context
 
@@ -116,6 +116,10 @@ def update_task_run_status(input: UpdateTaskRunStatusInput) -> None:
 
     if input.status in [TaskRun.Status.COMPLETED, TaskRun.Status.FAILED] and old_status != input.status:
         _capture_terminal_analytics(task_run, input)
+        # A cloud run finishing is the last thing that happens on the task, and this is the path
+        # that writes it — the `mark_completed`/`mark_failed` helpers are only reached by the
+        # janitor sweeps, so nothing else would move the task's `updated_at` here.
+        Task.bump_activity(task_id=task_run.task_id, team_id=task_run.team_id, at=task_run.completed_at)
 
     if input.timed_out_inactivity and old_status != input.status:
         task_run.task.soft_delete_if_unclaimed_prewarm(task_run)

--- a/products/tasks/backend/tests/test_models.py
+++ b/products/tasks/backend/tests/test_models.py
@@ -1,6 +1,7 @@
 import json
 import uuid
 import secrets
+from datetime import timedelta
 from typing import ClassVar
 
 from unittest.mock import AsyncMock, patch
@@ -9,6 +10,7 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError
 from django.test import TestCase
+from django.utils import timezone as django_timezone
 
 from parameterized import parameterized
 
@@ -674,6 +676,37 @@ class TestTaskRun(TestCase):
         run = self.task.create_run(mode="interactive")
 
         self.assertNotIn("initial_permission_mode", run.state)
+
+    def test_create_run_bumps_task_activity(self):
+        stale = django_timezone.now() - timedelta(hours=1)
+        # `.update()` bypasses `auto_now`, so the column can be aged without the model touching it.
+        Task.objects.filter(pk=self.task.pk).update(updated_at=stale)
+
+        self.task.create_run()
+
+        self.assertGreater(Task.objects.get(pk=self.task.pk).updated_at, stale)
+
+    @parameterized.expand(
+        [
+            ("completed", lambda run: run.mark_completed()),
+            ("failed", lambda run: run.mark_failed("nope")),
+        ]
+    )
+    def test_terminal_transition_persists_run_updated_at(self, _name, terminalize):
+        run = TaskRun.objects.create(
+            task=self.task,
+            team=self.team,
+            status=TaskRun.Status.IN_PROGRESS,
+        )
+        stale = django_timezone.now() - timedelta(hours=1)
+        TaskRun.objects.filter(pk=run.pk).update(updated_at=stale)
+        run.refresh_from_db()
+
+        terminalize(run)
+
+        # `auto_now` sets the attribute in `pre_save` regardless, so the row is what proves it —
+        # an `update_fields` that omits `updated_at` leaves the column behind while the object lies.
+        self.assertGreater(TaskRun.objects.get(pk=run.pk).updated_at, stale)
 
     @patch("products.tasks.backend.models.TaskRun.publish_stream_state_event")
     def test_prepare_for_cloud_handoff_clears_stale_sandbox_routing(self, _publish):

--- a/products/tasks/backend/tests/test_thread_updates.py
+++ b/products/tasks/backend/tests/test_thread_updates.py
@@ -1,7 +1,10 @@
+from datetime import datetime, timedelta
+
 from unittest.mock import patch
 
 from django.core.cache import cache
 from django.test import TestCase
+from django.utils import timezone as django_timezone
 
 from parameterized import parameterized
 
@@ -9,12 +12,14 @@ from posthog.models import Comment, Organization, OrganizationMembership, Team, 
 from posthog.models.scoping import team_scope
 
 from products.tasks.backend.facade.api import (
+    create_thread_message,
     list_mentions,
     list_thread_messages,
     post_artifact_thread_update,
     post_canvas_created_thread_update,
     post_commits_pushed_thread_update,
     post_pr_created_thread_update,
+    project_thread_message_activity,
     record_comment_activity,
     set_task_run_output,
     update_task_run,
@@ -49,6 +54,36 @@ class TestAgentThreadUpdates(TestCase):
 
     def _messages(self, task: Task) -> list[TaskThreadMessage]:
         return list(TaskThreadMessage.objects.for_team(self.team.id).filter(task=task).order_by("created_at"))
+
+    def _age_task(self, delta: timedelta) -> datetime:
+        """Age the task's `updated_at` past `auto_now`, which `.update()` doesn't trigger."""
+        aged = django_timezone.now() + delta
+        Task.objects.filter(pk=self.task.pk).update(updated_at=aged)
+        return aged
+
+    def test_thread_message_bumps_task_activity(self) -> None:
+        stale = self._age_task(-timedelta(hours=1))
+
+        with team_scope(self.team.id):
+            create_thread_message(self.task.id, self.team.id, self.user.id, content="ping")
+
+        self.assertGreater(Task.objects.get(pk=self.task.pk).updated_at, stale)
+
+    def test_a_late_thread_message_does_not_reorder_the_task_backwards(self) -> None:
+        # A message stamped in the past — a retried projection, or a write that raced the clock.
+        # The task's place in a recent-activity list may only ever move forward.
+        message = TaskThreadMessage.objects.for_team(self.team.id).create(
+            team=self.team,
+            task=self.task,
+            author=self.user,
+            content="late",
+            created_at=django_timezone.now() - timedelta(hours=2),
+        )
+        fresh = self._age_task(timedelta(0))
+
+        project_thread_message_activity(message)
+
+        self.assertEqual(Task.objects.get(pk=self.task.pk).updated_at, fresh)
 
     @patch(_FLAG_TARGET, return_value=True)
     def test_pr_created_posts_authorless_artifact_message(self, _flag) -> None:


### PR DESCRIPTION
## Problem

Sorting the PostHog Desktop Spaces sessions list by "Recent activity" — the default — puts sessions in roughly the order they were created. A session someone worked in an hour ago sits below one that has been idle since the day it was opened.

- `Task.updated_at` is the column every task list orders that sort by.
- It is `auto_now=True`, so it only moves when something calls `task.save()`.
- Nothing called one when a run started, a run terminalized, a turn completed, or a thread message landed.
- The only production writers were setup-time edits: attaching a GitHub integration, backfilling a description, setting repositories.

So the column settled near `created_at` and stayed there.

## Changes

- `Task.bump_activity` moves `updated_at` forward on the four events a reader would notice. Five call sites: run creation, the cloud terminal transition, the local-agent terminal transition, the thread-message projection, and the turn-complete projection.
- The bump uses `Greatest` over the current value. Events arrive out of order — a retried Temporal activity, the janitor finalizing an old run, a message carrying its own `created_at` — and a late one must not drag a session backwards.
- `TaskRun.mark_completed` and `mark_failed` now list `"updated_at"` in `update_fields`. They set the attribute through `auto_now` but never persisted the column, so the object and the row disagreed after a run finished, and `latest_run.updated_at` served stale.
- The desktop Spaces list orders on the max of that column, the latest run's own timestamps, and this device's local activity mark. The run term covers progress between the discrete events; the local term runs ahead of the 5s feed poll.

The split is deliberate. `updateTaskRun` fires many times per run as the agent merges state, and bumping the task there would write the task row on every progress tick. The backend bumps on discrete events; the client folds in the continuous churn.

> [!NOTE]
> The unread dot changes behavior too. `isTaskUnread` is untouched, but it reads the same column, so it stops being limited to sessions running on this machine — a teammate's reply or a finishing cloud run now lights it within one poll. `useTaskThread` marks the task viewed after a successful send, because a task-scoped column has no actor and your own message would otherwise dot your own row.
>
> The code sidebar's "Updated" sort improves with no code change, for the same reason. Its files are not in this diff.

No migration. `Task` has no index on `updated_at` — every index is on `-created_at` — so the bump churns nothing.

Nothing looks different in a screenshot: the change is which order the same rows appear in.

## How did you test this code?

Automated tests, each catching a regression nothing covered:

- `Task.create_run` bumps the parent task, and a terminal transition persists the run's own `updated_at`. The second one is invisible today, because the in-memory object reports a value the row never got.
- A thread message bumps the task, and a message stamped in the past leaves it where it is. That second case pins `Greatest`.
- The cloud terminal transition bumps the task, and a retried activity does not bump it again. This path had no task-level coverage at all.
- `buildChannelItems` orders a session by the run term and by the local term, parameterized. A working run does not mark the session unread.
- `runActivityTimestamp` prefers the later of the run's two timestamps, and returns 0 rather than `NaN` for a run without usable ones. Callers feed it into a `Math.max`, where one `NaN` swallows every other term.

Ran locally: `products/tasks/backend/tests/test_models.py`, `products/tasks/backend/tests/test_thread_updates.py`, `products/tasks/backend/temporal/process_task/activities/tests/test_update_task_run_status.py`, and the `@posthog/core` vitest suite. `@posthog/core` and `@posthog/ui` typecheck clean.

Not run: `test_push_dispatcher.py` and `test_channels_api.py`, which drive the two projections this PR edits. CI covers both.

Not done: no manual run of the desktop app against a backend. The ordering claims rest on the unit tests above, not on watching a list reorder.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus) in PostHog Desktop, directed by @frankh, who reported the symptom and chose the scope.

Skills invoked: `/writing-tests` for the test gate, `/writing-pr-descriptions` for this body. The repo's `.claude/rules` for Temporal workflow versioning and product isolation applied to the edited activity and facade.

Two scope decisions worth surfacing. A denormalized indexed `last_activity_at` column was considered and rejected: nothing orders by the field server-side, since the client re-sorts the feed itself, so the migration bought nothing this PR needs. `set_task_title` also omits `"updated_at"` from its `update_fields`, and stays that way — a relabel is not a timeline event.
