### PR TITLE
docs(data-warehouse): mark 47 newly implemented sources in SOURCES.md

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
@@ -82,6 +82,7 @@ the row lists both.
 | appsignal                        | HTTP (REST + GraphQL)       | requests                                                        | ✅                          |
 | appstack                         | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | argocd                           | HTTP                        | requests                                                        | ✅                          |
+| asaas                            | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | asana                            | HTTP                        | requests                                                        | ✅                          |
 | ashby                            | HTTP                        | requests                                                        | ✅                          |
 | asknicely                        | HTTP                        | requests                                                        | ✅                          |
@@ -90,14 +91,19 @@ the row lists both.
 | attio                            | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | automox                          | HTTP                        | requests                                                        | ✅                          |
 | autumn                           | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| avalara                          | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | aviationstack                    | HTTP                        | requests                                                        | ✅                          |
 | aviator                          | HTTP                        | requests                                                        | ✅                          |
 | awin                             | HTTP                        | requests                                                        | ✅                          |
+| aws_budgets                      | HTTP                        | requests                                                        | ✅                          |
+| aws_cost_anomaly_detection       | HTTP                        | requests                                                        | ✅                          |
 | aws_cost_explorer                | HTTP                        | requests                                                        | ✅                          |
+| aws_organizations                | HTTP                        | requests                                                        | ✅                          |
 | aws_ses                          | HTTP                        | requests                                                        | ✅                          |
 | azure_cost_management            | HTTP                        | requests                                                        | ✅                          |
 | azure_devops                     | HTTP                        | requests                                                        | ✅                          |
 | babelforce                       | HTTP                        | requests                                                        | ✅                          |
+| back_market                      | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | bamboohr                         | HTTP                        | requests                                                        | ✅                          |
 | baserow                          | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | baseten                          | HTTP                        | requests                                                        | ✅                          |
@@ -106,15 +112,19 @@ the row lists both.
 | better_stack                     | HTTP                        | requests                                                        | ✅                          |
 | bettermode                       | HTTP (GraphQL)              | requests                                                        | ✅                          |
 | bigcommerce                      | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| bigeye                           | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | bigmailer                        | HTTP                        | requests                                                        | ✅                          |
 | bigquery                         | HTTP + gRPC                 | google-cloud-bigquery + bigquery-storage                        | ✅ (HTTP + gRPC)            |
 | bill_com                         | HTTP                        | requests                                                        | ✅                          |
+| billomat                         | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | bing_ads                         | HTTP (vendor SDK, SOAP)     | bingads SDK                                                     | ⚠️                          |
 | bing_webmaster_tools             | HTTP                        | requests                                                        | ✅                          |
 | bitbucket                        | HTTP                        | requests                                                        | ✅                          |
 | bitrise                          | HTTP                        | requests                                                        | ✅                          |
 | bland_ai                         | HTTP                        | requests                                                        | ✅                          |
 | blogger                          | HTTP                        | requests                                                        | ✅                          |
+| bloomerang                       | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| bluesky                          | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | bluetally                        | HTTP                        | requests                                                        | ✅                          |
 | boldsign                         | HTTP                        | requests                                                        | ✅                          |
 | braintree                        | HTTP (GraphQL)              | requests                                                        | ✅                          |
@@ -138,9 +148,11 @@ the row lists both.
 | campayn                          | HTTP                        | requests                                                        | ✅                          |
 | campfire                         | HTTP                        | requests                                                        | ✅                          |
 | canny                            | HTTP                        | requests                                                        | ✅                          |
+| canvas_lms                       | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | capsule_crm                      | HTTP                        | requests                                                        | ✅                          |
 | care_quality_commission          | HTTP                        | requests                                                        | ✅                          |
 | cast_ai                          | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| cdc_open_data                    | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | census                           | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | chameleon                        | HTTP                        | requests                                                        | ✅                          |
 | chargebee                        | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
@@ -151,6 +163,9 @@ the row lists both.
 | checkmarx                        | HTTP                        | requests                                                        | ✅                          |
 | checkout_com                     | HTTP                        | requests                                                        | ✅                          |
 | churnkey                         | HTTP                        | requests                                                        | ✅                          |
