### PR TITLE
feat(data-warehouse): pick a materialized view as a destination or workflow trigger

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteSelectResults.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteSelectResults.tsx
@@ -201,6 +201,7 @@ export function InfiniteSelectResults({
     const showDataWarehouseLoadingState =
         (openTab === TaxonomicFilterGroupType.DataWarehouse ||
             openTab === TaxonomicFilterGroupType.DataWarehouseSourceTables ||
+            openTab === TaxonomicFilterGroupType.DataWarehouseMaterializedViews ||
             openTab === TaxonomicFilterGroupType.DataWarehouseProperties) &&
         totalListCount === 0 &&
         isLocalDataLoading

--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilterEmptyState.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilterEmptyState.tsx
@@ -260,6 +260,7 @@ const DefaultEmptyState = (): JSX.Element | null => {
 const EMPTY_STATES: Partial<Record<TaxonomicFilterGroupType, React.ComponentType<TaxonomicFilterEmptyStateProps>>> = {
     [TaxonomicFilterGroupType.DataWarehouse]: DataWarehouseEmptyState,
     [TaxonomicFilterGroupType.DataWarehouseSourceTables]: DataWarehouseEmptyState,
+    [TaxonomicFilterGroupType.DataWarehouseMaterializedViews]: DataWarehouseEmptyState,
     [TaxonomicFilterGroupType.DataWarehouseProperties]: DataWarehouseEmptyState,
     [TaxonomicFilterGroupType.DataWarehousePersonProperties]: DataWarehouseEmptyState,
     [TaxonomicFilterGroupType.RecentFilters]: RecentFiltersEmptyState,

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -142,6 +142,7 @@ export const NO_ITEM_SELECTED = -1
 const DATA_WAREHOUSE_GROUP_TYPES: TaxonomicFilterGroupType[] = [
     TaxonomicFilterGroupType.DataWarehouse,
     TaxonomicFilterGroupType.DataWarehouseSourceTables,
+    TaxonomicFilterGroupType.DataWarehouseMaterializedViews,
 ]
 
 export function getInitialPinnedRowIndex({

--- a/frontend/src/lib/components/TaxonomicFilter/recentTaxonomicFiltersLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/recentTaxonomicFiltersLogic.ts
@@ -21,6 +21,7 @@ const EXCLUDED_RECENT_FILTER_GROUP_TYPES = new Set<TaxonomicFilterGroupType>([
     ...META_GROUP_TYPES,
     TaxonomicFilterGroupType.DataWarehouse,
     TaxonomicFilterGroupType.DataWarehouseSourceTables,
+    TaxonomicFilterGroupType.DataWarehouseMaterializedViews,
     TaxonomicFilterGroupType.DataWarehouseProperties,
     TaxonomicFilterGroupType.DataWarehousePersonProperties,
 ])

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -1085,6 +1085,18 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         getPopoverHeader: () => 'Data Warehouse Table',
                         getIcon: () => <IconServer />,
                     },
+                    {
+                        name: 'Materialized views',
+                        searchPlaceholder: 'materialized views',
+                        type: TaxonomicFilterGroupType.DataWarehouseMaterializedViews,
+                        logic: dataWarehouseSettingsSceneLogic,
+                        value: 'materializedViews',
+                        valueLoading: 'materializedViewsLoading',
+                        getName: (table: DatabaseSchemaTable) => table.name,
+                        getValue: (table: DatabaseSchemaTable) => table.name,
+                        getPopoverHeader: () => 'Materialized view',
+                        getIcon: () => <IconServer />,
+                    },
                     ...(schemaColumns.length > 0 || schemaColumnsLoading
                         ? [
                               {

--- a/frontend/src/lib/components/TaxonomicFilter/types.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/types.ts
@@ -296,6 +296,9 @@ export enum TaxonomicFilterGroupType {
     // Like DataWarehouse but restricted to external-source tables (no views/saved queries or self-managed
     // tables) — used by CDP destination/workflow warehouse-row triggers.
     DataWarehouseSourceTables = 'data_warehouse_source_tables',
+    // Materialized views (saved queries with a backing table) — used by CDP destination/workflow
+    // materialized-view triggers, which fire on the rows a view's run writes.
+    DataWarehouseMaterializedViews = 'data_warehouse_materialized_views',
     DataWarehouseProperties = 'data_warehouse_properties',
     DataWarehousePersonProperties = 'data_warehouse_person_properties',
     Elements = 'elements',
@@ -374,6 +377,7 @@ export const OPEN_AS_SELF_ON_REOPEN = new Set<TaxonomicFilterGroupType>([
     TaxonomicFilterGroupType.HogQLExpression,
     TaxonomicFilterGroupType.DataWarehouse,
     TaxonomicFilterGroupType.DataWarehouseSourceTables,
+    TaxonomicFilterGroupType.DataWarehouseMaterializedViews,
     TaxonomicFilterGroupType.DataWarehouseProperties,
 ])
 

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -270,6 +270,7 @@ export const FEATURE_FLAGS = {
     BILLING_ALERTS: 'billing-alerts', // owner: #team-billing, gates the Billing > Alerts tab
     CDP_ACTIVITY_LOG_NOTIFICATIONS: 'cdp-activity-log-notifications', // owner: #team-workflows-cdp
     CDP_DWH_TABLE_SOURCE: 'cdp-dwh-table-source', // owner: #team-workflows-cdp
+    CDP_DWH_VIEW_SOURCE: 'cdp-dwh-view-source', // owner: #team-workflows-cdp
     CDP_HOG_SOURCES: 'cdp-hog-sources', // owner #team-workflows-cdp
     CDP_NEW_PRICING: 'cdp-new-pricing', // owner: #team-workflows
     CDP_PERSON_UPDATES: 'cdp-person-updates', // owner: #team-workflows-cdp

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -50963,6 +50963,7 @@
                 "cohorts_with_all",
                 "data_warehouse",
                 "data_warehouse_source_tables",
+                "data_warehouse_materialized_views",
                 "data_warehouse_properties",
                 "data_warehouse_person_properties",
                 "elements",

--- a/frontend/src/scenes/data-warehouse/settings/dataWarehouseSettingsSceneLogic.ts
+++ b/frontend/src/scenes/data-warehouse/settings/dataWarehouseSettingsSceneLogic.ts
@@ -51,6 +51,7 @@ export interface dataWarehouseSettingsSceneLogicValues {
     inEditSchemaMode: boolean
     isEditingSavedQuery: boolean
     materializedViews: DatabaseSchemaMaterializedViewTable[]
+    materializedViewsLoading: boolean
     nonMaterializedViews: DatabaseSchemaTable[]
     schemaModalIsOpen: boolean
     schemaUpdates: Record<string, DatabaseSerializedFieldType>
@@ -204,6 +205,7 @@ export interface dataWarehouseSettingsSceneLogicMeta {
             views: DatabaseSchemaViewTable[],
             dataWarehouseSavedQueryMapById: Record<string, DataWarehouseSavedQuery>
         ) => DatabaseSchemaTable[]
+        materializedViewsLoading: (databaseLoading: boolean, dataWarehouseSavedQueriesLoading: boolean) => boolean
         materializedViews: (
             views: DatabaseSchemaViewTable[],
             dataWarehouseSavedQueryMapById: Record<string, DataWarehouseSavedQuery>
@@ -400,6 +402,14 @@ export const dataWarehouseSettingsSceneLogic = kea<dataWarehouseSettingsSceneLog
                         type: 'view',
                     }))
             },
+        ],
+        // `materializedViews` needs both loaders: names come from the database schema, the
+        // materialized flag from the saved queries. Consumers that watch only one report an empty
+        // list while the other is still in flight.
+        materializedViewsLoading: [
+            (s) => [s.databaseLoading, s.dataWarehouseSavedQueriesLoading],
+            (databaseLoading: boolean, dataWarehouseSavedQueriesLoading: boolean): boolean =>
+                databaseLoading || dataWarehouseSavedQueriesLoading,
         ],
         materializedViews: [
             (s) => [s.views, s.dataWarehouseSavedQueryMapById],

--- a/frontend/src/scenes/hog-functions/filters/HogFunctionFilters.tsx
+++ b/frontend/src/scenes/hog-functions/filters/HogFunctionFilters.tsx
@@ -11,10 +11,13 @@ import { ExcludedProperties, TaxonomicFilterGroupType } from 'lib/components/Tax
 import { TestAccountFilterSwitch } from 'lib/components/TestAccountFiltersSwitch'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonField } from 'lib/lemon-ui/LemonField'
+import { Link } from 'lib/lemon-ui/Link'
 import { databaseTableListLogic } from 'scenes/data-management/database/databaseTableListLogic'
+import { dataWarehouseViewsLogic } from 'scenes/data-warehouse/saved_queries/dataWarehouseViewsLogic'
 import { ActionFilter } from 'scenes/insights/filters/ActionFilter/ActionFilter'
 import { MathAvailability } from 'scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow'
 import MaxTool from 'scenes/max/MaxTool'
+import { urls } from 'scenes/urls'
 
 import { groupsModel } from '~/models/groupsModel'
 import { AnyPropertyFilter, CyclotronJobFiltersType, EntityTypes, FilterType } from '~/types'
@@ -112,14 +115,20 @@ export function HogFunctionFilters({
     ])
 
     const isTransformation = type === 'transformation'
-    const isDataWarehouse = configuration?.filters?.source === 'data-warehouse-table'
+    const filterSource = configuration?.filters?.source
+    const isDataWarehouseView = filterSource === 'data-warehouse-view'
+    // Both warehouse sources deliver a row rather than an event, so everything downstream of here
+    // that hides person/event affordances applies to either.
+    const isDataWarehouse = filterSource === 'data-warehouse-table' || isDataWarehouseView
     const cdpPersonUpdatesEnabled = useFeatureFlag('CDP_PERSON_UPDATES')
     const cdpDwhTableSourceEnabled = useFeatureFlag('CDP_DWH_TABLE_SOURCE')
+    const cdpDwhViewSourceEnabled = useFeatureFlag('CDP_DWH_VIEW_SOURCE')
 
     // The table matcher's column suggestions read from databaseTableListLogic, which isn't loaded
     // automatically in this scene — kick it off when a warehouse table is the source.
     const { dataWarehouseTables, dataWarehouseTablesMap } = useValues(databaseTableListLogic)
     const { loadDatabase, ensureAllTableFields } = useActions(databaseTableListLogic)
+    const { dataWarehouseSavedQueries } = useValues(dataWarehouseViewsLogic)
     useEffect(() => {
         if (isDataWarehouse) {
             if (!dataWarehouseTables.length) {
@@ -182,9 +191,10 @@ export function HogFunctionFilters({
 
     // NOTE: Mappings won't work for person updates currently as they are totally event based...
     const showSourcePicker =
-        (cdpPersonUpdatesEnabled || cdpDwhTableSourceEnabled) && type === 'destination' && !useMapping
-    const showEventMatchers =
-        !useMapping && ['events', 'data-warehouse-table'].includes(configuration?.filters?.source ?? 'events')
+        (cdpPersonUpdatesEnabled || cdpDwhTableSourceEnabled || cdpDwhViewSourceEnabled) &&
+        type === 'destination' &&
+        !useMapping
+    const showEventMatchers = !useMapping && (isDataWarehouse || (filterSource ?? 'events') === 'events')
 
     const mainContent = (
         <div
@@ -222,6 +232,9 @@ export function HogFunctionFilters({
                                     ...(cdpDwhTableSourceEnabled
                                         ? [{ value: 'data-warehouse-table', label: 'Warehouse table' }]
                                         : []),
+                                    ...(cdpDwhViewSourceEnabled
+                                        ? [{ value: 'data-warehouse-view', label: 'Materialized view' }]
+                                        : []),
                                 ]}
                                 value={value?.source ?? 'events'}
                                 onChange={(val) => {
@@ -251,6 +264,14 @@ export function HogFunctionFilters({
                     const dataWarehouseColumns = dataWarehouseTableName
                         ? Object.values(dataWarehouseTablesMap[dataWarehouseTableName]?.fields ?? {})
                         : []
+                    // A full-refresh view re-emits every row on every run, which is worth saying out
+                    // loud before someone points a destination at one.
+                    const selectedFullRefreshView =
+                        isDataWarehouseView && dataWarehouseTableName
+                            ? dataWarehouseSavedQueries.find(
+                                  (view) => view.name === dataWarehouseTableName && !view.is_incremental
+                              )
+                            : undefined
 
                     const onChange = (newValue: CyclotronJobFiltersType): void => {
                         if (oldFilters && newFilters) {
@@ -299,11 +320,13 @@ export function HogFunctionFilters({
                                 <>
                                     <div className="flex gap-2 justify-between w-full">
                                         <LemonLabel>
-                                            {isDataWarehouse
-                                                ? 'Match tables'
-                                                : isTransformation
-                                                  ? 'Match events'
-                                                  : 'Match events and actions'}
+                                            {isDataWarehouseView
+                                                ? 'Match materialized views'
+                                                : isDataWarehouse
+                                                  ? 'Match tables'
+                                                  : isTransformation
+                                                    ? 'Match events'
+                                                    : 'Match events and actions'}
                                         </LemonLabel>
                                     </div>
                                     <p className="mb-0 text-xs text-secondary">
@@ -318,7 +341,7 @@ export function HogFunctionFilters({
                                                 ...sanitizeActionFilters(payload),
                                             })
                                         }}
-                                        typeKey="plugin-filters"
+                                        typeKey={isDataWarehouseView ? 'plugin-filters-view' : 'plugin-filters'}
                                         mathAvailability={MathAvailability.None}
                                         hideRename
                                         hideDuplicate
@@ -326,16 +349,23 @@ export function HogFunctionFilters({
                                         actionsTaxonomicGroupTypes={
                                             isTransformation
                                                 ? [TaxonomicFilterGroupType.Events]
-                                                : isDataWarehouse
-                                                  ? [TaxonomicFilterGroupType.DataWarehouseSourceTables]
-                                                  : [TaxonomicFilterGroupType.Events, TaxonomicFilterGroupType.Actions]
+                                                : isDataWarehouseView
+                                                  ? [TaxonomicFilterGroupType.DataWarehouseMaterializedViews]
+                                                  : isDataWarehouse
+                                                    ? [TaxonomicFilterGroupType.DataWarehouseSourceTables]
+                                                    : [
+                                                          TaxonomicFilterGroupType.Events,
+                                                          TaxonomicFilterGroupType.Actions,
+                                                      ]
                                         }
                                         propertiesTaxonomicGroupTypes={taxonomicGroupTypes}
                                         propertyFiltersPopover
                                         addFilterDefaultOptions={
                                             isDataWarehouse
                                                 ? {
-                                                      name: 'Select a table',
+                                                      name: isDataWarehouseView
+                                                          ? 'Select a materialized view'
+                                                          : 'Select a table',
                                                       type: EntityTypes.DATA_WAREHOUSE,
                                                   }
                                                 : {
@@ -344,10 +374,32 @@ export function HogFunctionFilters({
                                                       type: EntityTypes.EVENTS,
                                                   }
                                         }
-                                        buttonCopy={isDataWarehouse ? 'Add table matcher' : 'Add event matcher'}
+                                        buttonCopy={
+                                            isDataWarehouseView
+                                                ? 'Add view matcher'
+                                                : isDataWarehouse
+                                                  ? 'Add table matcher'
+                                                  : 'Add event matcher'
+                                        }
                                         excludedProperties={excludedProperties}
                                         allowNonCapturedEvents
                                     />
+                                    {selectedFullRefreshView ? (
+                                        <LemonBanner type="warning" className="w-full">
+                                            <p className="mb-0">
+                                                This view rebuilds its whole table on every run, so every row runs this
+                                                destination again each time. Set the view to update incrementally to run
+                                                only on the rows that changed.{' '}
+                                                <Link
+                                                    to={urls.sqlEditor({ view_id: selectedFullRefreshView.id })}
+                                                    target="_blank"
+                                                    className="font-semibold"
+                                                >
+                                                    Open the view
+                                                </Link>
+                                            </p>
+                                        </LemonBanner>
+                                    ) : null}
                                     {dataWarehouseTableName ? (
                                         <DataWarehouseColumnsHint
                                             schemaColumns={dataWarehouseColumns}

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -74,6 +74,13 @@ const DragHandle = ({ listeners }: DragHandleProps): JSX.Element => (
 // so numeric-only pickers must not be fed non-numeric columns in the first place.
 const NUMERIC_SCHEMA_FIELD_TYPES: DatabaseSerializedFieldType[] = ['integer', 'float', 'decimal']
 
+// Which warehouse tables a row's picker may offer, by the caller's typeKey. Anything not listed
+// gets the unrestricted data warehouse group.
+const DATA_WAREHOUSE_GROUP_TYPE_BY_TYPE_KEY: Record<string, TaxonomicFilterGroupType> = {
+    'plugin-filters': TaxonomicFilterGroupType.DataWarehouseSourceTables,
+    'plugin-filters-view': TaxonomicFilterGroupType.DataWarehouseMaterializedViews,
+}
+
 export function ActionFilterRow({
     logic,
     filter,
@@ -348,11 +355,10 @@ export function ActionFilterRow({
         )
 
     const isDataWarehouseFilter = filter.type === EntityTypes.DATA_WAREHOUSE
-    // CDP destination/workflow filters (plugin-filters) restrict the picker to external-source tables.
+    // CDP destination/workflow filters restrict the picker to the one warehouse table family their
+    // trigger fires on, so each family gets its own typeKey.
     const dataWarehouseGroupType =
-        typeKey === 'plugin-filters'
-            ? TaxonomicFilterGroupType.DataWarehouseSourceTables
-            : TaxonomicFilterGroupType.DataWarehouse
+        DATA_WAREHOUSE_GROUP_TYPE_BY_TYPE_KEY[typeKey] ?? TaxonomicFilterGroupType.DataWarehouse
     // The committed value's real group — it drives the picker's committed-selection
     // affordance (selected row floats to the top, with the series' rename applied).
     // The picker still opens on the suggested-filters surface either way. All-events

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/actionFilterRowUtils.ts
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/actionFilterRowUtils.ts
@@ -20,6 +20,7 @@ const taxonomicFilterGroupTypeToEntityTypeMapping: Partial<Record<TaxonomicFilte
     [TaxonomicFilterGroupType.Actions]: EntityTypes.ACTIONS,
     [TaxonomicFilterGroupType.DataWarehouse]: EntityTypes.DATA_WAREHOUSE,
     [TaxonomicFilterGroupType.DataWarehouseSourceTables]: EntityTypes.DATA_WAREHOUSE,
+    [TaxonomicFilterGroupType.DataWarehouseMaterializedViews]: EntityTypes.DATA_WAREHOUSE,
 }
 
 export function taxonomicFilterGroupTypeToEntityType(

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
@@ -78,6 +78,7 @@ export interface taxonomicBreakdownFilterLogicValues {
         | TaxonomicFilterGroupType.CohortsWithAllUsers
         | TaxonomicFilterGroupType.DataWarehouse
         | TaxonomicFilterGroupType.DataWarehouseSourceTables
+        | TaxonomicFilterGroupType.DataWarehouseMaterializedViews
         | TaxonomicFilterGroupType.DataWarehouseProperties
         | TaxonomicFilterGroupType.DataWarehousePersonProperties
         | TaxonomicFilterGroupType.Elements
@@ -242,6 +243,7 @@ export interface taxonomicBreakdownFilterLogicMeta {
             | TaxonomicFilterGroupType.CohortsWithAllUsers
             | TaxonomicFilterGroupType.DataWarehouse
             | TaxonomicFilterGroupType.DataWarehouseSourceTables
+            | TaxonomicFilterGroupType.DataWarehouseMaterializedViews
             | TaxonomicFilterGroupType.DataWarehouseProperties
             | TaxonomicFilterGroupType.DataWarehousePersonProperties
             | TaxonomicFilterGroupType.Elements

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -6245,6 +6245,9 @@ export interface DataWarehouseSavedQuery {
     latest_error: string | null
     latest_history_id?: string
     is_materialized?: boolean
+    /** Whether the view is set up to update incrementally. A run can still rebuild the whole table,
+     * for example on its first run or after the query changes. */
+    is_incremental?: boolean
     /** Engine → suspension details. Only included when fetching a single saved query, not in list responses */
     suspended?: DataWarehouseSavedQueryApiSuspended
     upstream_dependency_count?: number
@@ -7306,7 +7309,7 @@ export type CyclotronJobFilterPropertyFilter =
     | FlagPropertyFilter
 
 export interface CyclotronJobFiltersType {
-    source?: 'events' | 'person-updates' | 'data-warehouse-table'
+    source?: 'events' | 'person-updates' | 'data-warehouse-table' | 'data-warehouse-view'
     events?: CyclotronJobFilterEvents[]
     data_warehouse?: CyclotronJobFilterDataWarehouse[]
     actions?: CyclotronJobFilterActions[]

--- a/posthog/schema_enums.py
+++ b/posthog/schema_enums.py
@@ -3998,6 +3998,7 @@ class TaxonomicFilterGroupType(StrEnum):
     COHORTS_WITH_ALL = "cohorts_with_all"
     DATA_WAREHOUSE = "data_warehouse"
     DATA_WAREHOUSE_SOURCE_TABLES = "data_warehouse_source_tables"
+    DATA_WAREHOUSE_MATERIALIZED_VIEWS = "data_warehouse_materialized_views"
     DATA_WAREHOUSE_PROPERTIES = "data_warehouse_properties"
     DATA_WAREHOUSE_PERSON_PROPERTIES = "data_warehouse_person_properties"
     ELEMENTS = "elements"

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -5295,6 +5295,7 @@ export const TaxonomicFilterGroupTypeApi = {
     CohortsWithAll: 'cohorts_with_all',
     DataWarehouse: 'data_warehouse',
     DataWarehouseSourceTables: 'data_warehouse_source_tables',
+    DataWarehouseMaterializedViews: 'data_warehouse_materialized_views',
     DataWarehouseProperties: 'data_warehouse_properties',
     DataWarehousePersonProperties: 'data_warehouse_person_properties',
     Elements: 'elements',

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -4488,6 +4488,7 @@ export const TaxonomicFilterGroupTypeApi = {
     CohortsWithAll: 'cohorts_with_all',
     DataWarehouse: 'data_warehouse',
     DataWarehouseSourceTables: 'data_warehouse_source_tables',
+    DataWarehouseMaterializedViews: 'data_warehouse_materialized_views',
     DataWarehouseProperties: 'data_warehouse_properties',
     DataWarehousePersonProperties: 'data_warehouse_person_properties',
     Elements: 'elements',

--- a/products/workflows/frontend/Workflows/hogflows/hogFlowEditorLogic.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/hogFlowEditorLogic.tsx
@@ -752,6 +752,14 @@ export interface hogFlowEditorLogicActions {
                                       type: 'data-warehouse-table'
                                   }
                                 | {
+                                      filters: {
+                                          properties?: any[] | undefined
+                                      }
+                                      key_property?: string | undefined
+                                      table_name: string
+                                      type: 'data-warehouse-view'
+                                  }
+                                | {
                                       inputs: Record<
                                           string,
                                           {
@@ -898,6 +906,14 @@ export interface hogFlowEditorLogicActions {
                             key_property?: string | undefined
                             table_name: string
                             type: 'data-warehouse-table'
+                        }
+                      | {
+                            filters: {
+                                properties?: any[] | undefined
+                            }
+                            key_property?: string | undefined
+                            table_name: string
+                            type: 'data-warehouse-view'
                         }
                       | {
                             inputs: Record<
@@ -1564,6 +1580,14 @@ export interface hogFlowEditorLogicActions {
                                       type: 'data-warehouse-table'
                                   }
                                 | {
+                                      filters: {
+                                          properties?: any[] | undefined
+                                      }
+                                      key_property?: string | undefined
+                                      table_name: string
+                                      type: 'data-warehouse-view'
+                                  }
+                                | {
                                       inputs: Record<
                                           string,
                                           {
@@ -1710,6 +1734,14 @@ export interface hogFlowEditorLogicActions {
                             key_property?: string | undefined
                             table_name: string
                             type: 'data-warehouse-table'
+                        }
+                      | {
+                            filters: {
+                                properties?: any[] | undefined
+                            }
+                            key_property?: string | undefined
+                            table_name: string
+                            type: 'data-warehouse-view'
                         }
                       | {
                             inputs: Record<

--- a/products/workflows/frontend/Workflows/hogflows/panel/testing/hogFlowEditorTestLogic.ts
+++ b/products/workflows/frontend/Workflows/hogflows/panel/testing/hogFlowEditorTestLogic.ts
@@ -390,6 +390,14 @@ export interface hogFlowEditorTestLogicMeta {
                                 type: 'data-warehouse-table'
                             }
                           | {
+                                filters: {
+                                    properties?: any[] | undefined
+                                }
+                                key_property?: string | undefined
+                                table_name: string
+                                type: 'data-warehouse-view'
+                            }
+                          | {
                                 inputs: Record<
                                     string,
                                     {
@@ -510,6 +518,14 @@ export interface hogFlowEditorTestLogicMeta {
                                 key_property?: string | undefined
                                 table_name: string
                                 type: 'data-warehouse-table'
+                            }
+                          | {
+                                filters: {
+                                    properties?: any[] | undefined
+                                }
+                                key_property?: string | undefined
+                                table_name: string
+                                type: 'data-warehouse-view'
                             }
                           | {
                                 inputs: Record<

--- a/products/workflows/frontend/Workflows/hogflows/registry/triggers/data_warehouse_view.test.ts
+++ b/products/workflows/frontend/Workflows/hogflows/registry/triggers/data_warehouse_view.test.ts
@@ -1,0 +1,63 @@
+import { isDataWarehouseViewTriggerConfig } from './data_warehouse_view'
+import { getRegisteredTriggerTypes } from './triggerTypeRegistry'
+
+describe('materialized view trigger', () => {
+    const getTriggerType = (): ReturnType<typeof getRegisteredTriggerTypes>[number] => {
+        const triggerType = getRegisteredTriggerTypes().find((t) => t.value === 'data-warehouse-view')
+        if (!triggerType) {
+            throw new Error('Materialized view trigger type not registered')
+        }
+        return triggerType
+    }
+
+    describe('isDataWarehouseViewTriggerConfig', () => {
+        it.each([
+            {
+                name: 'data-warehouse-view config',
+                config: { type: 'data-warehouse-view', table_name: 'daily_revenue' } as any,
+                expected: true,
+            },
+            {
+                name: 'data-warehouse-table config',
+                config: { type: 'data-warehouse-table', table_name: 'daily_revenue' } as any,
+                expected: false,
+            },
+            { name: 'event config', config: { type: 'event', filters: {} } as any, expected: false },
+        ])('returns $expected for $name', ({ config, expected }) => {
+            expect(isDataWarehouseViewTriggerConfig(config)).toBe(expected)
+        })
+    })
+
+    describe('validate', () => {
+        it.each([
+            {
+                name: 'missing view name',
+                config: { type: 'data-warehouse-view', table_name: '', filters: { properties: [] } },
+                expected: { valid: false, errors: { table_name: 'Please select a materialized view' } },
+            },
+            {
+                name: 'view name set',
+                config: { type: 'data-warehouse-view', table_name: 'daily_revenue', filters: { properties: [] } },
+                expected: { valid: true, errors: {} },
+            },
+            {
+                name: 'non data-warehouse-view config returns null',
+                config: { type: 'data-warehouse-table', table_name: 'postgres.table_1' },
+                expected: null,
+            },
+        ])('returns $expected for $name', ({ config, expected }) => {
+            expect(getTriggerType().validate!(config as any)).toEqual(expected)
+        })
+    })
+
+    it('is gated behind its own feature flag, separately from the source table trigger', () => {
+        expect(getTriggerType().featureFlag).toBe('cdp-dwh-view-source')
+    })
+
+    it('buildConfig produces a config recognized by matchConfig', () => {
+        const triggerType = getTriggerType()
+        const config = triggerType.buildConfig()
+        expect(config.type).toBe('data-warehouse-view')
+        expect(triggerType.matchConfig!(config)).toBe(true)
+    })
+})

--- a/products/workflows/frontend/Workflows/hogflows/registry/triggers/data_warehouse_view.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/registry/triggers/data_warehouse_view.tsx
@@ -1,0 +1,186 @@
+import { useActions, useValues } from 'kea'
+import { useEffect } from 'react'
+
+import { IconServer } from '@posthog/icons'
+import { LemonBanner, LemonSelect, LemonTag } from '@posthog/lemon-ui'
+
+import { DataWarehouseColumnsHint } from 'lib/components/CyclotronJob/DataWarehouseColumnsHint'
+import { LemonField } from 'lib/lemon-ui/LemonField'
+import { Link } from 'lib/lemon-ui/Link'
+import { databaseTableListLogic } from 'scenes/data-management/database/databaseTableListLogic'
+import { dataWarehouseViewsLogic } from 'scenes/data-warehouse/saved_queries/dataWarehouseViewsLogic'
+import { urls } from 'scenes/urls'
+
+import { HogFlowPropertyFilters } from 'products/workflows/frontend/Workflows/hogflows/filters/HogFlowFilters'
+import { registerTriggerType } from 'products/workflows/frontend/Workflows/hogflows/registry/triggers/triggerTypeRegistry'
+import { workflowLogic } from 'products/workflows/frontend/Workflows/workflowLogic'
+
+import { HogFlowAction } from '../../types'
+
+export type DataWarehouseViewTriggerConfig = {
+    type: 'data-warehouse-view'
+    table_name: string
+    filters: {
+        properties?: any[]
+    }
+    key_property?: string
+}
+
+export function isDataWarehouseViewTriggerConfig(
+    config: Extract<HogFlowAction, { type: 'trigger' }>['config']
+): config is DataWarehouseViewTriggerConfig {
+    return config.type === 'data-warehouse-view'
+}
+
+function StepTriggerConfigurationDataWarehouseView({ node }: { node: any }): JSX.Element {
+    const { setWorkflowActionConfig } = useActions(workflowLogic)
+    const { actionValidationErrorsById } = useValues(workflowLogic)
+    const { dataWarehouseTables, dataWarehouseTablesMap, views, databaseLoading } = useValues(databaseTableListLogic)
+    const { loadDatabase, ensureAllTableFields } = useActions(databaseTableListLogic)
+    const { dataWarehouseSavedQueryMapById, dataWarehouseSavedQueriesLoading } = useValues(dataWarehouseViewsLogic)
+
+    useEffect(() => {
+        // The list isn't loaded automatically on mount, so kick it off when the panel opens.
+        if (!dataWarehouseTables.length && !views.length) {
+            loadDatabase()
+        } else {
+            // The store may hold a shallow (fields-less) schema left by the SQL editor.
+            ensureAllTableFields()
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
+
+    const config = node.data.config as DataWarehouseViewTriggerConfig
+    const selectedTableName = config.table_name || null
+    const properties = config.filters?.properties ?? []
+    const validationResult = actionValidationErrorsById[node.data.id]
+
+    // Only a materialized view writes rows on a schedule, so a plain view has nothing to trigger on.
+    const materializedViews = views.filter((view) => dataWarehouseSavedQueryMapById[view.id]?.is_materialized)
+    // The list needs both logics: the names come from the database schema and the materialized flag
+    // from the saved queries. Waiting on only one of them claims the project has no views while the
+    // other is still in flight.
+    const loading = databaseLoading || dataWarehouseSavedQueriesLoading
+    const hasNoViews = !loading && materializedViews.length === 0
+
+    const viewOptions = materializedViews.map((view) => {
+        const incremental = dataWarehouseSavedQueryMapById[view.id]?.is_incremental
+        return {
+            label: view.name,
+            value: view.name,
+            labelInMenu: (
+                <span className="flex items-center gap-2">
+                    {view.name}
+                    <LemonTag type={incremental ? 'success' : 'warning'}>
+                        {incremental ? 'Incremental' : 'Full refresh'}
+                    </LemonTag>
+                </span>
+            ),
+        }
+    })
+
+    const selectedView = materializedViews.find((view) => view.name === selectedTableName)
+    const selectedSavedQuery = selectedView ? dataWarehouseSavedQueryMapById[selectedView.id] : undefined
+    const selectedIsFullRefresh = !!selectedView && !selectedSavedQuery?.is_incremental
+
+    const schemaColumns = selectedTableName
+        ? Object.values(dataWarehouseTablesMap[selectedTableName]?.fields ?? {})
+        : []
+
+    const updateTriggerConfig = (tableName: string | null, newProperties: any[]): void => {
+        setWorkflowActionConfig(node.data.id, {
+            type: 'data-warehouse-view',
+            table_name: tableName ?? '',
+            filters: { properties: newProperties },
+            // Preserve any existing masking/dedup key set via the API or a future UI
+            ...(config.key_property ? { key_property: config.key_property } : {}),
+        })
+    }
+
+    return (
+        <div className="flex flex-col gap-2 w-full">
+            <p className="mb-0 text-sm text-muted-alt">
+                This workflow runs once for each row a materialized view adds or updates. Runs are row-scoped, so there
+                is no associated person and person-dependent steps are unavailable.
+            </p>
+            <LemonField.Pure label="Materialized view" error={validationResult?.errors?.table_name}>
+                <LemonSelect
+                    options={viewOptions}
+                    value={selectedTableName}
+                    loading={loading}
+                    disabledReason={hasNoViews ? 'Materialize a view first' : undefined}
+                    onChange={(tableName) => updateTriggerConfig(tableName, properties)}
+                    placeholder="Select a materialized view"
+                />
+                {hasNoViews && (
+                    <LemonBanner type="warning" className="w-full mt-1">
+                        <p className="mb-0">
+                            You don't have any materialized views yet, so this trigger has nothing to listen to.
+                            Materialize a view first, then come back and pick the one this workflow should run on.{' '}
+                            <Link to={urls.sqlEditor({})} target="_blank" className="font-semibold">
+                                Open the SQL editor
+                            </Link>
+                        </p>
+                    </LemonBanner>
+                )}
+            </LemonField.Pure>
+
+            {selectedIsFullRefresh && (
+                <LemonBanner type="warning" className="w-full">
+                    <p className="mb-0">
+                        This view rebuilds its whole table on every run, so every row runs this workflow again each
+                        time. Set the view to update incrementally to run only on the rows that changed.{' '}
+                        {selectedView && (
+                            <Link
+                                to={urls.sqlEditor({ view_id: selectedView.id })}
+                                target="_blank"
+                                className="font-semibold"
+                            >
+                                Open the view
+                            </Link>
+                        )}
+                    </p>
+                </LemonBanner>
+            )}
+
+            {selectedTableName ? (
+                <DataWarehouseColumnsHint schemaColumns={schemaColumns} tableName={selectedTableName} />
+            ) : null}
+
+            <LemonField.Pure label="Only trigger for specific rows">
+                <HogFlowPropertyFilters
+                    filtersKey={`data-warehouse-view-trigger-${node.data.id}`}
+                    filters={{ properties }}
+                    setFilters={(filters) => updateTriggerConfig(selectedTableName, filters?.properties ?? [])}
+                    schemaColumns={schemaColumns}
+                    dataWarehouseTableName={selectedTableName ?? undefined}
+                />
+            </LemonField.Pure>
+        </div>
+    )
+}
+
+registerTriggerType({
+    value: 'data-warehouse-view',
+    label: 'Materialized view row updated',
+    icon: <IconServer />,
+    description: 'Trigger when a materialized view adds or updates a row',
+    group: 'Data warehouse',
+    featureFlag: 'cdp-dwh-view-source',
+    matchConfig: (config) => isDataWarehouseViewTriggerConfig(config),
+    buildConfig: () => ({
+        type: 'data-warehouse-view',
+        table_name: '',
+        filters: { properties: [] },
+    }),
+    validate: (config): { valid: boolean; errors: Record<string, string> } | null => {
+        if (config.type !== 'data-warehouse-view') {
+            return null
+        }
+        if (!config.table_name) {
+            return { valid: false, errors: { table_name: 'Please select a materialized view' } }
+        }
+        return { valid: true, errors: {} }
+    },
+    ConfigComponent: StepTriggerConfigurationDataWarehouseView,
+})

--- a/products/workflows/frontend/Workflows/hogflows/registry/triggers/index.ts
+++ b/products/workflows/frontend/Workflows/hogflows/registry/triggers/index.ts
@@ -1,5 +1,6 @@
 import './conversations'
 import './customer_analytics'
 import './data_warehouse_table'
+import './data_warehouse_view'
 import './slack'
 import './surveys'

--- a/products/workflows/frontend/Workflows/hogflows/steps/stepDelayLogic.ts
+++ b/products/workflows/frontend/Workflows/hogflows/steps/stepDelayLogic.ts
@@ -223,6 +223,14 @@ export interface stepDelayLogicActions {
                   type: 'data-warehouse-table'
               }
             | {
+                  filters: {
+                      properties?: any[] | undefined
+                  }
+                  key_property?: string | undefined
+                  table_name: string
+                  type: 'data-warehouse-view'
+              }
+            | {
                   inputs: Record<
                       string,
                       {
@@ -415,6 +423,14 @@ export interface stepDelayLogicActions {
                   key_property?: string | undefined
                   table_name: string
                   type: 'data-warehouse-table'
+              }
+            | {
+                  filters: {
+                      properties?: any[] | undefined
+                  }
+                  key_property?: string | undefined
+                  table_name: string
+                  type: 'data-warehouse-view'
               }
             | {
                   inputs: Record<

--- a/products/workflows/frontend/Workflows/hogflows/steps/stepWaitUntilTimeWindowLogic.ts
+++ b/products/workflows/frontend/Workflows/hogflows/steps/stepWaitUntilTimeWindowLogic.ts
@@ -264,6 +264,14 @@ export interface stepWaitUntilTimeWindowLogicActions {
                   type: 'data-warehouse-table'
               }
             | {
+                  filters: {
+                      properties?: any[] | undefined
+                  }
+                  key_property?: string | undefined
+                  table_name: string
+                  type: 'data-warehouse-view'
+              }
+            | {
                   inputs: Record<
                       string,
                       {
@@ -457,6 +465,14 @@ export interface stepWaitUntilTimeWindowLogicActions {
                   key_property?: string | undefined
                   table_name: string
                   type: 'data-warehouse-table'
+              }
+            | {
+                  filters: {
+                      properties?: any[] | undefined
+                  }
+                  key_property?: string | undefined
+                  table_name: string
+                  type: 'data-warehouse-view'
               }
             | {
                   inputs: Record<

--- a/products/workflows/frontend/Workflows/hogflows/steps/types.ts
+++ b/products/workflows/frontend/Workflows/hogflows/steps/types.ts
@@ -189,6 +189,15 @@ export const HogFlowTriggerSchema = z.discriminatedUnion('type', [
             properties: z.array(z.any()).optional(),
         }),
     }),
+    z.object({
+        type: z.literal('data-warehouse-view'),
+        // The materialized view's own name, which is also its HogQL name
+        table_name: z.string(),
+        filters: z.object({
+            properties: z.array(z.any()).optional(),
+        }),
+        key_property: z.string().optional(),
+    }),
 ])
 
 /** Trigger types that use HogFlowSchedule for recurring execution */

--- a/products/workflows/frontend/Workflows/workflowLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowLogic.ts
@@ -112,9 +112,10 @@ export const NEW_WORKFLOW: HogFlow = {
 // data-warehouse-table triggers. Module-scoped to avoid reallocating on every selector recompute.
 export const PERSON_DEPENDENT_ACTION_TYPES = new Set(['wait_until_condition', 'random_cohort_branch'])
 
-// Trigger types whose runs have no person attached. Keep in sync with the backend's
-// ROW_SCOPED_TRIGGER_TYPES, which is the authoritative check.
-export const ROW_SCOPED_TRIGGER_TYPES = new Set(['data-warehouse-table', 'slack-message'])
+// Trigger types whose runs have no person attached: a synced warehouse row, a materialized view
+// row, and a Slack poster are all things no PostHog person is attached to. Keep in sync with the
+// backend's ROW_SCOPED_TRIGGER_TYPES, which is the authoritative check.
+export const ROW_SCOPED_TRIGGER_TYPES = new Set(['data-warehouse-table', 'data-warehouse-view', 'slack-message'])
 
 function getTemplatingError(value: string, templating?: 'liquid' | 'hog'): string | undefined {
     if (templating === 'liquid' && typeof value === 'string') {
@@ -762,6 +763,14 @@ export interface workflowLogicActions {
                                       type: 'data-warehouse-table'
                                   }
                                 | {
+                                      filters: {
+                                          properties?: any[] | undefined
+                                      }
+                                      key_property?: string | undefined
+                                      table_name: string
+                                      type: 'data-warehouse-view'
+                                  }
+                                | {
                                       inputs: Record<
                                           string,
                                           {
@@ -1018,6 +1027,14 @@ export interface workflowLogicActions {
                             key_property?: string | undefined
                             table_name: string
                             type: 'data-warehouse-table'
+                        }
+                      | {
+                            filters: {
+                                properties?: any[] | undefined
+                            }
+                            key_property?: string | undefined
+                            table_name: string
+                            type: 'data-warehouse-view'
                         }
                       | {
                             inputs: Record<
@@ -1574,6 +1591,14 @@ export interface workflowLogicActions {
                                       type: 'data-warehouse-table'
                                   }
                                 | {
+                                      filters: {
+                                          properties?: any[] | undefined
+                                      }
+                                      key_property?: string | undefined
+                                      table_name: string
+                                      type: 'data-warehouse-view'
+                                  }
+                                | {
                                       inputs: Record<
                                           string,
                                           {
@@ -1830,6 +1855,14 @@ export interface workflowLogicActions {
                             key_property?: string | undefined
                             table_name: string
                             type: 'data-warehouse-table'
+                        }
+                      | {
+                            filters: {
+                                properties?: any[] | undefined
+                            }
+                            key_property?: string | undefined
+                            table_name: string
+                            type: 'data-warehouse-view'
                         }
                       | {
                             inputs: Record<
@@ -2111,6 +2144,14 @@ export interface workflowLogicActions {
                   key_property?: string | undefined
                   table_name: string
                   type: 'data-warehouse-table'
+              }
+            | {
+                  filters: {
+                      properties?: any[] | undefined
+                  }
+                  key_property?: string | undefined
+                  table_name: string
+                  type: 'data-warehouse-view'
               }
             | {
                   inputs: Record<
@@ -2468,6 +2509,14 @@ export interface workflowLogicActions {
                   type: 'data-warehouse-table'
               }
             | {
+                  filters: {
+                      properties?: any[] | undefined
+                  }
+                  key_property?: string | undefined
+                  table_name: string
+                  type: 'data-warehouse-view'
+              }
+            | {
                   inputs: Record<
                       string,
                       {
@@ -2729,6 +2778,14 @@ export interface workflowLogicMeta {
                                 key_property?: string | undefined
                                 table_name: string
                                 type: 'data-warehouse-table'
+                            }
+                          | {
+                                filters: {
+                                    properties?: any[] | undefined
+                                }
+                                key_property?: string | undefined
+                                table_name: string
+                                type: 'data-warehouse-view'
                             }
                           | {
                                 inputs: Record<
@@ -3514,7 +3571,7 @@ export const workflowLogic = kea<workflowLogicType>([
         isRowScopedTrigger: [
             (s) => [s.triggerAction],
             (triggerAction: TriggerAction | null): boolean =>
-                ROW_SCOPED_TRIGGER_TYPES.has(triggerAction?.config?.type as string),
+                ROW_SCOPED_TRIGGER_TYPES.has(triggerAction?.config?.type ?? ''),
         ],
 
         workflowSanitized: [

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -6666,6 +6666,7 @@ export namespace Schemas {
       CohortsWithAll: 'cohorts_with_all',
       DataWarehouse: 'data_warehouse',
       DataWarehouseSourceTables: 'data_warehouse_source_tables',
+      DataWarehouseMaterializedViews: 'data_warehouse_materialized_views',
       DataWarehouseProperties: 'data_warehouse_properties',
       DataWarehousePersonProperties: 'data_warehouse_person_properties',
       Elements: 'elements',


### PR DESCRIPTION
## Problem

Someone can now pick a materialized view as the thing a destination or a workflow runs on. The backend for it landed in the PR below this one, with no way to reach it.

A full-refresh view rebuilds its whole table on every run, so every row runs the destination or workflow again each time. A person choosing a view has no way to know that from the picker, and the cost lands on them.

Behind `cdp-dwh-view-source`, so the picker is invisible until the flag goes on.

## Changes

- Workflows get a "Materialized view row updated" trigger. Destinations get a "Materialized view" source.
- Both list only materialized views, and reuse the column hints and row filters the table trigger already has.
- Each view carries an "Incremental" or "Full refresh" tag in the list.
- Selecting a full-refresh view shows a banner saying every row runs again on each refresh, and links to the view so the person can switch it.
- Materialized views get their own taxonomic group. The destination picker's group was hardcoded to source tables, so each family now gets its own `typeKey`.
- `is_incremental` joins the saved query list serializer. The list response deliberately omits the full incremental config, and the picker needs the flag.

The tag says "Incremental" for a view that is configured for it. A run can still rebuild the whole table, on its first run or after the query changes, which is why the copy says "set the view to update incrementally" rather than promising what the next run does.

> [!NOTE]
> No screenshots. Rendering either picker needs the dev stack plus a materialized view, and this
> machine could not start it: `phrocs` is not installed, and port 3000 is held by another checkout's
> dev server, so anything captured there would show that checkout's code rather than this branch.
> Both surfaces still need a look before the flag goes on.

## How did you test this code?

Added `data_warehouse_view.test.ts`, mirroring the existing table trigger test: registry shape, the flag it is gated on, and `validate()` rejecting an empty selection.

Verified locally: the trigger registry tests, `pnpm --filter=@posthog/frontend typescript:check`, oxlint and oxfmt, and `hogli ci:preflight --fix` with zero failures.

Not verified: no rendering test, no screenshot, and no manual click-through of either picker (see the note above). The banner and tag logic are plain derivations from the saved query list, and both components reuse the table trigger's structure.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None yet. The feature is flag-gated, so docs should follow the rollout.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5). Skills invoked: `/modifying-taxonomic-filter`, `/writing-user-facing-copy`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`, `/stacking-prs`.

Two notes for the reviewer:

The taxonomic filter has two parallel implementations with no lint enforcing parity. The rebuild arm (`buildTaxonomicGroups.tsx`) has no source-tables group either, so this change mirrors the legacy arm only, matching what is already there. Nothing about ordering or promotion changed.

The full-refresh guard is a warning, not a block. Blocking would be safer but a full-refresh view is a legitimate choice, so the copy states what happens and points at the setting.
