### PR TITLE
chore(owners): assign high-cost core tests

### DIFF
--- a/ee/owners.yaml
+++ b/ee/owners.yaml
@@ -1,7 +1,7 @@
 version: 1
 owners: []
 rules:
-    - match: ['/api/billing.py', '/billing/']
+    - match: ['/api/billing.py', '/api/test/test_billing.py', '/billing/']
       owners: team-billing
     - match: '/clickhouse/materialized_columns/'
       owners: team-analytics-platform

--- a/owners.yaml
+++ b/owners.yaml
@@ -75,6 +75,12 @@ rules:
       owners: [platform-ux, '@sampennington']
     - match: '/posthog/helpers/email_utils.py'
       owners: team-platform-features
+    - match: '/posthog/test/activity_logging/'
+      owners: team-platform-features
+    - match:
+          - '/posthog/api/test/test_playwright_setup.py'
+          - '/posthog/test/test_startup_import_budget.py'
+      owners: team-devex
     - match: '/posthog/management/commands/find_enum_collisions.py'
       owners: team-devex
     - match: '/posthog/settings/data_warehouse.py'

--- a/posthog/api/owners.yaml
+++ b/posthog/api/owners.yaml
@@ -1,17 +1,19 @@
 version: 1
 owners: []
 rules:
-    - match: '/cohort.py'
+    - match: ['/cohort.py', '/test/test_cohort.py']
       owners: team-feature-flags
     - match: '/comments.py'
       owners: conversations
     - match: '/documentation.py'
       owners: team-devex
+    - match: '/test/dashboards/'
+      owners: team-analytics-platform
     - match: ['/element.py', '/event.py', '/event_definition.py']
       owners: team-product-analytics
     - match: '/mixins.py'
       owners: team-devex
-    - match: '/person.py'
+    - match: ['/person.py', '/test/test_person.py', '/test/test_person_personhog.py']
       owners: team-product-analytics
     - match: ['/proxy_record.py', '/proxy_record_diagnostics.py', '/resource_transfer.py']
       owners: team-platform-features

--- a/posthog/dags/owners.yaml
+++ b/posthog/dags/owners.yaml
@@ -6,6 +6,8 @@ rules:
           - '/fix_missing_person_overrides.py'
           - '/fix_person_id_overrides.py'
           - '/person_property_reconciliation.py'
+          - '/tests/test_person_property_reconciliation.py'
+          - '/tests/test_person_property_reconciliation_restore.py'
       owners: team-ingestion
     - match: '/sessions.py'
       owners: team-analytics-platform

--- a/posthog/tasks/owners.yaml
+++ b/posthog/tasks/owners.yaml
@@ -24,5 +24,5 @@ rules:
           - '/update_survey_adaptive_sampling.py'
           - '/update_survey_iteration.py'
       owners: team-surveys
-    - match: '/usage_report.py'
+    - match: ['/usage_report.py', '/test/test_usage_report.py']
       owners: team-billing


### PR DESCRIPTION
> 🤖 Posted by an automated coding agent.

## Problem

CI reports cannot route several costly legacy tests because ownership rules cover their production files but omit matching tests.

## Changes

- Existing ownership rules now cover matching billing, ingestion, analytics, feature flag, and person tests.
- DevEx owns startup and Playwright setup tests.
- Platform features owns activity logging tests.

## How did you test this code?

- Resolved every changed test path through `posthog-owners` and checked the expected team.
- Ran `hogli owners:lint` and `hogli ci:preflight --fix`.
- The ownership lint retains four unrelated advisory warnings.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This change updates the canonical ownership data.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi implemented this change with repository shell tools. It used `/establishing-code-ownership`, `/stacking-prs`, and `/writing-pr-descriptions`.

This layer extends known source ownership. It does not assign a broad default owner to legacy code.
