### PR TITLE
fix(redshift): stop retrying a query that times out on every attempt

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/redshift/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/redshift/source.py
@@ -158,6 +158,13 @@ class RedshiftSource(SQLSource[RedshiftSourceConfig], SSHTunnelMixin, ValidateDa
             "server does not support SSL": None,
             "does not exist": None,
             "QueryTimeoutException": None,
+            # `QueryTimeoutException` above only matches once Temporal's `ApplicationError` wraps
+            # the failure with the class name (workflow layer) — the activity-level check matches
+            # `str(e)` on the raw exception, which is just the message with no class name. Match
+            # the stable prefix too (not the incremental field name, which varies per table) so a
+            # table missing the SORTKEY stops retrying at the activity layer instead of burning a
+            # full retry budget on a 10-minute query that will time out identically every time.
+            "10 min timeout statement reached": None,
             "TemporaryFileSizeExceedsLimitException": None,
             "Name or service not known": None,
             "Network is unreachable": None,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/redshift/tests/test_redshift.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/redshift/tests/test_redshift.py
@@ -1120,6 +1120,17 @@ class TestRedshiftSourceNonRetryableErrors:
         is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
         assert is_non_retryable
 
+    def test_query_timeout_raw_message_is_non_retryable(self):
+        # Mirrors the `InsufficientPrivilege` case above: the activity-level check matches raw
+        # `str(exception)`, which for `QueryTimeoutException` is just the message with no class
+        # name — only the `QueryTimeoutException` key (workflow layer only) would miss this,
+        # letting the activity retry a query that times out identically every attempt because the
+        # table's incremental field isn't a SORTKEY.
+        error_msg = "10 min timeout statement reached. Please ensure your incremental field (updated_at) is set as a SORTKEY on the table"
+        non_retryable = RedshiftSource().get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable
+
 
 class TestRedshiftValidateCredentials:
     def test_server_without_ssl_returns_friendly_error_without_capturing(self, mocker):


### PR DESCRIPTION
## Problem

A Redshift sync whose incremental field isn't set as a SORTKEY hits Redshift's 10-minute statement timeout on the row-count query, since the query then has to scan the whole table. That case ([error tracking issue](https://us.posthog.com/project/2/error_tracking/01a015b7-b0b1-7403-b933-f59f1de7d986)) can't be fixed by retrying: the same table scan times out identically every attempt.

The source already lists `QueryTimeoutException` as non-retryable, but that only stops retries once Temporal wraps the failure at the workflow layer. The activity-level check compares the raw exception's message, which carries no class name, so the activity kept retrying the doomed query and burning its full retry budget at ~10 minutes per attempt before the job eventually failed at the workflow layer.

## Changes

- Add the exception's stable message prefix (`10 min timeout statement reached`) alongside the existing `QueryTimeoutException` key in Redshift's `get_non_retryable_errors`, so the activity-level check (which matches on the raw message, not the class name) also stops retrying immediately.
- Follows the same pattern already used for `InsufficientPrivilege` in this file, documented inline.

## How did you test this code?

- Added `test_query_timeout_raw_message_is_non_retryable`, asserting the raw exception message matches the new key.
- Ran the full Redshift test suite locally: `pytest products/warehouse_sources/backend/temporal/data_imports/sources/redshift/tests/test_redshift.py` — 128 passed.
- Ran `ruff check` and `ruff format --check` on the changed files — clean.
- Not run: an end-to-end sync against a real Redshift cluster (no cluster available in this environment).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing or API behavior changes; this only affects internal retry classification.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated a live error-tracking issue for the Redshift warehouse source, traced the non-retryable-error matching code path across the activity and workflow layers to find the asymmetry, and added the missing message-substring key plus a regression test. No skills were invoked for this change beyond the standard PR-description guidance.