### PR TITLE
chore(tasks): bump sandbox gh to 2.97.0

### DIFF
--- a/products/tasks/backend/sandbox/images/Dockerfile.sandbox-base
+++ b/products/tasks/backend/sandbox/images/Dockerfile.sandbox-base
@@ -75,7 +75,7 @@ RUN UV_TOOL_BIN_DIR=/usr/local/bin uv tool install "ruff==${RUFF_VERSION}" && \
     ty --version
 
 # Install GitHub CLI without adding another apt repository refresh.
-ARG GH_CLI_VERSION=2.93.0
+ARG GH_CLI_VERSION=2.97.0
 RUN set -eux; \
     arch="$(dpkg --print-architecture)"; \
     curl -fsSL -o /tmp/gh.deb \


### PR DESCRIPTION
## Problem

Cloud-task sandboxes ship GitHub CLI 2.93.0 instead of the current 2.97.0 release.