### PR TITLE
fix(tasks): name the real failure class in task-run failure metrics

### DIFF
--- a/posthog/temporal/common/base.py
+++ b/posthog/temporal/common/base.py
@@ -3,6 +3,8 @@ import typing
 
 import temporalio.exceptions
 
+from posthog.temporal.common.errors import resolve_failure_type
+
 
 class PostHogWorkflow:
     """Base class for Temporal Workflows that can be executed in PostHog."""
@@ -29,7 +31,7 @@ class PostHogWorkflow:
         if error.cause:
             properties.update(
                 {
-                    "cause_error_type": type(error.cause).__name__,
+                    "cause_error_type": resolve_failure_type(error.cause),
                     "cause_error_message": str(error.cause)[:500],
                 }
             )

--- a/posthog/temporal/common/errors.py
+++ b/posthog/temporal/common/errors.py
@@ -33,6 +33,14 @@ def unwrap_temporal_cause(exc: BaseException) -> ApplicationError | None:
     return current if isinstance(current, ApplicationError) else None
 
 
+def resolve_failure_type(exc: BaseException) -> str:
+    """Temporal rebuilds a remote failure as a bare ApplicationError with the real class name on `.type`."""
+    failure_type = getattr(exc, "type", None)
+    if isinstance(failure_type, str) and failure_type:
+        return failure_type
+    return type(exc).__name__
+
+
 def resolve_exception_class(exc: BaseException) -> str:
     cause: BaseException = unwrap_temporal_cause(exc) or exc
     return getattr(cause, "type", None) or type(cause).__name__

--- a/posthog/temporal/common/test_errors.py
+++ b/posthog/temporal/common/test_errors.py
@@ -1,10 +1,12 @@
 import pytest
 
+import temporalio.exceptions
 from temporalio.exceptions import ActivityError, ApplicationError, ChildWorkflowError
 
 from posthog.temporal.common.errors import (
     MAX_ERROR_MESSAGE_CHARS,
     MAX_ERROR_TRACE_CHARS,
+    resolve_failure_type,
     truncate_for_temporal_payload,
     unwrap_temporal_cause,
 )
@@ -82,3 +84,23 @@ class TestUnwrapTemporalCause:
 
     def test_returns_none_when_wrapper_chain_bottoms_out_on_non_application(self) -> None:
         assert unwrap_temporal_cause(_activity_error(ValueError("not an app error"))) is None
+
+
+@pytest.mark.parametrize(
+    "exc,expected",
+    [
+        (ApplicationError("boom", type="SandboxProvisionError"), "SandboxProvisionError"),
+        (ApplicationError("boom", type=""), "ApplicationError"),
+        (
+            temporalio.exceptions.TimeoutError(
+                "timed out", type=temporalio.exceptions.TimeoutType.START_TO_CLOSE, last_heartbeat_details=[]
+            ),
+            "TimeoutError",
+        ),
+        (ValueError("boom"), "ValueError"),
+    ],
+)
+def test_resolve_failure_type(exc: BaseException, expected: str) -> None:
+    resolved = resolve_failure_type(exc)
+    assert resolved == expected
+    assert isinstance(resolved, str)

--- a/products/tasks/backend/temporal/process_task/tests/test_workflow.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_workflow.py
@@ -111,7 +111,6 @@ def _build_context(
     )
 
 
-@pytest.mark.django_db
 def test_activity_error_properties_includes_failed_activity_context():
     error = ActivityError(
         "Activity task timed out",
@@ -134,6 +133,23 @@ def test_activity_error_properties_includes_failed_activity_context():
         "cause_error_type": "TimeoutError",
         "cause_error_message": "start-to-close timeout",
     }
+
+
+def test_activity_error_properties_names_the_application_failure_class():
+    error = ActivityError(
+        "Activity task failed",
+        scheduled_event_id=10,
+        started_event_id=11,
+        identity="worker-1",
+        activity_type="create_sandbox_for_repository",
+        activity_id="activity-1",
+        retry_state=RetryState.NON_RETRYABLE_FAILURE,
+    )
+    error.__cause__ = ApplicationError("Failed to create sandbox", type="SandboxProvisionError")
+
+    properties = ProcessTaskWorkflow._activity_error_properties(error)
+
+    assert properties["cause_error_type"] == "SandboxProvisionError"
 
 
 @pytest.mark.django_db(transaction=True)


### PR DESCRIPTION
## Problem

`ApplicationError` as the cause of every failure is not ideal

- Temporal rebuilds a remote failure as a bare `ApplicationError` and carries the original class name on `.type`.
- `PostHogWorkflow._activity_error_properties` read `type(error.cause).__name__`, which returns `ApplicationError` for all of them.
- Three panels in `cloud-background-agents-runs.json` and the wizard dashboard group by `cause_error_type`. All three show one constant value.

## Changes

- `resolve_failure_type` reads `.type` when it holds a non-empty string, and falls back to the class name.
- `cause_error_type` now names the failing class, so a sandbox provisioning fault and a compute-quota denial are distinguishable on the dashboard.
- The `.type` value is trusted only when it is a string. A Temporal `TimeoutError` carries a `TimeoutType` enum there, and still reports `TimeoutError` instead of leaking an enum into a Prometheus label.


