### PR TITLE
feat(context-layer): pages API, enablement import, and commit landing

### DIFF
--- a/products/context_layer/backend/enablement.py
+++ b/products/context_layer/backend/enablement.py
@@ -55,7 +55,9 @@ def import_channel_context(organization_id: uuid.UUID | str) -> list[str]:
     """
     imported: dict[str, str] = {}
     existing_slugs: set[str] = set()
-    for team_id in Team.objects.filter(organization_id=organization_id).values_list("id", flat=True):
+    # Order the teams so a same-named channel in two projects always resolves its
+    # slug collision the same way; an unordered scan could swap the pages between runs.
+    for team_id in Team.objects.filter(organization_id=organization_id).order_by("id").values_list("id", flat=True):
         # The enable request is org-scoped, so the fail-closed channel models
         # need an explicit team scope per team we read from.
         with team_scope(team_id):

--- a/products/context_layer/backend/enablement.py
+++ b/products/context_layer/backend/enablement.py
@@ -1,0 +1,101 @@
+"""Enable the context layer for an organization: scaffold the wiki, then import
+existing channel CONTEXT.md documents once.
+
+The legacy ChannelInstructions rows are never deleted, so turning the flag off
+restores the old behavior exactly as it was at import time.
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+from django.utils.text import slugify
+
+import structlog
+
+from posthog.models.scoping import team_scope
+from posthog.models.team.team import Team
+
+from products.context_layer.backend import store
+from products.context_layer.backend.models import ContextLayerConfig
+from products.tasks.backend.facade import api as tasks_facade
+
+logger = structlog.get_logger(__name__)
+
+
+class RestrictedProjectsError(store.ContextLayerStoreError):
+    """The organization has private projects; enabling waits for per-project partitioning."""
+
+
+def enable_context_layer(
+    organization_id: uuid.UUID | str,
+    *,
+    created_by_id: int | None = None,
+) -> ContextLayerConfig:
+    """Idempotent: re-enabling scaffolds nothing and re-imports only missing pages."""
+    # Context extracted with one project's credentials must not become readable
+    # through another, so orgs with private projects cannot enable until the
+    # wiki is partitioned per project.
+    if Team.objects.filter(organization_id=organization_id, access_control=True).exists():
+        raise RestrictedProjectsError(
+            "This organization has private projects. The context layer does not support them yet."
+        )
+    config = store.initialize_repo(organization_id, created_by_id=created_by_id)
+    import_channel_context(organization_id)
+    return config
+
+
+def import_channel_context(organization_id: uuid.UUID | str) -> list[str]:
+    """Write each public channel's latest CONTEXT.md as `channels/<slug>.md`.
+
+    Pages that already exist are left alone, so the import runs once per channel
+    and never overwrites later wiki edits. Personal channels are skipped: their
+    context belongs to one person, and the wiki is org-visible.
+    """
+    imported: dict[str, str] = {}
+    existing_slugs: set[str] = set()
+    for team_id in Team.objects.filter(organization_id=organization_id).values_list("id", flat=True):
+        # The enable request is org-scoped, so the fail-closed channel models
+        # need an explicit team scope per team we read from.
+        with team_scope(team_id):
+            for channel in tasks_facade.list_channels(team_id, None):
+                if channel.channel_type != "public":
+                    continue
+                instructions = tasks_facade.get_channel_instructions(channel.id, team_id, None)
+                if instructions is None or instructions.version == 0 or not instructions.content.strip():
+                    continue
+                slug = _unique_slug(channel.name, channel.id, existing_slugs)
+                existing_slugs.add(slug)
+                imported[f"channels/{slug}.md"] = _channel_page(channel.id, channel.name, instructions.content)
+
+    if not imported:
+        return []
+
+    written: list[str] = []
+
+    def mutate(root: Path) -> None:
+        written.clear()
+        for path, content in imported.items():
+            target = root / path
+            if target.exists():
+                continue
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(content, encoding="utf-8")
+            written.append(path)
+
+    store.apply_changes(organization_id, message="Import channel context", mutate=mutate)
+    return sorted(written)
+
+
+def _unique_slug(name: str, channel_id: uuid.UUID, taken: set[str]) -> str:
+    slug = slugify(name) or str(channel_id)
+    if slug in taken:
+        # Channel names are only unique per team, so cross-team collisions get
+        # the channel id appended.
+        slug = f"{slug}-{str(channel_id)[:8]}"
+    return slug
+
+
+def _channel_page(channel_id: uuid.UUID, channel_name: str, content: str) -> str:
+    return f"---\nchannel_id: {channel_id}\nsource: channel-instructions-import\n---\n\n# {channel_name}\n\n{content}\n"

--- a/products/context_layer/backend/pages.py
+++ b/products/context_layer/backend/pages.py
@@ -11,9 +11,8 @@ import uuid
 import posixpath
 from pathlib import Path
 
-from django.core.cache import cache
-
 from posthog.dataclasses import frozen
+from posthog.utils import get_safe_cache, safe_cache_set
 
 from products.context_layer.backend import repo_lint, store
 
@@ -79,7 +78,7 @@ def normalize_page_path(path: str) -> str:
 def get_tree(organization_id: uuid.UUID | str) -> WikiTree:
     """Every page path in the wiki at the current head."""
     head_sha = store.get_config(organization_id).head_sha
-    paths = cache.get(_tree_cache_key(organization_id, head_sha))
+    paths = get_safe_cache(_tree_cache_key(organization_id, head_sha))
     if paths is None:
         # The head can move between the read above and the checkout; trust the
         # checkout's head so the returned sha always matches the returned paths.
@@ -90,7 +89,7 @@ def get_tree(organization_id: uuid.UUID | str) -> WikiTree:
 def get_page(organization_id: uuid.UUID | str, path: str) -> WikiPage:
     path = normalize_page_path(path)
     head_sha = store.get_config(organization_id).head_sha
-    content = cache.get(_page_cache_key(organization_id, head_sha, path))
+    content = get_safe_cache(_page_cache_key(organization_id, head_sha, path))
     if content is None:
         head_sha, _, pages = _warm_cache(organization_id)
         content = pages.get(path)
