### PR TITLE
feat(desktop): update-banner peek panel and restart-when-idle

### DIFF
--- a/products/desktop/apps/code/src/renderer/desktop-contributions.ts
+++ b/products/desktop/apps/code/src/renderer/desktop-contributions.ts
@@ -24,6 +24,7 @@ import { notificationsUiModule } from "@posthog/ui/features/notifications/notifi
 import { provisioningUiModule } from "@posthog/ui/features/provisioning/provisioning.module";
 import { settingsUiModule } from "@posthog/ui/features/settings/settings.module";
 import { setupUiModule } from "@posthog/ui/features/setup/setup.module";
+import { updatesUiModule } from "@posthog/ui/features/updates/updates.module";
 import { workspaceUiModule } from "@posthog/ui/features/workspace/workspace.module";
 import {
   AnalyticsBootContribution,
@@ -58,6 +59,7 @@ export function registerDesktopContributions(): void {
     setupUiModule,
     skillsCoreModule,
     speechCoreModule,
+    updatesUiModule,
     workspaceUiModule,
   ]) {
     container.load(module);

--- a/products/desktop/apps/code/src/renderer/platform-adapters/updates.ts
+++ b/products/desktop/apps/code/src/renderer/platform-adapters/updates.ts
@@ -42,6 +42,15 @@ void client
     log.error("Failed to get update enabled status", { error });
   });
 
