### PR TITLE
fix(llma): keep per-call fees at the served price

### DIFF
--- a/nodejs/src/ingestion/pipelines/ai/costs/scripts/update-ai-costs.test.ts
+++ b/nodejs/src/ingestion/pipelines/ai/costs/scripts/update-ai-costs.test.ts
@@ -2,6 +2,7 @@ import fs from 'fs'
 import path from 'path'
 
 import { parseJSON } from '~/common/utils/json-parse'
+import type { ModelCost } from '~/ingestion/pipelines/ai/costs/providers/types'
 
 import {
     type BuiltModelRow,
@@ -198,12 +199,10 @@ describe('buildModelCost() discount handling', () => {
         })
     })
 
-    it('leaves a flat fee alone whatever the rate', () => {
-        for (const discount of [-0.25, 0, 0.1, 0.41, 0.5, 0.9]) {
-            expect(
-                buildModelCost({ prompt: '0.000001', completion: '0.000006', web_search: '0.01', discount })
-            ).toEqual(expect.objectContaining({ web_search: 0.01 }))
-        }
+    it.each([-0.25, 0, 0.1, 0.41, 0.5, 0.9])('leaves a flat fee alone at a rate of %d', (discount) => {
+        expect(buildModelCost({ prompt: '0.000001', completion: '0.000006', web_search: '0.01', discount })).toEqual(
+            expect.objectContaining({ web_search: 0.01 })
+        )
     })
 
     it('does not adjust prices when the rate is out of range', () => {
@@ -248,7 +247,10 @@ describe('FLAT_FEE_FIELDS is bound to the field list it filters', () => {
         ])
     })
 
-    const policy: Record<string, 'flat' | 'de-discounted'> = {
+    // Partial, so the absent-policy guard below is type-honest. A stray key
+    // outside `keyof ModelCost` fails to compile; one inside it but outside the
+    // loop fails the keys-equality test.
+    const policy: Partial<Record<keyof ModelCost, 'flat' | 'de-discounted'>> = {
         cache_read_token: 'de-discounted',
         cache_write_token: 'de-discounted',
         request: 'flat',
@@ -495,19 +497,14 @@ describe('renderDiscountReport()', () => {
     it('says that per-call fees are not de-discounted', () => {
         const report = renderDiscountReport([entry()])
         expect(report).toContain(
-            'Per-call fees (`request`, `web_search`) carry across untouched: OpenRouter charges the\n' +
-                'same for them on a promotional route as on its undiscounted sibling.'
+            'Per-call fees (`request`, `web_search`) carry across untouched: promotional routes in\n' +
+                'the feed serve `web_search` at the same fee as their undiscounted siblings,\n' +
+                'and every other per-call fee follows the same policy.'
         )
     })
 
-    it('builds the flat-fee list from the set it is given, sorted', () => {
-        // A set the real one lacks, in an order sorting must change: retyping the
-        // sentence or dropping the sort both fail here.
-        const report = renderDiscountReport([entry()], 0, new Set(['web_search', 'image']))
-        expect(report).toContain('Per-call fees (`image`, `web_search`) carry across untouched')
-    })
-
-    it('names the real flat fees when no set is given', () => {
+    it('derives the flat-fee list from FLAT_FEE_FIELDS', () => {
+        // The literal pin above catches a retyped sentence; this binds it to the set.
         expect(renderDiscountReport([entry()])).toContain(
             `Per-call fees (${[...FLAT_FEE_FIELDS]
                 .sort()
@@ -989,8 +986,6 @@ describe('writeOutputs()', () => {
 
         const [, body] = writes.find(([f]) => f === summaryPath)!
         expect(body).toContain('openai/gpt-5.6-luna')
-        // Pins that the real run does not override the injectable set.
-        expect(body).toContain('Per-call fees (`request`, `web_search`)')
         expect(body).not.toContain('No discounted endpoints found')
     })
 

--- a/nodejs/src/ingestion/pipelines/ai/costs/scripts/update-ai-costs.test.ts
+++ b/nodejs/src/ingestion/pipelines/ai/costs/scripts/update-ai-costs.test.ts
@@ -9,6 +9,8 @@ import {
     DISCOUNT_SUMMARY_ENV,
     type DiscountReportEntry,
     type EndpointCandidate,
+    FLAT_FEE_FIELDS,
+    OPTIONAL_PRICING_FIELDS,
     type RunTotals,
     UNCHECKED_WARN_FRACTION,
     accumulateModelRow,
@@ -176,14 +178,15 @@ describe('buildModelCost() discount handling', () => {
         })
     })
 
-    it('applies the rate uniformly to every field, flat fees included', () => {
-        // web_search is a per-call fee and is discounted at the same ratio.
+    it('de-discounts the per-token rates but carries flat fees across untouched', () => {
+        // A promotional route serves web_search at the same price as its undiscounted sibling.
         expect(
             buildModelCost({
                 prompt: '0.0000005',
                 completion: '0.000003',
                 input_cache_read: '0.00000005',
-                web_search: '0.005',
+                web_search: '0.01',
+                request: '0.004',
                 discount: 0.5,
             })
         ).toEqual({
@@ -191,7 +194,16 @@ describe('buildModelCost() discount handling', () => {
             completion_token: 0.000006,
             cache_read_token: 0.0000001,
             web_search: 0.01,
+            request: 0.004,
         })
+    })
+
+    it('leaves a flat fee alone whatever the rate', () => {
+        for (const discount of [-0.25, 0, 0.1, 0.41, 0.5, 0.9]) {
+            expect(
+                buildModelCost({ prompt: '0.000001', completion: '0.000006', web_search: '0.01', discount })
+            ).toEqual(expect.objectContaining({ web_search: 0.01 }))
+        }
     })
 
     it('does not adjust prices when the rate is out of range', () => {
@@ -207,6 +219,66 @@ describe('buildModelCost() discount handling', () => {
             prompt_token: 0.000002,
             completion_token: 0.000012,
         })
+    })
+})
+
+describe('FLAT_FEE_FIELDS is bound to the field list it filters', () => {
+    // Neither direction is a type error: a member outside the loop is dead, and a
+    // loop field outside the set is silently de-discounted.
+    const targetFields = OPTIONAL_PRICING_FIELDS.map(([targetField]) => targetField)
+
+    it.each([...FLAT_FEE_FIELDS])('%s is a field the loop actually reads', (field) => {
+        expect(targetFields).toContain(field)
+    })
+
+    it('reads the OpenRouter field names this list claims to read', () => {
+        // Spelled out rather than derived: every other assertion feeds the source name
+        // back into its own fixture, so only a literal catches a typo or a dropped pair.
+        expect(OPTIONAL_PRICING_FIELDS).toEqual([
+            ['cache_read_token', 'input_cache_read'],
+            ['cache_write_token', 'input_cache_write'],
+            ['request', 'request'],
+            ['web_search', 'web_search'],
+            ['image', 'image'],
+            ['image_output', 'image_output'],
+            ['audio', 'audio'],
+            ['audio_output', 'audio_output'],
+            ['input_audio_cache', 'input_audio_cache'],
+            ['internal_reasoning', 'internal_reasoning'],
+        ])
+    })
+
+    const policy: Record<string, 'flat' | 'de-discounted'> = {
+        cache_read_token: 'de-discounted',
+        cache_write_token: 'de-discounted',
+        request: 'flat',
+        web_search: 'flat',
+        image: 'de-discounted',
+        image_output: 'de-discounted',
+        audio: 'de-discounted',
+        audio_output: 'de-discounted',
+        input_audio_cache: 'de-discounted',
+        internal_reasoning: 'de-discounted',
+    }
+
+    it('declares a policy for every field the loop reads, and no others', () => {
+        expect(Object.keys(policy).sort()).toEqual([...targetFields].sort())
+    })
+
+    it.each(OPTIONAL_PRICING_FIELDS)('%s is priced as its declared policy says', (targetField, sourceField) => {
+        const expected = policy[targetField]
+        // A loop field with no policy here fails rather than silently inheriting the de-discount.
+        expect(expected).toBeTruthy()
+
+        const built = buildModelCost({
+            prompt: '0.000001',
+            completion: '0.000001',
+            [sourceField]: '0.01',
+            discount: 0.5,
+        })
+
+        expect(built?.[targetField]).toBe(expected === 'flat' ? 0.01 : 0.02)
+        expect(FLAT_FEE_FIELDS.has(targetField)).toBe(expected === 'flat')
     })
 })
 
@@ -418,6 +490,30 @@ describe('renderDiscountReport()', () => {
 
     it('says so plainly when nothing is discounted', () => {
         expect(renderDiscountReport([])).toContain('No discounted endpoints found')
+    })
+
+    it('says that per-call fees are not de-discounted', () => {
+        const report = renderDiscountReport([entry()])
+        expect(report).toContain(
+            'Per-call fees (`request`, `web_search`) carry across untouched: OpenRouter charges the\n' +
+                'same for them on a promotional route as on its undiscounted sibling.'
+        )
+    })
+
+    it('builds the flat-fee list from the set it is given, sorted', () => {
+        // A set the real one lacks, in an order sorting must change: retyping the
+        // sentence or dropping the sort both fail here.
+        const report = renderDiscountReport([entry()], 0, new Set(['web_search', 'image']))
+        expect(report).toContain('Per-call fees (`image`, `web_search`) carry across untouched')
+    })
+
+    it('names the real flat fees when no set is given', () => {
+        expect(renderDiscountReport([entry()])).toContain(
+            `Per-call fees (${[...FLAT_FEE_FIELDS]
+                .sort()
+                .map((field) => `\`${field}\``)
+                .join(', ')}) carry across untouched`
+        )
     })
 
     it('names each discounted model, endpoint and rate', () => {
@@ -893,6 +989,8 @@ describe('writeOutputs()', () => {
 
         const [, body] = writes.find(([f]) => f === summaryPath)!
         expect(body).toContain('openai/gpt-5.6-luna')
+        // Pins that the real run does not override the injectable set.
+        expect(body).toContain('Per-call fees (`request`, `web_search`)')
         expect(body).not.toContain('No discounted endpoints found')
     })
 

--- a/nodejs/src/ingestion/pipelines/ai/costs/scripts/update-ai-costs.ts
+++ b/nodejs/src/ingestion/pipelines/ai/costs/scripts/update-ai-costs.ts
@@ -3,21 +3,7 @@ import bigDecimal from 'js-big-decimal'
 import path from 'path'
 
 import { normalizeProviderKey } from '~/ingestion/pipelines/ai/costs/provider-matching'
-
-interface ModelCost {
-    prompt_token: number
-    completion_token: number
-    cache_read_token?: number
-    cache_write_token?: number
-    request?: number
-    web_search?: number
-    image?: number
-    image_output?: number
-    audio?: number
-    audio_output?: number
-    input_audio_cache?: number
-    internal_reasoning?: number
-}
+import type { ModelCost } from '~/ingestion/pipelines/ai/costs/providers/types'
 
 interface ModelRow {
     model: string
@@ -57,11 +43,16 @@ const parsePricingNumber = (value: unknown): number | undefined => {
     }
 }
 
-/** OpenRouter charges these at the same price on a promotional route as on its
- * undiscounted sibling, so there is no rate to divide out. */
+/** Carried at the served price: the live feed corroborates this for `web_search`,
+ * where promotional routes serve the same fee as their undiscounted siblings. It
+ * corroborates neither `request` (no model in the feed carries a non-zero fee)
+ * nor a markup route (a negative rate has no sibling); both stay flat by policy. */
 export const FLAT_FEE_FIELDS: ReadonlySet<keyof ModelCost> = new Set(['request', 'web_search'])
 
-/** A field added here and not to `FLAT_FEE_FIELDS` is de-discounted by default. */
+/** A field added here and not to `FLAT_FEE_FIELDS` is de-discounted by default.
+ * `cache_write_1h_token` has no pair on purpose: OpenRouter serves no 1h write
+ * rate. Book-priced events fall back to 2x `prompt_token` (input-costs.ts); only
+ * the custom-pricing path reads it from event properties. */
 export const OPTIONAL_PRICING_FIELDS: ReadonlyArray<[keyof ModelCost, string]> = [
     ['cache_read_token', 'input_cache_read'],
     ['cache_write_token', 'input_cache_write'],
@@ -202,12 +193,7 @@ export const sanitizeReportCell = (value: string): string =>
 
 /** Renders promotions as line items in the generated PR. `uncheckedModels` is
  * reported too, so a bare "no discounts" cannot read as a verified negative. */
-export const renderDiscountReport = (
-    entries: DiscountReportEntry[],
-    uncheckedModels = 0,
-    /** Injectable so a test can prove the sentence is derived, not retyped. */
-    flatFeeFields: ReadonlySet<keyof ModelCost> = FLAT_FEE_FIELDS
-): string => {
+export const renderDiscountReport = (entries: DiscountReportEntry[], uncheckedModels = 0): string => {
     const unchecked =
         uncheckedModels > 0
             ? `\n${uncheckedModels} model(s) could not be checked (endpoint pricing unavailable); their prices may still carry a promotion.\n`
@@ -223,7 +209,7 @@ export const renderDiscountReport = (
     const checkable = verdicts.filter((v) => v.some((c) => c !== 'not-checkable')).length
     const endpointCount = rows.reduce((total, row) => total + row.endpoints.length, 0)
 
-    const flatFeeList = [...flatFeeFields]
+    const flatFeeList = [...FLAT_FEE_FIELDS]
         .sort()
         .map((field) => `\`${field}\``)
         .join(', ')
@@ -234,8 +220,9 @@ export const renderDiscountReport = (
         `OpenRouter is running a promotion on **${endpointCount} endpoint(s)** across **${rows.length} model(s)**.`,
         'Per-provider keys below are stored at list rate, with the promotion divided back',
         'out, so a provider key keeps meaning what that provider charges a direct caller.',
-        `Per-call fees (${flatFeeList}) carry across untouched: OpenRouter charges the`,
-        'same for them on a promotional route as on its undiscounted sibling.',
+        `Per-call fees (${flatFeeList}) carry across untouched: promotional routes in`,
+        'the feed serve `web_search` at the same fee as their undiscounted siblings,',
+        'and every other per-call fee follows the same policy.',
         'The `default` key is left as OpenRouter serves it.',
         '',
         `Independently confirmed against an undiscounted sibling route: ${confirmed}/${checkable} checkable model(s).`,

--- a/nodejs/src/ingestion/pipelines/ai/costs/scripts/update-ai-costs.ts
+++ b/nodejs/src/ingestion/pipelines/ai/costs/scripts/update-ai-costs.ts
@@ -57,6 +57,24 @@ const parsePricingNumber = (value: unknown): number | undefined => {
     }
 }
 
+/** OpenRouter charges these at the same price on a promotional route as on its
+ * undiscounted sibling, so there is no rate to divide out. */
+export const FLAT_FEE_FIELDS: ReadonlySet<keyof ModelCost> = new Set(['request', 'web_search'])
+
+/** A field added here and not to `FLAT_FEE_FIELDS` is de-discounted by default. */
+export const OPTIONAL_PRICING_FIELDS: ReadonlyArray<[keyof ModelCost, string]> = [
+    ['cache_read_token', 'input_cache_read'],
+    ['cache_write_token', 'input_cache_write'],
+    ['request', 'request'],
+    ['web_search', 'web_search'],
+    ['image', 'image'],
+    ['image_output', 'image_output'],
+    ['audio', 'audio'],
+    ['audio_output', 'audio_output'],
+    ['input_audio_cache', 'input_audio_cache'],
+    ['internal_reasoning', 'internal_reasoning'],
+]
+
 /** A provider key means what that provider charges a direct caller, so whatever
  * OpenRouter applied is divided back out. A negative `discount_to_user` is a
  * markup and the same division recovers list; only a rate at or above 1 is
@@ -109,8 +127,6 @@ export const buildModelCost = (pricing: Record<string, unknown> | undefined, con
         return null
     }
 
-    // The rate applies to every field, flat fees included: a 50%-off route serves
-    // web_search at 0.005 against 0.01 on its undiscounted sibling.
     const discount = parseDiscountRate(pricing, context)
     const toListPrice = (value: number): number =>
         discount === 0 ? value : parseFloat((value / (1 - discount)).toPrecision(10))
@@ -120,23 +136,10 @@ export const buildModelCost = (pricing: Record<string, unknown> | undefined, con
         completion_token: toListPrice(completionToken),
     }
 
-    const optionalPricingFields: Array<[keyof ModelCost, string]> = [
-        ['cache_read_token', 'input_cache_read'],
-        ['cache_write_token', 'input_cache_write'],
-        ['request', 'request'],
-        ['web_search', 'web_search'],
-        ['image', 'image'],
-        ['image_output', 'image_output'],
-        ['audio', 'audio'],
-        ['audio_output', 'audio_output'],
-        ['input_audio_cache', 'input_audio_cache'],
-        ['internal_reasoning', 'internal_reasoning'],
-    ]
-
-    for (const [targetField, sourceField] of optionalPricingFields) {
+    for (const [targetField, sourceField] of OPTIONAL_PRICING_FIELDS) {
         const parsedValue = parsePricingNumber(pricing[sourceField])
         if (parsedValue !== undefined && parsedValue !== 0) {
-            cost[targetField] = toListPrice(parsedValue)
+            cost[targetField] = FLAT_FEE_FIELDS.has(targetField) ? parsedValue : toListPrice(parsedValue)
         }
     }
 
@@ -199,7 +202,12 @@ export const sanitizeReportCell = (value: string): string =>
 
 /** Renders promotions as line items in the generated PR. `uncheckedModels` is
  * reported too, so a bare "no discounts" cannot read as a verified negative. */
-export const renderDiscountReport = (entries: DiscountReportEntry[], uncheckedModels = 0): string => {
+export const renderDiscountReport = (
+    entries: DiscountReportEntry[],
+    uncheckedModels = 0,
+    /** Injectable so a test can prove the sentence is derived, not retyped. */
+    flatFeeFields: ReadonlySet<keyof ModelCost> = FLAT_FEE_FIELDS
+): string => {
     const unchecked =
         uncheckedModels > 0
             ? `\n${uncheckedModels} model(s) could not be checked (endpoint pricing unavailable); their prices may still carry a promotion.\n`
@@ -215,12 +223,19 @@ export const renderDiscountReport = (entries: DiscountReportEntry[], uncheckedMo
     const checkable = verdicts.filter((v) => v.some((c) => c !== 'not-checkable')).length
     const endpointCount = rows.reduce((total, row) => total + row.endpoints.length, 0)
 
+    const flatFeeList = [...flatFeeFields]
+        .sort()
+        .map((field) => `\`${field}\``)
+        .join(', ')
+
     const lines = [
         '## Discounts',
         '',
         `OpenRouter is running a promotion on **${endpointCount} endpoint(s)** across **${rows.length} model(s)**.`,
         'Per-provider keys below are stored at list rate, with the promotion divided back',
         'out, so a provider key keeps meaning what that provider charges a direct caller.',
+        `Per-call fees (${flatFeeList}) carry across untouched: OpenRouter charges the`,
+        'same for them on a promotional route as on its undiscounted sibling.',
         'The `default` key is left as OpenRouter serves it.',
         '',
         `Independently confirmed against an undiscounted sibling route: ${confirmed}/${checkable} checkable model(s).`,


### PR DESCRIPTION
## Problem

Web search is billed above its real price on any event that names a provider. OpenRouter runs promotions on per-token rates but charges the same per-call `web_search` fee on a promotional route as on an undiscounted one, and the cost sync divides the promotion back out of every pricing field, inflating the fee by 1/(1 - discount). As of 2026-08-19 that is 19 price-book keys, 15 at 2x and 4 at 4x, and it deepens as the promotion does. Events with `$ai_provider: 'openrouter'` resolve to the `default` key, which keeps the served price, so only events naming a real provider are affected.

The affected keys are already in the price book, so this is live rather than pending.

## Changes

Adds a flat-fee carve-out to the de-discount step.

- **`FLAT_FEE_FIELDS`** (`web_search`, `request`) is carried across at the served price; every per-unit rate still has the promotion divided out.
- The generated cost-PR body renders that field list from the set rather than a retyped literal.
- The field list moves to module scope as `OPTIONAL_PRICING_FIELDS`, which lets a test bind it to the carve-out set.
- The script's private `ModelCost` copy is replaced by the canonical type from `providers/types.ts`; the sync deliberately never fills `cache_write_1h_token`, since OpenRouter serves no 1h write rate.

**Merging changes no stored price.** `llm-costs.json` is regenerated by the twice-daily sync, so corrected rates land on the next scheduled run.

## How did you test this code?

Ran the sync against the live OpenRouter API and diffed the regenerated price book against master: every affected key (16 at the time) dropped to the served rate, and no other `web_search` key moved. The carve-out was grounded in a feed where `google/gemini-3.7-flash` served `web_search` at the same `0.014` on its 50%-off route and its undiscounted sibling; the promotion has since deepened to 75% on the Vertex routes and no undiscounted sibling remains, which is what puts four keys at 4x.

New tests cover what nothing covered before:

- each of the ten optional rate fields against its declared policy, so a new per-call fee cannot silently inherit the de-discount
- the carve-out set against the field list in both directions, so neither a dead member nor a dropped pair passes
- the field list against the literal OpenRouter field names, the only thing catching a typo in eight of them
- a markup route, where the rate is negative

Reverting the carve-out reddens eight of them.

Not done: no manual verification against a deployed environment.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Opus 5 in Claude Code and put through four rounds of automated adversarial review, each attacking the previous round's fixes. Requires human review.

Left out of scope: `confirmDiscountAgainstSiblings` corroborates only `prompt_token` against an undiscounted sibling, which is why this mispricing shipped with a "confirmed" verdict. Extending it to flat fees would make a future change in OpenRouter's promotion policy visible instead of silent.