@@ -136,7 +135,7 @@ def _warm_cache(organization_id: uuid.UUID | str) -> tuple[str, list[str], dict[
             relative = str(file_path.relative_to(checkout.path))
             pages[relative] = file_path.read_text(encoding="utf-8")
         paths = sorted(pages)
-        cache.set(_tree_cache_key(organization_id, checkout.head_sha), paths, CACHE_TTL_SECONDS)
+        safe_cache_set(_tree_cache_key(organization_id, checkout.head_sha), paths, CACHE_TTL_SECONDS)
         for relative, content in pages.items():
-            cache.set(_page_cache_key(organization_id, checkout.head_sha, relative), content, CACHE_TTL_SECONDS)
+            safe_cache_set(_page_cache_key(organization_id, checkout.head_sha, relative), content, CACHE_TTL_SECONDS)
         return checkout.head_sha, paths, pages

--- a/products/context_layer/backend/pages.py
+++ b/products/context_layer/backend/pages.py
@@ -1,0 +1,142 @@
+"""Read and write wiki pages without putting a bundle download on the request path.
+
+Page contents are cached per head sha, so cache entries are immutable and need
+no invalidation: a landed write moves the head, and the next read warms the new
+sha's entries from one checkout.
+"""
+
+from __future__ import annotations
+
+import uuid
+import posixpath
+from pathlib import Path
+
+from django.core.cache import cache
+
+from posthog.dataclasses import frozen
+
+from products.context_layer.backend import repo_lint, store
+
+# Entries are keyed by head sha and therefore immutable; the TTL only bounds
+# storage for heads nothing reads anymore.
+CACHE_TTL_SECONDS = 24 * 60 * 60
+PAGE_MAX_BYTES = 1_000_000
+
+
+class PageNotFoundError(store.ContextLayerStoreError):
+    pass
+
+
+class InvalidPagePathError(store.ContextLayerStoreError):
+    pass
+
+
+@frozen
+class WikiPage:
+    path: str
+    content: str
+    head_sha: str
+
+
+@frozen
+class WikiTree:
+    head_sha: str
+    paths: list[str]
+
+
+def _tree_cache_key(organization_id: uuid.UUID | str, head_sha: str) -> str:
+    return f"context_layer:tree:{organization_id}:{head_sha}"
+
+
+def _page_cache_key(organization_id: uuid.UUID | str, head_sha: str, path: str) -> str:
+    return f"context_layer:page:{organization_id}:{head_sha}:{path}"
+
+
+def normalize_page_path(path: str) -> str:
+    """Reject anything that could escape the checkout or point at a non-page.
+
+    The structural rules come from `repo_lint` so a write into the wrong
+    directory fails here, before paying for a checkout, and fails the same way
+    the land-time lint would."""
+    normalized = posixpath.normpath(path.strip().lstrip("/"))
+    if (
+        not normalized
+        or normalized.startswith((".", "/"))
+        or ".." in normalized.split("/")
+        or not normalized.endswith(".md")
+    ):
+        raise InvalidPagePathError(f"{path!r} is not a wiki page path; expected a relative Markdown path")
+    first_segment = normalized.split("/", 1)[0]
+    # CLAUDE.md is deliberately not writable: it must stay a symlink to AGENTS.md.
+    if normalized != "AGENTS.md" and first_segment not in repo_lint.MARKDOWN_DIRECTORIES:
+        raise InvalidPagePathError(
+            f"{path!r} is outside the wiki structure; pages live in "
+            f"{', '.join(sorted(repo_lint.MARKDOWN_DIRECTORIES))} or at AGENTS.md"
+        )
+    return normalized
+
+
+def get_tree(organization_id: uuid.UUID | str) -> WikiTree:
+    """Every page path in the wiki at the current head."""
+    head_sha = store.get_config(organization_id).head_sha
+    paths = cache.get(_tree_cache_key(organization_id, head_sha))
+    if paths is None:
+        # The head can move between the read above and the checkout; trust the
+        # checkout's head so the returned sha always matches the returned paths.
+        head_sha, paths, _ = _warm_cache(organization_id)
+    return WikiTree(head_sha=head_sha, paths=paths)
+
+
+def get_page(organization_id: uuid.UUID | str, path: str) -> WikiPage:
+    path = normalize_page_path(path)
+    head_sha = store.get_config(organization_id).head_sha
+    content = cache.get(_page_cache_key(organization_id, head_sha, path))
+    if content is None:
+        head_sha, _, pages = _warm_cache(organization_id)
+        content = pages.get(path)
+    if content is None:
+        raise PageNotFoundError(f"no page at {path}")
+    return WikiPage(path=path, content=content, head_sha=head_sha)
+
+
+def write_page(
+    organization_id: uuid.UUID | str,
+    *,
+    path: str,
+    content: str,
+    base_head: str | None = None,
+    author: store.CommitAuthor | None = None,
+) -> str:
+    """Create or replace one page through the writer protocol; returns the new head."""
+    path = normalize_page_path(path)
+    if len(content.encode("utf-8")) > PAGE_MAX_BYTES:
+        raise InvalidPagePathError(f"page content exceeds the {PAGE_MAX_BYTES // 1_000_000} MB limit")
+
+    def mutate(root: Path) -> None:
+        target = root / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+
+    return store.apply_changes(
+        organization_id,
+        message=f"Edit {path}",
+        mutate=mutate,
+        author=author,
+        required_head=base_head,
+    )
+
+
+def _warm_cache(organization_id: uuid.UUID | str) -> tuple[str, list[str], dict[str, str]]:
+    """One checkout warms the tree and every page for the checkout's head."""
+    with store.checkout_repo(organization_id) as checkout:
+        pages: dict[str, str] = {}
+        for file_path in sorted(checkout.path.rglob("*.md")):
+            if ".git" in file_path.parts or file_path.is_symlink() or not file_path.is_file():
+                continue
+            relative = str(file_path.relative_to(checkout.path))
+            pages[relative] = file_path.read_text(encoding="utf-8")
+        paths = sorted(pages)
+        cache.set(_tree_cache_key(organization_id, checkout.head_sha), paths, CACHE_TTL_SECONDS)
+        for relative, content in pages.items():
+            cache.set(_page_cache_key(organization_id, checkout.head_sha, relative), content, CACHE_TTL_SECONDS)
+        return checkout.head_sha, paths, pages

--- a/products/context_layer/backend/presentation/serializers.py
+++ b/products/context_layer/backend/presentation/serializers.py
@@ -1,0 +1,94 @@
+from rest_framework import serializers
+
+from products.context_layer.backend.pages import PAGE_MAX_BYTES
+
+# A bundle carries a handful of Markdown commits; anything bigger is not a wiki write-back.
+COMMIT_BUNDLE_MAX_BYTES = 25_000_000
+
+
+class ContextLayerStatusSerializer(serializers.Serializer):
+    """Response shape for the wiki's current state."""
+
+    head_sha = serializers.CharField(help_text="Commit sha of the wiki's current head.")
+
+
+class WikiTreeSerializer(serializers.Serializer):
+    """Response shape for the wiki's page listing."""
+
+    head_sha = serializers.CharField(help_text="Commit sha of the wiki's current head.")
+    paths = serializers.ListField(
+        child=serializers.CharField(),
+        help_text="Repo-relative path of every Markdown page at the current head.",
+    )
+
+
+class WikiPageSerializer(serializers.Serializer):
+    """Response shape for one wiki page."""
+
+    path = serializers.CharField(help_text="Repo-relative path of the page, for example `areas/analytics.md`.")
+    content = serializers.CharField(allow_blank=True, help_text="The page's Markdown content.")
+    head_sha = serializers.CharField(
+        help_text="Commit sha the content was read at; pass back as `base_head` on writes."
+    )
+
+
+class WikiPageWriteSerializer(serializers.Serializer):
+    """Request body for creating or replacing one wiki page."""
+
+    path = serializers.CharField(
+        max_length=512,
+        help_text="Repo-relative Markdown path inside the wiki's structure, for example `channels/general.md`.",
+    )
+    content = serializers.CharField(
+        allow_blank=True,
+        trim_whitespace=False,
+        max_length=PAGE_MAX_BYTES,
+        help_text="The complete Markdown content for the page.",
+    )
+    base_head = serializers.CharField(
+        required=False,
+        allow_null=True,
+        help_text=(
+            "Optimistic-concurrency guard: the head sha the edit is based on. A moved head is rejected "
+            "with 409 and the current head; omit to write unguarded."
+        ),
+    )
+
+
+class CommitBundleSerializer(serializers.Serializer):
+    """Request body for landing agent commits posted back as a git bundle."""
+
+    bundle = serializers.FileField(
+        help_text=(
+            "A `git bundle` carrying the wiki's `main` ref, created in the agent's clone "
+            "(for example `git bundle create out.bundle origin/main..main`)."
+        )
+    )
+
+    def validate_bundle(self, value):  # noqa: ANN001, ANN201
+        if value.size > COMMIT_BUNDLE_MAX_BYTES:
+            raise serializers.ValidationError(f"Bundle exceeds the {COMMIT_BUNDLE_MAX_BYTES // 1_000_000} MB limit.")
+        return value
+
+
+class WikiExportSerializer(serializers.Serializer):
+    """Response shape for a wiki bundle export."""
+
+    url = serializers.CharField(help_text="Short-lived download URL for the wiki's current bundle.")
+    head_sha = serializers.CharField(help_text="Commit sha of the bundle behind the URL.")
+
+
+class HeadConflictSerializer(serializers.Serializer):
+    """409 body when a guarded write was based on a stale head."""
+
+    detail = serializers.CharField(help_text="What moved and what to do next.")
+    current_head = serializers.CharField(help_text="The wiki's current head sha; re-read pages at this head and retry.")
+
+
+class LintErrorSerializer(serializers.Serializer):
+    """400 body when a write violates the wiki's structure rules."""
+
+    detail = serializers.CharField(help_text="What was rejected.")
+    errors = serializers.ListField(
+        child=serializers.CharField(), help_text="One entry per structure violation found by the linter."
+    )

--- a/products/context_layer/backend/presentation/views.py
+++ b/products/context_layer/backend/presentation/views.py
@@ -3,6 +3,7 @@ from rest_framework import status, viewsets
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.decorators import action
 from rest_framework.exceptions import NotFound, Throttled, ValidationError
+from rest_framework.parsers import FormParser, MultiPartParser
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -170,7 +171,7 @@ class ContextLayerViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         },
         summary="Land agent commits from a git bundle",
     )
