### PR TITLE
fix(desktop): order the Spaces list by every activity signal it has

### DIFF
--- a/products/desktop/packages/core/src/canvas/channelItems.test.ts
+++ b/products/desktop/packages/core/src/canvas/channelItems.test.ts
@@ -1,5 +1,6 @@
 import type { Task, UserBasic } from "@posthog/shared/domain-types";
 import { describe, expect, it } from "vitest";
+import type { TaskTimestamp } from "../sidebar/buildSidebarData";
 import {
   buildChannelItems,
   type ChannelItemFilters,
@@ -76,6 +77,45 @@ describe("buildChannelItems", () => {
       ],
     });
     expect(items.map((i) => i.key)).toEqual(["task:new", "canvas:old"]);
+  });
+
+  // `updated_at` alone only moves on the coarse events the server bumps a task on, so a session
+  // whose run is working — or whose activity this device saw before the next poll — has to be able
+  // to outrank a task with a newer `updated_at` and nothing happening.
+  it.each<{
+    term: string;
+    mover: Task;
+    facts: Readonly<Record<string, TaskTimestamp>>;
+  }>([
+    {
+      term: "the latest run's own update",
+      mover: task({
+        id: "mover",
+        updated_at: new Date(1_000).toISOString(),
+        latest_run: {
+          updated_at: new Date(9_000).toISOString(),
+        } as Task["latest_run"],
+      }),
+      facts: {},
+    },
+    {
+      term: "this device's local activity mark",
+      mover: task({ id: "mover", updated_at: new Date(1_000).toISOString() }),
+      facts: { mover: { lastViewedAt: null, lastActivityAt: 9_000 } },
+    },
+  ])("orders a session by $term", ({ mover, facts }) => {
+    const items = build({
+      feedTasks: [
+        task({ id: "stale", updated_at: new Date(5_000).toISOString() }),
+        mover,
+      ],
+      sessionFacts: {
+        needsInputTaskIds: NONE,
+        viewedTimestamps: facts,
+        workspaceModeByTaskId: new Map(),
+      },
+    });
+    expect(items.map((i) => i.id)).toEqual(["mover", "stale"]);
   });
 
   it("drops archived tasks but keeps canvases", () => {
@@ -172,6 +212,15 @@ describe("buildChannelItems", () => {
         task({ id: "asking" }),
         task({ id: "unread" }),
         task({ id: "quiet" }),
+        // A working run reorders the list but says nothing about what you've read: the yellow dot
+        // still answers to the task's own `updated_at`, which here predates the last look.
+        task({
+          id: "running",
+          updated_at: new Date(500).toISOString(),
+          latest_run: {
+            updated_at: new Date(9_000).toISOString(),
+          } as Task["latest_run"],
+        }),
       ],
       sessionFacts: {
         needsInputTaskIds: new Set(["asking"]),
@@ -179,14 +228,20 @@ describe("buildChannelItems", () => {
         // never opened has no timestamp and is not unread.
         viewedTimestamps: {
           unread: { lastViewedAt: 1_000, lastActivityAt: null },
+          running: { lastViewedAt: 1_000, lastActivityAt: null },
         },
         workspaceModeByTaskId: new Map(),
       },
     });
-    expect(items.map((i) => [i.id, i.needsInput, i.unread])).toEqual([
+    expect(
+      items
+        .map((i) => [i.id, i.needsInput, i.unread])
+        .sort((a, b) => String(a[0]).localeCompare(String(b[0]))),
+    ).toEqual([
       ["asking", true, false],
-      ["unread", false, true],
       ["quiet", false, false],
+      ["running", false, false],
+      ["unread", false, true],
     ]);
   });
 

--- a/products/desktop/packages/core/src/canvas/channelItems.ts
+++ b/products/desktop/packages/core/src/canvas/channelItems.ts
@@ -8,7 +8,12 @@ import type {
   TaskRunStatus,
   UserBasic,
 } from "@posthog/shared/domain-types";
-import { isTaskUnread, type TaskTimestamp } from "../sidebar/buildSidebarData";
+import {
+  isTaskUnread,
+  type TaskTimestamp,
+  taskLastActivityAt,
+} from "../sidebar/buildSidebarData";
+import { runActivityTimestamp } from "../tasks/taskActivity";
 import type { DashboardRecord } from "./dashboardSchemas";
 
 /** Where a session runs. `worktree` is a local checkout, so it reads as local. */
@@ -19,6 +24,7 @@ export interface ChannelItemModel {
   kind: "task" | "canvas";
   id: string;
   title: string;
+  /** When it last moved, for the recent-activity sort. See `channelItemTimestamp`. */
   ts: number;
   /** When it was first made, for the created-first sort. */
   createdAt: number;
@@ -112,6 +118,26 @@ function sourceOf(task: Task): string | null {
   return origin && origin !== SELF_ORIGIN ? origin : null;
 }
 
+/**
+ * When a session last moved, from everything one client can see: the backend's `updated_at` (which
+ * the server bumps on the discrete events — a run starting or finishing, a turn completing, a
+ * thread message), its latest run's own timestamps (which keep moving between those events), and
+ * this device's local activity mark (which runs ahead of the 5s feed poll).
+ *
+ * `|| 0` on the first term because `taskLastActivityAt` parses with `new Date`, which yields NaN
+ * for an unparseable string — and a NaN `ts` both breaks the sort comparison and produces a
+ * garbage day header in `groupChannelItems`.
+ */
+function channelItemTimestamp(
+  task: Task,
+  timestamp: TaskTimestamp | undefined,
+): number {
+  return Math.max(
+    taskLastActivityAt(task.updated_at, timestamp) || 0,
+    runActivityTimestamp(task.latest_run),
+  );
+}
+
 export function buildChannelItems({
   dashboards,
   feedTasks,
@@ -156,7 +182,10 @@ export function buildChannelItems({
             kind: "task" as const,
             id: task.id,
             title: task.title || "Untitled task",
-            ts: Date.parse(task.updated_at) || 0,
+            ts: channelItemTimestamp(
+              task,
+              sessionFacts.viewedTimestamps[task.id],
+            ),
             createdAt: Date.parse(task.created_at) || 0,
             pinned: pinnedTaskIds.has(task.id),
             rawStatus: task.latest_run?.status ?? null,

--- a/products/desktop/packages/core/src/tasks/taskActivity.test.ts
+++ b/products/desktop/packages/core/src/tasks/taskActivity.test.ts
@@ -1,6 +1,10 @@
 import type { Task } from "@posthog/shared/domain-types";
 import { describe, expect, it } from "vitest";
-import { filterAndSortTasks, taskActivityTimestamp } from "./taskActivity";
+import {
+  filterAndSortTasks,
+  runActivityTimestamp,
+  taskActivityTimestamp,
+} from "./taskActivity";
 
 function makeTask(overrides: Partial<Task> = {}): Task {
   return {
@@ -50,6 +54,42 @@ describe("taskActivityTimestamp", () => {
     expect(taskActivityTimestamp(task, "updated")).toBe(
       new Date("2026-01-04T00:00:00Z").getTime(),
     );
+  });
+});
+
+describe("runActivityTimestamp", () => {
+  it.each([
+    {
+      what: "the terminal time when it is later than the run's own update",
+      run: {
+        updated_at: "2026-01-02T00:00:00Z",
+        completed_at: "2026-01-04T00:00:00Z",
+      },
+      expected: new Date("2026-01-04T00:00:00Z").getTime(),
+    },
+    {
+      what: "the run's update when it is the later of the two",
+      run: {
+        updated_at: "2026-01-05T00:00:00Z",
+        completed_at: "2026-01-04T00:00:00Z",
+      },
+      expected: new Date("2026-01-05T00:00:00Z").getTime(),
+    },
+    // Callers feed this straight into a Math.max, where a single NaN would swallow every other
+    // term — so a run without timestamps, or with unusable ones, has to read as zero.
+    { what: "zero for a task that never ran", run: null, expected: 0 },
+    {
+      what: "zero for a summary run that carries no timestamps",
+      run: {},
+      expected: 0,
+    },
+    {
+      what: "zero for an unparseable timestamp",
+      run: { updated_at: "whenever" },
+      expected: 0,
+    },
+  ])("returns $what", ({ run, expected }) => {
+    expect(runActivityTimestamp(run)).toBe(expected);
   });
 });
 

--- a/products/desktop/packages/core/src/tasks/taskActivity.ts
+++ b/products/desktop/packages/core/src/tasks/taskActivity.ts
@@ -12,6 +12,29 @@ export interface TaskActivityInput {
   latest_run?: { updated_at: string };
 }
 
+/**
+ * The newest timestamp a run carries, or 0 for a task that has never run.
+ *
+ * `completed_at` is in the max because runs written by older servers persisted the terminal time
+ * without their own `updated_at`, so they finish with a `completed_at` that is later. `created_at`
+ * is deliberately absent: `auto_now` sets `updated_at` on insert, so it can never exceed it.
+ *
+ * A structural parameter type because `/tasks/summaries/` returns a run with only `status` and
+ * `environment` — a caller on that endpoint gets 0 here rather than a wrong claim.
+ */
+export function runActivityTimestamp(
+  run:
+    | { updated_at?: string | null; completed_at?: string | null }
+    | null
+    | undefined,
+): number {
+  if (!run) return 0;
+  return Math.max(
+    Date.parse(run.updated_at ?? "") || 0,
+    Date.parse(run.completed_at ?? "") || 0,
+  );
+}
+
 export function taskActivityTimestamp(
   task: Pick<TaskActivityInput, "created_at" | "updated_at" | "latest_run">,
   sortMode: TaskActivitySortMode,

--- a/products/desktop/packages/ui/src/router/routes/website/$channelId/tasks/$taskId.tsx
+++ b/products/desktop/packages/ui/src/router/routes/website/$channelId/tasks/$taskId.tsx
@@ -50,9 +50,6 @@ function ChannelTaskDetailRoute() {
   // lets a canvas's generation task drop out of the nested sidebar row once the
   // user has actually looked at it.
   const { markAsViewed } = useTaskViewed();
-  useEffect(() => {
-    markAsViewed(taskId);
-  }, [taskId, markAsViewed]);
 
   const {
     data: fetched,
@@ -66,6 +63,15 @@ function ChannelTaskDetailRoute() {
   });
 
   const task = pickFreshestTask(fetched, initialTask);
+
+  // Keyed on the activity time rather than only on mount: `updated_at` moves when a turn finishes
+  // or a thread message lands, so marking once on open would dot the row being read. Waiting for
+  // the timestamp also keeps the mark from landing before there is a task to have seen.
+  const activityAt = task?.updated_at;
+  useEffect(() => {
+    if (!activityAt) return;
+    markAsViewed(taskId);
+  }, [taskId, activityAt, markAsViewed]);
 
   // While a cached/list copy exists, a 404 is NOT authoritative (optimistic
   // and cloud-pending tasks aren't returnable by the API yet — see the loader


### PR DESCRIPTION
## Problem

Sorting the PostHog Desktop Spaces sessions list by "Recent activity" — the default — puts sessions in roughly the order they were created. A session whose agent is working right now can sit below one that has been idle since the day it was opened.

- The sort compares one number per row, and for a task row that number is `Date.parse(task.updated_at)`.
- `updated_at` only moves on the coarse events the backend writes to the task.
- Two signals the client already holds go unused: the latest run's own timestamps, and this device's local activity mark.

The backend half of this fix is [#84283](https://github.com/PostHog/posthog/pull/84283), stacked on top. This PR stands alone: it reads only fields production already serves, and it improves ordering for any session with a run.

## Changes

- The row's sort value becomes the max of `task.updated_at`, the latest run's timestamps, and the local activity mark. The run term covers progress between the backend's discrete events; the local term runs ahead of the 5s feed poll.
- `runActivityTimestamp` returns 0, never `NaN`, for a run without usable timestamps. Callers feed it into a `Math.max`, where one `NaN` swallows every other term and yields a garbage day header.
- The Spaces task route re-marks the task viewed on each activity bump instead of only on mount, so the row a reader has open does not dot itself.

`taskLastActivityAt` is reused unchanged, so the code sidebar's own "Updated" sort is untouched. The mobile `taskActivityTimestamp` is left alone too: expressing it through the new helper would silently add `completed_at` to mobile's ordering.

Nothing looks different in a screenshot. The change is which order the same rows appear in.

## How did you test this code?

New tests, each catching a regression nothing covered:

- `buildChannelItems` orders a session by the run term and by the local term, parameterized over the two. This is the bug itself, and it fails on any refactor that drops a term.
- A session with a working run is not marked unread. That pins the constraint that this PR leaves `isTaskUnread`'s rule alone.
- `runActivityTimestamp` prefers the later of the run's two timestamps, and returns 0 for absent, empty, and unparseable input. That covers the `NaN` trap.

Ran locally: the full `@posthog/core` and `@posthog/ui` vitest suites, both green. Both packages typecheck clean.

Not done: no manual run of the desktop app. The ordering claims rest on the unit tests, not on watching a list reorder.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus) in PostHog Desktop, directed by @frankh, who reported the symptom and chose both the scope and the decision to ship this as a stack.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`, `/stacking-prs`.

This started as one PR carrying both halves ([#84227](https://github.com/PostHog/posthog/pull/84227), closed). The `Desktop backend coupling` check rejects that combination, because desktop auto-updates are not orchestrated with backend deploys. Splitting was chosen over the `skip-desktop-backend-check` label even though the halves are order-independent.

The self-dot mitigation moved during review of the first attempt. It began as a `markAsViewed` call in the thread composer's send mutation, which pulled `useTaskViewed` — and with it a tRPC-provider requirement — into a thin mutation hook and broke `useTaskThread.test.tsx`. The route already holds `markAsViewed` and sits under the providers, so the mark lives there instead. Its first form kept the timestamp only in the dependency array, and the lint-staged autofix removed it as an unused dependency; reading the value in the effect body is what makes the re-run survive that.
