### PR TITLE
chore(ci): show trunk lane in shared CI report

### DIFF
--- a/.github/scripts/post-ci-sections.test.mjs
+++ b/.github/scripts/post-ci-sections.test.mjs
@@ -3,7 +3,7 @@ import { describe, it } from 'node:test'
 
 import { buildDocsPreviewSection } from './post-docs-preview-section.mjs'
 import { buildHobbySection } from './post-hobby-section.mjs'
-import { buildTrunkLaneSection } from './post-trunk-lane-section.mjs'
+import { buildTrunkLaneSection, postTrunkLaneSection } from './post-trunk-lane-section.mjs'
 
 const commonHobby = {
     previewMode: true,
@@ -13,6 +13,33 @@ const commonHobby = {
 }
 
 describe('CI report section builders', () => {
+    for (const testCase of [
+        {
+            name: 'does not post a stale lane assignment',
+            expectedHeadSha: 'old-sha',
+            currentHeadSha: 'new-sha',
+            expectedPosts: 0,
+        },
+        {
+            name: 'posts the current lane assignment',
+            expectedHeadSha: 'current-sha',
+            currentHeadSha: 'current-sha',
+            expectedPosts: 1,
+        },
+    ]) {
+        it(testCase.name, async () => {
+            const postedSections = []
+            await postTrunkLaneSection({
+                impactedTargets: ['fe:core'],
+                isUniversal: false,
+                expectedHeadSha: testCase.expectedHeadSha,
+                getCurrentHeadSha: async () => testCase.currentHeadSha,
+                post: async (section) => postedSections.push(section),
+            })
+            assert.equal(postedSections.length, testCase.expectedPosts)
+        })
+    }
+
     for (const testCase of [
         {
             name: 'marks the universal lane red',

--- a/.github/scripts/post-ci-sections.test.mjs
+++ b/.github/scripts/post-ci-sections.test.mjs
@@ -3,6 +3,7 @@ import { describe, it } from 'node:test'
 
 import { buildDocsPreviewSection } from './post-docs-preview-section.mjs'
 import { buildHobbySection } from './post-hobby-section.mjs'
+import { buildTrunkLaneSection } from './post-trunk-lane-section.mjs'
 
 const commonHobby = {
     previewMode: true,
@@ -12,6 +13,28 @@ const commonHobby = {
 }
 
 describe('CI report section builders', () => {
+    for (const testCase of [
+        {
+            name: 'marks the universal lane red',
+            input: { impactedTargets: ['py:core', 'fe:core'], isUniversal: true },
+            expectedStatus: 'fail',
+        },
+        {
+            name: 'marks a backend Python lane yellow',
+            input: { impactedTargets: ['py:product:surveys'], isUniversal: false },
+            expectedStatus: 'warn',
+        },
+        {
+            name: 'marks other lanes green',
+            input: { impactedTargets: ['fe:core'], isUniversal: false },
+            expectedStatus: 'ok',
+        },
+    ]) {
+        it(testCase.name, () => {
+            assert.equal(buildTrunkLaneSection(testCase.input).status, testCase.expectedStatus)
+        })
+    }
+
     it('renders a docs preview link after a successful trigger', () => {
         const section = buildDocsPreviewSection({
             triggerStatus: 'success',

--- a/.github/scripts/post-trunk-lane-section.mjs
+++ b/.github/scripts/post-trunk-lane-section.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { pathToFileURL } from 'node:url'
 
-import { postSection } from '../../frontend/bin/ci-report/update-ci-report.mjs'
+import { gh, postSection, resolvePrContext } from '../../frontend/bin/ci-report/update-ci-report.mjs'
 
 export function buildTrunkLaneSection({ impactedTargets, isUniversal }) {
     if (
@@ -31,6 +31,31 @@ export function buildTrunkLaneSection({ impactedTargets, isUniversal }) {
     }
 }
 
+export async function postTrunkLaneSection({
+    impactedTargets,
+    isUniversal,
+    expectedHeadSha,
+    getCurrentHeadSha,
+    post = postSection,
+}) {
+    let currentHeadSha
+    try {
+        currentHeadSha = await getCurrentHeadSha()
+    } catch (error) {
+        console.warn(`Could not verify the current PR head: ${error.message}`)
+        return false
+    }
+
+    if (!expectedHeadSha || currentHeadSha !== expectedHeadSha) {
+        console.info(`Skipping stale Trunk lane assignment for ${expectedHeadSha || 'an unknown commit'}.`)
+        return false
+    }
+
+    const section = buildTrunkLaneSection({ impactedTargets, isUniversal })
+    await post({ id: 'trunk-lane', ...section })
+    return true
+}
+
 function parseJson(value) {
     try {
         const parsed = JSON.parse(value || '{}')
@@ -40,13 +65,26 @@ function parseJson(value) {
     }
 }
 
+async function getCurrentHeadSha() {
+    const context = resolvePrContext('checking the current PR head')
+    if (!context) {
+        return null
+    }
+    const pullRequest = await gh(context.token, `/repos/${context.repo}/pulls/${context.prNumber}`)
+    return pullRequest.head?.sha ?? null
+}
+
 async function main() {
     const impactedTargets = parseJson(process.env.IMPACTED_TARGETS).impactedTargets
     const laneProperties = parseJson(process.env.LANE_PROPERTIES)
     const isUniversal = typeof laneProperties.is_all === 'boolean' ? laneProperties.is_all : true
-    const section = buildTrunkLaneSection({ impactedTargets, isUniversal })
 
-    await postSection({ id: 'trunk-lane', ...section })
+    await postTrunkLaneSection({
+        impactedTargets,
+        isUniversal,
+        expectedHeadSha: process.env.EXPECTED_HEAD_SHA,
+        getCurrentHeadSha,
+    })
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/.github/scripts/post-trunk-lane-section.mjs
+++ b/.github/scripts/post-trunk-lane-section.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+import { pathToFileURL } from 'node:url'
+
+import { postSection } from '../../frontend/bin/ci-report/update-ci-report.mjs'
+
+export function buildTrunkLaneSection({ impactedTargets, isUniversal }) {
+    if (
+        isUniversal ||
+        !Array.isArray(impactedTargets) ||
+        !impactedTargets.every((target) => typeof target === 'string')
+    ) {
+        return {
+            status: 'fail',
+            summary: 'universal lane',
+            body: 'This PR is assigned to the universal lane. Trunk will merge it on its own.',
+        }
+    }
+
+    if (impactedTargets.some((target) => target.startsWith('py:'))) {
+        return {
+            status: 'warn',
+            summary: 'runs backend Python tests',
+            body: 'This PR is assigned to a lane that runs backend Python tests.',
+        }
+    }
+
+    return {
+        status: 'ok',
+        summary: 'does not run backend Python tests',
+        body: 'This PR is assigned to a lane that does not run backend Python tests.',
+    }
+}
+
+function parseJson(value) {
+    try {
+        const parsed = JSON.parse(value || '{}')
+        return parsed && typeof parsed === 'object' ? parsed : {}
+    } catch {
+        return {}
+    }
+}
+
+async function main() {
+    const impactedTargets = parseJson(process.env.IMPACTED_TARGETS).impactedTargets
+    const laneProperties = parseJson(process.env.LANE_PROPERTIES)
+    const isUniversal = typeof laneProperties.is_all === 'boolean' ? laneProperties.is_all : true
+    const section = buildTrunkLaneSection({ impactedTargets, isUniversal })
+
+    await postSection({ id: 'trunk-lane', ...section })
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    await main()
+}

--- a/.github/workflows/pr-housekeeping.yml
+++ b/.github/workflows/pr-housekeeping.yml
@@ -38,6 +38,9 @@ jobs:
         # can sit in draft long enough for the queue to have forgotten it.
         if: contains(fromJSON('["opened", "synchronize", "reopened", "ready_for_review"]'), github.event.action)
         uses: ./.github/workflows/trunk-impacted-targets.yml
+        permissions:
+            contents: read
+            pull-requests: write
         secrets:
             TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN }}
 

--- a/.github/workflows/trunk-impacted-targets.yml
+++ b/.github/workflows/trunk-impacted-targets.yml
@@ -24,7 +24,7 @@ name: Trunk impacted targets
 # secrets to code from untrusted forks ("pwn request"). The fork path
 # deliberately needs no secret, so `pull_request` is sufficient and safe.
 #
-# SECURITY: the two jobs below MUST stay separate, and `upload` MUST NOT check
+# SECURITY: `compute` and `upload` MUST stay separate. `upload` MUST NOT check
 # out or run anything from the PR. `compute` executes PR-controlled code (the
 # target script, and whatever the PR did to it), so it is kept free of secrets.
 # Splitting on a step boundary instead of a job boundary would not be enough:
@@ -248,3 +248,35 @@ jobs:
                       -X POST "$POSTHOG_TELEMETRY_HOST/i/v0/e/" \
                       -H "Content-Type: application/json" \
                       --data "$event" > /dev/null
+
+    comment:
+        name: Update Trunk lane in CI report
+        needs: [compute, upload]
+        if: github.event.pull_request.head.repo.full_name == github.repository && !startsWith(github.head_ref, 'trunk-merge/')
+        runs-on: ubuntu-24.04
+        timeout-minutes: 5
+        permissions:
+            contents: read
+            pull-requests: write
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  # Run only trusted base-branch code with the token that can edit PR comments.
+                  ref: ${{ github.event.pull_request.base.sha }}
+
+            - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+              with:
+                  node-version-file: .nvmrc
+                  token: ${{ github.token }}
+
+            - name: Post Trunk lane to CI report
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}
+                  IMPACTED_TARGETS: ${{ needs.compute.outputs.targets }}
+                  LANE_PROPERTIES: ${{ needs.compute.outputs.telemetry }}
+              run: |
+                  if [ -f .github/scripts/post-trunk-lane-section.mjs ]; then
+                      node .github/scripts/post-trunk-lane-section.mjs
+                  else
+                      echo "::warning::Skipping the Trunk lane section because the trusted base does not contain its poster."
+                  fi

--- a/.github/workflows/trunk-impacted-targets.yml
+++ b/.github/workflows/trunk-impacted-targets.yml
@@ -133,6 +133,8 @@ jobs:
         # Talks only to Trunk. It never checks out the repo, so it needs no
         # GitHub permissions whatsoever.
         permissions: {}
+        outputs:
+            uploaded: ${{ steps.upload.outputs.uploaded }}
         env:
             IS_FORK: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
             RUN_ID: ${{ github.run_id }}
@@ -145,6 +147,7 @@ jobs:
             TARGET_BRANCH: ${{ github.event.pull_request.base.ref }}
         steps:
             - name: Upload impacted targets to Trunk
+              id: upload
               # Not continue-on-error: a silent failure here is exactly what keeps
               # fork PRs out of the queue, so surface upload problems loudly.
               # --retry rides out transient Trunk/network blips.
@@ -191,6 +194,7 @@ jobs:
                       -H "$auth_header" \
                       --data "$payload" \
                       --output "$RUNNER_TEMP/trunk-response.json"
+                  echo 'uploaded=true' >> "$GITHUB_OUTPUT"
 
             # Lane-cost telemetry. Runs here rather than in `compute` because
             # `compute` executes PR-controlled code and is deliberately kept free
@@ -252,7 +256,16 @@ jobs:
     comment:
         name: Update Trunk lane in CI report
         needs: [compute, upload]
-        if: github.event.pull_request.head.repo.full_name == github.repository && !startsWith(github.head_ref, 'trunk-merge/')
+        if: >-
+            ${{
+                !cancelled() &&
+                needs.upload.outputs.uploaded == 'true' &&
+                github.event.pull_request.head.repo.full_name == github.repository &&
+                !startsWith(github.head_ref, 'trunk-merge/')
+            }}
+        concurrency:
+            group: trunk-lane-report-${{ github.event.pull_request.number }}
+            cancel-in-progress: true
         runs-on: ubuntu-24.04
         timeout-minutes: 5
         permissions:
@@ -272,6 +285,7 @@ jobs:
             - name: Post Trunk lane to CI report
               env:
                   GITHUB_TOKEN: ${{ github.token }}
+                  EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
                   IMPACTED_TARGETS: ${{ needs.compute.outputs.targets }}
                   LANE_PROPERTIES: ${{ needs.compute.outputs.telemetry }}
               run: |

--- a/frontend/bin/ci-report/update-ci-report.mjs
+++ b/frontend/bin/ci-report/update-ci-report.mjs
@@ -14,6 +14,7 @@ export const MARKER = '<!-- posthog-ci-report -->'
 // Adding a check means adding it here — that is deliberate: it keeps the order a
 // reviewed decision rather than an accident of which job happened to write first.
 export const SECTIONS = [
+    { id: 'trunk-lane', title: 'Trunk lane' },
     { id: 'bundle-size', title: 'Bundle size' },
     { id: 'eager-graph', title: 'Eager graph' },
     { id: 'toolbar-size', title: 'Toolbar bundle' },


### PR DESCRIPTION
> 🤖 Robot-created PR.

## Problem

PR reviewers cannot see which Trunk merge lane a PR uses from the shared CI report.

## Changes

Before:

```mermaid
flowchart LR
    A[Changed files] --> B[Compute targets]
    B --> C[Upload to Trunk]
```

After:

```mermaid
flowchart LR
    A[Changed files] --> B[Compute targets]
    B --> C[Upload to Trunk]
    C --> D[Update shared CI report]
```

- The shared report now includes a **Trunk lane** section.
- Universal lanes show red, backend Python lanes show yellow, and other lanes show green.
- Failed target computation reports the universal fallback after Trunk accepts it.
- Older PR events cannot overwrite the current lane assignment.
- The comment job runs trusted base-branch code because its token can edit PR comments.

## How did you test this code?

- Added parameterized Node tests for lane colors and stale assignments.
- Ran the CI report section tests, workflow convention lint, actionlint, and `hogli ci:preflight --fix` locally.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs update. This change only affects the shared CI report comment.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi used repository read, edit, test, lint, signed commit, and GitHub tools. It invoked `/authoring-ci-workflows`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-code-comments`, `/writing-pr-descriptions`, and `/triaging-visual-review-runs`.
