### PR TITLE
feat(cli): add --release-mode to proguard upload

### DIFF
--- a/cli/.sampo/changesets/proguard-event-release-mode.md
+++ b/cli/.sampo/changesets/proguard-event-release-mode.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-cli: minor
+---
+
+Add `--release-mode` to `proguard upload`, matching `sourcemap upload`. `symbol-set` (the default) keeps stamping the release onto the uploaded mapping. EXPERIMENTAL `event` creates the release but leaves the mapping unbound, so each event resolves its own release from the app version and namespace the SDK already sends — a map id is derived from the mapping's own content, so this keeps one symbol set for a mapping that several releases share. Also settable via `POSTHOG_RELEASE_MODE`.

--- a/cli/.sampo/changesets/proguard-event-release-mode.md
+++ b/cli/.sampo/changesets/proguard-event-release-mode.md
@@ -2,4 +2,4 @@
 cargo/posthog-cli: minor
 ---
 
-Add `--release-mode` to `proguard upload`, matching `sourcemap upload`. `symbol-set` (the default) keeps stamping the release onto the uploaded mapping. EXPERIMENTAL `event` creates the release but leaves the mapping unbound, so each event resolves its own release from the app version and namespace the SDK already sends — a map id is derived from the mapping's own content, so this keeps one symbol set for a mapping that several releases share. Also settable via `POSTHOG_RELEASE_MODE`.
+Add `--release-mode` to `proguard upload`, matching `sourcemap upload`. `symbol-set` (the default) keeps stamping the release onto the uploaded mapping. EXPERIMENTAL `event` creates the release but leaves the mapping unbound, so each event resolves its own release from the app version and namespace the SDK already sends. A map id is derived from the mapping's own content, so this keeps one symbol set for a mapping that several releases share. Also settable via `POSTHOG_RELEASE_MODE`.

--- a/cli/src/proguard/upload.rs
+++ b/cli/src/proguard/upload.rs
@@ -5,7 +5,7 @@ use anyhow::{anyhow, Result};
 use crate::{
     api::{self, releases::ReleaseBuilder, symbol_sets::SymbolSetUpload},
     proguard::ProguardFile,
-    sourcemaps::args::{pack_version, ReleaseArgs, UploadConflictArgs},
+    sourcemaps::args::{pack_version, ReleaseArgs, ReleaseMode, UploadConflictArgs},
     utils::git::get_git_info,
 };
 
