### PR TITLE
fix(data-imports): retry a transient S3 permission blip during table reset

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/table.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/table.py
@@ -27,6 +27,23 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.del
 _PURGE_S3_PREFIX_MAX_ATTEMPTS = 4
 
 
+def _is_retryable_purge_error(error: OSError) -> bool:
+    """True for an error worth retrying `_purge_s3_prefix` on.
+
+    Covers the known-transient object-store blips (see is_transient_object_store_error) plus a bare
+    `PermissionError`: s3fs translates every S3 auth-failure response code (AccessDenied,
+    ExpiredToken, InvalidAccessKeyId, ...) into this one exception type, and a HeadObject 403 never
+    carries the underlying code in its body (AWS omits it for HEAD requests), so a transient
+    credential-resolution race can't be told apart from a genuine permission problem by message here.
+    `_purge_s3_prefix` always runs against a freshly created client (aget_s3_client(fresh_instance=True)),
+    which re-resolves credentials on every call — the same IMDS/STS race already covered for
+    NoCredentialsError above, just surfacing as an explicit S3-side denial instead of a local
+    resolution failure. Retrying the same bounded budget lets that race self-heal; a persistent
+    misconfiguration still raises once the budget is exhausted, since this only defers the error.
+    """
+    return is_transient_object_store_error(error) or isinstance(error, PermissionError)
+
+
 async def _purge_s3_prefix(s3: Any, uri: str) -> None:
     """Delete every object under `uri`, retrying on transient S3 SlowDown throttling.
 
@@ -40,7 +57,7 @@ async def _purge_s3_prefix(s3: Any, uri: str) -> None:
             return
         except OSError as e:
             attempt += 1
-            if attempt >= _PURGE_S3_PREFIX_MAX_ATTEMPTS or not is_transient_object_store_error(e):
+            if attempt >= _PURGE_S3_PREFIX_MAX_ATTEMPTS or not _is_retryable_purge_error(e):
                 raise
             await asyncio.sleep(2**attempt)
 

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/test/test_table.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/test/test_table.py
@@ -11,7 +11,11 @@ from parameterized import parameterized
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.errors import (
     TransientObjectStoreError,
 )
-from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.table import DeltaTableRef
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.table import (
+    _PURGE_S3_PREFIX_MAX_ATTEMPTS,
+    DeltaTableRef,
+    _purge_s3_prefix,
+)
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.test.helpers import make_logger
 
 
@@ -294,3 +298,39 @@ class TestIsTableCorrupted:
             result = await table_ref.is_table_corrupted()
 
         assert result is expected
+
+
+class TestPurgeS3PrefixRetriesPermissionError:
+    _MODULE = "products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.table"
+
+    # A HeadObject 403 never carries the underlying S3 error code in its body (AWS omits it for HEAD
+    # requests), so a fresh client's brief IMDS/STS credential-resolution race surfaces identically to a
+    # genuine permission problem: a bare PermissionError("Forbidden"). Before this fix, `_purge_s3_prefix`
+    # only retried the needles in `is_transient_object_store_error` and raised immediately on any
+    # PermissionError, failing the whole sync for what was actually a transient, self-healing race.
+    @pytest.mark.asyncio
+    async def test_retries_permission_error_and_succeeds_once_it_clears(self):
+        with (
+            patch(
+                f"{self._MODULE}._purge_s3_prefix_once",
+                new=AsyncMock(side_effect=[PermissionError("Forbidden"), None]),
+            ) as mock_once,
+            patch(f"{self._MODULE}.asyncio.sleep", new=AsyncMock()),
+        ):
+            await _purge_s3_prefix(MagicMock(), "s3://bucket/prefix")
+
+        assert mock_once.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_gives_up_after_max_attempts_on_persistent_permission_error(self):
+        with (
+            patch(
+                f"{self._MODULE}._purge_s3_prefix_once",
+                new=AsyncMock(side_effect=PermissionError("Forbidden")),
+            ) as mock_once,
+            patch(f"{self._MODULE}.asyncio.sleep", new=AsyncMock()),
+        ):
+            with pytest.raises(PermissionError):
+                await _purge_s3_prefix(MagicMock(), "s3://bucket/prefix")
+
+        assert mock_once.await_count == _PURGE_S3_PREFIX_MAX_ATTEMPTS


### PR DESCRIPTION
## Problem

A Postgres incremental sync failed and reported a `PermissionError: Forbidden` to error tracking ([issue](https://us.posthog.com/project/2/error_tracking/01a014ea-e33e-7bc1-9ed5-1ccc455a681d)), even though the error came from our own data-warehouse storage, not the customer's database.

- The error surfaced from `_purge_s3_prefix_once`, called while resetting a schema's Delta table before a sync.
- It checks whether the table's S3 prefix exists via a HeadObject call, which returned a 403.
- HeadObject responses never carry the underlying S3 error code in their body, so this reads identically whether it is a genuine permission problem or a brief credential-resolution race on the fresh S3 client the reset creates.
- The same class of race is already retried for other object-store error shapes (`is_transient_object_store_error`); a bare `PermissionError` was not one of them, so it failed the whole activity attempt on the first hit.
- The burst affected one team over about five minutes and never recurred, matching a transient blip rather than a lasting misconfiguration.

## Changes

- `_purge_s3_prefix` now also retries a bare `PermissionError`, through its existing bounded backoff (`_PURGE_S3_PREFIX_MAX_ATTEMPTS`).
- A persistent permission problem still raises once that budget is exhausted, so a genuine misconfiguration keeps surfacing to error tracking exactly as before.
- Scoped to this purge helper only; the broader `is_transient_object_store_error` classifier used elsewhere for reporting decisions is unchanged.

## How did you test this code?

Added two cases to `TestPurgeS3PrefixRetriesPermissionError` in `test_table.py`:
- A `PermissionError` on the first attempt that clears on retry now succeeds instead of failing the whole purge.
- A `PermissionError` that never clears still raises after the existing attempt budget, so a real misconfiguration is not silently swallowed.

Ran locally: `pytest products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/test/test_table.py` (new cases pass; 8 pre-existing failures in `TestGetDeltaTableUnrecoverableErrors` reproduce unmodified on master too, from a missing local object-storage service, unrelated to this change). Also ran `ruff check`/`ruff format` and a full-repo `mypy` — both clean.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal retry classification, no user-facing or documented behavior changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via the `investigating-error-issue` skill against the linked PostHog error tracking issue, then read the stack trace down to `posthog/temporal/common/posthog_client.py` (the Temporal activity interceptor, not the root cause) and into the actual failure in `pipelines/core/delta/table.py`. Confirmed no open human-authored PR already covers this (searched by exception type, module path, and the maintainer's own open PRs). Invoked `/writing-tests` before adding the regression tests and `/writing-pr-descriptions` before drafting this body.