### PR TITLE
chore(tasks): bump sandbox git to 2.49.1

### DIFF
--- a/products/tasks/backend/sandbox/images/Dockerfile.sandbox-base
+++ b/products/tasks/backend/sandbox/images/Dockerfile.sandbox-base
@@ -40,6 +40,8 @@ RUN apt-get update && \
     redis-tools \
     # System libraries often needed by Python packages
     libssl-dev \
+    libcurl4-gnutls-dev \
+    libexpat1-dev \
     libffi-dev \
     libbz2-dev \
     libreadline-dev \
@@ -49,11 +51,26 @@ RUN apt-get update && \
     tk-dev \
     libxml2-dev \
     libxmlsec1-dev \
+    zlib1g-dev \
     # Other useful tools
     ca-certificates \
     gnupg \
     sudo \
     && rm -rf /var/lib/apt/lists/*
+
+ARG GIT_VERSION=2.49.1
+ARG GIT_SHA256=310831de967f1c8c5e8ff55f92807dea89f83dc3d3d2a5d16c209bd01a31def1
+RUN set -eux; \
+    curl -fsSL -o /tmp/git.tar.xz \
+      "https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.xz"; \
+    echo "${GIT_SHA256}  /tmp/git.tar.xz" | sha256sum -c -; \
+    mkdir /tmp/git; \
+    tar -xf /tmp/git.tar.xz -C /tmp/git --strip-components=1; \
+    make -C /tmp/git prefix=/usr NO_GETTEXT=YesPlease NO_TCLTK=YesPlease -j"$(nproc)" all; \
+    make -C /tmp/git prefix=/usr NO_GETTEXT=YesPlease NO_TCLTK=YesPlease install; \
+    rm -rf /tmp/git /tmp/git.tar.xz; \
+    git --version; \
+    git help -a | grep -q '[[:space:]]backfill'
 
 # Install Node.js 24.x
 RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - && \


### PR DESCRIPTION
## Problem

Cloud-task sandboxes use Git 2.43, which cannot run `git backfill`.

## Changes

- Pin Git 2.49.1 in the standard sandbox base image.
- Verify the image build exposes `git backfill`.

## How did you test this code?

- Built Git 2.49.1 in an Ubuntu 24.04 ARM64 container and confirmed `git backfill` is registered.
- Ran `hogli ci:preflight --fix`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented and validated the change using `/github:yeet`, `/writing-pr-descriptions`, and `/running-ci-preflight`.