### PR TITLE
feat(logs): add read endpoint for logs-alert notification destinations

### DIFF
--- a/posthog/helpers/tests/test_url_redaction.py
+++ b/posthog/helpers/tests/test_url_redaction.py
@@ -1,0 +1,32 @@
+import pytest
+
+from posthog.helpers.url_redaction import redact_webhook_url
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        pytest.param("https://hooks.slack.com/services/T0/B0/tok", "https://hooks.slack.com/…", id="path"),
+        pytest.param("https://hooks.example.com/svc/tok?k=v", "https://hooks.example.com/…", id="path_and_query"),
+        pytest.param(
+            "https://token:secret@hooks.example.com/path", "https://hooks.example.com/…", id="userinfo_credentials"
+        ),
+        pytest.param("https://hooks.example.com:8443/path?key=v", "https://hooks.example.com:8443/…", id="port"),
+        pytest.param("https://[2001:db8::1]:9000/path", "https://[2001:db8::1]:9000/…", id="ipv6_host"),
+    ],
+)
+def test_keeps_only_scheme_and_host(url: str, expected: str) -> None:
+    assert redact_webhook_url(url) == expected
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        pytest.param("not-a-url", id="no_scheme_or_host"),
+        pytest.param("", id="empty"),
+        pytest.param("https://example.com:99999/path", id="port_out_of_range"),
+        pytest.param("https://[2001:db8::1/path", id="unclosed_ipv6_bracket"),
+    ],
+)
+def test_hides_urls_it_cannot_parse(url: str) -> None:
+    assert redact_webhook_url(url) == "(hidden)"

--- a/posthog/helpers/url_redaction.py
+++ b/posthog/helpers/url_redaction.py
@@ -1,0 +1,16 @@
+from urllib.parse import urlparse
+
+HIDDEN_URL = "(hidden)"
+
+
+def redact_webhook_url(url: str) -> str:
+    try:
+        parsed = urlparse(url)
+        hostname, port = parsed.hostname, parsed.port
+    except ValueError:
+        return HIDDEN_URL
+    if not parsed.scheme or not hostname:
+        return HIDDEN_URL
+    host = f"[{hostname}]" if ":" in hostname else hostname
+    authority = f"{host}:{port}" if port else host
+    return f"{parsed.scheme}://{authority}/…"

--- a/products/alerts/backend/destination_configs.py
+++ b/products/alerts/backend/destination_configs.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, NotRequired, TypedDict
-from urllib.parse import urlparse
 
 from django.db import models
 
