### PR TITLE
feat(desktop): let canvases track live agent tasks via ph.tasks

### DIFF
--- a/products/canvas/skills/building-react-quill-canvases/SKILL.md
+++ b/products/canvas/skills/building-react-quill-canvases/SKILL.md
@@ -127,6 +127,14 @@ exactly `className="w-auto p-0"` and nothing is added to `DateTimePicker` beyond
 `value`/`onApply`/`onCancel` (it self-sizes; don't pass `compact` or widths). Re-run every query
 when the window changes — see the `querying-canvas-data` skill for feeding it into `dateRange`.
 
+## Task boards
+
+For "track my agents / parallel work" requests, build the board on `ph.tasks()` (see the "App
+state" section of the `querying-canvas-data` skill): needs-attention tasks first (status
+`waiting`/`error`, amber/destructive treatment), then running with spinners, then recently
+finished with their PR badges. Poll every few seconds and open a task on click with
+`ph.navigate.toTask(id)`.
+
 ## State and actions
 
 Persisting values across reloads (`ph.state`, with user/shared scopes) and writing into PostHog

--- a/products/canvas/skills/querying-canvas-data/SKILL.md
+++ b/products/canvas/skills/querying-canvas-data/SKILL.md
@@ -187,6 +187,28 @@ canvas) differ in payload shape, auth, and behavior. Invoking looks like:
 const { result } = await ph.actions.invoke('tasks.create', { title, description })
 ```
 
+## App state — ph.tasks
+
+`await ph.tasks({ limit? })` returns a live snapshot of the viewer's agent tasks in this app —
+for personal boards that track parallel agent work ("mission control", kanban, focus views).
+This is app state, not PostHog analytics data: no insight or SQL is involved, and it needs no
+capability declaration. In-app canvases only; the published tier's capability manifest denies it.
+
+```tsx
+const { tasks } = await ph.tasks({ limit: 50 }) // most recently updated first; limit 1-200
+// each task: { id, title, status, needsPermission, isGenerating, prUrl,
+//              repository, environment, runStatus, createdAt, updatedAt }
+```
+
+- `status` is `running | waiting | idle | error | completed`. `waiting` (with
+  `needsPermission: true`) means the agent is blocked on the viewer — surface it first and most
+  prominently.
+- Poll it: `setInterval` of 3–5 seconds inside a `useEffect` (cleared on unmount) keeps the board
+  live; the host serves list reads from a shared cache, so polling is cheap.
+- Wire each row's click to `ph.navigate.toTask(task.id)` so the board deep-links into the task.
+- `prUrl` is a GitHub URL — render it as a badge/label (e.g. `#4821`), not an `openExternal`
+  link (only posthog.com URLs open).
+
 ## Side effects
 
 - `ph.capture(event, properties?, distinctId?)` — analytics events for interactions