+| clever                           | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| cliniko                          | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| cloudability                     | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | cloudzero                        | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | coassemble                       | HTTP                        | requests                                                        | ✅                          |
 | coda                             | HTTP                        | requests                                                        | ✅                          |
@@ -165,6 +180,7 @@ the row lists both.
 | coingecko                        | HTTP                        | requests                                                        | ✅                          |
 | coinmarketcap                    | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | commercetools                    | HTTP                        | requests                                                        | ✅                          |
+| companycam                       | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | concord                          | HTTP                        | requests                                                        | ✅                          |
 | conekta                          | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | configcat                        | HTTP                        | requests                                                        | ✅                          |
@@ -196,6 +212,7 @@ the row lists both.
 | coveralls                        | HTTP                        | requests                                                        | ✅                          |
 | crates_io                        | HTTP                        | requests                                                        | ✅                          |
 | cronitor                         | HTTP                        | requests                                                        | ✅                          |
+| crossref                         | HTTP                        | requests                                                        | ✅                          |
 | crunchbase                       | HTTP                        | requests                                                        | ✅                          |
 | culture_amp                      | HTTP                        | requests                                                        | ✅                          |
 | cursor                           | HTTP                        | requests                                                        | ✅                          |
@@ -234,11 +251,14 @@ the row lists both.
 | dynatrace                        | HTTP                        | requests                                                        | ✅                          |
 | e2b                              | HTTP                        | requests                                                        | ✅                          |
 | e_conomic                        | HTTP                        | requests                                                        | ✅                          |
+| easybill                         | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | easypost                         | HTTP                        | requests                                                        | ✅                          |
 | easypromos                       | HTTP                        | requests                                                        | ✅                          |
+| ecb_data_portal                  | HTTP                        | requests                                                        | ✅                          |
 | elevenlabs                       | HTTP                        | requests                                                        | ✅                          |
 | eppo                             | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | etsy                             | HTTP                        | requests                                                        | ✅                          |
+| faire                            | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | fourthwall                       | HTTP + Webhook              | requests + `rest_source.RESTClient` + `WebhookSourceManager`    | ✅ (pull) / ➖ (webhook)    |
 | freshcaller                      | HTTP                        | requests                                                        | ✅                          |
 | freshchat                        | HTTP                        | requests                                                        | ✅                          |
@@ -282,6 +302,7 @@ the row lists both.
 | fulcrum                          | HTTP                        | requests                                                        | ✅                          |
 | fullstory                        | HTTP                        | requests                                                        | ✅                          |
 | fusionauth                       | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| g2                               | HTTP                        | requests                                                        | ✅                          |
 | gainsight_px                     | HTTP                        | requests                                                        | ✅                          |
 | gerrit                           | HTTP                        | requests                                                        | ✅                          |
 | gitbook                          | HTTP                        | requests                                                        | ✅                          |
@@ -292,6 +313,7 @@ the row lists both.
 | gitlab                           | HTTP                        | requests                                                        | ✅                          |
 | gladly                           | HTTP                        | requests                                                        | ✅                          |
 | glassfrog                        | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| gleif                            | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | gnews                            | HTTP                        | requests                                                        | ✅                          |
 | gocardless                       | HTTP                        | requests                                                        | ✅                          |
 | goldcast                         | HTTP                        | requests                                                        | ✅                          |
@@ -324,16 +346,19 @@ the row lists both.
 | hex                              | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | hibob                            | HTTP                        | requests                                                        | ✅                          |
 | hightouch                        | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| hitpay                           | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | honeybadger                      | HTTP                        | requests                                                        | ✅                          |
 | honeycomb                        | HTTP                        | requests                                                        | ✅                          |
 | hookdeck                         | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | hoorayhr                         | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| housecall_pro                    | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | humanitix                        | HTTP                        | requests                                                        | ✅                          |
 | hubplanner                       | HTTP                        | requests                                                        | ✅                          |
 | hubspot                          | HTTP                        | requests                                                        | ✅                          |
 | hugging_face                     | HTTP                        | requests                                                        | ✅                          |
 | huntr                            | HTTP                        | requests                                                        | ✅                          |
 | hyperspell                       | HTTP                        | requests                                                        | ✅                          |
