### PR TITLE
fix(retention): match actor id types across warehouse and events arms

### DIFF
--- a/posthog/hogql_queries/insights/retention/retention_base_query_builder.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_builder.py
@@ -12,6 +12,7 @@ from posthog.hogql import ast
 from posthog.hogql.parser import parse_expr
 from posthog.hogql.property import entity_to_expr, property_to_expr
 
+from posthog.clickhouse.query_tagging import tag_contains_user_hogql
 from posthog.hogql_queries.insights.retention.utils import breakdown_extract_expr
 
 if TYPE_CHECKING:
@@ -86,6 +87,7 @@ class RetentionBaseQueryBuilder(ABC):
         if entity.type == EntityType.DATA_WAREHOUSE:
             if not entity.aggregation_target_field:
                 raise ValidationError("A data warehouse retention series requires aggregation_target_field.")
+            tag_contains_user_hogql()
             return parse_expr(entity.aggregation_target_field)
         return ast.Field(chain=[self.aggregation_target_events_column])
 

--- a/posthog/hogql_queries/insights/retention/retention_base_query_builder.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_builder.py
@@ -78,14 +78,23 @@ class RetentionBaseQueryBuilder(ABC):
             return ast.Field(chain=[entity.table_name, entity.timestamp_field])
         return ast.Field(chain=["events", "timestamp"])
 
-    def entity_actor_id_column(self, entity: RetentionEntity) -> str:
-        # The column that identifies the actor (person or group) for an entity: the configured join field
-        # for a data warehouse entity, or the runner's resolved person/group column for events.
+    def entity_actor_id_expr(self, entity: RetentionEntity) -> ast.Expr:
+        # What identifies the actor (person or group) for an entity: the configured target for a data
+        # warehouse entity, or the runner's resolved person/group column for events. The warehouse target
+        # is parsed as HogQL, matching funnels and lifecycle, so it can reach a joined field such as
+        # `person.id` rather than only a column on the table itself.
         if entity.type == EntityType.DATA_WAREHOUSE:
             if not entity.aggregation_target_field:
                 raise ValidationError("A data warehouse retention series requires aggregation_target_field.")
-            return entity.aggregation_target_field
-        return self.aggregation_target_events_column
+            return parse_expr(entity.aggregation_target_field)
+        return ast.Field(chain=[self.aggregation_target_events_column])
+
+    @property
+    def has_data_warehouse_series(self) -> bool:
+        return self.runner.has_data_warehouse_series
+
+    def coerce_actor_id_expr(self, actor_id_expr: ast.Expr) -> ast.Expr:
+        return self.runner.coerce_actor_id_expr(actor_id_expr)
 
     @cached_property
     def start_entity_expr_no_props(self) -> ast.Expr:

--- a/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
@@ -54,11 +54,7 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
         start_interval_index_filter: int | None = None,
         selected_breakdown_value: str | list[str] | int | None = None,
     ) -> ast.SelectQuery:
-        has_data_warehouse_series = (
-            self.start_event.type == EntityType.DATA_WAREHOUSE or self.return_event.type == EntityType.DATA_WAREHOUSE
-        )
-
-        if has_data_warehouse_series or retention_fixed_interval_base_query_use_dwh_variant(self.team):
+        if self.has_data_warehouse_series or retention_fixed_interval_base_query_use_dwh_variant(self.team):
             return self.build_base_query_dwh(
                 start_interval_index_filter=start_interval_index_filter,
                 selected_breakdown_value=selected_breakdown_value,
@@ -549,8 +545,7 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
     ) -> ast.SelectQuery:
         entity_is_dwh = entity.type == EntityType.DATA_WAREHOUSE
 
-        actor_column_name = self.entity_actor_id_column(entity)
-        actor_field = ast.Field(chain=[actor_column_name])
+        actor_field = self.coerce_actor_id_expr(self.entity_actor_id_expr(entity))
 
         timestamp_column_name = entity.timestamp_field if entity_is_dwh else "timestamp"
         assert timestamp_column_name

--- a/posthog/hogql_queries/insights/retention/retention_base_query_rolling.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_rolling.py
@@ -22,10 +22,7 @@ class RetentionRollingIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
         else:  # Day
             unit, count = "hour", 24
 