--- a/products/desktop/packages/core/src/canvas/canvasTasks.test.ts
+++ b/products/desktop/packages/core/src/canvas/canvasTasks.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCanvasTaskSummaries,
+  type CanvasTaskSession,
+  type CanvasTaskSource,
+} from "./canvasTasks";
+import { canvasTasksResultSchema } from "./freeformSchemas";
+
+function makeTask(overrides: Partial<CanvasTaskSource> = {}): CanvasTaskSource {
+  return {
+    id: "task-1",
+    title: "Fix login redirect",
+    repository: "posthog/code",
+    created_at: "2026-08-18T10:00:00Z",
+    updated_at: "2026-08-18T11:00:00Z",
+    latest_run: null,
+    ...overrides,
+  };
+}
+
+function makeSession(
+  overrides: Partial<CanvasTaskSession> = {},
+): CanvasTaskSession {
+  return {
+    taskId: "task-1",
+    status: "connected",
+    pendingPermissions: { size: 0 },
+    isPromptPending: false,
+    ...overrides,
+  };
+}
+
+describe("buildCanvasTaskSummaries", () => {
+  it("returns idle for a task with no session and no run", () => {
+    const { tasks } = buildCanvasTaskSummaries([makeTask()], {});
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]).toMatchObject({
+      id: "task-1",
+      title: "Fix login redirect",
+      status: "idle",
+      runStatus: null,
+      environment: null,
+      repository: "posthog/code",
+      prUrl: null,
+      needsPermission: false,
+      isGenerating: false,
+      createdAt: "2026-08-18T10:00:00Z",
+      updatedAt: "2026-08-18T11:00:00Z",
+    });
+  });
+
+  it("derives live status from the task's session (keyed by run id, matched via taskId)", () => {
+    const { tasks } = buildCanvasTaskSummaries([makeTask()], {
+      "run-9": makeSession({ pendingPermissions: { size: 1 } }),
+    });
+    expect(tasks[0].status).toBe("waiting");
+    expect(tasks[0].needsPermission).toBe(true);
+  });
+
+  it("reports running + isGenerating while a connected session has a prompt in flight", () => {
+    const { tasks } = buildCanvasTaskSummaries([makeTask()], {
+      "run-9": makeSession({ isPromptPending: true }),
+    });
+    expect(tasks[0].status).toBe("running");
+    expect(tasks[0].isGenerating).toBe(true);
+  });
+
+  it.each([
+    { runStatus: "in_progress", expected: "running" },
+    { runStatus: "queued", expected: "running" },
+    { runStatus: "completed", expected: "completed" },
+    { runStatus: "failed", expected: "error" },
+    { runStatus: "cancelled", expected: "error" },
+    { runStatus: "not_started", expected: "idle" },
+  ] as const)(
+    "falls back to the run status when there is no live session ($runStatus → $expected)",
+    ({ runStatus, expected }) => {
+      const { tasks } = buildCanvasTaskSummaries(
+        [makeTask({ latest_run: { status: runStatus } })],
+        {},
+      );
+      expect(tasks[0].status).toBe(expected);
+      expect(tasks[0].runStatus).toBe(runStatus);
+    },
+  );
+
+  it("prefers the live session over the stale run status", () => {
+    const { tasks } = buildCanvasTaskSummaries(
+      [makeTask({ latest_run: { status: "completed" } })],
+      { "run-9": makeSession({ isPromptPending: true }) },
+    );
+    expect(tasks[0].status).toBe("running");
+  });
+
+  it.each([
+    { runStatus: "completed", expected: "completed" },
+    { runStatus: "failed", expected: "error" },
+    { runStatus: "cancelled", expected: "error" },
+  ] as const)(
+    "prefers the terminal run status ($runStatus) over a session that is merely idle",
+    ({ runStatus, expected }) => {
+      // A local session stays connected after its prompt finishes; the board
+      // should show the landed outcome, not "idle".
+      const { tasks } = buildCanvasTaskSummaries(
+        [makeTask({ latest_run: { status: runStatus } })],
+        { "run-9": makeSession() },
+      );
+      expect(tasks[0].status).toBe(expected);
+    },
+  );
+
+  it("keeps an idle session idle while the run record still claims in_progress", () => {
+    // The live session is the fresher signal — a stale in_progress run record
+    // must not resurrect "running".
+    const { tasks } = buildCanvasTaskSummaries(
+      [makeTask({ latest_run: { status: "in_progress" } })],
+      { "run-9": makeSession() },
+    );
+    expect(tasks[0].status).toBe("idle");
+  });
+
+  it("reads the PR url from the run output, falling back to the session's cloud output", () => {
+    const fromRun = buildCanvasTaskSummaries(
+      [
+        makeTask({
+          latest_run: {
+            status: "completed",
+            output: { pr_url: "https://github.com/posthog/code/pull/1" },
+          },
+        }),
+      ],
+      {},
+    );
+    expect(fromRun.tasks[0].prUrl).toBe(
+      "https://github.com/posthog/code/pull/1",
+    );
+
+    const fromSession = buildCanvasTaskSummaries([makeTask()], {
+      "run-9": makeSession({
+        cloudOutput: { pr_url: "https://github.com/posthog/code/pull/2" },
+      }),
+    });
+    expect(fromSession.tasks[0].prUrl).toBe(
+      "https://github.com/posthog/code/pull/2",
+    );
+  });
+
+  it("surfaces the run environment", () => {
+    const { tasks } = buildCanvasTaskSummaries(
+      [
+        makeTask({
+          latest_run: { status: "in_progress", environment: "cloud" },
+        }),
+      ],
+      {},
+    );
+    expect(tasks[0].environment).toBe("cloud");
+  });
+
+  it("sorts by updated_at, most recent first", () => {
+    const { tasks } = buildCanvasTaskSummaries(
+      [
+        makeTask({ id: "old", updated_at: "2026-08-18T09:00:00Z" }),
+        makeTask({ id: "new", updated_at: "2026-08-18T12:00:00Z" }),
+      ],
+      {},
+    );
+    expect(tasks.map((t) => t.id)).toEqual(["new", "old"]);
+  });
+
+  it("applies the requested limit after sorting", () => {
+    const { tasks } = buildCanvasTaskSummaries(
+      [
+        makeTask({ id: "old", updated_at: "2026-08-18T09:00:00Z" }),
+        makeTask({ id: "new", updated_at: "2026-08-18T12:00:00Z" }),
+      ],
+      {},
+      { limit: 1 },
+    );
+    expect(tasks.map((t) => t.id)).toEqual(["new"]);
+  });
+
+  it("caps at the default limit when none is given", () => {
+    const many = Array.from({ length: 60 }, (_, i) =>
+      makeTask({ id: `task-${i}` }),
+    );
+    const { tasks } = buildCanvasTaskSummaries(many, {});
+    expect(tasks).toHaveLength(50);
+  });
+
+  it("produces output that satisfies the wire schema", () => {
+    const result = buildCanvasTaskSummaries([makeTask({ repository: null })], {
+      "run-9": makeSession(),
+    });
+    expect(canvasTasksResultSchema.safeParse(result).success).toBe(true);
+  });
+});