+| hyros                            | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | imagga                           | HTTP                        | requests                                                        | ✅                          |
 | impact                           | HTTP                        | requests                                                        | ✅                          |
 | impact_partner                   | HTTP                        | requests                                                        | ✅                          |
@@ -367,6 +392,7 @@ the row lists both.
 | kandji                           | HTTP                        | requests (rest_source.RESTClient)                               | ✅                          |
 | katana                           | HTTP                        | requests                                                        | ✅                          |
 | kernel                           | HTTP                        | requests                                                        | ✅                          |
+| kickscale                        | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | klaus                            | HTTP                        | requests                                                        | ✅                          |
 | klaviyo                          | HTTP                        | requests                                                        | ✅                          |
 | knock                            | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
@@ -421,8 +447,10 @@ the row lists both.
 | meta_ads                         | HTTP                        | requests                                                        | ✅                          |
 | metabase                         | HTTP                        | requests                                                        | ✅                          |
 | metaplane                        | HTTP                        | requests                                                        | ✅                          |
+| meteostat                        | HTTP                        | requests                                                        | ✅                          |
 | metorial                         | HTTP                        | requests                                                        | ✅                          |
 | microsoft_clarity                | HTTP                        | requests                                                        | ✅                          |
+| mighty_networks                  | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | mistral_ai                       | HTTP                        | requests                                                        | ✅                          |
 | mixmax                           | HTTP                        | requests                                                        | ✅                          |
 | mixpanel                         | HTTP                        | requests                                                        | ✅                          |
@@ -431,11 +459,13 @@ the row lists both.
 | mongodb                          | DB protocol                 | pymongo                                                         | ➖                          |
 | monte_carlo                      | HTTP (GraphQL)              | requests                                                        | ✅                          |
 | motherduck                       | DB protocol                 | duckdb (MotherDuck `md:` connection)                            | ➖                          |
+| moxie                            | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | mssql                            | DB protocol                 | pyodbc / pymssql                                                | ➖                          |
 | mux                              | HTTP                        | requests                                                        | ✅                          |
 | my_hours                         | HTTP                        | requests                                                        | ✅                          |
 | mysql                            | DB protocol                 | pymysql                                                         | ➖                          |
 | n8n                              | HTTP                        | requests                                                        | ✅                          |
+| nager_date                       | HTTP                        | requests                                                        | ✅                          |
 | nebius_ai                        | HTTP                        | requests                                                        | ✅                          |
 | neon                             | DB protocol                 | psycopg (delegates to PostgresSource)                           | ➖                          |
 | netlify                          | HTTP                        | requests                                                        | ✅                          |
@@ -444,6 +474,7 @@ the row lists both.
 | news_api                         | HTTP                        | requests                                                        | ✅                          |
 | newsdata                         | HTTP                        | requests                                                        | ✅                          |
 | npm_registry                     | HTTP                        | requests                                                        | ✅                          |
+| nuntly                           | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | octolens                         | HTTP (POST body cursor)     | requests + `rest_source.RESTClient`                             | ✅                          |
 | okendo                           | HTTP (cursor pagination)    | requests + `rest_source.RESTClient`                             | ✅                          |
 | okta                             | HTTP                        | requests                                                        | ✅                          |
@@ -464,7 +495,9 @@ the row lists both.
 | openai                           | HTTP                        | requests                                                        | ✅                          |
 | openai_ads                       | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | openalex                         | HTTP (cursor pagination)    | requests + `rest_source.RESTClient`                             | ✅                          |