@@ -258,24 +257,3 @@ def read_alert_destination_data(*, destination_type: DestinationType, inputs: di
     if isinstance(webhook_url, str):
         data["webhook_url"] = webhook_url
     return data
-
-
-def redact_webhook_url(url: str) -> str:
-    """Reduce a webhook URL to scheme and host for read responses.
-
-    A Slack, Teams or Discord webhook URL is a bearer credential: the secret is in the path or
-    query, so whoever holds the URL can post to the channel. Keep enough for a reader to see
-    where notifications go, and drop the path, the query, and any `user:pass@` userinfo, which
-    `netloc` would carry. IPv6 hosts keep their brackets.
-    """
-    try:
-        parsed = urlparse(url)
-        hostname, port = parsed.hostname, parsed.port
-    except ValueError:
-        # urlparse rejects malformed IPv6 brackets and out-of-range ports.
-        return "(hidden)"
-    if not parsed.scheme or not hostname:
-        return "(hidden)"
-    host = f"[{hostname}]" if ":" in hostname else hostname
-    authority = f"{host}:{port}" if port else host
-    return f"{parsed.scheme}://{authority}/…"

--- a/products/alerts/backend/destination_configs.py
+++ b/products/alerts/backend/destination_configs.py
@@ -30,6 +30,12 @@ DESTINATION_REQUIRED_FIELDS: dict[DestinationType, tuple[str, ...]] = {
     DestinationType.TEAMS: ("webhook_url",),
 }
 
+DESTINATION_WEBHOOK_URL_INPUT_KEYS: dict[DestinationType, str] = {
+    DestinationType.DISCORD: "webhookUrl",
+    DestinationType.WEBHOOK: "url",
+    DestinationType.TEAMS: "webhookUrl",
+}
+
 
 class AlertDestinationData(TypedDict):
     type: DestinationType
@@ -235,12 +241,6 @@ def _input_value(inputs: dict[str, Any], key: str) -> Any:
 
 
 def read_alert_destination_data(*, destination_type: DestinationType, inputs: dict[str, Any]) -> AlertDestinationData:
-    """Recover the destination config a HogFunction was built from.
-
-    Inverse of build_alert_destination_config, so the two have to change together.
-    slack_channel_name is not recovered: it only shapes the HogFunction name and is never
-    written into inputs.
-    """
     data: AlertDestinationData = {"type": destination_type}
 
     if destination_type == DestinationType.SLACK:
@@ -252,8 +252,7 @@ def read_alert_destination_data(*, destination_type: DestinationType, inputs: di
             data["slack_channel_id"] = slack_channel_id
         return data
 
-    # Plain webhooks post to `url`; Discord and Teams both use `webhookUrl`.
-    webhook_url = _input_value(inputs, "url" if destination_type == DestinationType.WEBHOOK else "webhookUrl")
+    webhook_url = _input_value(inputs, DESTINATION_WEBHOOK_URL_INPUT_KEYS[destination_type])
     if isinstance(webhook_url, str):
         data["webhook_url"] = webhook_url
     return data

--- a/products/alerts/backend/destination_configs.py
+++ b/products/alerts/backend/destination_configs.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, NotRequired, TypedDict
+from urllib.parse import urlparse
 
 from django.db import models
 
@@ -257,3 +258,24 @@ def read_alert_destination_data(*, destination_type: DestinationType, inputs: di
     if isinstance(webhook_url, str):
         data["webhook_url"] = webhook_url
     return data
+
+
+def redact_webhook_url(url: str) -> str:
+    """Reduce a webhook URL to scheme and host for read responses.
+
+    A Slack, Teams or Discord webhook URL is a bearer credential: the secret is in the path or
+    query, so whoever holds the URL can post to the channel. Keep enough for a reader to see
+    where notifications go, and drop the path, the query, and any `user:pass@` userinfo, which
+    `netloc` would carry. IPv6 hosts keep their brackets.
+    """
+    try:
+        parsed = urlparse(url)
+        hostname, port = parsed.hostname, parsed.port
+    except ValueError:
+        # urlparse rejects malformed IPv6 brackets and out-of-range ports.
+        return "(hidden)"
+    if not parsed.scheme or not hostname:
+        return "(hidden)"
+    host = f"[{hostname}]" if ":" in hostname else hostname
+    authority = f"{host}:{port}" if port else host
+    return f"{parsed.scheme}://{authority}/…"

--- a/products/alerts/backend/destination_configs.py
+++ b/products/alerts/backend/destination_configs.py
@@ -227,3 +227,33 @@ def build_alert_destination_config(
             "inputs": inputs,
         },
     )
+
+
+def _input_value(inputs: dict[str, Any], key: str) -> Any:
+    entry = inputs.get(key)
+    return entry.get("value") if isinstance(entry, dict) else None
+
+
+def read_alert_destination_data(*, destination_type: DestinationType, inputs: dict[str, Any]) -> AlertDestinationData:
+    """Recover the destination config a HogFunction was built from.
+
+    Inverse of build_alert_destination_config, so the two have to change together.
+    slack_channel_name is not recovered: it only shapes the HogFunction name and is never
+    written into inputs.
+    """
+    data: AlertDestinationData = {"type": destination_type}
+
+    if destination_type == DestinationType.SLACK:
+        slack_workspace_id = _input_value(inputs, "slack_workspace")
+        slack_channel_id = _input_value(inputs, "channel")
+        if isinstance(slack_workspace_id, int):
+            data["slack_workspace_id"] = slack_workspace_id
+        if isinstance(slack_channel_id, str):
+            data["slack_channel_id"] = slack_channel_id
+        return data
+
+    # Plain webhooks post to `url`; Discord and Teams both use `webhookUrl`.
+    webhook_url = _input_value(inputs, "url" if destination_type == DestinationType.WEBHOOK else "webhookUrl")
+    if isinstance(webhook_url, str):
+        data["webhook_url"] = webhook_url
+    return data

--- a/products/alerts/backend/destinations.py
+++ b/products/alerts/backend/destinations.py
@@ -274,6 +274,9 @@ def list_active_alert_destinations(
 class AlertDestinationGroup:
     hog_function_ids: tuple[str, ...]
     data: AlertDestinationData
+    # True only when every HogFunction in the group is enabled. One disabled row means the
+    # destination stops receiving that event kind, so the group is no longer fully active.
+    enabled: bool
 
 
 def _destination_type_for_template(template_id: str | None) -> DestinationType | None:
@@ -307,12 +310,13 @@ def list_alert_destination_groups(
             filters__properties__contains=[{"key": "alert_id", "value": alert_id}],
         )
         .order_by("created_at", "id")
-        .values_list("id", "template_id", "inputs")
+        .values_list("id", "template_id", "inputs", "enabled")
     )
 
     ids_by_key: dict[tuple, list[str]] = {}
     data_by_key: dict[tuple, AlertDestinationData] = {}
-    for hog_function_id, template_id, inputs in rows:
+    enabled_by_key: dict[tuple, bool] = {}
+    for hog_function_id, template_id, inputs, enabled in rows:
         destination_type = _destination_type_for_template(template_id)
         if destination_type is None:
             continue
@@ -320,9 +324,14 @@ def list_alert_destination_groups(
         key = _destination_group_key(destination_type=destination_type, data=data, hog_function_id=str(hog_function_id))
         ids_by_key.setdefault(key, []).append(str(hog_function_id))
         data_by_key.setdefault(key, data)
+        enabled_by_key[key] = enabled_by_key.get(key, True) and enabled
 
     return [
-        AlertDestinationGroup(hog_function_ids=tuple(sorted(hog_function_ids)), data=data_by_key[key])
+        AlertDestinationGroup(
+            hog_function_ids=tuple(sorted(hog_function_ids)),
+            data=data_by_key[key],
+            enabled=enabled_by_key[key],
+        )
         for key, hog_function_ids in ids_by_key.items()
     ]
 

--- a/products/alerts/backend/destinations.py
+++ b/products/alerts/backend/destinations.py
@@ -272,10 +272,21 @@ def list_active_alert_destinations(
 
 @dataclass(frozen=True, kw_only=True)
 class AlertDestinationGroup:
-    """One destination as the user configured it, plus the HogFunctions standing in for it."""
-
     hog_function_ids: tuple[str, ...]
     data: AlertDestinationData
+
+
+def _destination_type_for_template(template_id: str | None) -> DestinationType | None:
+    destination_type_value = _TEMPLATE_ID_TO_DESTINATION_TYPE.get(template_id) if template_id else None
+    return DestinationType(destination_type_value) if destination_type_value else None
+
+
+def _destination_group_key(
+    *, destination_type: DestinationType, data: AlertDestinationData, hog_function_id: str
+) -> tuple:
+    shared_config = tuple(sorted((key, value) for key, value in data.items() if key != "type"))
+    unique_to_this_row = (("hog_function_id", hog_function_id),)
+    return (destination_type.value, shared_config or unique_to_this_row)
 
 
 def list_alert_destination_groups(
@@ -285,13 +296,6 @@ def list_alert_destination_groups(
     allowed_event_ids: Collection[str],
     allowed_destination_types: Collection[DestinationType],
 ) -> list[AlertDestinationGroup]:
-    """The alert's destinations, one entry each rather than one per HogFunction.
-
-    Creating a destination fans out into one HogFunction per event kind, so regroup them by
-    the config they share. Note this groups more finely than `soft_delete_alert_destinations`,
-    which groups by template alone, so two destinations of one type list separately here but
-    cannot yet be deleted individually.
-    """
     rows = (
         HogFunction.objects.filter(
             _allowed_event_filter(allowed_event_ids),
@@ -309,18 +313,11 @@ def list_alert_destination_groups(
     ids_by_key: dict[tuple, list[str]] = {}
     data_by_key: dict[tuple, AlertDestinationData] = {}
     for hog_function_id, template_id, inputs in rows:
-        # template_id is nullable on the model, so narrow it even though the filter above
-        # only matches the destination templates.
-        destination_type_value = _TEMPLATE_ID_TO_DESTINATION_TYPE.get(template_id) if template_id else None
-        if destination_type_value is None:
+        destination_type = _destination_type_for_template(template_id)
+        if destination_type is None:
             continue
-        destination_type = DestinationType(destination_type_value)
         data = read_alert_destination_data(destination_type=destination_type, inputs=inputs or {})
-        config: dict[str, Any] = {key: value for key, value in data.items() if key != "type"}
-        # A row with no readable config can't be matched against its siblings, so give it a
-        # key of its own instead of merging unrelated destinations together.
-        config_key = tuple(sorted(config.items())) if config else (("id", str(hog_function_id)),)
-        key = (destination_type.value, config_key)
+        key = _destination_group_key(destination_type=destination_type, data=data, hog_function_id=str(hog_function_id))
         ids_by_key.setdefault(key, []).append(str(hog_function_id))
         data_by_key.setdefault(key, data)
 

--- a/products/alerts/backend/destinations.py
+++ b/products/alerts/backend/destinations.py
@@ -274,9 +274,7 @@ def list_active_alert_destinations(
 class AlertDestinationGroup:
     hog_function_ids: tuple[str, ...]
     data: AlertDestinationData
-    # True only when every HogFunction in the group is enabled. One disabled row means the
-    # destination stops receiving that event kind, so the group is no longer fully active.
-    enabled: bool
+    fully_enabled: bool
 
 
 def _destination_type_for_template(template_id: str | None) -> DestinationType | None:
@@ -330,7 +328,7 @@ def list_alert_destination_groups(
         AlertDestinationGroup(
             hog_function_ids=tuple(sorted(hog_function_ids)),
             data=data_by_key[key],
-            enabled=enabled_by_key[key],
+            fully_enabled=enabled_by_key[key],
         )
         for key, hog_function_ids in ids_by_key.items()
     ]

--- a/products/alerts/backend/destinations.py
+++ b/products/alerts/backend/destinations.py
@@ -288,8 +288,9 @@ def list_alert_destination_groups(
     """The alert's destinations, one entry each rather than one per HogFunction.
 
     Creating a destination fans out into one HogFunction per event kind, so regroup them by
-    the config they share. Matches the ownership filter `soft_delete_alert_destinations`
-    uses, so anything listed here can also be deleted.
+    the config they share. Note this groups more finely than `soft_delete_alert_destinations`,
+    which groups by template alone, so two destinations of one type list separately here but
+    cannot yet be deleted individually.
     """
     rows = (
         HogFunction.objects.filter(

--- a/products/alerts/backend/destinations.py
+++ b/products/alerts/backend/destinations.py
@@ -22,7 +22,13 @@ from posthog.exceptions_capture import capture_exception
 from posthog.kafka_client.client import ProduceResult
 from posthog.plugins.plugin_server_api import reload_hog_functions_on_workers
 
-from products.alerts.backend.destination_configs import DESTINATION_TEMPLATE_IDS, AlertDestinationConfig
+from products.alerts.backend.destination_configs import (
+    DESTINATION_TEMPLATE_IDS,
+    AlertDestinationConfig,
+    AlertDestinationData,
+    DestinationType,
+    read_alert_destination_data,
+)
 from products.cdp.backend.api.hog_function import HogFunctionSerializer
 from products.cdp.backend.models.hog_functions.hog_function import HogFunction
 
@@ -262,6 +268,65 @@ def list_active_alert_destinations(
             )
         )
     return destinations
+
+
+@dataclass(frozen=True, kw_only=True)
+class AlertDestinationGroup:
+    """One destination as the user configured it, plus the HogFunctions standing in for it."""
+
+    hog_function_ids: tuple[str, ...]
+    data: AlertDestinationData
+
+
+def list_alert_destination_groups(
+    *,
+    team_id: int,
+    alert_id: str,
+    allowed_event_ids: Collection[str],
+    allowed_destination_types: Collection[DestinationType],
+) -> list[AlertDestinationGroup]:
+    """The alert's destinations, one entry each rather than one per HogFunction.
+
+    Creating a destination fans out into one HogFunction per event kind, so regroup them by
+    the config they share. Matches the ownership filter `soft_delete_alert_destinations`
+    uses, so anything listed here can also be deleted.
+    """
+    rows = (
+        HogFunction.objects.filter(
+            _allowed_event_filter(allowed_event_ids),
+            team_id=team_id,
+            deleted=False,
+            template_id__in=[
+                DESTINATION_TEMPLATE_IDS[destination_type] for destination_type in allowed_destination_types
+            ],
+            filters__properties__contains=[{"key": "alert_id", "value": alert_id}],
+        )
+        .order_by("created_at", "id")
+        .values_list("id", "template_id", "inputs")
+    )
+
+    ids_by_key: dict[tuple, list[str]] = {}
+    data_by_key: dict[tuple, AlertDestinationData] = {}
+    for hog_function_id, template_id, inputs in rows:
+        # template_id is nullable on the model, so narrow it even though the filter above
+        # only matches the destination templates.
+        destination_type_value = _TEMPLATE_ID_TO_DESTINATION_TYPE.get(template_id) if template_id else None
+        if destination_type_value is None:
+            continue
+        destination_type = DestinationType(destination_type_value)
+        data = read_alert_destination_data(destination_type=destination_type, inputs=inputs or {})
+        config: dict[str, Any] = {key: value for key, value in data.items() if key != "type"}
+        # A row with no readable config can't be matched against its siblings, so give it a
+        # key of its own instead of merging unrelated destinations together.
+        config_key = tuple(sorted(config.items())) if config else (("id", str(hog_function_id)),)
+        key = (destination_type.value, config_key)
+        ids_by_key.setdefault(key, []).append(str(hog_function_id))
+        data_by_key.setdefault(key, data)
+
+    return [
+        AlertDestinationGroup(hog_function_ids=tuple(sorted(hog_function_ids)), data=data_by_key[key])
+        for key, hog_function_ids in ids_by_key.items()
+    ]
 
 
 def _allowed_event_filter(allowed_event_ids: Collection[str]) -> Q:

--- a/products/alerts/backend/facade/api.py
+++ b/products/alerts/backend/facade/api.py
@@ -22,7 +22,6 @@ from products.alerts.backend.destination_configs import (
     AlertDestinationValidationError,
     DestinationType,
     build_alert_destination_config,
-    redact_webhook_url,
     validate_destination_data,
 )
 from products.alerts.backend.destinations import (
@@ -172,7 +171,6 @@ __all__ = [
     "get_alert_team_id",
     "insight_ids_with_alerts",
     "list_alert_destination_groups",
-    "redact_webhook_url",
     "snooze_alert_from_slack",
     "soft_delete_alert_destinations",
     "soft_delete_alert_destinations_for_alerts",

--- a/products/alerts/backend/facade/api.py
+++ b/products/alerts/backend/facade/api.py
@@ -25,7 +25,9 @@ from products.alerts.backend.destination_configs import (
     validate_destination_data,
 )
 from products.alerts.backend.destinations import (
+    AlertDestinationGroup,
     create_alert_destination_hog_functions,
+    list_alert_destination_groups,
     soft_delete_alert_destinations,
     soft_delete_alert_destinations_for_alerts,
     soft_delete_all_alert_destinations,
@@ -160,6 +162,7 @@ def snooze_alert_from_slack(
 __all__ = [
     "DESTINATION_TEMPLATE_IDS",
     "AlertDestinationData",
+    "AlertDestinationGroup",
     "AlertDestinationValidationError",
     "AlertScheduleRestriction",
     "DestinationType",
@@ -169,6 +172,7 @@ __all__ = [
     "create_alert_destination_hog_functions",
     "get_alert_team_id",
     "insight_ids_with_alerts",
+    "list_alert_destination_groups",
     "snooze_alert_from_slack",
     "soft_delete_alert_destinations",
     "soft_delete_alert_destinations_for_alerts",

--- a/products/alerts/backend/facade/api.py
+++ b/products/alerts/backend/facade/api.py
@@ -25,7 +25,6 @@ from products.alerts.backend.destination_configs import (
     validate_destination_data,
 )
 from products.alerts.backend.destinations import (
-    AlertDestinationGroup,
     create_alert_destination_hog_functions,
     list_alert_destination_groups,
     soft_delete_alert_destinations,
@@ -162,7 +161,6 @@ def snooze_alert_from_slack(
 __all__ = [
     "DESTINATION_TEMPLATE_IDS",
     "AlertDestinationData",
-    "AlertDestinationGroup",
     "AlertDestinationValidationError",
     "AlertScheduleRestriction",
     "DestinationType",

--- a/products/alerts/backend/facade/api.py
+++ b/products/alerts/backend/facade/api.py
@@ -22,6 +22,7 @@ from products.alerts.backend.destination_configs import (
     AlertDestinationValidationError,
     DestinationType,
     build_alert_destination_config,
+    redact_webhook_url,
     validate_destination_data,
 )
 from products.alerts.backend.destinations import (
@@ -171,6 +172,7 @@ __all__ = [
     "get_alert_team_id",
     "insight_ids_with_alerts",
     "list_alert_destination_groups",
+    "redact_webhook_url",
     "snooze_alert_from_slack",
     "soft_delete_alert_destinations",
     "soft_delete_alert_destinations_for_alerts",

--- a/products/alerts/backend/test/test_destination_configs.py
+++ b/products/alerts/backend/test/test_destination_configs.py
@@ -1,12 +1,4 @@
-import pytest
-
-from products.alerts.backend.destination_configs import (
-    AlertDestinationAction,
-    EventKindSpec,
-    redact_webhook_url,
-    slack_blocks,
-    teams_text,
-)
+from products.alerts.backend.destination_configs import AlertDestinationAction, EventKindSpec, slack_blocks, teams_text
 
 DEFAULT_SPEC = EventKindSpec(
     event_id="$insight_alert_firing",
@@ -62,22 +54,3 @@ class TestSpecVocabularyRendering:
         assert teams_text(DEFAULT_SPEC) == (
             "**Insight alert firing**\n\n**Threshold:** 30\n\n[View insight](https://example.com/insight)"
         )
-
-
-class TestRedactWebhookUrl:
-    @pytest.mark.parametrize(
-        "url,expected",
-        [
-            ("https://hooks.slack.com/services/T0/B0/tok", "https://hooks.slack.com/…"),
-            # Defense in depth: creation rejects embedded credentials, but redaction must not
-            # echo them if one ever reaches the read path.
-            ("https://token:secret@hooks.example.com/path", "https://hooks.example.com/…"),
-            ("https://hooks.example.com:8443/path?key=v", "https://hooks.example.com:8443/…"),
-            ("https://[2001:db8::1]:9000/path", "https://[2001:db8::1]:9000/…"),
-            ("not-a-url", "(hidden)"),
-            ("https://example.com:99999/path", "(hidden)"),
-            ("", "(hidden)"),
-        ],
-    )
-    def test_keeps_only_scheme_and_host(self, url: str, expected: str) -> None:
-        assert redact_webhook_url(url) == expected

--- a/products/alerts/backend/test/test_destination_configs.py
+++ b/products/alerts/backend/test/test_destination_configs.py
@@ -1,4 +1,15 @@
-from products.alerts.backend.destination_configs import AlertDestinationAction, EventKindSpec, slack_blocks, teams_text
+import pytest
+
+from products.alerts.backend.destination_configs import (
+    AlertDestinationAction,
+    AlertDestinationData,
+    DestinationType,
+    EventKindSpec,
+    build_alert_destination_config,
+    read_alert_destination_data,
+    slack_blocks,
+    teams_text,
+)
 
 DEFAULT_SPEC = EventKindSpec(
     event_id="$insight_alert_firing",
@@ -54,3 +65,50 @@ class TestSpecVocabularyRendering:
         assert teams_text(DEFAULT_SPEC) == (
             "**Insight alert firing**\n\n**Threshold:** 30\n\n[View insight](https://example.com/insight)"
         )
+
+
+def _build_payload(data: AlertDestinationData) -> dict:
+    config = build_alert_destination_config(
+        team=None,
+        spec=DEFAULT_SPEC,
+        alert_id="alert-1",
+        alert_name="Alert",
+        data=data,
+        slack_context_elements=(),
+    )
+    return config.payload
+
+
+class TestDestinationDataSurvivesTheHogFunctionRoundTrip:
+    @pytest.mark.parametrize(
+        "data",
+        [
+            pytest.param(
+                {"type": DestinationType.SLACK, "slack_workspace_id": 7, "slack_channel_id": "C1"}, id="slack"
+            ),
+            pytest.param({"type": DestinationType.WEBHOOK, "webhook_url": "https://example.com/hook"}, id="webhook"),
+            pytest.param({"type": DestinationType.DISCORD, "webhook_url": "https://example.com/discord"}, id="discord"),
+            pytest.param({"type": DestinationType.TEAMS, "webhook_url": "https://example.com/teams"}, id="teams"),
+        ],
+    )
+    def test_read_recovers_everything_build_was_given(self, data: AlertDestinationData) -> None:
+        payload = _build_payload(data)
+
+        assert read_alert_destination_data(destination_type=data["type"], inputs=payload["inputs"]) == data
+
+    def test_build_puts_slack_channel_name_in_the_name_so_read_cannot_recover_it(self) -> None:
+        payload = _build_payload(
+            {
+                "type": DestinationType.SLACK,
+                "slack_workspace_id": 7,
+                "slack_channel_id": "C1",
+                "slack_channel_name": "alerts",
+            }
+        )
+
+        assert "Slack #alerts" in payload["name"]
+        assert read_alert_destination_data(destination_type=DestinationType.SLACK, inputs=payload["inputs"]) == {
+            "type": DestinationType.SLACK,
+            "slack_workspace_id": 7,
+            "slack_channel_id": "C1",
+        }

--- a/products/alerts/backend/test/test_destination_configs.py
+++ b/products/alerts/backend/test/test_destination_configs.py
@@ -1,4 +1,12 @@
-from products.alerts.backend.destination_configs import AlertDestinationAction, EventKindSpec, slack_blocks, teams_text
+import pytest
+
+from products.alerts.backend.destination_configs import (
+    AlertDestinationAction,
+    EventKindSpec,
+    redact_webhook_url,
+    slack_blocks,
+    teams_text,
+)
 
 DEFAULT_SPEC = EventKindSpec(
     event_id="$insight_alert_firing",
@@ -54,3 +62,22 @@ class TestSpecVocabularyRendering:
         assert teams_text(DEFAULT_SPEC) == (
             "**Insight alert firing**\n\n**Threshold:** 30\n\n[View insight](https://example.com/insight)"
         )
+
+
+class TestRedactWebhookUrl:
+    @pytest.mark.parametrize(
+        "url,expected",
+        [
+            ("https://hooks.slack.com/services/T0/B0/tok", "https://hooks.slack.com/…"),
+            # Defense in depth: creation rejects embedded credentials, but redaction must not
+            # echo them if one ever reaches the read path.
+            ("https://token:secret@hooks.example.com/path", "https://hooks.example.com/…"),
+            ("https://hooks.example.com:8443/path?key=v", "https://hooks.example.com:8443/…"),
+            ("https://[2001:db8::1]:9000/path", "https://[2001:db8::1]:9000/…"),
+            ("not-a-url", "(hidden)"),
+            ("https://example.com:99999/path", "(hidden)"),
+            ("", "(hidden)"),
+        ],
+    )
+    def test_keeps_only_scheme_and_host(self, url: str, expected: str) -> None:
+        assert redact_webhook_url(url) == expected

--- a/products/logs/backend/presentation/views/alerts_api.py
+++ b/products/logs/backend/presentation/views/alerts_api.py
@@ -23,6 +23,7 @@ from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.event_usage import report_user_action
 from posthog.helpers.impersonation import is_impersonated
+from posthog.helpers.url_redaction import redact_webhook_url
 from posthog.models.activity_logging.activity_log import Change, Detail, log_activity
 from posthog.models.team.team import Team
 from posthog.models.user import User
@@ -38,7 +39,6 @@ from products.alerts.backend.facade.api import (
     build_alert_destination_config,
     create_alert_destination_hog_functions,
     list_alert_destination_groups,
-    redact_webhook_url,
     soft_delete_alert_destinations,
     soft_delete_all_alert_destinations,
     validate_and_normalize_schedule_restriction,
@@ -766,21 +766,12 @@ class LogsAlertDestinationResponseSerializer(serializers.Serializer):
 
 
 class LogsAlertDestinationConfigSerializer(LogsAlertDestinationResponseSerializer):
-    """A configured destination, with the fields it was created with.
-
-    Two of those fields do not come back as sent. slack_channel_name has no counterpart at all:
-    creation puts it in the HogFunction name rather than its inputs, so there is nothing to read
-    back. webhook_url comes back redacted to scheme and host, because the full URL is a bearer
-    credential and logs:read includes viewers — so a caller cannot use this response to compare
-    the stored URL against the one it sent.
-    """
-
     type = serializers.ChoiceField(choices=LOGS_DESTINATION_TYPES, help_text="Notification destination type.")
     slack_workspace_id = serializers.IntegerField(
         required=False, help_text="Integration ID for the Slack workspace. Present when type=slack."
     )
     slack_channel_id = serializers.CharField(required=False, help_text="Slack channel ID. Present when type=slack.")
-    webhook_url = serializers.URLField(
+    webhook_url = serializers.CharField(
         required=False,
         help_text=(
             "Endpoint posted to, redacted to scheme and host because the full URL is a credential. "
@@ -1043,9 +1034,6 @@ class LogsAlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             allowed_event_ids=LOGS_ALERT_EVENT_IDS,
             allowed_destination_types=LOGS_DESTINATION_TYPES,
         )
-        # A plain list, not a queryset — destinations are regrouped in Python. DRF paginates it
-        # anyway: get_count falls back to len() and the page is a slice. Groups come back in
-        # HogFunction creation order, so page boundaries are stable.
         destinations = [{"hog_function_ids": list(group.hog_function_ids), **group.data} for group in groups]
 
         page = self.paginate_queryset(destinations)

--- a/products/logs/backend/presentation/views/alerts_api.py
+++ b/products/logs/backend/presentation/views/alerts_api.py
@@ -767,6 +767,12 @@ class LogsAlertDestinationResponseSerializer(serializers.Serializer):
 
 class LogsAlertDestinationConfigSerializer(LogsAlertDestinationResponseSerializer):
     type = serializers.ChoiceField(choices=LOGS_DESTINATION_TYPES, help_text="Notification destination type.")
+    enabled = serializers.BooleanField(
+        help_text=(
+            "False when any HogFunction in the group is disabled, because the destination then misses "
+            "at least one alert event kind."
+        )
+    )
     slack_workspace_id = serializers.IntegerField(
         required=False, help_text="Integration ID for the Slack workspace. Present when type=slack."
     )
@@ -1032,7 +1038,10 @@ class LogsAlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             allowed_event_ids=LOGS_ALERT_EVENT_IDS,
             allowed_destination_types=LOGS_DESTINATION_TYPES,
         )
-        destinations = [{"hog_function_ids": list(group.hog_function_ids), **group.data} for group in groups]
+        destinations = [
+            {"hog_function_ids": list(group.hog_function_ids), "enabled": group.enabled, **group.data}
+            for group in groups
+        ]
 
         page = self.paginate_queryset(destinations)
         if page is not None:

--- a/products/logs/backend/presentation/views/alerts_api.py
+++ b/products/logs/backend/presentation/views/alerts_api.py
@@ -879,6 +879,12 @@ def _fill_empty_buckets(
     return result
 
 
+_DESTINATIONS_URL_REQUIRED_SCOPES: Final[dict[str, list[str]]] = {
+    "list_destinations": ["logs:read"],
+    "create_destination": ["logs:write"],
+}
+
+
 @extend_schema_view(list=extend_schema(parameters=[LogsAlertListQuerySerializer]))
 class LogsAlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     scope_object = "logs"
@@ -888,14 +894,8 @@ class LogsAlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     posthog_feature_flag = "logs-alerting"
     permission_classes = [PostHogFeatureFlagPermission]
 
-    # create_destination and list_destinations share the `destinations` URL, so they share one
-    # set of @action initkwargs and cannot each declare their own required_scopes.
     def dangerously_get_required_scopes(self, request: Request, view: Any) -> list[str] | None:
-        if view.action == "list_destinations":
-            return ["logs:read"]
-        if view.action == "create_destination":
-            return ["logs:write"]
-        return None
+        return _DESTINATIONS_URL_REQUIRED_SCOPES.get(view.action)
 
     def safely_get_queryset(self, queryset: QuerySet) -> QuerySet:
         if self.action == "list":
@@ -983,8 +983,6 @@ class LogsAlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         responses={201: LogsAlertDestinationResponseSerializer},
         description="Create a notification destination for this alert. One HogFunction is created per alert event kind (firing, resolved, ...) atomically.",
     )
-    # required_scopes is set in dangerously_get_required_scopes, not here. Setting it on the
-    # decorator would apply logs:write to list_destinations too, which shares this URL.
     @action(detail=True, methods=["POST"], url_path="destinations")
     def create_destination(self, request: Request, *args: object, **kwargs: object) -> Response:
         serializer = LogsAlertCreateDestinationSerializer(data=request.data)

--- a/products/logs/backend/presentation/views/alerts_api.py
+++ b/products/logs/backend/presentation/views/alerts_api.py
@@ -100,6 +100,10 @@ STATE_TIMELINE_LOOKBACK_HOURS = 24
 DEFAULT_CHECK_INTERVAL_MINUTES = 5
 _SENTINEL: Final = object()
 _NOT_ANNOTATED: Final = object()
+_DESTINATIONS_URL_REQUIRED_SCOPES: Final[dict[str, list[str]]] = {
+    "list_destinations": ["logs:read"],
+    "create_destination": ["logs:write"],
+}
 
 
 def _any_field_changed(instance: LogsAlertConfiguration, validated_data: dict, fields: set[str]) -> bool:
@@ -883,12 +887,6 @@ def _fill_empty_buckets(
             result.append(BucketedCount(timestamp=cursor, count=0))
         cursor += interval
     return result
-
-
-_DESTINATIONS_URL_REQUIRED_SCOPES: Final[dict[str, list[str]]] = {
-    "list_destinations": ["logs:read"],
-    "create_destination": ["logs:write"],
-}
 
 
 @extend_schema_view(list=extend_schema(parameters=[LogsAlertListQuerySerializer]))

--- a/products/logs/backend/presentation/views/alerts_api.py
+++ b/products/logs/backend/presentation/views/alerts_api.py
@@ -1039,7 +1039,7 @@ class LogsAlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             allowed_destination_types=LOGS_DESTINATION_TYPES,
         )
         destinations = [
-            {"hog_function_ids": list(group.hog_function_ids), "enabled": group.enabled, **group.data}
+            {"hog_function_ids": list(group.hog_function_ids), "enabled": group.fully_enabled, **group.data}
             for group in groups
         ]
 

--- a/products/logs/backend/presentation/views/alerts_api.py
+++ b/products/logs/backend/presentation/views/alerts_api.py
@@ -991,6 +991,9 @@ class LogsAlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         responses={201: LogsAlertDestinationResponseSerializer},
         description="Create a notification destination for this alert. One HogFunction is created per alert event kind (firing, resolved, ...) atomically.",
     )
+    # No required_scopes here because create (POST) and list (GET) share this route via
+    # .mapping, which can't carry per-method scopes. Their scopes live in
+    # _DESTINATIONS_URL_REQUIRED_SCOPES; a new destination action must be added there too.
     @action(detail=True, methods=["POST"], url_path="destinations")
     def create_destination(self, request: Request, *args: object, **kwargs: object) -> Response:
         serializer = LogsAlertCreateDestinationSerializer(data=request.data)

--- a/products/logs/backend/presentation/views/alerts_api.py
+++ b/products/logs/backend/presentation/views/alerts_api.py
@@ -100,6 +100,10 @@ STATE_TIMELINE_LOOKBACK_HOURS = 24
 DEFAULT_CHECK_INTERVAL_MINUTES = 5
 _SENTINEL: Final = object()
 _NOT_ANNOTATED: Final = object()
+# create_destination (POST) and list_destinations (GET) share one route via
+# @action.mapping. required_scopes doesn't compose with .mapping — it resolves from a
+# single attribute on the action — so these two declare their per-method scopes here,
+# applied by dangerously_get_required_scopes. Single-method actions use @action(required_scopes=...).
 _DESTINATIONS_URL_REQUIRED_SCOPES: Final[dict[str, list[str]]] = {
     "list_destinations": ["logs:read"],
     "create_destination": ["logs:write"],

--- a/products/logs/backend/presentation/views/alerts_api.py
+++ b/products/logs/backend/presentation/views/alerts_api.py
@@ -881,13 +881,13 @@ class LogsAlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     posthog_feature_flag = "logs-alerting"
     permission_classes = [PostHogFeatureFlagPermission]
 
-    # create_destination (POST) and list_destinations (GET) share the `destinations` URL via
-    # @create_destination.mapping.get, so they also share one set of @action initkwargs and
-    # cannot each declare their own required_scopes. Resolve per-method here instead.
+    # create_destination and list_destinations share the `destinations` URL, so they share one
+    # set of @action initkwargs and cannot each declare their own required_scopes.
     def dangerously_get_required_scopes(self, request: Request, view: Any) -> list[str] | None:
-        if view.action in ("create_destination", "list_destinations"):
-            # HEAD is auto-routed to the GET handler, so it reads too.
-            return ["logs:read"] if request.method in ("GET", "HEAD") else ["logs:write"]
+        if view.action == "list_destinations":
+            return ["logs:read"]
+        if view.action == "create_destination":
+            return ["logs:write"]
         return None
 
     def safely_get_queryset(self, queryset: QuerySet) -> QuerySet:
@@ -976,10 +976,8 @@ class LogsAlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         responses={201: LogsAlertDestinationResponseSerializer},
         description="Create a notification destination for this alert. One HogFunction is created per alert event kind (firing, resolved, ...) atomically.",
     )
-    # NOTE: `required_scopes` is intentionally not set on @action here. list_destinations is
-    # registered below via @create_destination.mapping.get and shares this URL pattern's
-    # initkwargs, so setting required_scopes here would apply logs:write to the read too.
-    # Scopes are resolved per-method in dangerously_get_required_scopes instead.
+    # required_scopes is set in dangerously_get_required_scopes, not here. Setting it on the
+    # decorator would apply logs:write to list_destinations too, which shares this URL.
     @action(detail=True, methods=["POST"], url_path="destinations")
     def create_destination(self, request: Request, *args: object, **kwargs: object) -> Response:
         serializer = LogsAlertCreateDestinationSerializer(data=request.data)

--- a/products/logs/backend/presentation/views/alerts_api.py
+++ b/products/logs/backend/presentation/views/alerts_api.py
@@ -38,6 +38,7 @@ from products.alerts.backend.facade.api import (
     build_alert_destination_config,
     create_alert_destination_hog_functions,
     list_alert_destination_groups,
+    redact_webhook_url,
     soft_delete_alert_destinations,
     soft_delete_all_alert_destinations,
     validate_and_normalize_schedule_restriction,
@@ -765,10 +766,13 @@ class LogsAlertDestinationResponseSerializer(serializers.Serializer):
 
 
 class LogsAlertDestinationConfigSerializer(LogsAlertDestinationResponseSerializer):
-    """A configured destination, with the fields it was created with so the two round-trip.
+    """A configured destination, with the fields it was created with.
 
-    slack_channel_name has no counterpart here: creation puts it in the HogFunction name
-    rather than its inputs, so there is nothing to read back.
+    Two of those fields do not come back as sent. slack_channel_name has no counterpart at all:
+    creation puts it in the HogFunction name rather than its inputs, so there is nothing to read
+    back. webhook_url comes back redacted to scheme and host, because the full URL is a bearer
+    credential and logs:read includes viewers — so a caller cannot use this response to compare
+    the stored URL against the one it sent.
     """
 
     type = serializers.ChoiceField(choices=LOGS_DESTINATION_TYPES, help_text="Notification destination type.")
@@ -776,7 +780,19 @@ class LogsAlertDestinationConfigSerializer(LogsAlertDestinationResponseSerialize
         required=False, help_text="Integration ID for the Slack workspace. Present when type=slack."
     )
     slack_channel_id = serializers.CharField(required=False, help_text="Slack channel ID. Present when type=slack.")
-    webhook_url = serializers.URLField(required=False, help_text="Endpoint posted to. Present for webhook and teams.")
+    webhook_url = serializers.URLField(
+        required=False,
+        help_text=(
+            "Endpoint posted to, redacted to scheme and host because the full URL is a credential. "
+            "Present for webhook and teams."
+        ),
+    )
+
+    def to_representation(self, instance: Any) -> dict[str, Any]:
+        data = cast(dict[str, Any], super().to_representation(instance))
+        if data.get("webhook_url"):
+            data["webhook_url"] = redact_webhook_url(data["webhook_url"])
+        return data
 
 
 def _build_reason(
@@ -1012,10 +1028,10 @@ class LogsAlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         request=None,
         responses={200: LogsAlertDestinationConfigSerializer(many=True)},
         description=(
-            "List the notification destinations configured for this alert. Creating a destination "
-            "fans out into one HogFunction per alert event kind (firing, resolved, ...); this returns "
-            "one entry per destination, carrying the whole group's HogFunction IDs and the config it "
-            "was created with."
+            "Paginated list of the notification destinations configured for this alert. Creating a "
+            "destination fans out into one HogFunction per alert event kind (firing, resolved, ...); "
+            "this returns one entry per destination, carrying the whole group's HogFunction IDs and "
+            "the config it was created with. webhook_url comes back redacted to scheme and host."
         ),
     )
     @create_destination.mapping.get
@@ -1027,10 +1043,17 @@ class LogsAlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             allowed_event_ids=LOGS_ALERT_EVENT_IDS,
             allowed_destination_types=LOGS_DESTINATION_TYPES,
         )
-        serializer = LogsAlertDestinationConfigSerializer(
-            [{"hog_function_ids": list(group.hog_function_ids), **group.data} for group in groups],
-            many=True,
-        )
+        # A plain list, not a queryset — destinations are regrouped in Python. DRF paginates it
+        # anyway: get_count falls back to len() and the page is a slice. Groups come back in
+        # HogFunction creation order, so page boundaries are stable.
+        destinations = [{"hog_function_ids": list(group.hog_function_ids), **group.data} for group in groups]
+
+        page = self.paginate_queryset(destinations)
+        if page is not None:
+            serializer = LogsAlertDestinationConfigSerializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+
+        serializer = LogsAlertDestinationConfigSerializer(destinations, many=True)
         return Response(serializer.data)
 
     @extend_schema(

--- a/products/logs/backend/presentation/views/alerts_api.py
+++ b/products/logs/backend/presentation/views/alerts_api.py
@@ -37,6 +37,7 @@ from products.alerts.backend.facade.api import (
     DestinationType,
     build_alert_destination_config,
     create_alert_destination_hog_functions,
+    list_alert_destination_groups,
     soft_delete_alert_destinations,
     soft_delete_all_alert_destinations,
     validate_and_normalize_schedule_restriction,
@@ -763,6 +764,21 @@ class LogsAlertDestinationResponseSerializer(serializers.Serializer):
     hog_function_ids = serializers.ListField(child=serializers.UUIDField())
 
 
+class LogsAlertDestinationConfigSerializer(LogsAlertDestinationResponseSerializer):
+    """A configured destination, with the fields it was created with so the two round-trip.
+
+    slack_channel_name has no counterpart here: creation puts it in the HogFunction name
+    rather than its inputs, so there is nothing to read back.
+    """
+
+    type = serializers.ChoiceField(choices=LOGS_DESTINATION_TYPES, help_text="Notification destination type.")
+    slack_workspace_id = serializers.IntegerField(
+        required=False, help_text="Integration ID for the Slack workspace. Present when type=slack."
+    )
+    slack_channel_id = serializers.CharField(required=False, help_text="Slack channel ID. Present when type=slack.")
+    webhook_url = serializers.URLField(required=False, help_text="Endpoint posted to. Present for webhook and teams.")
+
+
 def _build_reason(
     prev_state: AlertState,
     outcome: AlertCheckOutcome,
@@ -865,6 +881,15 @@ class LogsAlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     posthog_feature_flag = "logs-alerting"
     permission_classes = [PostHogFeatureFlagPermission]
 
+    # create_destination (POST) and list_destinations (GET) share the `destinations` URL via
+    # @create_destination.mapping.get, so they also share one set of @action initkwargs and
+    # cannot each declare their own required_scopes. Resolve per-method here instead.
+    def dangerously_get_required_scopes(self, request: Request, view: Any) -> list[str] | None:
+        if view.action in ("create_destination", "list_destinations"):
+            # HEAD is auto-routed to the GET handler, so it reads too.
+            return ["logs:read"] if request.method in ("GET", "HEAD") else ["logs:write"]
+        return None
+
     def safely_get_queryset(self, queryset: QuerySet) -> QuerySet:
         if self.action == "list":
             query_serializer = LogsAlertListQuerySerializer(data=self.request.query_params)
@@ -951,7 +976,11 @@ class LogsAlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         responses={201: LogsAlertDestinationResponseSerializer},
         description="Create a notification destination for this alert. One HogFunction is created per alert event kind (firing, resolved, ...) atomically.",
     )
-    @action(detail=True, methods=["POST"], url_path="destinations", required_scopes=["logs:write"])
+    # NOTE: `required_scopes` is intentionally not set on @action here. list_destinations is
+    # registered below via @create_destination.mapping.get and shares this URL pattern's
+    # initkwargs, so setting required_scopes here would apply logs:write to the read too.
+    # Scopes are resolved per-method in dangerously_get_required_scopes instead.
+    @action(detail=True, methods=["POST"], url_path="destinations")
     def create_destination(self, request: Request, *args: object, **kwargs: object) -> Response:
         serializer = LogsAlertCreateDestinationSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -980,6 +1009,31 @@ class LogsAlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         )
         response = LogsAlertDestinationResponseSerializer({"hog_function_ids": [hf.id for hf in hog_functions]})
         return Response(response.data, status=201)
+
+    @extend_schema(
+        request=None,
+        responses={200: LogsAlertDestinationConfigSerializer(many=True)},
+        description=(
+            "List the notification destinations configured for this alert. Creating a destination "
+            "fans out into one HogFunction per alert event kind (firing, resolved, ...); this returns "
+            "one entry per destination, carrying the whole group's HogFunction IDs and the config it "
+            "was created with."
+        ),
+    )
+    @create_destination.mapping.get
+    def list_destinations(self, request: Request, *args: object, **kwargs: object) -> Response:
+        alert = self.get_object()
+        groups = list_alert_destination_groups(
+            team_id=self.team_id,
+            alert_id=str(alert.id),
+            allowed_event_ids=LOGS_ALERT_EVENT_IDS,
+            allowed_destination_types=LOGS_DESTINATION_TYPES,
+        )
+        serializer = LogsAlertDestinationConfigSerializer(
+            [{"hog_function_ids": list(group.hog_function_ids), **group.data} for group in groups],
+            many=True,
+        )
+        return Response(serializer.data)
 
     @extend_schema(
         request=LogsAlertDeleteDestinationSerializer,

--- a/products/logs/backend/test/test_alerts_api.py
+++ b/products/logs/backend/test/test_alerts_api.py
@@ -1143,6 +1143,34 @@ class TestLogsAlertAPI(APIBaseTest):
         assert destinations[0]["type"] == "teams"
         assert destinations[0]["webhook_url"] == "https://prod-00.westus.logic.azure.com:443/…"
 
+    def test_list_destinations_reports_disabled_when_one_hog_function_is_disabled(self):
+        self._sync_destination_templates()
+        created = self._create_via_api()
+        ids = self._create_destination(created["id"], {"type": "webhook", "webhook_url": "https://example.com/hook"})
+        HogFunction.objects.filter(id=ids[0]).update(enabled=False)
+
+        response = self.client.get(self._destinations_url(created["id"]))
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        destinations = response.json()["results"]
+        assert len(destinations) == 1
+        assert destinations[0]["enabled"] is False
+
+    def test_list_destinations_reports_enabled_per_destination(self):
+        self._sync_destination_templates()
+        created = self._create_via_api()
+        paused_ids = self._create_destination(
+            created["id"], {"type": "webhook", "webhook_url": "https://paused.example.com/hook"}
+        )
+        self._create_destination(created["id"], {"type": "webhook", "webhook_url": "https://active.example.com/hook"})
+        HogFunction.objects.filter(id__in=paused_ids).update(enabled=False)
+
+        response = self.client.get(self._destinations_url(created["id"]))
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        by_url = {destination["webhook_url"]: destination["enabled"] for destination in response.json()["results"]}
+        assert by_url == {"https://paused.example.com/…": False, "https://active.example.com/…": True}
+
     def test_list_destinations_groups_each_destinations_hog_functions_into_one_entry(self):
         self._sync_destination_templates()
         created = self._create_via_api()
@@ -1255,17 +1283,17 @@ class TestLogsAlertAPI(APIBaseTest):
             (
                 "slack",
                 {"type": "slack", "slack_workspace_id": 42, "slack_channel_id": "C123"},
-                {"type": "slack", "slack_workspace_id": 42, "slack_channel_id": "C123"},
+                {"type": "slack", "enabled": True, "slack_workspace_id": 42, "slack_channel_id": "C123"},
             ),
             (
                 "webhook",
                 {"type": "webhook", "webhook_url": "https://example.com/hook"},
-                {"type": "webhook", "webhook_url": "https://example.com/…"},
+                {"type": "webhook", "enabled": True, "webhook_url": "https://example.com/…"},
             ),
             (
                 "teams",
                 {"type": "teams", "webhook_url": "https://example.com/teams"},
-                {"type": "teams", "webhook_url": "https://example.com/…"},
+                {"type": "teams", "enabled": True, "webhook_url": "https://example.com/…"},
             ),
         ]
     )

--- a/products/logs/backend/test/test_alerts_api.py
+++ b/products/logs/backend/test/test_alerts_api.py
@@ -1077,45 +1077,33 @@ class TestLogsAlertAPI(APIBaseTest):
         # Creation writes slack_channel_name into the HogFunction name, not its inputs.
         assert "slack_channel_name" not in destinations[0]
 
-    def test_list_destinations_returns_paginated_envelope(self):
+    def test_list_destinations_pages_in_creation_order_without_overlap(self):
         self._sync_destination_templates()
         created = self._create_via_api()
-        self._create_destination(created["id"], {"type": "webhook", "webhook_url": "https://example.com/hook"})
-
-        response = self.client.get(self._destinations_url(created["id"]))
-
-        assert response.status_code == status.HTTP_200_OK, response.json()
-        body = response.json()
-        assert set(body) == {"count", "next", "previous", "results"}
-        assert body["count"] == 1
-        assert body["next"] is None
-        assert body["previous"] is None
-        assert [destination["type"] for destination in body["results"]] == ["webhook"]
-
-    def test_list_destinations_pages_with_limit_and_offset(self):
-        self._sync_destination_templates()
-        created = self._create_via_api()
-        for host in ("first", "second", "third"):
-            self._create_destination(created["id"], {"type": "webhook", "webhook_url": f"https://{host}.example.com/h"})
-
-        first_page = self.client.get(self._destinations_url(created["id"]), {"limit": 2})
-        second_page = self.client.get(self._destinations_url(created["id"]), {"limit": 2, "offset": 2})
-
-        assert first_page.status_code == status.HTTP_200_OK, first_page.json()
-        assert second_page.status_code == status.HTTP_200_OK, second_page.json()
-        # Groups come back in HogFunction creation order, so the pages don't overlap.
-        assert first_page.json()["count"] == 3
-        assert [destination["webhook_url"] for destination in first_page.json()["results"]] == [
-            "https://first.example.com/…",
-            "https://second.example.com/…",
+        created_ids = [
+            sorted(
+                self._create_destination(
+                    created["id"], {"type": "webhook", "webhook_url": f"https://{host}.example.com/h"}
+                )
+            )
+            for host in ("first", "second", "third")
         ]
-        assert first_page.json()["next"] is not None
-        assert second_page.json()["count"] == 3
-        assert [destination["webhook_url"] for destination in second_page.json()["results"]] == [
-            "https://third.example.com/…",
-        ]
-        assert second_page.json()["next"] is None
-        assert second_page.json()["previous"] is not None
+
+        first_response = self.client.get(self._destinations_url(created["id"]), {"limit": 2})
+        second_response = self.client.get(self._destinations_url(created["id"]), {"limit": 2, "offset": 2})
+
+        assert first_response.status_code == status.HTTP_200_OK, first_response.json()
+        assert second_response.status_code == status.HTTP_200_OK, second_response.json()
+        first_page, second_page = first_response.json(), second_response.json()
+        assert set(first_page) == {"count", "next", "previous", "results"}
+        assert first_page["count"] == 3
+        assert second_page["count"] == 3
+        assert [sorted(d["hog_function_ids"]) for d in first_page["results"]] == created_ids[:2]
+        assert [sorted(d["hog_function_ids"]) for d in second_page["results"]] == created_ids[2:]
+        assert first_page["next"] is not None
+        assert first_page["previous"] is None
+        assert second_page["next"] is None
+        assert second_page["previous"] is not None
 
     def test_list_destinations_redacts_webhook_url(self):
         self._sync_destination_templates()
@@ -1130,7 +1118,6 @@ class TestLogsAlertAPI(APIBaseTest):
         destinations = response.json()["results"]
         assert len(destinations) == 1
         assert destinations[0]["type"] == "webhook"
-        # The path and query carry the credential, so only scheme and host come back.
         assert destinations[0]["webhook_url"] == "https://example.com/…"
 
     def test_list_destinations_redacts_teams_webhook_url(self):
@@ -1146,16 +1133,6 @@ class TestLogsAlertAPI(APIBaseTest):
         assert len(destinations) == 1
         assert destinations[0]["type"] == "teams"
         assert destinations[0]["webhook_url"] == "https://prod-00.westus.logic.azure.com:443/…"
-
-    def test_list_destinations_never_stores_the_redacted_url(self):
-        self._sync_destination_templates()
-        created = self._create_via_api()
-        ids = self._create_destination(created["id"], {"type": "webhook", "webhook_url": "https://example.com/hook"})
-
-        assert self.client.get(self._destinations_url(created["id"])).status_code == status.HTTP_200_OK
-        # Redaction is a read-path concern only — delivery still needs the real URL.
-        stored = HogFunction.objects.filter(id__in=ids).values_list("inputs", flat=True)
-        assert {inputs["url"]["value"] for inputs in stored} == {"https://example.com/hook"}
 
     def test_list_destinations_groups_each_destinations_hog_functions_into_one_entry(self):
         self._sync_destination_templates()
@@ -1251,12 +1228,26 @@ class TestLogsAlertAPI(APIBaseTest):
 
     @parameterized.expand(
         [
-            ("slack", {"type": "slack", "slack_workspace_id": 42, "slack_channel_id": "C123"}),
-            ("webhook", {"type": "webhook", "webhook_url": "https://example.com/hook"}),
-            ("teams", {"type": "teams", "webhook_url": "https://example.com/teams"}),
+            (
+                "slack",
+                {"type": "slack", "slack_workspace_id": 42, "slack_channel_id": "C123"},
+                {"type": "slack", "slack_workspace_id": 42, "slack_channel_id": "C123"},
+            ),
+            (
+                "webhook",
+                {"type": "webhook", "webhook_url": "https://example.com/hook"},
+                {"type": "webhook", "webhook_url": "https://example.com/…"},
+            ),
+            (
+                "teams",
+                {"type": "teams", "webhook_url": "https://example.com/teams"},
+                {"type": "teams", "webhook_url": "https://example.com/…"},
+            ),
         ]
     )
-    def test_list_destinations_round_trips_created_config(self, _name: str, payload: dict) -> None:
+    def test_list_destinations_round_trips_created_config(
+        self, _name: str, payload: dict, expected_read_back: dict
+    ) -> None:
         self._sync_destination_templates()
         created = self._create_via_api()
         ids = self._create_destination(created["id"], payload)
@@ -1267,11 +1258,7 @@ class TestLogsAlertAPI(APIBaseTest):
         destinations = response.json()["results"]
         assert len(destinations) == 1
         assert sorted(destinations[0].pop("hog_function_ids")) == sorted(ids)
-        # webhook_url is the one created field that cannot round-trip: the read redacts it.
-        expected = dict(payload)
-        if "webhook_url" in expected:
-            expected["webhook_url"] = "https://example.com/…"
-        assert destinations[0] == expected
+        assert destinations[0] == expected_read_back
 
     # --- Reset ---
 

--- a/products/logs/backend/test/test_alerts_api.py
+++ b/products/logs/backend/test/test_alerts_api.py
@@ -1040,15 +1040,15 @@ class TestLogsAlertAPI(APIBaseTest):
         assert response.status_code == status.HTTP_201_CREATED, response.json()
         return response.json()["hog_function_ids"]
 
-    def _make_foreign_hog_function(self, *, team: Team, alert_id: str, url: str) -> HogFunction:
+    def _make_webhook_hog_function(self, *, team: Team, alert_id: str, inputs: dict) -> HogFunction:
         return HogFunction.objects.create(
             team=team,
-            name="Other team destination",
+            name="Directly created destination",
             type="destination",
             template_id="template-webhook",
             enabled=True,
             inputs_schema=[{"key": "url", "type": "string"}],
-            inputs={"url": {"value": url}},
+            inputs=inputs,
             hog="return event",
             filters={
                 "events": [{"id": "$logs_alert_firing", "type": "events"}],
@@ -1056,7 +1056,24 @@ class TestLogsAlertAPI(APIBaseTest):
             },
         )
 
-    def test_list_destinations_returns_slack_config(self):
+    def test_list_destinations_returns_slack_ids_unredacted(self):
+        self._sync_destination_templates()
+        created = self._create_via_api()
+        self._create_destination(
+            created["id"],
+            {"type": "slack", "slack_workspace_id": 42, "slack_channel_id": "C123"},
+        )
+
+        response = self.client.get(self._destinations_url(created["id"]))
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        destinations = response.json()["results"]
+        assert len(destinations) == 1
+        assert destinations[0]["type"] == "slack"
+        assert destinations[0]["slack_workspace_id"] == 42
+        assert destinations[0]["slack_channel_id"] == "C123"
+
+    def test_list_destinations_omits_slack_channel_name(self):
         self._sync_destination_templates()
         created = self._create_via_api()
         self._create_destination(
@@ -1067,15 +1084,7 @@ class TestLogsAlertAPI(APIBaseTest):
         response = self.client.get(self._destinations_url(created["id"]))
 
         assert response.status_code == status.HTTP_200_OK, response.json()
-        destinations = response.json()["results"]
-        assert len(destinations) == 1
-        assert destinations[0]["type"] == "slack"
-        # Slack config is returned whole: the workspace is an integration ID, and the channel ID
-        # is useless without it, so neither is a credential the way a webhook URL is.
-        assert destinations[0]["slack_workspace_id"] == 42
-        assert destinations[0]["slack_channel_id"] == "C123"
-        # Creation writes slack_channel_name into the HogFunction name, not its inputs.
-        assert "slack_channel_name" not in destinations[0]
+        assert "slack_channel_name" not in response.json()["results"][0]
 
     def test_list_destinations_pages_in_creation_order_without_overlap(self):
         self._sync_destination_templates()
@@ -1148,7 +1157,6 @@ class TestLogsAlertAPI(APIBaseTest):
 
         assert response.status_code == status.HTTP_200_OK, response.json()
         destinations = response.json()["results"]
-        # Two destinations, four HogFunctions each, not eight single-function entries.
         assert len(destinations) == 2
         by_type = {destination["type"]: destination for destination in destinations}
         assert sorted(by_type["slack"]["hog_function_ids"]) == sorted(slack_ids)
@@ -1165,6 +1173,21 @@ class TestLogsAlertAPI(APIBaseTest):
         assert response.status_code == status.HTTP_200_OK, response.json()
         destinations = response.json()["results"]
         assert sorted(destination["slack_channel_id"] for destination in destinations) == ["C1", "C2"]
+
+    def test_list_destinations_keeps_rows_with_unreadable_inputs_apart(self):
+        self._sync_destination_templates()
+        created = self._create_via_api()
+        unreadable = [
+            self._make_webhook_hog_function(team=self.team, alert_id=created["id"], inputs={}) for _ in range(2)
+        ]
+
+        response = self.client.get(self._destinations_url(created["id"]))
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        destinations = response.json()["results"]
+        assert sorted(destination["hog_function_ids"] for destination in destinations) == sorted(
+            [str(hog_function.id)] for hog_function in unreadable
+        )
 
     def test_list_destinations_returns_empty_list_without_destinations(self):
         created = self._create_via_api()
@@ -1193,7 +1216,6 @@ class TestLogsAlertAPI(APIBaseTest):
         self._sync_destination_templates()
         created_a = self._create_via_api()
         created_b = self._create_via_api(name="Another alert")
-        # Distinct hosts, not distinct paths: the read redacts the path away.
         self._create_destination(created_a["id"], {"type": "webhook", "webhook_url": "https://a.example.com/hook"})
         self._create_destination(created_b["id"], {"type": "webhook", "webhook_url": "https://b.example.com/hook"})
 
@@ -1207,7 +1229,9 @@ class TestLogsAlertAPI(APIBaseTest):
         created = self._create_via_api()
         self._create_destination(created["id"], {"type": "webhook", "webhook_url": "https://ours.example.com/hook"})
         other_team = Team.objects.create(organization=self.organization, name="Other")
-        self._make_foreign_hog_function(team=other_team, alert_id=created["id"], url="https://theirs.example.com/hook")
+        self._make_webhook_hog_function(
+            team=other_team, alert_id=created["id"], inputs={"url": {"value": "https://theirs.example.com/hook"}}
+        )
 
         response = self.client.get(self._destinations_url(created["id"]))
 
@@ -2408,8 +2432,6 @@ class TestLogsAlertAPIPersonalAPIKeyScopes(APIBaseTest):
         assert response.status_code == 403, response.json()
 
     # --- list_destinations action (GET detail, requires logs:read) ---
-    # Shares the `destinations` URL with create_destination, so these also prove the
-    # per-method scope split holds in both directions.
 
     def test_list_destinations_allowed_with_logs_read_scope(self):
         key = self.create_personal_api_key_with_scopes(["logs:read"])

--- a/products/logs/backend/test/test_alerts_api.py
+++ b/products/logs/backend/test/test_alerts_api.py
@@ -1033,8 +1033,6 @@ class TestLogsAlertAPI(APIBaseTest):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json()["attr"] == "hog_function_ids"
 
-    # --- List destinations ---
-
     def _create_destination(self, alert_id: str, payload: dict) -> list[str]:
         response = self.client.post(self._destinations_url(alert_id), payload, format="json")
         assert response.status_code == status.HTTP_201_CREATED, response.json()

--- a/products/logs/backend/test/test_alerts_api.py
+++ b/products/logs/backend/test/test_alerts_api.py
@@ -1033,6 +1033,183 @@ class TestLogsAlertAPI(APIBaseTest):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json()["attr"] == "hog_function_ids"
 
+    # --- List destinations ---
+
+    def _create_destination(self, alert_id: str, payload: dict) -> list[str]:
+        response = self.client.post(self._destinations_url(alert_id), payload, format="json")
+        assert response.status_code == status.HTTP_201_CREATED, response.json()
+        return response.json()["hog_function_ids"]
+
+    def _make_foreign_hog_function(self, *, team: Team, alert_id: str, url: str) -> HogFunction:
+        return HogFunction.objects.create(
+            team=team,
+            name="Other team destination",
+            type="destination",
+            template_id="template-webhook",
+            enabled=True,
+            inputs_schema=[{"key": "url", "type": "string"}],
+            inputs={"url": {"value": url}},
+            hog="return event",
+            filters={
+                "events": [{"id": "$logs_alert_firing", "type": "events"}],
+                "properties": [{"key": "alert_id", "value": alert_id}],
+            },
+        )
+
+    def test_list_destinations_returns_slack_config(self):
+        self._sync_destination_templates()
+        created = self._create_via_api()
+        self._create_destination(
+            created["id"],
+            {"type": "slack", "slack_workspace_id": 42, "slack_channel_id": "C123", "slack_channel_name": "alerts"},
+        )
+
+        response = self.client.get(self._destinations_url(created["id"]))
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        destinations = response.json()
+        assert len(destinations) == 1
+        assert destinations[0]["type"] == "slack"
+        assert destinations[0]["slack_workspace_id"] == 42
+        assert destinations[0]["slack_channel_id"] == "C123"
+        # Creation writes slack_channel_name into the HogFunction name, not its inputs.
+        assert "slack_channel_name" not in destinations[0]
+
+    def test_list_destinations_returns_webhook_url(self):
+        self._sync_destination_templates()
+        created = self._create_via_api()
+        self._create_destination(created["id"], {"type": "webhook", "webhook_url": "https://example.com/hook"})
+
+        response = self.client.get(self._destinations_url(created["id"]))
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        destinations = response.json()
+        assert len(destinations) == 1
+        assert destinations[0]["type"] == "webhook"
+        assert destinations[0]["webhook_url"] == "https://example.com/hook"
+
+    def test_list_destinations_returns_teams_webhook_url(self):
+        self._sync_destination_templates()
+        created = self._create_via_api()
+        teams_url = "https://prod-00.westus.logic.azure.com:443/workflows/abc/triggers/manual/paths/invoke"
+        self._create_destination(created["id"], {"type": "teams", "webhook_url": teams_url})
+
+        response = self.client.get(self._destinations_url(created["id"]))
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        destinations = response.json()
+        assert len(destinations) == 1
+        assert destinations[0]["type"] == "teams"
+        assert destinations[0]["webhook_url"] == teams_url
+
+    def test_list_destinations_groups_each_destinations_hog_functions_into_one_entry(self):
+        self._sync_destination_templates()
+        created = self._create_via_api()
+        slack_ids = self._create_destination(
+            created["id"], {"type": "slack", "slack_workspace_id": 7, "slack_channel_id": "C999"}
+        )
+        webhook_ids = self._create_destination(
+            created["id"], {"type": "webhook", "webhook_url": "https://example.com/hook"}
+        )
+
+        response = self.client.get(self._destinations_url(created["id"]))
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        destinations = response.json()
+        # Two destinations, four HogFunctions each, not eight single-function entries.
+        assert len(destinations) == 2
+        by_type = {destination["type"]: destination for destination in destinations}
+        assert sorted(by_type["slack"]["hog_function_ids"]) == sorted(slack_ids)
+        assert sorted(by_type["webhook"]["hog_function_ids"]) == sorted(webhook_ids)
+
+    def test_list_destinations_separates_two_slack_channels(self):
+        self._sync_destination_templates()
+        created = self._create_via_api()
+        self._create_destination(created["id"], {"type": "slack", "slack_workspace_id": 7, "slack_channel_id": "C1"})
+        self._create_destination(created["id"], {"type": "slack", "slack_workspace_id": 7, "slack_channel_id": "C2"})
+
+        response = self.client.get(self._destinations_url(created["id"]))
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        destinations = response.json()
+        assert sorted(destination["slack_channel_id"] for destination in destinations) == ["C1", "C2"]
+
+    def test_list_destinations_returns_empty_list_without_destinations(self):
+        created = self._create_via_api()
+
+        response = self.client.get(self._destinations_url(created["id"]))
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        assert response.json() == []
+
+    def test_list_destinations_excludes_soft_deleted_destinations(self):
+        self._sync_destination_templates()
+        created = self._create_via_api()
+        ids = self._create_destination(created["id"], {"type": "webhook", "webhook_url": "https://example.com/hook"})
+        delete_response = self.client.post(
+            self._destinations_delete_url(created["id"]), {"hog_function_ids": ids}, format="json"
+        )
+        assert delete_response.status_code == status.HTTP_204_NO_CONTENT
+
+        response = self.client.get(self._destinations_url(created["id"]))
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        assert response.json() == []
+
+    def test_list_destinations_excludes_other_alerts_destinations(self):
+        self._sync_destination_templates()
+        created_a = self._create_via_api()
+        created_b = self._create_via_api(name="Another alert")
+        self._create_destination(created_a["id"], {"type": "webhook", "webhook_url": "https://example.com/a"})
+        self._create_destination(created_b["id"], {"type": "webhook", "webhook_url": "https://example.com/b"})
+
+        response = self.client.get(self._destinations_url(created_b["id"]))
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        assert [destination["webhook_url"] for destination in response.json()] == ["https://example.com/b"]
+
+    def test_list_destinations_excludes_other_teams_hog_functions(self):
+        self._sync_destination_templates()
+        created = self._create_via_api()
+        self._create_destination(created["id"], {"type": "webhook", "webhook_url": "https://example.com/ours"})
+        other_team = Team.objects.create(organization=self.organization, name="Other")
+        self._make_foreign_hog_function(team=other_team, alert_id=created["id"], url="https://example.com/theirs")
+
+        response = self.client.get(self._destinations_url(created["id"]))
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        assert [destination["webhook_url"] for destination in response.json()] == ["https://example.com/ours"]
+
+    def test_list_destinations_on_other_teams_alert_returns_404(self):
+        other_team = Team.objects.create(organization=self.organization, name="Other")
+        other_alert = LogsAlertConfiguration.objects.create(
+            team=other_team, name="Other", threshold_count=10, filters={"severityLevels": ["error"]}
+        )
+
+        response = self.client.get(self._destinations_url(str(other_alert.id)))
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @parameterized.expand(
+        [
+            ("slack", {"type": "slack", "slack_workspace_id": 42, "slack_channel_id": "C123"}),
+            ("webhook", {"type": "webhook", "webhook_url": "https://example.com/hook"}),
+            ("teams", {"type": "teams", "webhook_url": "https://example.com/teams"}),
+        ]
+    )
+    def test_list_destinations_round_trips_created_config(self, _name: str, payload: dict) -> None:
+        self._sync_destination_templates()
+        created = self._create_via_api()
+        ids = self._create_destination(created["id"], payload)
+
+        response = self.client.get(self._destinations_url(created["id"]))
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        destinations = response.json()
+        assert len(destinations) == 1
+        assert sorted(destinations[0].pop("hog_function_ids")) == sorted(ids)
+        assert destinations[0] == payload
+
     # --- Reset ---
 
     def _reset_url(self, alert_id: str) -> str:
@@ -2178,6 +2355,28 @@ class TestLogsAlertAPIPersonalAPIKeyScopes(APIBaseTest):
         key = self.create_personal_api_key_with_scopes(scopes)
         url = f"{self.base_url}{uuid4()}/destinations/"
         response = self.client.post(url, {}, format="json", **self._auth(key))
+        assert response.status_code == 403, response.json()
+
+    # --- list_destinations action (GET detail, requires logs:read) ---
+    # Shares the `destinations` URL with create_destination, so these also prove the
+    # per-method scope split holds in both directions.
+
+    def test_list_destinations_allowed_with_logs_read_scope(self):
+        key = self.create_personal_api_key_with_scopes(["logs:read"])
+        url = f"{self.base_url}{uuid4()}/destinations/"
+        response = self.client.get(url, **self._auth(key))
+        assert response.status_code == status.HTTP_404_NOT_FOUND, response.json()
+
+    @parameterized.expand(
+        [
+            ("unrelated_scope", ["insight:read"]),
+            ("no_scopes", []),
+        ]
+    )
+    def test_list_destinations_rejected_without_logs_read_scope(self, _name: str, scopes: list[str]):
+        key = self.create_personal_api_key_with_scopes(scopes)
+        url = f"{self.base_url}{uuid4()}/destinations/"
+        response = self.client.get(url, **self._auth(key))
         assert response.status_code == 403, response.json()
 
     # --- delete_destination action (POST detail, requires logs:write) ---

--- a/products/logs/backend/test/test_alerts_api.py
+++ b/products/logs/backend/test/test_alerts_api.py
@@ -1067,15 +1067,17 @@ class TestLogsAlertAPI(APIBaseTest):
         response = self.client.get(self._destinations_url(created["id"]))
 
         assert response.status_code == status.HTTP_200_OK, response.json()
-        destinations = response.json()
+        destinations = response.json()["results"]
         assert len(destinations) == 1
         assert destinations[0]["type"] == "slack"
+        # Slack config is returned whole: the workspace is an integration ID, and the channel ID
+        # is useless without it, so neither is a credential the way a webhook URL is.
         assert destinations[0]["slack_workspace_id"] == 42
         assert destinations[0]["slack_channel_id"] == "C123"
         # Creation writes slack_channel_name into the HogFunction name, not its inputs.
         assert "slack_channel_name" not in destinations[0]
 
-    def test_list_destinations_returns_webhook_url(self):
+    def test_list_destinations_returns_paginated_envelope(self):
         self._sync_destination_templates()
         created = self._create_via_api()
         self._create_destination(created["id"], {"type": "webhook", "webhook_url": "https://example.com/hook"})
@@ -1083,12 +1085,55 @@ class TestLogsAlertAPI(APIBaseTest):
         response = self.client.get(self._destinations_url(created["id"]))
 
         assert response.status_code == status.HTTP_200_OK, response.json()
-        destinations = response.json()
+        body = response.json()
+        assert set(body) == {"count", "next", "previous", "results"}
+        assert body["count"] == 1
+        assert body["next"] is None
+        assert body["previous"] is None
+        assert [destination["type"] for destination in body["results"]] == ["webhook"]
+
+    def test_list_destinations_pages_with_limit_and_offset(self):
+        self._sync_destination_templates()
+        created = self._create_via_api()
+        for host in ("first", "second", "third"):
+            self._create_destination(created["id"], {"type": "webhook", "webhook_url": f"https://{host}.example.com/h"})
+
+        first_page = self.client.get(self._destinations_url(created["id"]), {"limit": 2})
+        second_page = self.client.get(self._destinations_url(created["id"]), {"limit": 2, "offset": 2})
+
+        assert first_page.status_code == status.HTTP_200_OK, first_page.json()
+        assert second_page.status_code == status.HTTP_200_OK, second_page.json()
+        # Groups come back in HogFunction creation order, so the pages don't overlap.
+        assert first_page.json()["count"] == 3
+        assert [destination["webhook_url"] for destination in first_page.json()["results"]] == [
+            "https://first.example.com/…",
+            "https://second.example.com/…",
+        ]
+        assert first_page.json()["next"] is not None
+        assert second_page.json()["count"] == 3
+        assert [destination["webhook_url"] for destination in second_page.json()["results"]] == [
+            "https://third.example.com/…",
+        ]
+        assert second_page.json()["next"] is None
+        assert second_page.json()["previous"] is not None
+
+    def test_list_destinations_redacts_webhook_url(self):
+        self._sync_destination_templates()
+        created = self._create_via_api()
+        self._create_destination(
+            created["id"], {"type": "webhook", "webhook_url": "https://example.com/hook?token=s3cret"}
+        )
+
+        response = self.client.get(self._destinations_url(created["id"]))
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        destinations = response.json()["results"]
         assert len(destinations) == 1
         assert destinations[0]["type"] == "webhook"
-        assert destinations[0]["webhook_url"] == "https://example.com/hook"
+        # The path and query carry the credential, so only scheme and host come back.
+        assert destinations[0]["webhook_url"] == "https://example.com/…"
 
-    def test_list_destinations_returns_teams_webhook_url(self):
+    def test_list_destinations_redacts_teams_webhook_url(self):
         self._sync_destination_templates()
         created = self._create_via_api()
         teams_url = "https://prod-00.westus.logic.azure.com:443/workflows/abc/triggers/manual/paths/invoke"
@@ -1097,10 +1142,20 @@ class TestLogsAlertAPI(APIBaseTest):
         response = self.client.get(self._destinations_url(created["id"]))
 
         assert response.status_code == status.HTTP_200_OK, response.json()
-        destinations = response.json()
+        destinations = response.json()["results"]
         assert len(destinations) == 1
         assert destinations[0]["type"] == "teams"
-        assert destinations[0]["webhook_url"] == teams_url
+        assert destinations[0]["webhook_url"] == "https://prod-00.westus.logic.azure.com:443/…"
+
+    def test_list_destinations_never_stores_the_redacted_url(self):
+        self._sync_destination_templates()
+        created = self._create_via_api()
+        ids = self._create_destination(created["id"], {"type": "webhook", "webhook_url": "https://example.com/hook"})
+
+        assert self.client.get(self._destinations_url(created["id"])).status_code == status.HTTP_200_OK
+        # Redaction is a read-path concern only — delivery still needs the real URL.
+        stored = HogFunction.objects.filter(id__in=ids).values_list("inputs", flat=True)
+        assert {inputs["url"]["value"] for inputs in stored} == {"https://example.com/hook"}
 
     def test_list_destinations_groups_each_destinations_hog_functions_into_one_entry(self):
         self._sync_destination_templates()
@@ -1115,7 +1170,7 @@ class TestLogsAlertAPI(APIBaseTest):
         response = self.client.get(self._destinations_url(created["id"]))
 
         assert response.status_code == status.HTTP_200_OK, response.json()
-        destinations = response.json()
+        destinations = response.json()["results"]
         # Two destinations, four HogFunctions each, not eight single-function entries.
         assert len(destinations) == 2
         by_type = {destination["type"]: destination for destination in destinations}
@@ -1131,7 +1186,7 @@ class TestLogsAlertAPI(APIBaseTest):
         response = self.client.get(self._destinations_url(created["id"]))
 
         assert response.status_code == status.HTTP_200_OK, response.json()
-        destinations = response.json()
+        destinations = response.json()["results"]
         assert sorted(destination["slack_channel_id"] for destination in destinations) == ["C1", "C2"]
 
     def test_list_destinations_returns_empty_list_without_destinations(self):
@@ -1140,7 +1195,8 @@ class TestLogsAlertAPI(APIBaseTest):
         response = self.client.get(self._destinations_url(created["id"]))
 
         assert response.status_code == status.HTTP_200_OK, response.json()
-        assert response.json() == []
+        assert response.json()["count"] == 0
+        assert response.json()["results"] == []
 
     def test_list_destinations_excludes_soft_deleted_destinations(self):
         self._sync_destination_templates()
@@ -1154,31 +1210,34 @@ class TestLogsAlertAPI(APIBaseTest):
         response = self.client.get(self._destinations_url(created["id"]))
 
         assert response.status_code == status.HTTP_200_OK, response.json()
-        assert response.json() == []
+        assert response.json()["results"] == []
 
     def test_list_destinations_excludes_other_alerts_destinations(self):
         self._sync_destination_templates()
         created_a = self._create_via_api()
         created_b = self._create_via_api(name="Another alert")
-        self._create_destination(created_a["id"], {"type": "webhook", "webhook_url": "https://example.com/a"})
-        self._create_destination(created_b["id"], {"type": "webhook", "webhook_url": "https://example.com/b"})
+        # Distinct hosts, not distinct paths: the read redacts the path away.
+        self._create_destination(created_a["id"], {"type": "webhook", "webhook_url": "https://a.example.com/hook"})
+        self._create_destination(created_b["id"], {"type": "webhook", "webhook_url": "https://b.example.com/hook"})
 
         response = self.client.get(self._destinations_url(created_b["id"]))
 
         assert response.status_code == status.HTTP_200_OK, response.json()
-        assert [destination["webhook_url"] for destination in response.json()] == ["https://example.com/b"]
+        assert [destination["webhook_url"] for destination in response.json()["results"]] == ["https://b.example.com/…"]
 
     def test_list_destinations_excludes_other_teams_hog_functions(self):
         self._sync_destination_templates()
         created = self._create_via_api()
-        self._create_destination(created["id"], {"type": "webhook", "webhook_url": "https://example.com/ours"})
+        self._create_destination(created["id"], {"type": "webhook", "webhook_url": "https://ours.example.com/hook"})
         other_team = Team.objects.create(organization=self.organization, name="Other")
-        self._make_foreign_hog_function(team=other_team, alert_id=created["id"], url="https://example.com/theirs")
+        self._make_foreign_hog_function(team=other_team, alert_id=created["id"], url="https://theirs.example.com/hook")
 
         response = self.client.get(self._destinations_url(created["id"]))
 
         assert response.status_code == status.HTTP_200_OK, response.json()
-        assert [destination["webhook_url"] for destination in response.json()] == ["https://example.com/ours"]
+        assert [destination["webhook_url"] for destination in response.json()["results"]] == [
+            "https://ours.example.com/…"
+        ]
 
     def test_list_destinations_on_other_teams_alert_returns_404(self):
         other_team = Team.objects.create(organization=self.organization, name="Other")
@@ -1205,10 +1264,14 @@ class TestLogsAlertAPI(APIBaseTest):
         response = self.client.get(self._destinations_url(created["id"]))
 
         assert response.status_code == status.HTTP_200_OK, response.json()
-        destinations = response.json()
+        destinations = response.json()["results"]
         assert len(destinations) == 1
         assert sorted(destinations[0].pop("hog_function_ids")) == sorted(ids)
-        assert destinations[0] == payload
+        # webhook_url is the one created field that cannot round-trip: the read redacts it.
+        expected = dict(payload)
+        if "webhook_url" in expected:
+            expected["webhook_url"] = "https://example.com/…"
+        assert destinations[0] == expected
 
     # --- Reset ---
 

--- a/products/logs/frontend/generated/api.schemas.ts
+++ b/products/logs/frontend/generated/api.schemas.ts
@@ -678,15 +678,6 @@ export interface PatchedLogsAlertConfigurationApi {
     readonly updated_at?: string | null
 }
 
-/**
- * A configured destination, with the fields it was created with.
- *
- * Two of those fields do not come back as sent. slack_channel_name has no counterpart at all:
- * creation puts it in the HogFunction name rather than its inputs, so there is nothing to read
- * back. webhook_url comes back redacted to scheme and host, because the full URL is a bearer
- * credential and logs:read includes viewers — so a caller cannot use this response to compare
- * the stored URL against the one it sent.
- */
 export interface LogsAlertDestinationConfigApi {
     hog_function_ids: string[]
     /** Notification destination type.

--- a/products/logs/frontend/generated/api.schemas.ts
+++ b/products/logs/frontend/generated/api.schemas.ts
@@ -686,6 +686,8 @@ export interface LogsAlertDestinationConfigApi {
      * * `webhook` - webhook
      * * `teams` - teams */
     type: NotificationDestinationTypeEnumApi
+    /** False when any HogFunction in the group is disabled, because the destination then misses at least one alert event kind. */
+    enabled: boolean
     /** Integration ID for the Slack workspace. Present when type=slack. */
     slack_workspace_id?: number
     /** Slack channel ID. Present when type=slack. */

--- a/products/logs/frontend/generated/api.schemas.ts
+++ b/products/logs/frontend/generated/api.schemas.ts
@@ -678,6 +678,37 @@ export interface PatchedLogsAlertConfigurationApi {
     readonly updated_at?: string | null
 }
 
+/**
+ * A configured destination, with the fields it was created with so the two round-trip.
+ *
+ * slack_channel_name has no counterpart here: creation puts it in the HogFunction name
+ * rather than its inputs, so there is nothing to read back.
+ */
+export interface LogsAlertDestinationConfigApi {
+    hog_function_ids: string[]
+    /** Notification destination type.
+     *
+     * * `slack` - slack
+     * * `webhook` - webhook
+     * * `teams` - teams */
+    type: NotificationDestinationTypeEnumApi
+    /** Integration ID for the Slack workspace. Present when type=slack. */
+    slack_workspace_id?: number
+    /** Slack channel ID. Present when type=slack. */
+    slack_channel_id?: string
+    /** Endpoint posted to. Present for webhook and teams. */
+    webhook_url?: string
+}
+
+export interface PaginatedLogsAlertDestinationConfigListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: LogsAlertDestinationConfigApi[]
+}
+
 export interface LogsAlertCreateDestinationApi {
     /** Notification destination type.
      *
@@ -2291,6 +2322,17 @@ export type LogsAlertsListParams = {
      * Only return log alerts created by the user with this UUID.
      */
     created_by?: string
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number
+}
+
+export type LogsAlertsDestinationsListParams = {
     /**
      * Number of results to return per page.
      */

--- a/products/logs/frontend/generated/api.schemas.ts
+++ b/products/logs/frontend/generated/api.schemas.ts
@@ -679,10 +679,13 @@ export interface PatchedLogsAlertConfigurationApi {
 }
 
 /**
- * A configured destination, with the fields it was created with so the two round-trip.
+ * A configured destination, with the fields it was created with.
  *
- * slack_channel_name has no counterpart here: creation puts it in the HogFunction name
- * rather than its inputs, so there is nothing to read back.
+ * Two of those fields do not come back as sent. slack_channel_name has no counterpart at all:
+ * creation puts it in the HogFunction name rather than its inputs, so there is nothing to read
+ * back. webhook_url comes back redacted to scheme and host, because the full URL is a bearer
+ * credential and logs:read includes viewers — so a caller cannot use this response to compare
+ * the stored URL against the one it sent.
  */
 export interface LogsAlertDestinationConfigApi {
     hog_function_ids: string[]
@@ -696,7 +699,7 @@ export interface LogsAlertDestinationConfigApi {
     slack_workspace_id?: number
     /** Slack channel ID. Present when type=slack. */
     slack_channel_id?: string
-    /** Endpoint posted to. Present for webhook and teams. */
+    /** Endpoint posted to, redacted to scheme and host because the full URL is a credential. Present for webhook and teams. */
     webhook_url?: string
 }
 

--- a/products/logs/frontend/generated/api.ts
+++ b/products/logs/frontend/generated/api.ts
@@ -218,7 +218,7 @@ export const getLogsAlertsDestinationsListUrl = (
 }
 
 /**
- * List the notification destinations configured for this alert. Creating a destination fans out into one HogFunction per alert event kind (firing, resolved, ...); this returns one entry per destination, carrying the whole group's HogFunction IDs and the config it was created with.
+ * Paginated list of the notification destinations configured for this alert. Creating a destination fans out into one HogFunction per alert event kind (firing, resolved, ...); this returns one entry per destination, carrying the whole group's HogFunction IDs and the config it was created with. webhook_url comes back redacted to scheme and host.
  */
 export const logsAlertsDestinationsList = async (
     projectId: string,

--- a/products/logs/frontend/generated/api.ts
+++ b/products/logs/frontend/generated/api.ts
@@ -16,6 +16,7 @@ import type {
     LogsAlertDestinationResponseApi,
     LogsAlertSimulateRequestApi,
     LogsAlertSimulateResponseApi,
+    LogsAlertsDestinationsListParams,
     LogsAlertsEventsListParams,
     LogsAlertsListParams,
     LogsAnomalyScanRequestApi,
@@ -40,6 +41,7 @@ import type {
     LogsViewApi,
     LogsViewsListParams,
     PaginatedLogsAlertConfigurationListApi,
+    PaginatedLogsAlertDestinationConfigListApi,
     PaginatedLogsAlertEventListApi,
     PaginatedLogsMetricRuleListApi,
     PaginatedLogsRetentionRuleListApi,
@@ -193,6 +195,44 @@ export const logsAlertsDestroy = async (projectId: string, id: string, options?:
         ...options,
         method: 'DELETE',
     })
+}
+
+export const getLogsAlertsDestinationsListUrl = (
+    projectId: string,
+    id: string,
+    params?: LogsAlertsDestinationsListParams
+) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : String(value))
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/logs/alerts/${id}/destinations/?${stringifiedParams}`
+        : `/api/projects/${projectId}/logs/alerts/${id}/destinations/`
+}
+
+/**
+ * List the notification destinations configured for this alert. Creating a destination fans out into one HogFunction per alert event kind (firing, resolved, ...); this returns one entry per destination, carrying the whole group's HogFunction IDs and the config it was created with.
+ */
+export const logsAlertsDestinationsList = async (
+    projectId: string,
+    id: string,
+    params?: LogsAlertsDestinationsListParams,
+    options?: RequestInit
+): Promise<PaginatedLogsAlertDestinationConfigListApi> => {
+    return apiMutator<PaginatedLogsAlertDestinationConfigListApi>(
+        getLogsAlertsDestinationsListUrl(projectId, id, params),
+        {
+            ...options,
+            method: 'GET',
+        }
+    )
 }
 
 export const getLogsAlertsDestinationsCreateUrl = (projectId: string, id: string) => {

--- a/products/logs/mcp/tools.yaml
+++ b/products/logs/mcp/tools.yaml
@@ -103,6 +103,9 @@ tools:
             logs-alerts-destinations-create. Destinations are deleted as one atomic group — partial deletion fails the
             call.
         feature_flag: logs-alerting
+    logs-alerts-destinations-list:
+        operation: logs_alerts_destinations_list
+        enabled: false
     logs-alerts-destroy:
         operation: logs_alerts_destroy
         enabled: true

--- a/products/replay_vision/backend/api/vision_actions.py
+++ b/products/replay_vision/backend/api/vision_actions.py
@@ -27,6 +27,7 @@ from rest_framework.serializers import BaseSerializer
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.scoped_related_fields import TeamScopedPrimaryKeyRelatedField
 from posthog.api.shared import UserBasicSerializer
+from posthog.helpers.url_redaction import redact_webhook_url
 from posthog.models.integration import Integration
 
 from products.replay_vision.backend.api.delivery import archive_delivery, provision_delivery
@@ -246,19 +247,6 @@ MAX_ENABLED_ALERTS_PER_SCANNER = 10
 MAX_DELIVERY_TARGETS = 5
 
 
-def _redact_webhook_url(url: str) -> str:
-    # Show the scheme + host so a viewer can see *where* it delivers, but drop everything a credential
-    # can hide in: the path, the query, AND any `user:pass@` userinfo (which `netloc` would carry, so
-    # rebuild the authority from hostname/port only). IPv6 hosts keep their brackets. Falls back to a
-    # fully-opaque marker if the URL can't be parsed.
-    parsed = urlparse(url)
-    if parsed.scheme and parsed.hostname:
-        host = f"[{parsed.hostname}]" if ":" in parsed.hostname else parsed.hostname
-        authority = f"{host}:{parsed.port}" if parsed.port else host
-        return f"{parsed.scheme}://{authority}/…"
-    return "(hidden)"
-
-
 class VisionActionSerializer(serializers.ModelSerializer):
     """A Replay Vision action: a scheduled "and then…" automation over a scanner's observations."""
 
@@ -411,7 +399,7 @@ class VisionActionSerializer(serializers.ModelSerializer):
         # it in full so the edit form can round-trip it.
         if not self._can_edit(instance):
             data["delivery_config"] = [
-                {**target, "url": _redact_webhook_url(target["url"])}
+                {**target, "url": redact_webhook_url(target["url"])}
                 if target.get("type") == "webhook" and target.get("url")
                 else target
                 for target in data.get("delivery_config") or []

--- a/products/replay_vision/backend/tests/test_vision_actions_api.py
+++ b/products/replay_vision/backend/tests/test_vision_actions_api.py
@@ -16,7 +16,6 @@ from products.replay_vision.backend.api.vision_actions import (
     MAX_DELIVERY_TARGETS,
     MAX_ENABLED_ALERTS_PER_SCANNER,
     DeliveryTargetSerializer,
-    _redact_webhook_url,
 )
 from products.replay_vision.backend.models.replay_observation import ReplayObservation
 from products.replay_vision.backend.models.replay_scanner import ReplayScanner, ScannerModel, ScannerOrigin, ScannerType
@@ -826,15 +825,3 @@ class TestDeliveryTargetSerializer(SimpleTestCase):
         # The per-type shape (slack needs integration+channel, webhook needs a well-formed https url) is
         # pure in-memory validation — a bad target must be rejected before it reaches provisioning.
         self.assertEqual(DeliveryTargetSerializer(data=target).is_valid(), expected_valid)
-
-    @parameterized.expand(
-        [
-            ("path_and_query", "https://hooks.example.com/svc/tok?k=v", "https://hooks.example.com/…"),
-            # Defense in depth: even if userinfo slipped past validation, the redaction must not echo it.
-            ("userinfo", "https://token:secret@hooks.example.com/path", "https://hooks.example.com/…"),
-            ("port", "https://hooks.example.com:8443/path", "https://hooks.example.com:8443/…"),
-            ("ipv6", "https://[2001:db8::1]:9000/path", "https://[2001:db8::1]:9000/…"),
-        ]
-    )
-    def test_redact_webhook_url(self, _label: str, url: str, expected: str) -> None:
-        self.assertEqual(_redact_webhook_url(url), expected)

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -44085,6 +44085,8 @@ export namespace Schemas {
        * * `webhook` - webhook
        * * `teams` - teams */
       type: NotificationDestinationTypeEnum;
+      /** False when any HogFunction in the group is disabled, because the destination then misses at least one alert event kind. */
+      enabled: boolean;
       /** Integration ID for the Slack workspace. Present when type=slack. */
       slack_workspace_id?: number;
       /** Slack channel ID. Present when type=slack. */

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -44077,15 +44077,6 @@ export namespace Schemas {
       hog_function_ids: string[];
     }
 
-    /**
-     * A configured destination, with the fields it was created with.
-     *
-     * Two of those fields do not come back as sent. slack_channel_name has no counterpart at all:
-     * creation puts it in the HogFunction name rather than its inputs, so there is nothing to read
-     * back. webhook_url comes back redacted to scheme and host, because the full URL is a bearer
-     * credential and logs:read includes viewers — so a caller cannot use this response to compare
-     * the stored URL against the one it sent.
-     */
     export interface LogsAlertDestinationConfig {
       hog_function_ids: string[];
       /** Notification destination type.

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -44078,10 +44078,13 @@ export namespace Schemas {
     }
 
     /**
-     * A configured destination, with the fields it was created with so the two round-trip.
+     * A configured destination, with the fields it was created with.
      *
-     * slack_channel_name has no counterpart here: creation puts it in the HogFunction name
-     * rather than its inputs, so there is nothing to read back.
+     * Two of those fields do not come back as sent. slack_channel_name has no counterpart at all:
+     * creation puts it in the HogFunction name rather than its inputs, so there is nothing to read
+     * back. webhook_url comes back redacted to scheme and host, because the full URL is a bearer
+     * credential and logs:read includes viewers — so a caller cannot use this response to compare
+     * the stored URL against the one it sent.
      */
     export interface LogsAlertDestinationConfig {
       hog_function_ids: string[];
@@ -44095,7 +44098,7 @@ export namespace Schemas {
       slack_workspace_id?: number;
       /** Slack channel ID. Present when type=slack. */
       slack_channel_id?: string;
-      /** Endpoint posted to. Present for webhook and teams. */
+      /** Endpoint posted to, redacted to scheme and host because the full URL is a credential. Present for webhook and teams. */
       webhook_url?: string;
     }
 

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -44077,6 +44077,28 @@ export namespace Schemas {
       hog_function_ids: string[];
     }
 
+    /**
+     * A configured destination, with the fields it was created with so the two round-trip.
+     *
+     * slack_channel_name has no counterpart here: creation puts it in the HogFunction name
+     * rather than its inputs, so there is nothing to read back.
+     */
+    export interface LogsAlertDestinationConfig {
+      hog_function_ids: string[];
+      /** Notification destination type.
+       *
+       * * `slack` - slack
+       * * `webhook` - webhook
+       * * `teams` - teams */
+      type: NotificationDestinationTypeEnum;
+      /** Integration ID for the Slack workspace. Present when type=slack. */
+      slack_workspace_id?: number;
+      /** Slack channel ID. Present when type=slack. */
+      slack_channel_id?: string;
+      /** Endpoint posted to. Present for webhook and teams. */
+      webhook_url?: string;
+    }
+
     export interface LogsAlertDestinationResponse {
       hog_function_ids: string[];
     }
@@ -50038,6 +50060,15 @@ export namespace Schemas {
       /** @nullable */
       previous?: string | null;
       results: LogsAlertConfiguration[];
+    }
+
+    export interface PaginatedLogsAlertDestinationConfigList {
+      count: number;
+      /** @nullable */
+      next?: string | null;
+      /** @nullable */
+      previous?: string | null;
+      results: LogsAlertDestinationConfig[];
     }
 
     export interface PaginatedLogsAlertEventList {
@@ -89058,6 +89089,17 @@ export namespace Schemas {
      * Only return log alerts created by the user with this UUID.
      */
     created_by?: string;
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number;
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number;
+    };
+
+    export type LogsAlertsDestinationsListParams = {
     /**
      * Number of results to return per page.
      */


### PR DESCRIPTION
## Problem

Nobody can read a log alert's notification destinations back out of the API, so they cannot be managed as code.

- The PostHog UI attaches Slack, webhook and Teams destinations through the alert's `destinations` sub-endpoint, which only creates and deletes.
- `HogFunctionViewSet.safely_get_queryset` excludes managed alert events, so the generic API returns nothing for them from either list or retrieve.
- The Terraform provider therefore cannot detect drift, and PostHog/terraform-provider-posthog#153 is blocked on it.

## Changes

- `GET /api/projects/:id/logs/alerts/:alert_id/destinations/` returns one entry per destination, carrying its HogFunction group and the config it was created with.
- The read requires `logs:read`. Create keeps `logs:write`.
- `webhook_url` comes back as scheme and host only. The full URL is a bearer credential and `logs:read` includes RBAC viewers.
- The response is a paginated envelope, matching the schema its generated clients already declared.
- Each entry carries `enabled`, ANDed across the group. A destination whose rows are not all enabled does not deliver every event kind.
- `products/cdp` is untouched. The guard refusing user-created managed alert destinations stays.
- The URL redaction helper moves to `posthog/helpers/url_redaction.py`, deleting a duplicate in `products/replay_vision`.
- That copy raised on an out-of-range port instead of returning the sentinel. `tach` forbids importing across the two products.

> [!NOTE]
> `slack_channel_name` and `webhook_url` cannot round-trip. Creation puts the first in the HogFunction name and the read masks the second, so Terraform treats both as write-only.

`required_scopes` does not compose with `@action.mapping`, because `_get_required_scopes` reads one view attribute set from the action's initkwargs. Scopes resolve per method instead, following `products/skills/backend/api/skills.py`.

## How did you test this code?

New tests and the regression each catches:

- A destination round-trips from create to read for all four types — catches a builder and reader that drift apart.
- `webhook_url` is masked for webhook and Teams, and Slack config is returned whole — catches redaction that leaks or over-redacts.
- The list pages without overlap — catches a page boundary that hides or repeats a destination.
- Rows with unreadable inputs stay apart — catches unrelated destinations merging into one group.
- A pre-existing test proves create still refuses `logs:read`, which is the guard against the scope split downgrading the write.

Not run: the full monorepo suite, and this endpoint against a deployed environment. `test_geoip.py` fails locally for want of a MaxMind database and is untouched here.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. The `qa-team` skill reviewed an earlier version; all ten reviewers independently flagged that the endpoint returned a bare array while its generated clients declared a paginated envelope. `writing-pr-descriptions` shaped this body.

An earlier approach relaxed the CDP queryset exclusion so the generic API would return these rows. That was dropped: it would add a second product-shaped exception to shared infrastructure, after PostHog/posthog#83993 added the first, and the generic API has no vocabulary for one destination being several HogFunctions.

`list_alert_destination_groups` still duplicates a grouper on `fix/alert-destination-delete-grouping`. That branch owns the definition and merges first, then this one calls it.

