### PR TITLE
chore: recommend /simplify before opening PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -68,6 +68,7 @@
 - Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
 - Public OSS repo: no internal customers, incidents, or operational metrics.
 - Stack instead of stuffing: if the diff holds two or more separable steps (migration then behavior, rename then rewrite), open a stack rather than one big PR. See AGENTS.md, "Stacked PRs" and /stacking-prs.
+- Simplify before opening: if your agent has a behavior-preserving cleanup pass (Claude Code: `/simplify`), run it on a non-trivial diff before final tests and preflight, since it edits the tree. Skip it for small mechanical changes.
 - Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
 - Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
 - When a human directed the work, the PR must be attributable to that person, even if agent-assisted.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,13 +61,6 @@ Examples:
 - `chore(ci): update GitHub Actions workflow`
 - `chore: update AGENTS.md instructions`
 
-### Before opening a PR
-
-In Claude Code, run `/simplify` on a non-trivial agent-authored diff before opening the PR.
-It is a built-in cleanup pass that applies behavior-preserving refinements (reuse, simplification, efficiency) to the changed code.
-Run it before final tests and `ci:preflight`, since it edits the working tree.
-Skip it for small mechanical changes.
-
 ### PR descriptions
 
 **Required:** Before creating any PR, read `.github/pull_request_template.md` and use its exact section structure.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,13 @@ Examples:
 - `chore(ci): update GitHub Actions workflow`
 - `chore: update AGENTS.md instructions`
 
+### Before opening a PR
+
+In Claude Code, run `/simplify` on a non-trivial agent-authored diff before opening the PR.
+It is a built-in cleanup pass that applies behavior-preserving refinements (reuse, simplification, efficiency) to the changed code.
+Run it before final tests and `ci:preflight`, since it edits the working tree.
+Skip it for small mechanical changes.
+
 ### PR descriptions
 
 **Required:** Before creating any PR, read `.github/pull_request_template.md` and use its exact section structure.


### PR DESCRIPTION
## Problem

- Agent-authored diffs reach review with clutter a cleanup pass would catch: repetition, dead code, needless indirection.
- The PR template's agent rules cover drafts, stacking, and descriptions, but say nothing about refining the diff first.

## Changes

- The template's agent rules now say: run a behavior-preserving cleanup pass (Claude Code: `/simplify`) on a non-trivial diff before opening the PR.
- The advice is agent-generic; `/simplify` is named as the Claude Code example.
- The pass runs before final tests and preflight, since it edits the tree. Small mechanical changes are exempt.

## How did you test this code?

- Docs-only change. Checked formatting with oxfmt; `ci:preflight` reported no failures.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code session; skills invoked: /writing-user-facing-copy, /writing-pr-descriptions.
- First draft put the advice in AGENTS.md; moved to the PR template and made agent-generic on reviewer direction.
- Verified `/simplify` is built into current Claude Code: removed once, then restored as a cleanup-only review that applies fixes (per the Claude Code changelog).