+| opencorporates                   | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | opinion_stage                    | HTTP                        | requests                                                        | ✅                          |
+| opn_payments                     | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | opuswatch                        | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | orb                              | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | orca_security                    | HTTP (POST query DSL)       | requests                                                        | ✅                          |
@@ -476,6 +509,7 @@ the row lists both.
 | ortto                            | HTTP                        | requests                                                        | ✅                          |
 | oura                             | HTTP                        | requests                                                        | ✅                          |
 | outbrain                         | HTTP                        | requests                                                        | ✅                          |
+| ownerrez                         | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | pabbly_subscriptions_billing     | HTTP                        | requests                                                        | ✅                          |
 | packagist                        | HTTP                        | requests                                                        | ✅                          |
 | paddle                           | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
@@ -509,6 +543,7 @@ the row lists both.
 | plausible                        | HTTP                        | requests                                                        | ✅                          |
 | plivo                            | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | plunk                            | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| pluralsight_flow                 | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | polar                            | HTTP                        | requests                                                        | ✅                          |
 | plaid                            | HTTP                        | requests                                                        | ✅                          |
 | postgres                         | DB protocol                 | psycopg                                                         | ➖                          |
@@ -518,6 +553,7 @@ the row lists both.
 | pretix                           | HTTP                        | requests                                                        | ✅                          |
 | printify                         | HTTP                        | requests                                                        | ✅                          |
 | productboard                     | HTTP                        | requests                                                        | ✅                          |
+| propertyware                     | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | pulumi_cloud                     | HTTP                        | requests                                                        | ✅                          |
 | pylon                            | HTTP                        | requests                                                        | ✅                          |
 | pypi                             | HTTP                        | requests                                                        | ✅                          |
@@ -542,6 +578,7 @@ the row lists both.
 | resend                           | HTTP                        | requests                                                        | ✅                          |
 | retently                         | HTTP                        | requests                                                        | ✅                          |
 | revenuecat                       | HTTP + Webhook              | requests + `WebhookSourceManager`                               | ✅ (pull) / ➖ (webhook)    |
+| reverb                           | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | rippling                         | HTTP                        | requests                                                        | ✅                          |
 | rki_covid                        | HTTP                        | requests                                                        | ✅                          |
 | roark                            | HTTP                        | requests                                                        | ✅                          |
@@ -563,11 +600,14 @@ the row lists both.
 | secoda                           | HTTP                        | requests                                                        | ✅                          |
 | secureframe                      | HTTP                        | requests                                                        | ✅                          |
 | segment                          | HTTP                        | requests                                                        | ✅                          |
+| select_star                      | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| semantic_scholar                 | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | semgrep                          | HTTP                        | requests                                                        | ✅                          |
 | sendgrid                         | HTTP                        | requests                                                        | ✅                          |
 | sendowl                          | HTTP                        | requests                                                        | ✅                          |
 | sentinelone                      | HTTP                        | requests                                                        | ✅                          |
 | sentry                           | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| servicem8                        | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | servicenow                       | HTTP                        | requests                                                        | ✅                          |
 | sftp                             | SSH (SFTP)                  | paramiko                                                        | ➖                          |
 | shippo                           | HTTP                        | requests                                                        | ✅                          |
@@ -582,6 +622,7 @@ the row lists both.
 | similarweb                       | HTTP                        | requests                                                        | ✅                          |
 | simplecast                       | HTTP                        | requests                                                        | ✅                          |
 | simplesat                        | HTTP                        | requests                                                        | ✅                          |
+| singlestore                      | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | skyvern                          | HTTP                        | requests                                                        | ✅                          |
 | slack                            | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | smaily                           | HTTP                        | requests                                                        | ✅                          |
@@ -665,6 +706,7 @@ the row lists both.
 | upstash                          | HTTP                        | requests                                                        | ✅                          |
 | uppromote                        | HTTP + Webhook              | requests + `rest_source.RESTClient` + `WebhookSourceManager`    | ✅ (pull) / ➖ (webhook)    |
 | uptimerobot                      | HTTP                        | requests                                                        | ✅                          |