--- a/products/desktop/packages/core/src/canvas/canvasTasks.ts
+++ b/products/desktop/packages/core/src/canvas/canvasTasks.ts
@@ -1,0 +1,120 @@
+import { readPrUrls } from "@posthog/shared";
+import type {
+  TaskRunEnvironment,
+  TaskRunStatus,
+} from "@posthog/shared/domain-types";
+import {
+  type CellStatus,
+  deriveStatus,
+  type SessionStatusInput,
+} from "../command-center/status";
+import type {
+  CanvasTaskSummary,
+  CanvasTasksInput,
+  CanvasTasksResult,
+} from "./freeformSchemas";
+
+// Structural inputs (like buildSidebarData's FullTask/TaskSession) so the UI
+// can pass its real Task/AgentSession values and tests can fake minimal ones.
+
+export interface CanvasTaskSource {
+  id: string;
+  title: string;
+  repository?: string | null;
+  created_at: string;
+  updated_at: string;
+  latest_run?: {
+    status?: TaskRunStatus | null;
+    environment?: TaskRunEnvironment | null;
+    output?: Record<string, unknown> | null;
+  } | null;
+}
+
+export interface CanvasTaskSession extends SessionStatusInput {
+  taskId?: string;
+  cloudOutput?: Record<string, unknown> | null;
+}
+
+// A canvas that doesn't ask for a limit still gets a bounded board: recent
+// parallel work, not the whole task history.
+const DEFAULT_LIMIT = 50;
+
+// Coarsens a run's lifecycle status into the display status when the task has
+// no live session to derive from (e.g. a cloud run finished while the app was
+// closed). Mirrors what the Command Center would show once a session attaches.
+function statusFromRun(
+  runStatus: TaskRunStatus | null | undefined,
+): CellStatus {
+  switch (runStatus) {
+    case "completed":
+      return "completed";
+    case "failed":
+    case "cancelled":
+      return "error";
+    case "in_progress":
+    case "queued":
+      return "running";
+    default:
+      return "idle";
+  }
+}
+
+/**
+ * Projects the user's tasks + live session state into the `ph.tasks` wire shape
+ * — the read behind a canvas task board. Sessions are keyed by run id (the
+ * session store's shape) and matched to tasks via their `taskId`, exactly like
+ * the Command Center's join. Sorted most recently updated first, then capped.
+ */
+export function buildCanvasTaskSummaries(
+  tasks: CanvasTaskSource[],
+  sessions: Record<string, CanvasTaskSession>,
+  input: CanvasTasksInput = {},
+): CanvasTasksResult {
+  const sessionByTaskId = new Map<string, CanvasTaskSession>();
+  for (const session of Object.values(sessions)) {
+    if (session.taskId) sessionByTaskId.set(session.taskId, session);
+  }
+
+  const limit = input.limit ?? DEFAULT_LIMIT;
+  const summaries = [...tasks]
+    .sort(
+      (a, b) =>
+        new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
+    )
+    .slice(0, limit)
+    .map((task): CanvasTaskSummary => {
+      const session = sessionByTaskId.get(task.id);
+      const runStatus = task.latest_run?.status;
+      // Live session signals (waiting/running/error/completed) win. But a
+      // session that is merely idle-connected says nothing about the outcome —
+      // a local session stays connected after its prompt finishes — so a
+      // terminal run record shows the landed result instead. A non-terminal
+      // run record never overrides an idle session: the session is fresher.
+      let status = session ? deriveStatus(session) : statusFromRun(runStatus);
+      const runIsTerminal =
+        runStatus === "completed" ||
+        runStatus === "failed" ||
+        runStatus === "cancelled";
+      if (session && status === "idle" && runIsTerminal) {
+        status = statusFromRun(runStatus);
+      }
+      return {
+        id: task.id,
+        title: task.title,
+        status,
+        runStatus: task.latest_run?.status ?? null,
+        environment: task.latest_run?.environment ?? null,
+        repository: task.repository ?? null,
+        prUrl:
+          readPrUrls(task.latest_run?.output)[0] ??
+          readPrUrls(session?.cloudOutput)[0] ??
+          null,
+        needsPermission: (session?.pendingPermissions?.size ?? 0) > 0,
+        isGenerating: session?.isPromptPending ?? false,
+        createdAt: task.created_at,
+        updatedAt: task.updated_at,
+      };
+    });
+
+  return { tasks: summaries };
+}

