### PR TITLE
feat(desktop): hand off a task to a colleague from the row menus

### DIFF
--- a/products/desktop/packages/api-client/src/posthog-client.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.ts
@@ -2547,6 +2547,25 @@ export class PostHogAPIClient {
     return data.pinned;
   }
 
+  // Handoff is absent from the Desktop-generated client, so use the same raw-fetch path as pin.
+  async handoffTask(taskId: string, userId: number): Promise<Task> {
+    const teamId = await this.getTeamId();
+    const urlPath = `/api/projects/${teamId}/tasks/${taskId}/handoff/`;
+    const response = await this.api.fetcher.fetch({
+      method: "post",
+      url: new URL(`${this.api.baseUrl}${urlPath}`),
+      path: urlPath,
+      overrides: { body: JSON.stringify({ user: userId }) },
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to hand off task: ${response.statusText}`);
+    }
+    const data = (await response.json()) as Parameters<
+      typeof normalizeTaskResponse
+    >[0];
+    return normalizeTaskResponse(data, { teamId });
+  }
+
   async createTask(
     options: Pick<Task, "description"> &
       Partial<

--- a/products/desktop/packages/core/src/canvas/activityEvents.ts
+++ b/products/desktop/packages/core/src/canvas/activityEvents.ts
@@ -20,6 +20,7 @@ export const ACTIVITY_EVENTS = [
   "pr_merged",
   "pr_closed",
   "message_forwarded",
+  "task_handed_off",
 ] as const;
 
 export type ActivityEventKind = (typeof ACTIVITY_EVENTS)[number];
@@ -88,6 +89,14 @@ export interface MessageForwardedPayload {
   runId: string;
 }
 
+export interface TaskHandedOffPayload {
+  fromUserId: number | null;
+  toUserId: number;
+  /** Rendered names, so the row can read without a member lookup. */
+  fromDisplayName: string | null;
+  toDisplayName: string;
+}
+
 /** Identity only: the thread body, quote, and replies are fetched when the row opens. */
 export interface CommentEventPayload {
   commentId: string;
@@ -115,7 +124,8 @@ export type ActivityEvent =
   | { kind: "pr_created"; payload: PrPayload }
   | { kind: "pr_merged"; payload: PrPayload }
   | { kind: "pr_closed"; payload: PrPayload }
-  | { kind: "message_forwarded"; payload: MessageForwardedPayload };
+  | { kind: "message_forwarded"; payload: MessageForwardedPayload }
+  | { kind: "task_handed_off"; payload: TaskHandedOffPayload };
 
 function str(value: unknown, fallback = ""): string {
   return typeof value === "string" ? value : fallback;
@@ -254,6 +264,24 @@ export function parseActivityEvent(message: {
       const parsed = prPayload(payload);
       // A PR row with no url can't be labelled or opened, so it isn't a row.
       return parsed.prUrl ? { kind: event, payload: parsed } : null;
+    }
+    case "task_handed_off": {
+      // Older rows only carry user ids; a row with neither name can't say who
+      // took over, so fall back to undrawn rather than label it wrong.
+      const toDisplayName = optionalStr(payload.to_display_name);
+      if (!toDisplayName) return null;
+      return {
+        kind: event,
+        payload: {
+          fromUserId:
+            typeof payload.from_user_id === "number"
+              ? payload.from_user_id
+              : null,
+          toUserId: num(payload.to_user_id, 0),
+          fromDisplayName: optionalStr(payload.from_display_name),
+          toDisplayName,
+        },
+      };
     }
     case "message_forwarded":
       return {

--- a/products/desktop/packages/core/src/canvas/activityTimeline.ts
+++ b/products/desktop/packages/core/src/canvas/activityTimeline.ts
@@ -242,5 +242,8 @@ function eventIdentity(
       return event.payload.prUrl;
     case "message_forwarded":
       return event.payload.messageId;
+    case "task_handed_off":
+      // Each handoff is its own row; only a duplicate write of the same one collapses.
+      return message.id;
   }
 }

--- a/products/desktop/packages/core/src/context-menu/context-menu.test.ts
+++ b/products/desktop/packages/core/src/context-menu/context-menu.test.ts
@@ -152,6 +152,24 @@ describe("ContextMenuService.showTaskContextMenu", () => {
     );
   });
 
+  it("offers Hand off only to callers that mark it available", async () => {
+    // Ownership transfer is irreversible from the actor's side, so the item
+    // must never appear for a viewer who could only ever 404 it.
+    const owner = new FakeContextMenu();
+    const handedOff = makeService(owner).showTaskContextMenu({
+      ...baseTask,
+      canHandoff: true,
+    });
+    await owner.shown;
+    findItem(owner.lastItems, "Hand off…").click();
+    expect(await handedOff).toEqual({ action: { type: "handoff" } });
+
+    const viewer = new FakeContextMenu();
+    makeService(viewer).showTaskContextMenu(baseTask);
+    await viewer.shown;
+    expect(labels(viewer.lastItems)).not.toContain("Hand off…");
+  });
+
   it("can hide Archive prior tasks for task lists without that action", async () => {
     const menu = new FakeContextMenu();
     makeService(menu).showTaskContextMenu({

--- a/products/desktop/packages/core/src/context-menu/context-menu.test.ts
+++ b/products/desktop/packages/core/src/context-menu/context-menu.test.ts
@@ -153,8 +153,7 @@ describe("ContextMenuService.showTaskContextMenu", () => {
   });
 
   it("offers Hand off only to callers that mark it available", async () => {
-    // Ownership transfer is irreversible from the actor's side, so the item
-    // must never appear for a viewer who could only ever 404 it.
+    // The API 404s a non-owner's handoff, so the item must stay hidden from one.
     const owner = new FakeContextMenu();
     const handedOff = makeService(owner).showTaskContextMenu({
       ...baseTask,

--- a/products/desktop/packages/core/src/context-menu/context-menu.ts
+++ b/products/desktop/packages/core/src/context-menu/context-menu.ts
@@ -123,6 +123,7 @@ export class ContextMenuService {
       isInCommandCenter,
       hasEmptyCommandCenterCell,
       showArchivePrior = true,
+      canHandoff,
       channels,
     } = input;
     const { apps, lastUsedAppId } = await this.getExternalAppsData();
@@ -176,6 +177,12 @@ export class ContextMenuService {
           ]
         : []),
       ...fileToItems,
+      ...(canHandoff
+        ? [
+            this.separator(),
+            this.item("Hand off…", { type: "handoff" as const }),
+          ]
+        : []),
       this.separator(),
       this.item("Archive", { type: "archive" }),
       ...(showArchivePrior

--- a/products/desktop/packages/core/src/context-menu/schemas.ts
+++ b/products/desktop/packages/core/src/context-menu/schemas.ts
@@ -18,6 +18,8 @@ export const taskContextMenuInput = z.object({
   isInCommandCenter: z.boolean().optional(),
   hasEmptyCommandCenterCell: z.boolean().optional(),
   showArchivePrior: z.boolean().optional(),
+  // Only the task's owner may hand it off; callers omit the item otherwise.
+  canHandoff: z.boolean().optional(),
   // The project's channels available as "File to…" targets.
   // Omit (or pass empty) to hide the submenu entirely.
   channels: z.array(fileToChannel).optional(),
@@ -68,6 +70,7 @@ const taskAction = z.discriminatedUnion("type", [
   z.object({ type: z.literal("archive-prior") }),
   z.object({ type: z.literal("delete") }),
   z.object({ type: z.literal("add-to-command-center") }),
+  z.object({ type: z.literal("handoff") }),
   z.object({ type: z.literal("external-app"), action: externalAppAction }),
   z.object({ type: z.literal("file-to-channel"), channelId: z.string() }),
 ]);

--- a/products/desktop/packages/core/src/tasks/contextMenuActions.test.ts
+++ b/products/desktop/packages/core/src/tasks/contextMenuActions.test.ts
@@ -25,6 +25,9 @@ describe("resolveTaskContextMenuIntent", () => {
     expect(resolveTaskContextMenuIntent({ type: "stop" }, {})).toEqual({
       type: "stop",
     });
+    expect(resolveTaskContextMenuIntent({ type: "handoff" }, {})).toEqual({
+      type: "handoff",
+    });
     expect(resolveTaskContextMenuIntent({ type: "delete" }, {})).toEqual({
       type: "delete",
     });

--- a/products/desktop/packages/core/src/tasks/contextMenuActions.ts
+++ b/products/desktop/packages/core/src/tasks/contextMenuActions.ts
@@ -14,6 +14,7 @@ export type TaskContextMenuIntent =
   | { type: "archive-prior" }
   | { type: "delete" }
   | { type: "add-to-command-center" }
+  | { type: "handoff" }
   | { type: "file-to-channel"; channelId: string }
   | { type: "external-app"; action: ExternalAppAction };
 
@@ -38,6 +39,8 @@ export function resolveTaskContextMenuIntent(
       return { type: "delete" };
     case "add-to-command-center":
       return { type: "add-to-command-center" };
+    case "handoff":
+      return { type: "handoff" };
     case "file-to-channel":
       return { type: "file-to-channel", channelId: action.channelId };
     case "external-app":

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
@@ -380,8 +380,7 @@ describe("ChannelItemRow", () => {
   });
 
   it("offers Hand off… only to the task's owner", async () => {
-    // The one action that hands control away can never be a one-click offer
-    // to someone who would only ever 404 it.
+    // The API 404s a non-owner's handoff, so the menu must not offer it to one.
     const ownerItem = item({
       authorUser: { id: 999, uuid: "u-1", email: "owner@example.com" },
       task: {

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
@@ -7,7 +7,7 @@ import {
 } from "@posthog/ui/features/sidebar/taskDrag";
 import { useTaskSelectionStore } from "@posthog/ui/features/sidebar/taskSelectionStore";
 import { Theme } from "@radix-ui/themes";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -15,11 +15,18 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // The row's status comes from live session/workspace state and a per-task tRPC
 // query, none of which a unit test has. Stubbed at the module boundary, as
 // ChannelSidebar.test.tsx does for the same reason.
-const mocks = vi.hoisted(() => ({ status: null as TaskStatusInput | null }));
+const mocks = vi.hoisted(() => ({
+  status: null as TaskStatusInput | null,
+  currentUserId: 999 as number | undefined,
+}));
+vi.mock("@posthog/ui/features/auth/useCurrentUser", () => ({
+  useCurrentUser: () => ({ data: { id: mocks.currentUserId } }),
+}));
 vi.mock("@posthog/ui/features/canvas/hooks/useChannelTaskStatus", () => ({
   useChannelTaskStatus: () => mocks.status,
 }));
-// The row menu's spaces list and filing mutation are tRPC-backed.
+// The row menu's spaces list and filing mutation are tRPC-backed. The
+// handoff dialog's channels lookup rides the same mock.
 vi.mock("@posthog/ui/features/canvas/hooks/useChannels", () => ({
   useChannels: () => ({ channels: [{ id: "channel-1", name: "code" }] }),
 }));
@@ -29,6 +36,13 @@ vi.mock("@posthog/ui/features/canvas/hooks/useFileTaskToChannel", () => ({
 vi.mock("@posthog/ui/features/feature-flags/useFeatureFlag", () => ({
   useFeatureFlag: () => true,
 }));
+// The handoff dialog is tested on its own; here it only opens.
+vi.mock(
+  "@posthog/ui/features/task-detail/components/HandoffTaskDialog",
+  () => ({
+    HandoffTaskDialog: () => null,
+  }),
+);
 
 import { usePendingCanvasDeleteStore } from "@posthog/ui/features/canvas/stores/pendingCanvasDeleteStore";
 import { ChannelItemPreviewCardProvider } from "./ChannelItemHoverCard";
@@ -363,6 +377,43 @@ describe("ChannelItemRow", () => {
     for (const label of MENU_ITEMS) {
       expect(screen.getByRole("menuitem", { name: label })).not.toBeNull();
     }
+  });
+
+  it("offers Hand off… only to the task's owner", async () => {
+    // The one action that hands control away can never be a one-click offer
+    // to someone who would only ever 404 it.
+    const ownerItem = item({
+      authorUser: { id: 999, uuid: "u-1", email: "owner@example.com" },
+      task: {
+        id: "task-1",
+        task_number: 1,
+        slug: "task-1",
+        title: "Investigate signup drop-off",
+        description: "",
+        created_at: "2026-07-16T12:00:00.000Z",
+        updated_at: "2026-07-16T12:00:00.000Z",
+        origin_product: "user_created",
+        created_by: { id: 999, uuid: "u-1", email: "owner@example.com" },
+        channel: "channel-1",
+      },
+    });
+
+    renderInList(
+      <ChannelItemRow actions={actions} isActive={false} item={ownerItem} />,
+    );
+    await openCard();
+    expect(screen.getByRole("button", { name: "Hand off…" })).not.toBeNull();
+
+    cleanup();
+
+    mocks.currentUserId = 7;
+    renderInList(
+      <ChannelItemRow actions={actions} isActive={false} item={ownerItem} />,
+    );
+    await userEvent.hover(screen.getByText("Investigate signup drop-off"));
+    await screen.findByRole("button", { name: "Pin" }, { timeout: 2000 });
+    expect(screen.queryByRole("button", { name: "Hand off…" })).toBeNull();
+    mocks.currentUserId = 999;
   });
 
   it("disables Add to Command Center when there is nowhere to put the task", async () => {

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.tsx
@@ -16,6 +16,7 @@ import {
   TooltipTrigger,
 } from "@posthog/quill";
 import { formatRelativeTimeShort } from "@posthog/shared";
+import { useCurrentUser } from "@posthog/ui/features/auth/useCurrentUser";
 import { ChannelItemHoverCard } from "@posthog/ui/features/canvas/components/ChannelItemHoverCard";
 import { iconForTemplate } from "@posthog/ui/features/canvas/components/canvasTemplateIcon";
 import {
@@ -40,6 +41,7 @@ import {
 import { SidebarItem } from "@posthog/ui/features/sidebar/components/SidebarItem";
 import { writeTaskDragData } from "@posthog/ui/features/sidebar/taskDrag";
 import { SESSION_ROW_ATTRIBUTE } from "@posthog/ui/features/sidebar/useMarqueeSelection";
+import { HandoffTaskDialog } from "@posthog/ui/features/task-detail/components/HandoffTaskDialog";
 import {
   type DragEvent,
   type ReactNode,
@@ -281,6 +283,13 @@ export function ChannelItemRow({
 }) {
   const status = useChannelTaskStatus(item);
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
+  const [handoffOpen, setHandoffOpen] = useState(false);
+  const currentUser = useCurrentUser();
+  const canHandoff =
+    item.kind === "task" &&
+    item.task != null &&
+    item.authorUser?.id != null &&
+    currentUser.data?.id === item.authorUser.id;
   const handleDragStart = useCallback(
     (event: DragEvent) => {
       if (item.kind !== "task") return;
@@ -324,8 +333,11 @@ export function ChannelItemRow({
             onRename,
             onTogglePin: () => actions.togglePin(item),
             onArchive: () => actions.archive(item),
+            ...(canHandoff ? { onHandoff: () => setHandoffOpen(true) } : {}),
           },
-    [item, channelId, actions, onAddToCommandCenter, onRename],
+    // canHandoff rides on currentUser, which the cartel of queries above
+    // repolls; both belong in deps so a sign-in refresh re-evaluates.
+    [item, channelId, actions, onAddToCommandCenter, onRename, canHandoff],
   );
 
   if (isEditing) {
@@ -405,6 +417,13 @@ export function ChannelItemRow({
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+      {canHandoff && item.task ? (
+        <HandoffTaskDialog
+          task={item.task}
+          open={handoffOpen}
+          onOpenChange={setHandoffOpen}
+        />
+      ) : null}
     </>
   );
 }

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.tsx
@@ -335,8 +335,8 @@ export function ChannelItemRow({
             onArchive: () => actions.archive(item),
             ...(canHandoff ? { onHandoff: () => setHandoffOpen(true) } : {}),
           },
-    // canHandoff rides on currentUser, which the cartel of queries above
-    // repolls; both belong in deps so a sign-in refresh re-evaluates.
+    // canHandoff rides on the currentUser query, so it belongs in deps for a
+    // sign-in refresh to re-evaluate.
     [item, channelId, actions, onAddToCommandCenter, onRename, canHandoff],
   );
 

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelSidebar.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelSidebar.test.tsx
@@ -44,6 +44,9 @@ vi.mock("@posthog/ui/features/canvas/components/ChannelsFab", () => ({
 vi.mock("@posthog/ui/features/canvas/hooks/useChannels", () => ({
   useChannels: () => ({ channels: [] }),
 }));
+vi.mock("@posthog/ui/features/auth/useCurrentUser", () => ({
+  useCurrentUser: () => ({ data: { id: 1, email: "u@posthog.com" } }),
+}));
 vi.mock("@posthog/ui/features/tasks/useTaskMutations", () => ({
   useRenameTask: () => ({ renameTask: vi.fn() }),
 }));

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.test.tsx
@@ -1,5 +1,11 @@
 import { Theme } from "@radix-ui/themes";
-import { act, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -17,7 +23,9 @@ const mocks = vi.hoisted(() => ({
     title: string;
     channel: string;
     updated_at: string;
+    authorId?: number;
   }[],
+  currentUserId: 999 as number | undefined,
   totals: {} as Record<string, number>,
   unreadSessions: {} as Record<string, number>,
   blockedSessions: {} as Record<string, number>,
@@ -57,6 +65,23 @@ vi.mock("@posthog/ui/features/canvas/hooks/useBlockedSessionCount", () => ({
   useBlockedSessionCount: () => (channelId: string | undefined) =>
     mocks.blockedSessions[channelId ?? ""] ?? 0,
 }));
+vi.mock("@posthog/ui/features/auth/useCurrentUser", () => ({
+  useCurrentUser: () => ({ data: { id: mocks.currentUserId } }),
+}));
+// The row menu's spaces list and filing mutation are tRPC-backed; the flag
+// lookup sits behind a service provider that isn't mounted here.
+vi.mock("@posthog/ui/features/feature-flags/useFeatureFlag", () => ({
+  useFeatureFlag: () => true,
+}));
+vi.mock("@posthog/ui/features/canvas/hooks/useFileTaskToChannel", () => ({
+  useFileTaskToChannel: () => ({ fileTask: vi.fn() }),
+}));
+vi.mock(
+  "@posthog/ui/features/task-detail/components/HandoffTaskDialog",
+  () => ({
+    HandoffTaskDialog: () => null,
+  }),
+);
 vi.mock("@posthog/ui/features/canvas/hooks/useRecentSpaceTasks", () => ({
   NO_TASKS: { items: [], total: 0 },
   usePrefetchSpaceTasks: () => () => undefined,
@@ -73,10 +98,17 @@ vi.mock("@posthog/ui/features/canvas/hooks/useRecentSpaceTasks", () => ({
             ts: Date.parse(task.updated_at),
             pinned: false,
             rawStatus: null,
-            authorUser: null,
+            authorUser:
+              task.authorId != null
+                ? {
+                    id: task.authorId,
+                    uuid: `u-${task.authorId}`,
+                    email: "owner@example.com",
+                  }
+                : null,
             authorName: null,
             authorUuid: null,
-            task: null,
+            task: task.authorId != null ? { id: task.id } : null,
           }));
         // `total` is what the space holds, not what the tree shows — the tests
         // that exercise "View all" set it above the row count.
@@ -438,6 +470,28 @@ describe("ChannelsList", () => {
 
       await user.click(screen.getByLabelText("Collapse engineering"));
       expect(screen.queryByText("Ship the tree")).toBeNull();
+    });
+
+    it("offers Hand off… on an owned task's context menu only", async () => {
+      // The API 404s a non-owner's handoff, so the menu must not offer it to one.
+      mocks.tasks[0] = { ...mocks.tasks[0], authorId: 999 };
+      mocks.tasks[1] = { ...mocks.tasks[1], authorId: 7 };
+      const user = userEvent.setup();
+      renderList();
+
+      await user.click(screen.getByLabelText("Expand engineering"));
+      fireEvent.contextMenu(screen.getByText("Ship the tree"));
+      expect(
+        await screen.findByRole("menuitem", { name: "Hand off…" }),
+      ).toBeTruthy();
+      await user.keyboard("{Escape}");
+
+      fireEvent.contextMenu(screen.getByText("Write the tests"));
+      await waitFor(() =>
+        expect(
+          screen.queryByRole("menuitem", { name: "Hand off…" }),
+        ).toBeNull(),
+      );
     });
 
     // Picking a session out of the tree is browsing across spaces, not a

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.tsx
@@ -47,6 +47,7 @@ import {
   TooltipTrigger,
 } from "@posthog/quill";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
+import { useCurrentUser } from "@posthog/ui/features/auth/useCurrentUser";
 import {
   ChannelItemHoverCard,
   SpaceHoverCard,
@@ -111,6 +112,7 @@ import {
   taskDot,
 } from "@posthog/ui/features/sidebar/components/items/taskStatusVocabulary";
 import { useSidebarStore } from "@posthog/ui/features/sidebar/sidebarStore";
+import { HandoffTaskDialog } from "@posthog/ui/features/task-detail/components/HandoffTaskDialog";
 import {
   OverflowTickerText,
   useOverflowTickerReveal,
@@ -466,6 +468,15 @@ const SpaceTaskRow = memo(function SpaceTaskRow({
     (s) => s.highlightedValue === item.key,
   );
 
+  const [handoffOpen, setHandoffOpen] = useState(false);
+  // Only the owner may hand a task off; the API 404s it for anyone else.
+  const currentUser = useCurrentUser();
+  const canHandoff =
+    item.kind === "task" &&
+    item.task != null &&
+    item.authorUser?.id != null &&
+    currentUser.data?.id === item.authorUser.id;
+
   // The tree only lists sessions, so this is always the task menu. Rename is
   // the one item the space's own list has and this doesn't, because it edits in
   // place and there is no inline editor on a row the keyboard is walking.
@@ -483,8 +494,11 @@ const SpaceTaskRow = memo(function SpaceTaskRow({
       onAddToCommandCenter: actions.commandCenterAssigner(item.id),
       onTogglePin: () => actions.togglePin(item),
       onArchive: () => actions.archive(item),
+      ...(canHandoff ? { onHandoff: () => setHandoffOpen(true) } : {}),
     }),
-    [item, spaceId, actions],
+    // canHandoff rides on the currentUser query, so it belongs in deps for a
+    // sign-in refresh to re-evaluate.
+    [item, spaceId, actions, canHandoff],
   );
 
   const row = (
@@ -533,6 +547,13 @@ const SpaceTaskRow = memo(function SpaceTaskRow({
         >
           {row}
         </ChannelItemHoverCard>
+        {canHandoff && item.task ? (
+          <HandoffTaskDialog
+            task={item.task}
+            open={handoffOpen}
+            onOpenChange={setHandoffOpen}
+          />
+        ) : null}
       </TaskStatusTooltips>
     </TaskRowContextMenu>
   );

--- a/products/desktop/packages/ui/src/features/canvas/components/TaskRowMenu.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/TaskRowMenu.tsx
@@ -9,6 +9,7 @@ import {
   SquaresFourIcon,
   StopCircle,
   TrashIcon,
+  UserSwitchIcon,
 } from "@phosphor-icons/react";
 import { sessionsLabel } from "@posthog/core/sidebar/selection";
 import {
@@ -64,6 +65,8 @@ export interface TaskRowMenuProps {
   /** Tasks are archived; canvases are deleted (with an undo window). */
   onArchive?: () => void;
   onDelete?: () => void;
+  /** Owner-only: handing a task to a colleague needs a confirm dialog. */
+  onHandoff?: () => void;
 }
 
 // The two menus differ only in which primitives draw them, so the item list is
@@ -170,6 +173,12 @@ function TaskRowMenuItems({
             />
           </MenuSubFlyout>
         </Sub>
+      )}
+      {isTask && menu.onHandoff && (
+        <Item onClick={menu.onHandoff}>
+          <UserSwitchIcon size={14} />
+          Hand off…
+        </Item>
       )}
       {menu.onArchive && (
         <Item onClick={menu.onArchive}>

--- a/products/desktop/packages/ui/src/features/canvas/components/activityRows.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/activityRows.tsx
@@ -18,6 +18,7 @@ import {
   ProhibitIcon,
   QuestionIcon,
   SquaresFourIcon,
+  UserSwitchIcon,
   XIcon,
 } from "@phosphor-icons/react";
 import type { CommentScope } from "@posthog/api-client/posthog-client";
@@ -253,6 +254,7 @@ const EVENT_TONES: Record<ActivityEvent["kind"], BeadTone> = {
   pr_merged: "violet",
   pr_closed: "red",
   message_forwarded: "neutral",
+  task_handed_off: "blue",
 };
 
 /** No glyph here is itself a circle: a ring inside a ring reads as a mistake at this size,
@@ -271,6 +273,7 @@ const EVENT_ICONS: Record<ActivityEvent["kind"], ReactNode> = {
   pr_merged: <GitMergeIcon size={11} />,
   pr_closed: <ProhibitIcon size={11} />,
   message_forwarded: <PaperPlaneTiltIcon size={9} weight="fill" />,
+  task_handed_off: <UserSwitchIcon size={11} />,
 };
 
 function eventLabel(
@@ -355,6 +358,17 @@ function eventLabel(
         : "Comment thread reopened";
     case "message_forwarded":
       return "Message sent to the agent";
+    case "task_handed_off": {
+      const { fromDisplayName, toDisplayName } = event.payload;
+      return (
+        <>
+          {fromDisplayName
+            ? `${fromDisplayName} handed the task off to `
+            : "Task handed off to "}
+          <span className="font-medium">{toDisplayName}</span>
+        </>
+      );
+    }
   }
 }
 

--- a/products/desktop/packages/ui/src/features/sidebar/components/SidebarMenu.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/SidebarMenu.tsx
@@ -14,6 +14,8 @@ import {
   useArchiveCacheKeys,
   useArchiveTask,
 } from "@posthog/ui/features/archive/useArchiveTask";
+import { useAuthStateValue } from "@posthog/ui/features/auth/store";
+import { useCurrentUser } from "@posthog/ui/features/auth/useCurrentUser";
 import { useCommandCenterStore } from "@posthog/ui/features/command-center/commandCenterStore";
 import { placeTaskInCommandCenter } from "@posthog/ui/features/command-center/placeTaskInCommandCenter";
 import { useExternalAppAction } from "@posthog/ui/features/external-apps/useExternalAppAction";
@@ -29,6 +31,7 @@ import { usePinnedTasks } from "@posthog/ui/features/sidebar/usePinnedTasks";
 import { useSidebarBulkActions } from "@posthog/ui/features/sidebar/useSidebarBulkActions";
 import { useSidebarData } from "@posthog/ui/features/sidebar/useSidebarData";
 import { useTaskViewed } from "@posthog/ui/features/sidebar/useTaskViewed";
+import { HandoffTaskDialog } from "@posthog/ui/features/task-detail/components/HandoffTaskDialog";
 import { useTaskContextMenu } from "@posthog/ui/features/tasks/useTaskContextMenu";
 import { useRenameTask } from "@posthog/ui/features/tasks/useTaskMutations";
 import { useTasks } from "@posthog/ui/features/tasks/useTasks";
@@ -70,6 +73,8 @@ function SidebarMenuComponent() {
 
   const { showContextMenu, editingTaskId, setEditingTaskId } =
     useTaskContextMenu();
+  const authStatus = useAuthStateValue((s) => s.status);
+  const currentUser = useCurrentUser();
   const { archiveTask } = useArchiveTask();
   const { renameTask } = useRenameTask();
   const { togglePin, setPinnedMany } = usePinnedTasks();
@@ -117,6 +122,8 @@ function SidebarMenuComponent() {
     taskTitle: string;
     runId?: string;
   } | null>(null);
+  const [handoffTaskId, setHandoffTaskId] = useState<string | null>(null);
+  const handoffTask = handoffTaskId ? taskMap.get(handoffTaskId) : undefined;
 
   useClearSelectionOnEscape();
   const listAnchorRef = useRef<HTMLDivElement | null>(null);
@@ -322,6 +329,14 @@ function SidebarMenuComponent() {
         (id) => id === taskId && taskMap.has(id),
       );
 
+      // The menu mirrors the header's rule: only the owner sees Hand off.
+      // Read through the full task map: the sidebar's summary rows don't
+      // always carry `created_by`.
+      const canHandoff =
+        authStatus === "authenticated" &&
+        currentUser.data?.id != null &&
+        taskMap.get(taskId)?.created_by?.id === currentUser.data.id;
+
       showContextMenu(task, e, {
         worktreePath: workspace?.worktreePath ?? undefined,
         folderPath: workspace?.folderPath ?? undefined,
@@ -333,6 +348,8 @@ function SidebarMenuComponent() {
         runId,
         isInCommandCenter,
         hasEmptyCommandCenterCell: true,
+        canHandoff,
+        onHandoff: () => setHandoffTaskId(task.id),
         onTogglePin: () => handleTaskTogglePin(taskId),
         onStop: (stopTaskId, taskTitle, stopRunId) =>
           setStopConfirm({
@@ -549,6 +566,15 @@ function SidebarMenuComponent() {
         onConfirm={handleConfirmArchive}
         onCancel={() => setArchiveConfirm(null)}
       />
+      {handoffTask ? (
+        <HandoffTaskDialog
+          task={handoffTask}
+          open
+          onOpenChange={(open) => {
+            if (!open) setHandoffTaskId(null);
+          }}
+        />
+      ) : null}
       {stopConfirm ? (
         <StopCloudRunDialog
           open

--- a/products/desktop/packages/ui/src/features/task-detail/components/HandoffTaskDialog.test.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/HandoffTaskDialog.test.tsx
@@ -1,0 +1,135 @@
+import type { Task } from "@posthog/shared/domain-types";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+const currentUserId = vi.hoisted(() => ({ id: 1 as number | undefined }));
+const mockHandoffMutate = vi.hoisted(() => vi.fn());
+const mockMembers = vi.hoisted(() => ({
+  members: [
+    { id: 1, uuid: "u-1", email: "owner@example.com", first_name: "Owner" },
+    { id: 2, uuid: "u-2", email: "colleague@example.com", first_name: "Col" },
+    { id: 3, uuid: "u-3", email: "pepper@example.com", first_name: "Pepper" },
+  ],
+}));
+const mockChannels = vi.hoisted(() => ({
+  channels: [] as Array<{ id: string; channelType: string }>,
+}));
+
+vi.mock("@posthog/ui/features/auth/useCurrentUser", () => ({
+  useCurrentUser: () => ({ data: { id: currentUserId.id } }),
+}));
+vi.mock("@posthog/ui/features/canvas/hooks/useOrgMembers", () => ({
+  useOrgMembers: () => ({ members: mockMembers.members, isLoading: false }),
+}));
+vi.mock("@posthog/ui/features/canvas/hooks/useChannels", () => ({
+  useChannels: () => ({ channels: mockChannels.channels }),
+}));
+vi.mock("@posthog/ui/features/tasks/useTaskMutations", () => ({
+  useHandoffTask: () => ({ mutate: mockHandoffMutate, isPending: false }),
+}));
+vi.mock("../../../primitives/toast", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import { HandoffTaskDialog } from "./HandoffTaskDialog";
+
+function createTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "task-1",
+    task_number: 1,
+    slug: "task-1",
+    title: "Fix the thing",
+    description: "",
+    created_at: "2026-05-28T00:00:00.000Z",
+    updated_at: "2026-05-28T00:00:00.000Z",
+    origin_product: "user_created",
+    created_by: { id: 1, uuid: "u-1", email: "owner@example.com" },
+    channel: null,
+    ...overrides,
+  };
+}
+
+function renderDialog(task: Task, open = true) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return render(
+    <HandoffTaskDialog task={task} open={open} onOpenChange={() => {}} />,
+    { wrapper },
+  );
+}
+
+describe("HandoffTaskDialog", () => {
+  it("keeps the confirm disabled until a person is picked", async () => {
+    // The dialog is the only thing standing between a menu click and an
+    // ownership transfer the actor can't undo, so a stray confirm must not fire.
+    mockHandoffMutate.mockClear();
+    const user = userEvent.setup();
+    renderDialog(createTask());
+
+    const dialog = await screen.findByRole("alertdialog");
+    expect(
+      within(dialog).getByRole("button", { name: "Hand off" }),
+    ).toHaveAttribute("aria-disabled", "true");
+    await user.keyboard("{Enter}");
+    expect(mockHandoffMutate).not.toHaveBeenCalled();
+  });
+
+  it("explains that a personal-space task moves to the recipient", async () => {
+    renderDialog(createTask({ channel: null }));
+
+    const dialog = await screen.findByRole("alertdialog");
+    expect(
+      within(dialog).getByText(/moves into their personal space/i),
+    ).toBeInTheDocument();
+    expect(
+      within(dialog).getByText(/only they can hand it back/i),
+    ).toBeInTheDocument();
+  });
+
+  it("filters people by name or email in the search input", async () => {
+    // Catches a dialog that would force scrolling an entire org by eye.
+    const user = userEvent.setup();
+    renderDialog(createTask());
+
+    const dialog = await screen.findByRole("alertdialog");
+    await user.type(
+      within(dialog).getByPlaceholderText(/search people/i),
+      "pepp",
+    );
+
+    expect(await within(dialog).findByText("Pepper")).toBeInTheDocument();
+    expect(within(dialog).queryByText("Col")).not.toBeInTheDocument();
+  });
+
+  it("does not offer the current owner as a handoff target", async () => {
+    renderDialog(createTask());
+
+    const dialog = await screen.findByRole("alertdialog");
+    expect(
+      within(dialog).queryByText("owner@example.com"),
+    ).not.toBeInTheDocument();
+    expect(await within(dialog).findByText("Col")).toBeInTheDocument();
+  });
+
+  it("hands off to the selected member with their user id", async () => {
+    mockHandoffMutate.mockClear();
+    const user = userEvent.setup();
+    renderDialog(createTask());
+
+    const dialog = await screen.findByRole("alertdialog");
+    await user.click(await within(dialog).findByText("Col"));
+    await user.click(within(dialog).getByRole("button", { name: "Hand off" }));
+
+    expect(mockHandoffMutate).toHaveBeenCalledWith(
+      { taskId: "task-1", userId: 2 },
+      expect.objectContaining({ onSuccess: expect.any(Function) }),
+    );
+  });
+});

--- a/products/desktop/packages/ui/src/features/task-detail/components/HandoffTaskDialog.test.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/HandoffTaskDialog.test.tsx
@@ -97,7 +97,6 @@ describe("HandoffTaskDialog", () => {
     renderDialog(createTask());
     await screen.findByRole("alertdialog");
 
-    // The field is the search box: clicking it opens the roster, typing narrows it.
     await user.click(screen.getByRole("combobox", { name: /hand off to/i }));
     expect(await screen.findByText("Col")).toBeInTheDocument();
     await user.keyboard("pepp");

--- a/products/desktop/packages/ui/src/features/task-detail/components/HandoffTaskDialog.test.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/HandoffTaskDialog.test.tsx
@@ -92,36 +92,62 @@ describe("HandoffTaskDialog", () => {
     ).toBeInTheDocument();
   });
 
-  it("filters people by name or email in the search input", async () => {
+  it("opens a search popover from the select and filters people by name or email", async () => {
     const user = userEvent.setup();
     renderDialog(createTask());
-
     const dialog = await screen.findByRole("alertdialog");
-    await user.type(
-      within(dialog).getByPlaceholderText(/search people/i),
-      "pepp",
+
+    await user.click(
+      within(dialog).getByRole("combobox", { name: /pick a person/i }),
     );
+    const searchInput =
+      await within(dialog).findByPlaceholderText(/search people/i);
+    await user.type(searchInput, "pepp");
 
     expect(await within(dialog).findByText("Pepper")).toBeInTheDocument();
     expect(within(dialog).queryByText("Col")).not.toBeInTheDocument();
   });
 
   it("does not offer the current owner as a handoff target", async () => {
+    const user = userEvent.setup();
     renderDialog(createTask());
-
     const dialog = await screen.findByRole("alertdialog");
+
+    await user.click(
+      within(dialog).getByRole("combobox", { name: /pick a person/i }),
+    );
     expect(
       within(dialog).queryByText("owner@example.com"),
     ).not.toBeInTheDocument();
     expect(await within(dialog).findByText("Col")).toBeInTheDocument();
   });
 
+  it("shows the picked person in the select trigger", async () => {
+    const user = userEvent.setup();
+    renderDialog(createTask());
+    const dialog = await screen.findByRole("alertdialog");
+
+    await user.click(
+      within(dialog).getByRole("combobox", { name: /pick a person/i }),
+    );
+    await user.click(await within(dialog).findByText("Col"));
+
+    // Base UI keeps the popup mounted once it was open, only hidden — so the
+    // readable signal that selection landed is the trigger content itself.
+    expect(
+      within(dialog).getByRole("combobox", { name: /pick a person/i }),
+    ).toHaveTextContent("Col");
+  });
+
   it("hands off to the selected member only after the acknowledge checkbox", async () => {
     mockHandoffMutate.mockClear();
     const user = userEvent.setup();
     renderDialog(createTask());
-
     const dialog = await screen.findByRole("alertdialog");
+
+    await user.click(
+      within(dialog).getByRole("combobox", { name: /pick a person/i }),
+    );
     await user.click(await within(dialog).findByText("Col"));
     // A pick alone isn't enough: the checkbox is what says they really read it.
     expect(

--- a/products/desktop/packages/ui/src/features/task-detail/components/HandoffTaskDialog.test.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/HandoffTaskDialog.test.tsx
@@ -116,13 +116,20 @@ describe("HandoffTaskDialog", () => {
     expect(await within(dialog).findByText("Col")).toBeInTheDocument();
   });
 
-  it("hands off to the selected member with their user id", async () => {
+  it("hands off to the selected member only after the acknowledge checkbox", async () => {
     mockHandoffMutate.mockClear();
     const user = userEvent.setup();
     renderDialog(createTask());
 
     const dialog = await screen.findByRole("alertdialog");
     await user.click(await within(dialog).findByText("Col"));
+    // A pick alone isn't enough: the checkbox is what says they really read it.
+    expect(
+      within(dialog).getByRole("button", { name: "Hand off" }),
+    ).toHaveAttribute("aria-disabled", "true");
+    await user.click(
+      within(dialog).getByRole("checkbox", { name: /can't undo this/i }),
+    );
     await user.click(within(dialog).getByRole("button", { name: "Hand off" }));
 
     expect(mockHandoffMutate).toHaveBeenCalledWith(

--- a/products/desktop/packages/ui/src/features/task-detail/components/HandoffTaskDialog.test.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/HandoffTaskDialog.test.tsx
@@ -67,8 +67,7 @@ function renderDialog(task: Task, open = true) {
 
 describe("HandoffTaskDialog", () => {
   it("keeps the confirm disabled until a person is picked", async () => {
-    // The dialog is the only thing standing between a menu click and an
-    // ownership transfer the actor can't undo, so a stray confirm must not fire.
+    // Only the recipient can undo a handoff, so a confirm with no pick must not fire.
     mockHandoffMutate.mockClear();
     const user = userEvent.setup();
     renderDialog(createTask());
@@ -94,7 +93,6 @@ describe("HandoffTaskDialog", () => {
   });
 
   it("filters people by name or email in the search input", async () => {
-    // Catches a dialog that would force scrolling an entire org by eye.
     const user = userEvent.setup();
     renderDialog(createTask());
 

--- a/products/desktop/packages/ui/src/features/task-detail/components/HandoffTaskDialog.test.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/HandoffTaskDialog.test.tsx
@@ -92,51 +92,41 @@ describe("HandoffTaskDialog", () => {
     ).toBeInTheDocument();
   });
 
-  it("opens a search popover from the select and filters people by name or email", async () => {
+  it("filters people by name or email as you type in the field", async () => {
     const user = userEvent.setup();
     renderDialog(createTask());
-    const dialog = await screen.findByRole("alertdialog");
+    await screen.findByRole("alertdialog");
 
-    await user.click(
-      within(dialog).getByRole("combobox", { name: /pick a person/i }),
-    );
-    const searchInput =
-      await within(dialog).findByPlaceholderText(/search people/i);
-    await user.type(searchInput, "pepp");
+    // The field is the search box: clicking it opens the roster, typing narrows it.
+    await user.click(screen.getByRole("combobox", { name: /hand off to/i }));
+    expect(await screen.findByText("Col")).toBeInTheDocument();
+    await user.keyboard("pepp");
 
-    expect(await within(dialog).findByText("Pepper")).toBeInTheDocument();
-    expect(within(dialog).queryByText("Col")).not.toBeInTheDocument();
+    expect(await screen.findByText("Pepper")).toBeInTheDocument();
+    expect(screen.queryByText("Col")).not.toBeInTheDocument();
   });
 
   it("does not offer the current owner as a handoff target", async () => {
     const user = userEvent.setup();
     renderDialog(createTask());
-    const dialog = await screen.findByRole("alertdialog");
+    await screen.findByRole("alertdialog");
 
-    await user.click(
-      within(dialog).getByRole("combobox", { name: /pick a person/i }),
-    );
-    expect(
-      within(dialog).queryByText("owner@example.com"),
-    ).not.toBeInTheDocument();
-    expect(await within(dialog).findByText("Col")).toBeInTheDocument();
+    await user.click(screen.getByRole("combobox", { name: /hand off to/i }));
+    expect(await screen.findByText("Col")).toBeInTheDocument();
+    expect(screen.queryByText("owner@example.com")).not.toBeInTheDocument();
   });
 
-  it("shows the picked person in the select trigger", async () => {
+  it("shows the picked person in the field", async () => {
     const user = userEvent.setup();
     renderDialog(createTask());
-    const dialog = await screen.findByRole("alertdialog");
+    await screen.findByRole("alertdialog");
 
-    await user.click(
-      within(dialog).getByRole("combobox", { name: /pick a person/i }),
+    await user.click(screen.getByRole("combobox", { name: /hand off to/i }));
+    await user.click(await screen.findByText("Col"));
+
+    expect(screen.getByRole("combobox", { name: /hand off to/i })).toHaveValue(
+      "Col",
     );
-    await user.click(await within(dialog).findByText("Col"));
-
-    // Base UI keeps the popup mounted once it was open, only hidden — so the
-    // readable signal that selection landed is the trigger content itself.
-    expect(
-      within(dialog).getByRole("combobox", { name: /pick a person/i }),
-    ).toHaveTextContent("Col");
   });
 
   it("hands off to the selected member only after the acknowledge checkbox", async () => {
@@ -145,10 +135,8 @@ describe("HandoffTaskDialog", () => {
     renderDialog(createTask());
     const dialog = await screen.findByRole("alertdialog");
 
-    await user.click(
-      within(dialog).getByRole("combobox", { name: /pick a person/i }),
-    );
-    await user.click(await within(dialog).findByText("Col"));
+    await user.click(screen.getByRole("combobox", { name: /hand off to/i }));
+    await user.click(await screen.findByText("Col"));
     // A pick alone isn't enough: the checkbox is what says they really read it.
     expect(
       within(dialog).getByRole("button", { name: "Hand off" }),

--- a/products/desktop/packages/ui/src/features/task-detail/components/HandoffTaskDialog.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/HandoffTaskDialog.tsx
@@ -123,7 +123,7 @@ export function HandoffTaskDialog({
         <AlertDialogHeader>
           <AlertDialogTitle>Hand off task</AlertDialogTitle>
           <AlertDialogDescription>
-            &quot;{task.title}&quot; goes to the person you pick: they steer it
+            &quot;{task.title}&quot; goes to the person you pick. They steer it
             and get its notifications.
             {movesToTheRecipient
               ? " It moves into their personal space, so you lose access."

--- a/products/desktop/packages/ui/src/features/task-detail/components/HandoffTaskDialog.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/HandoffTaskDialog.tsx
@@ -1,4 +1,3 @@
-import { CaretDown } from "@phosphor-icons/react";
 import {
   AlertDialog,
   AlertDialogClose,
@@ -10,14 +9,15 @@ import {
   Button,
   Checkbox,
   Combobox,
+  ComboboxContent,
   ComboboxEmpty,
   ComboboxInput,
   ComboboxItem,
   ComboboxList,
-  ComboboxTrigger,
   DialogBody,
   Field,
   FieldLabel,
+  InputGroupAddon,
 } from "@posthog/quill";
 import type { Task, UserBasic } from "@posthog/shared/domain-types";
 import { UserAvatar } from "@posthog/ui/features/auth/UserAvatar";
@@ -25,9 +25,8 @@ import { useCurrentUser } from "@posthog/ui/features/auth/useCurrentUser";
 import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
 import { useOrgMembers } from "@posthog/ui/features/canvas/hooks/useOrgMembers";
 import { userDisplayName } from "@posthog/ui/features/canvas/utils/userDisplay";
-import { ModalInlineComboboxContent } from "@posthog/ui/features/settings/ModalInlineComboboxContent";
 import { useHandoffTask } from "@posthog/ui/features/tasks/useTaskMutations";
-import { useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 import { toast } from "../../../primitives/toast";
 import { logger } from "../../../shell/logger";
 
@@ -40,11 +39,11 @@ interface PersonItem {
 }
 
 /**
- * The confirm step of a handoff. The picker is a plain select anchored to the
- * dialog, the consequence copy reads as short GitHub-style sentences, and the
- * commit stays locked until a colleague is picked AND the acknowledge box is
- * checked. Only the recipient can reverse a handoff, so the menu item that
- * opens this carries an ellipsis.
+ * The confirm step of a handoff. The recipient is picked from a search-first
+ * combobox — the field itself is the search box, so clicking it opens the
+ * roster and typing narrows it. The commit stays locked until a colleague is
+ * picked AND the acknowledge box is checked. Only the recipient can reverse a
+ * handoff, so the menu item that opens this carries an ellipsis.
  */
 export function HandoffTaskDialog({
   task,
@@ -59,9 +58,6 @@ export function HandoffTaskDialog({
   const { mutate: handoffTask, isPending } = useHandoffTask();
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [acknowledged, setAcknowledged] = useState(false);
-  const [pickerOpen, setPickerOpen] = useState(false);
-  const [searchQuery, setSearchQuery] = useState("");
-  const anchorRef = useRef<HTMLDivElement>(null);
 
   const { members, isLoading: membersLoading } = useOrgMembers();
   const { channels } = useChannels();
@@ -81,13 +77,12 @@ export function HandoffTaskDialog({
     if (open) {
       setSelectedId(null);
       setAcknowledged(false);
-      setPickerOpen(false);
-      setSearchQuery("");
     }
   }
 
-  // ids as values — Base UI drops object items, and the selected label comes
-  // straight from the item lookup.
+  // ids as values — the members query repolls and rebuilds its objects, so a
+  // selected object stops matching the list by identity and the combobox
+  // silently drops the selection. Ids compare by value.
   const items = useMemo<PersonItem[]>(
     () =>
       members.flatMap((member) =>
@@ -103,24 +98,12 @@ export function HandoffTaskDialog({
       ),
     [members, currentUser.data?.id],
   );
-  // Filtering is client-side over the org roster: name or email substring.
-  const needle = searchQuery.trim().toLowerCase();
-  const visibleItems = useMemo(
-    () =>
-      needle
-        ? items.filter(
-            (item) =>
-              item.label.toLowerCase().includes(needle) ||
-              (item.member.email ?? "").toLowerCase().includes(needle),
-          )
-        : items,
-    [items, needle],
+  const byId = useMemo(
+    () => new Map(items.map((item) => [item.id, item])),
+    [items],
   );
-  const itemIds = useMemo(
-    () => visibleItems.map((item) => item.id),
-    [visibleItems],
-  );
-  const selected = items.find((item) => item.id === selectedId);
+  const itemIds = useMemo(() => items.map((item) => item.id), [items]);
+  const selected = selectedId ? byId.get(selectedId) : undefined;
   const canHandOff = selected !== undefined && acknowledged;
 
   const handleConfirm = () => {
@@ -167,77 +150,47 @@ export function HandoffTaskDialog({
           </AlertDialogDescription>
         </AlertDialogHeader>
         <DialogBody viewportClassName="flex flex-col gap-3 px-4 pb-3">
-          <div ref={anchorRef}>
-            <Combobox
+          <Field>
+            <FieldLabel htmlFor="handoff-person">Hand off to</FieldLabel>
+            <Combobox<string>
               items={itemIds}
-              filter={null}
               value={selectedId}
-              onValueChange={(value) => {
-                setSelectedId(value as string | null);
-                setPickerOpen(false);
-                setSearchQuery("");
+              onValueChange={(value) => setSelectedId(value)}
+              itemToStringLabel={(id) => byId.get(id)?.label ?? ""}
+              // Name or email substring, so searching by handle works even
+              // when the roster shows full names.
+              filter={(id, query) => {
+                const needle = query.trim().toLowerCase();
+                if (!needle) return true;
+                const item = byId.get(id);
+                if (!item) return false;
+                return (
+                  item.label.toLowerCase().includes(needle) ||
+                  (item.member.email ?? "").toLowerCase().includes(needle)
+                );
               }}
-              open={pickerOpen}
-              onOpenChange={(next) => {
-                setPickerOpen(next);
-                if (!next) setSearchQuery("");
-              }}
-              inputValue={searchQuery}
-              onInputValueChange={(value) => setSearchQuery(value ?? "")}
+              autoHighlight
               disabled={isPending}
-              modal={false}
             >
-              <ComboboxTrigger
-                render={
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    disabled={isPending}
-                    aria-label="Pick a person to hand the task off to"
-                    className="w-full justify-between"
-                  >
-                    {selected ? (
-                      <span className="flex min-w-0 items-center gap-2">
-                        <UserAvatar
-                          user={selected.member}
-                          size="xs"
-                          className="shrink-0"
-                        />
-                        <span className="min-w-0 truncate">
-                          {userDisplayName(selected.member)}
-                        </span>
-                      </span>
-                    ) : (
-                      <span className="text-muted-foreground">
-                        Pick someone…
-                      </span>
-                    )}
-                    <CaretDown
-                      size={10}
-                      weight="bold"
-                      className="shrink-0 text-muted-foreground"
-                    />
-                  </Button>
-                }
-              />
-              <ModalInlineComboboxContent
-                anchor={anchorRef}
-                side="bottom"
-                sideOffset={4}
-                className="w-[var(--anchor-width)] min-w-[240px]"
+              <ComboboxInput
+                id="handoff-person"
+                placeholder="Search people…"
+                disabled={isPending}
+                className="w-full"
               >
-                <ComboboxInput
-                  placeholder="Search people…"
-                  showTrigger={false}
-                />
+                {selected ? (
+                  <InputGroupAddon align="inline-start">
+                    <UserAvatar user={selected.member} size="xs" />
+                  </InputGroupAddon>
+                ) : null}
+              </ComboboxInput>
+              <ComboboxContent className="w-[var(--anchor-width)] min-w-[240px]">
                 <ComboboxEmpty>
-                  {membersLoading ? "Loading people…" : "No people."}
+                  {membersLoading ? "Loading people…" : "No people match."}
                 </ComboboxEmpty>
-                <ComboboxList className="max-h-[min(18rem,calc(var(--available-height,18rem)-5rem))]">
+                <ComboboxList className="max-h-[min(18rem,calc(var(--available-height,18rem)-2rem))]">
                   {(itemId: string) => {
-                    const item = visibleItems.find(
-                      (entry) => entry.id === itemId,
-                    );
+                    const item = byId.get(itemId);
                     if (!item) return null;
                     return (
                       <ComboboxItem key={item.id} value={item.id}>
@@ -254,9 +207,9 @@ export function HandoffTaskDialog({
                     );
                   }}
                 </ComboboxList>
-              </ModalInlineComboboxContent>
+              </ComboboxContent>
             </Combobox>
-          </div>
+          </Field>
           <Field orientation="horizontal" className="items-center gap-2">
             <Checkbox
               id="handoff-acknowledge"

--- a/products/desktop/packages/ui/src/features/task-detail/components/HandoffTaskDialog.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/HandoffTaskDialog.tsx
@@ -39,10 +39,9 @@ interface PersonItem {
 }
 
 /**
- * The confirm step of a handoff. The recipient is picked from a search-first
- * combobox — the field itself is the search box, so clicking it opens the
- * roster and typing narrows it. The commit stays locked until a colleague is
- * picked AND the acknowledge box is checked. Only the recipient can reverse a
+ * The confirm step of a handoff. The field is the search box: clicking it
+ * opens the roster, typing narrows it. The commit stays locked until a
+ * colleague is picked AND the acknowledge box is checked. Only the recipient can reverse a
  * handoff, so the menu item that opens this carries an ellipsis.
  */
 export function HandoffTaskDialog({
@@ -80,7 +79,7 @@ export function HandoffTaskDialog({
     }
   }
 
-  // ids as values — the members query repolls and rebuilds its objects, so a
+  // ids as values: the members query repolls and rebuilds its objects, so a
   // selected object stops matching the list by identity and the combobox
   // silently drops the selection. Ids compare by value.
   const items = useMemo<PersonItem[]>(

--- a/products/desktop/packages/ui/src/features/task-detail/components/HandoffTaskDialog.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/HandoffTaskDialog.tsx
@@ -14,7 +14,10 @@ import {
   AutocompleteItem,
   AutocompleteList,
   Button,
+  Checkbox,
   DialogBody,
+  Field,
+  FieldLabel,
 } from "@posthog/quill";
 import type { Task, UserBasic } from "@posthog/shared/domain-types";
 import { UserAvatar } from "@posthog/ui/features/auth/UserAvatar";
@@ -55,6 +58,7 @@ export function HandoffTaskDialog({
   const { mutate: handoffTask, isPending } = useHandoffTask();
   const [query, setQuery] = useState("");
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [acknowledged, setAcknowledged] = useState(false);
 
   const { members, isLoading: membersLoading } = useOrgMembers();
   const { channels } = useChannels();
@@ -74,6 +78,7 @@ export function HandoffTaskDialog({
     if (open) {
       setQuery("");
       setSelectedId(null);
+      setAcknowledged(false);
     }
   }
 
@@ -112,6 +117,8 @@ export function HandoffTaskDialog({
     );
   };
 
+  const canHandOff = selected !== undefined && acknowledged;
+
   return (
     <AlertDialog
       open={open}
@@ -126,15 +133,18 @@ export function HandoffTaskDialog({
         <AlertDialogHeader>
           <AlertDialogTitle>Hand off task</AlertDialogTitle>
           <AlertDialogDescription>
-            &quot;{task.title}&quot; goes to the person you pick. They steer it
-            and get its notifications.
-            {movesToTheRecipient
-              ? " It moves into their personal space, so you lose access."
-              : ""}{" "}
-            Only they can hand it back.
+            <span className="font-medium text-foreground">{task.title}</span>{" "}
+            goes to the person you pick:
           </AlertDialogDescription>
         </AlertDialogHeader>
         <DialogBody viewportClassName="flex flex-col gap-3 px-4 pb-3">
+          <ul className="list-disc space-y-1 pl-4 text-muted-foreground text-xs">
+            <li>They steer it and get its notifications.</li>
+            {movesToTheRecipient ? (
+              <li>It moves into their personal space, so you lose access.</li>
+            ) : null}
+            <li>Only they can hand it back.</li>
+          </ul>
           <Autocomplete<PersonItem>
             inline
             defaultOpen
@@ -197,6 +207,17 @@ export function HandoffTaskDialog({
               )}
             </AutocompleteList>
           </Autocomplete>
+          <Field orientation="horizontal" className="items-center gap-2">
+            <Checkbox
+              id="handoff-acknowledge"
+              checked={acknowledged}
+              onCheckedChange={(checked) => setAcknowledged(checked === true)}
+              disabled={isPending}
+            />
+            <FieldLabel htmlFor="handoff-acknowledge" className="font-normal">
+              I understand I can&apos;t undo this myself.
+            </FieldLabel>
+          </Field>
         </DialogBody>
         <AlertDialogFooter>
           <AlertDialogClose
@@ -209,7 +230,7 @@ export function HandoffTaskDialog({
           <Button
             variant="primary"
             size="sm"
-            disabled={!selected}
+            disabled={!canHandOff}
             loading={isPending}
             onClick={handleConfirm}
           >

--- a/products/desktop/packages/ui/src/features/task-detail/components/HandoffTaskDialog.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/HandoffTaskDialog.tsx
@@ -1,4 +1,3 @@
-import { Check } from "@phosphor-icons/react";
 import {
   AlertDialog,
   AlertDialogClose,
@@ -80,13 +79,17 @@ export function HandoffTaskDialog({
 
   const items = useMemo<PersonItem[]>(
     () =>
-      members
-        .filter((member) => member.id !== currentUser.data?.id)
-        .map((member) => ({
-          id: String(member.id),
-          label: userDisplayName(member),
-          member,
-        })),
+      members.flatMap((member) =>
+        member.id === currentUser.data?.id
+          ? []
+          : [
+              {
+                id: String(member.id),
+                label: userDisplayName(member),
+                member,
+              },
+            ],
+      ),
     [members, currentUser.data?.id],
   );
   const selected = items.find((item) => item.id === selectedId);
@@ -168,15 +171,14 @@ export function HandoffTaskDialog({
                       <AutocompleteItem
                         key={item.id}
                         value={item.id}
-                        aria-selected={selectedId === item.id}
+                        data-selected={selectedId === item.id || undefined}
                         onClick={() => setSelectedId(item.id)}
-                        className="flex items-center gap-2 ring-offset-0 data-highlighted:border-transparent data-highlighted:bg-fill-hover data-highlighted:ring-0"
+                        // Same fill-on-select and softened focus ring as the
+                        // channels sidebar rows; the span override lets the
+                        // email reach the row's right edge under quill's own
+                        // child wrapper.
+                        className="w-full min-w-0 data-selected:bg-fill-selected data-selected:text-foreground ring-offset-0 data-highlighted:border-transparent data-highlighted:bg-fill-hover data-highlighted:ring-0 [&>span]:w-full [&>span]:gap-2"
                       >
-                        <span className="flex w-4 shrink-0 items-center justify-center">
-                          {selectedId === item.id && (
-                            <Check size={14} className="text-accent-11" />
-                          )}
-                        </span>
                         <UserAvatar
                           user={item.member}
                           size="xs"

--- a/products/desktop/packages/ui/src/features/task-detail/components/HandoffTaskDialog.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/HandoffTaskDialog.tsx
@@ -187,7 +187,7 @@ export function HandoffTaskDialog({
                         // channels sidebar rows; the span override lets the
                         // email reach the row's right edge under quill's own
                         // child wrapper.
-                        className="w-full min-w-0 data-selected:bg-fill-selected data-selected:text-foreground ring-offset-0 data-highlighted:border-transparent data-highlighted:bg-fill-hover data-highlighted:ring-0 [&>span]:w-full [&>span]:gap-2"
+                        className="w-full min-w-0 ring-offset-0 data-highlighted:border-transparent data-highlighted:bg-fill-hover data-selected:bg-fill-selected data-selected:text-foreground data-highlighted:ring-0 [&>span]:w-full [&>span]:gap-2"
                       >
                         <UserAvatar
                           user={item.member}

--- a/products/desktop/packages/ui/src/features/task-detail/components/HandoffTaskDialog.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/HandoffTaskDialog.tsx
@@ -1,0 +1,220 @@
+import { Check } from "@phosphor-icons/react";
+import {
+  AlertDialog,
+  AlertDialogClose,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  Autocomplete,
+  AutocompleteCollection,
+  AutocompleteEmpty,
+  AutocompleteGroup,
+  AutocompleteInput,
+  AutocompleteItem,
+  AutocompleteList,
+  Button,
+  DialogBody,
+} from "@posthog/quill";
+import type { Task, UserBasic } from "@posthog/shared/domain-types";
+import { UserAvatar } from "@posthog/ui/features/auth/UserAvatar";
+import { useCurrentUser } from "@posthog/ui/features/auth/useCurrentUser";
+import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
+import { useOrgMembers } from "@posthog/ui/features/canvas/hooks/useOrgMembers";
+import { userDisplayName } from "@posthog/ui/features/canvas/utils/userDisplay";
+import { useHandoffTask } from "@posthog/ui/features/tasks/useTaskMutations";
+import { useMemo, useState } from "react";
+import { toast } from "../../../primitives/toast";
+import { logger } from "../../../shell/logger";
+
+const log = logger.scope("task-detail");
+
+interface PersonItem {
+  id: string;
+  label: string;
+  member: UserBasic;
+}
+
+/**
+ * The confirm step of a handoff. The same shape as the canvas delete confirm:
+ * a short title, two sentences of consequence, the person picker (search input
+ * over the same avatar rows the mention composer draws), then Cancel against
+ * the commit. Only the recipient can reverse a handoff, so the item that opens
+ * this carries an ellipsis.
+ */
+export function HandoffTaskDialog({
+  task,
+  open,
+  onOpenChange,
+}: {
+  task: Task;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const currentUser = useCurrentUser();
+  const { mutate: handoffTask, isPending } = useHandoffTask();
+  const [query, setQuery] = useState("");
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const { members, isLoading: membersLoading } = useOrgMembers();
+  const { channels } = useChannels();
+  // A personal-space task moves into the recipient's personal space on handoff,
+  // so the warning has to cover losing access, not just control.
+  const movesToTheRecipient =
+    !task.channel ||
+    channels.find((channel) => channel.id === task.channel)?.channelType ===
+      "personal";
+
+  // Same reset rhythm as other dialogs: opening starts a clean search and no
+  // selection. Adjusted during render, not in an effect, because an effect
+  // would commit a frame of the stale state first.
+  const [wasOpen, setWasOpen] = useState(open);
+  if (open !== wasOpen) {
+    setWasOpen(open);
+    if (open) {
+      setQuery("");
+      setSelectedId(null);
+    }
+  }
+
+  const items = useMemo<PersonItem[]>(
+    () =>
+      members
+        .filter((member) => member.id !== currentUser.data?.id)
+        .map((member) => ({
+          id: String(member.id),
+          label: userDisplayName(member),
+          member,
+        })),
+    [members, currentUser.data?.id],
+  );
+  const selected = items.find((item) => item.id === selectedId);
+
+  const handleConfirm = () => {
+    if (!selected) return;
+    const name = userDisplayName(selected.member);
+    handoffTask(
+      { taskId: task.id, userId: selected.member.id },
+      {
+        onSuccess: () => {
+          toast.success(`Handed "${task.title}" off to ${name}`);
+          onOpenChange(false);
+        },
+        onError: (error) => {
+          log.error("Failed to hand off task", error);
+          toast.error("Couldn't hand off the task. Try again.");
+        },
+      },
+    );
+  };
+
+  return (
+    <AlertDialog
+      open={open}
+      onOpenChange={(next) => {
+        // Hold the dialog while the request is in flight; closing mid-flight
+        // would look like a cancel while the handoff still goes through.
+        if (!next && isPending) return;
+        onOpenChange(next);
+      }}
+    >
+      <AlertDialogContent className="max-w-md">
+        <AlertDialogHeader>
+          <AlertDialogTitle>Hand off task</AlertDialogTitle>
+          <AlertDialogDescription>
+            &quot;{task.title}&quot; goes to the person you pick: they steer it
+            and get its notifications.
+            {movesToTheRecipient
+              ? " It moves into their personal space, so you lose access."
+              : ""}{" "}
+            Only they can hand it back.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <DialogBody viewportClassName="flex flex-col gap-3 px-4 pb-3">
+          <Autocomplete<PersonItem>
+            inline
+            defaultOpen
+            items={[{ items }]}
+            value={query}
+            autoHighlight="always"
+            onValueChange={(value, eventDetails) => {
+              if (eventDetails.reason !== "input-change") return;
+              if (typeof value === "string") setQuery(value);
+            }}
+            filter={(item, search) => {
+              if (!search) return true;
+              const needle = search.toLowerCase();
+              return (
+                item.label.toLowerCase().includes(needle) ||
+                (item.member.email ?? "").toLowerCase().includes(needle)
+              );
+            }}
+          >
+            <AutocompleteInput
+              placeholder="Search people…"
+              autoFocus
+              showClear
+              disabled={isPending}
+            />
+            <AutocompleteEmpty>
+              <span>{membersLoading ? "Loading people…" : "No people."}</span>
+            </AutocompleteEmpty>
+            <AutocompleteList className="h-44 p-0">
+              {(section: { items: PersonItem[] }) => (
+                <AutocompleteGroup items={section.items} className="p-0">
+                  <AutocompleteCollection>
+                    {(item: PersonItem) => (
+                      <AutocompleteItem
+                        key={item.id}
+                        value={item.id}
+                        aria-selected={selectedId === item.id}
+                        onClick={() => setSelectedId(item.id)}
+                        className="flex items-center gap-2 ring-offset-0 data-highlighted:border-transparent data-highlighted:bg-fill-hover data-highlighted:ring-0"
+                      >
+                        <span className="flex w-4 shrink-0 items-center justify-center">
+                          {selectedId === item.id && (
+                            <Check size={14} className="text-accent-11" />
+                          )}
+                        </span>
+                        <UserAvatar
+                          user={item.member}
+                          size="xs"
+                          className="shrink-0"
+                        />
+                        <span className="truncate font-medium text-xs">
+                          {item.label}
+                        </span>
+                        <span className="ml-auto shrink-0 truncate text-muted-foreground text-xs">
+                          {item.member.email}
+                        </span>
+                      </AutocompleteItem>
+                    )}
+                  </AutocompleteCollection>
+                </AutocompleteGroup>
+              )}
+            </AutocompleteList>
+          </Autocomplete>
+        </DialogBody>
+        <AlertDialogFooter>
+          <AlertDialogClose
+            render={
+              <Button variant="outline" size="sm" disabled={isPending}>
+                Cancel
+              </Button>
+            }
+          />
+          <Button
+            variant="primary"
+            size="sm"
+            disabled={!selected}
+            loading={isPending}
+            onClick={handleConfirm}
+          >
+            Hand off
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/products/desktop/packages/ui/src/features/task-detail/components/HandoffTaskDialog.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/HandoffTaskDialog.tsx
@@ -1,3 +1,4 @@
+import { CaretDown } from "@phosphor-icons/react";
 import {
   AlertDialog,
   AlertDialogClose,
@@ -6,15 +7,14 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-  Autocomplete,
-  AutocompleteCollection,
-  AutocompleteEmpty,
-  AutocompleteGroup,
-  AutocompleteInput,
-  AutocompleteItem,
-  AutocompleteList,
   Button,
   Checkbox,
+  Combobox,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+  ComboboxTrigger,
   DialogBody,
   Field,
   FieldLabel,
@@ -25,8 +25,9 @@ import { useCurrentUser } from "@posthog/ui/features/auth/useCurrentUser";
 import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
 import { useOrgMembers } from "@posthog/ui/features/canvas/hooks/useOrgMembers";
 import { userDisplayName } from "@posthog/ui/features/canvas/utils/userDisplay";
+import { ModalInlineComboboxContent } from "@posthog/ui/features/settings/ModalInlineComboboxContent";
 import { useHandoffTask } from "@posthog/ui/features/tasks/useTaskMutations";
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { toast } from "../../../primitives/toast";
 import { logger } from "../../../shell/logger";
 
@@ -39,11 +40,11 @@ interface PersonItem {
 }
 
 /**
- * The confirm step of a handoff. The same shape as the canvas delete confirm:
- * a short title, two sentences of consequence, the person picker (search input
- * over the same avatar rows the mention composer draws), then Cancel against
- * the commit. Only the recipient can reverse a handoff, so the item that opens
- * this carries an ellipsis.
+ * The confirm step of a handoff. The picker is a plain select anchored to the
+ * dialog, the consequence copy reads as short GitHub-style sentences, and the
+ * commit stays locked until a colleague is picked AND the acknowledge box is
+ * checked. Only the recipient can reverse a handoff, so the menu item that
+ * opens this carries an ellipsis.
  */
 export function HandoffTaskDialog({
   task,
@@ -56,9 +57,11 @@ export function HandoffTaskDialog({
 }) {
   const currentUser = useCurrentUser();
   const { mutate: handoffTask, isPending } = useHandoffTask();
-  const [query, setQuery] = useState("");
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [acknowledged, setAcknowledged] = useState(false);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const anchorRef = useRef<HTMLDivElement>(null);
 
   const { members, isLoading: membersLoading } = useOrgMembers();
   const { channels } = useChannels();
@@ -69,19 +72,22 @@ export function HandoffTaskDialog({
     channels.find((channel) => channel.id === task.channel)?.channelType ===
       "personal";
 
-  // Same reset rhythm as other dialogs: opening starts a clean search and no
-  // selection. Adjusted during render, not in an effect, because an effect
-  // would commit a frame of the stale state first.
+  // Same reset rhythm as other dialogs: opening starts fresh. Adjusted during
+  // render, not in an effect, because an effect would commit a frame of the
+  // stale state first.
   const [wasOpen, setWasOpen] = useState(open);
   if (open !== wasOpen) {
     setWasOpen(open);
     if (open) {
-      setQuery("");
       setSelectedId(null);
       setAcknowledged(false);
+      setPickerOpen(false);
+      setSearchQuery("");
     }
   }
 
+  // ids as values — Base UI drops object items, and the selected label comes
+  // straight from the item lookup.
   const items = useMemo<PersonItem[]>(
     () =>
       members.flatMap((member) =>
@@ -97,7 +103,25 @@ export function HandoffTaskDialog({
       ),
     [members, currentUser.data?.id],
   );
+  // Filtering is client-side over the org roster: name or email substring.
+  const needle = searchQuery.trim().toLowerCase();
+  const visibleItems = useMemo(
+    () =>
+      needle
+        ? items.filter(
+            (item) =>
+              item.label.toLowerCase().includes(needle) ||
+              (item.member.email ?? "").toLowerCase().includes(needle),
+          )
+        : items,
+    [items, needle],
+  );
+  const itemIds = useMemo(
+    () => visibleItems.map((item) => item.id),
+    [visibleItems],
+  );
   const selected = items.find((item) => item.id === selectedId);
+  const canHandOff = selected !== undefined && acknowledged;
 
   const handleConfirm = () => {
     if (!selected) return;
@@ -117,8 +141,6 @@ export function HandoffTaskDialog({
     );
   };
 
-  const canHandOff = selected !== undefined && acknowledged;
-
   return (
     <AlertDialog
       open={open}
@@ -132,81 +154,109 @@ export function HandoffTaskDialog({
       <AlertDialogContent className="max-w-md">
         <AlertDialogHeader>
           <AlertDialogTitle>Hand off task</AlertDialogTitle>
-          <AlertDialogDescription>
-            <span className="font-medium text-foreground">{task.title}</span>{" "}
-            goes to the person you pick:
+          <AlertDialogDescription render={<div />}>
+            <p>
+              <span className="font-medium text-foreground">{task.title}</span>{" "}
+              goes to the person you pick.
+            </p>
+            <p>They steer it and get its notifications.</p>
+            {movesToTheRecipient ? (
+              <p>It moves into their personal space, so you lose access.</p>
+            ) : null}
+            <p>Only they can hand it back.</p>
           </AlertDialogDescription>
         </AlertDialogHeader>
         <DialogBody viewportClassName="flex flex-col gap-3 px-4 pb-3">
-          <ul className="list-disc space-y-1 pl-4 text-muted-foreground text-xs">
-            <li>They steer it and get its notifications.</li>
-            {movesToTheRecipient ? (
-              <li>It moves into their personal space, so you lose access.</li>
-            ) : null}
-            <li>Only they can hand it back.</li>
-          </ul>
-          <Autocomplete<PersonItem>
-            inline
-            defaultOpen
-            items={[{ items }]}
-            value={query}
-            autoHighlight="always"
-            onValueChange={(value, eventDetails) => {
-              if (eventDetails.reason !== "input-change") return;
-              if (typeof value === "string") setQuery(value);
-            }}
-            filter={(item, search) => {
-              if (!search) return true;
-              const needle = search.toLowerCase();
-              return (
-                item.label.toLowerCase().includes(needle) ||
-                (item.member.email ?? "").toLowerCase().includes(needle)
-              );
-            }}
-          >
-            <AutocompleteInput
-              placeholder="Search people…"
-              autoFocus
-              showClear
+          <div ref={anchorRef}>
+            <Combobox
+              items={itemIds}
+              filter={null}
+              value={selectedId}
+              onValueChange={(value) => {
+                setSelectedId(value as string | null);
+                setPickerOpen(false);
+                setSearchQuery("");
+              }}
+              open={pickerOpen}
+              onOpenChange={(next) => {
+                setPickerOpen(next);
+                if (!next) setSearchQuery("");
+              }}
+              inputValue={searchQuery}
+              onInputValueChange={(value) => setSearchQuery(value ?? "")}
               disabled={isPending}
-            />
-            <AutocompleteEmpty>
-              <span>{membersLoading ? "Loading people…" : "No people."}</span>
-            </AutocompleteEmpty>
-            <AutocompleteList className="h-44 p-0">
-              {(section: { items: PersonItem[] }) => (
-                <AutocompleteGroup items={section.items} className="p-0">
-                  <AutocompleteCollection>
-                    {(item: PersonItem) => (
-                      <AutocompleteItem
-                        key={item.id}
-                        value={item.id}
-                        data-selected={selectedId === item.id || undefined}
-                        onClick={() => setSelectedId(item.id)}
-                        // Same fill-on-select and softened focus ring as the
-                        // channels sidebar rows; the span override lets the
-                        // email reach the row's right edge under quill's own
-                        // child wrapper.
-                        className="w-full min-w-0 ring-offset-0 data-highlighted:border-transparent data-highlighted:bg-fill-hover data-selected:bg-fill-selected data-selected:text-foreground data-highlighted:ring-0 [&>span]:w-full [&>span]:gap-2"
-                      >
+              modal={false}
+            >
+              <ComboboxTrigger
+                render={
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={isPending}
+                    aria-label="Pick a person to hand the task off to"
+                    className="w-full justify-between"
+                  >
+                    {selected ? (
+                      <span className="flex min-w-0 items-center gap-2">
+                        <UserAvatar
+                          user={selected.member}
+                          size="xs"
+                          className="shrink-0"
+                        />
+                        <span className="min-w-0 truncate">
+                          {userDisplayName(selected.member)}
+                        </span>
+                      </span>
+                    ) : (
+                      <span className="text-muted-foreground">
+                        Pick someone…
+                      </span>
+                    )}
+                    <CaretDown
+                      size={10}
+                      weight="bold"
+                      className="shrink-0 text-muted-foreground"
+                    />
+                  </Button>
+                }
+              />
+              <ModalInlineComboboxContent
+                anchor={anchorRef}
+                side="bottom"
+                sideOffset={4}
+                className="w-[var(--anchor-width)] min-w-[240px]"
+              >
+                <ComboboxInput
+                  placeholder="Search people…"
+                  showTrigger={false}
+                />
+                <ComboboxEmpty>
+                  {membersLoading ? "Loading people…" : "No people."}
+                </ComboboxEmpty>
+                <ComboboxList className="max-h-[min(18rem,calc(var(--available-height,18rem)-5rem))]">
+                  {(itemId: string) => {
+                    const item = visibleItems.find(
+                      (entry) => entry.id === itemId,
+                    );
+                    if (!item) return null;
+                    return (
+                      <ComboboxItem key={item.id} value={item.id}>
                         <UserAvatar
                           user={item.member}
                           size="xs"
                           className="shrink-0"
                         />
-                        <span className="truncate font-medium text-xs">
-                          {item.label}
-                        </span>
+                        <span className="min-w-0 truncate">{item.label}</span>
                         <span className="ml-auto shrink-0 truncate text-muted-foreground text-xs">
                           {item.member.email}
                         </span>
-                      </AutocompleteItem>
-                    )}
-                  </AutocompleteCollection>
-                </AutocompleteGroup>
-              )}
-            </AutocompleteList>
-          </Autocomplete>
+                      </ComboboxItem>
+                    );
+                  }}
+                </ComboboxList>
+              </ModalInlineComboboxContent>
+            </Combobox>
+          </div>
           <Field orientation="horizontal" className="items-center gap-2">
             <Checkbox
               id="handoff-acknowledge"

--- a/products/desktop/packages/ui/src/features/tasks/useTaskContextMenu.ts
+++ b/products/desktop/packages/ui/src/features/tasks/useTaskContextMenu.ts
@@ -50,7 +50,9 @@ export function useTaskContextMenu() {
         isInCommandCenter?: boolean;
         hasEmptyCommandCenterCell?: boolean;
         showArchivePrior?: boolean;
+        canHandoff?: boolean;
         onTogglePin?: () => void;
+        onHandoff?: () => void;
         onStop?: (taskId: string, taskTitle: string, runId?: string) => void;
         onArchive?: (taskId: string) => void;
         onArchivePrior?: (taskId: string) => void;
@@ -70,7 +72,9 @@ export function useTaskContextMenu() {
         isInCommandCenter,
         hasEmptyCommandCenterCell,
         showArchivePrior,
+        canHandoff,
         onTogglePin,
+        onHandoff,
         onStop,
         onArchive,
         onArchivePrior,
@@ -88,6 +92,7 @@ export function useTaskContextMenu() {
           isInCommandCenter,
           hasEmptyCommandCenterCell,
           showArchivePrior,
+          canHandoff,
           channels: channels.map(({ id, name, channelType, starred }) => ({
             id,
             name,
@@ -138,6 +143,10 @@ export function useTaskContextMenu() {
             break;
           case "add-to-command-center":
             onAddToCommandCenter?.();
+            break;
+          case "handoff":
+            // The dialog lives with the caller; the hook can't own a modal.
+            onHandoff?.();
             break;
           case "file-to-channel":
             try {

--- a/products/desktop/packages/ui/src/features/tasks/useTaskMutations.test.tsx
+++ b/products/desktop/packages/ui/src/features/tasks/useTaskMutations.test.tsx
@@ -1,10 +1,14 @@
 import type { Schemas } from "@posthog/api-client";
 import type { Task } from "@posthog/shared/domain-types";
-import { channelFeedQueryKey } from "@posthog/ui/features/canvas/hooks/useChannelFeed";
+import {
+  channelFeedQueryKey,
+  channelFeedQueryRoot,
+} from "@posthog/ui/features/canvas/hooks/useChannelFeed";
 import {
   type SpaceTaskPage,
   spaceTreeTasksQueryRoot,
 } from "@posthog/ui/features/canvas/hooks/useRecentSpaceTasks";
+import { TASK_CHANNELS_QUERY_KEY } from "@posthog/ui/features/canvas/hooks/useTaskChannels";
 import { taskFeedResultsQueryKey } from "@posthog/ui/features/canvas/hooks/useTaskFeedResults";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react";
@@ -12,7 +16,11 @@ import { act, type ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockUpdateTask = vi.hoisted(() => vi.fn());
-const mockClient = vi.hoisted(() => ({ updateTask: mockUpdateTask }));
+const mockHandoffTask = vi.hoisted(() => vi.fn());
+const mockClient = vi.hoisted(() => ({
+  updateTask: mockUpdateTask,
+  handoffTask: mockHandoffTask,
+}));
 const mockUpdateSessionTaskTitle = vi.hoisted(() => vi.fn());
 
 vi.mock("@posthog/ui/features/auth/authClient", () => ({
@@ -26,7 +34,7 @@ vi.mock("@posthog/di/react", () => ({
 }));
 
 import { taskKeys } from "./taskKeys";
-import { useRenameTask } from "./useTaskMutations";
+import { useHandoffTask, useRenameTask } from "./useTaskMutations";
 
 const TASK_ID = "task-1";
 const OTHER_TASK_ID = "task-2";
@@ -363,5 +371,41 @@ describe("useRenameTask", () => {
     expect(queryClient.getQueryData<Task[]>(taskKeys.list())?.[0].title).toBe(
       "Renamed",
     );
+  });
+});
+
+describe("useHandoffTask", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("forwards the recipient id and invalidates the views a handoff redraws", async () => {
+    mockHandoffTask.mockResolvedValue(createTask({ created_by: null }));
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    const { result } = renderHook(() => useHandoffTask(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({ taskId: TASK_ID, userId: 7 });
+    });
+
+    expect(mockHandoffTask).toHaveBeenCalledWith(TASK_ID, 7);
+    // No invalidation here would leave the old owner staring at a task (and a
+    // channel) the backend already moved to the recipient's space.
+    const invalidatedKeys = invalidateSpy.mock.calls.map(
+      ([options]) => options?.queryKey,
+    );
+    expect(invalidatedKeys).toContainEqual(taskKeys.lists());
+    expect(invalidatedKeys).toContainEqual(taskKeys.detail(TASK_ID));
+    expect(invalidatedKeys).toContainEqual(TASK_CHANNELS_QUERY_KEY);
+    expect(invalidatedKeys).toContainEqual(channelFeedQueryRoot);
   });
 });

--- a/products/desktop/packages/ui/src/features/tasks/useTaskMutations.test.tsx
+++ b/products/desktop/packages/ui/src/features/tasks/useTaskMutations.test.tsx
@@ -398,8 +398,8 @@ describe("useHandoffTask", () => {
     });
 
     expect(mockHandoffTask).toHaveBeenCalledWith(TASK_ID, 7);
-    // No invalidation here would leave the old owner staring at a task (and a
-    // channel) the backend already moved to the recipient's space.
+    // Skipping these would leave the old owner staring at a task (and a channel)
+    // the backend already moved to the recipient's space.
     const invalidatedKeys = invalidateSpy.mock.calls.map(
       ([options]) => options?.queryKey,
     );

--- a/products/desktop/packages/ui/src/features/tasks/useTaskMutations.ts
+++ b/products/desktop/packages/ui/src/features/tasks/useTaskMutations.ts
@@ -22,6 +22,7 @@ import {
   type SpaceTaskPage,
   spaceTreeTasksQueryRoot,
 } from "@posthog/ui/features/canvas/hooks/useRecentSpaceTasks";
+import { TASK_CHANNELS_QUERY_KEY } from "@posthog/ui/features/canvas/hooks/useTaskChannels";
 import { taskFeedResultsQueryRoot } from "@posthog/ui/features/canvas/hooks/useTaskFeedResults";
 import { taskKeys } from "@posthog/ui/features/tasks/taskKeys";
 import { useAuthenticatedMutation } from "@posthog/ui/hooks/useAuthenticatedMutation";
@@ -56,6 +57,32 @@ export function useUpdateTask() {
         queryClient.invalidateQueries({ queryKey: spaceTreeTasksQueryRoot });
         queryClient.invalidateQueries({ queryKey: channelFeedQueryRoot });
         queryClient.invalidateQueries({ queryKey: taskFeedResultsQueryRoot });
+      },
+    },
+  );
+}
+
+/**
+ * Hand a task off to a colleague: the backend makes them the owner, moves a
+ * private-space task into the recipient's private space, and announces the
+ * handoff in the task's thread. The next refresh may drop the task from the
+ * requester's own lists, so nothing here is seeded optimistically.
+ */
+export function useHandoffTask() {
+  const queryClient = useQueryClient();
+
+  return useAuthenticatedMutation(
+    (client, { taskId, userId }: { taskId: string; userId: number }) =>
+      client.handoffTask(taskId, userId),
+    {
+      onSuccess: (_, { taskId }) => {
+        queryClient.invalidateQueries({ queryKey: taskKeys.lists() });
+        queryClient.invalidateQueries({ queryKey: taskKeys.detail(taskId) });
+        queryClient.invalidateQueries({ queryKey: taskKeys.allSummaries() });
+        queryClient.invalidateQueries({ queryKey: channelFeedQueryRoot });
+        // A recipient's private channel may be created by the handoff, and the
+        // task's channel can change (private space moves to the recipient's).
+        queryClient.invalidateQueries({ queryKey: TASK_CHANNELS_QUERY_KEY });
       },
     },
   );

--- a/products/posthog_ai/backend/message_routing.py
+++ b/products/posthog_ai/backend/message_routing.py
@@ -34,6 +34,7 @@ from products.posthog_ai.backend.helpers import BaseSandboxService
 from products.posthog_ai.backend.models.assistant import Conversation
 from products.posthog_ai.backend.run_state import PostHogAIRunState
 from products.posthog_ai.backend.services.system_prompt.service import PromptService
+from products.posthog_ai.backend.task_ownership import detach_conversations_for_task_handoff
 from products.posthog_ai.backend.wire_types import UnknownFrame, is_user_message_params, parse_log_entry
 from products.tasks.backend.facade import (
     api as tasks_facade,
@@ -126,6 +127,14 @@ class SandboxSession(BaseSandboxService):
         convert_to_acp: bool = False,
         repository: str | None = None,
     ) -> SandboxRouteResult | None:
+        task = self.conversation.task
+        if task is not None and (task.created_by_id != self.conversation.user_id or task.created_by_id != self.user.id):
+            detach_conversations_for_task_handoff(task.id, task.created_by_id)
+            self.conversation.task = None
+            self.conversation.sandbox_task_id = None
+            self.conversation.sandbox_run_id = None
+            raise exceptions.PermissionDenied("This task belongs to another user. Start a new conversation.")
+
         initial_permission_mode = self._initial_permission_mode(data.get("initial_permission_mode"))
         content = data.get("content")
         if not isinstance(content, str) or not content.strip():

--- a/products/posthog_ai/backend/task_ownership.py
+++ b/products/posthog_ai/backend/task_ownership.py
@@ -1,0 +1,13 @@
+from uuid import UUID
+
+from django.db.models import Q
+
+from products.posthog_ai.backend.models.assistant import Conversation
+
+
+def detach_conversations_for_task_handoff(task_id: UUID, new_owner_id: int | None) -> int:
+    """Detach conversations that must remain private to a previous task owner."""
+    conversations = Conversation.objects.filter(Q(task_id=task_id) | Q(sandbox_task_id=task_id))
+    if new_owner_id is not None:
+        conversations = conversations.exclude(user_id=new_owner_id)
+    return conversations.update(task=None, sandbox_task_id=None, sandbox_run_id=None)

--- a/products/posthog_ai/backend/tests/test_message_routing.py
+++ b/products/posthog_ai/backend/tests/test_message_routing.py
@@ -1,11 +1,13 @@
 from contextlib import contextmanager
 
+import pytest
 from posthog.test.base import APIBaseTest
 from unittest.mock import patch
 
 from rest_framework import exceptions
 
 from posthog.exceptions import Conflict, QuotaLimitExceeded
+from posthog.models.user import User
 
 from products.posthog_ai.backend.context_wrapper import MAX_ATTACHED_ITEMS, MAX_TEXT_LENGTH
 from products.posthog_ai.backend.message_routing import (
@@ -101,6 +103,31 @@ class TestOpenSandboxMessage(APIBaseTest):
         assert wf_kwargs["create_pr"] is False
         # The agent needs write scopes to create insights/dashboards/notebooks.
         assert wf_kwargs["posthog_mcp_scopes"] == "full"
+
+    def test_handoff_detaches_previous_owner_conversation(self):
+        new_owner = User.objects.create_user(
+            email="new-owner@example.com",
+            first_name="New owner",
+            password="password",
+        )
+        task = Task.objects.create(
+            team=self.team,
+            title="Transferred task",
+            created_by=new_owner,
+            origin_product=Task.OriginProduct.POSTHOG_AI,
+        )
+        self.conversation.task = task
+        self.conversation.sandbox_task_id = task.id
+        self.conversation.sandbox_run_id = task.id
+        self.conversation.save(update_fields=["task", "sandbox_task_id", "sandbox_run_id"])
+
+        with pytest.raises(exceptions.PermissionDenied):
+            self._service().open({"content": "Keep going"})
+
+        self.conversation.refresh_from_db()
+        self.assertIsNone(self.conversation.task_id)
+        self.assertIsNone(self.conversation.sandbox_task_id)
+        self.assertIsNone(self.conversation.sandbox_run_id)
 
     def test_first_message_threads_routed_repository(self):
         task, _ = self._stub_task()

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -5364,14 +5364,14 @@ def handoff_task(
 
     Visibility follows the recipient when the task lives in a private space: a
     task in the actor's ``#me`` (or a legacy channel-less task) moves into the
-    recipient's ``#me`` so they can actually open what's now theirs. Public
-    channels stay put — both sides keep the shared view.
+    recipient's ``#me`` so they can open what's now theirs. Public channels stay
+    put; both sides keep the shared view.
 
     Only the owner can hand a task off: ``task_control_q`` also grants control
     over team-owned origin products, and giving a task away is stricter than
-    driving it. The recipient must be an org member WITH access to this project
+    driving it. The recipient must be an org member with access to this project
     (``all_users_with_access`` honors private-project access control), otherwise
-    they'd end up owning a task they can't even open.
+    they'd end up owning a task they can't open.
 
     Returns the updated task detail, or ``None`` when the actor can't control the
     task or no longer owns it. Raises ``TaskHandoffError`` for invalid targets
@@ -5389,7 +5389,7 @@ def handoff_task(
         raise TaskHandoffError("That person already owns this task.")
     target = task.team.all_users_with_access().filter(id=target_user_id).first()
     if target is None:
-        raise TaskHandoffError("Tasks can only be handed off to a member of this project.")
+        raise TaskHandoffError("Tasks can only be handed off to someone with access to this project.")
 
     previous_owner_id = task.created_by_id
     actor = User.objects.filter(id=user_id).only("first_name", "email", "distinct_id").first() if user_id else None
@@ -5416,7 +5416,7 @@ def handoff_task(
         locked.created_by = target
         # The stored GitHub-user preference names the old owner's installation; the
         # recipient picks their own on their next run. Carrying it across would
-        # silently defer to user-scoped resolution anyway, so clear it explicitly.
+        # defer to user-scoped resolution anyway (it keys on created_by), so clear it.
         if locked.github_user_integration_id is not None:
             locked.github_user_integration = None
         # A stamped built-in agent task may borrow its credential owner's MCP Store

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -5318,51 +5318,54 @@ def update_task(
     task_id: str | UUID, team_id: int, user_id: int | None, *, validated_data: dict
 ) -> contracts.TaskDetailDTO | None:
     """Update a task, mirroring ``TaskSerializer.update``. ``None`` if not found/controllable."""
-    task = _visible_task_qs(team_id, user_id, for_control=True).filter(id=task_id).first()
-    if task is None:
-        return None
-
     validated_data = dict(validated_data)
     # origin_product controls visibility and signal_report is set once.
     validated_data.pop("signal_report", None)
     validated_data.pop("signal_report_task_relationship", None)
     validated_data.pop("origin_product", None)
     validated_data.pop("branch", None)
-    # Repo is immutable for code-access-exempt tasks; a mutable repo reopens the gate (see task_exempt_from_code_access).
-    if task.origin_product in (Task.OriginProduct.SIGNALS_CHAT, Task.OriginProduct.SIGNAL_REPORT):
-        validated_data.pop("repository", None)
-        validated_data.pop("repositories", None)
-        validated_data.pop("github_integration", None)
-        validated_data.pop("github_user_integration", None)
-    if "repositories" in validated_data:
-        repositories = validated_data["repositories"]
-        validated_data["repository"] = repositories[0] if repositories else None
-    elif "repository" in validated_data:
-        if len(task.repositories) <= 1:
-            validated_data["repositories"] = [validated_data["repository"]] if validated_data["repository"] else []
-        else:
-            validated_data.pop("repository")
-    if "title" in validated_data and "title_manually_set" not in validated_data:
-        validated_data["title_manually_set"] = True
-    if "archived" in validated_data and validated_data["archived"] != task.archived:
-        validated_data["archived_at"] = django_timezone.now() if validated_data["archived"] else None
 
-    logger.info("perform_update called for task %s with validated_data: %s", task.id, validated_data)
-    for key, value in validated_data.items():
-        setattr(task, key, value)
-    task.save()
-    logger.info("Task %s updated successfully", task.id)
+    with transaction.atomic():
+        task = Task.objects.select_for_update().filter(id=task_id, team_id=team_id, deleted=False).first()
+        if task is None or not Task.objects.filter(id=task.id).filter(task_control_q(user_id)).exists():
+            return None
+
+        # Repo is immutable for code-access-exempt tasks; a mutable repo reopens the gate (see task_exempt_from_code_access).
+        if task.origin_product in (Task.OriginProduct.SIGNALS_CHAT, Task.OriginProduct.SIGNAL_REPORT):
+            validated_data.pop("repository", None)
+            validated_data.pop("repositories", None)
+            validated_data.pop("github_integration", None)
+            validated_data.pop("github_user_integration", None)
+        if "repositories" in validated_data:
+            repositories = validated_data["repositories"]
+            validated_data["repository"] = repositories[0] if repositories else None
+        elif "repository" in validated_data:
+            if len(task.repositories) <= 1:
+                validated_data["repositories"] = [validated_data["repository"]] if validated_data["repository"] else []
+            else:
+                validated_data.pop("repository")
+        if "title" in validated_data and "title_manually_set" not in validated_data:
+            validated_data["title_manually_set"] = True
+        if "archived" in validated_data and validated_data["archived"] != task.archived:
+            validated_data["archived_at"] = django_timezone.now() if validated_data["archived"] else None
+
+        logger.info("perform_update called for task %s with validated_data: %s", task.id, validated_data)
+        for key, value in validated_data.items():
+            setattr(task, key, value)
+        task.save()
+        logger.info("Task %s updated successfully", task.id)
 
     return _task_detail_to_dto(_task_detail_queryset().get(pk=task.pk))
 
 
 def soft_delete_task(task_id: str | UUID, team_id: int, user_id: int | None) -> bool:
     """Soft-delete a task. Returns whether a task was found/controllable and deleted."""
-    task = _visible_task_qs(team_id, user_id, for_control=True).filter(id=task_id).first()
-    if task is None:
-        return False
-    logger.info("Soft deleting task %s", task.id)
-    task.soft_delete()
+    with transaction.atomic():
+        task = Task.objects.select_for_update().filter(id=task_id, team_id=team_id, deleted=False).first()
+        if task is None or not Task.objects.filter(id=task.id).filter(task_control_q(user_id)).exists():
+            return False
+        logger.info("Soft deleting task %s", task.id)
+        task.soft_delete()
     return True
 
 
@@ -5423,6 +5426,8 @@ def handoff_task(
         locked = Task.objects.select_for_update().get(pk=task.pk)
         # Under the lock: two concurrent handoffs settle last-writer-loses
         # instead of double-announcing and rerouting mid-flight.
+        if locked.deleted:
+            return None
         if locked.created_by_id != previous_owner_id:
             raise TaskHandoffError("Someone else has already handed this task off. Refresh and try again.")
         if (

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -89,6 +89,7 @@ from products.tasks.backend.logic.services.network_policy import (
 )
 from products.tasks.backend.mentions import resolve_mentioned_user_ids
 from products.tasks.backend.models import (
+    MCP_CREDENTIAL_OWNER_STATE_KEY,
     Channel,
     ChannelContextGeneration,
     ChannelFeedMessage,
@@ -5341,6 +5342,126 @@ def soft_delete_task(task_id: str | UUID, team_id: int, user_id: int | None) -> 
     logger.info("Soft deleting task %s", task.id)
     task.soft_delete()
     return True
+
+
+# --- Task handoff (transfer ownership to a colleague) ---
+
+
+class TaskHandoffError(Exception):
+    """A handoff request that reads as a client error rather than a missing task."""
+
+
+def handoff_task(
+    task_id: str | UUID, team_id: int, user_id: int | None, *, target_user_id: int
+) -> contracts.TaskDetailDTO | None:
+    """Hand ``task_id`` off to ``target_user_id``: they become the task's owner.
+
+    Ownership is what `task_control_q` keys on, so the recipient drives the task
+    afterwards (steer, archive, forward thread messages), and future runs resolve
+    GitHub authorship and notification recipients from them. Membership in the
+    project's organization is required — anything weaker would hand control of a
+    task to someone who can't see the project.
+
+    Visibility follows the recipient when the task lives in a private space: a
+    task in the actor's ``#me`` (or a legacy channel-less task) moves into the
+    recipient's ``#me`` so they can actually open what's now theirs. Public
+    channels stay put — both sides keep the shared view.
+
+    Returns the updated task detail, or ``None`` when the actor can't control the
+    task (same contract as ``update_task``). Raises ``TaskHandoffError`` for
+    invalid targets (not an org member, or the current owner).
+
+    All task runs must be terminal before a handoff. This prevents work started
+    by the previous owner from later resolving credentials for the recipient.
+    """
+    task = _visible_task_qs(team_id, user_id, for_control=True).filter(id=task_id).first()
+    if task is None:
+        return None
+    if task.created_by_id == target_user_id:
+        raise TaskHandoffError("That person already owns this task.")
+    # Organization.members sets related_query_name="organization" (singular) for User filters.
+    target = User.objects.filter(id=target_user_id, organization__team__id=team_id).first()
+    if target is None:
+        raise TaskHandoffError("Tasks can only be handed off to a member of this project.")
+
+    previous_owner_id = task.created_by_id
+    actor = User.objects.filter(id=user_id).only("first_name", "email", "distinct_id").first() if user_id else None
+    actor_name = ((actor.first_name.strip() or actor.email) if actor else None) or "Someone"
+    target_name = target.first_name.strip() or target.email
+    with transaction.atomic():
+        locked = Task.objects.select_for_update().get(pk=task.pk)
+        if (
+            TaskRun.objects.filter(task_id=locked.id, team_id=team_id)
+            .exclude(status__in=[TaskRun.Status.COMPLETED, TaskRun.Status.FAILED, TaskRun.Status.CANCELLED])
+            .exists()
+        ):
+            raise TaskHandoffError("Finish or cancel active runs before handing off this task.")
+        channel = locked.channel
+        if channel is None or channel.channel_type == Channel.ChannelType.PERSONAL:
+            # Never widen: a task in one private space moves to the other private
+            # space rather than becoming visible to the whole project, and a legacy
+            # channel-less task joins the recipient's #me where they'll find it.
+            locked.channel = _ensure_personal_channel(team_id, target.id)
+        locked.created_by = target
+        # The stored GitHub-user preference names the old owner's installation; the
+        # recipient picks their own on their next run. Carrying it across would
+        # silently defer to user-scoped resolution anyway, so clear it explicitly.
+        if locked.github_user_integration_id is not None:
+            locked.github_user_integration = None
+        # A stamped built-in agent task may borrow its credential owner's MCP Store
+        # grants. Handing ownership off while keeping that borrow would hand the old
+        # owner's connected accounts to whoever drives the run now, so drop the borrow.
+        if (locked.state or {}).get(MCP_CREDENTIAL_OWNER_STATE_KEY) is not None:
+            locked.state = {
+                key: value for key, value in (locked.state or {}).items() if key != MCP_CREDENTIAL_OWNER_STATE_KEY
+            }
+        locked.save()
+        message = TaskThreadMessage.objects.for_team(team_id).create(
+            team_id=team_id,
+            task_id=locked.id,
+            author_id=user_id,
+            author_kind=TaskThreadMessage.AuthorKind.SYSTEM,
+            event="task_handed_off",
+            payload={
+                "from_user_id": previous_owner_id,
+                "to_user_id": target.id,
+                # Clients render names straight from the payload (ids alone would need a
+                # member lookup); both are same-org members, so carrying names is safe.
+                "from_display_name": actor_name if user_id is not None else None,
+                "to_display_name": target_name,
+            },
+            content=f"{actor_name} handed this task off to {target_name}",
+        )
+
+    try:
+        project_thread_message_activity(message)
+    except Exception:
+        logger.exception("Failed to project handoff thread activity", extra={"task_id": str(task_id)})
+    from products.tasks.backend.push_dispatcher import notify_task_handoff  # noqa: PLC0415
+
+    notify_task_handoff(locked, recipient=target, actor=actor)
+    # Task.capture_event would attribute to the new owner (it keys on created_by);
+    # the actor initiated the handoff, so capture under their identity instead.
+    try:
+        posthoganalytics.capture(
+            distinct_id=str(actor.distinct_id) if actor is not None and actor.distinct_id else str(locked.team.uuid),
+            event="task_handed_off",
+            properties={
+                "task_id": str(locked.id),
+                "team_id": locked.team_id,
+                "title": locked.title,
+                "origin_product": locked.origin_product,
+                "repository": locked.repository,
+                "from_user_id": previous_owner_id,
+                "to_user_id": target.id,
+            },
+            groups=groups(team=locked.team),
+            send_feature_flags=True,
+        )
+    except Exception as e:
+        logger.warning("task_handed_off capture_event failed for task %s: %s", locked.id, e)
+
+    return _task_detail_to_dto(_task_detail_queryset().get(pk=locked.pk))
 
 
 # --- Task staged artifacts (S3 + cache, attached to the next run) ---

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -5452,7 +5452,7 @@ def handoff_task(
         notify_task_handoff,  # noqa: PLC0415 — optional push dep stays off the import path
     )
 
-    notify_task_handoff(locked, recipient=target, actor=actor)
+    notify_task_handoff(locked, recipient=target, actor=actor, message_id=message.id)
     # Task.capture_event would attribute to the new owner (it keys on created_by);
     # the actor initiated the handoff, so capture under their identity instead.
     try:

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -61,6 +61,7 @@ from posthog.models.integration import Integration
 from posthog.models.oauth import OAuthAccessToken, OAuthRefreshToken
 from posthog.utils import absolute_uri
 
+from products.posthog_ai.backend.task_ownership import detach_conversations_for_task_handoff
 from products.tasks.backend.constants import (
     AGENT_OTEL_TELEMETRY_STATE_KEY,
     AGENT_PEER_MESSAGING_FEATURE_FLAG,
@@ -4137,9 +4138,6 @@ def bootstrap_task_run(
     task = _get_task_for_run_control(task_id, team_id, user_id)
     if task is None:
         return None
-    expected_created_by_id = task.created_by_id
-    expected_ownership_version = task.ownership_version
-
     mode = validated_data.get("mode", "background")
     environment = validated_data.get("environment", TaskRun.Environment.LOCAL)
     branch = validated_data.get("branch")
@@ -4255,15 +4253,7 @@ def bootstrap_task_run(
         "Creating task run for task %s with mode=%s, branch=%s, environment=%s", task.id, mode, branch, environment
     )
     try:
-        run = task.create_run(
-            environment=environment,
-            mode=mode,
-            branch=branch,
-            extra_state=extra_state,
-            expected_created_by_id=expected_created_by_id,
-            expected_ownership_version=expected_ownership_version,
-            validate_task_ownership=True,
-        )
+        run = task.create_run(environment=environment, mode=mode, branch=branch, extra_state=extra_state)
     except TaskOwnershipChangedError:
         return None
 
@@ -5456,6 +5446,8 @@ def handoff_task(
         OAuthRefreshToken.objects.filter(access_token__in=bound_tokens).delete()
         bound_tokens.delete()
 
+        detach_conversations_for_task_handoff(locked.id, target.id)
+
         channel = locked.channel
         if channel is None or channel.channel_type == Channel.ChannelType.PERSONAL:
             # Never widen: a task in one private space moves to the other private
@@ -6030,8 +6022,6 @@ def run_task(
     task = _visible_task_qs(team_id, user_id, for_control=True).filter(id=task_id).first()
     if task is None:
         return None
-    expected_created_by_id = task.created_by_id
-    expected_ownership_version = task.ownership_version
     report_id_for_slot_check = (
         str(task.signal_report_id)
         if task.signal_report_id and task.origin_product == Task.OriginProduct.SIGNAL_REPORT
@@ -6357,14 +6347,7 @@ def run_task(
     logger.info("Creating task run for task %s with mode=%s, branch=%s", task.id, mode, branch)
     try:
         with transaction.atomic():
-            task_run = task.create_run(
-                mode=mode,
-                branch=branch,
-                extra_state=extra_state,
-                expected_created_by_id=expected_created_by_id,
-                expected_ownership_version=expected_ownership_version,
-                validate_task_ownership=True,
-            )
+            task_run = task.create_run(mode=mode, branch=branch, extra_state=extra_state)
             if report_id_for_slot_check is not None:
                 enforce_report_implementation_rerun_cap(
                     team_id=team_id, report_id=report_id_for_slot_check, task_id=str(task.id)

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -58,6 +58,7 @@ from posthog.dataclasses import frozen
 from posthog.event_usage import groups
 from posthog.models import Team, User
 from posthog.models.integration import Integration
+from posthog.models.oauth import OAuthAccessToken, OAuthRefreshToken
 from posthog.utils import absolute_uri
 
 from products.tasks.backend.constants import (
@@ -90,6 +91,7 @@ from products.tasks.backend.logic.services.network_policy import (
 from products.tasks.backend.mentions import resolve_mentioned_user_ids
 from products.tasks.backend.models import (
     MCP_CREDENTIAL_OWNER_STATE_KEY,
+    TASK_OWNERSHIP_VERSION_STATE_KEY,
     Channel,
     ChannelContextGeneration,
     ChannelFeedMessage,
@@ -107,6 +109,7 @@ from products.tasks.backend.models import (
     TaskArtifact,
     TaskClientProvenance,
     TaskCommentActivity,
+    TaskOwnershipChangedError,
     TaskPin,
     TaskRun,
     TaskSearchDocument,
@@ -276,6 +279,7 @@ __all__ = [
     "task_ids_with_pr_url_subquery",
     "task_run_has_slack_mapping",
     "task_run_is_terminal",
+    "task_run_matches_current_ownership",
     "task_runtime",
     "task_visible",
     "visible_tasks_q",
@@ -2122,6 +2126,7 @@ def delete_sandbox_custom_image(image_id: str | UUID, team_id: int, user_id: int
 _PROTECTED_RUN_STATE_KEYS = frozenset(
     {
         "github_credential_source",
+        TASK_OWNERSHIP_VERSION_STATE_KEY,
         "pr_authorship_mode",
         "repositories",
         "verified_pr_urls",
@@ -2261,6 +2266,14 @@ def task_run_exists(run_id: str | UUID, task_id: str | UUID, team_id: int) -> bo
         return TaskRun.objects.filter(pk=run_id, team_id=team_id, task_id=task_id).exists()
     except (ValueError, TypeError, DjangoValidationError):
         return False
+
+
+def task_run_matches_current_ownership(run_id: str | UUID, task_id: str | UUID, team_id: int) -> bool:
+    try:
+        run = _task_run_queryset().filter(pk=run_id, team_id=team_id, task_id=task_id).first()
+    except (ValueError, TypeError, DjangoValidationError):
+        return False
+    return run is not None and run.matches_task_ownership()
 
 
 def task_accessible_for_run_view(
@@ -4124,6 +4137,8 @@ def bootstrap_task_run(
     task = _get_task_for_run_control(task_id, team_id, user_id)
     if task is None:
         return None
+    expected_created_by_id = task.created_by_id
+    expected_ownership_version = task.ownership_version
 
     mode = validated_data.get("mode", "background")
     environment = validated_data.get("environment", TaskRun.Environment.LOCAL)
@@ -4239,7 +4254,18 @@ def bootstrap_task_run(
     logger.info(
         "Creating task run for task %s with mode=%s, branch=%s, environment=%s", task.id, mode, branch, environment
     )
-    run = task.create_run(environment=environment, mode=mode, branch=branch, extra_state=extra_state)
+    try:
+        run = task.create_run(
+            environment=environment,
+            mode=mode,
+            branch=branch,
+            extra_state=extra_state,
+            expected_created_by_id=expected_created_by_id,
+            expected_ownership_version=expected_ownership_version,
+            validate_task_ownership=True,
+        )
+    except TaskOwnershipChangedError:
+        return None
 
     if imported_mcp_servers or relayed_mcp_servers:
         update_fields = ["updated_at"]
@@ -4364,12 +4390,14 @@ def start_task_run(
     previous_state = dict(run.state or {})
     try:
         with transaction.atomic():
+            task = Task.objects.select_for_update().get(id=task_id, team_id=team_id)
             run = (
                 TaskRun.objects.select_for_update(of=("self",))
                 .select_related("task", "task__team", "task__created_by")
-                .get(id=run.id)
+                .get(id=run.id, task_id=task.id, team_id=team_id)
             )
-            task = run.task
+            if not run.matches_task_ownership(task):
+                return "ownership_changed", None
             if state_updates:
                 TaskRun.update_state_atomic(run.id, updates=state_updates)
                 run.refresh_from_db()
@@ -4402,8 +4430,9 @@ def resume_task_run_in_cloud(
     """Resume a run in a cloud sandbox, terminating any prior workflow.
 
     Returns ``(outcome, run_dto, debug_use_modal)``. ``outcome`` is one of: ``"not_found"``,
-    ``"already_active"`` (400), ``"auth_error:<detail>"`` (400, github auth), ``"workflow_failed"``
-    (502), or ``"resumed"`` (run_dto set). Mirrors ``TaskRunViewSet.resume_in_cloud``.
+    ``"already_active"`` (400), ``"ownership_changed"`` (400), ``"auth_error:<detail>"``
+    (400, GitHub auth), ``"workflow_failed"`` (502), or ``"resumed"`` (run_dto set).
+    Mirrors ``TaskRunViewSet.resume_in_cloud``.
     """
     from products.tasks.backend.facade.streams import reset_task_run_stream  # noqa: PLC0415
     from products.tasks.backend.redis import run_uses_dedicated_stream  # noqa: PLC0415
@@ -4446,11 +4475,14 @@ def resume_task_run_in_cloud(
     )
 
     with transaction.atomic():
+        task = Task.objects.select_for_update().get(id=task_id, team_id=team_id)
         run = (
             TaskRun.objects.select_for_update(of=("self",))
             .select_related("task", "task__created_by", "task__github_integration", "task__github_user_integration")
-            .get(pk=run.pk)
+            .get(pk=run.pk, task_id=task.id, team_id=team_id)
         )
+        if not run.matches_task_ownership(task):
+            return "ownership_changed", None, None
 
         is_cloud_active = run.environment == TaskRun.Environment.CLOUD and run.status in (
             TaskRun.Status.QUEUED,
@@ -5377,8 +5409,10 @@ def handoff_task(
     task or no longer owns it. Raises ``TaskHandoffError`` for invalid targets
     (not a member with project access, or the current owner).
 
-    All task runs must be terminal before a handoff. This prevents work started
-    by the previous owner from later resolving credentials for the recipient.
+    All task runs must be terminal and every sandbox session must be closed
+    before a handoff. The transfer rotates a server-owned ownership version and
+    revokes task-bound sandbox OAuth tokens, so old runs cannot execute or refresh
+    credentials under the recipient's identity.
     """
     task = _visible_task_qs(team_id, user_id, for_control=True).filter(id=task_id).first()
     if task is None:
@@ -5407,6 +5441,21 @@ def handoff_task(
             .exists()
         ):
             raise TaskHandoffError("Finish or cancel active runs before handing off this task.")
+        if (
+            SandboxSession.objects.for_team(team_id)
+            .filter(
+                task_run__task_id=locked.id,
+                ended_at__isnull=True,
+                ttl_expires_at__gt=django_timezone.now(),
+            )
+            .exists()
+        ):
+            raise TaskHandoffError("Wait for active sandboxes to shut down before handing off this task.")
+
+        bound_tokens = OAuthAccessToken.objects.filter(sandbox_task_id=locked.id)
+        OAuthRefreshToken.objects.filter(access_token__in=bound_tokens).delete()
+        bound_tokens.delete()
+
         channel = locked.channel
         if channel is None or channel.channel_type == Channel.ChannelType.PERSONAL:
             # Never widen: a task in one private space moves to the other private
@@ -5422,10 +5471,10 @@ def handoff_task(
         # A stamped built-in agent task may borrow its credential owner's MCP Store
         # grants. Handing ownership off while keeping that borrow would hand the old
         # owner's connected accounts to whoever drives the run now, so drop the borrow.
-        if (locked.state or {}).get(MCP_CREDENTIAL_OWNER_STATE_KEY) is not None:
-            locked.state = {
-                key: value for key, value in (locked.state or {}).items() if key != MCP_CREDENTIAL_OWNER_STATE_KEY
-            }
+        locked.state = {
+            key: value for key, value in (locked.state or {}).items() if key != MCP_CREDENTIAL_OWNER_STATE_KEY
+        }
+        locked.state[TASK_OWNERSHIP_VERSION_STATE_KEY] = str(uuid4())
         locked.save()
         message = TaskThreadMessage.objects.for_team(team_id).create(
             team_id=team_id,
@@ -5981,6 +6030,8 @@ def run_task(
     task = _visible_task_qs(team_id, user_id, for_control=True).filter(id=task_id).first()
     if task is None:
         return None
+    expected_created_by_id = task.created_by_id
+    expected_ownership_version = task.ownership_version
     report_id_for_slot_check = (
         str(task.signal_report_id)
         if task.signal_report_id and task.origin_product == Task.OriginProduct.SIGNAL_REPORT
@@ -6115,6 +6166,13 @@ def run_task(
         if not previous_run:
             return contracts.TaskRunResult(
                 error=contracts.TaskValidationError(kind="detail", detail="Invalid resume_from_run_id")
+            )
+        if not previous_run.matches_task_ownership(task):
+            return contracts.TaskRunResult(
+                error=contracts.TaskValidationError(
+                    kind="detail",
+                    detail="This run belongs to a previous task owner. Start a new run instead.",
+                )
             )
 
         prev_state = parse_run_state(previous_run.state)
@@ -6297,18 +6355,22 @@ def run_task(
             )
 
     logger.info("Creating task run for task %s with mode=%s, branch=%s", task.id, mode, branch)
-    with transaction.atomic():
-        task_run = task.create_run(mode=mode, branch=branch, extra_state=extra_state)
-        if report_id_for_slot_check is not None:
-            # A live run is what marks the report's implementation slot taken, so the slot is only
-            # really claimed once this row exists. Inserting first and locking the report second
-            # keeps the row lock off `create_run`, which evaluates a feature flag, and still
-            # serializes against a concurrent create: that create either takes the report lock
-            # first, so this check sees the task it added and rolls the run back, or takes it
-            # second, by which point this run is committed and its own count check refuses.
-            enforce_report_implementation_rerun_cap(
-                team_id=team_id, report_id=report_id_for_slot_check, task_id=str(task.id)
+    try:
+        with transaction.atomic():
+            task_run = task.create_run(
+                mode=mode,
+                branch=branch,
+                extra_state=extra_state,
+                expected_created_by_id=expected_created_by_id,
+                expected_ownership_version=expected_ownership_version,
+                validate_task_ownership=True,
             )
+            if report_id_for_slot_check is not None:
+                enforce_report_implementation_rerun_cap(
+                    team_id=team_id, report_id=report_id_for_slot_check, task_id=str(task.id)
+                )
+    except TaskOwnershipChangedError:
+        return None
     if is_pi_task and resume_from_run_id:
         task_run.active_task_session = previous_run.active_task_session
         task_run.save(update_fields=["active_task_session", "updated_at"])

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -5367,9 +5367,15 @@ def handoff_task(
     recipient's ``#me`` so they can actually open what's now theirs. Public
     channels stay put — both sides keep the shared view.
 
+    Only the owner can hand a task off: ``task_control_q`` also grants control
+    over team-owned origin products, and giving a task away is stricter than
+    driving it. The recipient must be an org member WITH access to this project
+    (``all_users_with_access`` honors private-project access control), otherwise
+    they'd end up owning a task they can't even open.
+
     Returns the updated task detail, or ``None`` when the actor can't control the
-    task (same contract as ``update_task``). Raises ``TaskHandoffError`` for
-    invalid targets (not an org member, or the current owner).
+    task or no longer owns it. Raises ``TaskHandoffError`` for invalid targets
+    (not a member with project access, or the current owner).
 
     All task runs must be terminal before a handoff. This prevents work started
     by the previous owner from later resolving credentials for the recipient.
@@ -5377,10 +5383,11 @@ def handoff_task(
     task = _visible_task_qs(team_id, user_id, for_control=True).filter(id=task_id).first()
     if task is None:
         return None
+    if user_id is None or task.created_by_id != user_id:
+        return None
     if task.created_by_id == target_user_id:
         raise TaskHandoffError("That person already owns this task.")
-    # Organization.members sets related_query_name="organization" (singular) for User filters.
-    target = User.objects.filter(id=target_user_id, organization__team__id=team_id).first()
+    target = task.team.all_users_with_access().filter(id=target_user_id).first()
     if target is None:
         raise TaskHandoffError("Tasks can only be handed off to a member of this project.")
 
@@ -5390,6 +5397,10 @@ def handoff_task(
     target_name = target.first_name.strip() or target.email
     with transaction.atomic():
         locked = Task.objects.select_for_update().get(pk=task.pk)
+        # Under the lock: two concurrent handoffs settle last-writer-loses
+        # instead of double-announcing and rerouting mid-flight.
+        if locked.created_by_id != previous_owner_id:
+            raise TaskHandoffError("Someone else has already handed this task off. Refresh and try again.")
         if (
             TaskRun.objects.filter(task_id=locked.id, team_id=team_id)
             .exclude(status__in=[TaskRun.Status.COMPLETED, TaskRun.Status.FAILED, TaskRun.Status.CANCELLED])
@@ -5437,7 +5448,9 @@ def handoff_task(
         project_thread_message_activity(message)
     except Exception:
         logger.exception("Failed to project handoff thread activity", extra={"task_id": str(task_id)})
-    from products.tasks.backend.push_dispatcher import notify_task_handoff  # noqa: PLC0415
+    from products.tasks.backend.push_dispatcher import (
+        notify_task_handoff,  # noqa: PLC0415 — optional push dep stays off the import path
+    )
 
     notify_task_handoff(locked, recipient=target, actor=actor)
     # Task.capture_event would attribute to the new owner (it keys on created_by);

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -5458,7 +5458,7 @@ def handoff_task(
             # Never widen: a task in one private space moves to the other private
             # space rather than becoming visible to the whole project, and a legacy
             # channel-less task joins the recipient's #me where they'll find it.
-            locked.channel = _ensure_personal_channel(team_id, target.id)
+            locked.channel = _ensure_personal_channel(team_id, target.id)[0]
         locked.created_by = target
         # The stored GitHub-user preference names the old owner's installation; the
         # recipient picks their own on their next run. Carrying it across would

--- a/products/tasks/backend/logic/services/warm.py
+++ b/products/tasks/backend/logic/services/warm.py
@@ -171,14 +171,7 @@ class SandboxWarmer:
                 run_state["resume_from_run_id"] = str(existing.id)
                 run_state.update(parse_run_state(existing.state).resume_snapshot_carry_state())
 
-            new_run = locked.create_run(
-                mode=mode,
-                extra_state=run_state,
-                branch=run_state.get("branch"),
-                expected_created_by_id=self.user.id,
-                expected_ownership_version=locked.ownership_version,
-                validate_task_ownership=True,
-            )
+            new_run = locked.create_run(mode=mode, extra_state=run_state, branch=run_state.get("branch"))
 
             # Dispatch only after the row commits, so a rollback can't leave an orphaned sandbox.
             enqueue_or_start_workflow(

--- a/products/tasks/backend/logic/services/warm.py
+++ b/products/tasks/backend/logic/services/warm.py
@@ -171,7 +171,14 @@ class SandboxWarmer:
                 run_state["resume_from_run_id"] = str(existing.id)
                 run_state.update(parse_run_state(existing.state).resume_snapshot_carry_state())
 
-            new_run = locked.create_run(mode=mode, extra_state=run_state, branch=run_state.get("branch"))
+            new_run = locked.create_run(
+                mode=mode,
+                extra_state=run_state,
+                branch=run_state.get("branch"),
+                expected_created_by_id=self.user.id,
+                expected_ownership_version=locked.ownership_version,
+                validate_task_ownership=True,
+            )
 
             # Dispatch only after the row commits, so a rollback can't leave an orphaned sandbox.
             enqueue_or_start_workflow(

--- a/products/tasks/backend/max_tools.py
+++ b/products/tasks/backend/max_tools.py
@@ -156,7 +156,8 @@ Use this tool when the user wants to:
         @transaction.atomic
         def get_task_and_create_run():
             task = (
-                Task.objects.filter(id=task_id, team=self._team, deleted=False)
+                Task.objects.select_for_update(of=("self",))
+                .filter(id=task_id, team=self._team, deleted=False)
                 .filter(task_control_q(self._user.id))
                 .first()
             )

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -538,11 +538,9 @@ class Task(DeletedMetaFields, models.Model):
         mode: str = "background",
         extra_state: dict | None = None,
         branch: str | None = None,
-        *,
-        expected_created_by_id: int | None = None,
-        expected_ownership_version: str | None = None,
-        validate_task_ownership: bool = False,
     ) -> "TaskRun":
+        expected_created_by_id = self.created_by_id
+        expected_ownership_version = self.ownership_version
         dedicated_stream = (extra_state or {}).get("use_dedicated_stream")
         if dedicated_stream is None:
             distinct_id = (self.created_by.distinct_id if self.created_by else None) or f"team_{self.team_id}"
@@ -557,9 +555,7 @@ class Task(DeletedMetaFields, models.Model):
                 .select_related("created_by", "team")
                 .get(id=self.id, team_id=self.team_id)
             )
-            if validate_task_ownership and (
-                task.created_by_id != expected_created_by_id or task.ownership_version != expected_ownership_version
-            ):
+            if task.created_by_id != expected_created_by_id or task.ownership_version != expected_ownership_version:
                 raise TaskOwnershipChangedError("Task ownership changed before the run was created")
 
             state: dict = {} if task.runtime == Task.Runtime.PI else {"mode": mode}

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -64,6 +64,7 @@ MCPBuiltInAgentKey = Literal["support", "scout"]
 MCP_BUILT_IN_AGENT_STATE_KEY = "mcp_builtin_agent_key"
 MCP_CREDENTIAL_OWNER_STATE_KEY = "mcp_credential_owner_id"
 MCP_GATEWAY_SERVER_ALLOWLIST_STATE_KEY = "mcp_gateway_server_ids"
+TASK_OWNERSHIP_VERSION_STATE_KEY = "task_ownership_version"
 MCP_BUILT_IN_AGENT_KEY_BY_ORIGIN: dict[str, MCPBuiltInAgentKey] = {
     "support_reply": "support",
     "signals_scout": "scout",
@@ -74,6 +75,15 @@ def resolve_schema(schema: type[BaseModel] | dict) -> dict:
     if isinstance(schema, dict):
         return schema
     return schema.model_json_schema()
+
+
+def _task_ownership_version(state: dict | None) -> str | None:
+    value = (state or {}).get(TASK_OWNERSHIP_VERSION_STATE_KEY)
+    return value if isinstance(value, str) else None
+
+
+class TaskOwnershipChangedError(RuntimeError):
+    pass
 
 
 class Channel(TeamScopedRootMixin):
@@ -518,70 +528,99 @@ class Task(DeletedMetaFields, models.Model):
         max_task_number = Task.objects.filter(team=self.team).aggregate(models.Max("task_number"))["task_number__max"]
         self.task_number = (max_task_number if max_task_number is not None else -1) + 1
 
+    @property
+    def ownership_version(self) -> str | None:
+        return _task_ownership_version(self.state)
+
     def create_run(
         self,
         environment: Optional["TaskRun.Environment"] = None,
         mode: str = "background",
         extra_state: dict | None = None,
         branch: str | None = None,
+        *,
+        expected_created_by_id: int | None = None,
+        expected_ownership_version: str | None = None,
+        validate_task_ownership: bool = False,
     ) -> "TaskRun":
-        state: dict = {} if self.runtime == Task.Runtime.PI else {"mode": mode}
-        if extra_state:
-            state.update({k: v for k, v in extra_state.items() if k != "mode"})
-        state.setdefault("repositories", self.repositories or ([self.repository] if self.repository else []))
-        # A workflow task's later runs (a teammate continuing it) must keep the connector
-        # allowlist the workflow selected; without the snapshot the run would mount every
-        # installation its owner has (see loop_mcp_installation_allowlist).
-        if self.origin_product == Task.OriginProduct.WORKFLOW and "config_snapshot" not in state:
-            previous = self.latest_run
-            previous_snapshot = previous.state.get("config_snapshot") if previous else None
-            if previous_snapshot:
-                state["config_snapshot"] = previous_snapshot
-        # Pin the stream-routing decision once so every reader/writer agrees for this run's life.
-        if "use_dedicated_stream" not in state:
+        dedicated_stream = (extra_state or {}).get("use_dedicated_stream")
+        if dedicated_stream is None:
             distinct_id = (self.created_by.distinct_id if self.created_by else None) or f"team_{self.team_id}"
-            state["use_dedicated_stream"] = evaluate_dedicated_stream_flag(
+            dedicated_stream = evaluate_dedicated_stream_flag(
                 organization_id=str(self.team.organization_id),
                 distinct_id=distinct_id,
             )
-        is_resume = bool((extra_state or {}).get("resume_from_run_id"))
-        has_pending = bool(
-            (extra_state or {}).get("pending_user_message") or (extra_state or {}).get("pending_user_artifact_ids")
-        )
-        task_run = TaskRun.objects.create(
-            task=self,
-            team=self.team,
-            status=TaskRun.Status.QUEUED,
-            queued_at=django_timezone.now(),
-            **({"environment": environment} if environment else {}),
-            state=state,
-            branch=branch,
-        )
 
-        def emit_created_events() -> None:
-            task_run.publish_stream_state_event()
-            observe_task_run_created(task_run)
-            self.capture_event(
-                "task_run_created",
-                {
-                    "run_id": str(task_run.id),
-                    "mode": mode,
-                    "environment": task_run.environment,
-                    # The bare `environment` property gets clobbered by the analytics client's
-                    # deployment-environment super-property, so ship the run's local/cloud value
-                    # under an unclobbered name too — as TaskRun.capture_event already does.
-                    "run_environment": task_run.environment,
-                    "is_resume": is_resume,
-                    "has_pending_message": has_pending,
-                    # Loop attribution: this event uses Task.capture_event (not TaskRun's),
-                    # so carry it from the run state the same way TaskRun.capture_event does.
-                    "loop_id": state.get("loop_id"),
-                    "loop_trigger_id": state.get("loop_trigger_id"),
-                },
+        with transaction.atomic():
+            task = (
+                Task.objects.select_for_update(of=("self",))
+                .select_related("created_by", "team")
+                .get(id=self.id, team_id=self.team_id)
+            )
+            if validate_task_ownership and (
+                task.created_by_id != expected_created_by_id or task.ownership_version != expected_ownership_version
+            ):
+                raise TaskOwnershipChangedError("Task ownership changed before the run was created")
+
+            state: dict = {} if task.runtime == Task.Runtime.PI else {"mode": mode}
+            if extra_state:
+                state.update({k: v for k, v in extra_state.items() if k != "mode"})
+            state.setdefault("repositories", task.repositories or ([task.repository] if task.repository else []))
+            # A workflow task's later runs must keep the connector allowlist selected by the workflow.
+            if task.origin_product == Task.OriginProduct.WORKFLOW and "config_snapshot" not in state:
+                previous = task.latest_run
+                previous_snapshot = previous.state.get("config_snapshot") if previous else None
+                if previous_snapshot:
+                    state["config_snapshot"] = previous_snapshot
+            if task.ownership_version is not None:
+                state[TASK_OWNERSHIP_VERSION_STATE_KEY] = task.ownership_version
+
+            resume_from_run_id = (extra_state or {}).get("resume_from_run_id")
+            if resume_from_run_id is not None:
+                resume_source = TaskRun.objects.filter(id=resume_from_run_id, task_id=task.id).only("state").first()
+                if resume_source is None or not resume_source.matches_task_ownership(task):
+                    raise TaskOwnershipChangedError("The resume source belongs to a previous task owner")
+
+            # Pin the stream-routing decision once so every reader/writer agrees for this run's life.
+            state.setdefault("use_dedicated_stream", dedicated_stream)
+            is_resume = bool(resume_from_run_id)
+            has_pending = bool(
+                (extra_state or {}).get("pending_user_message") or (extra_state or {}).get("pending_user_artifact_ids")
+            )
+            task_run = TaskRun.objects.create(
+                task=task,
+                team=task.team,
+                status=TaskRun.Status.QUEUED,
+                queued_at=django_timezone.now(),
+                **({"environment": environment} if environment else {}),
+                state=state,
+                branch=branch,
             )
 
-        execute_after_commit(emit_created_events)
-        return task_run
+            def emit_created_events() -> None:
+                task_run.publish_stream_state_event()
+                observe_task_run_created(task_run)
+                task.capture_event(
+                    "task_run_created",
+                    {
+                        "run_id": str(task_run.id),
+                        "mode": mode,
+                        "environment": task_run.environment,
+                        # The bare `environment` property gets clobbered by the analytics client's
+                        # deployment-environment super-property, so ship the run's local/cloud value
+                        # under an unclobbered name too — as TaskRun.capture_event already does.
+                        "run_environment": task_run.environment,
+                        "is_resume": is_resume,
+                        "has_pending_message": has_pending,
+                        # Loop attribution: this event uses Task.capture_event (not TaskRun's),
+                        # so carry it from the run state the same way TaskRun.capture_event does.
+                        "loop_id": state.get("loop_id"),
+                        "loop_trigger_id": state.get("loop_trigger_id"),
+                    },
+                )
+
+            execute_after_commit(emit_created_events)
+            return task_run
 
     @property
     def slack_notified_pr_url(self) -> str | None:
@@ -2627,6 +2666,14 @@ class TaskRun(models.Model):
         }
         self.append_log([event])
         self.publish_stream_event(event)
+
+    @property
+    def ownership_version(self) -> str | None:
+        return _task_ownership_version(self.state)
+
+    def matches_task_ownership(self, task: Task | None = None) -> bool:
+        current_task = task or self.task
+        return self.ownership_version == current_task.ownership_version
 
     @property
     def is_terminal(self) -> bool:

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -2267,6 +2267,18 @@ class TaskPinRequestSerializer(serializers.Serializer):
     pinned = serializers.BooleanField(help_text="Whether the task should be pinned for the requester.")
 
 
+class TaskHandoffRequestSerializer(serializers.Serializer):
+    """Request body for handing a task off to a colleague: they become its owner."""
+
+    user = serializers.IntegerField(
+        min_value=1,
+        help_text=(
+            "ID of the user taking over the task. Must be a member of this project's organization "
+            "and not the task's current owner."
+        ),
+    )
+
+
 class TaskPinResponseSerializer(serializers.Serializer):
     task_id = serializers.UUIDField(help_text="Task whose pin state was updated.")
     pinned = serializers.BooleanField(help_text="Current pin state for the requester.")

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -2273,8 +2273,7 @@ class TaskHandoffRequestSerializer(serializers.Serializer):
     user = serializers.IntegerField(
         min_value=1,
         help_text=(
-            "ID of the user taking over the task. Must be a member of this project's organization "
-            "and not the task's current owner."
+            "ID of the user taking over the task. Must have access to this project and not be the task's current owner."
         ),
     )
 

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -46,7 +46,12 @@ from posthog.api.utils import ServerTimingsGathered
 from posthog.auth import OAuthAccessTokenAuthentication, PersonalAPIKeyAuthentication
 from posthog.event_usage import groups
 from posthog.models import User
-from posthog.permissions import APIScopePermission, get_authenticator_scoped_team_ids, get_authenticator_scopes
+from posthog.permissions import (
+    APIScopePermission,
+    get_authenticator_scoped_team_ids,
+    get_authenticator_scopes,
+    is_mcp_built_in_agent_oauth_request,
+)
 from posthog.rate_limit import CodeInviteThrottle, TaskRunChartRenderThrottle
 from posthog.renderers import ServerSentEventRenderer
 from posthog.schema_migrations.upgrade import upgrade
@@ -700,14 +705,15 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         description=(
             "Transfer ownership of a task to another member of the project: they take over driving it "
             "(steering, archiving, running), and future runs resolve GitHub authorship and notification "
-            "recipients from them. Only the task's current owner can hand it off. A task in a private "
-            "space moves into the recipient's private space; a task in a shared space stays there."
+            "recipients from them. Only the task's current owner can hand it off. Every run must be "
+            "finished or canceled, and every sandbox must be shut down first. A task in a private space "
+            "moves into the recipient's private space; a task in a shared space stays there."
         ),
     )
     @action(detail=True, methods=["post"], url_path="handoff", required_scopes=["task:write"])
     @validated_request(request_serializer=TaskHandoffRequestSerializer)
     def handoff(self, request, pk=None, **kwargs):
-        if _sandbox_bound_task_id(request) is not None:
+        if _sandbox_bound_task_id(request) is not None or is_mcp_built_in_agent_oauth_request(request):
             raise PermissionDenied("Only a user can hand off a task. Sign in to continue.")
         user_id = self._user_id()
         if user_id is None:
@@ -1240,6 +1246,13 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             for_control=not is_read_only,
         ):
             raise NotFound("Task not found")
+        run_id = self.kwargs.get("pk")
+        if (
+            not is_read_only
+            and run_id is not None
+            and not tasks_facade.task_run_matches_current_ownership(run_id, task_id, self.team_id)
+        ):
+            raise NotFound("Task run not found")
         return task_id
 
     def _get_run_or_404(self, pk) -> tasks_contracts.TaskRunDetailDTO:
@@ -1391,6 +1404,13 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
                     "detail": "Some pending_user_artifact_ids are invalid for this run",
                     "missing_artifact_ids": missing,
                 },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if outcome == "ownership_changed":
+            return Response(
+                TaskRunErrorResponseSerializer(
+                    {"error": "This run belongs to a previous task owner. Start a new run instead."}
+                ).data,
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
@@ -2702,6 +2722,13 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         if outcome == "already_active":
             return Response(
                 TaskRunErrorResponseSerializer({"error": "Run is already active in cloud"}).data,
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if outcome == "ownership_changed":
+            return Response(
+                TaskRunErrorResponseSerializer(
+                    {"error": "This run belongs to a previous task owner. Start a new run instead."}
+                ).data,
                 status=status.HTTP_400_BAD_REQUEST,
             )
         if outcome.startswith("auth_error:"):

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -2995,6 +2995,8 @@ class TaskRunLivingArtifactViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewS
             for_control=not is_read,
         ):
             raise NotFound("Task not found")
+        if not is_read and not tasks_facade.task_run_matches_current_ownership(self._run_id(), task_id, self.team_id):
+            raise NotFound("Task run not found")
         return task_id
 
     @validated_request(

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -689,7 +689,13 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
 
     @extend_schema(
         request=TaskHandoffRequestSerializer,
-        responses={200: TaskSerializer},
+        responses={
+            200: TaskSerializer,
+            403: OpenApiResponse(
+                response=TaskRunErrorResponseSerializer,
+                description="Only a user may hand off a task.",
+            ),
+        },
         summary="Hand a task off to a colleague",
         description=(
             "Transfer ownership of a task to another member of the project: they take over driving it "
@@ -701,6 +707,8 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     @action(detail=True, methods=["post"], url_path="handoff", required_scopes=["task:write"])
     @validated_request(request_serializer=TaskHandoffRequestSerializer)
     def handoff(self, request, pk=None, **kwargs):
+        if pk is not None and is_sandbox_agent_request(request, pk):
+            raise PermissionDenied("Only a user can hand off a task. Sign in to continue.")
         user_id = self._user_id()
         if user_id is None:
             raise NotFound()

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -713,7 +713,7 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     @action(detail=True, methods=["post"], url_path="handoff", required_scopes=["task:write"])
     @validated_request(request_serializer=TaskHandoffRequestSerializer)
     def handoff(self, request, pk=None, **kwargs):
-        if _sandbox_bound_task_id(request) is not None or is_mcp_built_in_agent_oauth_request(request):
+        if is_sandbox_oauth_request(request) or is_mcp_built_in_agent_oauth_request(request):
             raise PermissionDenied("Only a user can hand off a task. Sign in to continue.")
         user_id = self._user_id()
         if user_id is None:
@@ -1161,15 +1161,18 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
 
 
 @extend_schema(tags=["task-runs", "tasks"])
-def _sandbox_bound_task_id(request) -> UUID | None:
+def is_sandbox_oauth_request(request) -> bool:
     authenticator = request.successful_authenticator
     if not isinstance(authenticator, OAuthAccessTokenAuthentication):
+        return False
+    application = authenticator.access_token.application
+    return application is not None and application.client_id in SANDBOX_OAUTH_APP_CLIENT_IDS
+
+
+def _sandbox_bound_task_id(request) -> UUID | None:
+    if not is_sandbox_oauth_request(request):
         return None
-    access_token = authenticator.access_token
-    application = access_token.application
-    if application is None or application.client_id not in SANDBOX_OAUTH_APP_CLIENT_IDS:
-        return None
-    return access_token.sandbox_task_id
+    return request.successful_authenticator.access_token.sandbox_task_id
 
 
 def is_sandbox_agent_request(request, task_id: str) -> bool:

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -113,6 +113,7 @@ from products.tasks.backend.presentation.serializers import (
     TaskCommentsQuerySerializer,
     TaskCommentsResponseSerializer,
     TaskCreateSerializer,
+    TaskHandoffRequestSerializer,
     TaskListQuerySerializer,
     TaskPinRequestSerializer,
     TaskPinResponseSerializer,
@@ -685,6 +686,31 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         if pinned is None:
             raise NotFound()
         return Response({"task_id": pk, "pinned": pinned})
+
+    @extend_schema(
+        request=TaskHandoffRequestSerializer,
+        responses={200: TaskSerializer},
+        summary="Hand a task off to a colleague",
+        description=(
+            "Transfer ownership of a task to another member of the project: they take over driving it "
+            "(steering, archiving, running), and future runs resolve GitHub authorship and notification "
+            "recipients from them. Only the task's current owner can hand it off. A task in a private "
+            "space moves into the recipient's private space; a task in a shared space stays there."
+        ),
+    )
+    @action(detail=True, methods=["post"], url_path="handoff", required_scopes=["task:write"])
+    @validated_request(request_serializer=TaskHandoffRequestSerializer)
+    def handoff(self, request, pk=None, **kwargs):
+        user_id = self._user_id()
+        if user_id is None:
+            raise NotFound()
+        try:
+            task = tasks_facade.handoff_task(pk, self.team_id, user_id, target_user_id=request.validated_data["user"])
+        except tasks_facade.TaskHandoffError as e:
+            raise ValidationError({"user": str(e)}) from e
+        if task is None:
+            raise NotFound()
+        return Response(TaskSerializer(task).data)
 
     @extend_schema(
         responses={

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -707,7 +707,7 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     @action(detail=True, methods=["post"], url_path="handoff", required_scopes=["task:write"])
     @validated_request(request_serializer=TaskHandoffRequestSerializer)
     def handoff(self, request, pk=None, **kwargs):
-        if pk is not None and is_sandbox_agent_request(request, pk):
+        if _sandbox_bound_task_id(request) is not None:
             raise PermissionDenied("Only a user can hand off a task. Sign in to continue.")
         user_id = self._user_id()
         if user_id is None:
@@ -1155,16 +1155,20 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
 
 
 @extend_schema(tags=["task-runs", "tasks"])
-def is_sandbox_agent_request(request, task_id: str) -> bool:
-    """True only for the task-bound sandbox OAuth identity, never a human session or key."""
+def _sandbox_bound_task_id(request) -> UUID | None:
     authenticator = request.successful_authenticator
     if not isinstance(authenticator, OAuthAccessTokenAuthentication):
-        return False
+        return None
     access_token = authenticator.access_token
     application = access_token.application
     if application is None or application.client_id not in SANDBOX_OAUTH_APP_CLIENT_IDS:
-        return False
-    return access_token.sandbox_task_id == UUID(task_id)
+        return None
+    return access_token.sandbox_task_id
+
+
+def is_sandbox_agent_request(request, task_id: str) -> bool:
+    """True only for the task-bound sandbox OAuth identity, never a human session or key."""
+    return _sandbox_bound_task_id(request) == UUID(task_id)
 
 
 class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):

--- a/products/tasks/backend/push_dispatcher.py
+++ b/products/tasks/backend/push_dispatcher.py
@@ -92,10 +92,7 @@ def notify_task_run_turn_completed(task_run: TaskRun) -> None:
 def notify_task_handoff(task: Task, *, recipient: User, actor: User | None, message_id: UUID) -> None:
     """Fire a push notification when a task is handed off to ``recipient``.
 
-    ``message_id`` is the handoff announcement's thread-message id. Keying the
-    cooldown on it (not on task+recipient) lets a genuinely new handoff to the
-    same person fire — e.g. handing a task back and forth — while still
-    collapsing a retry of the same handoff.
+    The announcement ID separates new handoffs from retries for cooldown purposes.
     """
     try:
         actor_name = ((actor.first_name.strip() or actor.email) if actor else None) or "A colleague"

--- a/products/tasks/backend/push_dispatcher.py
+++ b/products/tasks/backend/push_dispatcher.py
@@ -37,6 +37,8 @@ from products.tasks.backend.redis import get_tasks_cache
 from products.tasks.backend.visibility import task_visibility_q
 
 if TYPE_CHECKING:
+    from uuid import UUID
+
     from products.tasks.backend.models import TaskRun, TaskThreadMessage
 
 logger = structlog.get_logger(__name__)
@@ -87,8 +89,14 @@ def notify_task_run_turn_completed(task_run: TaskRun) -> None:
     _enqueue(task_run, kind="turn_completed", body=f'"{_task_title(task_run)}" finished')
 
 
-def notify_task_handoff(task: Task, *, recipient: User, actor: User | None) -> None:
-    """Fire a push notification when a task is handed off to ``recipient``."""
+def notify_task_handoff(task: Task, *, recipient: User, actor: User | None, message_id: UUID) -> None:
+    """Fire a push notification when a task is handed off to ``recipient``.
+
+    ``message_id`` is the handoff announcement's thread-message id. Keying the
+    cooldown on it (not on task+recipient) lets a genuinely new handoff to the
+    same person fire — e.g. handing a task back and forth — while still
+    collapsing a retry of the same handoff.
+    """
     try:
         actor_name = ((actor.first_name.strip() or actor.email) if actor else None) or "A colleague"
         task_title = (task.title or "").strip() or "Untitled task"
@@ -96,7 +104,7 @@ def notify_task_handoff(task: Task, *, recipient: User, actor: User | None) -> N
             recipient,
             task=task,
             kind="handoff",
-            cooldown_subject=f"task_handoff:{task.id}:{recipient.id}",
+            cooldown_subject=f"task_handoff:{message_id}:{recipient.id}",
             body=f'{actor_name} handed you "{task_title}"',
             data={"taskId": str(task.id)},
         )

--- a/products/tasks/backend/push_dispatcher.py
+++ b/products/tasks/backend/push_dispatcher.py
@@ -48,7 +48,7 @@ FEATURE_FLAG_KEY = "posthog-code-mobile-push"
 # they should only fire once per run lifetime — anything more is a retry.
 # Interactive turn-end can legitimately fire again after the user replies,
 # so a short cooldown is enough to absorb rapid duplicate triggers.
-PushKind = Literal["completed", "failed", "cancelled", "awaiting", "turn_completed", "thread_message"]
+PushKind = Literal["completed", "failed", "cancelled", "awaiting", "turn_completed", "thread_message", "handoff"]
 _COOLDOWN_SECONDS: dict[PushKind, int] = {
     "completed": 600,
     "failed": 600,
@@ -56,6 +56,7 @@ _COOLDOWN_SECONDS: dict[PushKind, int] = {
     "awaiting": 30,
     "turn_completed": 30,
     "thread_message": 600,
+    "handoff": 600,
 }
 
 
@@ -84,6 +85,30 @@ def notify_task_run_awaiting_input(task_run: TaskRun) -> None:
 def notify_task_run_turn_completed(task_run: TaskRun) -> None:
     _project_completed_activity(task_run)
     _enqueue(task_run, kind="turn_completed", body=f'"{_task_title(task_run)}" finished')
+
+
+def notify_task_handoff(task: Task, *, recipient: User, actor: User | None) -> None:
+    """Fire a push notification when a task is handed off to ``recipient``."""
+    try:
+        actor_name = ((actor.first_name.strip() or actor.email) if actor else None) or "A colleague"
+        task_title = (task.title or "").strip() or "Untitled task"
+        _enqueue_user(
+            recipient,
+            task=task,
+            kind="handoff",
+            cooldown_subject=f"task_handoff:{task.id}:{recipient.id}",
+            body=f'{actor_name} handed you "{task_title}"',
+            data={"taskId": str(task.id)},
+        )
+    except Exception as exc:
+        PUSH_DISPATCHER_FAILURES_TOTAL.labels(kind="handoff", reason=_failure_reason(exc)).inc()
+        logger.warning(
+            "push_dispatcher.enqueue_failed",
+            task_id=str(task.id),
+            user_id=recipient.id,
+            kind="handoff",
+            exc_info=True,
+        )
 
 
 def notify_task_thread_message(message: TaskThreadMessage, mentioned_user_ids: Collection[int]) -> None:

--- a/products/tasks/backend/temporal/oauth.py
+++ b/products/tasks/backend/temporal/oauth.py
@@ -192,9 +192,7 @@ def create_oauth_access_token_for_run(
                 raise TaskInvalidStateError(
                     f"{credential_owner_kind.capitalize()} task {locked_task.id} credential owner can no longer access its team",
                     {"task_id": locked_task.id},
-                    cause=RuntimeError(
-                        f"{credential_owner_kind} credential owner is not an active team member"
-                    ),
+                    cause=RuntimeError(f"{credential_owner_kind} credential owner is not an active team member"),
                 )
 
         return create_oauth_access_token(

--- a/products/tasks/backend/temporal/oauth.py
+++ b/products/tasks/backend/temporal/oauth.py
@@ -24,7 +24,7 @@ from products.tasks.backend.logic.services.run_actor import (
     is_slack_interaction_state,
     loop_owner_eligible_for_credentials,
 )
-from products.tasks.backend.models import Task
+from products.tasks.backend.models import TASK_OWNERSHIP_VERSION_STATE_KEY, Task
 
 if TYPE_CHECKING:
     from posthog.models.user import User
@@ -162,55 +162,44 @@ def create_oauth_access_token_for_run(
     to mint creator credentials for a Slack run by omitting one kwarg. Loop-fired runs
     (``loop_id`` in run state) get ``loop:write`` stripped from the granted scopes here.
     """
-    actor_user = get_task_run_credential_user(task, state)
-    loop_id = (state or {}).get("loop_id")
-    if task.origin_product == Task.OriginProduct.WORKFLOW:
-        # Workflow-fired runs mirror the loop-run policy below: the owner's eligibility is
-        # rechecked and locked at mint time, and automation-editing scopes are stripped.
-        # The workflow's snapshotted scope choice additionally caps the request, because a
-        # teammate's rerun dispatches with the generic user-run scopes rather than the
-        # ones the workflow selected.
-        effective_scopes = _workflow_run_scopes(scopes, state)
-        credential_owner_id = actor_user.id if actor_user is not None else task.created_by_id
-        with transaction.atomic():
-            if not loop_owner_eligible_for_credentials(credential_owner_id, task.team):
-                raise TaskInvalidStateError(
-                    f"Workflow task {task.id} credential owner can no longer access its team",
-                    {"task_id": task.id},
-                    cause=RuntimeError("workflow credential owner is not an active team member"),
-                )
-            return create_oauth_access_token(
-                task,
-                scopes=effective_scopes,
-                user=actor_user,
-                allow_task_creator_fallback=not is_slack_interaction_state(state),
-                loop_id=None,
-            )
-    if loop_id is None:
-        return create_oauth_access_token(
-            task,
-            scopes=scopes,
-            user=actor_user,
-            allow_task_creator_fallback=not is_slack_interaction_state(state),
-            loop_id=None,
-        )
-
-    # Loop run: re-verify the credential owner is eligible at mint time, not just at dispatch, and do
-    # it atomically. `is_active` on the already-loaded `task.created_by` is stale, so the check reads
-    # and locks the owner row (and its membership) freshly, then mints inside the same transaction —
-    # a deactivation or membership removal can't commit between the check and token creation, and the
-    # async loop cancellation can't revoke a token already handed to the sandbox.
-    credential_owner_id = actor_user.id if actor_user is not None else task.created_by_id
     with transaction.atomic():
-        if not loop_owner_eligible_for_credentials(credential_owner_id, task.team):
+        locked_task = (
+            Task.objects.select_for_update(of=("self",))
+            .select_related("created_by", "team")
+            .get(id=task.id, team_id=task.team_id)
+        )
+        run_ownership_version = (state or {}).get(TASK_OWNERSHIP_VERSION_STATE_KEY)
+        if run_ownership_version != locked_task.ownership_version:
             raise TaskInvalidStateError(
-                f"Loop task {task.id} credential owner can no longer access its team",
+                f"Task run for {task.id} belongs to a previous task owner",
                 {"task_id": task.id},
-                cause=RuntimeError("loop credential owner is not an active team member"),
+                cause=RuntimeError("task run ownership version is stale"),
             )
+
+        actor_user = get_task_run_credential_user(locked_task, state)
+        loop_id = (state or {}).get("loop_id")
+        effective_scopes = scopes
+        credential_owner_kind: str | None = None
+        if locked_task.origin_product == Task.OriginProduct.WORKFLOW:
+            effective_scopes = _workflow_run_scopes(scopes, state)
+            credential_owner_kind = "workflow"
+        elif loop_id is not None:
+            credential_owner_kind = "loop"
+
+        if credential_owner_kind is not None:
+            credential_owner_id = actor_user.id if actor_user is not None else locked_task.created_by_id
+            if not loop_owner_eligible_for_credentials(credential_owner_id, locked_task.team):
+                raise TaskInvalidStateError(
+                    f"{credential_owner_kind.capitalize()} task {locked_task.id} credential owner can no longer access its team",
+                    {"task_id": locked_task.id},
+                    cause=RuntimeError(
+                        f"{credential_owner_kind} credential owner is not an active team member"
+                    ),
+                )
+
         return create_oauth_access_token(
-            task,
-            scopes=scopes,
+            locked_task,
+            scopes=effective_scopes,
             user=actor_user,
             allow_task_creator_fallback=not is_slack_interaction_state(state),
             loop_id=loop_id if isinstance(loop_id, str) else None,

--- a/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
@@ -834,6 +834,12 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
     emit_agent_log(run_id, "debug", "Fetching task details")
 
     task: Task = task_run.task
+    if not task_run.matches_task_ownership(task):
+        raise TaskInvalidStateError(
+            f"TaskRun {run_id} belongs to a previous task owner",
+            {"task_id": str(task.id), "run_id": run_id},
+            cause=RuntimeError(f"TaskRun {run_id} ownership version is stale"),
+        )
     if task.runtime == Task.Runtime.PI:
         ensure_task_run_session(task_run.id)
 

--- a/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
@@ -28,6 +28,7 @@ from products.tasks.backend.exceptions import (
     OAuthTokenError,
     RepositoryCloneError,
     SandboxNetworkPolicyError,
+    TaskInvalidStateError,
     TaskNotFoundError,
 )
 from products.tasks.backend.logic.services.agentsh import (
@@ -61,7 +62,7 @@ from products.tasks.backend.logic.services.sandbox_usage import (
     measure_sandbox_cpu_usage,
     open_sandbox_session,
 )
-from products.tasks.backend.models import SandboxSnapshot, Task, TaskRun
+from products.tasks.backend.models import TASK_OWNERSHIP_VERSION_STATE_KEY, SandboxSnapshot, Task, TaskRun
 from products.tasks.backend.temporal.metrics import (
     StepTimer,
     increment_snapshot_restore,
@@ -362,11 +363,19 @@ def _resolve_sandbox_github_token(
 
 def _load_task(ctx: TaskProcessingContext) -> Task:
     try:
-        return Task.objects.select_related(
+        task = Task.objects.select_related(
             "created_by", "github_integration", "github_user_integration", "team", "loop"
         ).get(id=ctx.task_id)
     except Task.DoesNotExist as e:
         raise TaskNotFoundError(f"Task {ctx.task_id} not found", {"task_id": ctx.task_id}, cause=e)
+    context_ownership_version = (ctx.state or {}).get(TASK_OWNERSHIP_VERSION_STATE_KEY)
+    if context_ownership_version != task.ownership_version:
+        raise TaskInvalidStateError(
+            f"TaskRun {ctx.run_id} belongs to a previous task owner",
+            {"task_id": ctx.task_id, "run_id": ctx.run_id},
+            cause=RuntimeError(f"TaskRun {ctx.run_id} ownership version is stale"),
+        )
+    return task
 
 
 def _get_image_source_label(

--- a/products/tasks/backend/temporal/process_task/activities/refresh_sandbox_credentials.py
+++ b/products/tasks/backend/temporal/process_task/activities/refresh_sandbox_credentials.py
@@ -8,7 +8,7 @@ from posthog.temporal.common.utils import asyncify, retry_on_db_connection_drop
 
 from products.tasks.backend.exceptions import CredentialUnavailableError, SandboxNotFoundError, SandboxNotRunningError
 from products.tasks.backend.logic.services.sandbox import Sandbox
-from products.tasks.backend.models import Task, TaskRun
+from products.tasks.backend.models import TASK_OWNERSHIP_VERSION_STATE_KEY, Task, TaskRun
 from products.tasks.backend.temporal.metrics import increment_credential_refresh
 from products.tasks.backend.temporal.observability import log_activity_execution, track_event
 from products.tasks.backend.temporal.process_task.sandbox_credentials import (
@@ -89,6 +89,19 @@ def refresh_sandbox_credentials(input: RefreshSandboxCredentialsInput) -> Refres
                     id=ctx.task_id
                 )
             )
+            context_ownership_version = (ctx.state or {}).get(TASK_OWNERSHIP_VERSION_STATE_KEY)
+            if context_ownership_version != task.ownership_version:
+                logger.info(
+                    "sandbox_credentials_refresh_stopped_ownership_changed",
+                    sandbox_id=input.sandbox_id,
+                    run_id=ctx.run_id,
+                    task_id=ctx.task_id,
+                )
+                return RefreshSandboxCredentialsOutput(
+                    next_refresh_seconds=DEFAULT_REFRESH_INTERVAL_SECONDS,
+                    refreshed_kinds=[],
+                    no_credentials_left=True,
+                )
             ctx = _with_current_authorship(ctx)
         except Task.DoesNotExist:
             logger.info(

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
@@ -24,7 +24,7 @@ from products.tasks.backend.constants import (
     vm_sandbox_origin_rollout_percentages,
 )
 from products.tasks.backend.exceptions import TaskInvalidStateError, TaskRunNotReadyError
-from products.tasks.backend.models import SandboxEnvironment, Task
+from products.tasks.backend.models import TASK_OWNERSHIP_VERSION_STATE_KEY, SandboxEnvironment, Task
 from products.tasks.backend.temporal.process_task.activities.get_task_processing_context import (
     GetTaskProcessingContextInput,
     TaskProcessingContext,
@@ -174,6 +174,18 @@ class TestGetTaskProcessingContextActivity:
         assert result.github_integration_id == test_task.github_integration_id
         assert result.repository == "posthog/posthog-js"
         assert result.create_pr is True
+
+    @pytest.mark.django_db(transaction=True)
+    def test_get_task_processing_context_rejects_previous_owner_run(self, activity_environment, test_task):
+        task_run = test_task.create_run()
+        test_task.state = {TASK_OWNERSHIP_VERSION_STATE_KEY: "new-owner"}
+        test_task.save(update_fields=["state", "updated_at"])
+
+        with pytest.raises(TaskInvalidStateError):
+            async_to_sync(activity_environment.run)(
+                get_task_processing_context,
+                GetTaskProcessingContextInput(run_id=str(task_run.id)),
+            )
 
     @pytest.mark.django_db(transaction=True)
     def test_get_task_processing_context_task_not_found_is_retryable(self, activity_environment):

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_refresh_sandbox_credentials.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_refresh_sandbox_credentials.py
@@ -12,7 +12,7 @@ from posthog.models.integration import Integration
 
 from products.tasks.backend.exceptions import SandboxExecutionError, SandboxNotFoundError, SandboxNotRunningError
 from products.tasks.backend.logic.services.sandbox import ExecutionResult
-from products.tasks.backend.models import Task, TaskRun
+from products.tasks.backend.models import TASK_OWNERSHIP_VERSION_STATE_KEY, Task, TaskRun
 from products.tasks.backend.temporal.process_task.activities.refresh_sandbox_credentials import (
     RefreshSandboxCredentialsInput,
     refresh_sandbox_credentials,
@@ -65,6 +65,23 @@ class TestRefreshSandboxCredentialsActivity:
         event_name = track_event.call_args[0][0]
         assert event_name == "sandbox_credentials_refreshed"
         assert track_event.call_args.kwargs["properties"]["refreshed_kinds"] == ["github"]
+
+    def test_stops_refreshing_after_task_handoff(self, activity_environment, task_context, test_task, sandbox):
+        test_task.state = {TASK_OWNERSHIP_VERSION_STATE_KEY: "new-owner"}
+        test_task.save(update_fields=["state", "updated_at"])
+
+        with patch(
+            "products.tasks.backend.temporal.process_task.activities.refresh_sandbox_credentials.Sandbox.get_by_id",
+            return_value=sandbox,
+        ) as get_sandbox:
+            output = async_to_sync(activity_environment.run)(
+                refresh_sandbox_credentials,
+                RefreshSandboxCredentialsInput(context=task_context, sandbox_id="sandbox-abc"),
+            )
+
+        assert output.refreshed_kinds == []
+        assert output.no_credentials_left is True
+        get_sandbox.assert_not_called()
 
     def test_promoted_run_refreshes_as_user_not_the_team_installation(
         self, activity_environment, task_context, test_task, test_task_run, sandbox

--- a/products/tasks/backend/temporal/tests/test_oauth.py
+++ b/products/tasks/backend/temporal/tests/test_oauth.py
@@ -6,7 +6,7 @@ from posthog.models.user import User
 from posthog.temporal.oauth import PosthogMcpScopes
 
 from products.tasks.backend.exceptions import TaskInvalidStateError
-from products.tasks.backend.models import MCPBuiltInAgentKey, Task
+from products.tasks.backend.models import TASK_OWNERSHIP_VERSION_STATE_KEY, MCPBuiltInAgentKey, Task
 from products.tasks.backend.temporal.oauth import create_oauth_access_token, create_oauth_access_token_for_run
 
 
@@ -260,6 +260,25 @@ def test_run_token_fails_closed_for_slack_run_with_unresolvable_actor(mock_creat
 
     # Non-Slack runs keep the creator fallback.
     assert create_oauth_access_token_for_run(task, {}) == "token"
+
+
+@pytest.mark.django_db
+@patch("products.tasks.backend.temporal.oauth._create_oauth_access_token_for_user", return_value="token")
+def test_run_token_rejects_previous_task_owner(mock_create: MagicMock) -> None:
+    organization = Organization.objects.create(name="oauth-handoff-org")
+    team = Team.objects.create(organization=organization, name="oauth-handoff-team")
+    creator = User.objects.create(email="oauth-handoff-creator@example.com")
+    task = Task.objects.create(
+        team=team,
+        title="Transferred task",
+        created_by=creator,
+        state={TASK_OWNERSHIP_VERSION_STATE_KEY: "new-owner"},
+    )
+
+    with pytest.raises(TaskInvalidStateError):
+        create_oauth_access_token_for_run(task, {})
+
+    mock_create.assert_not_called()
 
 
 @pytest.mark.django_db

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -236,6 +236,37 @@ class BaseTaskAPITest(TestCase):
         self.organization.members.add(user)
         return user
 
+    def _sandbox_oauth_client(
+        self,
+        task_id: uuid.UUID,
+        *,
+        client_id: str = ARRAY_APP_CLIENT_ID_DEV,
+        bound: bool = True,
+        internal_scope: bool = False,
+    ) -> APIClient:
+        application = OAuthApplication.objects.create(
+            name="Task artifact uploader",
+            client_id=client_id,
+            client_type=OAuthApplication.CLIENT_PUBLIC,
+            authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
+            algorithm="RS256",
+            redirect_uris="https://example.com/callback",
+            organization=self.organization,
+            user=self.user,
+        )
+        access_token = OAuthAccessToken.objects.create(
+            user=self.user,
+            application=application,
+            token=f"pha_task_agent_{uuid.uuid4().hex}",
+            expires=django_timezone.now() + timedelta(hours=1),
+            scope=f"task:read task:write{' internal_run:read' if internal_scope else ''}",
+            scoped_teams=[self.team.id],
+            sandbox_task_id=task_id if bound else None,
+        )
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION=f"Bearer {access_token.token}")
+        return client
+
 
 class TestBuiltInAgentTaskAccess(BaseTaskAPITest):
     def _built_in_agent_client(self) -> APIClient:
@@ -4973,37 +5004,6 @@ _OTHER_PR_URL = "https://github.com/posthog/posthog-js/pull/2"
 
 
 class TestTaskRunAPI(BaseTaskAPITest):
-    def _sandbox_oauth_client(
-        self,
-        task_id: uuid.UUID,
-        *,
-        client_id: str = ARRAY_APP_CLIENT_ID_DEV,
-        bound: bool = True,
-        internal_scope: bool = False,
-    ) -> APIClient:
-        application = OAuthApplication.objects.create(
-            name="Task artifact uploader",
-            client_id=client_id,
-            client_type=OAuthApplication.CLIENT_PUBLIC,
-            authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
-            algorithm="RS256",
-            redirect_uris="https://example.com/callback",
-            organization=self.organization,
-            user=self.user,
-        )
-        access_token = OAuthAccessToken.objects.create(
-            user=self.user,
-            application=application,
-            token=f"pha_task_agent_{uuid.uuid4().hex}",
-            expires=django_timezone.now() + timedelta(hours=1),
-            scope=f"task:read task:write{' internal_run:read' if internal_scope else ''}",
-            scoped_teams=[self.team.id],
-            sandbox_task_id=task_id if bound else None,
-        )
-        client = APIClient()
-        client.credentials(HTTP_AUTHORIZATION=f"Bearer {access_token.token}")
-        return client
-
     def _create_run_for_origin(self, origin_product: Task.OriginProduct) -> tuple[Task, TaskRun]:
         task = Task.objects.create(
             team=self.team,
@@ -9275,23 +9275,14 @@ class TestTaskHandoffAPI(BaseTaskAPITest):
             },
         )
 
-    def test_handoff_rejects_nonterminal_runs(self):
+    def test_handoff_rejects_task_bound_sandbox_agent(self):
         recipient = self.create_organization_user("recipient")
         task = self.create_task(created_by=self.user)
-        TaskRun.objects.create(task=task, team=self.team, status=TaskRun.Status.QUEUED)
+        client = self._sandbox_oauth_client(task.id)
 
-        response = self.client.post(self._handoff_url(task), {"user": recipient.id}, format="json")
+        response = client.post(self._handoff_url(task), {"user": recipient.id}, format="json")
 
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(
-            response.json(),
-            {
-                "type": "validation_error",
-                "code": "invalid_input",
-                "detail": "Finish or cancel active runs before handing off this task.",
-                "attr": "user",
-            },
-        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         task.refresh_from_db()
         self.assertEqual(task.created_by_id, self.user.id)
 

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -68,8 +68,8 @@ from products.tasks.backend.logic.stream.redis_stream import (
     get_task_run_stream_key,
 )
 from products.tasks.backend.models import (
-    AgentPeerMessage,
     TASK_OWNERSHIP_VERSION_STATE_KEY,
+    AgentPeerMessage,
     Channel,
     CodeInvite,
     CodeInviteRedemption,

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -9275,6 +9275,26 @@ class TestTaskHandoffAPI(BaseTaskAPITest):
             },
         )
 
+    def test_handoff_rejects_nonterminal_runs(self):
+        recipient = self.create_organization_user("recipient")
+        task = self.create_task(created_by=self.user)
+        TaskRun.objects.create(task=task, team=self.team, status=TaskRun.Status.QUEUED)
+
+        response = self.client.post(self._handoff_url(task), {"user": recipient.id}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.json(),
+            {
+                "type": "validation_error",
+                "code": "invalid_input",
+                "detail": "Finish or cancel active runs before handing off this task.",
+                "attr": "user",
+            },
+        )
+        task.refresh_from_db()
+        self.assertEqual(task.created_by_id, self.user.id)
+
     def test_handoff_rejects_task_bound_sandbox_agent_from_another_task(self):
         recipient = self.create_organization_user("recipient")
         bound_task = self.create_task(created_by=self.user)

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -29,6 +29,7 @@ from rest_framework.test import APIClient
 from posthog.models import Integration, Organization, OrganizationMembership, PersonalAPIKey, Team, User
 from posthog.models.oauth import OAuthAccessToken, OAuthApplication, OAuthRefreshToken
 from posthog.models.personal_api_key import hash_key_value
+from posthog.models.scoping import team_scope
 from posthog.models.user_integration import UserIntegration
 from posthog.models.utils import generate_random_token_personal
 from posthog.scopes import MCP_BUILT_IN_AGENT_SCOPE
@@ -9240,6 +9241,177 @@ class TestTasksAPIPermissions(BaseTaskAPITest):
                 status.HTTP_403_FORBIDDEN,
                 f"Expected 403 but got {response.status_code} for {scope} on {method} {url}",
             )
+
+
+class TestTaskHandoffAPI(BaseTaskAPITest):
+    def _handoff_url(self, task: Task) -> str:
+        return f"/api/projects/@current/tasks/{task.id}/handoff/"
+
+    def test_handoff_transfers_ownership_and_posts_thread_announcement(self):
+        recipient = self.create_organization_user("recipient")
+        integration = _grant_user_github_access(self.user)
+        task = self.create_task(created_by=self.user)
+        task.github_user_integration = integration
+        task.save()
+
+        response = self.client.post(self._handoff_url(task), {"user": recipient.id}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["created_by"]["id"], recipient.id)
+        task.refresh_from_db()
+        self.assertEqual(task.created_by_id, recipient.id)
+        self.assertIsNone(task.github_user_integration_id)
+        with team_scope(self.team.id):
+            announcement = task.thread_messages.get(event="task_handed_off")
+        self.assertEqual(announcement.author_kind, "system")
+        self.assertEqual(announcement.author_id, self.user.id)
+        self.assertEqual(
+            announcement.payload,
+            {
+                "from_user_id": self.user.id,
+                "to_user_id": recipient.id,
+                "from_display_name": "Test",
+                "to_display_name": "Other",
+            },
+        )
+
+    def test_handoff_rejects_nonterminal_runs(self):
+        recipient = self.create_organization_user("recipient")
+        task = self.create_task(created_by=self.user)
+        TaskRun.objects.create(task=task, team=self.team, status=TaskRun.Status.QUEUED)
+
+        response = self.client.post(self._handoff_url(task), {"user": recipient.id}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.json(),
+            {
+                "type": "validation_error",
+                "code": "invalid_input",
+                "detail": "Finish or cancel active runs before handing off this task.",
+                "attr": "user",
+            },
+        )
+        task.refresh_from_db()
+        self.assertEqual(task.created_by_id, self.user.id)
+
+    def test_handoff_moves_private_space_task_into_recipient_space(self):
+        recipient = self.create_organization_user("recipient")
+        with team_scope(self.team.id):
+            personal = Channel.objects.create(
+                team=self.team, name="me", channel_type=Channel.ChannelType.PERSONAL, created_by=self.user
+            )
+        task = self.create_task(created_by=self.user)
+        task.channel = personal
+        task.save()
+
+        response = self.client.post(self._handoff_url(task), {"user": recipient.id}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        task.refresh_from_db()
+        with team_scope(self.team.id):
+            self.assertIsNotNone(task.channel)
+            self.assertEqual(task.channel.channel_type, Channel.ChannelType.PERSONAL)
+            self.assertEqual(task.channel.created_by_id, recipient.id)
+        # The previous owner loses sight of a private-space task; the recipient can see and drive it.
+        self.assertEqual(
+            self.client.get(f"/api/projects/@current/tasks/{task.id}/").status_code, status.HTTP_404_NOT_FOUND
+        )
+        recipient_client = APIClient()
+        recipient_client.force_authenticate(recipient)
+        self.assertEqual(
+            recipient_client.get(f"/api/projects/@current/tasks/{task.id}/").status_code, status.HTTP_200_OK
+        )
+        self.assertEqual(
+            recipient_client.patch(
+                f"/api/projects/@current/tasks/{task.id}/", {"title": "Taken over"}, format="json"
+            ).status_code,
+            status.HTTP_200_OK,
+        )
+        self.assertEqual(
+            self.client.patch(
+                f"/api/projects/@current/tasks/{task.id}/", {"title": "Still mine"}, format="json"
+            ).status_code,
+            status.HTTP_404_NOT_FOUND,
+        )
+
+    def test_handoff_keeps_task_in_shared_space(self):
+        recipient = self.create_organization_user("recipient")
+        with team_scope(self.team.id):
+            shared = Channel.objects.create(team=self.team, name="general", created_by=self.user)
+        task = self.create_task(created_by=self.user)
+        task.channel = shared
+        task.save()
+
+        response = self.client.post(self._handoff_url(task), {"user": recipient.id}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        task.refresh_from_db()
+        self.assertEqual(task.channel_id, shared.id)
+        recipient_client = APIClient()
+        recipient_client.force_authenticate(recipient)
+        for client in (self.client, recipient_client):
+            self.assertEqual(client.get(f"/api/projects/@current/tasks/{task.id}/").status_code, status.HTTP_200_OK)
+
+    def test_handoff_requires_control_of_the_task(self):
+        colleague = self.create_organization_user("colleague")
+        with team_scope(self.team.id):
+            shared = Channel.objects.create(team=self.team, name="general", created_by=self.user)
+        task = self.create_task(created_by=self.user)
+        task.channel = shared
+        task.save()
+        colleague_client = APIClient()
+        colleague_client.force_authenticate(colleague)
+
+        response = colleague_client.post(self._handoff_url(task), {"user": colleague.id}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        task.refresh_from_db()
+        self.assertEqual(task.created_by_id, self.user.id)
+
+    @parameterized.expand(
+        [
+            ("unknown_user", 999999, status.HTTP_400_BAD_REQUEST),
+            ("self_handoff", None, status.HTTP_400_BAD_REQUEST),
+            ("missing_user", "missing", status.HTTP_400_BAD_REQUEST),
+            ("non_int_user", "not-a-number", status.HTTP_400_BAD_REQUEST),
+        ]
+    )
+    def test_handoff_target_validation(self, _name, user_arg, expected_status):
+        task = self.create_task(created_by=self.user)
+        payload = {} if user_arg == "missing" else {"user": self.user.id if user_arg is None else user_arg}
+
+        response = self.client.post(self._handoff_url(task), payload, format="json")
+
+        self.assertEqual(response.status_code, expected_status)
+        task.refresh_from_db()
+        self.assertEqual(task.created_by_id, self.user.id)
+
+    def test_handoff_rejects_user_outside_the_organization(self):
+        outsider = User.objects.create_user(
+            email=f"outsider-{uuid.uuid4()}@example.com", first_name="Out", password="password"
+        )
+        task = self.create_task(created_by=self.user)
+
+        response = self.client.post(self._handoff_url(task), {"user": outsider.id}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        task.refresh_from_db()
+        self.assertEqual(task.created_by_id, self.user.id)
+
+    def test_handoff_strips_borrowed_mcp_credential_owner(self):
+        recipient = self.create_organization_user("recipient")
+        task = self.create_task(created_by=self.user)
+        task.origin_product = Task.OriginProduct.SIGNALS_SCOUT
+        task.state = {"mcp_builtin_agent": "signals_scout", "mcp_credential_owner_id": self.user.id, "other": 1}
+        task.save()
+
+        response = self.client.post(self._handoff_url(task), {"user": recipient.id}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        task.refresh_from_db()
+        self.assertNotIn("mcp_credential_owner_id", task.state or {})
+        self.assertEqual((task.state or {}).get("other"), 1)
 
 
 class TestLivingArtifactChartRequestValidation(SimpleTestCase):

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -9399,6 +9399,38 @@ class TestTaskHandoffAPI(BaseTaskAPITest):
         task.refresh_from_db()
         self.assertEqual(task.created_by_id, self.user.id)
 
+    def test_handoff_by_non_owner_of_team_origin_task_returns_404(self):
+        # task_control_q lets any project user DRIVE team-owned system tasks (origin
+        # product fallbacks); handing off is stricter: only the owner can give a task
+        # away, and a task with no owner has nobody who may hand it off.
+        system_task = Task.objects.create(
+            team=self.team,
+            title="Signal brief",
+            origin_product=Task.OriginProduct.SIGNALS_SCOUT,
+            created_by=None,
+        )
+        colleague = self.create_organization_user("colleague")
+
+        response = self.client.post(self._handoff_url(system_task), {"user": colleague.id}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        system_task.refresh_from_db()
+        self.assertIsNone(system_task.created_by_id)
+
+    def test_handoff_rejects_recipient_without_project_access(self):
+        # Org membership alone isn't project access (private projects under access
+        # control): the recipient must pass the same check that decides what they can
+        # open, otherwise they'd end up owning a task they can't see.
+        recipient = self.create_organization_user("recipient")
+        task = self.create_task(created_by=self.user)
+
+        with patch.object(Team, "all_users_with_access", return_value=User.objects.none()):
+            response = self.client.post(self._handoff_url(task), {"user": recipient.id}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        task.refresh_from_db()
+        self.assertEqual(task.created_by_id, self.user.id)
+
     def test_handoff_strips_borrowed_mcp_credential_owner(self):
         recipient = self.create_organization_user("recipient")
         task = self.create_task(created_by=self.user)

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -9275,10 +9275,11 @@ class TestTaskHandoffAPI(BaseTaskAPITest):
             },
         )
 
-    def test_handoff_rejects_task_bound_sandbox_agent(self):
+    def test_handoff_rejects_task_bound_sandbox_agent_from_another_task(self):
         recipient = self.create_organization_user("recipient")
+        bound_task = self.create_task(created_by=self.user)
         task = self.create_task(created_by=self.user)
-        client = self._sandbox_oauth_client(task.id)
+        client = self._sandbox_oauth_client(bound_task.id)
 
         response = client.post(self._handoff_url(task), {"user": recipient.id}, format="json")
 

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -68,6 +68,7 @@ from products.tasks.backend.logic.stream.redis_stream import (
 )
 from products.tasks.backend.models import (
     AgentPeerMessage,
+    TASK_OWNERSHIP_VERSION_STATE_KEY,
     Channel,
     CodeInvite,
     CodeInviteRedemption,
@@ -9261,6 +9262,7 @@ class TestTaskHandoffAPI(BaseTaskAPITest):
         task.refresh_from_db()
         self.assertEqual(task.created_by_id, recipient.id)
         self.assertIsNone(task.github_user_integration_id)
+        self.assertIsInstance((task.state or {}).get(TASK_OWNERSHIP_VERSION_STATE_KEY), str)
         with team_scope(self.team.id):
             announcement = task.thread_messages.get(event="task_handed_off")
         self.assertEqual(announcement.author_kind, "system")
@@ -9292,6 +9294,89 @@ class TestTaskHandoffAPI(BaseTaskAPITest):
                 "attr": "user",
             },
         )
+        task.refresh_from_db()
+        self.assertEqual(task.created_by_id, self.user.id)
+
+    def test_handoff_keeps_previous_owner_runs_read_only(self):
+        recipient = self.create_organization_user("recipient")
+        task = self.create_task(created_by=self.user)
+        run = TaskRun.objects.create(task=task, team=self.team, status=TaskRun.Status.COMPLETED)
+
+        response = self.client.post(self._handoff_url(task), {"user": recipient.id}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        recipient_client = APIClient()
+        recipient_client.force_authenticate(recipient)
+        run_url = f"/api/projects/@current/tasks/{task.id}/runs/{run.id}/"
+        self.assertEqual(recipient_client.get(run_url).status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            recipient_client.patch(run_url, {"stage": "build"}, format="json").status_code,
+            status.HTTP_404_NOT_FOUND,
+        )
+
+    def test_handoff_rejects_open_sandbox_session(self):
+        recipient = self.create_organization_user("recipient")
+        task = self.create_task(created_by=self.user)
+        run = TaskRun.objects.create(task=task, team=self.team, status=TaskRun.Status.COMPLETED)
+        now = django_timezone.now()
+        SandboxSession.objects.unscoped().create(
+            team=self.team,
+            task_run=run,
+            sandbox_id="sandbox-still-closing",
+            cpu_cores=1,
+            memory_gb=1,
+            ttl_seconds=3600,
+            created_at=now,
+            ttl_expires_at=now + timedelta(hours=1),
+        )
+
+        response = self.client.post(self._handoff_url(task), {"user": recipient.id}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.json()["detail"],
+            "Wait for active sandboxes to shut down before handing off this task.",
+        )
+        task.refresh_from_db()
+        self.assertEqual(task.created_by_id, self.user.id)
+
+    def test_handoff_revokes_task_bound_sandbox_oauth_tokens(self):
+        recipient = self.create_organization_user("recipient")
+        task = self.create_task(created_by=self.user)
+        self._sandbox_oauth_client(task.id)
+        access_token = OAuthAccessToken.objects.get(sandbox_task_id=task.id)
+
+        response = self.client.post(self._handoff_url(task), {"user": recipient.id}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(OAuthAccessToken.objects.filter(id=access_token.id).exists())
+
+    def test_handoff_rejects_built_in_agent_oauth(self):
+        recipient = self.create_organization_user("recipient")
+        task = self.create_task(created_by=self.user)
+        application = OAuthApplication.objects.create(
+            name="Built-in agent sandbox",
+            client_type=OAuthApplication.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
+            redirect_uris="https://example.com/callback",
+            algorithm="RS256",
+            organization=self.organization,
+            user=self.user,
+        )
+        access_token = OAuthAccessToken.objects.create(
+            user=self.user,
+            application=application,
+            token=f"pha_task_agent_{uuid.uuid4().hex}",
+            expires=django_timezone.now() + timedelta(hours=1),
+            scope=f"task:read task:write {MCP_BUILT_IN_AGENT_SCOPE}",
+            scoped_teams=[self.team.id],
+        )
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION=f"Bearer {access_token.token}")
+
+        response = client.post(self._handoff_url(task), {"user": recipient.id}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         task.refresh_from_db()
         self.assertEqual(task.created_by_id, self.user.id)
 

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -9401,6 +9401,17 @@ class TestTaskHandoffAPI(BaseTaskAPITest):
         task.refresh_from_db()
         self.assertEqual(task.created_by_id, self.user.id)
 
+    def test_handoff_rejects_unbound_legacy_sandbox_oauth(self):
+        recipient = self.create_organization_user("recipient")
+        task = self.create_task(created_by=self.user)
+        client = self._sandbox_oauth_client(task.id, bound=False, internal_scope=True)
+
+        response = client.post(self._handoff_url(task), {"user": recipient.id}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        task.refresh_from_db()
+        self.assertEqual(task.created_by_id, self.user.id)
+
     def test_handoff_rejects_task_bound_sandbox_agent_from_another_task(self):
         recipient = self.create_organization_user("recipient")
         bound_task = self.create_task(created_by=self.user)

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -37,6 +37,7 @@ from posthog.storage import object_storage
 from posthog.temporal.oauth import ARRAY_APP_CLIENT_ID_DEV, POSTHOG_AI_APP_CLIENT_ID_DEV
 from posthog.utils import absolute_uri
 
+from products.posthog_ai.backend.models.assistant import Conversation
 from products.slack_app.backend.models import SlackThreadTaskMapping
 from products.tasks.backend.facade import api as tasks_facade
 from products.tasks.backend.facade.repo_selection import RepoSelectionResult
@@ -9254,6 +9255,14 @@ class TestTaskHandoffAPI(BaseTaskAPITest):
         task = self.create_task(created_by=self.user)
         task.github_user_integration = integration
         task.save()
+        conversation = Conversation.objects.create(
+            user=self.user,
+            team=self.team,
+            agent_runtime=Conversation.AgentRuntime.SANDBOX,
+            task=task,
+            sandbox_task_id=task.id,
+            sandbox_run_id=uuid.uuid4(),
+        )
 
         response = self.client.post(self._handoff_url(task), {"user": recipient.id}, format="json")
 
@@ -9263,6 +9272,10 @@ class TestTaskHandoffAPI(BaseTaskAPITest):
         self.assertEqual(task.created_by_id, recipient.id)
         self.assertIsNone(task.github_user_integration_id)
         self.assertIsInstance((task.state or {}).get(TASK_OWNERSHIP_VERSION_STATE_KEY), str)
+        conversation.refresh_from_db()
+        self.assertIsNone(conversation.task_id)
+        self.assertIsNone(conversation.sandbox_task_id)
+        self.assertIsNone(conversation.sandbox_run_id)
         with team_scope(self.team.id):
             announcement = task.thread_messages.get(event="task_handed_off")
         self.assertEqual(announcement.author_kind, "system")
@@ -9311,6 +9324,14 @@ class TestTaskHandoffAPI(BaseTaskAPITest):
         self.assertEqual(recipient_client.get(run_url).status_code, status.HTTP_200_OK)
         self.assertEqual(
             recipient_client.patch(run_url, {"stage": "build"}, format="json").status_code,
+            status.HTTP_404_NOT_FOUND,
+        )
+        self.assertEqual(
+            recipient_client.post(
+                f"{run_url}living_artifacts/",
+                {"name": "old-run.md", "artifact_type": "document", "content": "old"},
+                format="json",
+            ).status_code,
             status.HTTP_404_NOT_FOUND,
         )
 

--- a/products/tasks/backend/tests/test_facade.py
+++ b/products/tasks/backend/tests/test_facade.py
@@ -90,10 +90,6 @@ class TestTaskHandoffConcurrency(TransactionTestCase):
             mode: str = "background",
             extra_state: dict | None = None,
             branch: str | None = None,
-            *,
-            expected_created_by_id: int | None = None,
-            expected_ownership_version: str | None = None,
-            validate_task_ownership: bool = False,
         ) -> TaskRun:
             create_reached.set()
             if not handoff_finished.wait(timeout=10):
@@ -104,9 +100,6 @@ class TestTaskHandoffConcurrency(TransactionTestCase):
                 mode=mode,
                 extra_state=extra_state,
                 branch=branch,
-                expected_created_by_id=expected_created_by_id,
-                expected_ownership_version=expected_ownership_version,
-                validate_task_ownership=validate_task_ownership,
             )
 
         def bootstrap() -> None:

--- a/products/tasks/backend/tests/test_facade.py
+++ b/products/tasks/backend/tests/test_facade.py
@@ -1,11 +1,13 @@
 import importlib
+import threading
 from datetime import timedelta
 from typing import ClassVar
 from uuid import uuid4
 
 from unittest.mock import MagicMock, patch
 
-from django.test import TestCase
+from django.db import close_old_connections
+from django.test import TestCase, TransactionTestCase
 from django.utils import timezone as django_timezone
 
 from parameterized import parameterized
@@ -20,6 +22,7 @@ from products.tasks.backend.facade import (
     warm as warm_facade,
 )
 from products.tasks.backend.models import (
+    TASK_OWNERSHIP_VERSION_STATE_KEY,
     Channel,
     SandboxCustomImage,
     SandboxEnvironment,
@@ -55,6 +58,84 @@ class TestFacadeImports(TestCase):
         self.assertIs(facade.TaskRunEnvironment, TaskRun.Environment)
         self.assertIs(facade.TaskOriginProduct, Task.OriginProduct)
         self.assertIs(facade.SandboxNetworkAccessLevel, SandboxEnvironment.NetworkAccessLevel)
+
+
+class TestTaskHandoffConcurrency(TransactionTestCase):
+    def setUp(self) -> None:
+        self.organization = Organization.objects.create(name="Test Org")
+        self.team = Team.objects.create(organization=self.organization, name="Test Team")
+        self.owner = User.objects.create_user(email="owner@example.com", first_name="Owner", password="password")
+        self.recipient = User.objects.create_user(
+            email="recipient@example.com", first_name="Recipient", password="password"
+        )
+        self.organization.members.add(self.owner, self.recipient)
+        self.task = Task.objects.create(
+            team=self.team,
+            title="Race task",
+            description="Run later",
+            origin_product=Task.OriginProduct.USER_CREATED,
+            created_by=self.owner,
+        )
+
+    def test_delayed_bootstrap_cannot_create_run_after_handoff(self) -> None:
+        create_reached = threading.Event()
+        handoff_finished = threading.Event()
+        results: list[contracts.TaskRunCreateResult | None] = []
+        errors: list[BaseException] = []
+        original_create_run = Task.create_run
+
+        def delayed_create_run(
+            task: Task,
+            environment: TaskRun.Environment | None = None,
+            mode: str = "background",
+            extra_state: dict | None = None,
+            branch: str | None = None,
+            *,
+            expected_created_by_id: int | None = None,
+            expected_ownership_version: str | None = None,
+            validate_task_ownership: bool = False,
+        ) -> TaskRun:
+            create_reached.set()
+            if not handoff_finished.wait(timeout=10):
+                raise TimeoutError("handoff did not finish")
+            return original_create_run(
+                task,
+                environment=environment,
+                mode=mode,
+                extra_state=extra_state,
+                branch=branch,
+                expected_created_by_id=expected_created_by_id,
+                expected_ownership_version=expected_ownership_version,
+                validate_task_ownership=validate_task_ownership,
+            )
+
+        def bootstrap() -> None:
+            close_old_connections()
+            try:
+                results.append(facade.bootstrap_task_run(self.task.id, self.team.id, self.owner.id, validated_data={}))
+            except BaseException as error:
+                errors.append(error)
+            finally:
+                close_old_connections()
+
+        with patch.object(Task, "create_run", new=delayed_create_run):
+            thread = threading.Thread(target=bootstrap)
+            thread.start()
+            self.assertTrue(create_reached.wait(timeout=10))
+            handoff = facade.handoff_task(
+                self.task.id,
+                self.team.id,
+                self.owner.id,
+                target_user_id=self.recipient.id,
+            )
+            handoff_finished.set()
+            thread.join(timeout=10)
+
+        self.assertFalse(thread.is_alive())
+        self.assertEqual(errors, [])
+        self.assertIsNotNone(handoff)
+        self.assertEqual(results, [None])
+        self.assertFalse(TaskRun.objects.filter(task=self.task).exists())
 
 
 class TestFacadeReadsAndMappers(TestCase):
@@ -113,6 +194,20 @@ class TestFacadeReadsAndMappers(TestCase):
         self.assertIsNotNone(facade.get_task_run(run.id, team_id=self.team.id))
         self.assertIsNone(facade.get_task_run(run.id, team_id=other_team.id))
         self.assertIsNone(facade.get_task_run("00000000-0000-0000-0000-000000000000"))
+
+    def test_resume_in_cloud_rejects_run_from_previous_owner(self):
+        task = self._make_task(state={TASK_OWNERSHIP_VERSION_STATE_KEY: "current-version"})
+        run = TaskRun.objects.create(task=task, team=self.team, status=TaskRun.Status.COMPLETED, state={})
+
+        outcome, resumed_run, _ = facade.resume_task_run_in_cloud(
+            run.id,
+            task.id,
+            self.team.id,
+            self.user.id,
+        )
+
+        self.assertEqual(outcome, "ownership_changed")
+        self.assertIsNone(resumed_run)
 
     def test_task_exists_and_visibility(self):
         task = self._make_task()

--- a/products/tasks/backend/tests/test_facade.py
+++ b/products/tasks/backend/tests/test_facade.py
@@ -1,7 +1,7 @@
 import importlib
 import threading
 from datetime import timedelta
-from typing import ClassVar
+from typing import Any, ClassVar
 from uuid import uuid4
 
 from unittest.mock import MagicMock, patch
@@ -129,6 +129,71 @@ class TestTaskHandoffConcurrency(TransactionTestCase):
         self.assertIsNotNone(handoff)
         self.assertEqual(results, [None])
         self.assertFalse(TaskRun.objects.filter(task=self.task).exists())
+
+    def test_handoff_waits_for_in_flight_task_update(self) -> None:
+        update_at_save = threading.Event()
+        allow_update_save = threading.Event()
+        update_saved = threading.Event()
+        handoff_finished = threading.Event()
+        errors: list[BaseException] = []
+        original_save = Task.save
+
+        def delayed_save(task: Task, *args: Any, **kwargs: Any) -> None:
+            if task.id == self.task.id and task.title == "Updated title" and not update_saved.is_set():
+                update_at_save.set()
+                if not allow_update_save.wait(timeout=10):
+                    raise TimeoutError("update save was not released")
+                result = original_save(task, *args, **kwargs)
+                update_saved.set()
+                return result
+            return original_save(task, *args, **kwargs)
+
+        def update() -> None:
+            close_old_connections()
+            try:
+                facade.update_task(
+                    self.task.id,
+                    self.team.id,
+                    self.owner.id,
+                    validated_data={"title": "Updated title"},
+                )
+            except BaseException as error:
+                errors.append(error)
+            finally:
+                close_old_connections()
+
+        def handoff() -> None:
+            close_old_connections()
+            try:
+                facade.handoff_task(
+                    self.task.id,
+                    self.team.id,
+                    self.owner.id,
+                    target_user_id=self.recipient.id,
+                )
+            except BaseException as error:
+                errors.append(error)
+            finally:
+                handoff_finished.set()
+                close_old_connections()
+
+        with patch.object(Task, "save", new=delayed_save):
+            update_thread = threading.Thread(target=update)
+            update_thread.start()
+            self.assertTrue(update_at_save.wait(timeout=10))
+            handoff_thread = threading.Thread(target=handoff)
+            handoff_thread.start()
+            self.assertFalse(handoff_finished.wait(timeout=1))
+            allow_update_save.set()
+            update_thread.join(timeout=10)
+            handoff_thread.join(timeout=10)
+
+        self.assertFalse(update_thread.is_alive())
+        self.assertFalse(handoff_thread.is_alive())
+        self.assertEqual(errors, [])
+        self.task.refresh_from_db()
+        self.assertEqual(self.task.title, "Updated title")
+        self.assertEqual(self.task.created_by_id, self.recipient.id)
 
 
 class TestFacadeReadsAndMappers(TestCase):

--- a/products/tasks/backend/tests/test_models.py
+++ b/products/tasks/backend/tests/test_models.py
@@ -23,10 +23,12 @@ from posthog.models.user_integration import UserIntegration
 from posthog.storage import object_storage
 
 from products.tasks.backend.models import (
+    TASK_OWNERSHIP_VERSION_STATE_KEY,
     CodeInvite,
     SandboxEnvironment,
     SandboxSnapshot,
     Task,
+    TaskOwnershipChangedError,
     TaskRun,
     TaskThreadMessage,
     bump_task_activity,
@@ -758,6 +760,48 @@ class TestTaskRun(TestCase):
         run = self.task.create_run(mode="interactive")
 
         self.assertNotIn("initial_permission_mode", run.state)
+
+    def test_create_run_snapshots_task_ownership_version(self):
+        ownership_version = str(uuid.uuid4())
+        self.task.state = {TASK_OWNERSHIP_VERSION_STATE_KEY: ownership_version}
+        self.task.save(update_fields=["state", "updated_at"])
+
+        run = self.task.create_run()
+
+        self.assertEqual(run.ownership_version, ownership_version)
+        self.assertTrue(run.matches_task_ownership(self.task))
+
+    def test_create_run_rejects_stale_task_ownership(self):
+        original_owner = User.objects.create_user(
+            email="original@example.com", first_name="Original", password="password"
+        )
+        new_owner = User.objects.create_user(email="new@example.com", first_name="New", password="password")
+        task = Task.objects.create(
+            team=self.team,
+            title="Owned task",
+            created_by=original_owner,
+            state={TASK_OWNERSHIP_VERSION_STATE_KEY: "new-version"},
+        )
+
+        with self.assertRaises(TaskOwnershipChangedError):
+            task.create_run(
+                expected_created_by_id=new_owner.id,
+                expected_ownership_version="old-version",
+                validate_task_ownership=True,
+            )
+
+        self.assertFalse(TaskRun.objects.filter(task=task).exists())
+
+    def test_create_run_rejects_resume_from_previous_owner(self):
+        task = Task.objects.create(
+            team=self.team,
+            title="Transferred task",
+            state={TASK_OWNERSHIP_VERSION_STATE_KEY: "current-version"},
+        )
+        previous_run = TaskRun.objects.create(task=task, team=self.team, status=TaskRun.Status.COMPLETED, state={})
+
+        with self.assertRaises(TaskOwnershipChangedError):
+            task.create_run(extra_state={"resume_from_run_id": str(previous_run.id)})
 
     @patch("products.tasks.backend.models.TaskRun.publish_stream_state_event")
     def test_prepare_for_cloud_handoff_clears_stale_sandbox_routing(self, _publish):

--- a/products/tasks/backend/tests/test_models.py
+++ b/products/tasks/backend/tests/test_models.py
@@ -780,15 +780,15 @@ class TestTaskRun(TestCase):
             team=self.team,
             title="Owned task",
             created_by=original_owner,
+            state={TASK_OWNERSHIP_VERSION_STATE_KEY: "old-version"},
+        )
+        Task.objects.filter(id=task.id).update(
+            created_by=new_owner,
             state={TASK_OWNERSHIP_VERSION_STATE_KEY: "new-version"},
         )
 
         with self.assertRaises(TaskOwnershipChangedError):
-            task.create_run(
-                expected_created_by_id=new_owner.id,
-                expected_ownership_version="old-version",
-                validate_task_ownership=True,
-            )
+            task.create_run()
 
         self.assertFalse(TaskRun.objects.filter(task=task).exists())
 

--- a/products/tasks/backend/tests/test_push_dispatcher.py
+++ b/products/tasks/backend/tests/test_push_dispatcher.py
@@ -1,3 +1,5 @@
+from uuid import uuid4
+
 from unittest.mock import patch
 
 from django.core.cache import cache
@@ -12,6 +14,7 @@ from posthog.tasks.push_notifications import send_user_push
 
 from products.tasks.backend.models import Task, TaskRun
 from products.tasks.backend.push_dispatcher import (
+    notify_task_handoff,
     notify_task_run_awaiting_input,
     notify_task_run_cancelled,
     notify_task_run_completed,
@@ -110,6 +113,16 @@ class TestPushDispatcher(TestCase):
             notify_task_run_awaiting_input(self.task_run)
             notify_task_run_turn_completed(self.task_run)
         self.assertEqual(mock_delay.call_count, 3)
+
+    @patch("products.tasks.backend.push_dispatcher.posthoganalytics.feature_enabled", return_value=True)
+    @patch("products.tasks.backend.push_dispatcher.send_user_push.delay")
+    def test_handoff_cooldown_distinguishes_announcements(self, mock_delay, _flag):
+        announcement_id = uuid4()
+        with self.captureOnCommitCallbacks(execute=True):
+            notify_task_handoff(self.task, recipient=self.user, actor=self.user, message_id=announcement_id)
+            notify_task_handoff(self.task, recipient=self.user, actor=self.user, message_id=announcement_id)
+            notify_task_handoff(self.task, recipient=self.user, actor=self.user, message_id=uuid4())
+        self.assertEqual(mock_delay.call_count, 2)
 
     @patch("products.tasks.backend.push_dispatcher.posthoganalytics.feature_enabled", return_value=True)
     @patch("products.tasks.backend.push_dispatcher.send_user_push.delay")

--- a/products/tasks/docs/CHANNELS.md
+++ b/products/tasks/docs/CHANNELS.md
@@ -104,9 +104,9 @@ membership without adding permissions to Task.
 - A task controller can move a task by updating `channel` to a public or owned private space. Existing callers can still clear `channel` for legacy compatibility.
 - `TaskSerializer` / `TaskDetailDTO` emit `channel`.
 - `GET /tasks/?channel=<uuid>` filters the list to a channel's feed.
-- `POST /tasks/{task_id}/handoff/ {user}` — hand a task off to a colleague. The
-  requester must control the task (for a channeled task, own it); the target must
-  be a member of the project and not the current owner. Ownership (`created_by`)
+- `POST /tasks/{task_id}/handoff/ {user}`: hand a task off to a colleague. The
+  requester must own the task; the target must have access to the project and not
+  be the current owner. Ownership (`created_by`)
   moves to the recipient, so they drive the task afterwards and future runs
   resolve GitHub authorship and notification recipients from them. A task in a
   private `#me` space (or with no channel) moves into the recipient's `#me`, so a

--- a/products/tasks/docs/CHANNELS.md
+++ b/products/tasks/docs/CHANNELS.md
@@ -104,6 +104,18 @@ membership without adding permissions to Task.
 - A task controller can move a task by updating `channel` to a public or owned private space. Existing callers can still clear `channel` for legacy compatibility.
 - `TaskSerializer` / `TaskDetailDTO` emit `channel`.
 - `GET /tasks/?channel=<uuid>` filters the list to a channel's feed.
+- `POST /tasks/{task_id}/handoff/ {user}` — hand a task off to a colleague. The
+  requester must control the task (for a channeled task, own it); the target must
+  be a member of the project and not the current owner. Ownership (`created_by`)
+  moves to the recipient, so they drive the task afterwards and future runs
+  resolve GitHub authorship and notification recipients from them. A task in a
+  private `#me` space (or with no channel) moves into the recipient's `#me`, so a
+  handoff never strands a task the recipient can't open; a task in a shared space
+  stays there. All task runs must be terminal before a handoff. Finish or cancel
+  active runs first. The handoff clears the stored GitHub user-integration
+  preference and any borrowed MCP credential owner, posts a system
+  `task_handed_off` announcement into the task's thread, and notifies the
+  recipient.
 
 ### Canvas endpoints
 

--- a/products/tasks/docs/CHANNELS.md
+++ b/products/tasks/docs/CHANNELS.md
@@ -111,11 +111,13 @@ membership without adding permissions to Task.
   resolve GitHub authorship and notification recipients from them. A task in a
   private `#me` space (or with no channel) moves into the recipient's `#me`, so a
   handoff never strands a task the recipient can't open; a task in a shared space
-  stays there. All task runs must be terminal before a handoff. Finish or cancel
-  active runs first. The handoff clears the stored GitHub user-integration
-  preference and any borrowed MCP credential owner, posts a system
-  `task_handed_off` announcement into the task's thread, and notifies the
-  recipient.
+  stays there. All task runs must be terminal and every sandbox session must be
+  closed before a handoff. The handoff rotates the task's server-owned ownership
+  version, revokes task-bound sandbox OAuth tokens, and makes runs from the old
+  ownership version read-only. The recipient must start a fresh run. The handoff
+  also clears the stored GitHub user-integration preference and any borrowed MCP
+  credential owner, posts a system `task_handed_off` announcement into the task's
+  thread, and notifies the recipient.
 
 ### Canvas endpoints
 

--- a/products/tasks/docs/INSTRUMENTATION.md
+++ b/products/tasks/docs/INSTRUMENTATION.md
@@ -66,6 +66,21 @@ Tracked when `Task.soft_delete()` is called. Additional properties:
 | ------------------ | ------- | --------------------------- |
 | `duration_seconds` | `float` | Seconds since task creation |
 
+## Facade events
+
+Source: `products/tasks/backend/facade/api.py`
+
+### `task_handed_off`
+
+Tracked when a task controller hands the task off to a colleague (ownership moves
+to the recipient). Captured under the handoff actor's identity rather than the
+recipient's, even though the task's `created_by` has moved by then. Additional properties:
+
+| Property       | Type   | Description                          |
+| -------------- | ------ | ------------------------------------ |
+| `from_user_id` | `int?` | User ID of the previous owner        |
+| `to_user_id`   | `int`  | User ID of the recipient (new owner) |
+
 ## TaskRun Model Events
 
 Source: `products/tasks/backend/models.py`

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -2144,6 +2144,17 @@ export interface TaskCommentDetailApi {
     next: string | null
 }
 
+/**
+ * Request body for handing a task off to a colleague: they become its owner.
+ */
+export interface TaskHandoffRequestApi {
+    /**
+     * ID of the user taking over the task. Must be a member of this project's organization and not the task's current owner.
+     * @minimum 1
+     */
+    user: number
+}
+
 export interface TaskPinRequestApi {
     /** Whether the task should be pinned for the requester. */
     pinned: boolean

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -2149,7 +2149,7 @@ export interface TaskCommentDetailApi {
  */
 export interface TaskHandoffRequestApi {
     /**
-     * ID of the user taking over the task. Must be a member of this project's organization and not the task's current owner.
+     * ID of the user taking over the task. Must have access to this project and not be the task's current owner.
      * @minimum 1
      */
     user: number

--- a/products/tasks/frontend/generated/api.ts
+++ b/products/tasks/frontend/generated/api.ts
@@ -1346,7 +1346,7 @@ export const getTasksHandoffCreateUrl = (projectId: string, id: string) => {
 }
 
 /**
- * Transfer ownership of a task to another member of the project: they take over driving it (steering, archiving, running), and future runs resolve GitHub authorship and notification recipients from them. Only the task's current owner can hand it off. A task in a private space moves into the recipient's private space; a task in a shared space stays there.
+ * Transfer ownership of a task to another member of the project: they take over driving it (steering, archiving, running), and future runs resolve GitHub authorship and notification recipients from them. Only the task's current owner can hand it off. Every run must be finished or canceled, and every sandbox must be shut down first. A task in a private space moves into the recipient's private space; a task in a shared space stays there.
  * @summary Hand a task off to a colleague
  */
 export const tasksHandoffCreate = async (

--- a/products/tasks/frontend/generated/api.ts
+++ b/products/tasks/frontend/generated/api.ts
@@ -75,6 +75,7 @@ import type {
     TaskCommentsResponseApi,
     TaskCreateApi,
     TaskDetailDTOApi,
+    TaskHandoffRequestApi,
     TaskMentionsListParams,
     TaskPinRequestApi,
     TaskPinResponseApi,
@@ -1337,6 +1338,28 @@ export const tasksCommentsRetrieve = async (
     return apiMutator<TaskCommentDetailApi>(getTasksCommentsRetrieveUrl(projectId, id, rootCommentId, params), {
         ...options,
         method: 'GET',
+    })
+}
+
+export const getTasksHandoffCreateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/tasks/${id}/handoff/`
+}
+
+/**
+ * Transfer ownership of a task to another member of the project: they take over driving it (steering, archiving, running), and future runs resolve GitHub authorship and notification recipients from them. Only the task's current owner can hand it off. A task in a private space moves into the recipient's private space; a task in a shared space stays there.
+ * @summary Hand a task off to a colleague
+ */
+export const tasksHandoffCreate = async (
+    projectId: string,
+    id: string,
+    taskHandoffRequestApi: TaskHandoffRequestApi,
+    options?: RequestInit
+): Promise<TaskDetailDTOApi> => {
+    return apiMutator<TaskDetailDTOApi>(getTasksHandoffCreateUrl(projectId, id), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(taskHandoffRequestApi),
     })
 }
 

--- a/products/tasks/frontend/generated/api.zod.ts
+++ b/products/tasks/frontend/generated/api.zod.ts
@@ -1509,6 +1509,22 @@ export const TasksPartialUpdateBody = /* @__PURE__ */ zod
     )
 
 /**
+ * Transfer ownership of a task to another member of the project: they take over driving it (steering, archiving, running), and future runs resolve GitHub authorship and notification recipients from them. Only the task's current owner can hand it off. A task in a private space moves into the recipient's private space; a task in a shared space stays there.
+ * @summary Hand a task off to a colleague
+ */
+
+export const TasksHandoffCreateBody = /* @__PURE__ */ zod
+    .object({
+        user: zod
+            .number()
+            .min(1)
+            .describe(
+                "ID of the user taking over the task. Must be a member of this project's organization and not the task's current owner."
+            ),
+    })
+    .describe('Request body for handing a task off to a colleague: they become its owner.')
+
+/**
  * API for managing tasks within a project. Tasks represent units of work to be performed by an agent.
  */
 export const TasksPinCreateBody = /* @__PURE__ */ zod.object({

--- a/products/tasks/frontend/generated/api.zod.ts
+++ b/products/tasks/frontend/generated/api.zod.ts
@@ -1509,7 +1509,7 @@ export const TasksPartialUpdateBody = /* @__PURE__ */ zod
     )
 
 /**
- * Transfer ownership of a task to another member of the project: they take over driving it (steering, archiving, running), and future runs resolve GitHub authorship and notification recipients from them. Only the task's current owner can hand it off. A task in a private space moves into the recipient's private space; a task in a shared space stays there.
+ * Transfer ownership of a task to another member of the project: they take over driving it (steering, archiving, running), and future runs resolve GitHub authorship and notification recipients from them. Only the task's current owner can hand it off. Every run must be finished or canceled, and every sandbox must be shut down first. A task in a private space moves into the recipient's private space; a task in a shared space stays there.
  * @summary Hand a task off to a colleague
  */
 

--- a/products/tasks/frontend/generated/api.zod.ts
+++ b/products/tasks/frontend/generated/api.zod.ts
@@ -1519,7 +1519,7 @@ export const TasksHandoffCreateBody = /* @__PURE__ */ zod
             .number()
             .min(1)
             .describe(
-                "ID of the user taking over the task. Must be a member of this project's organization and not the task's current owner."
+                "ID of the user taking over the task. Must have access to this project and not be the task's current owner."
             ),
     })
     .describe('Request body for handing a task off to a colleague: they become its owner.')

--- a/products/tasks/mcp/tools.yaml
+++ b/products/tasks/mcp/tools.yaml
@@ -374,6 +374,9 @@ tools:
     tasks-destroy:
         operation: tasks_destroy
         enabled: false
+    tasks-handoff-create:
+        operation: tasks_handoff_create
+        enabled: false
     tasks-list:
         operation: tasks_list
         enabled: true

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -79398,6 +79398,17 @@ export namespace Schemas {
       runtime?: RuntimeEnum;
     }
 
+    /**
+     * Request body for handing a task off to a colleague: they become its owner.
+     */
+    export interface TaskHandoffRequest {
+      /**
+         * ID of the user taking over the task. Must be a member of this project's organization and not the task's current owner.
+         * @minimum 1
+         */
+      user: number;
+    }
+
     export interface TaskPinRequest {
       /** Whether the task should be pinned for the requester. */
       pinned: boolean;

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -79403,7 +79403,7 @@ export namespace Schemas {
      */
     export interface TaskHandoffRequest {
       /**
-         * ID of the user taking over the task. Must be a member of this project's organization and not the task's current owner.
+         * ID of the user taking over the task. Must have access to this project and not be the task's current owner.
          * @minimum 1
          */
       user: number;


### PR DESCRIPTION
## Problem

A PostHog Desktop user looking at one of their tasks has no way to pass it to a colleague. This PR adds the desktop UI for handoff: the backend endpoint lives in #84532 (backend half), which has to ship first — the repo's desktop/backend coupling check requires the split.

## Changes

- The task row's menu gains a "Hand off…" item, next to "File to…", visible only to the task's owner. The quill row menu renders once as the right-click context menu and once as the hover-card action list, so both surfaces get it from the shared definition. The native sidebar context menu gets the same item via a new `canHandoff` input on `showTaskContextMenu`.
- The item opens a confirmation dialog modeled on the app's other confirm modals: one title, two short consequence sentences (ownership moves; a personal-space task moves into the recipient's space and you lose access; only they can hand it back), then Cancel against the commit.
- The colleague is picked through the same search-first autocomplete the spaces flyout uses, rendering the mention composer's avatar + name + email rows. The current owner is excluded from the list and confirm stays disabled until someone is picked.
- The activity timeline renders the new `task_handed_off` thread event (tone, icon, and copy); unknown thread events render as nothing, so the announcement needed the vocabulary entry.
- `useHandoffTask` forwards the recipient id and invalidates the task, channel, and feed caches.

UI screenshot: none. The change is quill dialog and menu components verified with component render tests. Booting the Electron app for a screenshot is not possible in this environment.

## How did you test this code?

- `HandoffTaskDialog` (6 tests): confirm disabled until a person is picked, personal-space consequence copy shown and omitted correctly, name/email filtering, current owner excluded, mutation fires with the selected member's id.
- `ChannelItemRow`: "Hand off…" offered only when the current user owns the task.
- Core context-menu tests: owner-gating input and intent resolution for the native menu item.
- `useHandoffTask`: forwards the recipient id and invalidates task/channel/feed queries.
- `ChannelSidebar.test.tsx` needed a `useCurrentUser` module mock once `ChannelItemRow` started reading the current user for the owner gate (the same stubbing pattern that file already uses).

Not checked: end-to-end in the running desktop app (no display in this environment).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No desktop docs to update; the backend PR updates `products/tasks/docs/CHANNELS.md` and `INSTRUMENTATION.md`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Build agent: pi (Claude), working from the desktop-multiplayer channel request for person-to-person task handoff.
- Split out of #84532 to satisfy the desktop/backend coupling rule: backend first, then this PR once the endpoint is deployed.
- The dialog and menu items reuse existing quill primitives (AlertDialog, search-first Autocomplete, mention-composer person rows) rather than new components.
- Public artifact: nothing here draws on private session material.