+// The banner and peek panel compare the running version against the pending
+// update ("You're on X — N releases behind").
+void hostTrpcClient.os.getAppVersion
+  .query()
+  .then((version) => store().setCurrentVersion(version))
+  .catch((error: unknown) => {
+    log.error("Failed to get current app version", { error });
+  });
+
 void client
   .getStatus()
   .then((status) => {

--- a/products/desktop/apps/web/src/web-container.ts
+++ b/products/desktop/apps/web/src/web-container.ts
@@ -262,6 +262,7 @@ import {
   SHELL_CLIENT,
   type ShellClient,
 } from "@posthog/ui/features/terminal/shellClient";
+import { updatesUiModule } from "@posthog/ui/features/updates/updates.module";
 import {
   UPDATES_CLIENT,
   type UpdatesClient,
@@ -671,7 +672,9 @@ container.bind(ARCHIVE_CLIENT).toConstantValue({
 
 // ── Updates (UpdateAvailableModal / WhatsNewModal at __root) ──
 // Auto-update is a desktop (Electron) capability; a web app updates on reload.
-// Report disabled/up-to-date and never emit update events.
+// Report disabled/up-to-date and never emit update events. The module's
+// deferred-install contribution stays dormant: the phase never leaves "off".
+container.load(updatesUiModule);
 container.bind(UPDATES_CLIENT).toConstantValue({
   install: () => Promise.resolve({ installed: false }),
   check: () => Promise.resolve({ success: true }),

--- a/products/desktop/packages/core/src/sessions/busyLocalSessions.test.ts
+++ b/products/desktop/packages/core/src/sessions/busyLocalSessions.test.ts
@@ -1,0 +1,68 @@
+import type { AgentSession } from "@posthog/shared";
+import { describe, expect, it } from "vitest";
+import { countBusyLocalSessions } from "./busyLocalSessions";
+
+function session(overrides: Partial<AgentSession>): AgentSession {
+  return {
+    taskRunId: "run-1",
+    taskId: "task-1",
+    taskTitle: "Task",
+    channel: "channel",
+    events: [],
+    startedAt: 0,
+    status: "connected",
+    isPromptPending: false,
+    isCompacting: false,
+    promptStartedAt: null,
+    pendingPermissions: new Map(),
+    pausedDurationMs: 0,
+    messageQueue: [],
+    optimisticItems: [],
+    ...overrides,
+  };
+}
+
+describe("countBusyLocalSessions", () => {
+  it.each([
+    {
+      name: "counts a local session with a prompt in flight",
+      overrides: { isPromptPending: true },
+      expected: 1,
+    },
+    {
+      name: "ignores an idle local session",
+      overrides: { isPromptPending: false },
+      expected: 0,
+    },
+    {
+      name: "ignores a cloud session even while it is working",
+      overrides: { isCloud: true, isPromptPending: true },
+      expected: 0,
+    },
+    {
+      name: "ignores a disconnected local session with a stale pending prompt",
+      overrides: { status: "disconnected" as const, isPromptPending: true },
+      expected: 0,
+    },
+    {
+      name: "ignores an errored local session",
+      overrides: { status: "error" as const, isPromptPending: true },
+      expected: 0,
+    },
+  ])("$name", ({ overrides, expected }) => {
+    expect(countBusyLocalSessions({ "run-1": session(overrides) })).toBe(
+      expected,
+    );
+  });
+
+  it("counts across multiple sessions", () => {
+    expect(
+      countBusyLocalSessions({
+        a: session({ taskRunId: "a", isPromptPending: true }),
+        b: session({ taskRunId: "b", isPromptPending: true }),
+        c: session({ taskRunId: "c", isCloud: true, isPromptPending: true }),
+        d: session({ taskRunId: "d" }),
+      }),
+    ).toBe(2);
+  });
+});

--- a/products/desktop/packages/core/src/sessions/busyLocalSessions.ts
+++ b/products/desktop/packages/core/src/sessions/busyLocalSessions.ts
@@ -1,0 +1,23 @@
+import type { AgentSession } from "@posthog/shared";
+
+/**
+ * Sessions an app restart would actually interrupt: local agents with a turn
+ * in flight. Cloud runs execute on PostHog's infrastructure and reattach after
+ * a relaunch, and an idle local session resumes from its persisted transcript,
+ * so neither counts.
+ */
+export function countBusyLocalSessions(
+  sessions: Record<string, AgentSession>,
+): number {
+  let count = 0;
+  for (const session of Object.values(sessions)) {
+    if (
+      !session.isCloud &&
+      session.status === "connected" &&
+      session.isPromptPending
+    ) {
+      count += 1;
+    }
+  }
+  return count;
+}

--- a/products/desktop/packages/core/src/updates/updateStore.test.ts
+++ b/products/desktop/packages/core/src/updates/updateStore.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  deriveDeferredInstallTransition,
   deriveUpdateUiStatus,
   resolveMenuCheckFromStatus,
   resolveMenuCheckResult,
@@ -146,6 +147,82 @@ describe("resolveMenuCheckFromStatus", () => {
 
   it("keeps pending while still checking", () => {
     expect(resolveMenuCheckFromStatus({ checking: true }, true)).toBeNull();
+  });
+});
+
+describe("deriveDeferredInstallTransition", () => {
+  it.each([
+    {
+      name: "does nothing while off",
+      phase: "off" as const,
+      updateStatus: "ready" as const,
+      busyLocalSessions: 0,
+      expected: null,
+    },
+    {
+      name: "waits while local agents are busy",
+      phase: "waiting" as const,
+      updateStatus: "ready" as const,
+      busyLocalSessions: 2,
+      expected: null,
+    },
+    {
+      name: "begins the countdown once idle",
+      phase: "waiting" as const,
+      updateStatus: "ready" as const,
+      busyLocalSessions: 0,
+      expected: "begin-countdown",
+    },
+    {
+      name: "stays armed while a newer update downloads",
+      phase: "waiting" as const,
+      updateStatus: "downloading" as const,
+      busyLocalSessions: 0,
+      expected: null,
+    },
+    {
+      name: "aborts the countdown when an agent starts working",
+      phase: "countdown" as const,
+      updateStatus: "ready" as const,
+      busyLocalSessions: 1,
+      expected: "return-to-waiting",
+    },
+    {
+      name: "aborts the countdown when the update stops being ready",
+      phase: "countdown" as const,
+      updateStatus: "downloading" as const,
+      busyLocalSessions: 0,
+      expected: "return-to-waiting",
+    },
+    {
+      name: "keeps counting down while idle and ready",
+      phase: "countdown" as const,
+      updateStatus: "ready" as const,
+      busyLocalSessions: 0,
+      expected: null,
+    },
+    {
+      name: "disarms when a manual install starts",
+      phase: "waiting" as const,
+      updateStatus: "installing" as const,
+      busyLocalSessions: 0,
+      expected: "disarm",
+    },
+    {
+      name: "disarms when updates shut off",
+      phase: "countdown" as const,
+      updateStatus: "idle" as const,
+      busyLocalSessions: 0,
+      expected: "disarm",
+    },
+  ])("$name", ({ phase, updateStatus, busyLocalSessions, expected }) => {
+    expect(
+      deriveDeferredInstallTransition({
+        phase,
+        updateStatus,
+        busyLocalSessions,
+      }),
+    ).toBe(expected);
   });
 });
 

--- a/products/desktop/packages/core/src/updates/updateStore.ts
+++ b/products/desktop/packages/core/src/updates/updateStore.ts
@@ -9,10 +9,20 @@ export type UpdateUiStatus =
   | "ready"
   | "installing";
 
+/**
+ * Deferred install ("restart when idle") lifecycle: `off` until the user arms
+ * it, `waiting` while local agents are still working, `countdown` once the app
+ * is idle and a cancellable restart timer is running.
+ */
+export type DeferredInstallPhase = "off" | "waiting" | "countdown";
+
+export const DEFERRED_INSTALL_COUNTDOWN_SECONDS = 10;
+
 interface UpdateState {
   status: UpdateUiStatus;
   version: string | null;
   availableVersion: string | null;
+  currentVersion: string | null;
   releaseNotes: string | null;
   releaseDate: string | null;
   downloadPercent: number | null;
@@ -20,12 +30,20 @@ interface UpdateState {
   downloadSizeBytes: number | null;
   isEnabled: boolean;
   menuCheckPending: boolean;
+  deferredInstallPhase: DeferredInstallPhase;
+  deferredInstallCountdown: number | null;
 
   setStatus: (status: UpdateUiStatus) => void;
   setVersion: (version: string | null) => void;
+  setCurrentVersion: (currentVersion: string | null) => void;
   setEnabled: (isEnabled: boolean) => void;
   setMenuCheckPending: (menuCheckPending: boolean) => void;
   setReady: (version: string | null) => void;
+  armDeferredInstall: () => void;
+  disarmDeferredInstall: () => void;
+  beginDeferredInstallCountdown: (seconds: number) => void;
+  tickDeferredInstallCountdown: (seconds: number) => void;
+  returnDeferredInstallToWaiting: () => void;
   applyStatusUpdate: (update: UpdateStatusUpdate) => void;
 }
 
@@ -33,6 +51,7 @@ export const updateStore = createStore<UpdateState>((set) => ({
   status: "idle",
   version: null,
   availableVersion: null,
+  currentVersion: null,
   releaseNotes: null,
   releaseDate: null,
   downloadPercent: null,
@@ -40,12 +59,28 @@ export const updateStore = createStore<UpdateState>((set) => ({
   downloadSizeBytes: null,
   isEnabled: false,
   menuCheckPending: false,
+  deferredInstallPhase: "off",
+  deferredInstallCountdown: null,
 
   setStatus: (status) => set({ status }),
   setVersion: (version) => set({ version }),
+  setCurrentVersion: (currentVersion) => set({ currentVersion }),
   setEnabled: (isEnabled) => set({ isEnabled }),
   setMenuCheckPending: (menuCheckPending) => set({ menuCheckPending }),
   setReady: (version) => set({ status: "ready", version }),
+  armDeferredInstall: () =>
+    set({ deferredInstallPhase: "waiting", deferredInstallCountdown: null }),
+  disarmDeferredInstall: () =>
+    set({ deferredInstallPhase: "off", deferredInstallCountdown: null }),
+  beginDeferredInstallCountdown: (seconds) =>
+    set({
+      deferredInstallPhase: "countdown",
+      deferredInstallCountdown: seconds,
+    }),
+  tickDeferredInstallCountdown: (seconds) =>
+    set({ deferredInstallCountdown: seconds }),
+  returnDeferredInstallToWaiting: () =>
+    set({ deferredInstallPhase: "waiting", deferredInstallCountdown: null }),
   applyStatusUpdate: (update) =>
     set((state) => ({
       status: update.status ?? state.status,
@@ -190,6 +225,40 @@ export interface MenuCheckResult {
   success: boolean;
   errorCode?: string;
   errorMessage?: string;
+}
+
+export type DeferredInstallTransition =
+  | "begin-countdown"
+  | "return-to-waiting"
+  | "disarm";
+
+/**
+ * Decides how an armed "restart when idle" install reacts to update-status and
+ * agent-activity changes. Cloud runs continue server-side across a restart, so
+ * `busyLocalSessions` counts only local agents mid-turn. The arm survives a
+ * newer update arriving (ready → downloading → ready); it is only dropped when
+ * an install is already underway or updates shut off entirely.
+ */
+export function deriveDeferredInstallTransition(input: {
+  phase: DeferredInstallPhase;
+  updateStatus: UpdateUiStatus;
+  busyLocalSessions: number;
+}): DeferredInstallTransition | null {
+  const { phase, updateStatus, busyLocalSessions } = input;
+  if (phase === "off") {
+    return null;
+  }
+  if (updateStatus === "installing" || updateStatus === "idle") {
+    return "disarm";
+  }
+  if (phase === "waiting") {
+    return updateStatus === "ready" && busyLocalSessions === 0
+      ? "begin-countdown"
+      : null;
+  }
+  return updateStatus !== "ready" || busyLocalSessions > 0
+    ? "return-to-waiting"
+    : null;
 }
 
 export function resolveMenuCheckResult(

--- a/products/desktop/packages/ui/src/features/sessions/useBusyLocalSessionCount.ts
+++ b/products/desktop/packages/ui/src/features/sessions/useBusyLocalSessionCount.ts
@@ -1,0 +1,7 @@
+import { countBusyLocalSessions } from "@posthog/core/sessions/busyLocalSessions";
+import { useSessionStore } from "@posthog/ui/features/sessions/sessionStore";
+
+/** Count of local agent sessions mid-turn, i.e. what an app restart interrupts. */
+export function useBusyLocalSessionCount(): number {
+  return useSessionStore((state) => countBusyLocalSessions(state.sessions));
+}

--- a/products/desktop/packages/ui/src/features/sidebar/components/UpdateBanner.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/UpdateBanner.tsx
@@ -1,12 +1,14 @@
 import { ArrowsClockwise, Gift, Spinner, X } from "@phosphor-icons/react";
+import { updateStore } from "@posthog/core/updates/updateStore";
 import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
+import { UpdateReadyPeek } from "@posthog/ui/features/updates/UpdateReadyPeek";
 import { useUpdateBannerStore } from "@posthog/ui/features/updates/updateBannerStore";
 import { useUpdateModalStore } from "@posthog/ui/features/updates/updateModalStore";
 import {
   useInstallUpdate,
   useUpdateView,
 } from "@posthog/ui/features/updates/updateStore";
-import { Box } from "@radix-ui/themes";
+import { Box, Popover } from "@radix-ui/themes";
 import { AnimatePresence, motion } from "framer-motion";
 
 interface UpdateBannerProps {
@@ -14,8 +16,16 @@ interface UpdateBannerProps {
 }
 
 export function UpdateBanner({ variant = "sidebar" }: UpdateBannerProps) {
-  const { status, version, availableVersion, downloadPercent, isEnabled } =
-    useUpdateView();
+  const {
+    status,
+    version,
+    availableVersion,
+    currentVersion,
+    downloadPercent,
+    isEnabled,
+    deferredInstallPhase,
+    deferredInstallCountdown,
+  } = useUpdateView();
   const installUpdate = useInstallUpdate();
   const openModal = useUpdateModalStore((state) => state.open);
   const canDismiss = useSettingsStore(
@@ -38,6 +48,16 @@ export function UpdateBanner({ variant = "sidebar" }: UpdateBannerProps) {
       status === "installing");
 
   const percent = Math.round(downloadPercent ?? 0);
+
+  const isDeferredArmed = deferredInstallPhase !== "off";
+  const readySubline =
+    deferredInstallPhase === "countdown" && deferredInstallCountdown !== null
+      ? `Restarting in ${deferredInstallCountdown}s…`
+      : deferredInstallPhase === "waiting"
+        ? "Restarting once agents finish"
+        : currentVersion
+          ? `You're on ${currentVersion} — restart to apply`
+          : "Restart to apply";
 
   if (variant === "compact") {
     return (
@@ -177,45 +197,63 @@ export function UpdateBanner({ variant = "sidebar" }: UpdateBannerProps) {
 
             {status === "ready" && (
               <BannerCard key="ready">
-                <div className="group relative flex w-full items-center gap-3 rounded-md border border-[var(--green-a5)] bg-[var(--green-a3)] px-3 py-2.5 text-[13px] text-[var(--green-11)]">
-                  <motion.div
-                    className="shrink-0"
-                    animate={{ rotate: [0, -12, 12, -8, 8, -4, 0] }}
-                    transition={{
-                      duration: 0.6,
-                      repeat: Infinity,
-                      repeatDelay: 4,
-                      ease: "easeInOut",
-                    }}
-                  >
-                    <Gift size={20} weight="duotone" />
-                  </motion.div>
-                  <button
-                    type="button"
-                    onClick={openModal}
-                    className="flex min-w-0 flex-1 flex-col gap-0.5 text-left"
-                  >
-                    <span className="font-medium">
-                      {version ? `${version} ready` : "Update ready"}
-                    </span>
-                    <span className="text-[11px] text-[var(--green-a11)]">
-                      Restart to apply
-                    </span>
-                  </button>
-                  <button
-                    type="button"
-                    className="shrink-0 rounded-2 bg-[var(--green-a4)] px-2 py-1 font-medium text-[12px] text-[var(--green-11)] transition-colors hover:bg-[var(--green-a5)]"
-                    onClick={() => void installUpdate()}
-                  >
-                    Restart
-                  </button>
-                  {canDismiss && (
-                    <DismissButton
-                      variant="overlay"
-                      onClick={() => dismissBanner(dismissKey)}
-                    />
-                  )}
-                </div>
+                <Popover.Root>
+                  <div className="group relative flex w-full items-center gap-3 rounded-md border border-[var(--green-a5)] bg-[var(--green-a3)] px-3 py-2.5 text-[13px] text-[var(--green-11)]">
+                    <motion.div
+                      className="shrink-0"
+                      animate={{ rotate: [0, -12, 12, -8, 8, -4, 0] }}
+                      transition={{
+                        duration: 0.6,
+                        repeat: Infinity,
+                        repeatDelay: 4,
+                        ease: "easeInOut",
+                      }}
+                    >
+                      <Gift size={20} weight="duotone" />
+                    </motion.div>
+                    <Popover.Trigger>
+                      <button
+                        type="button"
+                        className="flex min-w-0 flex-1 flex-col gap-0.5 text-left"
+                      >
+                        <span className="font-medium">
+                          {version ? `${version} ready` : "Update ready"}
+                        </span>
+                        <span className="truncate text-[11px] text-[var(--green-a11)]">
+                          {readySubline}
+                        </span>
+                      </button>
+                    </Popover.Trigger>
+                    {isDeferredArmed ? (
+                      <button
+                        type="button"
+                        className="shrink-0 rounded-2 bg-[var(--green-a4)] px-2 py-1 font-medium text-[12px] text-[var(--green-11)] transition-colors hover:bg-[var(--green-a5)]"
+                        onClick={() =>
+                          updateStore.getState().disarmDeferredInstall()
+                        }
+                      >
+                        Cancel
+                      </button>
+                    ) : (
+                      <button
+                        type="button"
+                        className="shrink-0 rounded-2 bg-[var(--green-a4)] px-2 py-1 font-medium text-[12px] text-[var(--green-11)] transition-colors hover:bg-[var(--green-a5)]"
+                        onClick={() => void installUpdate()}
+                      >
+                        Restart
+                      </button>
+                    )}
+                    {canDismiss && (
+                      <DismissButton
+                        variant="overlay"
+                        onClick={() => dismissBanner(dismissKey)}
+                      />
+                    )}
+                  </div>
+                  <Popover.Content side="top" align="start" sideOffset={8}>
+                    <UpdateReadyPeek />
+                  </Popover.Content>
+                </Popover.Root>
               </BannerCard>
             )}
 

--- a/products/desktop/packages/ui/src/features/updates/UpdateReadyPeek.tsx
+++ b/products/desktop/packages/ui/src/features/updates/UpdateReadyPeek.tsx
@@ -1,0 +1,201 @@
+import { DiscordLogo, Warning } from "@phosphor-icons/react";
+import { updateStore } from "@posthog/core/updates/updateStore";
+import { useHostTRPC } from "@posthog/host-router/react";
+import { EXTERNAL_LINKS } from "@posthog/shared";
+import { useBusyLocalSessionCount } from "@posthog/ui/features/sessions/useBusyLocalSessionCount";
+import { ReleaseNotesSections } from "@posthog/ui/features/updates/ReleaseNotesSections";
+import {
+  mergeReleaseNotes,
+  parseReleaseNotes,
+  releasesBetween,
+} from "@posthog/ui/features/updates/releaseNotes";
+import {
+  useInstallUpdate,
+  useUpdateView,
+} from "@posthog/ui/features/updates/updateStore";
+import { useWhatsNewStore } from "@posthog/ui/features/updates/whatsNewStore";
+import { openExternalUrl } from "@posthog/ui/shell/openExternal";
+import { Button, Flex, ScrollArea, Skeleton, Text } from "@radix-ui/themes";
+import { useQuery } from "@tanstack/react-query";
+
+function NotesSkeleton() {
+  return (
+    <Flex direction="column" gap="2">
+      <Skeleton width="56px" height="12px" />
+      <Skeleton width="90%" height="14px" />
+      <Skeleton width="80%" height="14px" />
+      <Skeleton width="85%" height="14px" />
+    </Flex>
+  );
+}
+
+/**
+ * The expanded "Restart to apply" panel: what shipped since the version the
+ * user is running, whether a restart would interrupt working agents, and the
+ * restart-now / restart-when-idle actions.
+ */
+export function UpdateReadyPeek() {
+  const {
+    version,
+    currentVersion,
+    releaseNotes,
+    deferredInstallPhase,
+    deferredInstallCountdown,
+  } = useUpdateView();
+  const installUpdate = useInstallUpdate();
+  const openWhatsNew = useWhatsNewStore((state) => state.open);
+  const busyAgents = useBusyLocalSessionCount();
+  const hostTRPC = useHostTRPC();
+  const { data: releasesData, isPending: isPendingReleases } = useQuery(
+    hostTRPC.releaseFeed.list.queryOptions(
+      version ? { expectVersion: version } : undefined,
+    ),
+  );
+
+  const releases = releasesData?.releases ?? [];
+  const delta = version
+    ? releasesBetween(releases, currentVersion, version)
+    : [];
+  const mergedNotes = mergeReleaseNotes(delta);
+  // The feed can lag a fresh release; fall back to the updater's own notes.
+  const notes =
+    mergedNotes.improved.length > 0 || mergedNotes.fixed.length > 0
+      ? mergedNotes
+      : releaseNotes
+        ? parseReleaseNotes(releaseNotes)
+        : null;
+  const hasNotes =
+    !!notes && (notes.improved.length > 0 || notes.fixed.length > 0);
+  const behindCount = currentVersion ? delta.length : 0;
+
+  const isArmed = deferredInstallPhase !== "off";
+
+  return (
+    <Flex direction="column" gap="3" className="w-[320px]">
+      <Flex direction="column" gap="0">
+        <Text className="font-medium text-(--gray-12) text-[13px]">
+          {version ? `PostHog ${version} is ready` : "Update ready"}
+        </Text>
+        <Text className="text-(--gray-10) text-[12px]">
+          {currentVersion
+            ? `You're on ${currentVersion}${
+                behindCount > 0
+                  ? ` — ${behindCount} release${behindCount === 1 ? "" : "s"} behind`
+                  : ""
+              }`
+            : "Restart to apply the update"}
+        </Text>
+      </Flex>
+
+      {isPendingReleases && !hasNotes ? (
+        <NotesSkeleton />
+      ) : hasNotes && notes ? (
+        <ScrollArea
+          type="auto"
+          scrollbars="vertical"
+          style={{ maxHeight: 260 }}
+        >
+          <div className="pr-3">
+            <ReleaseNotesSections notes={notes} />
+          </div>
+        </ScrollArea>
+      ) : (
+        <Text className="text-(--gray-10) text-[12px]">
+          No release notes available.
+        </Text>
+      )}
+
+      {busyAgents > 0 && !isArmed ? (
+        <Flex gap="2" className="rounded-md bg-(--amber-a3) p-2">
+          <Warning size={14} className="mt-px shrink-0 text-(--amber-11)" />
+          <Text className="text-(--amber-11) text-[12px]">
+            {busyAgents === 1 ? "1 agent is" : `${busyAgents} agents are`} still
+            working — restarting now interrupts{" "}
+            {busyAgents === 1 ? "it" : "them"}. Cloud tasks keep running.
+          </Text>
+        </Flex>
+      ) : null}
+
+      {isArmed ? (
+        <Flex
+          align="center"
+          justify="between"
+          gap="2"
+          className="rounded-md bg-(--green-a3) p-2"
+        >
+          <Text className="text-(--green-11) text-[12px]">
+            {deferredInstallPhase === "countdown" &&
+            deferredInstallCountdown !== null
+              ? `Restarting in ${deferredInstallCountdown}s…`
+              : "Restarting once agents finish"}
+          </Text>
+          <Button
+            size="1"
+            variant="soft"
+            color="gray"
+            onClick={() => updateStore.getState().disarmDeferredInstall()}
+          >
+            Cancel
+          </Button>
+        </Flex>
+      ) : (
+        <Flex gap="2">
+          {busyAgents > 0 ? (
+            <>
+              <Button
+                size="1"
+                className="flex-1"
+                onClick={() => updateStore.getState().armDeferredInstall()}
+              >
+                Restart when agents finish
+              </Button>
+              <Button
+                size="1"
+                variant="soft"
+                color="gray"
+                onClick={() => void installUpdate()}
+              >
+                Restart now
+              </Button>
+            </>
+          ) : (
+            <Button
+              size="1"
+              className="flex-1"
+              onClick={() => void installUpdate()}
+            >
+              Restart now
+            </Button>
+          )}
+        </Flex>
+      )}
+
+      <Flex
+        align="center"
+        justify="between"
+        className="border-(--gray-4) border-t pt-2"
+      >
+        <Text className="text-(--gray-9) text-[11px]">
+          Also applies next time you quit
+        </Text>
+        <Flex align="center" gap="3">
+          <button
+            type="button"
+            className="text-(--gray-10) text-[11px] transition-colors hover:text-(--gray-12)"
+            onClick={openWhatsNew}
+          >
+            Full changelog
+          </button>
+          <button
+            type="button"
+            className="flex items-center gap-1 text-(--gray-10) text-[11px] transition-colors hover:text-(--gray-12)"
+            onClick={() => openExternalUrl(EXTERNAL_LINKS.discord)}
+          >
+            <DiscordLogo size={12} />
+            Feedback
+          </button>
+        </Flex>
+      </Flex>
+    </Flex>
+  );
+}

--- a/products/desktop/packages/ui/src/features/updates/deferred-install.contribution.ts
+++ b/products/desktop/packages/ui/src/features/updates/deferred-install.contribution.ts
@@ -1,0 +1,111 @@
+import { countBusyLocalSessions } from "@posthog/core/sessions/busyLocalSessions";
+import { sessionStore } from "@posthog/core/sessions/sessionStore";
+import {
+  DEFERRED_INSTALL_COUNTDOWN_SECONDS,
+  deriveDeferredInstallTransition,
+  updateStore,
+} from "@posthog/core/updates/updateStore";
+import type { Contribution } from "@posthog/di/contribution";
+import { performInstallUpdate } from "@posthog/ui/features/updates/updateStore";
+import {
+  UPDATES_CLIENT,
+  type UpdatesClient,
+} from "@posthog/ui/features/updates/updatesClient";
+import { toast } from "@posthog/ui/primitives/toast";
+import { inject, injectable } from "inversify";
+
+const COUNTDOWN_TOAST_ID = "deferred-install-countdown";
+
+/**
+ * Drives "restart when idle": once the user arms it from the update banner,
+ * watches local agent activity and, when the app goes idle with an update
+ * ready, runs a short cancellable countdown before installing. An agent
+ * starting mid-countdown sends it back to waiting; a manual restart disarms it.
+ */
+@injectable()
+export class DeferredInstallContribution implements Contribution {
+  private countdownTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(@inject(UPDATES_CLIENT) private readonly client: UpdatesClient) {}
+
+  start(): void {
+    updateStore.subscribe(() => this.evaluate());
+    sessionStore.subscribe(() => this.evaluate());
+  }
+
+  private evaluate(): void {
+    const { deferredInstallPhase, status } = updateStore.getState();
+    if (deferredInstallPhase === "off") {
+      // Covers the user cancelling mid-countdown from the banner or popover.
+      if (this.countdownTimer) {
+        this.clearTimer();
+        toast.dismiss(COUNTDOWN_TOAST_ID);
+      }
+      return;
+    }
+
+    const transition = deriveDeferredInstallTransition({
+      phase: deferredInstallPhase,
+      updateStatus: status,
+      busyLocalSessions: countBusyLocalSessions(
+        sessionStore.getState().sessions,
+      ),
+    });
+    if (transition === "begin-countdown") {
+      this.beginCountdown();
+    } else if (transition === "return-to-waiting") {
+      this.clearTimer();
+      toast.dismiss(COUNTDOWN_TOAST_ID);
+      updateStore.getState().returnDeferredInstallToWaiting();
+    } else if (transition === "disarm") {
+      this.clearTimer();
+      toast.dismiss(COUNTDOWN_TOAST_ID);
+      updateStore.getState().disarmDeferredInstall();
+    }
+  }
+
+  private beginCountdown(): void {
+    this.clearTimer();
+    let remaining = DEFERRED_INSTALL_COUNTDOWN_SECONDS;
+    updateStore.getState().beginDeferredInstallCountdown(remaining);
+    toast.info("Agents finished — restarting to update", {
+      id: COUNTDOWN_TOAST_ID,
+      description: `The update applies in ${remaining} seconds`,
+      duration: remaining * 1000,
+      action: {
+        label: "Cancel",
+        onClick: () => updateStore.getState().disarmDeferredInstall(),
+      },
+    });
+
+    this.countdownTimer = setInterval(() => {
+      remaining -= 1;
+      if (remaining > 0) {
+        updateStore.getState().tickDeferredInstallCountdown(remaining);
+        return;
+      }
+      this.clearTimer();
+      // Re-check right before the trigger: an evaluate() between ticks may
+      // have aborted, or an agent may have started in the final second.
+      const state = updateStore.getState();
+      const busy = countBusyLocalSessions(sessionStore.getState().sessions);
+      if (
+        state.deferredInstallPhase !== "countdown" ||
+        state.status !== "ready" ||
+        busy > 0
+      ) {
+        return;
+      }
+      state.disarmDeferredInstall();
+      toast.dismiss(COUNTDOWN_TOAST_ID);
+      void performInstallUpdate(this.client);
+    }, 1000);
+  }
+
+  private clearTimer(): void {
+    if (this.countdownTimer) {
+      clearInterval(this.countdownTimer);
+      this.countdownTimer = null;
+    }
+  }
+}

--- a/products/desktop/packages/ui/src/features/updates/releaseNotes.test.ts
+++ b/products/desktop/packages/ui/src/features/updates/releaseNotes.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
+  compareVersions,
   groupReleases,
   mergeReleaseNotes,
   parseReleaseNotes,
+  releasesBetween,
 } from "./releaseNotes";
 
 describe("parseReleaseNotes", () => {
@@ -95,5 +97,59 @@ describe("groupReleases", () => {
     );
 
     expect(groups[0].isLatest).toBe(true);
+  });
+});
+
+describe("compareVersions", () => {
+  it.each([
+    { a: "0.60.249", b: "0.60.231", expected: 1 },
+    { a: "0.60.231", b: "0.60.249", expected: -1 },
+    { a: "0.60.249", b: "0.60.249", expected: 0 },
+    { a: "0.61.0", b: "0.60.999", expected: 1 },
+    { a: "1.0.0", b: "0.99.99", expected: 1 },
+    { a: "0.60", b: "0.60.0", expected: 0 },
+    { a: "0.61.0", b: "0.61.0-beta.1", expected: 1 },
+    { a: "0.61.0-beta.1", b: "0.61.0-beta.2", expected: -1 },
+  ])("compares $a vs $b", ({ a, b, expected }) => {
+    expect(Math.sign(compareVersions(a, b))).toBe(expected);
+  });
+});
+
+describe("releasesBetween", () => {
+  const release = (version: string) => ({
+    name: `v${version}`,
+    version,
+    notes: "",
+    date: null,
+  });
+  const feed = [
+    release("0.60.249"),
+    release("0.60.240"),
+    release("0.60.231"),
+    release("0.60.220"),
+  ];
+
+  it("returns releases newer than current up to and including the target", () => {
+    expect(releasesBetween(feed, "0.60.231", "0.60.249")).toEqual([
+      release("0.60.249"),
+      release("0.60.240"),
+    ]);
+  });
+
+  it("returns nothing when already on the target", () => {
+    expect(releasesBetween(feed, "0.60.249", "0.60.249")).toEqual([]);
+  });
+
+  it("falls back to just the target release without a current version", () => {
+    expect(releasesBetween(feed, null, "0.60.240")).toEqual([
+      release("0.60.240"),
+    ]);
+  });
+
+  it("excludes releases beyond the pending update", () => {
+    expect(releasesBetween(feed, "0.60.220", "0.60.240")).toEqual([
+      release("0.60.240"),
+      release("0.60.231"),
+    ]);
   });
 });

--- a/products/desktop/packages/ui/src/features/updates/releaseNotes.ts
+++ b/products/desktop/packages/ui/src/features/updates/releaseNotes.ts
@@ -65,6 +65,49 @@ export function mergeReleaseNotes(releases: ReleaseLike[]): CategorizedNotes {
   };
 }
 
+// Desktop versions are dotted numerics ("0.60.249"), optionally with a
+// prerelease suffix ("0.61.0-beta.1"). Numeric segments compare numerically;
+// a release without a suffix sorts above the same version with one.
+export function compareVersions(a: string, b: string): number {
+  const [aBase, aSuffix = ""] = a.split("-", 2);
+  const [bBase, bSuffix = ""] = b.split("-", 2);
+  const aParts = aBase.split(".");
+  const bParts = bBase.split(".");
+  for (let i = 0; i < Math.max(aParts.length, bParts.length); i++) {
+    const aNum = Number(aParts[i] ?? 0);
+    const bNum = Number(bParts[i] ?? 0);
+    if (Number.isNaN(aNum) || Number.isNaN(bNum)) {
+      const cmp = (aParts[i] ?? "").localeCompare(bParts[i] ?? "");
+      if (cmp !== 0) return cmp;
+      continue;
+    }
+    if (aNum !== bNum) return aNum - bNum;
+  }
+  if (aSuffix === bSuffix) return 0;
+  if (aSuffix === "") return 1;
+  if (bSuffix === "") return -1;
+  return aSuffix.localeCompare(bSuffix);
+}
+
+// Everything the user gains by restarting: releases newer than what they run,
+// up to and including the pending update. Order is preserved (the feed is
+// newest-first). Without a known current version, fall back to just the
+// pending release so the peek still shows something.
+export function releasesBetween(
+  releases: ReleaseLike[],
+  currentVersion: string | null,
+  targetVersion: string,
+): ReleaseLike[] {
+  if (!currentVersion) {
+    return releases.filter((release) => release.version === targetVersion);
+  }
+  return releases.filter(
+    (release) =>
+      compareVersions(release.version, currentVersion) > 0 &&
+      compareVersions(release.version, targetVersion) <= 0,
+  );
+}
+
 function dayLabel(date: Date): string {
   return date.toLocaleDateString(undefined, {
     year: "numeric",

--- a/products/desktop/packages/ui/src/features/updates/updateStore.ts
+++ b/products/desktop/packages/ui/src/features/updates/updateStore.ts
@@ -1,4 +1,5 @@
 import {
+  type DeferredInstallPhase,
   getUpdateUiStatus,
   type UpdateUiStatus,
   updateStore,
@@ -17,11 +18,14 @@ interface UpdateView {
   status: UpdateUiStatus;
   version: string | null;
   availableVersion: string | null;
+  currentVersion: string | null;
   releaseNotes: string | null;
   downloadPercent: number | null;
   bytesPerSecond: number | null;
   downloadSizeBytes: number | null;
   isEnabled: boolean;
+  deferredInstallPhase: DeferredInstallPhase;
+  deferredInstallCountdown: number | null;
 }
 
 export function useUpdateView(): UpdateView {
@@ -29,11 +33,14 @@ export function useUpdateView(): UpdateView {
     status: state.status,
     version: state.version,
     availableVersion: state.availableVersion,
+    currentVersion: state.currentVersion,
     releaseNotes: state.releaseNotes,
     downloadPercent: state.downloadPercent,
     bytesPerSecond: state.bytesPerSecond,
     downloadSizeBytes: state.downloadSizeBytes,
     isEnabled: state.isEnabled,
+    deferredInstallPhase: state.deferredInstallPhase,
+    deferredInstallCountdown: state.deferredInstallCountdown,
   }));
 }
 
@@ -54,27 +61,31 @@ export function useHasActiveUpdate(): boolean {
  * callers that commit state at the handoff (announcement acknowledgements)
  * use it to revert.
  */
+export async function performInstallUpdate(
+  client: UpdatesClient,
+): Promise<boolean> {
+  if (getUpdateUiStatus() === "installing") {
+    return false;
+  }
+
+  updateStore.getState().setStatus("installing");
+
+  try {
+    const result = await client.install();
+    if (!result.installed) {
+      log.error("Update install returned not installed");
+      updateStore.getState().setStatus("ready");
+    }
+    return result.installed;
+  } catch (error) {
+    log.error("Failed to install update", { error });
+    updateStore.getState().setStatus("ready");
+    return false;
+  }
+}
+
 export function useInstallUpdate(): () => Promise<boolean> {
   const client = useService<UpdatesClient>(UPDATES_CLIENT);
 
-  return async () => {
-    if (getUpdateUiStatus() === "installing") {
-      return false;
-    }
-
-    updateStore.getState().setStatus("installing");
-
-    try {
-      const result = await client.install();
-      if (!result.installed) {
-        log.error("Update install returned not installed");
-        updateStore.getState().setStatus("ready");
-      }
-      return result.installed;
-    } catch (error) {
-      log.error("Failed to install update", { error });
-      updateStore.getState().setStatus("ready");
-      return false;
-    }
-  };
+  return () => performInstallUpdate(client);
 }

--- a/products/desktop/packages/ui/src/features/updates/updates.module.ts
+++ b/products/desktop/packages/ui/src/features/updates/updates.module.ts
@@ -1,0 +1,7 @@
+import { CONTRIBUTION } from "@posthog/di/contribution";
+import { ContainerModule } from "inversify";
+import { DeferredInstallContribution } from "./deferred-install.contribution";
+
+export const updatesUiModule = new ContainerModule(({ bind }) => {
+  bind(CONTRIBUTION).to(DeferredInstallContribution).inSingletonScope();
+});


### PR DESCRIPTION
## Problem

Desktop users with long-running agent tasks sit on stale versions: the "Restart to apply" banner gives no sense of what the update contains or how far behind the running build is, and restarting mid-task interrupts working agents — so updates get deferred indefinitely.

## Changes

- The ready-state banner shows the running version ("You're on 0.60.231 — restart to apply") next to the pending one.
- Clicking the banner opens an upward popover with the merged release notes for every release between the running and pending versions, a "N releases behind" count, a link to the full changelog, and a Discord feedback link.
- The popover warns when local agents are mid-turn and notes that cloud tasks keep running (they execute server-side and reattach after relaunch).
- New "Restart when agents finish" action: a `DeferredInstallContribution` watches local agent activity and, once idle, applies the update after a 10-second cancellable countdown (banner ticker + toast with Cancel). An agent starting mid-countdown returns it to waiting; a manual restart disarms it; it stays armed across a newer update landing.
- The deferred-install state machine and busy-session counting are pure functions in `@posthog/core` (`deriveDeferredInstallTransition`, `countBusyLocalSessions`); the web host loads the module but stays dormant since updates are disabled there.

## How did you test this code?

- Unit tests added for the deferred-install transitions, busy-local-session counting (cloud/idle/disconnected exclusions), and the version-delta helpers (`compareVersions`, `releasesBetween`).
- Ran `typecheck` for `@posthog/core`, `@posthog/ui`, `@posthog/code`, and `@posthog/web`; full `@posthog/core` and `@posthog/ui` vitest suites; Biome on touched files; `check-host-boundaries.mjs` (no new violations). `src/canvas/activityTimeline.test.ts` fails identically on clean `master` (pre-existing, unrelated).
- Not done: no manual run of the packaged app with a staged update, so the popover and countdown were not exercised against a live update feed.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code from a PostHog Desktop task session. The design was refined in-thread before implementation: cloud runs were confirmed to survive restarts (so only busy local sessions count toward the interrupt warning), and the idle grace period and countdown were merged into a single visible cancellable countdown per the driver's choice. Originally built against the archived `posthog/code` repo, then ported onto `products/desktop` here (one drifted file, `updateStore.ts`, re-merged by hand around the install-handoff boolean).

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
