### PR TITLE
fix(e2e): restore migrated schema before database setup

### DIFF
--- a/bin/mprocs-e2e.yaml
+++ b/bin/mprocs-e2e.yaml
@@ -62,7 +62,7 @@ procs:
             done && \
             echo "=== Running migrations ===" && \
             bin/wait-for-docker && \
-            python manage.py migrate && \
+            bin/migrate --scope=postgres --scope=persons && \
             python manage.py migrate_clickhouse && \
             echo "=== Setting up demo data ===" && \
             python manage.py setup_dev && \

--- a/bin/mprocs-e2e.yaml
+++ b/bin/mprocs-e2e.yaml
@@ -52,6 +52,7 @@ procs:
             echo "=== Dropping and recreating databases ===" && \
             dropdb --if-exists posthog_e2e_test && \
             createdb posthog_e2e_test && \
+            bin/hogli db:restore-schema-if-fresh --target-db posthog_e2e_test && \
             echo "DROP DATABASE IF EXISTS posthog_test SYNC" | curl 'http://localhost:8123/' --data-binary @- && \
             echo "CREATE DATABASE posthog_test" | curl 'http://localhost:8123/' --data-binary @- && \
             echo "=== Detaching conflicting Kafka-engine tables from posthog DB (shared consumer group 'group1') ===" && \

--- a/playwright/README.md
+++ b/playwright/README.md
@@ -27,6 +27,8 @@ hogli test:e2e
 
 This uses `bin/mprocs-e2e.yaml` under the hood. If you need to reset the E2E database, trigger the `reset-db` process in the phrocs UI.
 
+The reset downloads a compatible pre-migrated PostgreSQL schema from CI, then applies newer migrations. Authenticate `gh` or set `GH_TOKEN` to enable the download. If the download is unavailable, the reset applies the full migration history instead. ClickHouse and persons database migrations run separately.
+
 To run tests against an already-running PostHog instance:
 
 ```bash

--- a/tools/hogli-commands/hogli_commands/tests/test_db_schema.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_db_schema.py
@@ -218,8 +218,8 @@ def test_restore_schema_if_fresh_recreates_empty_db(monkeypatch: pytest.MonkeyPa
     monkeypatch.setattr(db_schema, "download_latest_compatible_schema", lambda **kwargs: None)
     monkeypatch.setattr(db_schema, "restore_schema_dump", lambda **kwargs: restore_calls.append(kwargs))
 
-    assert db_schema.restore_schema_if_fresh(target_db="posthog", mode="auto") is True
-    assert restore_calls == [{"target_db": "posthog", "recreate": True, "ensure_defaults": True}]
+    assert db_schema.restore_schema_if_fresh(target_db="posthog_e2e_test", mode="auto") is True
+    assert restore_calls == [{"target_db": "posthog_e2e_test", "recreate": True, "ensure_defaults": True}]
 
 
 def test_restore_schema_if_fresh_skips_when_db_populated_after_download(


### PR DESCRIPTION
## Problem

Bare checkouts spend most of their E2E setup time applying PostgreSQL migrations, then lack the persons tables required by Playwright workspace setup.

**Why:** Faster, complete database setup lets contributors and agents reach runnable E2E tests sooner.

## Changes

- E2E database reset restores the compatible CI schema before applying migration deltas.
- The standard migration command also creates and migrates the persons database.
- Auto mode keeps full PostgreSQL migrations as the fallback when the schema artifact is unavailable.
- ClickHouse keeps its independent reset and migration path.
- The Playwright guide documents authentication and fallback behavior.

## How did you test this code?

- `uv run bin/hogli test tools/hogli-commands/hogli_commands/tests/test_db_schema.py`
- `uv run bin/hogli ci:preflight --fix`
- A live E2E reset restored the schema, applied all migration scopes, and seeded the fixed test login.
- PostgreSQL checks confirmed the persons and group-type tables exist after reset.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The Playwright guide now explains the schema artifact authentication requirement and fallback.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented this change using the `hogli`, `playwright-test`, `run-posthog`, `writing-tests`, `writing-user-facing-copy`, and `writing-pr-descriptions` skills. The review kept the lightweight fixed E2E seed because the general demo-data generator would slow reset.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*