### PR TITLE
fix(funnels): treat a missing funnel viz type as conversion steps

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/InsightVizDisplay.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightVizDisplay.tsx
@@ -172,10 +172,10 @@ export function InsightVizDisplay({
     } = useValues(insightVizDataLogic(insightProps))
     const { loadData, updateQuerySource } = useActions(insightVizDataLogic(insightProps))
     const { exportContext, queryId } = useValues(insightDataLogic(insightProps))
-    const { funnelsFilter, hasFunnelResults, isFunnelWithEnoughSteps, isFunnelWithIncompleteDataWarehouseStep } =
+    const { funnelVizType, hasFunnelResults, isFunnelWithEnoughSteps, isFunnelWithIncompleteDataWarehouseStep } =
         useValues(funnelDataLogic(insightProps))
 
-    const isFlowViz = funnelsFilter?.funnelVizType === FunnelVizType.Flow
+    const isFlowViz = funnelVizType === FunnelVizType.Flow
     const actionable = !embedded && editMode
 
     // Empty states that completely replace the graph
@@ -404,7 +404,6 @@ export function InsightVizDisplay({
             hasFunnelResults &&
             !disableTable
         ) {
-            const funnelVizType = funnelsFilter?.funnelVizType
             const funnelTable =
                 funnelVizType === FunnelVizType.TimeToConvert ? (
                     <FunnelTimeToConvertTable />

--- a/frontend/src/scenes/funnels/Funnel.tsx
+++ b/frontend/src/scenes/funnels/Funnel.tsx
@@ -17,8 +17,8 @@ import { FunnelFlowGraph } from './FunnelFlowGraph/FunnelFlowGraph'
 
 export function Funnel(props: ChartParams): JSX.Element {
     const { insightProps } = useValues(insightLogic)
-    const { funnelsFilter } = useValues(funnelDataLogic(insightProps))
-    const { funnelVizType, layout } = funnelsFilter || {}
+    const { funnelsFilter, funnelVizType } = useValues(funnelDataLogic(insightProps))
+    const { layout } = funnelsFilter || {}
 
     let viz: JSX.Element | null = null
     if (funnelVizType == FunnelVizType.Trends) {
@@ -35,7 +35,7 @@ export function Funnel(props: ChartParams): JSX.Element {
 
     return (
         <div
-            className={`FunnelInsight FunnelInsight--type-${funnelVizType?.toLowerCase()}${
+            className={`FunnelInsight FunnelInsight--type-${funnelVizType.toLowerCase()}${
                 funnelVizType === FunnelVizType.Steps ? '-' + (layout ?? FunnelLayout.vertical) : ''
             }`}
         >

--- a/frontend/src/scenes/funnels/FunnelCanvasLabel.tsx
+++ b/frontend/src/scenes/funnels/FunnelCanvasLabel.tsx
@@ -19,12 +19,12 @@ import { FunnelVizType, type QueryBasedInsightModel } from '~/types'
 
 export function FunnelCanvasLabel(): JSX.Element | null {
     const { insightProps, insight, supportsCreatingExperiment, derivedName } = useValues(insightLogic)
-    const { conversionMetrics, aggregationTargetLabel, funnelsFilter } = useValues(funnelDataLogic(insightProps))
+    const { conversionMetrics, aggregationTargetLabel, funnelVizType } = useValues(funnelDataLogic(insightProps))
     const { updateInsightFilter } = useActions(funnelDataLogic(insightProps))
     const { addProductIntentForCrossSell } = useActions(teamLogic)
 
     const labels = [
-        ...(funnelsFilter?.funnelVizType === FunnelVizType.Steps
+        ...(funnelVizType === FunnelVizType.Steps
             ? [
                   <>
                       <span className="flex items-center text-secondary mr-1">
@@ -39,7 +39,7 @@ export function FunnelCanvasLabel(): JSX.Element | null {
                   </>,
               ]
             : []),
-        ...(funnelsFilter?.funnelVizType !== FunnelVizType.Trends && conversionMetrics.medianTime != null
+        ...(funnelVizType !== FunnelVizType.Trends && conversionMetrics.medianTime != null
             ? [
                   <>
                       <span className="flex items-center text-secondary">
@@ -50,9 +50,9 @@ export function FunnelCanvasLabel(): JSX.Element | null {
                           </Tooltip>
                           <span>Median time to convert</span>
                       </span>
-                      {funnelsFilter?.funnelVizType === FunnelVizType.TimeToConvert && <FunnelStepsPicker />}
+                      {funnelVizType === FunnelVizType.TimeToConvert && <FunnelStepsPicker />}
                       <span className="text-secondary mr-1">:</span>
-                      {funnelsFilter?.funnelVizType === FunnelVizType.TimeToConvert ? (
+                      {funnelVizType === FunnelVizType.TimeToConvert ? (
                           <span className="font-bold">{humanFriendlyDuration(conversionMetrics.medianTime)}</span>
                       ) : (
                           <Link
@@ -65,7 +65,7 @@ export function FunnelCanvasLabel(): JSX.Element | null {
                   </>,
               ]
             : []),
-        ...(funnelsFilter?.funnelVizType === FunnelVizType.Trends
+        ...(funnelVizType === FunnelVizType.Trends
             ? [
                   <>
                       <span className="text-secondary">Conversion rate</span>

--- a/frontend/src/scenes/funnels/funnelDataLogic.test.ts
+++ b/frontend/src/scenes/funnels/funnelDataLogic.test.ts
@@ -134,6 +134,34 @@ describe('funnelDataLogic', () => {
                 isTrendsFunnel: true,
             })
         })
+
+        // Saved funnels can carry a funnelsFilter with no viz type. Without a resolved default the
+        // conversion rate label and the detailed results table disappear.
+        it.each([
+            ['no funnelsFilter', {}, FunnelVizType.Steps],
+            [
+                'a funnelsFilter without a viz type',
+                { funnelsFilter: { funnelWindowInterval: 14 } },
+                FunnelVizType.Steps,
+            ],
+            [
+                'an explicit viz type',
+                { funnelsFilter: { funnelVizType: FunnelVizType.TimeToConvert } },
+                FunnelVizType.TimeToConvert,
+            ],
+        ])('resolves the viz type for %s', async (_name, queryPatch, expected) => {
+            const query: FunnelsQuery = {
+                kind: NodeKind.FunnelsQuery,
+                series: [],
+                ...queryPatch,
+            }
+
+            await expectLogic(logic, () => {
+                logic.actions.updateQuerySource(query)
+            }).toMatchValues({
+                funnelVizType: expected,
+            })
+        })
     })
 
     describe('empty funnel', () => {

--- a/frontend/src/scenes/funnels/funnelDataLogic.ts
+++ b/frontend/src/scenes/funnels/funnelDataLogic.ts
@@ -231,6 +231,7 @@ export interface funnelDataLogicValues {
     exclusionDefaultStepRange: FunnelExclusionSteps
     exclusionFilters: FilterType
     flattenedBreakdowns: FlattenedFunnelStepByBreakdown[]
+    funnelVizType: FunnelVizType
     getFunnelsColor: (dataset: FlattenedFunnelStepByBreakdown | FunnelStepWithConversionMetrics) => string
     getFunnelsColorToken: (
         dataset: FlattenedFunnelStepByBreakdown | FunnelStepWithConversionMetrics
@@ -358,6 +359,7 @@ export interface funnelDataLogicMeta {
         isTimeToConvertFunnel: (funnelsFilter: FunnelsFilter | null | undefined) => boolean | null
         isTrendsFunnel: (funnelsFilter: FunnelsFilter | null | undefined) => boolean | null
         isEmptyFunnel: (querySource: FunnelsQuery | null) => boolean | null
+        funnelVizType: (funnelsFilter: FunnelsFilter | null | undefined) => FunnelVizType
         aggregationTargetLabel: (
             querySource: FunnelsQuery | null,
             aggregationLabel: (groupTypeIndex: number | null | undefined, deferToUserWording?: boolean) => Noun
@@ -665,6 +667,14 @@ export const funnelDataLogic = kea<funnelDataLogicType>([
                           .length === 0
                     : null
             },
+        ],
+
+        // Saved funnels can lack a viz type entirely: the backend relies on a schema default that never
+        // reaches the stored JSON the frontend reads. Resolve it once so every consumer agrees.
+        funnelVizType: [
+            (s) => [s.funnelsFilter],
+            (funnelsFilter: FunnelsFilter | null | undefined): FunnelVizType =>
+                funnelsFilter?.funnelVizType ?? FunnelVizType.Steps,
         ],
 
         aggregationTargetLabel: [

--- a/frontend/src/scenes/insights/views/Funnels/FunnelCorrelation.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelCorrelation.tsx
@@ -15,9 +15,8 @@ import { FunnelPropertyCorrelationTable } from './FunnelPropertyCorrelationTable
 
 export const FunnelCorrelation = (): JSX.Element | null => {
     const { insightProps } = useValues(insightLogic)
-    const { steps, funnelsFilter, hasDataWarehouseSeries } = useValues(funnelDataLogic(insightProps))
+    const { steps, funnelVizType: vizType, hasDataWarehouseSeries } = useValues(funnelDataLogic(insightProps))
     useMountedLogic(funnelCorrelationUsageLogic(insightProps))
-    const vizType = funnelsFilter?.funnelVizType
     if (
         (vizType !== FunnelVizType.Steps && vizType !== FunnelVizType.Flow) ||
         steps.length <= 1 ||


### PR DESCRIPTION
## TL;DR

Some saved funnels don't record which funnel chart they are. The funnel page treated "not recorded" as "not a steps funnel" and hid the conversion rate, the results table, correlation analysis, and the chart's reserved height. Now the page assumes conversion steps when nothing is recorded, which is what those funnels are.

## Problem

Someone opening one of these funnels sees a funnel with pieces missing. The chart still draws, so it reads as an odd half-broken insight rather than an error.

- The total conversion rate label disappears (`FunnelCanvasLabel`).
- The detailed results table disappears, because the table picker falls through every branch to `null` (`InsightVizDisplay`).
- Correlation analysis disappears, because the panel returns `null` unless the viz type is steps or flow (`FunnelCorrelation`).
- The chart loses its reserved height, because `Funnel` builds the class `FunnelInsight--type-undefined` and `InsightViz.scss` only sets `min-height` for the four real variants.

The query still computes as a steps funnel, so only the frontend disagrees. The backend applies the `FunnelVizType.STEPS` schema default when it parses a query into a model, but the API serves the stored JSON and the frontend reads that raw, so no default ever arrives.

Both shapes hit this: a `funnelsFilter` that holds sibling keys but no `funnelVizType`, and a funnel query stored with no `funnelsFilter` at all. The second is reachable from the paths to funnel action, which builds a `FunnelsQuery` without one. Saved insights keep whatever the client sent, because `InsightSerializer.validate_query` round-trips an already-wrapped node verbatim by design.

## Changes

- Add a `funnelVizType` selector to `funnelDataLogic` that resolves the missing value to `steps`.
- Read that selector in `FunnelCanvasLabel`, `InsightVizDisplay`, `Funnel` and `FunnelCorrelation` instead of reaching into `funnelsFilter`.

One selector rather than a fallback per component, so the surfaces cannot drift apart again. Other readers of `funnelsFilter?.funnelVizType` are left alone: they compare against `time_to_convert`, `trends` or `flow`, where a missing value already resolves the way a steps funnel should.

[#83627](https://github.com/PostHog/posthog/pull/83627) fixes a fifth reader, the layout switcher, through `isStepsFunnel`. This PR does not depend on it, and once it lands `isStepsFunnel` can fold onto this selector and drop its own fallback.

> [!NOTE]
> This is a reader-side fix on purpose. It repairs insights already saved, which no writer-side change can do. [#84365](https://github.com/PostHog/posthog/pull/84365) closes the one writer this investigation could pin down.

## How did you test this code?

- Added three `it.each` rows to `funnelDataLogic.test.ts` covering both broken shapes and an explicit `time_to_convert`, so a blanket default would fail too.
- The regression they catch that nothing else did: no existing test asserts a resolved viz type, so `undefined` reached the components unnoticed.
- Confirmed the rows fail against the unfixed selector: the two missing-viz-type rows fail, the explicit one passes.
- Ran the `scenes/funnels` and `queries/nodes/InsightViz` Jest suites, plus Oxlint and Oxfmt over the changed files.
- `tsgo --noEmit` reports no errors in these files. It does fail in this sandbox, on 17 pre-existing missing-module errors in unrelated product frontends, because the nested `@posthog/quill` workspace is unbuilt here.
- No screenshots: the sandbox has no running app, so the restored surfaces were traced through the components and `InsightViz.scss` rather than rendered. The min-height claim rests on reading the generated class name against the stylesheet.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This restores intended behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code in PostHog Desktop, after tracing a report of one funnel that had lost its `funnelVizType`. Repo skills invoked: `/writing-tests` and `/writing-pr-descriptions`.

The investigation started from the layout switcher and swept every reader of the viz type, which is how the other four surfaced. Two of them only showed up from checking the consequence rather than the code: the min-height needed reading the generated class name against the stylesheet, and correlation analysis hides itself by returning `null`.

Two rejected alternatives, both worth knowing about:

- Defaulting inside the shared `funnelsFilter` selector. That value feeds edits and change detection, so injecting a default there would mark untouched legacy funnels as modified.
- A companion backend change defaulting the viz type in the legacy filter conversion, opened as #84355 and closed unmerged. It was a no-op: `filter_to_query` ends with `Query(**Query(**data).model_dump(exclude_none=True))`, and that re-parse already re-applies the pydantic default.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