+| us_bea                           | HTTP                        | requests                                                        | ✅                          |
 | us_census                        | HTTP                        | requests                                                        | ✅                          |
 | usersnap                         | HTTP                        | requests + PyJWT                                                | ✅                          |
 | uservoice                        | HTTP                        | requests                                                        | ✅                          |
@@ -672,14 +714,17 @@ the row lists both.
 | vapi                             | HTTP                        | requests                                                        | ✅                          |
 | vellum                           | HTTP                        | requests                                                        | ✅                          |
 | veeqo                            | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| vendr                            | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | veracode                         | HTTP                        | requests (custom HMAC signing)                                  | ✅                          |
 | vercel                           | HTTP                        | requests                                                        | ✅                          |
 | vitally                          | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | vultr                            | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | wasabi                           | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | watchmode                        | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| waydev                           | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | webflow                          | HTTP + Webhook              | requests + `WebhookSourceManager`                               | ✅ (pull) / ➖ (webhook)    |
 | weights_and_biases               | HTTP (GraphQL)              | requests                                                        | ✅                          |
+| who_gho                          | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | whop                             | HTTP + Webhook              | requests + `rest_source.RESTClient` + `WebhookSourceManager`    | ✅ (pull) / ➖ (webhook)    |
 | wikipedia_pageviews              | HTTP                        | requests                                                        | ✅                          |
 | windmill                         | HTTP                        | requests                                                        | ✅                          |
@@ -687,6 +732,7 @@ the row lists both.
 | wordpress                        | HTTP                        | requests                                                        | ✅                          |
 | workable                         | HTTP                        | requests                                                        | ✅                          |
 | workday                          | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| workiz                           | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | workos                           | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | world_bank                       | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | wrike                            | HTTP                        | requests                                                        | ✅                          |
@@ -704,6 +750,7 @@ the row lists both.
 | zenduty                          | HTTP                        | requests                                                        | ✅                          |
 | zenloop                          | HTTP                        | requests                                                        | ✅                          |
 | zep                              | HTTP                        | requests                                                        | ✅                          |
+| zero                             | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | zoho_crm                         | HTTP                        | requests                                                        | ✅                          |
 | zonka_feedback                   | HTTP                        | requests                                                        | ✅                          |
 | zoom                             | HTTP                        | requests                                                        | ✅                          |
@@ -791,7 +838,6 @@ doesn't conflict with concurrent PRs.
 - apptivo
 - appwrite
 - arxiv
-- asaas
 - asknicely
 - astronomer
 - athenahealth
@@ -799,24 +845,20 @@ doesn't conflict with concurrent PRs.
 - auth0
 - autodesk_construction_cloud
 - automox
-- avalara
 - aws_athena
 - aws_batch
-- aws_budgets
 - aws_cloudformation
 - aws_cloudtrail
 - aws_compute_optimizer
 - aws_config
 - aws_connect
 - aws_cost_and_usage_report
-- aws_cost_anomaly_detection
 - aws_glue_data_catalog
 - aws_guardduty
 - aws_health
 - aws_iam_access_analyzer
 - aws_inspector
 - aws_macie
-- aws_organizations
 - aws_rds_performance_insights
 - aws_sagemaker
 - aws_savings_plans
@@ -846,21 +888,16 @@ doesn't conflict with concurrent PRs.
 - azure_service_health
 - azure_synapse
 - azure_table_storage
-- back_market
 - backblaze
 - basecamp
 - bcms
 - bexio
-- bigeye
 - billit
-- billomat
 - bitly
 - bitwarden
 - blackbaud_raisers_edge_nxt
 - blackboard_learn
 - bling
-- bloomerang
-- bluesky
 - bol_retailer
 - boulevard
 - box
@@ -875,14 +912,12 @@ doesn't conflict with concurrent PRs.
 - calendarific
 - calibre
 - campaign_manager_360
-- canvas_lms
 - captain_data
 - captivate
 - cart_com
 - cashfree
 - castor_edc
 - catchpoint
-- cdc_open_data
 - checkly
 - chift
 - chorus
@@ -894,12 +929,9 @@ doesn't conflict with concurrent PRs.
 - clay
 - clazar
 - cleartax