-    @action(methods=["POST"], detail=False)
+    @action(methods=["POST"], detail=False, parser_classes=[MultiPartParser, FormParser])
     def commits(self, request: Request, **kwargs) -> Response:
         serializer = CommitBundleSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)

--- a/products/context_layer/backend/presentation/views.py
+++ b/products/context_layer/backend/presentation/views.py
@@ -1,0 +1,196 @@
+from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
+from rest_framework import status, viewsets
+from rest_framework.authentication import SessionAuthentication
+from rest_framework.decorators import action
+from rest_framework.exceptions import NotFound, Throttled, ValidationError
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from posthog.api.routing import TeamAndOrgViewSetMixin
+from posthog.auth import OAuthAccessTokenAuthentication, PersonalAPIKeyAuthentication
+from posthog.permissions import APIScopePermission, PostHogFeatureFlagPermission
+
+from products.context_layer.backend import enablement, pages, store
+from products.context_layer.backend.presentation.serializers import (
+    CommitBundleSerializer,
+    ContextLayerStatusSerializer,
+    HeadConflictSerializer,
+    LintErrorSerializer,
+    WikiExportSerializer,
+    WikiPageSerializer,
+    WikiPageWriteSerializer,
+    WikiTreeSerializer,
+)
+
+
+def _store_error_response(error: store.ContextLayerStoreError) -> Response:
+    """One mapping from store errors to HTTP for every action, so new writers
+    added in later layers cannot drift from this contract."""
+    if isinstance(error, store.RepoNotFoundError):
+        raise NotFound("The context layer is not enabled for this organization.") from error
+    if isinstance(error, pages.InvalidPagePathError):
+        raise ValidationError(str(error)) from error
+    if isinstance(error, store.RepoLockUnavailableError):
+        raise Throttled(detail=str(error))
+    if isinstance(error, pages.PageNotFoundError):
+        raise NotFound(str(error)) from error
+    if isinstance(error, store.HeadConflictError):
+        return Response(
+            {
+                "detail": "The wiki changed since this edit was based; re-read and retry.",
+                "current_head": error.current_head,
+            },
+            status=status.HTTP_409_CONFLICT,
+        )
+    if isinstance(error, store.BundleConflictError):
+        return Response({"detail": str(error)}, status=status.HTTP_409_CONFLICT)
+    if isinstance(error, store.LintFailedError):
+        return Response(
+            {"detail": "The change violates the wiki structure.", "errors": error.errors},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+    raise error
+
+
+@extend_schema(tags=["context_layer"])
+class ContextLayerViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
+    """The organization's context wiki: a git repo of Markdown pages hosted by PostHog."""
+
+    authentication_classes = [SessionAuthentication, PersonalAPIKeyAuthentication, OAuthAccessTokenAuthentication]
+    # The flag is the rollout boundary: the whole surface stays off until the
+    # organization opts into `context-layer`.
+    posthog_feature_flag = "context-layer"
+    permission_classes = [IsAuthenticated, APIScopePermission, PostHogFeatureFlagPermission]
+    scope_object = "organization"
+    scope_object_read_actions = ["status", "tree", "page", "export"]
+    scope_object_write_actions = ["enable", "update_page", "commits"]
+
+    @extend_schema(
+        request=None,
+        responses={201: ContextLayerStatusSerializer},
+        summary="Enable the context layer",
+        description=(
+            "Create the organization's wiki with the default structure and import existing channel "
+            "CONTEXT.md documents once. Idempotent."
+        ),
+    )
+    @action(methods=["POST"], detail=False)
+    def enable(self, request: Request, **kwargs) -> Response:
+        user_id = request.user.id if request.user and request.user.is_authenticated else None
+        try:
+            config = enablement.enable_context_layer(self.organization.id, created_by_id=user_id)
+        except enablement.RestrictedProjectsError as error:
+            raise ValidationError(str(error)) from error
+        return Response(
+            ContextLayerStatusSerializer({"head_sha": config.head_sha}).data, status=status.HTTP_201_CREATED
+        )
+
+    @extend_schema(
+        responses={
+            200: ContextLayerStatusSerializer,
+            404: OpenApiResponse(description="The context layer is not enabled."),
+        },
+        summary="Get the wiki head",
+    )
+    @action(methods=["GET"], detail=False)
+    def status(self, request: Request, **kwargs) -> Response:
+        try:
+            config = store.get_config(self.organization.id)
+        except store.ContextLayerStoreError as error:
+            return _store_error_response(error)
+        return Response(ContextLayerStatusSerializer({"head_sha": config.head_sha}).data)
+
+    @extend_schema(
+        responses={200: WikiTreeSerializer, 404: OpenApiResponse(description="The context layer is not enabled.")},
+        summary="List wiki pages",
+    )
+    @action(methods=["GET"], detail=False)
+    def tree(self, request: Request, **kwargs) -> Response:
+        try:
+            wiki_tree = pages.get_tree(self.organization.id)
+        except store.ContextLayerStoreError as error:
+            return _store_error_response(error)
+        return Response(WikiTreeSerializer(wiki_tree).data)
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="path", type=str, required=True, description="Repo-relative Markdown path of the page to read."
+            )
+        ],
+        responses={200: WikiPageSerializer, 404: OpenApiResponse(description="No page at this path.")},
+        summary="Read a wiki page",
+    )
+    @action(methods=["GET"], detail=False, url_path="pages", url_name="pages")
+    def page(self, request: Request, **kwargs) -> Response:
+        try:
+            wiki_page = pages.get_page(self.organization.id, request.query_params.get("path", ""))
+        except store.ContextLayerStoreError as error:
+            return _store_error_response(error)
+        return Response(WikiPageSerializer(wiki_page).data)
+
+    @extend_schema(
+        request=WikiPageWriteSerializer,
+        responses={
+            200: ContextLayerStatusSerializer,
+            400: LintErrorSerializer,
+            409: HeadConflictSerializer,
+        },
+        summary="Create or replace a wiki page",
+    )
+    @page.mapping.put
+    def update_page(self, request: Request, **kwargs) -> Response:
+        serializer = WikiPageWriteSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        user = request.user
+        author = (
+            store.CommitAuthor(name=user.first_name or user.email, email=user.email)
+            if user and user.is_authenticated
+            else None
+        )
+        try:
+            head_sha = pages.write_page(
+                self.organization.id,
+                path=serializer.validated_data["path"],
+                content=serializer.validated_data["content"],
+                base_head=serializer.validated_data.get("base_head"),
+                author=author,
+            )
+        except store.ContextLayerStoreError as error:
+            return _store_error_response(error)
+        return Response(ContextLayerStatusSerializer({"head_sha": head_sha}).data)
+
+    @extend_schema(
+        request=CommitBundleSerializer,
+        responses={
+            200: ContextLayerStatusSerializer,
+            400: LintErrorSerializer,
+            409: OpenApiResponse(description="The posted commits conflict with the current head; re-pull and retry."),
+        },
+        summary="Land agent commits from a git bundle",
+    )
+    @action(methods=["POST"], detail=False)
+    def commits(self, request: Request, **kwargs) -> Response:
+        serializer = CommitBundleSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        bundle_bytes = serializer.validated_data["bundle"].read()
+        try:
+            head_sha = store.land_commit_bundle(self.organization.id, bundle_bytes)
+        except store.ContextLayerStoreError as error:
+            return _store_error_response(error)
+        return Response(ContextLayerStatusSerializer({"head_sha": head_sha}).data)
+
+    @extend_schema(
+        responses={200: WikiExportSerializer},
+        summary="Export the wiki",
+        description="A short-lived download URL for the wiki's current bundle: the whole repo and its history, one file, standard git.",
+    )
+    @action(methods=["GET"], detail=False)
+    def export(self, request: Request, **kwargs) -> Response:
+        try:
+            config = store.get_config(self.organization.id)
+            url = store.get_bundle_presigned_url(self.organization.id)
+        except store.ContextLayerStoreError as error:
+            return _store_error_response(error)
+        return Response(WikiExportSerializer({"url": url, "head_sha": config.head_sha}).data)

