### PR TITLE
fix(demo): make default test user organization owner

### DIFF
--- a/products/demo/backend/logic/matrix/manager.py
+++ b/products/demo/backend/logic/matrix/manager.py
@@ -83,7 +83,7 @@ class MatrixManager:
                     email,
                     password,
                     first_name,
-                    OrganizationMembership.Level.ADMIN,
+                    OrganizationMembership.Level.OWNER,
                     is_staff=is_staff,
                     theme_mode="system",
                     role_at_organization="engineering",

--- a/products/demo/backend/test/test_matrix_manager.py
+++ b/products/demo/backend/test/test_matrix_manager.py
@@ -6,6 +6,7 @@ from zoneinfo import ZoneInfo
 from posthog.test.base import ClickhouseDestroyTablesMixin
 
 from posthog.clickhouse.client import sync_execute
+from posthog.models import OrganizationMembership
 
 from products.demo.backend.logic.matrix.manager import MatrixManager
 from products.demo.backend.logic.matrix.matrix import Cluster, Matrix
@@ -78,6 +79,14 @@ class TestMatrixManager(ClickhouseDestroyTablesMixin):
         assert demo_team.organization == self.organization
         assert demo_team.ingested_event
         assert demo_team.is_demo
+
+    def test_ensure_account_creates_organization_owner(self):
+        manager = MatrixManager(self.matrix)
+
+        organization, _, user = manager.ensure_account_and_save("demo@example.com", "Demo", "Demo organization")
+
+        membership = OrganizationMembership.objects.get(organization=organization, user=user)
+        assert membership.level == OrganizationMembership.Level.OWNER
 
     def test_run_on_team(self):
         manager = MatrixManager(self.matrix)


### PR DESCRIPTION
## Problem

The only member of a generated demo organization receives the admin role instead of the owner role. This makes the default org configuration kinda weird - 1 member with the admin role. This means there are no owners in the org which is obviously wrong, and also annoying since I can't access the billing page by default unless I turn off the billing only owner feature flag.

## Changes

- New demo organizations assign their generated user the owner role.
- A regression test verifies the persisted organization membership level.

## How did you test this code?

- Ruff lint and formatting checks pass for both changed files.
- The focused test file could not run because this environment has no Postgres service.
- The new test catches demo account creation reverting to a non-owner membership.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented the focused fix through PostHog Desktop. The writing-tests and writing-pr-descriptions skills shaped the regression coverage and this description.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*