--- a/products/desktop/packages/core/src/canvas/canvasTemplates.ts
+++ b/products/desktop/packages/core/src/canvas/canvasTemplates.ts
@@ -3,6 +3,11 @@ import type { CanvasTemplateSummary } from "./templateSchemas";
 
 const FREEFORM_SUGGESTIONS = [
   {
+    label: "Agent task board",
+    prompt:
+      "Build a live board of my agent tasks using ph.tasks(): a 'Needs attention' section first (waiting/error), then running, then recently finished. Show each task's title, status, repo, and PR link, refresh every few seconds, and open a task when I click it.",
+  },
+  {
     label: "Signups chart",
     prompt:
       "Build an app that shows daily new signups for the last 30 days as a line chart, with a total at the top.",

--- a/products/desktop/packages/core/src/canvas/freeformSchemas.test.ts
+++ b/products/desktop/packages/core/src/canvas/freeformSchemas.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  canvasTasksInput,
   canvasToHostMessageSchema,
   hostToCanvasMessageSchema,
   limitCanvasCommentHighlights,
@@ -157,5 +158,46 @@ describe("canvasToHostMessageSchema", () => {
       channel: "posthog-canvas",
       type: "clear-text-selection",
     });
+  });
+});
+
+describe("canvasTasksInput", () => {
+  it.each([{}, { limit: 1 }, { limit: 200 }])("accepts %o", (input) => {
+    expect(canvasTasksInput.safeParse(input).success).toBe(true);
+  });
+
+  it.each([
+    { limit: 0 },
+    { limit: -5 },
+    { limit: 1.5 },
+    { limit: 201 },
+    { limit: "10" },
+  ])("rejects %o", (input) => {
+    expect(canvasTasksInput.safeParse(input).success).toBe(false);
+  });
+});
+
+describe("canvasToHostMessageSchema data-request methods", () => {
+  const request = (method: string) => ({
+    channel: "posthog-canvas",
+    type: "data-request",
+    id: "1",
+    method,
+    payload: {},
+  });
+
+  // The wire enum is the first gate a new ph.* method has to pass: a method
+  // missing here is silently dropped by the host, which looks like a hang
+  // from inside the canvas.
+  it.each(["tasks", "query", "stateGet"])("accepts %s", (method) => {
+    expect(canvasToHostMessageSchema.safeParse(request(method)).success).toBe(
+      true,
+    );
+  });
+
+  it("rejects unknown methods", () => {
+    expect(
+      canvasToHostMessageSchema.safeParse(request("filesystem")).success,
+    ).toBe(false);
   });
 });

--- a/products/desktop/packages/core/src/canvas/freeformSchemas.ts
+++ b/products/desktop/packages/core/src/canvas/freeformSchemas.ts
@@ -82,6 +82,77 @@ export const canvasLoadInsightInput = z.object({
 });
 export type CanvasLoadInsightInput = z.infer<typeof canvasLoadInsightInput>;
 
+// ---------------------------------------------------------------------------
+// Tasks avenue: the read behind the `ph.tasks` shim. A live snapshot of the
+// user's agent tasks — joined with in-memory session state (status, pending
+// permissions, prompt-in-flight) — so a canvas can be a personal board tracking
+// parallel agent work. Resolved entirely in the renderer from the same data the
+// sidebar and Command Center render; nothing here carries credentials, and the
+// canvas only ever sees this projected summary shape. In-app (edit-tier)
+// canvases only: the published tier's capability manifest denies unknown
+// methods by default, so a built artifact cannot reach it.
+// ---------------------------------------------------------------------------
+export const CANVAS_TASKS_MAX_LIMIT = 200;
+
+export const canvasTasksInput = z.object({
+  // How many tasks to return (most recently updated first). Bounded so a canvas
+  // can't ask the host to serialize thousands of rows across the postMessage
+  // boundary; defaults host-side when omitted.
+  limit: z.number().int().min(1).max(CANVAS_TASKS_MAX_LIMIT).optional(),
+});
+export type CanvasTasksInput = z.infer<typeof canvasTasksInput>;
+
+// The live display status, mirroring the Command Center's `CellStatus` (see
+// `command-center/status.ts`, the canonical derivation) so a canvas board and
+// the built-in grid never disagree about what an agent is doing.
+export const canvasTaskStatusSchema = z.enum([
+  "running",
+  "waiting",
+  "idle",
+  "error",
+  "completed",
+]);
+export type CanvasTaskStatus = z.infer<typeof canvasTaskStatusSchema>;
+
+export const canvasTaskSummarySchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  // Live status: derived from the task's connected session when one exists
+  // (with a terminal run status winning over a merely idle session), else
+  // coarsened from the latest run. "waiting" = blocked on the user (a pending
+  // permission) — the attention state a board should surface first.
+  status: canvasTaskStatusSchema,
+  // The latest run's raw lifecycle status, for boards that want run mechanics.
+  runStatus: z
+    .enum([
+      "not_started",
+      "queued",
+      "in_progress",
+      "completed",
+      "failed",
+      "cancelled",
+    ])
+    .nullable(),
+  environment: z.enum(["local", "cloud"]).nullable(),
+  // "owner/repo", when the task is bound to a repository.
+  repository: z.string().nullable(),
+  // The task's pull request, once a run has opened one.
+  prUrl: z.string().nullable(),
+  // Blocked on the user right now (pending permission request).
+  needsPermission: z.boolean(),
+  // The agent is actively producing output right now.
+  isGenerating: z.boolean(),
+  // ISO timestamps, as the API reports them.
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+export type CanvasTaskSummary = z.infer<typeof canvasTaskSummarySchema>;
+
+export const canvasTasksResultSchema = z.object({
+  tasks: z.array(canvasTaskSummarySchema),
+});
+export type CanvasTasksResult = z.infer<typeof canvasTasksResultSchema>;
+
 // Capture (write) avenue behind the `ph.capture` shim. The host sends the event
 // to the project using its PUBLIC project key (phc_…, safe to be client-side) —
 // the private read token still never enters the iframe. `distinctId` is who the