--- a/products/context_layer/backend/presentation/views.py
+++ b/products/context_layer/backend/presentation/views.py
@@ -83,6 +83,8 @@ class ContextLayerViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             config = enablement.enable_context_layer(self.organization.id, created_by_id=user_id)
         except enablement.RestrictedProjectsError as error:
             raise ValidationError(str(error)) from error
+        except store.ContextLayerStoreError as error:
+            return _store_error_response(error)
         return Response(
             ContextLayerStatusSerializer({"head_sha": config.head_sha}).data, status=status.HTTP_201_CREATED
         )

--- a/products/context_layer/backend/presentation/views.py
+++ b/products/context_layer/backend/presentation/views.py
@@ -190,8 +190,7 @@ class ContextLayerViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     @action(methods=["GET"], detail=False)
     def export(self, request: Request, **kwargs) -> Response:
         try:
-            config = store.get_config(self.organization.id)
-            url = store.get_bundle_presigned_url(self.organization.id)
+            bundle = store.get_bundle_export(self.organization.id)
         except store.ContextLayerStoreError as error:
             return _store_error_response(error)
-        return Response(WikiExportSerializer({"url": url, "head_sha": config.head_sha}).data)
+        return Response(WikiExportSerializer({"url": bundle.url, "head_sha": bundle.head_sha}).data)

--- a/products/context_layer/backend/routes.py
+++ b/products/context_layer/backend/routes.py
@@ -1,0 +1,9 @@
+from posthog.api.routing import RouterRegistry
+
+from products.context_layer.backend.presentation.views import ContextLayerViewSet
+
+
+def register_routes(routers: RouterRegistry) -> None:
+    routers.organizations.register(
+        r"context_layer", ContextLayerViewSet, "organization_context_layer", ["organization_id"]
+    )

--- a/products/context_layer/backend/store.py
+++ b/products/context_layer/backend/store.py
@@ -87,6 +87,14 @@ class CommitAuthor:
     email: str
 
 
+@frozen
+class BundleExport:
+    """A presigned download URL for a bundle and the head sha it points at."""
+
+    url: str
+    head_sha: str
+
+
 SYSTEM_AUTHOR = CommitAuthor(name=COMMITTER_NAME, email=COMMITTER_EMAIL)
 
 
