### PR TITLE
feat(ingestion): bound consumer batches by payload bytes

### DIFF
--- a/rust/ingestion-consumer/src/config.rs
+++ b/rust/ingestion-consumer/src/config.rs
@@ -117,6 +117,29 @@ pub struct Config {
     #[envconfig(default = "500")]
     pub consumer_batch_size: usize,
 
+    /// Maximum payload bytes to collect before dispatching a batch, in KiB.
+    /// `0` (default) disables the bound, leaving collection count-only.
+    ///
+    /// Resident memory is `CONSUMER_MAX_BACKGROUND_TASKS x batch x event size`,
+    /// doubled while a sub-batch is in flight, so a count-only cap only bounds
+    /// memory if every lane's event size is known and stable. It is not: measured
+    /// mean payloads across analytics lanes span ~1KB to ~43KB, a 45x spread, and
+    /// the same `CONSUMER_BATCH_SIZE` therefore means 45x the memory on one lane
+    /// versus another. This bound restates the limit in the unit that actually
+    /// constrains the pod, so one value is safe everywhere.
+    ///
+    /// Whichever bound is reached first ends collection. The count cap stays
+    /// useful as a downstream-shape guard (worker request size, per-batch
+    /// overhead); this one is the memory guard. Checked before appending, so a
+    /// batch always carries at least one message and overshoot is bounded by a
+    /// single message (itself capped by `fetch.message.max.bytes`).
+    ///
+    /// Default is off so that rolling this image out changes no lane's batch
+    /// composition; lanes opt in where their memory arithmetic is already
+    /// written down.
+    #[envconfig(from = "CONSUMER_BATCH_SIZE_KB", default = "0")]
+    pub consumer_batch_size_kb: usize,
+
     /// Maximum time to wait while collecting a batch (milliseconds)
     #[envconfig(default = "500")]
     pub consumer_batch_timeout_ms: u64,

--- a/rust/ingestion-consumer/src/consumer.rs
+++ b/rust/ingestion-consumer/src/consumer.rs
@@ -71,6 +71,9 @@ struct InFlightBatch {
 /// Used in integration tests where the Kafka consumer is created externally.
 pub struct IngestionConsumerOptions {
     pub batch_size: usize,
+    /// Payload-byte bound on a batch; `0` disables it (count-only collection).
+    /// See `Config::consumer_batch_size_kb`.
+    pub batch_size_bytes: usize,
     pub batch_timeout: Duration,
     pub max_in_flight_batches: usize,
     pub group_id: String,
@@ -95,6 +98,7 @@ pub struct IngestionConsumer {
     transport: Arc<HttpTransport>,
     worker_urls: Vec<String>,
     batch_size: usize,
+    batch_size_bytes: usize,
     batch_timeout: Duration,
     max_in_flight_batches: usize,
     deferred_flush_timeout: Duration,
@@ -131,6 +135,7 @@ impl IngestionConsumer {
             transport,
             worker_urls,
             batch_size: options.batch_size,
+            batch_size_bytes: options.batch_size_bytes,
             batch_timeout: options.batch_timeout,
             max_in_flight_batches: options.max_in_flight_batches.max(1),
             deferred_flush_timeout: options.deferred_flush_timeout,
@@ -173,6 +178,7 @@ impl IngestionConsumer {
             group = %config.ingestion_consumer_group_id,
             workers = worker_urls.len(),
             batch_size = config.consumer_batch_size,
+            batch_size_kb = config.consumer_batch_size_kb,
             "Kafka consumer subscribed"
         );
 
@@ -184,6 +190,7 @@ impl IngestionConsumer {
             transport,
             worker_urls,
             batch_size: config.consumer_batch_size,
+            batch_size_bytes: config.consumer_batch_size_kb.saturating_mul(1024),
             batch_timeout: Duration::from_millis(config.consumer_batch_timeout_ms),
             max_in_flight_batches: config.consumer_max_background_tasks.max(1),
             deferred_flush_timeout: Duration::from_millis(
@@ -311,6 +318,7 @@ impl IngestionConsumer {
         let transport = Arc::clone(&self.transport);
         let group_id = self.group_id.clone();
         let max_batch_size = self.batch_size;
+        let max_batch_bytes = self.batch_size_bytes;
 
         let handle = tokio::spawn(async move {
             Self::process_collected_batch(
@@ -320,6 +328,7 @@ impl IngestionConsumer {
                 transport,
                 group_id,
                 max_batch_size,
+                max_batch_bytes,
             )
             .await
         });
@@ -559,6 +568,7 @@ impl IngestionConsumer {
         transport: Arc<HttpTransport>,
         group_id: String,
         max_batch_size: usize,
+        max_batch_bytes: usize,
     ) -> anyhow::Result<ProcessedBatch> {
         let batch_size = collected.messages.len();
         let start = Instant::now();
@@ -572,6 +582,17 @@ impl IngestionConsumer {
         if max_batch_size > 0 {
             gauge!("consumer_batch_utilization", "groupId" => group_id.clone())
                 .set(batch_size as f64 / max_batch_size as f64);
+        }
+
+        // The same ratio against the byte bound. Reported separately because the
+        // two disagree on lanes whose events are large: a count utilization can
+        // sit far below 1.0 while batches are in fact full, simply because the
+        // byte bound (or the prefetch queue behind it) ends collection first.
+        // Reading only the count ratio there invites raising a cap that cannot
+        // be reached. Absent when the byte bound is disabled.
+        if max_batch_bytes > 0 {
+            gauge!("consumer_batch_utilization_bytes", "groupId" => group_id.clone())
+                .set(collected.stats.total_bytes as f64 / max_batch_bytes as f64);
         }
 
         // Batch size distribution — matches Node.js `consumer_batch_size` histogram.
@@ -697,7 +718,14 @@ impl IngestionConsumer {
         Ok(accepted)
     }
 
-    /// Collect messages from Kafka up to batch_size or batch_timeout.
+    /// Collect messages from Kafka until the first of `batch_size` messages,
+    /// `batch_size_bytes` of payload (when enabled), or `batch_timeout`.
+    ///
+    /// The byte bound is checked at the top of the loop, where accumulated
+    /// bytes are those of messages already appended: a batch therefore always
+    /// carries at least one message — a single payload larger than the whole
+    /// bound still moves rather than wedging the partition — and overshoot is
+    /// at most one message, itself bounded by `fetch.message.max.bytes`.
     async fn collect_batch(&self) -> anyhow::Result<CollectedBatch> {
         let mut messages = Vec::with_capacity(self.batch_size);
         let mut offsets: HashMap<(String, i32), OffsetSpan> = HashMap::new();
@@ -709,6 +737,11 @@ impl IngestionConsumer {
 
         loop {
             if messages.len() >= self.batch_size {
+                break;
+            }
+
+            if self.batch_size_bytes > 0 && stats.total_bytes >= self.batch_size_bytes {
+                counter!("ingestion_consumer_batches_byte_capped_total").increment(1);
                 break;
             }
 

--- a/rust/ingestion-consumer/tests/e2e_integration_test.rs
+++ b/rust/ingestion-consumer/tests/e2e_integration_test.rs
@@ -122,6 +122,10 @@ struct FakeWorker {
     pub url: String,
     /// (distinct_id, seq) pairs in arrival order.
     pub received: Arc<Mutex<Vec<(String, usize)>>>,
+    /// Message count of each accepted /ingest request, in arrival order. With a
+    /// single worker and partition a sub-batch is the whole Kafka batch, which
+    /// is what lets the batching-bound tests read batch sizes from here.
+    pub batch_sizes: Arc<Mutex<Vec<usize>>>,
     /// Gates /_ready (pool membership). When false the worker leaves the pool.
     pub healthy: Arc<AtomicBool>,
     /// Gates /ingest only. When false the worker stays ready (in the pool) but
@@ -167,6 +171,7 @@ impl FakeWorker {
 
     async fn start_inner(delivery_log: Option<DeliveryLog>) -> Self {
         let received: Arc<Mutex<Vec<(String, usize)>>> = Arc::new(Mutex::new(Vec::new()));
+        let batch_sizes: Arc<Mutex<Vec<usize>>> = Arc::new(Mutex::new(Vec::new()));
         let healthy = Arc::new(AtomicBool::new(true));
         let ingest_ok = Arc::new(AtomicBool::new(true));
         let ack_lost_once = Arc::new(AtomicBool::new(false));
@@ -196,6 +201,7 @@ impl FakeWorker {
                 "/ingest",
                 post({
                     let recv = Arc::clone(&received);
+                    let sizes = Arc::clone(&batch_sizes);
                     let h = Arc::clone(&healthy);
                     let ingest_ok = Arc::clone(&ingest_ok);
                     let ack_lost_once = Arc::clone(&ack_lost_once);
@@ -206,6 +212,7 @@ impl FakeWorker {
                     let delivery_log = delivery_log.clone();
                     move |AxumJson(req): AxumJson<IngestBatchRequest>| {
                         let recv = recv.clone();
+                        let sizes = sizes.clone();
                         let h = h.clone();
                         let ingest_ok = ingest_ok.clone();
                         let ack_lost_once = ack_lost_once.clone();
@@ -266,6 +273,7 @@ impl FakeWorker {
                                 })
                                 .collect();
                             recv.lock().unwrap().extend(entries.iter().cloned());
+                            sizes.lock().unwrap().push(req.messages.len());
                             // Record the whole batch as one contiguous slot in the
                             // shared total order (it was accepted as a unit).
                             if let Some(log) = &delivery_log {
@@ -315,6 +323,7 @@ impl FakeWorker {
         Self {
             url,
             received,
+            batch_sizes,
             healthy,
             ingest_ok,
             ack_lost_once,
@@ -328,6 +337,11 @@ impl FakeWorker {
 
     fn count(&self) -> usize {
         self.received.lock().unwrap().len()
+    }
+
+    /// Message count of each accepted /ingest request, in arrival order.
+    fn batch_sizes(&self) -> Vec<usize> {
+        self.batch_sizes.lock().unwrap().clone()
     }
 
     /// /ingest requests that have reached this worker (including any held by the gate).
@@ -436,6 +450,44 @@ impl Harness {
         deferred_flush_timeout: Duration,
         registry_config: WorkerRegistryConfig,
     ) -> Self {
+        Self::start_inner(
+            topic,
+            partitions,
+            worker_count,
+            max_in_flight,
+            deferred_flush_timeout,
+            registry_config,
+            0,
+        )
+        .await
+    }
+
+    /// Like `start`, but bounds batch collection by payload bytes as well as
+    /// count (`CONSUMER_BATCH_SIZE_KB`). Single worker and partition, so each
+    /// /ingest request is one whole Kafka batch.
+    async fn start_byte_capped(topic: &str, batch_size_bytes: usize) -> Self {
+        Self::start_inner(
+            topic,
+            1,
+            1,
+            1,
+            Duration::from_secs(60),
+            fast_registry_config(),
+            batch_size_bytes,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn start_inner(
+        topic: &str,
+        partitions: i32,
+        worker_count: usize,
+        max_in_flight: usize,
+        deferred_flush_timeout: Duration,
+        registry_config: WorkerRegistryConfig,
+        batch_size_bytes: usize,
+    ) -> Self {
         create_topic(topic, partitions).await;
 
         let delivery_log: DeliveryLog = Arc::new(Mutex::new(Vec::new()));
@@ -483,6 +535,7 @@ impl Harness {
             worker_urls,
             IngestionConsumerOptions {
                 batch_size: 50,
+                batch_size_bytes,
                 batch_timeout: Duration::from_millis(100),
                 max_in_flight_batches: max_in_flight,
                 group_id: "e2e-test".to_string(),
@@ -560,6 +613,7 @@ impl Harness {
             worker_urls,
             IngestionConsumerOptions {
                 batch_size: 50,
+                batch_size_bytes: 0,
                 batch_timeout: Duration::from_millis(100),
                 max_in_flight_batches: self.max_in_flight,
                 group_id: "e2e-test".to_string(),
@@ -704,6 +758,84 @@ async fn messages_per_distinct_id_arrive_in_order() {
             );
         }
     }
+
+    harness.stop().await;
+}
+
+/// The byte bound ends collection before the count bound when payloads are
+/// large, so batch memory tracks bytes rather than event count.
+///
+/// Twelve 2KiB messages sit far inside the 50-message count cap, so without the
+/// byte bound they batch together; the 4KiB cap admits at most two per batch
+/// (the second crosses it). The count cap alone cannot express that, which is
+/// the regression: a lane whose events are large gets the memory of a full
+/// count batch no matter how the count is tuned.
+#[tokio::test]
+async fn byte_bound_caps_batches_below_the_count_bound() {
+    let topic = format!("e2e-bytecap-{}", Uuid::new_v4());
+    let harness = Harness::start_byte_capped(&topic, 4096).await;
+
+    let producer = make_producer();
+    let payload = vec![b'x'; 2048];
+    for seq in 0..12usize {
+        produce_raw(
+            &producer,
+            &topic,
+            0,
+            &format!("tok:user-1:{seq}"),
+            &payload,
+            None,
+        )
+        .await;
+    }
+
+    harness.wait_for(12, Duration::from_secs(20)).await;
+
+    let sizes = harness.workers[0].batch_sizes();
+    assert_eq!(
+        sizes.iter().sum::<usize>(),
+        12,
+        "every message must still be delivered, got batches {sizes:?}"
+    );
+    // A collection timeout can only make a batch smaller, so this holds
+    // regardless of how production interleaves with the 100ms window.
+    assert!(
+        sizes.iter().all(|&n| n <= 2),
+        "no batch may exceed the byte bound by more than one message, got {sizes:?}"
+    );
+
+    harness.stop().await;
+}
+
+/// A single message larger than the whole byte bound still moves.
+///
+/// The bound is checked before appending, so the first message of a batch is
+/// always admitted. Checking after would let one oversized payload produce an
+/// empty batch and wedge its partition — the message can never be skipped, and
+/// no smaller batch can ever contain it.
+#[tokio::test]
+async fn message_larger_than_byte_bound_is_still_delivered() {
+    let topic = format!("e2e-bytecap-oversize-{}", Uuid::new_v4());
+    let harness = Harness::start_byte_capped(&topic, 4096).await;
+
+    let producer = make_producer();
+    produce_raw(
+        &producer,
+        &topic,
+        0,
+        "tok:user-1:0",
+        &vec![b'x'; 16384],
+        None,
+    )
+    .await;
+
+    harness.wait_for(1, Duration::from_secs(20)).await;
+
+    assert_eq!(
+        harness.workers[0].batch_sizes(),
+        vec![1],
+        "the oversized message must arrive as a batch of one"
+    );
 
     harness.stop().await;
 }
@@ -2035,6 +2167,7 @@ async fn second_consumer_joining_the_group_preserves_all_messages() {
         worker_urls,
         IngestionConsumerOptions {
             batch_size: 50,
+            batch_size_bytes: 0,
             batch_timeout: Duration::from_millis(100),
             max_in_flight_batches: 1,
             group_id: "e2e-test".to_string(),
@@ -2112,6 +2245,7 @@ async fn fenced_static_member_exits_on_fatal_error() {
         urls,
         IngestionConsumerOptions {
             batch_size: 50,
+            batch_size_bytes: 0,
             batch_timeout: Duration::from_millis(100),
             max_in_flight_batches: 1,
             group_id: "e2e-test".to_string(),


### PR DESCRIPTION
## Problem

Operators sizing an ingestion-consumer lane cannot bound its memory with the settings available today.

Resident memory is `CONSUMER_MAX_BACKGROUND_TASKS x CONSUMER_BATCH_SIZE x event size`, doubled while a sub-batch is in flight. Both knobs count messages, so the bound only holds if event size is known and stable. It is not. Measured mean payloads across the analytics lanes span roughly 1KB to 43KB, so the same `CONSUMER_BATCH_SIZE` buys 45x the memory on one lane as on another.

Two consequences follow:

- Sizing has to be redone by hand for every lane each time either number moves. Getting it wrong OOMs the pod rather than degrading it.
- Where events are large the count cap is unreachable. The 100MB `queued.max.messages.kbytes` prefetch queue holds ~2500 events at 43KB, so a 5000 cap can never fill, and `consumer_batch_utilization` reads ~34% at full saturation. That looks like room to raise the cap, which spends memory for no throughput.

## Changes

`CONSUMER_BATCH_SIZE_KB` ends batch collection at a payload-byte total. Whichever of the count and byte bounds is reached first wins.

- Default `0` leaves the bound off. Rolling this image out changes no lane's batch composition; lanes opt in where their memory arithmetic is already written down.
- `collect_batch` already accumulated `stats.total_bytes` for the `consumer_batch_size_kb` histogram, so the bound reuses it rather than adding accounting.
- The check sits at the top of the collection loop, over bytes already appended. A batch therefore always carries at least one message, so a payload larger than the whole bound still moves instead of wedging its partition. Overshoot is at most one message, itself bounded by `fetch.message.max.bytes`.
- The obvious alternative — refuse to exceed the bound, counting the incoming message — has no such floor. An oversized payload yields an empty batch forever, and the loop spins hot enough to starve the runtime.
- `consumer_batch_utilization_bytes` reports fill against the byte bound, so a count ratio far below 1.0 is no longer mistaken for headroom. Absent when the bound is off.
- `ingestion_consumer_batches_byte_capped_total` counts batches the bound ended.

The count cap keeps its job as a downstream-shape guard (worker request size, per-batch overhead). This one is the memory guard.

## How did you test this code?

Two e2e tests, both against local Kafka, and each verified by mutation to fail without the change:

- `byte_bound_caps_batches_below_the_count_bound` — twelve 2KiB messages under a 4KiB byte bound and a 50-message count bound. Catches a byte bound that does not end collection: removing the bound batches all twelve into one request. The assertion is an upper bound per batch, so a collection timeout cannot flake it.
- `message_larger_than_byte_bound_is_still_delivered` — one 16KiB message under a 4KiB bound. Catches the never-exceed variant above; under that mutation the message never arrives and the consumer spins.

The mock worker now records each accepted request's message count, which is what makes batch composition observable. With one worker and one partition a sub-batch is the whole Kafka batch.

The full `ingestion-consumer` suite passes locally, including the pre-existing e2e tests that share the refactored harness. Not exercised: any lane running with the bound enabled — no chart sets `CONSUMER_BATCH_SIZE_KB` yet.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. No repo skills applied to the code itself; `/writing-pr-descriptions` was unavailable in this session, so this body follows `.github/pull_request_template.md` directly.

The default was the main open decision. A non-zero default would bound every lane immediately, but this image ships to all of them at once, and on the large-event lane any useful value changes batch composition during a live incident. Off by default keeps the rollout inert and moves the choice to the per-lane values, where the memory arithmetic already lives.

The byte-bound check placement was the other. Both candidate positions bound memory; only the one that admits the first message unconditionally keeps a payload larger than the bound moving. That property is what the second test pins.

A companion charts change (PostHog/charts#14413) resizes the affected lane by hand in the meantime. It can come back down once this lands and the lanes opt in.
