### PR TITLE
fix(funnels): default missing funnel viz type to steps in legacy conversion

### DIFF
--- a/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
@@ -506,6 +506,11 @@ def _insight_filter(filter: dict, allow_variables: bool = False):
         # Before Filter.funnel_viz_type funnel trends were indicated by Filter.display being TRENDS_LINEAR
         if funnel_viz_type is None and filter.get("display") == "ActionsLineGraph":
             funnel_viz_type = FunnelVizType.TRENDS
+        # Resolve the default here instead of relying on the model default: callers serialize the
+        # converted query with `exclude_none`, which drops a None and leaves stored queries with no
+        # visualization type at all. The frontend reads that JSON raw, so it can't fall back.
+        if funnel_viz_type is None:
+            funnel_viz_type = FunnelVizType.STEPS
 
         insight_filter = {
             "funnelsFilter": FunnelsFilter(

--- a/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
@@ -3,6 +3,8 @@ from typing import Any, cast
 import pytest
 from posthog.test.base import BaseTest
 
+from parameterized import parameterized
+
 from posthog.schema import (
     ActionsNode,
     AggregationAxisFormat,
@@ -1496,6 +1498,25 @@ class TestFilterToQuery(BaseTest):
                 # funnel_step_reference=FunnelStepReference.previous,
             ),
         )
+
+    @parameterized.expand(
+        [
+            ("no_viz_type", {"layout": "horizontal"}, "steps"),
+            ("legacy_trends_display", {"display": "ActionsLineGraph"}, "trends"),
+        ]
+    )
+    def test_funnels_filter_serializes_a_viz_type_when_filters_omit_it(
+        self, _name: str, extra_filter: dict[str, Any], expected_viz_type: str
+    ):
+        # Callers dump the converted query with exclude_none, so a None viz type disappears from the
+        # stored JSON and the frontend loses the layout switcher, conversion rate and results table.
+        filter: dict[str, Any] = {"insight": "FUNNELS", **extra_filter}
+
+        query = filter_to_query(filter)
+
+        assert isinstance(query, FunnelsQuery)
+        dumped = query.model_dump(exclude_none=True)
+        self.assertEqual(dumped["funnelsFilter"]["funnelVizType"], expected_viz_type)
 
     def test_retention_filter(self):
         filter: dict[str, Any] = {


### PR DESCRIPTION
## TL;DR

Very old funnels were saved without a "which funnel chart is this" setting. When we convert them to the modern format we were leaving that setting blank, and a blank setting makes parts of the funnel page disappear. Now we fill in "conversion steps", which is what those funnels always were.

## Problem

Someone opening a funnel saved before `funnel_viz_type` existed sees a funnel with pieces missing: no layout switcher, no total conversion rate, and no detailed results table. The chart itself still renders, so the insight looks half-broken rather than broken.

- `filter_to_query` passes `funnelVizType=filter.get("funnel_viz_type")`, which is `None` for those filters.
- Every caller serializes the result with `exclude_none`, so the key disappears instead of falling back to the model default.
- `Insight.query_from_filters` runs this on every read, and the API serves that query. Editing or duplicating such an insight persists the lossy shape into a new row, so the state spreads to insights created today.
- The pydantic default (`FunnelVizType.STEPS`) only applies when JSON is parsed back into a model. The frontend reads the stored JSON raw, so it never sees a default.

Legacy keys like `layout` survive the same conversion, which is why the broken funnels carry a `funnelsFilter` that holds everything except the visualization type.

## Changes

- Resolve the viz type to `steps` at conversion time when the legacy filter has none.
- Keep the existing `ActionsLineGraph` special case ahead of it, so legacy funnel trends still convert to `trends`.

This fixes the writer. The readers need their own fix, because a funnel query can also legitimately arrive with no `funnelsFilter` at all: [#83627](https://github.com/PostHog/posthog/pull/83627) restores the layout switcher, and a companion PR covers the conversion rate label and the results table.

> [!NOTE]
> Query cache keys are unaffected. `to_dict` in `posthog/schema_helpers.py` builds them with `exclude_defaults=True`, which strips `steps` again, so no insight recomputes because of this change.

## How did you test this code?

- Added two parameterized cases to `test_filter_to_query.py`: a filter with a `layout` and no viz type now serializes as `steps`, and the legacy `ActionsLineGraph` display still serializes as `trends`. Both assert on the `exclude_none` dump, because that is the boundary where the key used to vanish.
- The regression neither case covered before: no existing test dumps a converted funnels query, so a `None` viz type passed unnoticed.
- Verified the four conversion shapes (missing, legacy trends display, explicit `time_to_convert`, bare `FUNNELS`) through the function directly.
- Not verified: the test suite run. Creating the test database in this sandbox exceeded the time available, so CI is the first full run of these tests. No manual UI testing was done.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This restores intended behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code in PostHog Desktop, starting from a report of one funnel that had lost its `funnelVizType`. Repo skills invoked: `/writing-tests` and `/writing-pr-descriptions`.

Tracing the reported insight showed it was created recently, not by the 2024 `filters` to `query` migration, which pointed at the serve-then-save path through `query_from_filters` rather than a one-off migration artifact. The alternative was normalizing queries in `InsightSerializer.validate_query`, which is rejected: that serializer deliberately round-trips already-wrapped nodes verbatim.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
