### PR TITLE
fix(mongodb): stop reporting SRV DNS lookup failures as bugs

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/source.py
@@ -85,6 +85,12 @@ _DNS_RESOLUTION_FAILURE_MARKERS = (
     "Temporary failure in name resolution",
 )
 
+# For a `mongodb+srv://` URI, pymongo resolves the SRV record via dnspython inside the
+# MongoClient constructor and wraps any dnspython exception as ConfigurationError. dnspython's
+# NXDOMAIN carries this fixed prefix when the SRV record's DNS name doesn't exist at all —
+# a deleted, renamed, or mistyped cluster hostname — distinct from a timed-out lookup.
+_SRV_DNS_NAME_NOT_FOUND_MARKER = "The DNS query name does not exist"
+
 
 @SourceRegistry.register
 class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin):
@@ -217,7 +223,7 @@ class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin
         schema_name: Optional[str] = None,
         api_version: str | None = None,
     ) -> tuple[bool, str | None]:
-        from pymongo.errors import OperationFailure, ServerSelectionTimeoutError
+        from pymongo.errors import ConfigurationError, OperationFailure, ServerSelectionTimeoutError
 
         try:
             connection_params = _parse_connection_string(config.connection_string, config.database_name)
@@ -270,14 +276,24 @@ class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin
             if any(marker in message for marker in _DNS_RESOLUTION_FAILURE_MARKERS):
                 return False, _MONGO_HOST_UNRESOLVED_MESSAGE
             return False, _MONGO_UNREACHABLE_MESSAGE
-        except Exception as e:
-            # pymongo raises InvalidURI with the RFC-3986 hint before any network call when the
-            # credentials contain unescaped reserved characters. This is a malformed connection
-            # string the user must fix — already surfaced with an actionable message — so don't
-            # report it to error tracking as a bug. Any other exception is unexpected: capture it
-            # and fall back to a generic message so internal exception text never reaches the user.
-            if "must be escaped according to RFC 3986" in str(e):
+        except ConfigurationError as e:
+            # InvalidURI (raised with the RFC-3986 hint before any network call when
+            # credentials contain unescaped reserved characters) is itself a ConfigurationError
+            # subclass, so it lands here too. An SRV DNS name that doesn't exist is the same
+            # user-side problem as the non-SRV host-not-found case above. Both are malformed-
+            # input problems the user must fix — already surfaced with an actionable message —
+            # so don't report them to error tracking as noise. Any other ConfigurationError is
+            # unexpected, so capture it and fall back to a generic message.
+            message = str(e)
+            if _SRV_DNS_NAME_NOT_FOUND_MARKER in message:
+                return False, _MONGO_HOST_UNRESOLVED_MESSAGE
+            if "must be escaped according to RFC 3986" in message:
                 return False, _MONGO_UNESCAPED_CREDENTIALS_MESSAGE
+            capture_exception(e)
+            return False, _MONGO_CONNECT_FAILED_MESSAGE
+        except Exception as e:
+            # Any other exception is unexpected: capture it and fall back to a generic message
+            # so internal exception text never reaches the user.
             capture_exception(e)
             return False, _MONGO_CONNECT_FAILED_MESSAGE
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/test_database_name.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/test_database_name.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import patch
 
-from pymongo.errors import InvalidURI, OperationFailure, ServerSelectionTimeoutError
+from pymongo.errors import ConfigurationError, InvalidURI, OperationFailure, ServerSelectionTimeoutError
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs.mongodb import (
     MongoDBSourceConfig,
@@ -179,6 +179,20 @@ class TestMongoValidateCredentialsErrorTrackingNoise:
                 ),
                 _MONGO_UNREACHABLE_MESSAGE,
                 False,
+            ),
+            (
+                # dnspython's NXDOMAIN, wrapped by pymongo as ConfigurationError, when a
+                # mongodb+srv:// URI's SRV DNS record doesn't exist at all.
+                ConfigurationError("The DNS query name does not exist: _mongodb._tcp.cluster.abc.mongodb.net."),
+                _MONGO_HOST_UNRESOLVED_MESSAGE,
+                False,
+            ),
+            (
+                # An unrecognized ConfigurationError still falls back to capturing, same as any
+                # other unexpected exception.
+                ConfigurationError("some-unrecognized-configuration-problem"),
+                _MONGO_CONNECT_FAILED_MESSAGE,
+                True,
             ),
             (Exception("some-internal-driver-detail"), _MONGO_CONNECT_FAILED_MESSAGE, True),
         ],


### PR DESCRIPTION
## Problem

Testing a MongoDB source connection with a stale or mistyped `mongodb+srv://` cluster hostname shows a generic "could not connect" message instead of a message that points at the real problem, and reports the failure to error tracking as an internal bug ([issue](https://us.posthog.com/project/2/error_tracking/01a014b1-961f-79e0-a521-9d8b28134237)).

## Changes

- `validate_credentials` now catches pymongo's `ConfigurationError`, raised when the SRV DNS record in a connection string doesn't exist, and returns the existing host-unresolved message instead of a generic one.
- The failure is no longer reported to error tracking, mirroring how the same DNS-not-found case is already handled for non-SRV connection strings via `ServerSelectionTimeoutError`.
- `InvalidURI` (the unescaped-credentials case) is itself a `ConfigurationError` subclass, so that check moved into the new branch to keep matching ahead of the generic fallback.

## How did you test this code?

Extended the existing parametrized error-tracking-noise test in `test_database_name.py` with two cases: the SRV NXDOMAIN message maps to the host-unresolved message without reporting to error tracking, and an unrecognized `ConfigurationError` still falls back to reporting. No existing test exercised `ConfigurationError` at all, so this guards the new branch and the fallback within it.

Ran `pytest` on the mongodb source tests (all pass) and `mypy` across the repo (clean).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error tracking webhook. Used the `writing-tests` and `writing-pr-descriptions` skills while producing this PR. Confirmed the stack trace originates in `mongo.py`/`source.py`, read pymongo's SRV resolver source to identify the exact failure mode, and checked for duplicate open PRs (none found).