### PR TITLE
fix(meta_ads): stop retrying invalid attribution window config

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/source.py
@@ -142,6 +142,17 @@ class MetaAdsSource(ResumableSource[MetaAdsSourceConfig, MetaAdsResumeConfig], O
                 "widening OAuth consent for every customer. Re-authorizing will not fix this — "
                 "contact PostHog support if this table keeps failing."
             ),
+            # Graph API code 100: the source's "Attribution windows for insights" setting (a
+            # free-text field, see `SourceFieldInputConfig` above) contains a value Meta's
+            # Insights API doesn't recognise. Retrying resends the same invalid parameter, so
+            # only editing the source config fixes it. Matches the message regardless of which
+            # array index Meta reports as invalid.
+            "action_attribution_windows[": (
+                'Meta rejected the "Attribution windows for insights" setting on this source — one '
+                "of the configured values isn't a window Meta supports (e.g. 1d_click, 7d_click, "
+                "28d_click, 1d_view, 7d_view, 28d_view). Fix it in your Meta Ads source settings, "
+                "then run the sync again."
+            ),
             # Meta returns this 500 when the requested query is too large for their backend to
             # service. Both pagination paths adapt to it (stats chunks shrink 30 → 7 → 1 day, and
             # both paths shrink the per-page limit 500 → 100 → 50); if it still escapes after those

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/test_meta_ads.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/test_meta_ads.py
@@ -1345,6 +1345,10 @@ class TestNonRetryableErrors:
             'Meta API request failed: 400 - {"error":{"message":"(#100) This endpoint cannot be loaded due to missing permissions."}}',
             # 400 when a business_management-gated field is requested without that scope.
             'Meta API request failed: 400 - {"error":{"message":"(#200) Requires business_management permission to manage the object.","type":"OAuthException","code":200}}',
+            # 400 when the source's configured attribution windows include a value Meta's
+            # Insights API doesn't recognise.
+            'Meta API request failed: 400 - {"error":{"message":"(#100) action_attribution_windows[0] must be '
+            'one of the following values: 1d_view, 7d_view, 28d_view, 1d_click, 7d_click, 28d_click","type":"OAuthException","code":100}}',
             # 500 when Meta's backend refuses to service the query even after adaptive
             # chunking has shrunk the window to its smallest size.
             'Meta API request failed: 500 - {"error":{"code":1,"message":"Please reduce the amount of data you\'re asking for, then retry your request"}}',


### PR DESCRIPTION
## Problem

A Meta Ads data warehouse sync fails on every retry when the source's "Attribution windows for insights" setting holds a value Meta's Insights API does not support.
Each retry resends the identical invalid value, so the sync can never succeed and the failure keeps generating error tracking noise until someone notices and fixes the config.
Surfaced by [error tracking issue 01a015a7](https://us.posthog.com/project/2/error_tracking/01a015a7-f84e-75f2-a771-07ef18a00ec7): Meta returns a 400, code 100, `action_attribution_windows[0] must be one of the following values: ...`.

## Changes

- Adds a `MetaAdsSource.get_non_retryable_errors()` entry matching `action_attribution_windows[`, so this error stops the sync instead of retrying indefinitely.
- Surfaces a customer-facing message naming the setting to fix and a few example valid values.
- Matches on the parameter name rather than a specific array index, since Meta can report any index depending on which configured window is invalid.

## How did you test this code?

Added one parametrized case to `TestNonRetryableErrors::test_errors_match_pattern`, using the real Meta response shape from the error tracking issue — guards that this specific error string keeps routing to the non-retryable path.
Ran the full `meta_ads` test suite locally (214 passed) and `ruff check`/`ruff format` on the changed files.
Not run: a live sync against Meta's API, since this environment has no Meta Ads credentials.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing docs describe this source's error handling.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via the `investigating-error-issue` skill against the linked error tracking issue, confirming the full stack trace resolves entirely within `meta_ads.py`.
Read the Stripe source's `get_non_retryable_errors` as the reference pattern this change mirrors.
Invoked `/writing-tests` before adding the test case and `/writing-pr-descriptions` before writing this body.
No open PR (human- or bot-authored) addressed this error.