@@ -29,6 +29,19 @@ pub struct Args {
 
     #[clap(flatten)]
     pub conflict: UploadConflictArgs,
+
+    /// How the release is associated with exceptions. `symbol-set` (the default) stamps the
+    /// release id onto the uploaded mapping: the previous behavior. EXPERIMENTAL `event` leaves
+    /// the mapping release-independent, and each event resolves its own release from the app
+    /// version and namespace the SDK already sends. The release is created either way. Also
+    /// settable via `POSTHOG_RELEASE_MODE`.
+    #[arg(
+        long,
+        env = "POSTHOG_RELEASE_MODE",
+        value_enum,
+        default_value = "symbol-set"
+    )]
+    pub release_mode: ReleaseMode,
 }
 
 pub fn upload(args: &Args) -> Result<()> {
@@ -38,6 +51,7 @@ pub fn upload(args: &Args) -> Result<()> {
         batch_size,
         release,
         conflict,
+        release_mode,
     } = args;
 
     let ReleaseArgs {
@@ -73,7 +87,20 @@ pub fn upload(args: &Args) -> Result<()> {
         .then(|| release_builder.fetch_or_create())
         .transpose()?;
 
-    file.release_id = release.map(|r| r.id.to_string());
+    // The release is created in both modes, so the server has a row to resolve an event's
+    // `$app_namespace` / `$app_version` / `$app_build` onto. Event mode only skips binding it to
+    // the mapping: a map id is derived from the mapping's own content, so the same mapping keeps
+    // one symbol set across releases instead of colliding with the release the first upload
+    // stamped on it.
+    //
+    // Unlike sourcemaps, event mode does not imply `--force` here. The uploaded bytes are the
+    // mapping itself, with no injected release id, so a rebuild of unchanged code produces
+    // identical content under the same id and never conflicts. A conflict means the caller reused
+    // a `--map-id` for a different mapping, which is worth reporting in either mode.
+    file.release_id = match release_mode {
+        ReleaseMode::Event => None,
+        ReleaseMode::SymbolSet => release.map(|r| r.id.to_string()),
+    };
 
     let to_upload: SymbolSetUpload = file.try_into()?;
 
@@ -87,4 +114,46 @@ pub fn upload(args: &Args) -> Result<()> {
     upload_result?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[derive(Parser)]
+    struct ProguardCli {
+        #[command(subcommand)]
+        command: crate::proguard::ProguardSubcommand,
+    }
+
+    fn parse(extra: &[&str]) -> Args {
+        let mut argv = vec![
+            "proguard",
+            "upload",
+            "--path",
+            "mapping.txt",
+            "--map-id",
+            "id",
+        ];
+        argv.extend_from_slice(extra);
+        let crate::proguard::ProguardSubcommand::Upload(args) =
+            ProguardCli::parse_from(argv).command;
+        args
+    }
+
+    #[test]
+    fn defaults_to_binding_the_release_to_the_mapping() {
+        // Every existing caller omits the flag, and they must keep uploading mappings stamped with
+        // their release.
+        assert_eq!(parse(&[]).release_mode, ReleaseMode::SymbolSet);
+    }
+
+    #[test]
+    fn accepts_event_release_mode() {
+        assert_eq!(
+            parse(&["--release-mode", "event"]).release_mode,
+            ReleaseMode::Event
+        );
+    }
 }

--- a/cli/src/proguard/upload.rs
+++ b/cli/src/proguard/upload.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use anyhow::{anyhow, Result};
+use tracing::warn;
 
 use crate::{
     api::{self, releases::ReleaseBuilder, symbol_sets::SymbolSetUpload},
@@ -30,11 +31,12 @@ pub struct Args {
     #[clap(flatten)]
     pub conflict: UploadConflictArgs,
 
-    /// How the release is associated with exceptions. `symbol-set` (the default) stamps the
-    /// release id onto the uploaded mapping: the previous behavior. EXPERIMENTAL `event` leaves
-    /// the mapping release-independent, and each event resolves its own release from the app
-    /// version and namespace the SDK already sends. The release is created either way. Also
-    /// settable via `POSTHOG_RELEASE_MODE`.
+    /// How the release is associated with exceptions. `symbol-set`, the default, stamps the
+    /// release id onto the uploaded mapping, and an exception takes the release of the mappings
+    /// its frames resolved against. EXPERIMENTAL `event` leaves the mapping
+    /// release-independent, and each event resolves its own release from the app version and
+    /// namespace the SDK already sends, so the release coordinates have to match the app's. The
+    /// release is created either way. Also settable via `POSTHOG_RELEASE_MODE`.
     #[arg(
         long,
         env = "POSTHOG_RELEASE_MODE",
@@ -60,6 +62,18 @@ pub fn upload(args: &Args) -> Result<()> {
         build,
         skip_release_on_fail,
     } = release;
+
+    // Event mode leaves nothing on the symbol set for the server to fall back to, so an
+    // exception resolves its release only from the app metadata on the event itself. Coordinates
+    // derived from git rather than passed explicitly will not match that metadata, and the
+    // exception then reports no release at all, silently.
+    if *release_mode == ReleaseMode::Event && (name.is_none() || version.is_none()) {
+        warn!(
+            "--release-mode=event resolves each exception's release from the app's namespace and \
+             version. Pass --release-name, --release-version and --build matching the app's \
+             applicationId, versionName and versionCode, or exceptions will report no release."
+        );
+    }
 
     let path = path
         .canonicalize()


### PR DESCRIPTION
`proguard upload` binds the release it creates to the uploaded mapping. Map ids are derived from the mapping's content, so two releases shipping the same mapping both report whichever one uploaded it first.

`--release-mode event` (also `POSTHOG_RELEASE_MODE`) leaves the mapping unbound. Nothing is injected into the app in exchange — the server already resolves a mobile event's release from `$app_namespace` / `$app_version` / `$app_build`, and the release is still created here for it to land on. Mirrors `sourcemap upload` rather than dsym's `--no-release-bind`.

Unlike sourcemaps, event mode does not imply `--force`: nothing is injected into a mapping, so unchanged code re-uploads identical bytes and a conflict still means a reused `--map-id`.

Consumed by PostHog/posthog-android#704.