-        has_data_warehouse_series = (
-            self.start_event.type == EntityType.DATA_WAREHOUSE or self.return_event.type == EntityType.DATA_WAREHOUSE
-        )
-        if has_data_warehouse_series:
+        if self.has_data_warehouse_series:
             return self._build_base_query_data_warehouse(
                 unit, count, start_interval_index_filter, selected_breakdown_value
             )
@@ -256,11 +253,11 @@ class RetentionRollingIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
         return_table_name = self.return_event.table_name if return_is_dwh else "events"
         assert return_table_name
         return_ts_field = self.entity_timestamp_field(self.return_event)
-        return_actor_column = self.entity_actor_id_column(self.return_event)
+        return_actor_expr = self.coerce_actor_id_expr(self.entity_actor_id_expr(self.return_event))
 
         return ast.SelectQuery(
             select=[
-                ast.Alias(alias="actor_id", expr=ast.Field(chain=[return_table_name, return_actor_column])),
+                ast.Alias(alias="actor_id", expr=return_actor_expr),
                 ast.Alias(alias="timestamp", expr=return_ts_field),
             ],
             select_from=ast.JoinExpr(table=ast.Field(chain=[return_table_name])),
@@ -277,8 +274,7 @@ class RetentionRollingIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
         start_ts_field = self.entity_timestamp_field(self.start_event)
         start_table_name = self.start_event.table_name if start_is_dwh else "events"
         assert start_table_name
-        start_actor_column = self.entity_actor_id_column(self.start_event)
-        actor_id_expr = ast.Field(chain=[start_table_name, start_actor_column])
+        actor_id_expr = self.coerce_actor_id_expr(self.entity_actor_id_expr(self.start_event))
 
         where: ast.Expr | None
         having: ast.Expr | None

--- a/posthog/hogql_queries/insights/retention/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/retention_query_runner.py
@@ -247,6 +247,20 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
         return "person_id"
 
     @cached_property
+    def has_data_warehouse_series(self) -> bool:
+        return self.start_event.type == EntityType.DATA_WAREHOUSE or self.return_event.type == EntityType.DATA_WAREHOUSE
+
+    def coerce_actor_id_expr(self, actor_id_expr: ast.Expr) -> ast.Expr:
+        # A query's arms resolve actor_id against different sources, which give it different ClickHouse
+        # types — a person_id UUID on the events side, whatever the configured target yields on the
+        # warehouse side. The UNION ALL, the 24-hour-window JOIN, and the actors-modal events JOIN each
+        # need one common type, so coerce to string the way funnels does for its own aggregation_target.
+        # Events-only series keep their UUID keys.
+        if not self.has_data_warehouse_series:
+            return actor_id_expr
+        return ast.Call(name="toString", args=[actor_id_expr])
+
+    @cached_property
     def global_event_filters(self) -> list[ast.Expr]:
         global_event_filters = self.events_where_clause(
             self.is_first_occurrence_matching_filters, self.is_first_ever_occurrence
@@ -1015,7 +1029,9 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
                         "actor_subquery": actor_subquery,
                         "join_condition": ast.CompareOperation(
                             op=ast.CompareOperationOp.Eq,
-                            left=ast.Field(chain=["events", self.aggregation_target_events_column]),
+                            left=self.coerce_actor_id_expr(
+                                ast.Field(chain=["events", self.aggregation_target_events_column])
+                            ),
                             right=ast.Field(chain=["actors", "actor_id"]),
                         ),
                         "start_of_interval_sql": self.query_date_range.get_start_of_interval_hogql(

--- a/posthog/hogql_queries/insights/retention/test/__snapshots__/test_retention_data_warehouse.ambr
+++ b/posthog/hogql_queries/insights/retention/test/__snapshots__/test_retention_data_warehouse.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: TestRetentionDataWarehouse.test_retention_data_warehouse_and_events
+# name: TestRetentionDataWarehouse.test_retention_data_warehouse_and_events_0_UUID
   '''
   SELECT actor_activity.start_interval_index AS start_event_matching_interval,
          actor_activity.intervals_from_base AS intervals_from_base,
@@ -12,12 +12,64 @@
             arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date, _start_event_timestamps) -> if(has(_start_event_timestamps, interval_date), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range, arrayResize([start_event_timestamps], length(date_range), start_event_timestamps)))) AS start_interval_index,
             arrayJoin(arrayConcat(if(has(start_event_timestamps, date_range[plus(start_interval_index, 1)]), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 4), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
      FROM
-       (SELECT posthog_test_warehouse_event_mix_signups.person_id AS actor_id,
-               arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(posthog_test_warehouse_event_mix_signups.signed_up_at, 'UTC')), and(greaterOrEquals(toTimeZone(posthog_test_warehouse_event_mix_signups.signed_up_at, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(posthog_test_warehouse_event_mix_signups.signed_up_at, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))))) AS start_event_timestamps,
+       (SELECT toString(posthog_test_warehouse_event_mix_signups_uuid.person_id) AS actor_id,
+               arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(posthog_test_warehouse_event_mix_signups_uuid.signed_up_at, 'UTC')), and(greaterOrEquals(toTimeZone(posthog_test_warehouse_event_mix_signups_uuid.signed_up_at, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(posthog_test_warehouse_event_mix_signups_uuid.signed_up_at, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))))) AS start_event_timestamps,
                [] AS return_event_timestamps
-        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.hogql_queries.insights.retention.data_warehouse/posthog_test_warehouse_event_mix_signups/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Int64, `person_id` UUID, `signed_up_at` DateTime64(3, \'UTC\')') AS posthog_test_warehouse_event_mix_signups
+        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.hogql_queries.insights.retention.data_warehouse/posthog_test_warehouse_event_mix_signups_uuid/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Int64, `person_id` UUID, `signed_up_at` DateTime64(3, \'UTC\')') AS posthog_test_warehouse_event_mix_signups_uuid
         GROUP BY actor_id
-        UNION ALL SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
+        UNION ALL SELECT toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS actor_id,
+                         [] AS start_event_timestamps,
+                         arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, 'paid'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(events.event, tuple('paid')), equals(events.event, 'paid'))
+        GROUP BY actor_id) AS retention_events
+     GROUP BY actor_id
+     HAVING 1) AS actor_activity
+  GROUP BY start_event_matching_interval,
+           intervals_from_base
+  ORDER BY start_event_matching_interval ASC,
+           intervals_from_base ASC
+  LIMIT 100000 SETTINGS format_csv_allow_double_quotes=1,
+                        readonly=2,
+                        max_execution_time=600,
+                        allow_experimental_object_type=1,
+                        max_ast_elements=4000000,
+                        max_expanded_ast_elements=4000000,
+                        max_bytes_before_external_group_by=23622320128,
+                        transform_null_in=1,
+                        optimize_min_equality_disjunction_chain_length=4294967295,
+                        optimize_rewrite_aggregate_function_with_if=0,
+                        optimize_min_inequality_conjunction_chain_length=4294967295,
+                        allow_experimental_join_condition=1,
+                        use_hive_partitioning=0
+  '''
+# ---
+# name: TestRetentionDataWarehouse.test_retention_data_warehouse_and_events_1_String
+  '''
+  SELECT actor_activity.start_interval_index AS start_event_matching_interval,
+         actor_activity.intervals_from_base AS intervals_from_base,
+         count(DISTINCT actor_activity.actor_id) AS count
+  FROM
+    (SELECT retention_events.actor_id AS actor_id,
+            arrayFlatten(groupArray(retention_events.start_event_timestamps)) AS start_event_timestamps,
+            arrayFlatten(groupArray(retention_events.return_event_timestamps)) AS return_event_timestamps,
+            arrayMap(x -> plus(toStartOfInterval(assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(x)), range(0, 5)) AS date_range,
+            arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date, _start_event_timestamps) -> if(has(_start_event_timestamps, interval_date), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range, arrayResize([start_event_timestamps], length(date_range), start_event_timestamps)))) AS start_interval_index,
+            arrayJoin(arrayConcat(if(has(start_event_timestamps, date_range[plus(start_interval_index, 1)]), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 4), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
+     FROM
+       (SELECT toString(posthog_test_warehouse_event_mix_signups_string.person_id) AS actor_id,
+               arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(posthog_test_warehouse_event_mix_signups_string.signed_up_at, 'UTC')), and(greaterOrEquals(toTimeZone(posthog_test_warehouse_event_mix_signups_string.signed_up_at, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(posthog_test_warehouse_event_mix_signups_string.signed_up_at, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))))) AS start_event_timestamps,
+               [] AS return_event_timestamps
+        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.hogql_queries.insights.retention.data_warehouse/posthog_test_warehouse_event_mix_signups_string/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Int64, `person_id` String, `signed_up_at` DateTime64(3, \'UTC\')') AS posthog_test_warehouse_event_mix_signups_string
+        GROUP BY actor_id
+        UNION ALL SELECT toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS actor_id,
                          [] AS start_event_timestamps,
                          arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, 'paid'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps
         FROM events
@@ -66,14 +118,14 @@
             arrayJoin(arrayConcat(if(has(start_event_timestamps, date_range[plus(start_interval_index, 1)]), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 4), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base,
             retention_events.breakdown_value AS breakdown_value
      FROM
-       (SELECT posthog_test_warehouse_activity_breakdown.person_id AS actor_id,
+       (SELECT toString(posthog_test_warehouse_activity_breakdown.person_id) AS actor_id,
                arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(posthog_test_warehouse_activity_breakdown.occurred_at, 'UTC')), and(equals(posthog_test_warehouse_activity_breakdown.activity_type, 'signed_up'), and(greaterOrEquals(toTimeZone(posthog_test_warehouse_activity_breakdown.occurred_at, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(posthog_test_warehouse_activity_breakdown.occurred_at, 'UTC'), toDateTime64('2025-01-06 00:00:00.000000', 6, 'UTC')))))) AS start_event_timestamps,
                [] AS return_event_timestamps,
                ifNull(toString(posthog_test_warehouse_activity_breakdown.plan), '') AS breakdown_value
         FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.hogql_queries.insights.retention.data_warehouse/posthog_test_warehouse_activity_breakdown/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Int64, `plan` String, `person_id` UUID, `occurred_at` DateTime64(3, \'UTC\'), `activity_type` String') AS posthog_test_warehouse_activity_breakdown
         GROUP BY actor_id,
                  breakdown_value
-        UNION ALL SELECT posthog_test_warehouse_activity_breakdown.person_id AS actor_id,
+        UNION ALL SELECT toString(posthog_test_warehouse_activity_breakdown.person_id) AS actor_id,
                          [] AS start_event_timestamps,
                          arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(posthog_test_warehouse_activity_breakdown.occurred_at, 'UTC')), and(equals(posthog_test_warehouse_activity_breakdown.activity_type, 'renewed'), and(greaterOrEquals(toTimeZone(posthog_test_warehouse_activity_breakdown.occurred_at, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(posthog_test_warehouse_activity_breakdown.occurred_at, 'UTC'), toDateTime64('2025-01-06 00:00:00.000000', 6, 'UTC')))))) AS return_event_timestamps,
                          ifNull(toString(posthog_test_warehouse_activity_breakdown.plan), '') AS breakdown_value
@@ -117,12 +169,12 @@
             arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date, _start_event_timestamps) -> if(has(_start_event_timestamps, interval_date), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range, arrayResize([start_event_timestamps], length(date_range), start_event_timestamps)))) AS start_interval_index,
             arrayJoin(arrayConcat(if(has(start_event_timestamps, date_range[plus(start_interval_index, 1)]), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 4), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
      FROM
-       (SELECT posthog_test_warehouse_signups.person_id AS actor_id,
+       (SELECT toString(posthog_test_warehouse_signups.person_id) AS actor_id,
                arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(posthog_test_warehouse_signups.signed_up_at, 'UTC')), and(greaterOrEquals(toTimeZone(posthog_test_warehouse_signups.signed_up_at, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(posthog_test_warehouse_signups.signed_up_at, 'UTC'), toDateTime64('2025-01-06 00:00:00.000000', 6, 'UTC'))))) AS start_event_timestamps,
                [] AS return_event_timestamps
         FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.hogql_queries.insights.retention.data_warehouse/posthog_test_warehouse_signups/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Int64, `person_id` UUID, `signed_up_at` DateTime64(3, \'UTC\')') AS posthog_test_warehouse_signups
         GROUP BY actor_id
-        UNION ALL SELECT posthog_test_warehouse_renewals.person_id AS actor_id,
+        UNION ALL SELECT toString(posthog_test_warehouse_renewals.person_id) AS actor_id,
                          [] AS start_event_timestamps,
                          arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(posthog_test_warehouse_renewals.renewed_at, 'UTC')), and(greaterOrEquals(toTimeZone(posthog_test_warehouse_renewals.renewed_at, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(posthog_test_warehouse_renewals.renewed_at, 'UTC'), toDateTime64('2025-01-06 00:00:00.000000', 6, 'UTC'))))) AS return_event_timestamps
         FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.hogql_queries.insights.retention.data_warehouse/posthog_test_warehouse_renewals/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Int64, `person_id` UUID, `renewed_at` DateTime64(3, \'UTC\')') AS posthog_test_warehouse_renewals
@@ -161,12 +213,12 @@
             arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date, _start_event_timestamps) -> if(has(_start_event_timestamps, interval_date), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range, arrayResize([start_event_timestamps], length(date_range), start_event_timestamps)))) AS start_interval_index,
             arrayJoin(arrayConcat(if(has(start_event_timestamps, date_range[plus(start_interval_index, 1)]), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 4), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
      FROM
-       (SELECT posthog_test_warehouse_activity.person_id AS actor_id,
+       (SELECT toString(posthog_test_warehouse_activity.person_id) AS actor_id,
                arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(posthog_test_warehouse_activity.occurred_at, 'UTC')), and(equals(posthog_test_warehouse_activity.activity_type, 'signed_up'), and(greaterOrEquals(toTimeZone(posthog_test_warehouse_activity.occurred_at, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(posthog_test_warehouse_activity.occurred_at, 'UTC'), toDateTime64('2025-01-06 00:00:00.000000', 6, 'UTC')))))) AS start_event_timestamps,
                [] AS return_event_timestamps
         FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.hogql_queries.insights.retention.data_warehouse/posthog_test_warehouse_activity/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Int64, `person_id` UUID, `occurred_at` DateTime64(3, \'UTC\'), `activity_type` String') AS posthog_test_warehouse_activity
         GROUP BY actor_id
-        UNION ALL SELECT posthog_test_warehouse_activity.person_id AS actor_id,
+        UNION ALL SELECT toString(posthog_test_warehouse_activity.person_id) AS actor_id,
                          [] AS start_event_timestamps,
                          arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(posthog_test_warehouse_activity.occurred_at, 'UTC')), and(equals(posthog_test_warehouse_activity.activity_type, 'renewed'), and(greaterOrEquals(toTimeZone(posthog_test_warehouse_activity.occurred_at, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(posthog_test_warehouse_activity.occurred_at, 'UTC'), toDateTime64('2025-01-06 00:00:00.000000', 6, 'UTC')))))) AS return_event_timestamps
         FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.hogql_queries.insights.retention.data_warehouse/posthog_test_warehouse_activity/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Int64, `person_id` UUID, `occurred_at` DateTime64(3, \'UTC\'), `activity_type` String') AS posthog_test_warehouse_activity

--- a/posthog/hogql_queries/insights/retention/test/__snapshots__/test_retention_data_warehouse_24h_window.ambr
+++ b/posthog/hogql_queries/insights/retention/test/__snapshots__/test_retention_data_warehouse_24h_window.ambr
@@ -9,7 +9,7 @@
             floor(divide(dateDiff('hour', assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), actors_with_t0.t_0), 24)) AS start_interval_index,
             arrayJoin(arrayDistinct(arrayConcat([0], arrayFilter(x -> ifNull(greaterOrEquals(x, 0), 0), groupUniqArray(if(ifNull(greaterOrEquals(return_events.timestamp, actors_with_t0.t_0), 0), floor(divide(dateDiff('hour', actors_with_t0.t_0, return_events.timestamp), 24)), -1)))))) AS intervals_from_base
      FROM
-       (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
+       (SELECT toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS actor_id,
                if(and(greaterOrEquals(minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, '$signup')), toStartOfInterval(assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), toIntervalDay(1))), less(minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, '$signup')), toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, '$signup')), NULL) AS t_0
         FROM events
         LEFT OUTER JOIN
@@ -23,7 +23,7 @@
         GROUP BY actor_id
         HAVING isNotNull(t_0)) AS actors_with_t0
      LEFT JOIN
-       (SELECT posthog_test_warehouse_renewals_ft.person_id AS actor_id,
+       (SELECT toString(posthog_test_warehouse_renewals_ft.person_id) AS actor_id,
                toTimeZone(posthog_test_warehouse_renewals_ft.occurred_at, 'UTC') AS timestamp
         FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.hogql_queries.insights.retention.data_warehouse_24h_window/posthog_test_warehouse_renewals_ft/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Int64, `person_id` UUID, `occurred_at` DateTime64(3, \'UTC\')') AS posthog_test_warehouse_renewals_ft
         WHERE and(greaterOrEquals(posthog_test_warehouse_renewals_ft.occurred_at, toStartOfInterval(assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), toIntervalDay(1))), less(posthog_test_warehouse_renewals_ft.occurred_at, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))) AS return_events ON equals(actors_with_t0.actor_id, return_events.actor_id)
@@ -58,13 +58,13 @@
             floor(divide(dateDiff('hour', assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), actors_with_t0.t_0), 24)) AS start_interval_index,
             arrayJoin(arrayDistinct(arrayConcat([0], arrayFilter(x -> ifNull(greaterOrEquals(x, 0), 0), groupUniqArray(if(greaterOrEquals(return_events.timestamp, actors_with_t0.t_0), floor(divide(dateDiff('hour', actors_with_t0.t_0, return_events.timestamp), 24)), -1)))))) AS intervals_from_base
      FROM
-       (SELECT posthog_test_warehouse_activity.person_id AS actor_id,
+       (SELECT toString(posthog_test_warehouse_activity.person_id) AS actor_id,
                min(toTimeZone(posthog_test_warehouse_activity.occurred_at, 'UTC')) AS t_0
         FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.hogql_queries.insights.retention.data_warehouse_24h_window/posthog_test_warehouse_activity/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Int64, `person_id` UUID, `occurred_at` DateTime64(3, \'UTC\'), `activity_type` String') AS posthog_test_warehouse_activity
         WHERE and(equals(posthog_test_warehouse_activity.activity_type, 'signed_up'), and(greaterOrEquals(posthog_test_warehouse_activity.occurred_at, toStartOfInterval(assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), toIntervalDay(1))), less(posthog_test_warehouse_activity.occurred_at, toDateTime64('2025-01-06 00:00:00.000000', 6, 'UTC'))))
         GROUP BY actor_id) AS actors_with_t0
      LEFT JOIN
-       (SELECT posthog_test_warehouse_activity.person_id AS actor_id,
+       (SELECT toString(posthog_test_warehouse_activity.person_id) AS actor_id,
                toTimeZone(posthog_test_warehouse_activity.occurred_at, 'UTC') AS timestamp
         FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.hogql_queries.insights.retention.data_warehouse_24h_window/posthog_test_warehouse_activity/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Int64, `person_id` UUID, `occurred_at` DateTime64(3, \'UTC\'), `activity_type` String') AS posthog_test_warehouse_activity
         WHERE and(equals(posthog_test_warehouse_activity.activity_type, 'renewed'), and(greaterOrEquals(posthog_test_warehouse_activity.occurred_at, toStartOfInterval(assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), toIntervalDay(1))), less(posthog_test_warehouse_activity.occurred_at, toDateTime64('2025-01-06 00:00:00.000000', 6, 'UTC'))))) AS return_events ON equals(actors_with_t0.actor_id, return_events.actor_id)

--- a/posthog/hogql_queries/insights/retention/test/test_retention_data_warehouse.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_data_warehouse.py
@@ -936,12 +936,15 @@ class TestRetentionDataWarehouse(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(result[0]["values"][1]["count"], 2)
         self.assertEqual(result[0]["values"][1]["aggregation_value"], expected_aggregation_values[1])
 
+    # A warehouse actor column typed anything other than UUID has no common type with events.person_id,
+    # so the arms' actor_id must be coerced before the UNION ALL is grouped.
+    @parameterized.expand([("UUID",), ("String",)])
     @snapshot_clickhouse_queries
-    def test_retention_data_warehouse_and_events(self):
+    def test_retention_data_warehouse_and_events(self, actor_column_type: str):
         person_ids = self._create_people()
         signups_table_name = self._create_data_warehouse_table(
-            filename="warehouse_event_mix_signups.csv",
-            table_name="warehouse_event_mix_signups",
+            filename=f"warehouse_event_mix_signups_{actor_column_type}.csv",
+            table_name=f"warehouse_event_mix_signups_{actor_column_type.lower()}",
             header=["id", "person_id", "signed_up_at"],
             rows=[
                 [1, person_ids["user-1"], "2025-01-01 09:00:00"],
@@ -951,7 +954,7 @@ class TestRetentionDataWarehouse(ClickhouseTestMixin, APIBaseTest):
             ],
             table_columns={
                 "id": "Int64",
-                "person_id": "UUID",
+                "person_id": actor_column_type,
                 "signed_up_at": "DateTime64(3, 'UTC')",
             },
         )
@@ -986,6 +989,75 @@ class TestRetentionDataWarehouse(ClickhouseTestMixin, APIBaseTest):
                         "name": "paid",
                         "type": "events",
                     },
+                },
+            }
+        )
+
+        self.assertEqual(
+            pluck(result, "values", "count"),
+            pad(
+                [
+                    [2, 1, 1, 0],
+                    [2, 1, 0],
+                    [0, 0],
+                    [0],
+                    [0],
+                ]
+            ),
+        )
+
+    def test_retention_data_warehouse_aggregation_target_resolves_through_join(self):
+        # A warehouse table keyed by distinct_id reaches events only through a persons join, so the
+        # aggregation target has to be a HogQL expression (`person.id`) rather than a column name.
+        self._create_people()
+        signups_table_name = self._create_data_warehouse_table(
+            filename="warehouse_joined_signups.csv",
+            table_name="warehouse_joined_signups",
+            header=["id", "distinct_id", "signed_up_at"],
+            rows=[
+                [1, "user-1", "2025-01-01 09:00:00"],
+                [2, "user-2", "2025-01-01 10:00:00"],
+                [3, "user-3", "2025-01-02 09:00:00"],
+                [4, "user-4", "2025-01-02 10:00:00"],
+            ],
+            table_columns={
+                "id": "Int64",
+                "distinct_id": "String",
+                "signed_up_at": "DateTime64(3, 'UTC')",
+            },
+        )
+        DataWarehouseJoin.objects.create(
+            team=self.team,
+            source_table_name=signups_table_name,
+            source_table_key="distinct_id",
+            joining_table_name="persons",
+            joining_table_key="pdi.distinct_id",
+            field_name="person",
+        )
+
+        for distinct_id, timestamp in [
+            ("user-1", "2025-01-02T12:00:00Z"),
+            ("user-2", "2025-01-03T12:00:00Z"),
+            ("user-3", "2025-01-03T13:00:00Z"),
+        ]:
+            _create_event(team=self.team, event="paid", distinct_id=distinct_id, timestamp=timestamp)
+        flush_persons_and_events()
+
+        result = self.run_query(
+            query={
+                "dateRange": {"date_from": "2025-01-01T00:00:00Z", "date_to": "2025-01-05T00:00:00Z"},
+                "retentionFilter": {
+                    "period": "Day",
+                    "totalIntervals": 4,
+                    "targetEntity": {
+                        "id": signups_table_name,
+                        "name": signups_table_name,
+                        "type": "data_warehouse",
+                        "table_name": signups_table_name,
+                        "aggregation_target_field": "person.id",
+                        "timestamp_field": "signed_up_at",
+                    },
+                    "returningEntity": {"id": "paid", "name": "paid", "type": "events"},
                 },
             }
         )

--- a/posthog/hogql_queries/insights/retention/test/test_retention_data_warehouse_24h_window.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_data_warehouse_24h_window.py
@@ -168,7 +168,7 @@ class TestRetentionDataWarehouse24hWindow(ClickhouseTestMixin, APIBaseTest):
             _create_event(team=self.team, event=event, distinct_id=distinct_id, timestamp=timestamp)
         flush_persons_and_events()
 
-    def _create_renewals_table(self, table_name: str, rows: list[list[object]]) -> str:
+    def _create_renewals_table(self, table_name: str, rows: list[list[object]], actor_column_type: str = "UUID") -> str:
         # Single-purpose table (every row is a renewal), so the retention entity needs no property filter — exercises
         # the no-property data warehouse return predicate (constant True) where >= t_0 is the only join discriminator.
         return self._create_data_warehouse_table(
@@ -176,7 +176,7 @@ class TestRetentionDataWarehouse24hWindow(ClickhouseTestMixin, APIBaseTest):
             table_name=table_name,
             header=["id", "person_id", "occurred_at"],
             rows=rows,
-            table_columns={"id": "Int64", "person_id": "UUID", "occurred_at": "DateTime64(3, 'UTC')"},
+            table_columns={"id": "Int64", "person_id": actor_column_type, "occurred_at": "DateTime64(3, 'UTC')"},
         )
 
     @staticmethod
@@ -224,14 +224,18 @@ class TestRetentionDataWarehouse24hWindow(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(day_0["values"][1]["count"], 1)  # interval 1: user-1
         self.assertEqual(day_0["values"][2]["count"], 0)
 
-    def test_dwh_start_events_return_24h_window(self):
+    # This shape joins the two scans on actor_id, which needs one common key type: a warehouse actor
+    # column typed anything but UUID has no supertype with events.person_id.
+    @parameterized.expand([("UUID",), ("String",)])
+    def test_dwh_start_events_return_24h_window(self, actor_column_type: str):
         person_ids = self._create_people()
         signups_table = self._create_renewals_table(
-            "warehouse_signups_b",
+            f"warehouse_signups_b_{actor_column_type.lower()}",
             rows=[
                 [1, person_ids["user-1"], "2025-01-01 09:00:00"],
                 [2, person_ids["user-2"], "2025-01-02 09:00:00"],
             ],
+            actor_column_type=actor_column_type,
         )
         self._create_events(
             [


### PR DESCRIPTION
## TL;DR

Retention on a data warehouse table crashed whenever the table identified people by anything other than a person UUID. The two halves of the query used different column types, and ClickHouse refused to group by the mix. This makes both halves strings, and lets the aggregation target point at a joined person field.

## Problem

- Retention on a warehouse table errors out when its actor column is not a UUID and the other entity is events.
- The user sees a raw ClickHouse dump: `Data types Variant/Dynamic are not allowed in GROUP BY keys`.
- Each arm aliases its own actor column to `actor_id`: the warehouse column on one side, `events.person_id` (UUID) on the other. Neither is cast.
- ClickHouse 26.6 defaults `use_variant_as_common_type=1`, so `String` and `UUID` union to `Variant(String, UUID)`.
- The outer `GROUP BY actor_id` rejects that type.
- The 24-hour-window shape joins the arms on `actor_id` instead, and fails with `NO_COMMON_TYPE`.
- Every warehouse test fixture typed its actor column `UUID`, so nothing covered this.
- A table keyed by `distinct_id` could not reach events at all. `aggregation_target_field` accepted a column name only, so nothing could point it at a joined person.

## Changes

- Coerce `actor_id` to string on both arms when a warehouse entity is involved. Funnels already does this for its own `aggregation_target` in `funnel_event_query.py`.
- Events-only retention keeps its UUID keys, so the flagged dwh-variant path for events series is unchanged.
- Apply the same coercion to the actors-modal events join, which compares `events.person_id` to `actor_id`.
- Parse `aggregation_target_field` as HogQL, matching funnels and lifecycle. A target of `person.id` through a `DataWarehouseJoin` now resolves, which is how a distinct_id-keyed table reaches events.
- Casting the warehouse column to UUID instead does not work. Group keys such as `$group_0` are strings, so there is no single non-string target type.

> [!NOTE]
> Coercing the type stops the crash. It does not make every column meaningful. A target of `distinct_id` against an events entity still returns zero retention, because distinct_ids are not person UUIDs. Reaching persons needs the join and a `person.id` target. The aggregation target picker offers any column with no signal about this, which is worth deciding on separately.

## How did you test this code?

Three new cases, each confirmed to fail on master and pass here:

| Case | Error on master |
| --- | --- |
| `test_retention_data_warehouse_and_events`, `String` parameter | `Variant/Dynamic are not allowed in GROUP BY keys` |
| `test_dwh_start_events_return_24h_window`, `String` parameter | `There is no supertype for types String, UUID` |
| `test_retention_data_warehouse_aggregation_target_resolves_through_join` | `Unable to resolve field: person.id` |

The first two are parameterized cases on existing tests, not new functions. The 24-hour-window one is a separate builder and a separate failure, so it is not redundant with the first. The third guards the HogQL parsing of the target.

The union type behavior was confirmed directly against a local ClickHouse 26.6:

```
SELECT toTypeName(actor_id) FROM (SELECT 'a'::String AS actor_id UNION ALL SELECT generateUUIDv4() AS actor_id)
-> Variant(String, UUID)
```

`test_retention_query_runner.py` passes with its 49 snapshots unchanged, which is the guard that the gating leaves events-only retention alone.

Not done: no manual check in a running app.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with PostHog Code (Claude Opus 5). Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

The starting point was a failing insight during manual testing of the retention warehouse rollout, reported only as the ClickHouse error text. Diagnosis traced it to the union of the two arms rather than to any warehouse column type, and a query against a local ClickHouse confirmed the `Variant` supertype.

Funnels turned out to have hit and fixed the same problem already, including a comment naming it, so this follows that shape rather than inventing one. That precedent also surfaced the second gap: funnels and lifecycle parse the aggregation target as HogQL and retention did not, which is what made the reported configuration unreachable rather than merely broken.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