@@ -362,10 +370,13 @@ def purge_repo_history(organization_id: uuid.UUID | str, *, message: str = "Purg
     return apply_changes(organization_id, message=message, mutate=reinitialize_history)
 
 
-def get_bundle_presigned_url(organization_id: uuid.UUID | str, *, expiration_seconds: int = 300) -> str:
-    """Short-lived download URL for the current bundle, for sandbox mounts and export."""
+def get_bundle_export(organization_id: uuid.UUID | str, *, expiration_seconds: int = 300) -> BundleExport:
+    """Short-lived download URL for the current bundle, for sandbox mounts and export.
+
+    Reads the head once, so the returned url and head_sha always name the same
+    revision even if a writer lands between calls."""
     config = get_config(organization_id)
     url = object_storage.get_presigned_url(bundle_key(organization_id, config.head_sha), expiration=expiration_seconds)
     if url is None:
         raise ContextLayerStoreError(f"could not presign the bundle for organization {organization_id}")
-    return url
+    return BundleExport(url=url, head_sha=config.head_sha)

--- a/products/context_layer/backend/store.py
+++ b/products/context_layer/backend/store.py
@@ -55,6 +55,18 @@ class HeadMovedError(ContextLayerStoreError):
     """The head sha moved underneath a landing writer, twice."""
 
 
+class HeadConflictError(ContextLayerStoreError):
+    """A write guarded by `required_head` was based on a stale head."""
+
+    def __init__(self, *, current_head: str) -> None:
+        super().__init__(f"the wiki head moved to {current_head}; re-read and retry")
+        self.current_head = current_head
+
+
+class BundleConflictError(ContextLayerStoreError):
+    """A posted commit bundle could not be read or rebased onto the current head."""
+
+
 class LintFailedError(ContextLayerStoreError):
     def __init__(self, errors: list[str]) -> None:
         super().__init__("wiki structure lint failed: " + "; ".join(errors))
@@ -235,37 +247,35 @@ def initialize_repo(
         return config
 
 
-def apply_changes(
+def _run_landing(
     organization_id: uuid.UUID | str,
     *,
-    message: str,
-    mutate: Callable[[Path], None],
-    author: CommitAuthor | None = None,
+    prepare: Callable[[Path], str | None],
+    required_head: str | None = None,
 ) -> str:
-    """Run the writer protocol for a working-tree mutation and return the new head sha.
+    """The landing half of the writer protocol, shared by every writer.
 
-    `mutate` receives the checkout path and edits files in place; the store
-    commits, lints, uploads, and lands the result. A no-op mutation returns the
-    current head without landing anything.
+    `prepare` receives a working clone of the current head and returns the new
+    head sha it committed, or `None` for a no-op. All writers hold the per-org
+    lock, so the CAS only loses when a previous writer's lock expired mid-land
+    and its CAS raced ours. One retry re-reads the moved head and replays
+    `prepare` on top of it.
     """
-    author = author or SYSTEM_AUTHOR
-    # All writers hold the per-org lock, so the CAS only loses when a previous
-    # writer's lock expired mid-land and its CAS raced ours. One retry re-reads
-    # the moved head and replays the mutation on top of it.
     for attempt in (1, 2):
         with repo_writer_lock(organization_id):
             expected_head = get_config(organization_id).head_sha
+            if required_head is not None and required_head != expected_head:
+                raise HeadConflictError(current_head=expected_head)
             with tempfile.TemporaryDirectory(prefix="context-layer-") as tmp:
                 tmpdir = Path(tmp)
                 bundle_path = _download_bundle(organization_id, expected_head, tmpdir)
                 workdir = tmpdir / "repo"
                 _clone_from_bundle(bundle_path, workdir)
 
-                mutate(workdir)
-                if not _has_changes(workdir):
+                new_head = prepare(workdir)
+                if new_head is None:
                     return expected_head
                 _lint_or_raise(workdir)
-                new_head = _commit_all(workdir, message, author)
                 _upload_bundle(organization_id, new_head, workdir)
 
                 updated = ContextLayerConfig.objects.filter(
@@ -274,12 +284,71 @@ def apply_changes(
                 if updated:
                     return new_head
         logger.warning(
-            "context_layer.apply_changes.head_moved",
+            "context_layer.landing.head_moved",
             organization_id=str(organization_id),
             expected_head=expected_head,
             attempt=attempt,
         )
     raise HeadMovedError(f"head moved twice while landing changes for organization {organization_id}")
+
+
+def apply_changes(
+    organization_id: uuid.UUID | str,
+    *,
+    message: str,
+    mutate: Callable[[Path], None],
+    author: CommitAuthor | None = None,
+    required_head: str | None = None,
+) -> str:
+    """Run the writer protocol for a working-tree mutation and return the new head sha.
+
+    `mutate` receives the checkout path and edits files in place; the store
+    commits, lints, uploads, and lands the result. A no-op mutation returns the
+    current head without landing anything. `required_head` is the optimistic
+    concurrency guard: when the head no longer matches, `HeadConflictError`
+    carries the current head for the caller's 409.
+    """
+
+    def prepare(workdir: Path) -> str | None:
+        mutate(workdir)
+        if not _has_changes(workdir):
+            return None
+        return _commit_all(workdir, message, author or SYSTEM_AUTHOR)
+
+    return _run_landing(organization_id, prepare=prepare, required_head=required_head)
+
+
+def land_commit_bundle(organization_id: uuid.UUID | str, bundle_bytes: bytes) -> str:
+    """Land commits an agent made in its own clone, posted back as a bundle.
+
+    The bundle must carry the wiki's `main` ref, with the commits based on some
+    (possibly stale) head we already store. The incoming commits are rebased
+    onto the current head; a rebase conflict raises `BundleConflictError` so the
+    agent can re-pull and retry.
+    """
+
+    def prepare(workdir: Path) -> str | None:
+        incoming = workdir.parent / "incoming.bundle"
+        incoming.write_bytes(bundle_bytes)
+        try:
+            _run_git(["bundle", "verify", "--quiet", str(incoming)], cwd=workdir)
+            _run_git(["fetch", "--quiet", str(incoming), DEFAULT_BRANCH], cwd=workdir)
+        except ContextLayerStoreError as error:
+            raise BundleConflictError(f"could not read the posted bundle: {error}") from error
+        fetched = _run_git(["rev-parse", "FETCH_HEAD"], cwd=workdir)
+        if fetched == _run_git(["rev-parse", "HEAD"], cwd=workdir):
+            return None
+        _run_git(["checkout", "--quiet", "-B", "incoming", fetched], cwd=workdir)
+        try:
+            _run_git(["rebase", "--quiet", DEFAULT_BRANCH], cwd=workdir)
+        except ContextLayerStoreError as error:
+            raise BundleConflictError(f"the posted commits conflict with the current head: {error}") from error
+        rebased = _run_git(["rev-parse", "HEAD"], cwd=workdir)
+        _run_git(["checkout", "--quiet", DEFAULT_BRANCH], cwd=workdir)
+        _run_git(["merge", "--ff-only", "--quiet", rebased], cwd=workdir)
+        return _run_git(["rev-parse", "HEAD"], cwd=workdir)
+
+    return _run_landing(organization_id, prepare=prepare)
 
 
 def purge_repo_history(organization_id: uuid.UUID | str, *, message: str = "Purge wiki history") -> str:

--- a/products/context_layer/backend/test/test_api.py
+++ b/products/context_layer/backend/test/test_api.py
@@ -1,0 +1,160 @@
+import tempfile
+import subprocess
+from pathlib import Path
+
+from posthog.test.base import APIBaseTest
+from unittest.mock import patch
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import override_settings
+
+import posthog.storage.object_storage as object_storage_module
+from posthog.models.scoping import team_scope
+from posthog.storage.object_storage import UnavailableStorage
+
+from products.context_layer.backend import store
+from products.tasks.backend.facade import api as tasks_facade
+
+
+@override_settings(OBJECT_STORAGE_ENABLED=True)
+@patch("posthog.permissions.posthog_feature_flag_enabled", return_value=True)
+class TestContextLayerAPI(APIBaseTest):
+    def setUp(self) -> None:
+        super().setUp()
+        object_storage_module._client = UnavailableStorage()
+        self.addCleanup(setattr, object_storage_module, "_client", UnavailableStorage())
+        self.base_url = f"/api/organizations/{self.organization.id}/context_layer"
+
+    def _enable(self) -> str:
+        response = self.client.post(f"{self.base_url}/enable/")
+        assert response.status_code == 201, response.content
+        return response.json()["head_sha"]
+
+    def test_enable_scaffolds_wiki_and_imports_channel_context(self, _flag) -> None:
+        with team_scope(self.team.id):
+            channel = tasks_facade.resolve_channel(self.team.id, self.user.id, name="growth", star=False)
+            assert channel is not None
+            tasks_facade.publish_channel_instructions(
+                channel.id, self.team.id, self.user.id, content="Focus on activation.", base_version=0
+            )
+
+        self._enable()
+
+        tree = self.client.get(f"{self.base_url}/tree/").json()
+        assert "AGENTS.md" in tree["paths"]
+        assert "channels/growth.md" in tree["paths"]
+        page = self.client.get(f"{self.base_url}/pages/", {"path": "channels/growth.md"}).json()
+        assert f"channel_id: {channel.id}" in page["content"]
+        assert "Focus on activation." in page["content"]
+
+    def test_enable_is_blocked_for_orgs_with_private_projects(self, _flag) -> None:
+        self.team.access_control = True
+        self.team.save()
+        response = self.client.post(f"{self.base_url}/enable/")
+        assert response.status_code == 400
+        assert "private projects" in response.json()["detail"]
+
+    def test_endpoints_404_before_enablement(self, _flag) -> None:
+        assert self.client.get(f"{self.base_url}/tree/").status_code == 404
+        assert self.client.get(f"{self.base_url}/status/").status_code == 404
+
+    def test_flag_off_blocks_the_surface(self, flag_mock) -> None:
+        flag_mock.return_value = False
+        assert self.client.post(f"{self.base_url}/enable/").status_code == 403
+
+    def test_page_write_moves_head_and_read_returns_new_content(self, _flag) -> None:
+        head = self._enable()
+        response = self.client.put(
+            f"{self.base_url}/pages/",
+            {"path": "areas/analytics.md", "content": "# Analytics\n", "base_head": head},
+            format="json",
+        )
+        assert response.status_code == 200, response.content
+        new_head = response.json()["head_sha"]
+        assert new_head != head
+
+        page = self.client.get(f"{self.base_url}/pages/", {"path": "areas/analytics.md"}).json()
+        assert page["content"] == "# Analytics\n"
+        assert page["head_sha"] == new_head
+
+    def test_page_write_with_stale_base_head_returns_409_with_current_head(self, _flag) -> None:
+        head = self._enable()
+        first = self.client.put(
+            f"{self.base_url}/pages/",
+            {"path": "areas/replay.md", "content": "# Replay\n", "base_head": head},
+            format="json",
+        )
+        assert first.status_code == 200
+        stale = self.client.put(
+            f"{self.base_url}/pages/",
+            {"path": "areas/replay.md", "content": "# Replay, but stale\n", "base_head": head},
+            format="json",
+        )
+        assert stale.status_code == 409
+        assert stale.json()["current_head"] == first.json()["head_sha"]
+
+    def test_page_write_outside_the_structure_returns_400(self, _flag) -> None:
+        self._enable()
+        response = self.client.put(
+            f"{self.base_url}/pages/",
+            {"path": "rogue.md", "content": "# rogue\n"},
+            format="json",
+        )
+        assert response.status_code == 400
+
+    def test_page_write_with_traversal_path_returns_400(self, _flag) -> None:
+        self._enable()
+        response = self.client.put(
+            f"{self.base_url}/pages/",
+            {"path": "../escape.md", "content": "# escape\n"},
+            format="json",
+        )
+        assert response.status_code == 400
+
+    def test_commits_endpoint_lands_a_bundle(self, _flag) -> None:
+        self._enable()
+        bundle_bytes = self._bundle_with_edit("areas/from-agent.md", "# From an agent\n")
+        response = self.client.post(
+            f"{self.base_url}/commits/",
+            {"bundle": SimpleUploadedFile("out.bundle", bundle_bytes)},
+            format="multipart",
+        )
+        assert response.status_code == 200, response.content
+        page = self.client.get(f"{self.base_url}/pages/", {"path": "areas/from-agent.md"}).json()
+        assert page["content"] == "# From an agent\n"
+
+    def test_commits_endpoint_rejects_lint_violations(self, _flag) -> None:
+        self._enable()
+        bundle_bytes = self._bundle_with_edit("rogue.txt", "nope")
+        response = self.client.post(
+            f"{self.base_url}/commits/",
+            {"bundle": SimpleUploadedFile("out.bundle", bundle_bytes)},
+            format="multipart",
+        )
+        assert response.status_code == 400
+        assert response.json()["errors"]
+
+    def test_export_returns_a_download_url(self, _flag) -> None:
+        head = self._enable()
+        response = self.client.get(f"{self.base_url}/export/")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["head_sha"] == head
+        assert body["url"].startswith("http")
+
+    def _bundle_with_edit(self, path: str, content: str) -> bytes:
+        """Clone the wiki the way a sandbox does, commit one edit, pack it as a thin bundle."""
+        with store.checkout_repo(self.organization.id) as checkout:
+            target = checkout.path / path
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(content)
+            env_git = ["git", "-c", "user.name=agent", "-c", "user.email=agent@example.com"]
+            subprocess.run([*env_git, "add", "--all"], cwd=checkout.path, check=True)
+            subprocess.run([*env_git, "commit", "--quiet", "-m", f"Edit {path}"], cwd=checkout.path, check=True)
+            with tempfile.NamedTemporaryFile(suffix=".bundle") as bundle_file:
+                subprocess.run(
+                    [*env_git, "bundle", "create", bundle_file.name, "origin/main..main"],
+                    cwd=checkout.path,
+                    check=True,
+                )
+                return Path(bundle_file.name).read_bytes()

--- a/products/context_layer/backend/test/test_api.py
+++ b/products/context_layer/backend/test/test_api.py
@@ -54,6 +54,14 @@ class TestContextLayerAPI(APIBaseTest):
         assert response.status_code == 400
         assert "private projects" in response.json()["detail"]
 
+    def test_enable_returns_429_when_a_writer_holds_the_lock(self, _flag) -> None:
+        with patch(
+            "products.context_layer.backend.store.repo_writer_lock",
+            side_effect=store.RepoLockUnavailableError("another writer holds the lock"),
+        ):
+            response = self.client.post(f"{self.base_url}/enable/")
+        assert response.status_code == 429
+
     def test_endpoints_404_before_enablement(self, _flag) -> None:
         assert self.client.get(f"{self.base_url}/tree/").status_code == 404
         assert self.client.get(f"{self.base_url}/status/").status_code == 404

--- a/products/context_layer/frontend/generated/api.schemas.ts
+++ b/products/context_layer/frontend/generated/api.schemas.ts
@@ -1,0 +1,104 @@
+/**
+ * Auto-generated from the Django backend OpenAPI schema.
+ * To modify these types, update the Django serializers or views, then run:
+ *   hogli build:openapi
+ * Questions or issues? #team-devex on Slack
+ *
+ * PostHog API - generated
+ * OpenAPI spec version: 1.0.0
+ */
+/**
+ * Request body for landing agent commits posted back as a git bundle.
+ */
+export interface CommitBundleApi {
+    /** A `git bundle` carrying the wiki's `main` ref, created in the agent's clone (for example `git bundle create out.bundle origin/main..main`). */
+    bundle: string
+}
+
+/**
+ * Response shape for the wiki's current state.
+ */
+export interface ContextLayerStatusApi {
+    /** Commit sha of the wiki's current head. */
+    head_sha: string
+}
+
+/**
+ * 400 body when a write violates the wiki's structure rules.
+ */
+export interface LintErrorApi {
+    /** What was rejected. */
+    detail: string
+    /** One entry per structure violation found by the linter. */
+    errors: string[]
+}
+
+/**
+ * Response shape for a wiki bundle export.
+ */
+export interface WikiExportApi {
+    /** Short-lived download URL for the wiki's current bundle. */
+    url: string
+    /** Commit sha of the bundle behind the URL. */
+    head_sha: string
+}
+
+/**
+ * Response shape for one wiki page.
+ */
+export interface WikiPageApi {
+    /** Repo-relative path of the page, for example `areas/analytics.md`. */
+    path: string
+    /** The page's Markdown content. */
+    content: string
+    /** Commit sha the content was read at; pass back as `base_head` on writes. */
+    head_sha: string
+}
+
+/**
+ * Request body for creating or replacing one wiki page.
+ */
+export interface WikiPageWriteApi {
+    /**
+     * Repo-relative Markdown path inside the wiki's structure, for example `channels/general.md`.
+     * @maxLength 512
+     */
+    path: string
+    /**
+     * The complete Markdown content for the page.
+     * @maxLength 1000000
+     */
+    content: string
+    /**
+     * Optimistic-concurrency guard: the head sha the edit is based on. A moved head is rejected with 409 and the current head; omit to write unguarded.
+     * @nullable
+     */
+    base_head?: string | null
+}
+
+/**
+ * 409 body when a guarded write was based on a stale head.
+ */
+export interface HeadConflictApi {
+    /** What moved and what to do next. */
+    detail: string
+    /** The wiki's current head sha; re-read pages at this head and retry. */
+    current_head: string
+}
+
+/**
+ * Response shape for the wiki's page listing.
+ */
+export interface WikiTreeApi {
+    /** Commit sha of the wiki's current head. */
+    head_sha: string
+    /** Repo-relative path of every Markdown page at the current head. */
+    paths: string[]
+}
+
+export type ContextLayerPagesRetrieveParams = {
+    /**
+     * Repo-relative Markdown path of the page to read.
+     */
+    path: string
+}

--- a/products/context_layer/frontend/generated/api.ts
+++ b/products/context_layer/frontend/generated/api.ts
@@ -31,11 +31,13 @@ export const contextLayerCommitsCreate = async (
     commitBundleApi: CommitBundleApi,
     options?: RequestInit
 ): Promise<ContextLayerStatusApi> => {
+    const formData = new FormData()
+    formData.append(`bundle`, commitBundleApi.bundle)
+
     return apiMutator<ContextLayerStatusApi>(getContextLayerCommitsCreateUrl(organizationId), {
         ...options,
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...options?.headers },
-        body: JSON.stringify(commitBundleApi),
+        body: formData,
     })
 }
 

--- a/products/context_layer/frontend/generated/api.ts
+++ b/products/context_layer/frontend/generated/api.ts
@@ -1,0 +1,161 @@
+import { apiMutator } from '../../../../frontend/src/lib/api-orval-mutator'
+/**
+ * Auto-generated from the Django backend OpenAPI schema.
+ * To modify these types, update the Django serializers or views, then run:
+ *   hogli build:openapi
+ * Questions or issues? #team-devex on Slack
+ *
+ * PostHog API - generated
+ * OpenAPI spec version: 1.0.0
+ */
+import type {
+    CommitBundleApi,
+    ContextLayerPagesRetrieveParams,
+    ContextLayerStatusApi,
+    WikiExportApi,
+    WikiPageApi,
+    WikiPageWriteApi,
+    WikiTreeApi,
+} from './api.schemas'
+
+export const getContextLayerCommitsCreateUrl = (organizationId: string) => {
+    return `/api/organizations/${organizationId}/context_layer/commits/`
+}
+
+/**
+ * The organization's context wiki: a git repo of Markdown pages hosted by PostHog.
+ * @summary Land agent commits from a git bundle
+ */
+export const contextLayerCommitsCreate = async (
+    organizationId: string,
+    commitBundleApi: CommitBundleApi,
+    options?: RequestInit
+): Promise<ContextLayerStatusApi> => {
+    return apiMutator<ContextLayerStatusApi>(getContextLayerCommitsCreateUrl(organizationId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(commitBundleApi),
+    })
+}
+
+export const getContextLayerEnableCreateUrl = (organizationId: string) => {
+    return `/api/organizations/${organizationId}/context_layer/enable/`
+}
+
+/**
+ * Create the organization's wiki with the default structure and import existing channel CONTEXT.md documents once. Idempotent.
+ * @summary Enable the context layer
+ */
+export const contextLayerEnableCreate = async (
+    organizationId: string,
+    options?: RequestInit
+): Promise<ContextLayerStatusApi> => {
+    return apiMutator<ContextLayerStatusApi>(getContextLayerEnableCreateUrl(organizationId), {
+        ...options,
+        method: 'POST',
+    })
+}
+
+export const getContextLayerExportRetrieveUrl = (organizationId: string) => {
+    return `/api/organizations/${organizationId}/context_layer/export/`
+}
+
+/**
+ * A short-lived download URL for the wiki's current bundle: the whole repo and its history, one file, standard git.
+ * @summary Export the wiki
+ */
+export const contextLayerExportRetrieve = async (
+    organizationId: string,
+    options?: RequestInit
+): Promise<WikiExportApi> => {
+    return apiMutator<WikiExportApi>(getContextLayerExportRetrieveUrl(organizationId), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getContextLayerPagesRetrieveUrl = (organizationId: string, params: ContextLayerPagesRetrieveParams) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : String(value))
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/organizations/${organizationId}/context_layer/pages/?${stringifiedParams}`
+        : `/api/organizations/${organizationId}/context_layer/pages/`
+}
+
+/**
+ * The organization's context wiki: a git repo of Markdown pages hosted by PostHog.
+ * @summary Read a wiki page
+ */
+export const contextLayerPagesRetrieve = async (
+    organizationId: string,
+    params: ContextLayerPagesRetrieveParams,
+    options?: RequestInit
+): Promise<WikiPageApi> => {
+    return apiMutator<WikiPageApi>(getContextLayerPagesRetrieveUrl(organizationId, params), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getContextLayerPagesUpdateUrl = (organizationId: string) => {
+    return `/api/organizations/${organizationId}/context_layer/pages/`
+}
+
+/**
+ * The organization's context wiki: a git repo of Markdown pages hosted by PostHog.
+ * @summary Create or replace a wiki page
+ */
+export const contextLayerPagesUpdate = async (
+    organizationId: string,
+    wikiPageWriteApi: WikiPageWriteApi,
+    options?: RequestInit
+): Promise<ContextLayerStatusApi> => {
+    return apiMutator<ContextLayerStatusApi>(getContextLayerPagesUpdateUrl(organizationId), {
+        ...options,
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(wikiPageWriteApi),
+    })
+}
+
+export const getContextLayerStatusRetrieveUrl = (organizationId: string) => {
+    return `/api/organizations/${organizationId}/context_layer/status/`
+}
+
+/**
+ * The organization's context wiki: a git repo of Markdown pages hosted by PostHog.
+ * @summary Get the wiki head
+ */
+export const contextLayerStatusRetrieve = async (
+    organizationId: string,
+    options?: RequestInit
+): Promise<ContextLayerStatusApi> => {
+    return apiMutator<ContextLayerStatusApi>(getContextLayerStatusRetrieveUrl(organizationId), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getContextLayerTreeRetrieveUrl = (organizationId: string) => {
+    return `/api/organizations/${organizationId}/context_layer/tree/`
+}
+
+/**
+ * The organization's context wiki: a git repo of Markdown pages hosted by PostHog.
+ * @summary List wiki pages
+ */
+export const contextLayerTreeRetrieve = async (organizationId: string, options?: RequestInit): Promise<WikiTreeApi> => {
+    return apiMutator<WikiTreeApi>(getContextLayerTreeRetrieveUrl(organizationId), {
+        ...options,
+        method: 'GET',
+    })
+}

--- a/products/context_layer/frontend/generated/api.zod.ts
+++ b/products/context_layer/frontend/generated/api.zod.ts
@@ -1,0 +1,51 @@
+/**
+ * Auto-generated Zod validation schemas from the Django backend OpenAPI schema.
+ * To modify these schemas, update the Django serializers or views, then run:
+ *   hogli build:openapi
+ * Questions or issues? #team-devex on Slack
+ *
+ * PostHog API - generated
+ * OpenAPI spec version: 1.0.0
+ */
+import * as zod from 'zod'
+
+/**
+ * The organization's context wiki: a git repo of Markdown pages hosted by PostHog.
+ * @summary Land agent commits from a git bundle
+ */
+export const ContextLayerCommitsCreateBody = /* @__PURE__ */ zod
+    .object({
+        bundle: zod
+            .url()
+            .describe(
+                "A `git bundle` carrying the wiki's `main` ref, created in the agent's clone (for example `git bundle create out.bundle origin\/main..main`)."
+            ),
+    })
+    .describe('Request body for landing agent commits posted back as a git bundle.')
+
+/**
+ * The organization's context wiki: a git repo of Markdown pages hosted by PostHog.
+ * @summary Create or replace a wiki page
+ */
+export const contextLayerPagesUpdateBodyPathMax = 512
+
+export const contextLayerPagesUpdateBodyContentMax = 1000000
+
+export const ContextLayerPagesUpdateBody = /* @__PURE__ */ zod
+    .object({
+        path: zod
+            .string()
+            .max(contextLayerPagesUpdateBodyPathMax)
+            .describe("Repo-relative Markdown path inside the wiki's structure, for example `channels\/general.md`."),
+        content: zod
+            .string()
+            .max(contextLayerPagesUpdateBodyContentMax)
+            .describe('The complete Markdown content for the page.'),
+        base_head: zod
+            .string()
+            .nullish()
+            .describe(
+                'Optimistic-concurrency guard: the head sha the edit is based on. A moved head is rejected with 409 and the current head; omit to write unguarded.'
+            ),
+    })
+    .describe('Request body for creating or replacing one wiki page.')

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -17173,6 +17173,14 @@ export namespace Schemas {
     } as const;
 
     /**
+     * Request body for landing agent commits posted back as a git bundle.
+     */
+    export interface CommitBundle {
+      /** A `git bundle` carrying the wiki's `main` ref, created in the agent's clone (for example `git bundle create out.bundle origin/main..main`). */
+      bundle: string;
+    }
+
+    /**
      * Response for the `commit` artefact diff endpoint — the commit's branch rendered against the
      * repository default branch.
      */
@@ -17529,6 +17537,14 @@ export namespace Schemas {
       Rocket: 'rocket',
       Eyes: 'eyes',
     } as const;
+
+    /**
+     * Response shape for the wiki's current state.
+     */
+    export interface ContextLayerStatus {
+      /** Commit sha of the wiki's current head. */
+      head_sha: string;
+    }
 
     export type ConversationMessagesItem = { [key: string]: unknown };
 
@@ -38119,6 +38135,16 @@ export namespace Schemas {
       math_property?: string | null;
     }
 
+    /**
+     * 409 body when a guarded write was based on a stale head.
+     */
+    export interface HeadConflict {
+      /** What moved and what to do next. */
+      detail: string;
+      /** The wiki's current head sha; re-read pages at this head and retry. */
+      current_head: string;
+    }
+
     export type HealthCheckSignalExtraPayload = { [key: string]: unknown };
 
     export type HealthCheckSignalExtraSeverityEnum = typeof HealthCheckSignalExtraSeverityEnum[keyof typeof HealthCheckSignalExtraSeverityEnum];
@@ -43825,6 +43851,16 @@ export namespace Schemas {
       title: string | null;
       /** Current report status (e.g. `potential`, `ready`, `resolved`). */
       status: string;
+    }
+
+    /**
+     * 400 body when a write violates the wiki's structure rules.
+     */
+    export interface LintError {
+      /** What was rejected. */
+      detail: string;
+      /** One entry per structure violation found by the linter. */
+      errors: string[];
     }
 
     /**
@@ -80361,6 +80397,59 @@ export namespace Schemas {
     }
 
     /**
+     * Response shape for a wiki bundle export.
+     */
+    export interface WikiExport {
+      /** Short-lived download URL for the wiki's current bundle. */
+      url: string;
+      /** Commit sha of the bundle behind the URL. */
+      head_sha: string;
+    }
+
+    /**
+     * Response shape for one wiki page.
+     */
+    export interface WikiPage {
+      /** Repo-relative path of the page, for example `areas/analytics.md`. */
+      path: string;
+      /** The page's Markdown content. */
+      content: string;
+      /** Commit sha the content was read at; pass back as `base_head` on writes. */
+      head_sha: string;
+    }
+
+    /**
+     * Request body for creating or replacing one wiki page.
+     */
+    export interface WikiPageWrite {
+      /**
+         * Repo-relative Markdown path inside the wiki's structure, for example `channels/general.md`.
+         * @maxLength 512
+         */
+      path: string;
+      /**
+         * The complete Markdown content for the page.
+         * @maxLength 1000000
+         */
+      content: string;
+      /**
+         * Optimistic-concurrency guard: the head sha the edit is based on. A moved head is rejected with 409 and the current head; omit to write unguarded.
+         * @nullable
+         */
+      base_head?: string | null;
+    }
+
+    /**
+     * Response shape for the wiki's page listing.
+     */
+    export interface WikiTree {
+      /** Commit sha of the wiki's current head. */
+      head_sha: string;
+      /** Repo-relative path of every Markdown page at the current head. */
+      paths: string[];
+    }
+
+    /**
      * The team's active onboarding wizard cloud run, used to rehydrate
      * the setup-progress FAB when the run was started server-side (drop flow).
      */
@@ -82771,6 +82860,13 @@ export namespace Schemas {
      * The initial index from which to return the results.
      */
     offset?: number;
+    };
+
+    export type ContextLayerPagesRetrieveParams = {
+    /**
+     * Repo-relative Markdown path of the page to read.
+     */
+    path: string;
     };
 
     export type DomainsListParams = {

--- a/tach.toml
+++ b/tach.toml
@@ -509,6 +509,7 @@ layer = "modules"
 path = "products.context_layer"
 depends_on = [
     "posthog",
+    "products.tasks",
 ]
 layer = "modules"
 


### PR DESCRIPTION
## Problem

- Layer 2 of the context layer stack, on top of [#84387](https://github.com/PostHog/posthog/pull/84387): the store exists, but nothing can read or write it.
- Desktop needs to read and edit wiki pages without downloading bundles, and agents need a way to land the commits they make in their sandbox clones.

## Changes

- New org-scoped API at `/api/organizations/:organization_id/context_layer/`, gated server-side by the `context-layer` flag (`PostHogFeatureFlagPermission`).
- `POST /enable` scaffolds the wiki and imports each public channel's latest CONTEXT.md once as `channels/<slug>.md`. The legacy ChannelInstructions rows stay frozen, so turning the flag off restores the old behavior.
- Personal channels are not imported: their context belongs to one person, and the wiki is org-visible.
- Enabling is blocked for organizations with private projects until per-project partitioning lands.
- `GET /tree` and `GET /pages` read from a cache keyed by head sha. Entries are immutable, so there is no invalidation; one checkout warms a head.
- `PUT /pages` lands one page through the writer protocol. A stale `base_head` returns 409 with the current head, the same contract ChannelInstructions uses today.
- `POST /commits` takes a git bundle from an agent's clone, rebases it onto the current head, lints, and lands it. Conflicts return 409; structure violations return 400 with the linter's reasons.
- `GET /export` returns a short-lived download URL for the whole bundle.
- One shared mapping (`_store_error_response`) turns store errors into HTTP for every action, so later layers' writers cannot drift from the contract.
- The riskiest parts are the bundle rebase-and-land path in `store.land_commit_bundle` and the import; the serializers and routing are mechanical.

## How did you test this code?

- `test_api.py` covers: enable + import round-trip (public channel imported with frontmatter, personal skipped by design), the 409 stale-`base_head` contract, traversal and out-of-structure paths rejected before checkout, landing a real thin bundle, lint rejection of a bundle, flag-off 403, pre-enablement 404s, and export.
- Each case guards a contract no existing test covers; the store internals are covered by layer 1's tests.
- Ran `hogli build:openapi`; the regenerated MCP client (`services/mcp/src/api/generated.ts`) is committed.
- Repo-wide mypy was clean before the final views refactor; later runs were OOM-killed in this sandbox, so CI's mypy job is the authoritative check here.
- Not run: the full backend suite locally; CI covers it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- None; user-facing docs land with the rollout layer.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Layer 2 of the gh-stack; authored by Claude Code from Peter's locked implementation plan.
- Skills invoked: /stacking-prs, /improving-drf-endpoints, /writing-tests, /writing-user-facing-copy, /writing-code-comments, /writing-pr-descriptions, /simplify.
- The /simplify pass centralized the store-error-to-HTTP mapping, switched the lock-busy path to DRF's `Throttled`, removed double config reads per request, and made the cheap path pre-check derive from the linter's constants instead of duplicating them.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*