-- clever
 - clevertap
-- cliniko
 - clio
 - clip
-- cloudability
 - cloudbeds
 - cloudinary
 - clover
@@ -908,7 +940,6 @@ doesn't conflict with concurrent PRs.
 - codacy
 - codecov
 - collibra
-- companycam
 - constant_contact
 - conta_azul
 - contentsquare
@@ -918,7 +949,6 @@ doesn't conflict with concurrent PRs.
 - couchbase
 - crisp
 - criteo
-- crossref
 - crowdstrike_falcon
 - cube_cloud
 - curve
@@ -951,9 +981,7 @@ doesn't conflict with concurrent PRs.
 - dynamics365
 - dynamics_365_business_central
 - e2b
-- easybill
 - ebay
-- ecb_data_portal
 - eloqua
 - emarsys
 - embrace
@@ -963,7 +991,6 @@ doesn't conflict with concurrent PRs.
 - eurostat
 - expensify
 - facebook_pages
-- faire
 - faros_ai
 - fastbill
 - fauna
@@ -992,7 +1019,6 @@ doesn't conflict with concurrent PRs.
 - freshservice
 - frontegg
 - fulcrum
-- g2
 - gcore
 - gcp_apigee
 - gcp_artifact_registry
@@ -1030,7 +1056,6 @@ doesn't conflict with concurrent PRs.
 - ghost
 - gitea
 - givebutter
-- gleif
 - gmail
 - gnews
 - gojiberry
@@ -1063,18 +1088,15 @@ doesn't conflict with concurrent PRs.
 - heygen
 - hibob
 - high_level
-- hitpay
 - hivebrite
 - holded
 - honeybadger
 - honeycomb
 - hootsuite
 - hostaway
-- housecall_pro
 - hubplanner
 - humanitec
 - humanitix
-- hyros
 - ikas
 - illumina_basespace
 - imf_data
@@ -1097,7 +1119,6 @@ doesn't conflict with concurrent PRs.
 - keka
 - kestra
 - kick
-- kickscale
 - kickstarter
 - kinde
 - kion
@@ -1135,7 +1156,6 @@ doesn't conflict with concurrent PRs.
 - mercado_ads
 - mercado_pago
 - merge
-- meteostat
 - metricool
 - metriport
 - metronome
@@ -1156,7 +1176,6 @@ doesn't conflict with concurrent PRs.
 - microsoft_teams
 - microsoft_teams_call_records
 - midtrans
-- mighty_networks
 - mindbody
 - mintlify
 - mirakl
@@ -1168,10 +1187,8 @@ doesn't conflict with concurrent PRs.
 - mono
 - moodle
 - motion
-- moxie
 - msg91
 - mycase
-- nager_date
 - nasa
 - navan
 - neon_crm
@@ -1186,7 +1203,6 @@ doesn't conflict with concurrent PRs.
 - nolt
 - nops
 - northpass_lms
-- nuntly
 - nutshell
 - nylas
 - odoo
@@ -1197,9 +1213,7 @@ doesn't conflict with concurrent PRs.
 - onesignal
 - open_data_dc
 - open_dental
-- opencorporates
 - openfec
-- opn_payments
 - opslevel
 - oracle
 - oracle_ebs
@@ -1209,7 +1223,6 @@ doesn't conflict with concurrent PRs.
 - outlook
 - outreach
 - oveit
-- ownerrez
 - pagbank
 - pagerduty
 - patreon
@@ -1235,7 +1248,6 @@ doesn't conflict with concurrent PRs.
 - piwik
 - planning_center
 - plunk
-- pluralsight_flow
 - pocket
 - podbean
 - podium
@@ -1253,7 +1265,6 @@ doesn't conflict with concurrent PRs.
 - prompting_company
 - promptwatch
 - proofpoint_tap
-- propertyware
 - pubnub
 - qdrant
 - qonto
@@ -1277,7 +1288,6 @@ doesn't conflict with concurrent PRs.
 - retail_express
 - retell_ai
 - retently
