### PR TITLE
fix(experiments): use saved metric names in AI results summary

### DIFF
--- a/products/experiments/backend/experiment_summary_data_service.py
+++ b/products/experiments/backend/experiment_summary_data_service.py
@@ -294,6 +294,10 @@ class ExperimentSummaryDataService:
             query = link.saved_metric.query
             if not query:
                 continue
+            # The display name lives on the saved metric model, not in its query dict —
+            # without it the summary falls back to raw event names.
+            if link.saved_metric.name:
+                query = {**query, "name": link.saved_metric.name}
             metric_type = (link.metadata or {}).get("type", "primary")
             if metric_type == "primary":
                 primary_metrics.append(query)

--- a/products/experiments/backend/test/test_experiment_summary_tool.py
+++ b/products/experiments/backend/test/test_experiment_summary_tool.py
@@ -470,6 +470,10 @@ class TestExperimentSummaryDataService(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(len(context.primary_metrics_results), 1)
         self.assertEqual(len(context.secondary_metrics_results), 1)
 
+        # Saved metrics must surface under their display name, not an event-derived fallback
+        self.assertEqual(context.primary_metrics_results[0].name, "1. Team Growth NSM")
+        self.assertEqual(context.secondary_metrics_results[0].name, "1. Onboarding Completion")
+
         # Verify the saved metric queries were actually passed to the query runner
         query_runner_calls = mock_query_runner_class.call_args_list
         self.assertEqual(len(query_runner_calls), 2)


### PR DESCRIPTION
## Problem

The PostHog AI experiment summary refers to shared metrics by raw event names ("VIDEO_DOWNLOADED", "AGENT_CLK_SUBMIT conversion") instead of their display names. A shared metric's name lives on the `ExperimentSavedMetric` model, not in its query dict, so the summary data service falls back to the event-derived default title.

## Changes

Merge `saved_metric.name` into the query dict when collecting saved metrics in `ExperimentSummaryDataService`, matching how the frontend metrics list titles shared metrics.

## How did you test this code?

Extended `test_fetch_experiment_data_includes_saved_metrics` to assert saved metrics surface under their display names. Without the fix, the assertion fails with the event-derived fallback name. Ran the full `test_experiment_summary_tool.py` suite (28 passed).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code investigated why the AI summary named metrics that don't appear in the metrics list, traced it to the saved-metric name living on the model rather than the query dict, and made the fix. Skills invoked: /wt, /writing-tests. Two sibling PRs follow for related issues found in the same code path (metric ordering, summary metric cap).
