### PR TITLE
fix(paths): set the viz type when converting a path to a funnel

### DIFF
--- a/frontend/src/scenes/paths/pathsDataLogic.ts
+++ b/frontend/src/scenes/paths/pathsDataLogic.ts
@@ -13,7 +13,7 @@ import { urls } from 'scenes/urls'
 import { actionsAndEventsToSeries } from '~/queries/nodes/InsightQuery/utils/filtersToQueryNode'
 import { InsightActorsQuery, InsightVizNode, NodeKind, PathsLink, PathsQuery } from '~/queries/schema/schema-general'
 import { isPathsQuery } from '~/queries/utils'
-import { ActionFilter, InsightLogicProps, PathType, PropertyFilterType, PropertyOperator } from '~/types'
+import { ActionFilter, FunnelVizType, InsightLogicProps, PathType, PropertyFilterType, PropertyOperator } from '~/types'
 
 import type { DataColorTheme } from '../../lib/colors'
 import type { FeatureFlagsSet } from '../../lib/logic/featureFlagLogic'
@@ -254,6 +254,9 @@ export const pathsDataLogic = kea<pathsDataLogicType>([
                         MathAvailability.None,
                         NodeKind.FunnelsDataWarehouseNode
                     ),
+                    funnelsFilter: {
+                        funnelVizType: FunnelVizType.Steps,
+                    },
                     dateRange: {
                         date_from: values.dateRange?.date_from,
                     },


### PR DESCRIPTION
## TL;DR

Turning a path into a funnel produced a funnel that never recorded which funnel chart it is. Saving it stored that gap. Now it records conversion steps, like every other funnel the app creates.

## Problem

"View funnel" on a path node opens a `FunnelsQuery` with no `funnelsFilter`, so an insight saved from it has no `funnelVizType`. The funnel renders as conversion steps but does not say so, and readers that check the viz type have to guess.

Every other funnel writer in the frontend sets one: the new-insight defaults, product tours, customer analytics, and the journey builder.

## Changes

- Set `funnelVizType: steps` on the query the paths to funnel action builds.

This is writer-side hardening, not the fix for insights already saved. [#84359](https://github.com/PostHog/posthog/pull/84359) makes the readers resolve a missing viz type, which is what repairs existing ones.

## How did you test this code?

- No test added. With #84359 the readers default anyway, so a test here would pin the stored shape rather than any behavior a person sees, which does not clear the bar in `/writing-tests`.
- Ran Oxlint and Oxfmt over the changed file.
- Not verified: the app was not run, so the saved query shape was traced through `viewPathToFunnel` and compared against the other funnel writers rather than observed.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code in PostHog Desktop. Found while tracing which code paths can save a funnel with no visualization type, after a report of one funnel that had lost its `funnelVizType`. Repo skills invoked: `/writing-tests` and `/writing-pr-descriptions`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