-- reverb
 - revolut_merchant
 - ringcentral
 - rocket_chat
@@ -1305,15 +1315,12 @@ doesn't conflict with concurrent PRs.
 - search_ads_360
 - sec_edgar
 - secureframe
-- select_star
-- semantic_scholar
 - semaphore
 - semrush
 - sendpulse
 - senseforce
 - serpstat
 - service_fusion
-- servicem8
 - servicetitan
 - servicetrade
 - sevalla
@@ -1333,7 +1340,6 @@ doesn't conflict with concurrent PRs.
 - simplesat
 - simpro
 - sinch
-- singlestore
 - singular
 - site24x7
 - skyvern
@@ -1411,13 +1417,11 @@ doesn't conflict with concurrent PRs.
 - uploadcare
 - uppromote
 - uptick
-- us_bea
 - us_bls
 - us_eia
 - us_treasury_fiscal_data
 - uservoice
 - vanta
-- vendr
 - vespa
 - virtuous
 - visma_economic
@@ -1428,12 +1432,10 @@ doesn't conflict with concurrent PRs.
 - walmart_marketplace
 - wasabi
 - watchmode
-- waydev
 - wayfair
 - whatsapp_business_management
 - when_i_work
 - whmcs
-- who_gho
 - wikipedia_pageviews
 - windsor_ai
 - wisprflow
@@ -1442,7 +1444,6 @@ doesn't conflict with concurrent PRs.
 - wompi
 - workato
 - workflowmax
-- workiz
 - workramp
 - wufoo
 - xero
@@ -1459,7 +1460,6 @@ doesn't conflict with concurrent PRs.
 - zellify
 - zenefits
 - zenloop
-- zero
 - zitadel
 - zluri
 - zoho_analytics


### PR DESCRIPTION
## Problem

`SOURCES.md` is the authoritative inventory of every registered warehouse source and whether it is implemented. 47 sources were just implemented across 47 separate PRs, but each of those PRs deliberately left this file alone: 47 concurrent edits to one shared file would have conflicted with each other. So the inventory still lists all 47 as scaffolded stubs with no sync logic.

## Changes

- Adds a row to the Implemented sources table for each of the 47 sources, recording HTTP as the comm method and whether the source rides `rest_source.RESTClient` or plain `requests`.
- Removes those 47 names from the Scaffolded sources list.
- Touches nothing else. The diff is exactly 47 added table rows and 47 removed list lines.

**This PR must merge after the 47 source PRs.** On its own it would claim sources are implemented while master still has stubs. The source PRs are: asaas #84289, avalara #84313, aws_budgets #84475, aws_cost_anomaly_detection #84472, aws_organizations #84479, back_market #84287, bigeye #84310, billomat #84315, bloomerang #84314, bluesky #84321, canvas_lms #84326, cdc_open_data #84327, clever #84348, cliniko #84349, cloudability #84357, companycam #84361, crossref #84353, easybill #84464, ecb_data_portal #84358, faire #84362, g2 #84364, gleif #84371, hitpay #84393, housecall_pro #84372, hyros #84476, kickscale #84291, meteostat #84373, mighty_networks #84423, moxie #84463, nager_date #84422, nuntly #84286, opencorporates #84421, opn_payments #84425, ownerrez #84433, pluralsight_flow #84434, propertyware #84431, reverb #84436, select_star #84451, semantic_scholar #84450, servicem8 #84445, singlestore #84457, us_bea #84454, vendr #84453, waydev #84456, who_gho #84462, workiz #84471, zero #84477

## How did you test this code?

No tests: this is a documentation inventory change with no code in it.

Verified mechanically rather than by hand:

- Every added row names a source whose branch has a working `get_schemas` and passing tests.
- Confirmed the diff contains no removed table rows, so no existing row was reordered. The implemented table is not sorted in master, and re-sorting it would have churned ~94 unrelated lines.
- Confirmed the only changed table rows are the 47 new ones, by diffing the changed row names against the source list.
- Column widths match the surrounding rows.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This is an internal engineering inventory, not user-facing docs.
