### PR TITLE
chore(tests): serialize funnel compare queries in tests

### DIFF
--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_time_to_convert.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_time_to_convert.py
@@ -9,6 +9,8 @@ from posthog.test.base import (
 )
 from unittest.case import skip
 
+from django.test import override_settings
+
 from posthog.schema import (
     CompareFilter,
     DateRange,
@@ -643,6 +645,7 @@ class TestFunnelTimeToConvert(ClickhouseTestMixin, APIBaseTest):
         )
 
 
+@override_settings(IN_UNIT_TESTING=True)
 class TestFunnelTimeToConvertCompare(ClickhouseTestMixin, APIBaseTest):
     """Compare-to-previous on funnel TIME_TO_CONVERT viz: two histograms on shared bin boundaries."""
 


### PR DESCRIPTION
> 🤖 Posted by an automated coding agent.

## Problem

A funnel comparison test waits for a five-minute database timeout on every Backend CI run.

The test starts comparison queries in worker threads. Django's test transaction is not visible to those threads, so they wait on database locks.

## Changes

- The funnel comparison class now uses the existing serial query path for unit tests.
- Production query execution remains parallel.
- The measured test call fell from 302.88 seconds to 1.74 seconds locally.

## How did you test this code?

- Reproduced the CI setting with `IN_UNIT_TESTING=0` before and after the change.
- Ran the complete comparison test class with the CI setting.
- Ran Ruff, repository-wide mypy, and `hogli ci:preflight --fix`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This change only corrects test execution behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi implemented this change with repository shell tools and CI trace analysis. It used `/writing-tests` and `/writing-pr-descriptions`.

The same serial-test setting already protects the funnel steps and trends comparison suites. This change applies it to time-to-convert comparison.
