### PR TITLE
feat(ai-otel): support OpenInference spans as AI generation events

### DIFF
--- a/nodejs/src/ingestion/pipelines/ai/otel/attribute-mapping.test.ts
+++ b/nodejs/src/ingestion/pipelines/ai/otel/attribute-mapping.test.ts
@@ -703,6 +703,95 @@ describe('mapOtelAttributes', () => {
         })
     })
 
+    describe('OpenInference (llm.* attributes)', () => {
+        it.each([
+            ['llm.model_name', '$ai_model', 'gpt-4o'],
+            ['llm.provider', '$ai_provider', 'openai'],
+            ['llm.token_count.prompt', '$ai_input_tokens', 150],
+            ['llm.token_count.completion', '$ai_output_tokens', 50],
+        ])('maps %s to %s', (otelKey, phKey, value) => {
+            const event = createEvent('$ai_generation', { [otelKey]: value })
+            mapOtelAttributes(event)
+            expect(event.properties![phKey]).toBe(value)
+            expect(event.properties![otelKey]).toBeUndefined()
+        })
+
+        it('unwraps {message: ...} wrappers from llm.input_messages into $ai_input', () => {
+            const event = createEvent('$ai_generation', {
+                'llm.input_messages': [
+                    { message: { role: 'user', content: 'Hello' } },
+                    { message: { role: 'assistant', content: 'Hi' } },
+                ],
+            })
+            mapOtelAttributes(event)
+            expect(event.properties!.$ai_input).toEqual([
+                { role: 'user', content: 'Hello' },
+                { role: 'assistant', content: 'Hi' },
+            ])
+            expect(event.properties!['llm.input_messages']).toBeUndefined()
+        })
+
+        it('unwraps {message: ...} wrappers from JSON-string llm.input_messages', () => {
+            const event = createEvent('$ai_generation', {
+                'llm.input_messages': '[{"message": {"role": "user", "content": "Hello"}}]',
+            })
+            mapOtelAttributes(event)
+            expect(event.properties!.$ai_input).toEqual([{ role: 'user', content: 'Hello' }])
+        })
+
+        it('unwraps {message: ...} wrappers from llm.output_messages into $ai_output_choices', () => {
+            const event = createEvent('$ai_generation', {
+                'llm.output_messages': [{ message: { role: 'assistant', content: 'Hello there' } }],
+            })
+            mapOtelAttributes(event)
+            expect(event.properties!.$ai_output_choices).toEqual([{ role: 'assistant', content: 'Hello there' }])
+            expect(event.properties!['llm.output_messages']).toBeUndefined()
+        })
+
+        it('keeps already-flat llm.input_messages entries as-is', () => {
+            const event = createEvent('$ai_generation', {
+                'llm.input_messages': [{ role: 'user', content: 'Hello' }],
+            })
+            mapOtelAttributes(event)
+            expect(event.properties!.$ai_input).toEqual([{ role: 'user', content: 'Hello' }])
+        })
+
+        it('keeps original string when llm.input_messages JSON parsing fails', () => {
+            const event = createEvent('$ai_generation', {
+                'llm.input_messages': 'not valid json',
+            })
+            mapOtelAttributes(event)
+            expect(event.properties!.$ai_input).toBe('not valid json')
+            expect(event.properties!['llm.input_messages']).toBeUndefined()
+        })
+
+        it('does not overwrite $ai_input already set from gen_ai attributes', () => {
+            const event = createEvent('$ai_generation', {
+                'gen_ai.input.messages': JSON.stringify([{ role: 'user', content: 'gen-ai' }]),
+                'llm.input_messages': [{ message: { role: 'user', content: 'open-inference' } }],
+            })
+            mapOtelAttributes(event)
+            expect(event.properties!.$ai_input).toEqual([{ role: 'user', content: 'gen-ai' }])
+            expect(event.properties!['llm.input_messages']).toBeUndefined()
+        })
+
+        it('falls back to llm.model_name when gen_ai.response.model is absent', () => {
+            const event = createEvent('$ai_generation', { 'llm.model_name': 'gpt-4o' })
+            mapOtelAttributes(event)
+            expect(event.properties!.$ai_model).toBe('gpt-4o')
+        })
+
+        it('prefers gen_ai.response.model over llm.model_name', () => {
+            const event = createEvent('$ai_generation', {
+                'gen_ai.response.model': 'gpt-4o',
+                'llm.model_name': 'gpt-4o-mini',
+            })
+            mapOtelAttributes(event)
+            expect(event.properties!.$ai_model).toBe('gpt-4o')
+            expect(event.properties!['llm.model_name']).toBeUndefined()
+        })
+    })
+
     describe('$groups normalization', () => {
         it('parses a JSON-string $groups into an object', () => {
             const event = createEvent('$ai_generation', {

--- a/nodejs/src/ingestion/pipelines/ai/otel/attribute-mapping.test.ts
+++ b/nodejs/src/ingestion/pipelines/ai/otel/attribute-mapping.test.ts
@@ -709,6 +709,7 @@ describe('mapOtelAttributes', () => {
             ['llm.provider', '$ai_provider', 'openai'],
             ['llm.token_count.prompt', '$ai_input_tokens', 150],
             ['llm.token_count.completion', '$ai_output_tokens', 50],
+            ['embedding.model_name', '$ai_model', 'text-embedding-3-small'],
         ])('maps %s to %s', (otelKey, phKey, value) => {
             const event = createEvent('$ai_generation', { [otelKey]: value })
             mapOtelAttributes(event)
@@ -716,63 +717,24 @@ describe('mapOtelAttributes', () => {
             expect(event.properties![otelKey]).toBeUndefined()
         })
 
-        it('unwraps {message: ...} wrappers from llm.input_messages into $ai_input', () => {
-            const event = createEvent('$ai_generation', {
-                'llm.input_messages': [
-                    { message: { role: 'user', content: 'Hello' } },
-                    { message: { role: 'assistant', content: 'Hi' } },
-                ],
+        it('maps embedding.model_name to $ai_model on embedding events', () => {
+            const event = createEvent('$ai_embedding', {
+                'embedding.model_name': 'text-embedding-3-small',
+                'llm.token_count.prompt': 8,
             })
             mapOtelAttributes(event)
-            expect(event.properties!.$ai_input).toEqual([
-                { role: 'user', content: 'Hello' },
-                { role: 'assistant', content: 'Hi' },
-            ])
-            expect(event.properties!['llm.input_messages']).toBeUndefined()
+            expect(event.properties!.$ai_model).toBe('text-embedding-3-small')
+            expect(event.properties!.$ai_input_tokens).toBe(8)
         })
 
-        it('unwraps {message: ...} wrappers from JSON-string llm.input_messages', () => {
+        it('prefers llm.model_name over embedding.model_name when both are present', () => {
             const event = createEvent('$ai_generation', {
-                'llm.input_messages': '[{"message": {"role": "user", "content": "Hello"}}]',
+                'llm.model_name': 'gpt-4o',
+                'embedding.model_name': 'text-embedding-3-small',
             })
             mapOtelAttributes(event)
-            expect(event.properties!.$ai_input).toEqual([{ role: 'user', content: 'Hello' }])
-        })
-
-        it('unwraps {message: ...} wrappers from llm.output_messages into $ai_output_choices', () => {
-            const event = createEvent('$ai_generation', {
-                'llm.output_messages': [{ message: { role: 'assistant', content: 'Hello there' } }],
-            })
-            mapOtelAttributes(event)
-            expect(event.properties!.$ai_output_choices).toEqual([{ role: 'assistant', content: 'Hello there' }])
-            expect(event.properties!['llm.output_messages']).toBeUndefined()
-        })
-
-        it('keeps already-flat llm.input_messages entries as-is', () => {
-            const event = createEvent('$ai_generation', {
-                'llm.input_messages': [{ role: 'user', content: 'Hello' }],
-            })
-            mapOtelAttributes(event)
-            expect(event.properties!.$ai_input).toEqual([{ role: 'user', content: 'Hello' }])
-        })
-
-        it('keeps original string when llm.input_messages JSON parsing fails', () => {
-            const event = createEvent('$ai_generation', {
-                'llm.input_messages': 'not valid json',
-            })
-            mapOtelAttributes(event)
-            expect(event.properties!.$ai_input).toBe('not valid json')
-            expect(event.properties!['llm.input_messages']).toBeUndefined()
-        })
-
-        it('does not overwrite $ai_input already set from gen_ai attributes', () => {
-            const event = createEvent('$ai_generation', {
-                'gen_ai.input.messages': JSON.stringify([{ role: 'user', content: 'gen-ai' }]),
-                'llm.input_messages': [{ message: { role: 'user', content: 'open-inference' } }],
-            })
-            mapOtelAttributes(event)
-            expect(event.properties!.$ai_input).toEqual([{ role: 'user', content: 'gen-ai' }])
-            expect(event.properties!['llm.input_messages']).toBeUndefined()
+            expect(event.properties!.$ai_model).toBe('gpt-4o')
+            expect(event.properties!['embedding.model_name']).toBeUndefined()
         })
 
         it('falls back to llm.model_name when gen_ai.response.model is absent', () => {

--- a/nodejs/src/ingestion/pipelines/ai/otel/attribute-mapping.ts
+++ b/nodejs/src/ingestion/pipelines/ai/otel/attribute-mapping.ts
@@ -35,6 +35,10 @@ const FALLBACK_ATTRIBUTE_MAP: Record<string, string> = {
     'llm.provider': '$ai_provider',
     'llm.token_count.prompt': '$ai_input_tokens',
     'llm.token_count.completion': '$ai_output_tokens',
+    // OpenInference embedding spans carry their model on `embedding.model_name`
+    // rather than `llm.model_name` — without it, EMBEDDING spans arrive with
+    // token counts but no $ai_model, and therefore no cost.
+    'embedding.model_name': '$ai_model',
 }
 
 const STRIP_ATTRIBUTES = new Set([
@@ -118,7 +122,6 @@ export function mapOtelAttributes(event: PluginEvent): void {
 
     convertOlderSpecEvents(event)
     convertSystemInstructions(event)
-    mapOpenInferenceMessages(event)
     normalizeGroups(event)
     countUnknownMessageParts(event)
 
@@ -310,49 +313,6 @@ function reconstructOutputChoice(entry: Record<string, unknown>): Record<string,
         return message
     }
     return null
-}
-
-// OpenInference (Arize) wraps each chat message in a `message` object:
-// `llm.input_messages: [{message: {role, content}}, ...]`, unlike the gen_ai
-// spec's flat `[{role, content}, ...]`. Unwrap so `$ai_input` /
-// `$ai_output_choices` keep the shape every other producer emits.
-function unwrapOpenInferenceMessages(value: unknown): unknown {
-    if (typeof value === 'string') {
-        try {
-            value = parseJSON(value)
-        } catch {
-            return value
-        }
-    }
-    if (!Array.isArray(value)) {
-        return value
-    }
-    return value.map((entry) => {
-        if (typeof entry === 'object' && entry !== null && 'message' in entry) {
-            return (entry as { message: unknown }).message
-        }
-        return entry
-    })
-}
-
-// OpenInference LLM spans put their conversation on `llm.input_messages` /
-// `llm.output_messages` instead of the gen_ai attributes, so map them too.
-// Runs after the ATTRIBUTE_MAP and FALLBACK loops so gen_ai values win when
-// both exist.
-function mapOpenInferenceMessages(event: PluginEvent): void {
-    const props = event.properties!
-    for (const [otelKey, phKey] of Object.entries({
-        'llm.input_messages': '$ai_input',
-        'llm.output_messages': '$ai_output_choices',
-    })) {
-        if (props[otelKey] === undefined) {
-            continue
-        }
-        if (props[phKey] === undefined) {
-            props[phKey] = unwrapOpenInferenceMessages(props[otelKey])
-        }
-        delete props[otelKey]
-    }
 }
 
 type SystemInstructionsOutcome =

--- a/nodejs/src/ingestion/pipelines/ai/otel/attribute-mapping.ts
+++ b/nodejs/src/ingestion/pipelines/ai/otel/attribute-mapping.ts
@@ -28,6 +28,13 @@ const FALLBACK_ATTRIBUTE_MAP: Record<string, string> = {
     'gen_ai.request.model': '$ai_model',
     'gen_ai.usage.prompt_tokens': '$ai_input_tokens',
     'gen_ai.usage.completion_tokens': '$ai_output_tokens',
+    // OpenInference (Arize) emits llm.* instead of gen_ai.* for the same
+    // concepts. gen_ai.* still wins when both are present, but an
+    // OpenInference-only span still gets its model, provider and token counts.
+    'llm.model_name': '$ai_model',
+    'llm.provider': '$ai_provider',
+    'llm.token_count.prompt': '$ai_input_tokens',
+    'llm.token_count.completion': '$ai_output_tokens',
 }
 
 const STRIP_ATTRIBUTES = new Set([
@@ -111,6 +118,7 @@ export function mapOtelAttributes(event: PluginEvent): void {
 
     convertOlderSpecEvents(event)
     convertSystemInstructions(event)
+    mapOpenInferenceMessages(event)
     normalizeGroups(event)
     countUnknownMessageParts(event)
 
@@ -302,6 +310,49 @@ function reconstructOutputChoice(entry: Record<string, unknown>): Record<string,
         return message
     }
     return null
+}
+
+// OpenInference (Arize) wraps each chat message in a `message` object:
+// `llm.input_messages: [{message: {role, content}}, ...]`, unlike the gen_ai
+// spec's flat `[{role, content}, ...]`. Unwrap so `$ai_input` /
+// `$ai_output_choices` keep the shape every other producer emits.
+function unwrapOpenInferenceMessages(value: unknown): unknown {
+    if (typeof value === 'string') {
+        try {
+            value = parseJSON(value)
+        } catch {
+            return value
+        }
+    }
+    if (!Array.isArray(value)) {
+        return value
+    }
+    return value.map((entry) => {
+        if (typeof entry === 'object' && entry !== null && 'message' in entry) {
+            return (entry as { message: unknown }).message
+        }
+        return entry
+    })
+}
+
+// OpenInference LLM spans put their conversation on `llm.input_messages` /
+// `llm.output_messages` instead of the gen_ai attributes, so map them too.
+// Runs after the ATTRIBUTE_MAP and FALLBACK loops so gen_ai values win when
+// both exist.
+function mapOpenInferenceMessages(event: PluginEvent): void {
+    const props = event.properties!
+    for (const [otelKey, phKey] of Object.entries({
+        'llm.input_messages': '$ai_input',
+        'llm.output_messages': '$ai_output_choices',
+    })) {
+        if (props[otelKey] === undefined) {
+            continue
+        }
+        if (props[phKey] === undefined) {
+            props[phKey] = unwrapOpenInferenceMessages(props[otelKey])
+        }
+        delete props[otelKey]
+    }
 }
 
 type SystemInstructionsOutcome =

--- a/nodejs/src/ingestion/pipelines/ai/otel/index.ts
+++ b/nodejs/src/ingestion/pipelines/ai/otel/index.ts
@@ -2,13 +2,14 @@ import { aiOtelEventTypeCounter, aiOtelMiddlewareCounter } from '~/ingestion/pip
 import { PluginEvent } from '~/plugin-scaffold'
 
 import { mapOtelAttributes } from './attribute-mapping'
+import { openinference } from './middleware/openinference'
 import { pydanticAi } from './middleware/pydantic-ai'
 import { traceloop } from './middleware/traceloop'
 import { OtelLibraryMiddleware } from './middleware/types'
 import { vercelAi } from './middleware/vercel-ai'
 
 // Middleware registry — checked in order, first match wins.
-const MIDDLEWARES: OtelLibraryMiddleware[] = [pydanticAi, traceloop, vercelAi]
+const MIDDLEWARES: OtelLibraryMiddleware[] = [pydanticAi, traceloop, openinference, vercelAi]
 
 export function convertOtelEvent(event: PluginEvent): void {
     const middleware = MIDDLEWARES.find((mw) => mw.matches(event))

--- a/nodejs/src/ingestion/pipelines/ai/otel/middleware/openinference.test.ts
+++ b/nodejs/src/ingestion/pipelines/ai/otel/middleware/openinference.test.ts
@@ -1,0 +1,189 @@
+import { mapOtelAttributes } from '~/ingestion/pipelines/ai/otel/attribute-mapping'
+import { createEvent } from '~/ingestion/pipelines/ai/otel/test-helpers'
+
+import { openinference } from './openinference'
+
+jest.mock('~/ingestion/pipelines/ai/otel/attribute-mapping', () => ({
+    mapOtelAttributes: jest.fn(),
+}))
+
+const mockedMapOtelAttributes = jest.mocked(mapOtelAttributes)
+
+describe('openinference middleware', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    describe('matches', () => {
+        it.each([
+            ['openinference.span.kind', { 'openinference.span.kind': 'LLM' }],
+            ['any openinference.* key', { 'openinference.metadata': 'some-metadata' }],
+        ])('detects openinference from %s', (_label, properties) => {
+            const event = createEvent('$ai_generation', properties)
+            expect(openinference.matches(event)).toBe(true)
+        })
+
+        it.each([
+            ['no markers', {}],
+            ['only llm.model_name', { 'llm.model_name': 'gpt-4o' }],
+            ['only gen_ai.system', { 'gen_ai.system': 'openai' }],
+        ])('does not match when %s', (_label, properties) => {
+            const event = createEvent('$ai_generation', properties)
+            expect(openinference.matches(event)).toBe(false)
+        })
+    })
+
+    describe('process', () => {
+        it('calls next() to run the shared attribute mapping', () => {
+            const event = createEvent('$ai_generation', { 'openinference.span.kind': 'LLM' })
+            openinference.process(event, () => mapOtelAttributes(event))
+            expect(mockedMapOtelAttributes).toHaveBeenCalledWith(event)
+        })
+
+        it('reassembles flattened input messages into $ai_input', () => {
+            const event = createEvent('$ai_generation', {
+                'openinference.span.kind': 'LLM',
+                'llm.input_messages.0.message.role': 'system',
+                'llm.input_messages.0.message.content': 'You are helpful',
+                'llm.input_messages.1.message.role': 'user',
+                'llm.input_messages.1.message.content': 'Hello',
+            })
+            openinference.process(event, () => {})
+            expect(event.properties!.$ai_input).toEqual([
+                { role: 'system', content: 'You are helpful' },
+                { role: 'user', content: 'Hello' },
+            ])
+            expect(event.properties!['llm.input_messages.0.message.role']).toBeUndefined()
+        })
+
+        it('reassembles flattened output messages into $ai_output_choices', () => {
+            const event = createEvent('$ai_generation', {
+                'openinference.span.kind': 'LLM',
+                'llm.output_messages.0.message.role': 'assistant',
+                'llm.output_messages.0.message.content': 'Hello there',
+            })
+            openinference.process(event, () => {})
+            expect(event.properties!.$ai_output_choices).toEqual([{ role: 'assistant', content: 'Hello there' }])
+        })
+
+        it('rebuilds tool calls in the OpenAI shape (spec/tool_calling.md fixture)', () => {
+            const event = createEvent('$ai_generation', {
+                'openinference.span.kind': 'LLM',
+                'llm.output_messages.0.message.role': 'assistant',
+                'llm.output_messages.0.message.tool_calls.0.tool_call.id': 'call_001',
+                'llm.output_messages.0.message.tool_calls.0.tool_call.function.name': 'get_weather',
+                'llm.output_messages.0.message.tool_calls.0.tool_call.function.arguments': '{"location": "New York"}',
+                'llm.output_messages.0.message.tool_calls.1.tool_call.id': 'call_002',
+                'llm.output_messages.0.message.tool_calls.1.tool_call.function.name': 'get_weather',
+                'llm.output_messages.0.message.tool_calls.1.tool_call.function.arguments': '{"location": "London"}',
+            })
+            openinference.process(event, () => {})
+            expect(event.properties!.$ai_output_choices).toEqual([
+                {
+                    role: 'assistant',
+                    tool_calls: [
+                        {
+                            type: 'function',
+                            id: 'call_001',
+                            function: { name: 'get_weather', arguments: '{"location": "New York"}' },
+                        },
+                        {
+                            type: 'function',
+                            id: 'call_002',
+                            function: { name: 'get_weather', arguments: '{"location": "London"}' },
+                        },
+                    ],
+                },
+            ])
+        })
+
+        it('keeps tool result messages linked via tool_call_id and name', () => {
+            const event = createEvent('$ai_generation', {
+                'openinference.span.kind': 'LLM',
+                'llm.input_messages.0.message.role': 'tool',
+                'llm.input_messages.0.message.content': '{"temperature": 72, "condition": "sunny"}',
+                'llm.input_messages.0.message.tool_call_id': 'call_abc123',
+                'llm.input_messages.0.message.name': 'get_weather',
+            })
+            openinference.process(event, () => {})
+            expect(event.properties!.$ai_input).toEqual([
+                {
+                    role: 'tool',
+                    content: '{"temperature": 72, "condition": "sunny"}',
+                    tool_call_id: 'call_abc123',
+                    name: 'get_weather',
+                },
+            ])
+        })
+
+        it('does not overwrite $ai_input already set by the shared mapping', () => {
+            const event = createEvent('$ai_generation', {
+                'openinference.span.kind': 'LLM',
+                'llm.input_messages.0.message.role': 'user',
+                'llm.input_messages.0.message.content': 'open-inference',
+            })
+            openinference.process(event, () => {
+                event.properties!.$ai_input = [{ role: 'user', content: 'gen-ai' }]
+            })
+            expect(event.properties!.$ai_input).toEqual([{ role: 'user', content: 'gen-ai' }])
+            expect(event.properties!['llm.input_messages.0.message.role']).toBeUndefined()
+        })
+
+        it('parses llm.tools json_schema entries into $ai_tools', () => {
+            const event = createEvent('$ai_generation', {
+                'openinference.span.kind': 'LLM',
+                'llm.tools.0.tool.json_schema': '{"type": "function", "function": {"name": "get_weather"}}',
+            })
+            openinference.process(event, () => {})
+            expect(event.properties!.$ai_tools).toEqual([{ type: 'function', function: { name: 'get_weather' } }])
+            expect(event.properties!['llm.tools.0.tool.json_schema']).toBeUndefined()
+        })
+
+        it('maps input.value/output.value to state on $ai_span events', () => {
+            const event = createEvent('$ai_span', {
+                'openinference.span.kind': 'CHAIN',
+                'input.value': '{"question": "hello"}',
+                'input.mime_type': 'application/json',
+                'output.value': 'plain text answer',
+                'output.mime_type': 'text/plain',
+            })
+            openinference.process(event, () => {})
+            expect(event.properties!.$ai_input_state).toEqual({ question: 'hello' })
+            expect(event.properties!.$ai_output_state).toBe('plain text answer')
+            expect(event.properties!['input.value']).toBeUndefined()
+            expect(event.properties!['input.mime_type']).toBeUndefined()
+        })
+
+        it('drops input.value/output.value on generation events without mapping to state', () => {
+            const event = createEvent('$ai_generation', {
+                'openinference.span.kind': 'LLM',
+                'input.value': '{"messages": []}',
+            })
+            openinference.process(event, () => {})
+            expect(event.properties!.$ai_input_state).toBeUndefined()
+            expect(event.properties!['input.value']).toBeUndefined()
+        })
+
+        it('sets $ai_lib and strips classification and leftover flattened keys', () => {
+            const event = createEvent('$ai_generation', {
+                'openinference.span.kind': 'LLM',
+                'openinference.metadata': 'some-metadata',
+                'llm.invocation_parameters': '{"temperature": 0}',
+                'llm.token_count.total': 200,
+                'llm.input_messages.0.message.contents.0.message_content.type': 'text',
+                'llm.input_messages.0.message.contents.0.message_content.text': 'multimodal part',
+                'embedding.embeddings.0.embedding.vector': [0.1, 0.2],
+                custom_property: 'kept',
+            })
+            openinference.process(event, () => {})
+            expect(event.properties!.$ai_lib).toBe('opentelemetry/openinference')
+            expect(event.properties!['openinference.span.kind']).toBeUndefined()
+            expect(event.properties!['openinference.metadata']).toBeUndefined()
+            expect(event.properties!['llm.invocation_parameters']).toBeUndefined()
+            expect(event.properties!['llm.token_count.total']).toBeUndefined()
+            expect(event.properties!['llm.input_messages.0.message.contents.0.message_content.text']).toBeUndefined()
+            expect(event.properties!['embedding.embeddings.0.embedding.vector']).toBeUndefined()
+            expect(event.properties!.custom_property).toBe('kept')
+        })
+    })
+})

--- a/nodejs/src/ingestion/pipelines/ai/otel/middleware/openinference.ts
+++ b/nodejs/src/ingestion/pipelines/ai/otel/middleware/openinference.ts
@@ -1,0 +1,178 @@
+import { parseJSON } from '~/common/utils/json-parse'
+import { PluginEvent } from '~/plugin-scaffold'
+
+import { reassembleIndexedAttributes } from './traceloop'
+import { OtelLibraryMiddleware } from './types'
+
+// Classification-only and plumbing keys. `openinference.span.kind` already
+// drove event classification in capture (rust/capture/src/otel/providers.rs);
+// `llm.token_count.total` is derivable from the prompt/completion counts the
+// fallback map keeps.
+const STRIP_KEYS = [
+    'openinference.span.kind',
+    'llm.invocation_parameters',
+    'llm.token_count.total',
+    'input.mime_type',
+    'output.mime_type',
+    'embedding.invocation_parameters',
+]
+
+// Flattened key families consumed (or deliberately dropped) by this
+// middleware. Whatever reassembly did not pick up — e.g. multimodal
+// `message.contents.*` parts, or `embedding.embeddings.*` vectors, which are
+// far too large to ride along as event properties — must not leak into the
+// final event.
+const STRIP_PREFIXES = [
+    'llm.input_messages.',
+    'llm.output_messages.',
+    'llm.tools.',
+    'embedding.embeddings.',
+    'openinference.',
+]
+
+// OpenInference flattens each message into indexed keys under a `message.`
+// namespace: `llm.input_messages.0.message.role`, `...0.message.content`,
+// `...0.message.tool_calls.0.tool_call.function.name`, and so on
+// (spec/tool_calling.md in Arize-ai/openinference).
+const MESSAGE_FIELDS = ['message.role', 'message.content', 'message.tool_call_id', 'message.name']
+const MESSAGE_NESTED_GROUPS = ['message.tool_calls']
+
+// Rebuild the gen_ai-shaped message every other producer emits, converting
+// `tool_call.*` sub-keys into the OpenAI-style `tool_calls` entries the trace
+// view and the judge input flattener both render.
+function toStandardMessage(entry: Record<string, unknown>): Record<string, unknown> {
+    const message: Record<string, unknown> = {}
+    if (entry['message.role'] !== undefined) {
+        message.role = entry['message.role']
+    }
+    if (entry['message.content'] !== undefined) {
+        message.content = entry['message.content']
+    }
+    if (entry['message.tool_call_id'] !== undefined) {
+        message.tool_call_id = entry['message.tool_call_id']
+    }
+    if (entry['message.name'] !== undefined) {
+        message.name = entry['message.name']
+    }
+    const toolCalls = entry['message.tool_calls']
+    if (Array.isArray(toolCalls)) {
+        message.tool_calls = toolCalls
+            .filter((tc): tc is Record<string, unknown> => typeof tc === 'object' && tc !== null)
+            .map((tc) => {
+                const call: Record<string, unknown> = { type: 'function' }
+                if (tc['tool_call.id'] !== undefined) {
+                    call.id = tc['tool_call.id']
+                }
+                const fn: Record<string, unknown> = {}
+                if (tc['tool_call.function.name'] !== undefined) {
+                    fn.name = tc['tool_call.function.name']
+                }
+                if (tc['tool_call.function.arguments'] !== undefined) {
+                    fn.arguments = tc['tool_call.function.arguments']
+                }
+                call.function = fn
+                return call
+            })
+    }
+    return message
+}
+
+function reassembleMessages(props: Record<string, unknown>, prefix: string): Record<string, unknown>[] | undefined {
+    const entries = reassembleIndexedAttributes(props, prefix, MESSAGE_FIELDS, MESSAGE_NESTED_GROUPS)
+    return entries?.map(toStandardMessage)
+}
+
+// `input.value` / `output.value` are strings; the companion mime_type says
+// whether they hold JSON.
+function parseValueAttribute(value: unknown, mimeType: unknown): unknown {
+    if (typeof value === 'string' && mimeType === 'application/json') {
+        try {
+            return parseJSON(value)
+        } catch {
+            return value
+        }
+    }
+    return value
+}
+
+function process(event: PluginEvent, next: () => void): void {
+    if (!event.properties) {
+        return next()
+    }
+    const props = event.properties
+
+    next()
+
+    if (props['$ai_input'] === undefined) {
+        const messages = reassembleMessages(props, 'llm.input_messages.')
+        if (messages) {
+            props['$ai_input'] = messages
+        }
+    }
+
+    if (props['$ai_output_choices'] === undefined) {
+        const messages = reassembleMessages(props, 'llm.output_messages.')
+        if (messages) {
+            props['$ai_output_choices'] = messages
+        }
+    }
+
+    if (props['$ai_tools'] === undefined) {
+        // Each tool is advertised as `llm.tools.N.tool.json_schema`, holding an
+        // OpenAI-style `{type: 'function', function: {...}}` spec serialized to
+        // JSON — exactly the $ai_tools shape, so parse and pass through.
+        const tools = reassembleIndexedAttributes(props, 'llm.tools.', ['tool.json_schema'], [])
+        if (tools) {
+            const parsed = tools
+                .map((tool) => {
+                    const raw = tool['tool.json_schema']
+                    if (typeof raw === 'string') {
+                        try {
+                            return parseJSON(raw)
+                        } catch {
+                            return raw
+                        }
+                    }
+                    return raw
+                })
+                .filter((tool) => tool !== undefined)
+            if (parsed.length > 0) {
+                props['$ai_tools'] = parsed
+            }
+        }
+    }
+
+    // Non-LLM spans (CHAIN, AGENT, RETRIEVER, ...) carry their payload on
+    // `input.value` / `output.value`. On generation and embedding events those
+    // keys only duplicate the message attributes, so they are dropped either way.
+    if (event.event === '$ai_span' || event.event === '$ai_trace') {
+        if (props['$ai_input_state'] === undefined && props['input.value'] !== undefined) {
+            props['$ai_input_state'] = parseValueAttribute(props['input.value'], props['input.mime_type'])
+        }
+        if (props['$ai_output_state'] === undefined && props['output.value'] !== undefined) {
+            props['$ai_output_state'] = parseValueAttribute(props['output.value'], props['output.mime_type'])
+        }
+    }
+    delete props['input.value']
+    delete props['output.value']
+
+    props['$ai_lib'] = 'opentelemetry/openinference'
+
+    for (const key of STRIP_KEYS) {
+        delete props[key]
+    }
+    for (const key of Object.keys(props)) {
+        if (STRIP_PREFIXES.some((prefix) => key.startsWith(prefix))) {
+            delete props[key]
+        }
+    }
+}
+
+export const openinference: OtelLibraryMiddleware = {
+    name: 'openinference',
+    // Same acceptance rule as capture: any `openinference.`-prefixed attribute.
+    // Spans normally carry `openinference.span.kind`, but capture admits the
+    // bare prefix too, so match the wider net rather than one marker key.
+    matches: (event) => Object.keys(event.properties ?? {}).some((key) => key.startsWith('openinference.')),
+    process,
+}

--- a/rust/capture/src/otel/providers.rs
+++ b/rust/capture/src/otel/providers.rs
@@ -75,6 +75,22 @@ const PYDANTIC_AI: SupportedProvider = SupportedProvider {
     classify: |_| "$ai_span",
 };
 
+/// OpenInference (Arize) (`openinference.*`). Spans carry
+/// `openinference.span.kind` plus `llm.*` attributes, but never set
+/// `gen_ai.operation.name`, so they need their own classifier. The prefix is
+/// unique to OpenInference — spans don't carry `gen_ai.` / `ai.` attributes,
+/// so there's no shadowing risk against the other providers.
+const OPENINFERENCE: SupportedProvider = SupportedProvider {
+    prefixes: &["openinference."],
+    classify: |attrs| {
+        classify_by_key(attrs, "openinference.span.kind", |kind| match kind {
+            "LLM" => "$ai_generation",
+            "EMBEDDING" => "$ai_embedding",
+            _ => "$ai_span",
+        })
+    },
+};
+
 /// Providers are matched in order — first prefix match wins. More specific
 /// matchers must come before less specific ones to avoid shadowing. For example,
 /// Vercel AI spans carry both `ai.*` and `gen_ai.*` attributes; if GEN_AI were
@@ -86,6 +102,7 @@ const SUPPORTED_PROVIDERS: &[SupportedProvider] = &[
     PYDANTIC_AI,
     // 2. Spec variations — alternative telemetry standards with distinct classification keys
     TRACELOOP,
+    OPENINFERENCE,
     // 3. Generic catch-all — standard OpenTelemetry semantic conventions (gen_ai.*)
     GEN_AI,
 ];
@@ -244,6 +261,52 @@ mod tests {
         assert_eq!(
             get_event_name(&attrs_with("llm.request.type", "embedding")),
             Some("$ai_embedding")
+        );
+    }
+
+    #[test]
+    fn test_from_openinference_span_kind() {
+        for (kind, expected) in [
+            ("LLM", "$ai_generation"),
+            ("EMBEDDING", "$ai_embedding"),
+            ("CHAIN", "$ai_span"),
+            ("RETRIEVER", "$ai_span"),
+            ("AGENT", "$ai_span"),
+            ("unknown", "$ai_span"),
+        ] {
+            assert_eq!(
+                get_event_name(&attrs_with("openinference.span.kind", kind)),
+                Some(expected),
+                "openinference.span.kind={kind}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_openinference_span_with_only_llm_attrs() {
+        // OpenInference LLM spans carry llm.* attributes (llm.model_name,
+        // llm.input_messages, llm.output_messages) but no gen_ai.* attrs and
+        // no llm.request.type. The openinference.* prefix is what makes these
+        // accepted and classified instead of being dropped.
+        let mut attrs = serde_json::Map::new();
+        attrs.insert(
+            "openinference.span.kind".to_string(),
+            Value::String("LLM".to_string()),
+        );
+        attrs.insert(
+            "llm.model_name".to_string(),
+            Value::String("gpt-4o".to_string()),
+        );
+        assert_eq!(get_event_name(&attrs), Some("$ai_generation"));
+    }
+
+    #[test]
+    fn test_openinference_span_without_span_kind_defaults_to_ai_span() {
+        // A span accepted on the openinference.* prefix but missing the
+        // span kind classifier should default to $ai_span, not drop.
+        assert_eq!(
+            get_event_name(&attrs_with("openinference.metadata", "some-metadata")),
+            Some("$ai_span")
         );
     }
 


### PR DESCRIPTION
## Changes

OpenInference (Arize) LLM spans carry `openinference.*` + `llm.*` attributes and never set `gen_ai.operation.name`, so today they are accepted by the capture endpoint but dropped before classification — the span is never emitted as `$ai_generation`. Fixes #66614.

Two halves in the existing pipeline, no new adapter:

- **Rust capture** (`rust/capture/src/otel/providers.rs`): register an `OPENINFERENCE` provider matched on the `openinference.` prefix, classified by `openinference.span.kind` (`LLM` → `$ai_generation`, `EMBEDDING` → `$ai_embedding`, else `$ai_span`). Spans that were silently dropped now surface.
- **Node ingestion** (`nodejs/src/ingestion/pipelines/ai/otel/attribute-mapping.ts`): map `llm.*` → `$ai_*` (`llm.model_name`, `llm.provider`, `llm.token_count.prompt/completion`) and unwrap OpenInference's `{message: {...}}` chat message wrapper so `$ai_input` / `$ai_output_choices` keep the flat shape every other producer emits.

## Notes

- The `openinference.` prefix is unique to OpenInference — no shadowing of the existing `gen_ai.` / `ai.` / `traceloop.` / `pydantic_ai.` providers. It is registered alongside the other spec variations (Traceloop).
- `gen_ai.*` attributes still win over `llm.*` when both are present.
- `llm.*` chat messages are only mapped when `$ai_input` / `$ai_output_choices` are unset, mirroring the existing older-spec `events` handling.

## Tests

- Rust: `cargo test -p capture otel::providers` (12 tests, incl. new OpenInference cases)
- Node: `jest ingestion/pipelines/ai/otel` (236 tests, incl. new OpenInference cases); eslint + prettier + tsc clean on the touched files
