### PR TITLE
feat(error-tracking): set app metadata from the resolved release

### DIFF
--- a/rust/cymbal/src/core/types/frames/releases.rs
+++ b/rust/cymbal/src/core/types/frames/releases.rs
@@ -189,6 +189,21 @@ fn pack_version(version: Option<&str>, build: Option<&str>) -> Option<String> {
     }
 }
 
+/// Split a packed release version back into the app version and the build number, inverting
+/// `pack_version`. Splitting on the last `+` recovers the build from a version that itself carries
+/// semver build metadata, such as `1.0.0+sha.abc` built as `1.0.0+sha.abc+42`.
+///
+/// The inverse is lossy in the one direction `pack_version` is: a release packed from a build
+/// alone is a bare build string on the way back out, and comes back as a version with no build.
+pub fn unpack_version(packed: &str) -> (&str, Option<&str>) {
+    match packed.rsplit_once('+') {
+        Some((version, build)) if !version.is_empty() && !build.is_empty() => {
+            (version, Some(build))
+        }
+        _ => (packed, None),
+    }
+}
+
 fn release_hash_id(name: &str, version: &str) -> String {
     let mut hasher = Sha512::new();
     hasher.update(name.as_bytes());
@@ -241,6 +256,30 @@ mod tests {
                 mobile_release_hash_id(name, version, build).as_deref(),
                 Some(expected),
                 "release hash_id drift for {name} {version:?}+{build:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn unpack_version_recovers_the_build_pack_version_folded_in() {
+        // (packed version, app version, build number)
+        let cases: [(&str, &str, Option<&str>); 5] = [
+            ("1.0+42", "1.0", Some("42")),
+            // Splitting on the last `+` is what keeps semver build metadata with the version.
+            ("1.0.0+sha.abc+42", "1.0.0+sha.abc", Some("42")),
+            ("2.3", "2.3", None),
+            // A version whose own metadata reads as a build number: the packing is ambiguous, and
+            // the build wins so a real `--build` is never dropped.
+            ("1.0.0+sha.abc", "1.0.0", Some("sha.abc")),
+            // An empty half is not a build, or events would carry an empty `$app_build`.
+            ("1.0+", "1.0+", None),
+        ];
+
+        for (packed, version, build) in cases {
+            assert_eq!(
+                unpack_version(packed),
+                (version, build),
+                "unpacking {packed}"
             );
         }
     }

--- a/rust/cymbal/src/modes/processing/stages/resolution/event_release.rs
+++ b/rust/cymbal/src/modes/processing/stages/resolution/event_release.rs
@@ -319,6 +319,17 @@ mod tests {
         );
         assert_eq!(mobile.properties()["$app_version"], json!("1.0"));
         assert_eq!(mobile.properties()["$app_build"], json!(7));
+
+        // The React Native SDK spreads its app properties into every event whether or not the
+        // platform supplied them, so an Expo app that cannot read its own version sends explicit
+        // nulls. A null is not a value the SDK observed, so it does not block the backfill.
+        let mut expo = parsed_event(json!({
+            "$app_namespace": null, "$app_version": null, "$app_build": null
+        }));
+        backfill_app_properties(&mut expo, &release("my-app", "1.2.3+42"));
+        assert_eq!(expo.properties()["$app_namespace"], json!("my-app"));
+        assert_eq!(expo.properties()["$app_version"], json!("1.2.3"));
+        assert_eq!(expo.properties()["$app_build"], json!("42"));
     }
 
     const TEAM_ID: TeamId = 1;

