### PR TITLE
feat(desktop): pick code, canvas, or question for a new session

### DIFF
--- a/products/desktop/packages/core/src/canvas/canvasApplicationService.test.ts
+++ b/products/desktop/packages/core/src/canvas/canvasApplicationService.test.ts
@@ -5,7 +5,7 @@ import type { RootLogger } from "@posthog/di/logger";
 import { describe, expect, it, vi } from "vitest";
 import {
   CanvasApplicationService,
-  type CanvasGenerationGateway,
+  type CanvasCreationGateway,
   type GenerateCanvasInput,
 } from "./canvasApplicationService";
 
@@ -37,13 +37,18 @@ function makeDeps(overrides?: {
 
 function makeGateway() {
   return {
+    createCanvas: vi.fn(
+      async (_input: { channelId: string; name: string }) => ({
+        id: "dash-new",
+      }),
+    ),
     fileTask: vi.fn(async (_channelId: string, _taskId: string) => {}),
     setGenerationTask: vi.fn(
       async (_dashboardId: string, _taskId: string) => {},
     ),
     renameCanvas: vi.fn(async (_dashboardId: string, _title: string) => {}),
     onAutoNamed: vi.fn((_taskId: string, _title: string) => {}),
-  } satisfies CanvasGenerationGateway;
+  } satisfies CanvasCreationGateway;
 }
 
 function input(
@@ -160,6 +165,62 @@ describe("CanvasApplicationService", () => {
 
     expect(generateCanvasName).not.toHaveBeenCalled();
     expect(gateway.renameCanvas).not.toHaveBeenCalled();
+  });
+
+  it("creates the canvas a prompt-first session targets, then generates into it", async () => {
+    const { service, createTask } = makeDeps();
+    const gateway = makeGateway();
+
+    const result = await service.startCanvasFromPrompt(
+      {
+        instruction: "build a signups chart",
+        channelId: "chan-1",
+        channelName: "growth",
+        cloudRegion: "us",
+      },
+      gateway,
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      taskId: "task-1",
+      dashboardId: "dash-new",
+    });
+    expect(gateway.createCanvas).toHaveBeenCalledWith({
+      channelId: "chan-1",
+      name: "Untitled canvas",
+      templateId: "freeform",
+    });
+    expect(createTask.mock.calls[0][0].content).toContain(
+      'canvas id: "dash-new"',
+    );
+    expect(gateway.setGenerationTask).toHaveBeenCalledWith(
+      "dash-new",
+      "task-1",
+    );
+  });
+
+  it("reports a failed canvas creation without starting a run", async () => {
+    const { service, createTask } = makeDeps();
+    const gateway = makeGateway();
+    gateway.createCanvas.mockRejectedValue(new Error("offline"));
+
+    const result = await service.startCanvasFromPrompt(
+      {
+        instruction: "build a signups chart",
+        channelId: "chan-1",
+        channelName: "growth",
+        cloudRegion: "us",
+      },
+      gateway,
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      reason: "create-failed",
+      error: "offline",
+    });
+    expect(createTask).not.toHaveBeenCalled();
   });
 
   it("still starts the task when recording the generation task fails", async () => {

--- a/products/desktop/packages/core/src/canvas/canvasApplicationService.ts
+++ b/products/desktop/packages/core/src/canvas/canvasApplicationService.ts
@@ -20,7 +20,8 @@ import {
   type WorkspaceMode,
 } from "@posthog/shared";
 import { inject, injectable } from "inversify";
-import { isPlaceholderCanvasName } from "./canvasNaming";
+import { isPlaceholderCanvasName, UNTITLED_CANVAS_NAME } from "./canvasNaming";
+import { FREEFORM_TEMPLATE_ID } from "./freeformSchemas";
 import { buildCanvasGenerationPrompt } from "./generationPrompt";
 
 export interface GenerateCanvasInput {
@@ -59,8 +60,26 @@ export interface CanvasGenerationGateway {
   onAutoNamed?(taskId: string, title: string): void;
 }
 
+/**
+ * A gateway that can also create the canvas the generation targets, for the
+ * surfaces where the prompt comes first and the canvas doesn't exist yet.
+ */
+export interface CanvasCreationGateway extends CanvasGenerationGateway {
+  /** Create an empty canvas in the channel and return its id. */
+  createCanvas(input: {
+    channelId: string;
+    name: string;
+    templateId: string;
+  }): Promise<{ id: string }>;
+}
+
 export type GenerateCanvasResult =
   | { ok: true; taskId: string }
+  | { ok: false; reason: "no-model" }
+  | { ok: false; reason: "create-failed"; error: string };
+
+export type StartCanvasResult =
+  | { ok: true; taskId: string; dashboardId: string }
   | { ok: false; reason: "no-model" }
   | { ok: false; reason: "create-failed"; error: string };
 
@@ -85,6 +104,39 @@ export class CanvasApplicationService {
     @inject(ROOT_LOGGER) rootLogger: RootLogger,
   ) {
     this.log = rootLogger.scope("canvas-application");
+  }
+
+  /**
+   * Create a canvas from a prompt alone and start its generation — the
+   * composer path, where the user describes a canvas before one exists. The
+   * canvas lands unnamed so generation auto-names it from the instruction.
+   */
+  async startCanvasFromPrompt(
+    input: Omit<GenerateCanvasInput, "dashboardId" | "name">,
+    gateway: CanvasCreationGateway,
+  ): Promise<StartCanvasResult> {
+    const templateId = input.templateId ?? FREEFORM_TEMPLATE_ID;
+    let dashboardId: string;
+    try {
+      const canvas = await gateway.createCanvas({
+        channelId: input.channelId,
+        name: UNTITLED_CANVAS_NAME,
+        templateId,
+      });
+      dashboardId = canvas.id;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.log.error("Canvas creation failed", { error: message });
+      return { ok: false, reason: "create-failed", error: message };
+    }
+
+    // A failed generation leaves the empty canvas behind on purpose: it has its
+    // own generate bar, so the user can retry there instead of losing the prompt.
+    const result = await this.generateCanvas(
+      { ...input, dashboardId, name: UNTITLED_CANVAS_NAME, templateId },
+      gateway,
+    );
+    return result.ok ? { ...result, dashboardId } : result;
   }
 
   async generateCanvas(

--- a/products/desktop/packages/core/src/task-detail/questionPrompt.ts
+++ b/products/desktop/packages/core/src/task-detail/questionPrompt.ts
@@ -1,0 +1,8 @@
+// A question session asks the agent for an answer, not a change. The user's
+// prompt leads and this block follows it, so the agent investigates and replies
+// instead of editing. The run also starts in plan mode, which enforces it.
+export const QUESTION_SESSION_INSTRUCTIONS = `<question_instructions>
+Answer the question above. Investigate as much as you need: read the code, query PostHog data, check the docs. Then reply with the answer and the evidence behind it.
+
+Do not edit files, commit, or open a pull request. When the answer implies work, propose the next steps instead of taking them.
+</question_instructions>`;

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useGenerateFreeformCanvas.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useGenerateFreeformCanvas.ts
@@ -1,7 +1,9 @@
 import type {
   CanvasApplicationService,
+  CanvasCreationGateway,
   CanvasGenerationGateway,
 } from "@posthog/core/canvas/canvasApplicationService";
+import { UNTITLED_CANVAS_NAME } from "@posthog/core/canvas/canvasNaming";
 import { CANVAS_APPLICATION_SERVICE } from "@posthog/core/canvas/identifiers";
 import { useService } from "@posthog/di/react";
 import { useHostTRPC } from "@posthog/host-router/react";
@@ -44,7 +46,8 @@ export function useGenerateFreeformCanvas(args: {
   const queryClient = useQueryClient();
   const { invalidateTasks } = useCreateTask();
   const { fileTask } = useChannelTaskMutations();
-  const { setGenerationTask, renameDashboard } = useDashboardMutations();
+  const { createDashboard, setGenerationTask, renameDashboard } =
+    useDashboardMutations();
   // The channel's CONTEXT.md, passed to the agent as optional background so the
   // generated canvas starts with the shared context. Absent/empty is fine.
   const callerOwnsContext = "channelContext" in args;
@@ -55,6 +58,114 @@ export function useGenerateFreeformCanvas(args: {
     ? args.channelContext
     : instructions?.content;
   const [isStarting, setIsStarting] = useState(false);
+
+  const buildGateway = useCallback(
+    (): CanvasCreationGateway => ({
+      createCanvas: ({ channelId: cid, name, templateId }) =>
+        createDashboard(cid, name, templateId),
+      fileTask: async (cid, taskId) => {
+        await fileTask(cid, taskId);
+      },
+      setGenerationTask: async (id, taskId) => {
+        await setGenerationTask(id, taskId);
+      },
+      renameCanvas: async (id, title) => {
+        await renameDashboard(id, title);
+      },
+      onTaskReady: (task) => invalidateTasks(task),
+      // Keep the tracked generation's name in sync so its completion toast
+      // reads the real title, not "Untitled canvas".
+      onAutoNamed: (taskId, title) =>
+        useCanvasGenerationTrackerStore.getState().updateName(taskId, title),
+    }),
+    [
+      createDashboard,
+      fileTask,
+      setGenerationTask,
+      renameDashboard,
+      invalidateTasks,
+    ],
+  );
+
+  // Refresh the workspace cache so the new cloud workspace row appears and the
+  // task view resolves the cloud run instead of the repo-picker prompt.
+  const invalidateWorkspaces = useCallback(() => {
+    void queryClient.invalidateQueries({
+      queryKey: trpc.workspace.getAll.queryKey(),
+    });
+  }, [queryClient, trpc]);
+
+  const reportFailure = useCallback(
+    (result: { reason: string; error?: string }) => {
+      if (result.reason === "no-model") {
+        toast.error("Couldn't start canvas generation", {
+          description: "No model is configured for cloud runs.",
+        });
+        return;
+      }
+      toastError("Couldn't start canvas generation", result.error);
+    },
+    [],
+  );
+
+  /**
+   * Create a canvas from a prompt alone and start generating it — the composer
+   * path, where the user describes a canvas before one exists. Resolves to the
+   * new canvas's ids so the caller can navigate to it.
+   */
+  const startNewCanvas = useCallback(
+    async (opts: {
+      instruction: string;
+      adapter?: Adapter;
+      model?: string;
+      reasoningLevel?: string;
+      workspaceMode?: WorkspaceMode;
+    }): Promise<{ taskId: string; dashboardId: string } | null> => {
+      setIsStarting(true);
+      try {
+        const result = await canvasApplication.startCanvasFromPrompt(
+          {
+            instruction: opts.instruction,
+            channelId,
+            channelName,
+            channelContext,
+            adapter: opts.adapter,
+            model: opts.model,
+            reasoningLevel: opts.reasoningLevel,
+            workspaceMode: opts.workspaceMode,
+            cloudRegion,
+          },
+          buildGateway(),
+        );
+
+        if (!result.ok) {
+          reportFailure(result);
+          return null;
+        }
+
+        useCanvasGenerationTrackerStore.getState().track({
+          taskId: result.taskId,
+          dashboardId: result.dashboardId,
+          channelId,
+          name: UNTITLED_CANVAS_NAME,
+        });
+        invalidateWorkspaces();
+        return { taskId: result.taskId, dashboardId: result.dashboardId };
+      } finally {
+        setIsStarting(false);
+      }
+    },
+    [
+      buildGateway,
+      canvasApplication,
+      channelContext,
+      channelId,
+      channelName,
+      cloudRegion,
+      invalidateWorkspaces,
+      reportFailure,
+    ],
+  );
 
   const generate = useCallback(
     async (opts: {
@@ -74,24 +185,7 @@ export function useGenerateFreeformCanvas(args: {
       const { dashboardId, name, instruction } = opts;
       setIsStarting(true);
       try {
-        const gateway: CanvasGenerationGateway = {
-          fileTask: async (cid, taskId) => {
-            await fileTask(cid, taskId);
-          },
-          setGenerationTask: async (id, taskId) => {
-            await setGenerationTask(id, taskId);
-          },
-          renameCanvas: async (id, title) => {
-            await renameDashboard(id, title);
-          },
-          onTaskReady: (task) => invalidateTasks(task),
-          // Keep the tracked generation's name in sync so its completion toast
-          // reads the real title, not "Untitled canvas".
-          onAutoNamed: (taskId, title) =>
-            useCanvasGenerationTrackerStore
-              .getState()
-              .updateName(taskId, title),
-        };
+        const gateway: CanvasGenerationGateway = buildGateway();
 
         const result = await canvasApplication.generateCanvas(
           {
@@ -112,13 +206,7 @@ export function useGenerateFreeformCanvas(args: {
         );
 
         if (!result.ok) {
-          if (result.reason === "no-model") {
-            toast.error("Couldn't start canvas generation", {
-              description: "No model is configured for cloud runs.",
-            });
-          } else {
-            toastError("Couldn't start canvas generation", result.error);
-          }
+          reportFailure(result);
           return null;
         }
 
@@ -130,30 +218,23 @@ export function useGenerateFreeformCanvas(args: {
           channelId,
           name,
         });
-        // Refresh the workspace cache so the new cloud workspace row appears and
-        // the task view resolves the cloud run instead of the repo-picker prompt.
-        void queryClient.invalidateQueries({
-          queryKey: trpc.workspace.getAll.queryKey(),
-        });
+        invalidateWorkspaces();
         return result.taskId;
       } finally {
         setIsStarting(false);
       }
     },
     [
+      buildGateway,
       canvasApplication,
-      cloudRegion,
-      trpc,
-      queryClient,
-      invalidateTasks,
-      fileTask,
-      setGenerationTask,
-      renameDashboard,
+      channelContext,
       channelId,
       channelName,
-      channelContext,
+      cloudRegion,
+      invalidateWorkspaces,
+      reportFailure,
     ],
   );
 
-  return { generate, isStarting };
+  return { generate, startNewCanvas, isStarting };
 }

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useStartCanvasSession.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useStartCanvasSession.ts
@@ -1,0 +1,52 @@
+import type { Adapter } from "@posthog/shared";
+import { useGenerateFreeformCanvas } from "@posthog/ui/features/canvas/hooks/useGenerateFreeformCanvas";
+import { useDashboardEditStore } from "@posthog/ui/features/canvas/stores/dashboardEditStore";
+import { useNavigate } from "@tanstack/react-router";
+import { useCallback } from "react";
+
+/**
+ * The composer's canvas path: turn a prompt into a new canvas, start the
+ * generation task, and open the canvas so its build streams in. Mirrors
+ * `useCreateAndOpenDashboard`, which opens an empty canvas instead.
+ */
+export function useStartCanvasSession(args: {
+  channelId: string;
+  channelName: string;
+  channelContext?: string;
+}): {
+  startCanvasSession: (opts: {
+    instruction: string;
+    adapter?: Adapter;
+    model?: string;
+    reasoningLevel?: string;
+  }) => Promise<string | null>;
+  isStartingCanvas: boolean;
+} {
+  const { channelId } = args;
+  const { startNewCanvas, isStarting } = useGenerateFreeformCanvas(args);
+  const setEditing = useDashboardEditStore((s) => s.setEditing);
+  const navigate = useNavigate();
+
+  const startCanvasSession = useCallback(
+    async (opts: {
+      instruction: string;
+      adapter?: Adapter;
+      model?: string;
+      reasoningLevel?: string;
+    }): Promise<string | null> => {
+      const started = await startNewCanvas(opts);
+      if (!started) return null;
+      // Edit mode is what shows the generation chat beside the canvas, so the
+      // user lands on the run rather than on a blank published view.
+      setEditing(started.dashboardId, true);
+      await navigate({
+        to: "/website/$channelId/dashboards/$dashboardId",
+        params: { channelId, dashboardId: started.dashboardId },
+      });
+      return started.dashboardId;
+    },
+    [channelId, navigate, setEditing, startNewCanvas],
+  );
+
+  return { startCanvasSession, isStartingCanvas: isStarting };
+}

--- a/products/desktop/packages/ui/src/features/task-detail/components/SessionKindSelect.stories.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/SessionKindSelect.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+import { type SessionKind, SessionKindSelect } from "./SessionKindSelect";
+
+/**
+ * The chip holds no state of its own — the composer does — so the story
+ * supplies it, and a pick sticks the way it does above the prompt box.
+ */
+function Harness({ initialKind }: { initialKind: SessionKind }) {
+  const [kind, setKind] = useState<SessionKind>(initialKind);
+  return (
+    <div className="flex items-center gap-1 p-2">
+      <SessionKindSelect value={kind} onChange={setKind} />
+    </div>
+  );
+}
+
+const meta: Meta<typeof Harness> = {
+  title: "Spaces/SessionKindSelect",
+  component: Harness,
+  args: { initialKind: "code" },
+};
+
+export default meta;
+type Story = StoryObj<typeof Harness>;
+
+export const Code: Story = {};
+
+/** A canvas session: the composer drops its workspace and repository chips. */
+export const Canvas: Story = { args: { initialKind: "canvas" } };
+
+/** A question session: answered in plan mode, so nothing gets changed. */
+export const Question: Story = { args: { initialKind: "question" } };

--- a/products/desktop/packages/ui/src/features/task-detail/components/SessionKindSelect.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/SessionKindSelect.tsx
@@ -1,0 +1,112 @@
+import { ChatCircleText, Code, SquaresFour } from "@phosphor-icons/react";
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  ItemContent,
+  ItemDescription,
+  ItemMedia,
+  ItemMenuItem,
+  ItemTitle,
+} from "@posthog/quill";
+import { useState } from "react";
+
+/** What a new session in a space produces. */
+export type SessionKind = "code" | "canvas" | "question";
+
+export const DEFAULT_SESSION_KIND: SessionKind = "code";
+
+const SESSION_KINDS: {
+  kind: SessionKind;
+  label: string;
+  description: string;
+  icon: React.ReactNode;
+}[] = [
+  {
+    kind: "code",
+    label: "Code",
+    description: "Work in a repository and open a pull request",
+    icon: <Code size={14} weight="regular" />,
+  },
+  {
+    kind: "canvas",
+    label: "Canvas",
+    description: "Build an app or document from your PostHog data",
+    icon: <SquaresFour size={14} weight="regular" />,
+  },
+  {
+    kind: "question",
+    label: "Question",
+    description: "Get an answer, without changing anything",
+    icon: <ChatCircleText size={14} weight="regular" />,
+  },
+];
+
+/**
+ * What the new session should produce — a chip for the composer's selector row,
+ * drawn like the WorkspaceModeSelect beside it. Canvas sessions run in the
+ * cloud without a repository, so picking one hides those chips.
+ */
+export function SessionKindSelect({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: SessionKind;
+  onChange: (kind: SessionKind) => void;
+  disabled?: boolean;
+}) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const current =
+    SESSION_KINDS.find((item) => item.kind === value) ?? SESSION_KINDS[0];
+
+  return (
+    <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
+      <DropdownMenuTrigger
+        render={
+          <Button
+            type="button"
+            variant="default"
+            size="sm"
+            disabled={disabled}
+            aria-label="Session kind"
+          >
+            <span className="text-muted-foreground">{current.icon}</span>
+            {current.label}
+          </Button>
+        }
+      />
+      <DropdownMenuContent
+        align="start"
+        side="bottom"
+        sideOffset={6}
+        className="w-auto min-w-[280px]"
+      >
+        <DropdownMenuGroup>
+          {SESSION_KINDS.map((item) => (
+            <DropdownMenuItem
+              key={item.kind}
+              onClick={() => onChange(item.kind)}
+              render={
+                <ItemMenuItem size="xs" className="w-full">
+                  <ItemMedia variant="icon" className="mt-2 ml-2">
+                    <span>{item.icon}</span>
+                  </ItemMedia>
+                  <ItemContent variant="menuItem">
+                    <ItemTitle>{item.label}</ItemTitle>
+                    <ItemDescription className="whitespace-nowrap leading-none">
+                      {item.description}
+                    </ItemDescription>
+                  </ItemContent>
+                </ItemMenuItem>
+              }
+            />
+          ))}
+        </DropdownMenuGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -10,6 +10,7 @@ import type {
   PiThinkingLevel,
 } from "@posthog/core/pi-runtime/piSessionController";
 import { isValidConfigValue } from "@posthog/core/task-detail/configOptions";
+import { QUESTION_SESSION_INSTRUCTIONS } from "@posthog/core/task-detail/questionPrompt";
 import { useServiceOptional } from "@posthog/di/react";
 import { useHostTRPC, useHostTRPCClient } from "@posthog/host-router/react";
 import { ButtonGroup } from "@posthog/quill";
@@ -19,6 +20,7 @@ import {
   TaskRepositoryChip,
   TaskRepositoryDialog,
 } from "@posthog/ui/features/canvas/components/TaskRepositoryDialog";
+import { useStartCanvasSession } from "@posthog/ui/features/canvas/hooks/useStartCanvasSession";
 import { useUpdateTaskChannelRepositories } from "@posthog/ui/features/canvas/hooks/useTaskChannels";
 import {
   resolveTaskRepositoryDraft,
@@ -82,7 +84,7 @@ import {
 import { skillToEditorCommand } from "../../message-editor/commands";
 import { PromptHistoryDialog } from "../../message-editor/components/PromptHistoryDialog";
 import { PromptInput } from "../../message-editor/components/PromptInput";
-import { contentToXml } from "../../message-editor/content";
+import { contentToPlainText, contentToXml } from "../../message-editor/content";
 import { useDraftStore } from "../../message-editor/draftStore";
 import { useTaskInputHistoryStore } from "../../message-editor/taskInputHistoryStore";
 import type { EditorHandle } from "../../message-editor/types";
@@ -113,6 +115,11 @@ import { resolveWorkspaceModePreference } from "../hooks/workspaceModePreference
 import { ChannelContextChip } from "./ChannelContextChip";
 import { CloudGithubMissingNotice } from "./CloudGithubMissingNotice";
 import { NewTaskSuggestions } from "./ContinueCliSessions";
+import {
+  DEFAULT_SESSION_KIND,
+  type SessionKind,
+  SessionKindSelect,
+} from "./SessionKindSelect";
 import {
   type SuggestedPrompt,
   SuggestedPromptCard,
@@ -321,6 +328,24 @@ export function TaskInput({
   const [activeReportAssociation, setActiveReportAssociation] = useState(
     reportAssociation ?? null,
   );
+
+  // What this session produces. Canvas generation files into a space, so the
+  // picker only shows on the space composer; everywhere else stays code.
+  const [sessionKind, setSessionKind] =
+    useState<SessionKind>(DEFAULT_SESSION_KIND);
+  const canPickSessionKind = !!channelId;
+  const activeSessionKind: SessionKind = canPickSessionKind
+    ? sessionKind
+    : "code";
+  const isCanvasSession = activeSessionKind === "canvas";
+  const isQuestionSession = activeSessionKind === "question";
+  const { startCanvasSession, isStartingCanvas } = useStartCanvasSession({
+    channelId: channelId ?? "",
+    channelName: channelName ?? "",
+    // Passing the key (even undefined) marks this component as the context's
+    // owner, so the hook doesn't fetch it a second time.
+    channelContext,
+  });
 
   // Channel CONTEXT.md is included by default; the chip lets the user drop it
   // from this task's prompt. Re-include whenever the source context changes
@@ -808,6 +833,11 @@ export function TaskInput({
   const currentExecutionMode =
     getCurrentModeFromConfigOptions(modeOption ? [modeOption] : undefined) ??
     modeFallback;
+  // A question is answered, never applied — plan mode is what makes that true,
+  // rather than the prompt asking the agent nicely. Both adapters accept it.
+  const executionModeForTask = isQuestionSession
+    ? "plan"
+    : currentExecutionMode;
   const currentReasoningLevel =
     thoughtOption?.type === "select" ? thoughtOption.currentValue : undefined;
   const currentPiModel =
@@ -996,7 +1026,7 @@ export function TaskInput({
     editorIsEmpty,
     adapter,
     runtime,
-    executionMode: runtime === "pi" ? undefined : currentExecutionMode,
+    executionMode: runtime === "pi" ? undefined : executionModeForTask,
     model: taskModel,
     reasoningLevel: taskReasoningLevel,
     contextWindow: runtime === "pi" ? undefined : currentContextWindow,
@@ -1085,9 +1115,81 @@ export function TaskInput({
     sessionId,
   ]);
 
-  const submitTask = autoresearchDraft
-    ? handleAutoresearchSubmit
-    : handleSubmit;
+  // Canvas sessions don't create a repo task at all: the prompt becomes a new
+  // canvas in the space, and its generation run opens with it.
+  const handleCanvasSubmit = useCallback(async (): Promise<boolean> => {
+    const editor = editorRef.current;
+    if (!editor || isStartingCanvas) return false;
+    const content = editor.getContent();
+    const instruction = contentToPlainText(content).trim();
+    if (!instruction) return false;
+
+    track(ANALYTICS_EVENTS.DASHBOARD_ACTION, {
+      action_type: "create",
+      surface: "new_task",
+      channel_id: channelId,
+    });
+    const dashboardId = await startCanvasSession({
+      instruction,
+      // Pi models don't run canvas generation; leaving these unset lets the
+      // service resolve the adapter's cloud default.
+      adapter: runtime === "pi" ? undefined : (adapter ?? undefined),
+      model: runtime === "pi" ? undefined : currentModel,
+      reasoningLevel: runtime === "pi" ? undefined : currentReasoningLevel,
+    });
+    if (!dashboardId) return false;
+
+    useDraftStore.getState().actions.setDraft(sessionId, null);
+    try {
+      editor.clear();
+    } catch {
+      // Opening the canvas can tear the editor down first.
+    }
+    return true;
+  }, [
+    adapter,
+    channelId,
+    currentModel,
+    currentReasoningLevel,
+    isStartingCanvas,
+    runtime,
+    sessionId,
+    startCanvasSession,
+  ]);
+
+  // A question rides on the normal task path; only the trailing instructions
+  // block is added, so chips and attachments in the prompt survive.
+  const handleQuestionSubmit = useCallback(async (): Promise<boolean> => {
+    const editor = editorRef.current;
+    if (!editor || !canSubmit) return false;
+    const content = editor.getContent();
+    const override: EditorContent = {
+      segments: [
+        ...content.segments,
+        { type: "text", text: `\n\n${QUESTION_SESSION_INSTRUCTIONS}` },
+      ],
+      attachments: content.attachments,
+    };
+    return handleSubmit(override);
+  }, [canSubmit, handleSubmit]);
+
+  const isBusy = isCreatingTask || isStartingCanvas;
+  // A canvas session skips the task composer's repo checks (it never has one),
+  // and neither canvas nor question offers a mode: canvas always runs
+  // unattended, a question always runs in plan mode.
+  const canSubmitSession = isCanvasSession
+    ? !editorIsEmpty && !isBusy
+    : canSubmit;
+  const hideModePicker =
+    runtime === "pi" || isCanvasSession || isQuestionSession;
+
+  const submitTask = isCanvasSession
+    ? handleCanvasSubmit
+    : isQuestionSession
+      ? handleQuestionSubmit
+      : autoresearchDraft
+        ? handleAutoresearchSubmit
+        : handleSubmit;
 
   const handleModeChange = useCallback(
     (value: string) => {
@@ -1273,39 +1375,52 @@ export function TaskInput({
                 align="center"
                 className="absolute bottom-full left-0 mb-1 min-w-0 gap-1"
               >
-                {spaceSelector?.({ disabled: isCreatingTask })}
-                <WorkspaceModeSelect
-                  value={workspaceMode}
-                  onChange={setWorkspaceMode}
-                  selectedCloudEnvironmentId={selectedCloudEnvId}
-                  onCloudEnvironmentChange={setSelectedCloudEnvId}
-                  selectedCustomImageId={selectedCustomImageId}
-                  onCustomImageChange={setSelectedCustomImageId}
-                  size="1"
-                />
-                {allowNoRepo && (
+                {spaceSelector?.({ disabled: isBusy })}
+                {canPickSessionKind && (
+                  <SessionKindSelect
+                    value={activeSessionKind}
+                    onChange={setSessionKind}
+                    disabled={isBusy}
+                  />
+                )}
+                {/* A canvas is always generated in the cloud without a repo,
+                    so the workspace and repository chips have nothing to say. */}
+                {!isCanvasSession && (
+                  <WorkspaceModeSelect
+                    value={workspaceMode}
+                    onChange={setWorkspaceMode}
+                    selectedCloudEnvironmentId={selectedCloudEnvId}
+                    onCloudEnvironmentChange={setSelectedCloudEnvId}
+                    selectedCustomImageId={selectedCustomImageId}
+                    onCustomImageChange={setSelectedCustomImageId}
+                    size="1"
+                  />
+                )}
+                {!isCanvasSession && allowNoRepo && (
                   <TaskRepositoryChip
                     cloud={workspaceMode === "cloud"}
                     repositoryCount={taskRepositories.length}
                     hasFolder={!!taskFolder}
-                    disabled={isCreatingTask}
+                    disabled={isBusy}
                     onOpen={() => setRepositoryDialogOpen(true)}
                   />
                 )}
-                {!allowNoRepo && workspaceMode === "worktree" && (
-                  <EnvironmentSelector
-                    repoPath={effectiveRepoPath ?? null}
-                    value={selectedEnvironment}
-                    onChange={setSelectedEnvironment}
-                    disabled={isCreatingTask}
-                    onCreateEnvironment={() =>
-                      openSettings("environments", {
-                        repoPath: effectiveRepoPath ?? undefined,
-                      })
-                    }
-                  />
-                )}
-                {!allowNoRepo && (
+                {!isCanvasSession &&
+                  !allowNoRepo &&
+                  workspaceMode === "worktree" && (
+                    <EnvironmentSelector
+                      repoPath={effectiveRepoPath ?? null}
+                      value={selectedEnvironment}
+                      onChange={setSelectedEnvironment}
+                      disabled={isCreatingTask}
+                      onCreateEnvironment={() =>
+                        openSettings("environments", {
+                          repoPath: effectiveRepoPath ?? undefined,
+                        })
+                      }
+                    />
+                  )}
+                {!isCanvasSession && !allowNoRepo && (
                   <ButtonGroup
                     ref={buttonGroupRef}
                     data-tour="folder-picker"
@@ -1395,14 +1510,16 @@ export function TaskInput({
                     />
                   </ButtonGroup>
                 )}
-                {!allowNoRepo && workspaceMode !== "cloud" && (
-                  <AdditionalDirectoriesButton
-                    values={additionalDirectories}
-                    onChange={setAdditionalDirectories}
-                    primaryDirectory={selectedDirectory}
-                    disabled={isCreatingTask}
-                  />
-                )}
+                {!isCanvasSession &&
+                  !allowNoRepo &&
+                  workspaceMode !== "cloud" && (
+                    <AdditionalDirectoriesButton
+                      values={additionalDirectories}
+                      onChange={setAdditionalDirectories}
+                      primaryDirectory={selectedDirectory}
+                      disabled={isCreatingTask}
+                    />
+                  )}
                 {cloudRegion === "dev" && (
                   <Flex align="center" gap="1" className="shrink-0">
                     <span
@@ -1443,19 +1560,27 @@ export function TaskInput({
                   placeholder={
                     autoresearchDraft
                       ? "Example: Reduce memory usage measured by `pnpm bench:memory` without changing behavior."
-                      : `What do you want to ship?`
+                      : isCanvasSession
+                        ? "What do you want to build?"
+                        : isQuestionSession
+                          ? "What do you want to know?"
+                          : `What do you want to ship?`
                   }
                   editorHeight="large"
-                  disabled={isCreatingTask}
-                  isLoading={isCreatingTask}
+                  disabled={isBusy}
+                  isLoading={isBusy}
                   autoFocus
                   clearOnSubmit={false}
                   submitDisabledExternal={
-                    !canSubmit ||
-                    isCreatingTask ||
+                    isBusy ||
                     !isOnline ||
-                    (runtime === "pi" ? isPiConfigLoading : isPreviewLoading) ||
-                    (runtime === "pi" && !currentPiModel)
+                    (isCanvasSession
+                      ? editorIsEmpty
+                      : !canSubmit ||
+                        (runtime === "pi"
+                          ? isPiConfigLoading
+                          : isPreviewLoading) ||
+                        (runtime === "pi" && !currentPiModel))
                   }
                   tourTarget="task-input"
                   submitAdornment={
@@ -1468,11 +1593,12 @@ export function TaskInput({
                     ) : undefined
                   }
                   repoPath={selectedDirectory}
-                  modeOption={runtime === "pi" ? undefined : modeOption}
-                  onModeChange={runtime === "pi" ? undefined : handleModeChange}
+                  modeOption={hideModePicker ? undefined : modeOption}
+                  onModeChange={hideModePicker ? undefined : handleModeChange}
                   allowBypassPermissions={allowBypassPermissions}
                   autoresearch={
                     runtime !== "pi" &&
+                    activeSessionKind === "code" &&
                     autoresearchService &&
                     autoresearchEnabled
                       ? {
@@ -1538,7 +1664,7 @@ export function TaskInput({
                   onEmptyChange={handleEditorEmptyChange}
                   onSubmitClick={() => void submitTask()}
                   onSubmit={() => {
-                    if (canSubmit) void submitTask();
+                    if (canSubmitSession) void submitTask();
                   }}
                 />
                 {activeReportAssociation && (


### PR DESCRIPTION
## Problem

Starting a new session in a space (⌘N) could only produce one thing: a coding task against a repository. Canvas generation lives elsewhere — you have to create a canvas first, then describe it in that canvas's own bar — so the composer people already use for everything else can't reach it. There was also no way to ask a question and be sure the agent would only answer it.

## Changes

- The space composer now has a kind picker beside the space chip, left of the workspace chip. It defaults to **Code**, and offers **Canvas** and **Question**.
- **Code** is today's behavior, unchanged.
- **Canvas** turns the prompt into a new canvas in the space: the canvas is created, its generation run starts, and the canvas opens so the build streams in. The run auto-names the canvas from the prompt, same as generating from an existing canvas.
- Canvas sessions hide the workspace-mode and repository chips. Generation always runs repo-less in the cloud, so those chips had nothing to say.
- **Question** submits on the normal task path but pins the run to plan mode and appends a short instruction block asking the agent to investigate and reply. Plan mode is what actually prevents edits; the block only sets the expectation. Canvas and question hide the mode picker, since neither leaves a mode to choose.
- The picker only appears where a space owns the session (the per-space new-session screen). The /code screen and the space-less new-session screen keep the old row.
- Orchestration for the new "prompt first, canvas second" path sits in `CanvasApplicationService.startCanvasFromPrompt`, next to the existing generation flow, rather than in the composer.

A Storybook story (`Spaces/SessionKindSelect`) covers the new chip. It renders at the same 24px height as the workspace chip beside it, and its menu lists: "Code / Work in a repository and open a pull request", "Canvas / Build an app or document from your PostHog data", "Question / Get an answer, without changing anything". No screenshot here: the image upload tool isn't runnable in this environment.

## How did you test this code?

- Added `CanvasApplicationService` tests for the new path: it creates the canvas the prompt targets and generates into it, and it reports a failed canvas creation without starting a run. Neither case was reachable before this PR.
- Ran `pnpm --filter @posthog/core test` (3456 tests) and `pnpm --filter @posthog/ui test` (3232 tests), plus `pnpm typecheck` across the desktop workspace and `pnpm lint`.
- Rendered the new picker headlessly in Storybook (Chromium via Playwright) and asserted the trigger label per kind and the three menu entries, with no page errors.
- Not tested by me: the end-to-end canvas run and the question run against a real backend — the composer's submit paths were exercised only through type checking and the unit tests above.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written by the PostHog coding agent (pi harness, Claude) from a request to add canvas generation to the new-session composer.
- No repo skills applied to this area; the work followed `products/desktop/AGENTS.md` (layer boundaries, DI, stores-hold-state-only) and the user-facing copy rules for the menu labels.
- Decision worth flagging: "Question" needed a concrete meaning. It pins the run to plan mode rather than only asking the agent nicely in the prompt, so the guarantee comes from the permission mode. The prompt block is additive and keeps chips and attachments intact.
- A failed generation leaves the freshly created canvas behind on purpose — it has its own generate bar, so a retry doesn't lose the work.