@@ -287,6 +358,7 @@ export const canvasToHostMessageSchema = z.discriminatedUnion("type", [
       "loadInsight",
       "capture",
       "run",
+      "tasks",
       "stateGet",
       "stateSet",
       "stateList",

--- a/products/desktop/packages/ui/src/features/canvas/components/FreeformPreview.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/FreeformPreview.tsx
@@ -2,6 +2,7 @@ import { ShapesIcon, WarningIcon } from "@phosphor-icons/react";
 import { cn, Skeleton, Text } from "@posthog/quill";
 import { FreeformCanvas } from "@posthog/ui/features/canvas/freeform/FreeformCanvas";
 import { handleFreeformDataRequest } from "@posthog/ui/features/canvas/freeform/freeformDataBridge";
+import { useCanvasTasksResolver } from "@posthog/ui/features/canvas/freeform/useCanvasTasksResolver";
 import { useInView } from "@posthog/ui/primitives/hooks/useInView";
 import { ErrorBoundary } from "@posthog/ui/shell/ErrorBoundary";
 import { Box, Flex } from "@radix-ui/themes";
@@ -40,12 +41,15 @@ export function FreeformPreview({
   // preview shows real-ish content. (posthog-js itself is never booted — no
   // `analytics` prop — so there's no autocapture/pageview/replay either.)
   const queryClient = useQueryClient();
+  const resolveCanvasTasks = useCanvasTasksResolver();
   const onDataRequest = useCallback(
     (method: string, payload: unknown) =>
       method === "capture"
         ? Promise.resolve({ ok: true })
-        : handleFreeformDataRequest(method, payload, queryClient),
-    [queryClient],
+        : handleFreeformDataRequest(method, payload, queryClient, {
+            tasks: resolveCanvasTasks,
+          }),
+    [queryClient, resolveCanvasTasks],
   );
 
   return (

--- a/products/desktop/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
@@ -108,6 +108,7 @@ import {
 } from "./canvasVersionNavigation";
 import { handleFreeformDataRequest } from "./freeformDataBridge";
 import { useCanvasNavigation } from "./useCanvasNavigation";
+import { useCanvasTasksResolver } from "./useCanvasTasksResolver";
 import { usePinnedArtifact } from "./usePinnedArtifact";
 
 // A freeform (React-in-iframe) canvas. The rendered output is, in priority
@@ -589,11 +590,13 @@ export function FreeformCanvasView({
       setAgentRequest(null);
     }
   }, [dashboardId]);
+  const resolveCanvasTasks = useCanvasTasksResolver();
   const onDataRequest = useCallback(
     (method: string, payload: unknown) => {
       if (method !== "agentRequest") {
         return handleFreeformDataRequest(method, payload, queryClient, {
           dashboardId,
+          tasks: resolveCanvasTasks,
         });
       }
       const input = canvasAgentRequestInputSchema.parse(payload);
@@ -609,7 +612,7 @@ export function FreeformCanvasView({
         agentRequestPromiseRef.current = { resolve, reject };
       });
     },
-    [queryClient, dashboardId],
+    [queryClient, dashboardId, resolveCanvasTasks],
   );
   const cancelAgentRequest = useCallback(() => {
     agentRequestPromiseRef.current?.reject(new Error("Agent request canceled"));

--- a/products/desktop/packages/ui/src/features/canvas/freeform/freeformDataBridge.test.ts
+++ b/products/desktop/packages/ui/src/features/canvas/freeform/freeformDataBridge.test.ts
@@ -177,3 +177,48 @@ describe("handleFreeformDataRequest", () => {
     ).rejects.toThrow("between 30 and 86400 seconds");
   });
 });
+
+describe("handleFreeformDataRequest tasks", () => {
+  // The "tasks" avenue never touches the QueryClient (live status must not be
+  // served stale from cache), so a bare client is enough here.
+  it("routes to the context tasks resolver with the parsed input", async () => {
+    const queryClient = new QueryClient();
+    const result = { tasks: [] };
+    const tasks = vi.fn().mockResolvedValue(result);
+    await expect(
+      handleFreeformDataRequest("tasks", { limit: 5 }, queryClient, { tasks }),
+    ).resolves.toBe(result);
+    expect(tasks).toHaveBeenCalledWith({ limit: 5 });
+  });
+
+  it("defaults a missing payload to an empty input", async () => {
+    const queryClient = new QueryClient();
+    const tasks = vi.fn().mockResolvedValue({ tasks: [] });
+    await handleFreeformDataRequest("tasks", undefined, queryClient, { tasks });
+    expect(tasks).toHaveBeenCalledWith({});
+  });
+
+  it.each([{ limit: 0 }, { limit: -1 }, { limit: 1.5 }, { limit: 10_000 }])(
+    "rejects an invalid limit %o",
+    async (payload) => {
+      const queryClient = new QueryClient();
+      const tasks = vi.fn();
+      await expect(
+        handleFreeformDataRequest("tasks", payload, queryClient, { tasks }),
+      ).rejects.toThrow("ph.tasks");
+      expect(tasks).not.toHaveBeenCalled();
+    },
+  );
+
+  it("rejects when no resolver is wired (e.g. a surface without task data)", async () => {
+    await expect(
+      handleFreeformDataRequest("tasks", {}, new QueryClient()),
+    ).rejects.toThrow("ph.tasks is not available here");
+  });
+
+  it("stays denied for built canvases (capability manifests do not cover it)", () => {
+    expect(() => assertCanvasCapability(capabilities, "tasks", {})).toThrow(
+      'Method "tasks" is not allowed',
+    );
+  });
+});

--- a/products/desktop/packages/ui/src/features/canvas/freeform/freeformDataBridge.ts
+++ b/products/desktop/packages/ui/src/features/canvas/freeform/freeformDataBridge.ts
@@ -1,7 +1,10 @@
-import type {
-  CanvasCaptureInput,
-  CanvasDataQueryInput,
-  CanvasLoadInsightInput,
+import {
+  type CanvasCaptureInput,
+  type CanvasDataQueryInput,
+  type CanvasLoadInsightInput,
+  type CanvasTasksInput,
+  type CanvasTasksResult,
+  canvasTasksInput,
 } from "@posthog/core/canvas/freeformSchemas";
 import type { QueryClient } from "@tanstack/react-query";
 import { hostClient } from "../hostClient";
@@ -84,8 +87,14 @@ export async function handleFreeformDataRequest(
   payload: unknown,
   queryClient: QueryClient,
   // State and actions are canvas-scoped, unlike the content-keyed reads above,
-  // so the caller passes the canvas identity in.
-  context?: { dashboardId?: string },
+  // so the caller passes the canvas identity in. `tasks` is the renderer-local
+  // resolver behind ph.tasks (app state, not a PostHog API call) — injected by
+  // the calling component, which holds the hooks/stores; a surface that can't
+  // serve it simply omits it and the shim call rejects.
+  context?: {
+    dashboardId?: string;
+    tasks?: (input: CanvasTasksInput) => Promise<CanvasTasksResult>;
+  },
 ): Promise<unknown> {
   const requireDashboardId = (): string => {
     if (!context?.dashboardId) {
@@ -201,6 +210,20 @@ export async function handleFreeformDataRequest(
         verb: input.verb,
         payload: input.payload ?? {},
       });
+    }
+    case "tasks": {
+      // Live status must never be served stale, so this read bypasses the
+      // QueryClient cache — the resolver reads current app state directly.
+      if (!context?.tasks) {
+        throw new Error("ph.tasks is not available here");
+      }
+      const parsed = canvasTasksInput.safeParse(payload ?? {});
+      if (!parsed.success) {
+        throw new Error(
+          "ph.tasks accepts an optional { limit } between 1 and 200",
+        );
+      }
+      return context.tasks(parsed.data);
     }
     case "run":
       // Named, server-stored insights land in Phase 3 (the live published tier).

--- a/products/desktop/packages/ui/src/features/canvas/freeform/sandboxRuntime.test.ts
+++ b/products/desktop/packages/ui/src/features/canvas/freeform/sandboxRuntime.test.ts
@@ -58,6 +58,11 @@ describe("decodeJsxUnicodeEscapes", () => {
 });
 
 describe("buildSandboxDocument", () => {
+  it("exposes the ph.tasks shim in the bootstrap", () => {
+    const html = buildSandboxDocument("edit");
+    expect(html).toContain('tasks: (opts) => call("tasks", opts ?? {})');
+  });
+
   it("inlines the unicode-escape decoder into the bootstrap", () => {
     const html = buildSandboxDocument();
     expect(html).toContain(

--- a/products/desktop/packages/ui/src/features/canvas/freeform/sandboxRuntime.ts
+++ b/products/desktop/packages/ui/src/features/canvas/freeform/sandboxRuntime.ts
@@ -256,6 +256,13 @@ export function buildSandboxDocument(
             ? { hogql: queryOrHogql, params: params ?? {}, refresh: opts && opts.refresh }
             : { query: queryOrHogql, params: params ?? {}, refresh: opts && opts.refresh },
         ),
+      // Live snapshot of the user's agent tasks in this app, joined with
+      // session state — \`{ tasks: [{ id, title, status, needsPermission,
+      // isGenerating, prUrl, repository, environment, runStatus, createdAt,
+      // updatedAt }] }\`, most recently updated first. Poll it (e.g. every few
+      // seconds) to build a live board tracking parallel agent work; pair with
+      // \`ph.navigate.toTask(id)\` to jump into a task. In-app canvases only.
+      tasks: (opts) => call("tasks", opts ?? {}),
       // Send an analytics event. Prefer in-iframe posthog-js (so it shares the
       // session/replay); otherwise host-mediated (no replay, still captured).
       capture: (event, properties, distinctId) => {

--- a/products/desktop/packages/ui/src/features/canvas/freeform/useCanvasTasksResolver.ts
+++ b/products/desktop/packages/ui/src/features/canvas/freeform/useCanvasTasksResolver.ts
@@ -1,0 +1,68 @@
+import { buildCanvasTaskSummaries } from "@posthog/core/canvas/canvasTasks";
+import type {
+  CanvasTasksInput,
+  CanvasTasksResult,
+} from "@posthog/core/canvas/freeformSchemas";
+import { sessionStore } from "@posthog/core/sessions/sessionStore";
+import type { Task } from "@posthog/shared/domain-types";
+import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
+import { AUTH_SCOPED_QUERY_META } from "@posthog/ui/features/auth/useCurrentUser";
+import { useMeQuery } from "@posthog/ui/features/auth/useMeQuery";
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback, useRef } from "react";
+import { taskKeys } from "../../tasks/taskKeys";
+
+// How stale the task LIST may be when a canvas polls ph.tasks. The list only
+// carries identity + run metadata; the live signals a board watches (waiting/
+// running/needs-permission) come from the session-store snapshot taken on every
+// call, so a short list window costs no status freshness. Deliberately lazy:
+// nothing is fetched until a canvas actually calls ph.tasks — canvases that
+// never use it add zero poll load (idle-poll churn is this app's top drain).
+const TASKS_STALE_MS = 15_000;
+
+/**
+ * The renderer-local resolver behind a canvas's `ph.tasks` — the user's tasks
+ * from the shared tasks query cache (same key as `useTasks`, so reads dedupe
+ * with the sidebar's poll) joined with the live session store by the tested
+ * core builder. Sessions are snapshotted at call time, not subscribed, so
+ * streamed events never re-render the canvas host; a board polls ph.tasks from
+ * inside the iframe instead. Pass the returned resolver to
+ * `handleFreeformDataRequest`'s context.
+ */
+export function useCanvasTasksResolver(): (
+  input: CanvasTasksInput,
+) => Promise<CanvasTasksResult> {
+  const queryClient = useQueryClient();
+  const client = useOptionalAuthenticatedClient();
+  const { data: me } = useMeQuery();
+  // Read via a ref so the returned callback stays referentially stable — its
+  // identity feeds onDataRequest memoization, and churning it on every auth/me
+  // refresh would rebuild those callbacks for no visible change.
+  const authRef = useRef({ client, meId: me?.id });
+  authRef.current = { client, meId: me?.id };
+
+  return useCallback(
+    async (input: CanvasTasksInput) => {
+      const { client: apiClient, meId } = authRef.current;
+      if (!apiClient || !meId) {
+        throw new Error("ph.tasks requires a signed-in app");
+      }
+      // Same key shape as useTasks' default view (undefined filters drop out
+      // of the hash), so this shares the sidebar's cache entry instead of
+      // double-fetching.
+      const tasks = await queryClient.fetchQuery({
+        queryKey: taskKeys.list({ createdBy: meId }),
+        queryFn: () =>
+          apiClient.getTasks({ createdBy: meId }) as unknown as Promise<Task[]>,
+        staleTime: TASKS_STALE_MS,
+        meta: AUTH_SCOPED_QUERY_META,
+      });
+      return buildCanvasTaskSummaries(
+        tasks,
+        sessionStore.getState().sessions,
+        input,
+      );
+    },
+    [queryClient],
+  );
+}

--- a/products/desktop/packages/ui/src/features/canvas/freeform/useCanvasTasksResolver.ts
+++ b/products/desktop/packages/ui/src/features/canvas/freeform/useCanvasTasksResolver.ts
@@ -9,7 +9,7 @@ import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authCl
 import { AUTH_SCOPED_QUERY_META } from "@posthog/ui/features/auth/useCurrentUser";
 import { useMeQuery } from "@posthog/ui/features/auth/useMeQuery";
 import { useQueryClient } from "@tanstack/react-query";
-import { useCallback, useRef } from "react";
+import { useCallback } from "react";
 import { taskKeys } from "../../tasks/taskKeys";
 
 // How stale the task LIST may be when a canvas polls ph.tasks. The list only
@@ -35,16 +35,14 @@ export function useCanvasTasksResolver(): (
   const queryClient = useQueryClient();
   const client = useOptionalAuthenticatedClient();
   const { data: me } = useMeQuery();
-  // Read via a ref so the returned callback stays referentially stable — its
-  // identity feeds onDataRequest memoization, and churning it on every auth/me
-  // refresh would rebuild those callbacks for no visible change.
-  const authRef = useRef({ client, meId: me?.id });
-  authRef.current = { client, meId: me?.id };
+  // Plain deps, no latest-value ref: the client identity only moves on an auth
+  // state change and meId is a stable scalar, so the resolver (and the
+  // onDataRequest callbacks it feeds) rebuilds rarely — and never mid-request.
+  const meId = me?.id;
 
   return useCallback(
     async (input: CanvasTasksInput) => {
-      const { client: apiClient, meId } = authRef.current;
-      if (!apiClient || !meId) {
+      if (!client || !meId) {
         throw new Error("ph.tasks requires a signed-in app");
       }
       // Same key shape as useTasks' default view (undefined filters drop out
@@ -53,7 +51,7 @@ export function useCanvasTasksResolver(): (
       const tasks = await queryClient.fetchQuery({
         queryKey: taskKeys.list({ createdBy: meId }),
         queryFn: () =>
-          apiClient.getTasks({ createdBy: meId }) as unknown as Promise<Task[]>,
+          client.getTasks({ createdBy: meId }) as unknown as Promise<Task[]>,
         staleTime: TASKS_STALE_MS,
         meta: AUTH_SCOPED_QUERY_META,
       });
@@ -63,6 +61,6 @@ export function useCanvasTasksResolver(): (
         input,
       );
     },
-    [queryClient],
+    [queryClient, client, meId],
   );
 }


### PR DESCRIPTION
## Problem

Anyone running several agents in parallel tracks them through two fixed surfaces: the sidebar list and the Command Center grid. There is no way for each person to shape their own view of the parallel work. Canvases are the natural per-person surface — they are authored by chatting with an agent — but a canvas cannot see the app's agent tasks, so it cannot be a task board.

Separately, every Quill-based canvas currently fails to mount in the edit sandbox: Quill's transitive `@base-ui/react` floats as a `^range` on esm.sh, and the newly-released 1.7.0 emits an `import "/#prehydration/..."` line that esm.sh serves as its HTML homepage, killing the whole module graph.

Refs #38394

## Changes

**`ph.tasks({ limit? })`** — a new sandbox read returning a live snapshot of the viewer's agent tasks (`status`, `needsPermission`, `isGenerating`, `prUrl`, `repository`, `environment`, `runStatus`, timestamps), most recently updated first. A canvas polls it and becomes a personal board tracking parallel agent work — everyone customizes by prompt, not by settings UI.

![walkthrough](https://raw.githubusercontent.com/PostHog/posthog/8d60077727ffd9880719c8d2081a3e14b1dc99a3/demo-assets/canvas-ph-tasks/walkthrough.gif)

Three canvases, three people's preferences, one feed — each written exactly as the canvas agent would ([full video](https://raw.githubusercontent.com/PostHog/posthog/8d60077727ffd9880719c8d2081a3e14b1dc99a3/demo-assets/canvas-ph-tasks/walkthrough.mp4), [screenshots branch](https://github.com/PostHog/posthog/tree/posthog/canvas-ph-tasks-assets/demo-assets/canvas-ph-tasks)):

| Mission control | Kanban | Focus mode |
| --- | --- | --- |
| ![mission](https://raw.githubusercontent.com/PostHog/posthog/8d60077727ffd9880719c8d2081a3e14b1dc99a3/demo-assets/canvas-ph-tasks/1-mission-control.png) | ![kanban](https://raw.githubusercontent.com/PostHog/posthog/8d60077727ffd9880719c8d2081a3e14b1dc99a3/demo-assets/canvas-ph-tasks/4-kanban.png) | ![focus](https://raw.githubusercontent.com/PostHog/posthog/8d60077727ffd9880719c8d2081a3e14b1dc99a3/demo-assets/canvas-ph-tasks/6-focus.png) |

- Resolved entirely in the renderer: a pure core builder (`buildCanvasTaskSummaries`) joins the shared tasks query cache with the live session store, mirroring the Command Center's `deriveStatus` (a terminal run status wins over a merely idle session, so a landed PR reads "completed", not "idle"). No new credential crosses into the iframe.
- Deliberately lazy: nothing is fetched until a canvas actually calls it, and list reads share `useTasks`' cache key — canvases that never use it add zero poll load.
- In-app (edit-tier) canvases only: the published tier's capability manifest denies unknown methods by default.
- Canvas skills (`querying-canvas-data`, `building-react-quill-canvases`) document the API and the board pattern, and the create-picker gains an "Agent task board" suggestion chip.
- Pins `@base-ui/react@1.6.0` via `deps=` on Quill's esm.sh URL, restoring every Quill canvas mount and stopping silent transitive drift.

## How did you test this code?

- TDD unit tests: the core builder (status derivation incl. the terminal-run-over-idle-session precedence), the wire-schema method enum (a method missing there is silently dropped by the host, which reads as a hang from inside the canvas — the first end-to-end run hit exactly this), bridge routing/validation, and the shim's presence in the sandbox document.
- Full `@posthog/core` and `@posthog/ui` suites, typecheck, and biome pass locally.
- Observed end to end in a real browser: the actual sandbox document, `FreeformCanvas` broker, bridge, and builder mounted in a Playwright-driven harness that recorded the video above — live status flips, permission approvals, PRs appearing, click-through navigation intents, and a live light/dark re-theme. The task/session timeline was scripted (this environment cannot complete the app's OAuth), so full-app manual testing was not done; the three demo canvases use only whitelisted imports and Quill per the generation rules.
- The base-ui pin was verified by observation: before it, Quill's graph requests the esm.sh homepage as a module and every mount fails; after it, all three canvases mount.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None beyond the in-repo canvas skills.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code running as a PostHog Desktop cloud task, at the assignee's direction, after researching how sessions and canvases could give each person a customizable view of parallel agent work. The work started against the archived `posthog/code` repo and was re-ported here after finding that repo locked for the monorepo migration. All demo task titles, repos, and PR numbers in the media are invented; no customer or internal data is included.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