--- a/rust/cymbal/src/modes/processing/stages/resolution/event_release.rs
+++ b/rust/cymbal/src/modes/processing/stages/resolution/event_release.rs
@@ -7,7 +7,7 @@ use uuid::Uuid;
 
 use crate::{
     error::UnhandledError,
-    frames::releases::{mobile_release_hash_id, ReleaseRecord},
+    frames::releases::{mobile_release_hash_id, unpack_version, ReleaseRecord},
     metric_consts::{ANCILLARY_CACHE, EVENT_RELEASE_RESOLUTION, EVENT_RELEASE_RESOLVER_OPERATOR},
     stages::{pipeline::HandledError, resolution::ResolutionStage},
     types::{
@@ -113,6 +113,9 @@ fn record_cache_outcome(cache_type: &'static str, cache_miss: bool) {
 ///      stack mixes symbol sets from several releases reports the latest.
 ///
 /// When none resolve, the event release stays unset and `$exception_release` is omitted.
+///
+/// Whatever release it lands on also backfills the event's app metadata, so an exception from
+/// any technology reports the app the way a mobile SDK does.
 #[derive(Clone, Default)]
 pub struct EventReleaseResolver;
 
@@ -140,6 +143,9 @@ impl ValueOperator for EventReleaseResolver {
         )
         .await?;
 
+        if let Some(record) = &record {
+            backfill_app_properties(&mut evt, record);
+        }
         evt.set_event_release(record);
 
         Ok(Ok(evt))
@@ -205,6 +211,22 @@ fn mobile_release_hash_from_props(props: &HashMap<String, Value>) -> Option<Stri
     mobile_release_hash_id(namespace, version, build.as_deref())
 }
 
+/// The app a release describes, in the properties mobile SDKs already report on every event:
+/// the release's project is the app namespace it was created under, and its version is the app
+/// version with the build number packed in.
+///
+/// Mobile SDKs are the only ones that send these, so copying them off the release is what gives an
+/// exception from any other technology the same app metadata, and lets a filter or a grouping rule
+/// on app version mean the same thing whichever SDK sent the event.
+fn backfill_app_properties(evt: &mut ExceptionEvent<Parsed>, release: &ReleaseRecord) {
+    let (version, build) = unpack_version(&release.version);
+    evt.set_property_if_absent("$app_namespace", Value::String(release.project.clone()));
+    evt.set_property_if_absent("$app_version", Value::String(version.to_string()));
+    if let Some(build) = build {
+        evt.set_property_if_absent("$app_build", Value::String(build.to_string()));
+    }
+}
+
 fn scalar_to_string(value: &Value) -> Option<String> {
     match value {
         Value::String(s) => Some(s.clone()),
@@ -248,6 +270,55 @@ mod tests {
             mobile_release_hash_from_props(&props(json!({"$app_version": "1.0"}))),
             None
         );
+    }
+
+    fn release(project: &str, version: &str) -> ReleaseRecord {
+        ReleaseRecord {
+            id: Uuid::now_v7(),
+            team_id: 1,
+            hash_id: "hash".to_string(),
+            created_at: chrono::Utc::now(),
+            version: version.to_string(),
+            project: project.to_string(),
+            metadata: None,
+        }
+    }
+
+    fn parsed_event(properties: Value) -> ExceptionEvent<Parsed> {
+        let mut properties = properties;
+        properties["$exception_list"] = json!([{"type": "Error", "value": "boom"}]);
+        crate::types::event::AnyEvent {
+            uuid: Uuid::now_v7(),
+            event: "$exception".to_string(),
+            team_id: 1,
+            timestamp: String::new(),
+            properties,
+            others: HashMap::new(),
+        }
+        .try_into()
+        .expect("valid exception properties")
+    }
+
+    #[test]
+    fn the_release_fills_app_metadata_the_sdk_did_not_send() {
+        let mut web = parsed_event(json!({}));
+        backfill_app_properties(&mut web, &release("my-app", "1.2.3+42"));
+        assert_eq!(web.properties()["$app_namespace"], json!("my-app"));
+        assert_eq!(web.properties()["$app_version"], json!("1.2.3"));
+        assert_eq!(web.properties()["$app_build"], json!("42"));
+
+        // A mobile SDK read these off the running app, and its release may have been created under
+        // a name that is not the bundle identifier, so nothing it sent is replaced.
+        let mut mobile = parsed_event(json!({
+            "$app_namespace": "com.example.app", "$app_version": "1.0", "$app_build": 7
+        }));
+        backfill_app_properties(&mut mobile, &release("my-app", "1.2.3+42"));
+        assert_eq!(
+            mobile.properties()["$app_namespace"],
+            json!("com.example.app")
+        );
+        assert_eq!(mobile.properties()["$app_version"], json!("1.0"));
+        assert_eq!(mobile.properties()["$app_build"], json!(7));
     }
 
     const TEAM_ID: TeamId = 1;

--- a/rust/cymbal/src/modes/processing/types/exception_event.rs
+++ b/rust/cymbal/src/modes/processing/types/exception_event.rs
@@ -221,6 +221,15 @@ impl<S> ExceptionEvent<S> {
         &self.props
     }
 
+    /// Fill a property the event did not send. Cymbal derives properties that SDKs also report,
+    /// and an SDK read them off the running app, so a value already on the event is the better one
+    /// and is left alone.
+    pub(crate) fn set_property_if_absent(&mut self, key: &str, value: Value) {
+        if !self.props.contains_key(key) {
+            self.props.insert(key.to_string(), value);
+        }
+    }
+
     pub(crate) fn exception_level(&self) -> Option<&str> {
         self.props.get("$exception_level").and_then(Value::as_str)
     }

--- a/rust/cymbal/src/modes/processing/types/exception_event.rs
+++ b/rust/cymbal/src/modes/processing/types/exception_event.rs
@@ -224,8 +224,12 @@ impl<S> ExceptionEvent<S> {
     /// Fill a property the event did not send. Cymbal derives properties that SDKs also report,
     /// and an SDK read them off the running app, so a value already on the event is the better one
     /// and is left alone.
+    ///
+    /// A null counts as not sent, because SDKs do send one. The React Native SDK spreads its app
+    /// properties into every event whether or not the platform could supply them, so an Expo app
+    /// that cannot read its own version sends `"$app_version": null`.
     pub(crate) fn set_property_if_absent(&mut self, key: &str, value: Value) {
-        if !self.props.contains_key(key) {
+        if matches!(self.props.get(key), None | Some(Value::Null)) {
             self.props.insert(key.to_string(), value);
         }
     }


### PR DESCRIPTION
## Problem

- An exception from a JS, Python, Go or Node SDK shows a blank "App" row in error tracking, and cannot be filtered by app version.
- Mobile SDKs report `$app_namespace`, `$app_version` and `$app_build` on every event. No other SDK reports any of them.
- Cymbal already resolves one release per exception for every technology, and that release records the same app.

## Changes

- Every exception that resolves a release now carries the three app properties, whichever SDK sent it.
- `$app_namespace` comes from the release project. `$app_version` and `$app_build` come from its version.
- The backfill runs in `EventReleaseResolver`, where all three release sources converge: an injected `$release_id`, the mobile app-metadata hash, and the symbol sets resolution used.
- A property the SDK already sent is never replaced. The SDK read it off the running app, and a mobile release may have been created under a name that is not the bundle identifier.
- The CLI packs `--release-version` and `--build` into one string as `1.2.3+42`, so `unpack_version` splits it back apart. An iOS release row and an iOS SDK event then agree on shape.
- A release versioned `1.0.0+sha.abc` with no build unpacks as version `1.0.0` and build `sha.abc`. The packing is ambiguous in that one direction, and this reading never drops a real `--build`.
- Exceptions that resolve no release are unchanged. There is no other source for the properties.
- No frontend code changed. The existing "App" row in `ContextDisplay.tsx` reads these two properties already, so it starts filling in for web and backend exceptions.

> [!NOTE]
> The properties land on the event only, not the person. Ingestion sets `$initial_app_version` before cymbal runs.

## How did you test this code?

| Event now carries `app_x` properties |
|--------|
| <img width="1555" height="416" alt="CleanShot 2026-08-18 at 14 49 07" src="https://github.com/user-attachments/assets/f11b5e56-e10f-4ee2-a3ea-7b7b3093a0d0" /> | 

- `unpack_version_recovers_the_build_pack_version_folded_in` catches a split that reads semver build metadata as the build number, which would put `sha.abc` in `$app_build` for a release built as `1.0.0+sha.abc+42`.
- `the_release_fills_app_metadata_the_sdk_did_not_send` catches a backfill that overwrites instead of fills, which would replace a mobile event's real bundle identifier with the release name.
- Not run: the sqlx tests in this file, because this machine has no Postgres for them. Not run: the pipeline against a live event, so the properties are unverified end to end.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code (Opus 5). Skills invoked: `/writing-code-comments`, `/writing-tests`, `/writing-pr-descriptions`.

The mapping from release fields to event properties was specified by the assignee. Two decisions came out of the session: splitting the packed version rather than passing it through whole, so mobile releases and mobile SDK events describe a build the same way, and letting the SDK's own values win over the release.
