### PR TITLE
fix(tasks): report repository clone failures correctly

### DIFF
--- a/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
@@ -24,6 +24,7 @@ from products.tasks.backend.exceptions import (
     CredentialUnavailableError,
     GitHubAuthenticationError,
     OAuthTokenError,
+    RepositoryCloneError,
     SandboxNetworkPolicyError,
     TaskNotFoundError,
 )
@@ -893,8 +894,20 @@ def clone_repository_in_sandbox(input: CloneRepositoryInSandboxInput) -> CloneRe
                     branch=None,
                 )
 
-        if clone_result.exit_code != 0:
-            raise RuntimeError(f"Failed to clone repository {input.repository}: {clone_result.stderr}")
+            if clone_result.exit_code != 0:
+                error_output = clone_result.stderr or clone_result.stdout or clone_result.error or "No output captured"
+                raise RepositoryCloneError(
+                    f"Git clone failed with exit code {clone_result.exit_code}",
+                    {
+                        "repository": input.repository,
+                        "sandbox_id": input.sandbox_id,
+                        "exit_code": clone_result.exit_code,
+                        "stderr": clone_result.stderr[:500],
+                        "stdout": clone_result.stdout[:500],
+                        "error": clone_result.error,
+                    },
+                    cause=RuntimeError(error_output[:200]),
+                )
 
         # A fresh single-repository run checks its requested branch out in the next
         # activity. Resumes clone that branch directly, and multi-repo runs do not run

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_provision_sandbox.py
@@ -9,6 +9,7 @@ from django.test import override_settings
 
 from asgiref.sync import async_to_sync
 
+from products.tasks.backend.exceptions import RepositoryCloneError
 from products.tasks.backend.logic.services.docker_sandbox import DockerSandbox
 from products.tasks.backend.logic.services.sandbox import ExecutionResult, Sandbox
 from products.tasks.backend.temporal.metrics import modal_sandbox_backend_label
@@ -302,3 +303,59 @@ def test_resume_clone_falls_back_to_default_branch_when_saved_branch_is_missing(
             branch=None,
         ),
     ]
+
+
+def test_clone_failure_records_failed_latency_and_captures_command_result(mocker, activity_environment):
+    context = TaskProcessingContext(
+        task_id="task-id",
+        run_id="run-id",
+        team_id=1,
+        team_uuid="team-uuid",
+        organization_id="organization-id",
+        github_integration_id=123,
+        repository="posthog/posthog",
+        distinct_id="distinct-id",
+        state={},
+    )
+    sandbox = mocker.Mock()
+    sandbox.clone_repository.return_value = ExecutionResult(
+        stdout="clone output",
+        stderr="",
+        exit_code=124,
+        error="execution stopped",
+    )
+    mocker.patch.object(Sandbox, "get_by_id", return_value=sandbox)
+    metric_meter = mocker.patch("products.tasks.backend.temporal.metrics._metric_meter")
+    capture_exception = mocker.patch("products.tasks.backend.exceptions.capture_exception")
+
+    with pytest.raises(RepositoryCloneError) as error:
+        async_to_sync(activity_environment.run)(
+            clone_repository_in_sandbox,
+            CloneRepositoryInSandboxInput(
+                context=context,
+                sandbox_id="sandbox-id",
+                repository="posthog/posthog",
+                github_token="github-token",
+                shallow_clone=True,
+            ),
+        )
+
+    assert "exit code 124" in str(error.value)
+    assert error.value.context == {
+        "repository": "posthog/posthog",
+        "sandbox_id": "sandbox-id",
+        "exit_code": 124,
+        "stderr": "",
+        "stdout": "clone output",
+        "error": "execution stopped",
+        "team": "array",
+    }
+    metric_meter.assert_called_once_with(
+        {
+            "step": "repository_clone",
+            "used_snapshot": "false",
+            "status": "FAILED",
+            "runtime": "gvisor",
+        }
+    )
+    assert str(capture_exception.call_args.args[0]) == "clone output"


### PR DESCRIPTION
## Problem

Repository clone commands that exit unsuccessfully appear as completed latency samples and omit useful command results from error tracking.

## Changes

- Raise the existing retryable clone error before latency timing ends.
- Capture the exit code and bounded command output.
- Cover the failed metric label and captured error context.


