### PR TITLE
fix(ci): skip CLI releases without changesets

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -137,16 +137,6 @@ jobs:
             release-tag: ${{ steps.release-metadata.outputs.release-tag }}
             release-commit: ${{ steps.commit-release.outputs.commit-hash }}
         steps:
-            - name: Notify Slack - Approved
-              if: needs.notify-approval-needed.outputs.slack_ts != ''
-              uses: posthog/.github/.github/actions/slack-thread-reply@03565438486849ac0d19543de36c248a27d32a2f
-              with:
-                  slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
-                  slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
-                  thread_ts: ${{ needs.notify-approval-needed.outputs.slack_ts }}
-                  message: 'Release approved. Preparing posthog-cli version bump.'
-                  emoji_reaction: 'white_check_mark'
-
             - name: Get GitHub App token
               id: app-token
               uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
@@ -165,7 +155,30 @@ jobs:
             - name: Update to latest master before preparing release
               run: git pull --ff-only origin master
 
+            - name: Check for remaining changesets
+              id: recheck-changesets
+              run: |
+                  changeset_count=$(find cli/.sampo/changesets -name '*.md' 2>/dev/null | wc -l)
+                  if [ "$changeset_count" -gt 0 ]; then
+                      echo "has-changesets=true" >> "$GITHUB_OUTPUT"
+                      echo "Found $changeset_count CLI changeset(s), continuing release preparation"
+                  else
+                      echo "has-changesets=false" >> "$GITHUB_OUTPUT"
+                      echo "No CLI changesets remain; skipping release preparation"
+                  fi
+
+            - name: Notify Slack - Approved
+              if: steps.recheck-changesets.outputs.has-changesets == 'true' && needs.notify-approval-needed.outputs.slack_ts != ''
+              uses: posthog/.github/.github/actions/slack-thread-reply@03565438486849ac0d19543de36c248a27d32a2f
+              with:
+                  slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
+                  slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
+                  thread_ts: ${{ needs.notify-approval-needed.outputs.slack_ts }}
+                  message: 'Release approved. Preparing posthog-cli version bump.'
+                  emoji_reaction: 'white_check_mark'
+
             - name: Install Rust
+              if: steps.recheck-changesets.outputs.has-changesets == 'true'
               uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
               with:
                   toolchain: 1.91.1
@@ -173,17 +186,19 @@ jobs:
 
             - name: Cache Sampo CLI
               id: cache-sampo
+              if: steps.recheck-changesets.outputs.has-changesets == 'true'
               uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
               with:
                   path: ~/.cargo/bin/sampo
                   key: sampo-${{ runner.os }}-${{ runner.arch }}-${{ env.SAMPO_VERSION }}
 
             - name: Install Sampo CLI
-              if: steps.cache-sampo.outputs.cache-hit != 'true'
+              if: steps.recheck-changesets.outputs.has-changesets == 'true' && steps.cache-sampo.outputs.cache-hit != 'true'
               run: cargo install sampo --version "$SAMPO_VERSION" --locked
 
             - name: Prepare release with Sampo
               id: prepare-release
+              if: steps.recheck-changesets.outputs.has-changesets == 'true'
               working-directory: cli
               env:
                   GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -200,6 +215,7 @@ jobs:
                   echo "Prepared posthog-cli v$new_version"
 
             - name: Check release tag
+              if: steps.prepare-release.outputs.new-version != ''
               env:
                   NEW_VERSION: ${{ steps.prepare-release.outputs.new-version }}
               run: |
@@ -211,6 +227,7 @@ jobs:
 
             - name: Check release changes
               id: check-changes
+              if: steps.prepare-release.outputs.new-version != ''
               run: |
                   changed_files=$(git diff --name-only)
                   if [ -z "$changed_files" ]; then
@@ -233,6 +250,7 @@ jobs:
                   echo "committed=true" >> "$GITHUB_OUTPUT"
 
             - name: Ensure master did not advance during release prep
