### PR TITLE
fix(devenv): add librdkafka runtime libs to the linux flox env

### DIFF
--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -20,9 +20,7 @@ nodejs = { pkg-path = "nodejs_24", pkg-group = "nodejs", version = "24.13.0" } #
 corepack = { pkg-path = "corepack_24", pkg-group = "nodejs", version = "24.13.0", priority = 4 } # Same maj.min as in Dockerfile; diverges from patch ver
 brotli = { pkg-path = "brotli", pkg-group = "nodejs" }
 zstd = { pkg-path = "zstd", pkg-group = "nodejs" }
-# librdkafka (node-rdkafka) links liblz4/libsasl2 when pkg-config finds them and dlopens
-# them at runtime. Linux only: macOS finds neither, so it builds against bundled lz4 without
-# SASL. Their .so sits outside the default outputs, hence the explicit output lists.
+# node-rdkafka's librdkafka dlopens liblz4/libsasl2 at runtime on Linux; the .so files live outside the default outputs
 lz4 = { pkg-path = "lz4", pkg-group = "nodejs", outputs = ["out", "lib", "dev"], systems = ["x86_64-linux", "aarch64-linux"] }
 cyrus_sasl = { pkg-path = "cyrus_sasl", pkg-group = "nodejs", outputs = ["out", "dev"], systems = ["x86_64-linux", "aarch64-linux"] }
 openssl = { pkg-path = "openssl", version = "3.4.1", pkg-group = "openssl", outputs = ["bin", "man", "dev", "out"] }

--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -20,6 +20,11 @@ nodejs = { pkg-path = "nodejs_24", pkg-group = "nodejs", version = "24.13.0" } #
 corepack = { pkg-path = "corepack_24", pkg-group = "nodejs", version = "24.13.0", priority = 4 } # Same maj.min as in Dockerfile; diverges from patch ver
 brotli = { pkg-path = "brotli", pkg-group = "nodejs" }
 zstd = { pkg-path = "zstd", pkg-group = "nodejs" }
+# librdkafka (node-rdkafka) links liblz4/libsasl2 when pkg-config finds them and dlopens
+# them at runtime. Linux only: macOS finds neither, so it builds against bundled lz4 without
+# SASL. Their .so sits outside the default outputs, hence the explicit output lists.
+lz4 = { pkg-path = "lz4", pkg-group = "nodejs", outputs = ["out", "lib", "dev"], systems = ["x86_64-linux", "aarch64-linux"] }
+cyrus_sasl = { pkg-path = "cyrus_sasl", pkg-group = "nodejs", outputs = ["out", "dev"], systems = ["x86_64-linux", "aarch64-linux"] }
 openssl = { pkg-path = "openssl", version = "3.4.1", pkg-group = "openssl", outputs = ["bin", "man", "dev", "out"] }
 nodemon = { pkg-path = "nodemon" }
 # Rust toolchain (based on https://flox.dev/docs/cookbook/languages/rust/)


### PR DESCRIPTION
## Problem

- The `nodejs` and `ingestion` dev-stack units never start on Linux. Both crash-loop instead of reaching ready.
- Loading `node-rdkafka` fails with `liblz4.so.1: cannot open shared object file`.
- `node-rdkafka` compiles librdkafka with the host toolchain. System pkg-config finds `liblz4.pc` and `libsasl2.pc` in `/usr/lib/pkgconfig`, so the build enables `WITH_LZ4_EXT` and `WITH_SASL_CYRUS`.
- The resulting `librdkafka.so.1` carries no RUNPATH. Flox resolves libraries from `$FLOX_ENV/lib` and node's nix RUNPATH, never `/usr/lib`, so the addon cannot find them.
- macOS never hits this. It has no system `liblz4.pc` or `libsasl2.pc`, so librdkafka falls back to bundled lz4 and builds without SASL.

## Changes

```diff
+lz4 = { pkg-path = "lz4", pkg-group = "nodejs", outputs = ["out", "lib", "dev"], systems = ["x86_64-linux", "aarch64-linux"] }
+cyrus_sasl = { pkg-path = "cyrus_sasl", pkg-group = "nodejs", outputs = ["out", "dev"], systems = ["x86_64-linux", "aarch64-linux"] }
```

- Installing both packages puts `liblz4.so.1` and `libsasl2.so.3` where the loader looks.
- The outputs are explicit because the default install carries no shared library. `liblz4.so.1` lives in lz4's `lib` output and `libsasl2.so.3` in cyrus_sasl's `out`. `openssl` in this manifest already works around the same trap.
- The `dev` outputs put flox's `.pc` files on `PKG_CONFIG_PATH`, which precedes the system default. The build then links the same copies the runtime loads.
- The `systems` fields keep macOS unchanged. Without them, Mac pkg-config would find these `.pc` files and switch librdkafka to external lz4 and Cyrus SASL, changing a build that works today.

> [!NOTE]
> A hermetic alternative was considered and rejected: disable the librdkafka probes so every platform builds bundled lz4 without SASL. That makes the artifact identical everywhere, but it changes what every developer's Kafka client supports. This PR fixes the broken platform without touching the working ones.

## How did you test this code?

Verified on `x86_64-linux` against the running dev stack.

- `flox activate` now places `liblz4.so.1` and `libsasl2.so.3` in `$FLOX_ENV/lib`, symlinked to the named outputs.
- Loading the addon inside the env succeeds. It raised `ERR_DLOPEN_FAILED` before the change.
- `ingestion` reaches ready in 11.8s. It had never reached ready before.
- The lockfile resolves `lz4` and `cyrus_sasl` for `aarch64-linux` and `x86_64-linux` only, so darwin is untouched.
- `hogli ci:preflight --fix` reports no failures.

Not checked: macOS behavior, which was reasoned from the absent system `.pc` files rather than run on a Mac. No automated tests cover the flox environment.

<details>
<summary>Addon load, before and after</summary>

```
before:  Error: liblz4.so.1: cannot open shared object file: No such file or directory
         code: 'ERR_DLOPEN_FAILED'
after:   >>> ADDON LOADED OK <<<
```

</details>

`nodejs` still fails after this change, on an unrelated CDP and cyclotron launchpad error with no shared-library involvement. This PR does not address it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Opus 5) investigated and wrote the change, using the phrocs MCP tools to read dev-stack process status and logs. Skills invoked: `/writing-pr-descriptions`.
- The trail started from two units stuck pending. Their logs pointed at the rdkafka addon, and ELF plus `LD_DEBUG` inspection located the missing libraries and showed `/usr/lib` was never searched.
- Pointing `LD_LIBRARY_PATH` at `/usr/lib` was tried and abandoned. Node then loads the system glibc and dies on `__pointer_chk_guard`.
- An earlier revision installed both packages without `outputs`. It resolved in the catalog but placed no shared library in the environment, which is why the outputs are named.
- An earlier revision also applied to all systems. The `systems` scoping was added to keep macOS builds unchanged.
