### PR TITLE
fix(cdp): classify Meta Graph code 190 refresh failures as invalid_grant

### DIFF
--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -307,6 +307,12 @@ def oauth_refresh_failure_reason(status_code: int, body: dict, kind: str | None 
     # `BAD_REFRESH_TOKEN` responses do carry `"error": "invalid_grant"` and need no special case.
     if kind == "hubspot" and status_code < 500 and body.get("status") == "BAD_HUB":
         return REFRESH_FAILURE_REASON_INVALID_GRANT
+    # Meta Graph nests its error as an object (`{"error": {"code": 190, ...}}`) and never
+    # sends the `invalid_grant` string. Code 190 means the access token is dead (password
+    # change, checkpoint, expiry, revocation). Without this mapping, a revoked Meta token
+    # classifies as `other`. Meta rate limits use codes 4, 17, and 32, which do not match.
+    if kind in ("meta-ads", "instagram") and status_code < 500 and isinstance(error, dict) and error.get("code") == 190:
+        return REFRESH_FAILURE_REASON_INVALID_GRANT
     # Transient throttling, not a credential problem: the backoff cap synchronises failed
     # integrations into retry herds that can trip a provider's per-second limit and take
     # healthy refreshes in the same second down with them.

--- a/posthog/models/test/test_integration_model.py
+++ b/posthog/models/test/test_integration_model.py
@@ -1125,6 +1125,30 @@ class TestOauthIntegrationModel(BaseTest):
             ),
             ("rate_limited", 429, {"status": "error", "errorType": "RATE_LIMIT"}, "hubspot", "rate_limited"),
             ("rate_limited_any_kind", 429, {}, None, "rate_limited"),
+            (
+                "meta_dead_token",
+                400,
+                {
+                    "error": {
+                        "message": "Error validating access token: The session has been invalidated because the user changed their password.",
+                        "type": "OAuthException",
+                        "code": 190,
+                        "error_subcode": 460,
+                    }
+                },
+                "meta-ads",
+                "invalid_grant",
+            ),
+            (
+                "instagram_dead_token",
+                400,
+                {"error": {"type": "OAuthException", "code": 190}},
+                "instagram",
+                "invalid_grant",
+            ),
+            ("meta_shape_on_other_kind", 400, {"error": {"code": 190}}, "hubspot", "other"),
+            ("meta_non_grant_error_code", 400, {"error": {"type": "OAuthException", "code": 10}}, "meta-ads", "other"),
+            ("meta_190_5xx_is_outage", 502, {"error": {"code": 190}}, "meta-ads", "http_5xx"),
         ]
     )
     def test_oauth_refresh_failure_reason(self, _name, status_code, body, kind, expected):


### PR DESCRIPTION
## Problem

On-call cannot tell a revoked Meta token from an unclassified provider error. Both count as refresh failure reason `other`.

- Meta Graph reports a dead access token as a nested object: `{"error": {"code": 190, ...}}`.
- The classifier only matches the flat string `"error": "invalid_grant"`, so no Meta failure ever classifies as a dead grant.
- The `CdpIntegrationOauthCustomerGrantFailure` alert and its runbook split on this reason label. When Meta tokens die, the label points at the wrong bucket.

## Changes

- `oauth_refresh_failure_reason` maps Meta Graph error code 190 to `invalid_grant` for the `meta-ads` and `instagram` kinds.
- Code 190 means the access token is dead: password change, account checkpoint, expiry, or revocation. Meta rate limits use codes 4, 17, and 32 and stay unmatched.
- The mapping follows the existing HubSpot `BAD_HUB` and Reddit numeric-400 cases: gated on kind, and on a non-5xx status so provider outages still classify as `http_5xx`.
- The change only affects the metric label and the failure counters. Meta kinds refresh on use and never consult the refresh sweep's backoff gate, so retry behavior is unchanged.
- Companion alert-wording change: PostHog/charts#14418.

## How did you test this code?

- 5 new parameterized rows in `test_oauth_refresh_failure_reason`, written first and watched fail.
- Regression caught: a revoked Meta token silently classifying as `other` again, which hides dead grants from the alert and the invalid_grant streak handling. No existing row exercised a nested error object with a kind.
- Guard rows: the Meta shape on another kind stays `other`, a non-190 code stays `other`, and a 5xx with a 190 body stays `http_5xx`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The runbook update lives in PostHog/charts#14418.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (Fable 5), directed by Harley. The change came out of investigating three firings of the grant-failure alert: metrics and Loki showed each was one customer's revoked Meta token, classified as `other`. Skills invoked: writing-tests, writing-code-comments (via review), asd-ste100, writing-pr-descriptions. Committed data is invented or generic: no customer identifiers from the session appear in the diff or this description.