### PR TITLE
fix(data-warehouse): stop requesting a day past freshness on google play console syncs

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_play_console/google_play_console.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_play_console/google_play_console.py
@@ -315,7 +315,12 @@ class GooglePlayConsoleClient:
         freshness_info = payload.get("freshnessInfo") or {}
         for freshness in freshness_info.get("freshnesses") or []:
             if freshness.get("aggregationPeriod") == AGGREGATION_PERIOD:
-                return _date_from_message(freshness.get("latestEndTime"))
+                # `latestEndTime` is already the exclusive bound Play expects back in
+                # `timelineSpec.endTime` (one day past the last day with data), so convert it to an
+                # inclusive date here — everything else in this module treats `latest` as inclusive
+                # and adds its own `+1 day` when building a query's endTime.
+                latest_end = _date_from_message(freshness.get("latestEndTime"))
+                return latest_end - dt.timedelta(days=1) if latest_end else None
         return None
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_play_console/tests/test_google_play_console.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_play_console/tests/test_google_play_console.py
@@ -266,6 +266,17 @@ def test_list_apps_follows_pagination() -> None:
     assert session.request.call_args_list[1].kwargs["params"]["pageToken"] == "t1"
 
 
+def test_latest_available_date_converts_the_exclusive_freshness_bound_to_an_inclusive_day() -> None:
+    # Play documents `latestEndTime` as already being the exclusive bound ready to reuse as
+    # `timelineSpec.endTime` (one day past the last day with data) — not the last day itself.
+    session = mock.MagicMock()
+    session.post.return_value = _token_response()
+    session.request.return_value = _response(200, _freshness(dt.date(2024, 3, 10)))
+    client = _client(session)
+
+    assert client.latest_available_date("com.example.app", "crashRateMetricSet") == dt.date(2024, 3, 9)
+
+
 @pytest.mark.parametrize(
     "dimension,expected",
     [
@@ -392,10 +403,11 @@ def test_metric_set_windows_the_timeline_and_stops_at_the_freshness_date() -> No
     timeline = query_bodies[0]["timelineSpec"] if query_bodies[0] else {}
     assert timeline["aggregationPeriod"] == "DAILY"
     assert timeline["startTime"] == {"year": 2024, "month": 3, "day": 1}
-    # The timeline end is exclusive, so the day after the freshness date is requested.
-    assert timeline["endTime"] == {"year": 2024, "month": 3, "day": 11}
+    # `_freshness` reports latestEndTime 2024-03-10, already Play's exclusive bound, so it is
+    # requested as-is rather than being pushed a further day out.
+    assert timeline["endTime"] == {"year": 2024, "month": 3, "day": 10}
     assert cast("dict[str, Any]", query_bodies[0])["dimensions"] == ["versionCode"]
-    assert manager.saved == [GooglePlayConsoleResumeConfig(app="com.example.app", date="2024-03-11")]
+    assert manager.saved == [GooglePlayConsoleResumeConfig(app="com.example.app", date="2024-03-10")]
 
 
 def test_metric_set_falls_back_to_a_lagged_end_date_without_freshness() -> None:
@@ -797,7 +809,9 @@ def test_metric_set_source_streams_rows_for_the_incremental_window() -> None:
 
     # The window starts at the stored watermark rather than the full history window.
     assert [row["date"] for batch in batches for row in batch] == [dt.date(2024, 3, 29)]
-    assert manager.saved[-1].date == "2024-03-31"
+    # `_freshness` reports latestEndTime 2024-03-30, already Play's exclusive bound, so the
+    # window closes out at 2024-03-29 and the checkpoint moves to the day after.
+    assert manager.saved[-1].date == "2024-03-30"
 
 
 def test_error_reports_always_carry_an_event_time_column() -> None:


### PR DESCRIPTION
## Problem

Google Play Console syncs (crash rate, ANR rate, error counts, and every other vitals metric set) fail on their final sync window with a 400 from the Play Developer Reporting API, surfaced in [error tracking](https://us.posthog.com/project/2/error_tracking/01a0155d-a228-70d0-8e68-5214150d745f) as an `HTTPError`. This reproduces on every affected sync, every run, since it always requests the same over-the-limit date.

## Changes

- `latest_available_date()` misreads the API's freshness report. Play's `latestEndTime` is already the exclusive bound meant to be reused directly as `timelineSpec.endTime` (one day past the last day with data), documented as such in the [FreshnessInfo reference](https://developers.google.com/play/developer/reporting/reference/rest/v1beta1/FreshnessInfo).
- The connector instead treated `latestEndTime` as the last available day and added its own `+1 day` when building the query, so the final window of every sync asked for one day beyond the true cutoff.
- Google rejected that request: `'timeline_spec.end_date' field should be at most the current freshness <date>`, confirmed from the connector's own warning logs at the point of the failing request.
- The fix subtracts one day when parsing `latestEndTime`, so the rest of the module's inclusive-date math stays correct.

## How did you test this code?

- Added `test_latest_available_date_converts_the_exclusive_freshness_bound_to_an_inclusive_day`, asserting the parsed date is one day before the raw `latestEndTime` value — this is the direct regression test for the off-by-one.
- Corrected two existing tests whose hardcoded expected dates encoded the old off-by-one behavior (`test_metric_set_windows_the_timeline_and_stops_at_the_freshness_date`, `test_metric_set_source_streams_rows_for_the_incremental_window`).
- Ran the full `test_google_play_console.py` suite (77 tests) locally; all pass.
- Ran `ruff check`/`ruff format` and `mypy` on the changed files; both clean.
- Not run: a live sync against the real Play Developer Reporting API — no test credentials available in this environment.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing config or behavior changed, only the internal date math for an alpha-release source.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a live error-tracking issue reported by webhook. Root cause confirmed by reading the connector source, cross-referencing Google's Play Developer Reporting API docs (`FreshnessInfo`, `TimelineSpec`), and pulling the connector's own warning logs (service `temporal-worker-data-warehouse`) to see the literal Google error body. Skills invoked: `/writing-tests` before adding/editing test cases, `/writing-pr-descriptions` before writing this body.