### PR TITLE
feat(ingestion): add ingestion_api_event_seconds_in_flight_total

### DIFF
--- a/nodejs/src/servers/ingestion-api-server.test.ts
+++ b/nodejs/src/servers/ingestion-api-server.test.ts
@@ -1,4 +1,4 @@
-import { Gauge, register } from 'prom-client'
+import { Counter, Gauge, register } from 'prom-client'
 
 import { GROUPS_OUTPUT } from '~/common/outputs'
 import { GroupFlushResult } from '~/ingestion/common/groups/group-store.interface'
@@ -36,6 +36,12 @@ describe('IngestionApiServer', () => {
         return (server as any).handleIngestRequest(req, res)
     }
 
+    async function eventSecondsInFlight(): Promise<number> {
+        const counter = register.getSingleMetric('ingestion_api_event_seconds_in_flight_total') as Counter<string>
+        const { values } = await counter.get()
+        return values[0]?.value ?? 0
+    }
+
     async function eventsInFlight(): Promise<number> {
         const gauge = register.getSingleMetric('ingestion_api_events_in_flight') as Gauge<string>
         const { values } = await gauge.get()
@@ -56,6 +62,7 @@ describe('IngestionApiServer', () => {
         stopSpy = jest.spyOn(server, 'stop').mockResolvedValue(undefined)
         // The gauge is a module-level singleton shared across tests in this file.
         register.getSingleMetric('ingestion_api_events_in_flight')?.reset()
+        register.getSingleMetric('ingestion_api_event_seconds_in_flight_total')?.reset()
     })
 
     it('reports healthy before any failure', () => {
@@ -102,9 +109,9 @@ describe('IngestionApiServer', () => {
         expect(stopSpy).not.toHaveBeenCalled()
     })
 
-    describe('events in flight gauge', () => {
-        type Gate = { resolve: () => void; reject: (error: Error) => void }
+    type Gate = { resolve: () => void; reject: (error: Error) => void }
 
+    describe('events in flight gauge', () => {
         // One gate per in-flight batch. The handler calls next() exactly once
         // (the mock resolves to null, ending its drain loop), so holding that
         // promise open holds the batch in flight and lets a test decide the
@@ -248,6 +255,120 @@ describe('IngestionApiServer', () => {
             await handle(makeRes(), 5)
 
             expect(await eventsInFlight()).toBe(0)
+        })
+    })
+
+    describe('event-seconds counter', () => {
+        // The counter is the integral of the gauge, so its whole value is that
+        // rate() over it recovers mean events in flight without depending on
+        // when a scrape lands. Driving Date.now directly keeps that arithmetic
+        // exact and avoids faking the timers the request path runs on.
+        let clock: jest.SpyInstance
+
+        beforeEach(() => {
+            clock = jest.spyOn(Date, 'now')
+        })
+
+        afterEach(() => {
+            clock.mockRestore()
+        })
+
+        function gateBatches(): Gate[] {
+            const gates: Gate[] = []
+            pipeline.feed.mockResolvedValue({ ok: true })
+            pipeline.next.mockImplementation(
+                () =>
+                    new Promise<null>((resolve, reject) => {
+                        gates.push({ resolve: () => resolve(null), reject })
+                    })
+            )
+            return gates
+        }
+
+        function flush(): Promise<void> {
+            return new Promise((resolve) => setImmediate(resolve))
+        }
+
+        it('accumulates events multiplied by seconds in flight', async () => {
+            const gates = gateBatches()
+            clock.mockReturnValue(1_000)
+
+            const batch = handle(makeRes(), 10)
+            await flush()
+
+            clock.mockReturnValue(3_500)
+            gates[0].resolve()
+            await batch
+
+            // 10 events held for 2.5s.
+            expect(await eventSecondsInFlight()).toBe(25)
+        })
+
+        it('credits each concurrent batch its own duration', async () => {
+            const gates = gateBatches()
+            clock.mockReturnValue(0)
+
+            const long = handle(makeRes(), 100)
+            await flush()
+            clock.mockReturnValue(1_000)
+            const short = handle(makeRes(), 4)
+            await flush()
+
+            // short: accepted at 1s, ends at 3s  -> 4 * 2  =   8
+            clock.mockReturnValue(3_000)
+            gates[1].resolve()
+            await short
+            expect(await eventSecondsInFlight()).toBe(8)
+
+            // long: accepted at 0s, ends at 4s   -> 100 * 4 = 400
+            clock.mockReturnValue(4_000)
+            gates[0].resolve()
+            await long
+            expect(await eventSecondsInFlight()).toBe(408)
+        })
+
+        it('recovers mean events in flight, which is the point of the counter', async () => {
+            // One event held for 60s and 60 events each held for 1s both mean
+            // "1 event in flight on average over a minute". A gauge scraped
+            // once would report 1 or 60 depending on timing; the counter says
+            // 60 event-seconds either way.
+            const gates = gateBatches()
+
+            clock.mockReturnValue(0)
+            const steady = handle(makeRes(), 1)
+            await flush()
+            clock.mockReturnValue(60_000)
+            gates[0].resolve()
+            await steady
+            const heldLong = await eventSecondsInFlight()
+
+            register.getSingleMetric('ingestion_api_event_seconds_in_flight_total')?.reset()
+
+            for (let i = 0; i < 60; i++) {
+                clock.mockReturnValue(i * 1_000)
+                const burst = handle(makeRes(), 60)
+                await flush()
+                clock.mockReturnValue(i * 1_000 + 1_000)
+                gates[gates.length - 1].resolve()
+                await burst
+            }
+            const burstsShort = await eventSecondsInFlight()
+
+            expect(heldLong).toBe(60)
+            expect(burstsShort).toBe(3_600)
+            // Same mean over their own window: 60/60s = 1, 3600/60s = 60.
+            expect(heldLong / 60).toBe(1)
+            expect(burstsShort / 60).toBe(60)
+        })
+
+        it('does not credit a batch rejected at capacity', async () => {
+            clock.mockReturnValue(0)
+            pipeline.feed.mockResolvedValue({ ok: false, kind: 'at_capacity', reason: 'at capacity' })
+
+            clock.mockReturnValue(5_000)
+            await handle(makeRes(), 10)
+
+            expect(await eventSecondsInFlight()).toBe(0)
         })
     })
 

--- a/nodejs/src/servers/ingestion-api-server.ts
+++ b/nodejs/src/servers/ingestion-api-server.ts
@@ -159,6 +159,19 @@ const eventsInFlight = new Gauge({
     help: 'Number of events in accepted batches currently being processed by the ingestion API',
 })
 
+// The integral of `eventsInFlight` over time, accumulated one batch at a time:
+// a batch holding N events for T seconds contributes N*T. Because
+// integral(in_flight dt) equals sum(events * time in flight), rate() over this
+// counter is the exact time-weighted mean events in flight for the interval,
+// where the gauge above only reports whatever instant the scrape happened to
+// land on. In-flight turns over on a sub-second timescale and scrapes are tens
+// of seconds apart, so the gauge is far too noisy to autoscale on directly.
+// Same relationship as container_cpu_usage_seconds_total and CPU utilization.
+const eventSecondsInFlight = new Counter({
+    name: 'ingestion_api_event_seconds_in_flight_total',
+    help: 'Cumulative event-seconds spent in flight; rate() gives mean events in flight',
+})
+
 /**
  * Ingestion API server that exposes the ingestion pipeline as an HTTP endpoint.
  *
@@ -481,10 +494,10 @@ export class IngestionApiServer implements NodeServer {
 
         const startTime = Date.now()
 
-        // Event count of this batch once accepted, or null while it is not.
-        // Holding the count (rather than a bool) makes the `finally` decrement
-        // exactly what was incremented, even if `messages` is out of scope.
-        let inFlight: number | null = null
+        // Event count and acceptance time of this batch once accepted, or null
+        // while it is not. Holding both (rather than a bool) makes the `finally`
+        // credit exactly what was counted, even if `messages` is out of scope.
+        let inFlight: { events: number; acceptedAt: number } | null = null
 
         try {
             const messages: Message[] = serializedMessages.map(deserializeKafkaMessage)
@@ -529,7 +542,7 @@ export class IngestionApiServer implements NodeServer {
             // slot until processing completes below.
             batchesInFlight.inc()
             eventsInFlight.inc(messages.length)
-            inFlight = messages.length
+            inFlight = { events: messages.length, acceptedAt: Date.now() }
 
             // The pipeline handles its own side effects (scheduling them on
             // the promise scheduler), so draining results is all that's left
@@ -569,7 +582,8 @@ export class IngestionApiServer implements NodeServer {
         } finally {
             if (inFlight !== null) {
                 batchesInFlight.dec()
-                eventsInFlight.dec(inFlight)
+                eventsInFlight.dec(inFlight.events)
+                eventSecondsInFlight.inc((inFlight.events * (Date.now() - inFlight.acceptedAt)) / 1000)
             }
         }
     }


### PR DESCRIPTION
## Problem

`ingestion_api_events_in_flight` is too noisy to autoscale on, and no averaging window fully fixes it.

- Events in flight is a level on a sub-second timescale — mean batch duration is ~600ms — scraped every ~50 seconds. Each scrape catches one arbitrary instant of a quantity that turns over many times between scrapes.
- Measured on the overflow lane over 90 minutes, the value swung **25×** (2,776 → 68,140) while throughput moved 1.6×. At the configured threshold that is replica demand ranging 3 to 69.
- Averaging the samples helps but hits a floor: at a ~50s scrape a 2-minute window holds 2.4 samples, and the noise is autocorrelated rather than white, so it still leaves 67% coefficient of variation. Only a 10-minute window gets to 40%, and that costs ~5 minutes of lag on a genuine load change (PostHog/charts#14407).

Averaging samples cannot fix a sampling problem. It only averages over it.

## Changes

Export the integral of the gauge rather than only the level. On batch completion, a batch holding `N` events for `T` seconds adds `N × T`:

```ts
eventSecondsInFlight.inc((inFlight.events * (Date.now() - inFlight.acceptedAt)) / 1000)
```

The identity that makes this work:

```
∫ in_flight dt  =  Σ (events_i × time_i in flight)
```

The left side is the area under the in-flight curve. The right side is a sum accumulable one batch at a time, without ever sampling the curve. So `rate(ingestion_api_event_seconds_in_flight_total[3m])` is the **exact** time-weighted mean events in flight over those three minutes, including everything that happened between scrapes — the same relationship `container_cpu_usage_seconds_total` has with CPU utilization.

With sampling error gone, the remaining variation is genuine load variation, so a short window becomes viable and most of the lag comes back.

The gauge stays. It is the right thing for a point-in-time view ("what is this pod holding right now"), and it remains the `stalenessGuard` canary. This adds the counter alongside it.

One caveat: a batch still running at scrape time has not contributed yet, so the rate trails by about one batch duration (~600ms). Irrelevant at any usable window.

## How did you test this code?

Four tests, driving `Date.now` directly so the arithmetic is exact — faking timers would also fake the `setImmediate` the request path runs on.

- `accumulates events multiplied by seconds in flight` — 10 events held 2.5s must record 25, not 10 and not 2.5. Catches the counter being wired to either factor alone.
- `credits each concurrent batch its own duration` — overlapping batches with different sizes and different accept times, finished out of order. Catches a batch being credited another's duration, which is the failure mode under concurrency.
- `recovers mean events in flight, which is the point of the counter` — 1 event held 60s and 60 events each held 1s. A single scrape of the gauge would report 1 or 60 depending on timing; the counter records 60 and 3,600 event-seconds, giving means of 1 and 60 over their own windows. This is the property the whole change exists for.
- `does not credit a batch rejected at capacity` — a 503 must contribute nothing.

`pnpm jest src/servers/ingestion-api-server.test.ts` passes (17 tests). Mutation-checked: dropping the time factor from the increment fails 3 of them.

No manual testing against a running processor.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude, in Claude Code) wrote this. Skills invoked: `/writing-pr-descriptions`.

Follows PostHog/posthog#84096, which added the gauge, and PostHog/charts#14407, which put a 10-minute window on it as an interim measure. The window was chosen from measurement (2m/3m/5m/10m/15m each evaluated against replica churn) rather than picked, and its cost in lag is what motivated fixing the metric instead. A companion charts change moves the overflow trigger onto `rate()` over this counter and shortens the window accordingly.

Nothing in this diff draws on material that is not already in this repository.