+              if: steps.check-changes.outputs.committed == 'true'
               run: |
                   git fetch origin master
                   if [ "$(git rev-parse HEAD)" != "$(git rev-parse FETCH_HEAD)" ]; then

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -386,7 +386,7 @@ jobs:
         needs:
             - release
             - plan-release
-        if: ${{ fromJson(needs.plan-release.outputs.val).ci.github.artifacts_matrix.include != null }}
+        if: ${{ needs.plan-release.result == 'success' && fromJson(needs.plan-release.outputs.val).ci.github.artifacts_matrix.include != null }}
         strategy:
             fail-fast: false
             # Target platforms/runners are computed by dist in create-release.
@@ -699,7 +699,7 @@ jobs:
         env:
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             PLAN: ${{ needs.plan-release.outputs.val }}
-        if: ${{ !fromJson(needs.plan-release.outputs.val).announcement_is_prerelease || fromJson(needs.plan-release.outputs.val).publish_prereleases }}
+        if: ${{ needs.plan-release.result == 'success' && (!fromJson(needs.plan-release.outputs.val).announcement_is_prerelease || fromJson(needs.plan-release.outputs.val).publish_prereleases) }}
         permissions:
             id-token: write
         steps:

--- a/cli/RELEASING.md
+++ b/cli/RELEASING.md
@@ -16,11 +16,12 @@ After the pull request merges to `master`, the `Release CLI` workflow:
 
 1. Checks for pending CLI changesets
 2. Waits for approval in the GitHub `Release SDK` environment
-3. Runs `sampo release` from `./cli`
-4. Updates `cli/Cargo.toml`, `cli/Cargo.lock`, and `cli/CHANGELOG.md`
-5. Commits the release bump to `master`
-6. Runs cargo-dist against the release bump commit
-7. Creates the `posthog-cli/vX.Y.Z` GitHub release, refreshes `posthog-cli-latest` for stable releases, and publishes the npm package
+3. Updates to the latest `master` and stops successfully if no changesets remain
+4. Runs `sampo release` from `./cli`
+5. Updates `cli/Cargo.toml`, `cli/Cargo.lock`, and `cli/CHANGELOG.md`
+6. Commits the release bump to `master`
+7. Runs cargo-dist against the release bump commit
+8. Creates the `posthog-cli/vX.Y.Z` GitHub release, refreshes `posthog-cli-latest` for stable releases, and publishes the npm package
 
 Do not run `sampo publish`; cargo-dist owns publishing for `posthog-cli`.
 


### PR DESCRIPTION
## Problem

CLI release runs can fail after approval when an earlier run has already consumed every pending changeset.

[This release run](https://github.com/PostHog/posthog/actions/runs/32122572513/job/95710347677) refreshed `master`, then Sampo exited because no changesets remained.

## Changes

- The release job now rechecks changesets after refreshing `master` and finishes successfully when none remain.
- Release preparation continues unchanged when changesets remain.
- The release guide documents the successful no-op path.

Before:

```mermaid
flowchart LR
    A[Approval] --> B[Refresh master] --> C[Run Sampo] --> D[Fail without changesets]
```

After:

```mermaid
flowchart LR
    A[Approval] --> B[Refresh master] --> C{Changesets remain?}
    C -- No --> D[Finish successfully]
    C -- Yes --> E[Run Sampo]
```

## How did you test this code?

- `hogli ci:preflight --fix`
- `bin/hogli lint:workflows`
- `actionlint -shellcheck= .github/workflows/release-cli.yml`
- Ran the changeset check with empty and populated temporary directories.
- The full release workflow was not run because it requires release approval and credentials.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated `cli/RELEASING.md` with the successful no-op path.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi implemented the workflow fix using `/debugging-ci-failures`, `/authoring-ci-workflows`, `/writing-user-facing-copy`, `/running-ci-preflight`, `/writing-pr-descriptions`, and `/pr`.

The change uses only public repository content and the linked public GitHub Actions run.
