### PR TITLE
chore(agents): restore PR diagram guidance

### DIFF
--- a/.agents/skills/writing-pr-descriptions/SKILL.md
+++ b/.agents/skills/writing-pr-descriptions/SKILL.md
@@ -231,7 +231,7 @@ A "no" anywhere means the body is ordered for the writer, not the reader. Go bac
 8. Rewrite every passive sentence in active voice, unless the actor is genuinely unknown. Break every noun string longer than three words with a preposition.
 9. Does any sentence take its author as the subject? Rewrite it around the change. "I", "me" and "my" appear nowhere.
 10. Does the PR change anything a person sees? Include before-and-after screenshots, or say why nothing looks different.
-11. Does the PR change a flow or topology? Include branded before-and-after diagrams. If the change is too trivial for a diagram, explain the omission in `## 🤖 Agent context`.
+11. Does the PR change a flow or topology? Include branded before-and-after diagrams.
 12. Does prose compare several values across the same dimensions? Replace it with a table.
 13. Does every claim about what you ran, measured or saw link its evidence, or say it went unchecked? Descriptions of behavior need no link.
 14. Did a `<!-- -->` template comment survive anywhere? That section is unfilled. Fill it or delete it.

--- a/.agents/skills/writing-pr-descriptions/SKILL.md
+++ b/.agents/skills/writing-pr-descriptions/SKILL.md
@@ -64,7 +64,7 @@ Prose is the slowest form on the page. Before writing a sentence, ask what carri
 | The fact you have                                                                    | The form that carries it                                  |
 | ------------------------------------------------------------------------------------ | --------------------------------------------------------- |
 | A visual change (any UI a person sees)                                               | Screenshot, before and after. Mandatory, not optional     |
-| A change to a flow or topology (CI wiring, pipelines, state machines, request paths) | Two `flowchart` blocks, before first                      |
+| A change to a flow or topology (CI wiring, pipelines, state machines, request paths) | Two branded `flowchart` blocks, before first              |
 | Several values compared across the same dimensions                                   | A markdown table                                          |
 | A config or setting change                                                           | A fenced `diff` block                                     |
 | Existing code a reviewer needs to see                                                | A line-range permalink, which GitHub renders as a snippet |
@@ -230,12 +230,14 @@ A "no" anywhere means the body is ordered for the writer, not the reader. Go bac
 7. Count the words in the longest sentence. Over 25, split it.
 8. Rewrite every passive sentence in active voice, unless the actor is genuinely unknown. Break every noun string longer than three words with a preposition.
 9. Does any sentence take its author as the subject? Rewrite it around the change. "I", "me" and "my" appear nowhere.
-10. Is any fact in the wrong form? A visual change needs a screenshot. A flow change needs before and after diagrams. A comparison needs a table.
-11. Does every claim about what you ran, measured or saw link its evidence, or say it went unchecked? Descriptions of behavior need no link.
-12. Did a `<!-- -->` template comment survive anywhere? That section is unfilled. Fill it or delete it.
-13. Is the `## 🤖 Agent context` section filled, listing the skills invoked?
-14. Does the body claim manual testing that did not happen? Delete it.
-15. Does the body name an internal customer, incident, Slack quote, or operational metric? This repo is public. Delete it.
+10. Does the PR change anything a person sees? Include before-and-after screenshots, or say why nothing looks different.
+11. Does the PR change a flow or topology? Include branded before-and-after diagrams. If the change is too trivial for a diagram, explain the omission in `## 🤖 Agent context`.
+12. Does prose compare several values across the same dimensions? Replace it with a table.
+13. Does every claim about what you ran, measured or saw link its evidence, or say it went unchecked? Descriptions of behavior need no link.
+14. Did a `<!-- -->` template comment survive anywhere? That section is unfilled. Fill it or delete it.
+15. Is the `## 🤖 Agent context` section filled, listing the skills invoked?
+16. Does the body claim manual testing that did not happen? Delete it.
+17. Does the body name an internal customer, incident, Slack quote, or operational metric? This repo is public. Delete it.
 
 ## Background
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -66,6 +66,7 @@
 - Description: high-level rationale, not a step-by-step replay.
 - Voice: the subject of every sentence is the change, never its author. No "I", "me" or "my" anywhere in the body. "I (actually Claude)" is worse than either half: it hands the assignee an account of work they did not do. Authorship is one stated fact in the Agent context section below.
 - Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
+- Flow and topology changes: include separate before-and-after Mermaid `flowchart` blocks with PostHog colors. This includes CI wiring, pipelines, state machines, and request paths. If the change is too trivial for a diagram, explain the omission in Agent context. Use `/writing-pr-descriptions` for the palette and role mapping.
 - Public OSS repo: no internal customers, incidents, or operational metrics.
 - Stack instead of stuffing: if the diff holds two or more separable steps (migration then behavior, rename then rewrite), open a stack rather than one big PR. See AGENTS.md, "Stacked PRs" and /stacking-prs.
 - Simplify before opening: if your agent has a behavior-preserving cleanup pass (Claude Code: `/simplify`), run it on a non-trivial diff before final tests and preflight, since it edits the tree. Skip it for small mechanical changes.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -66,7 +66,7 @@
 - Description: high-level rationale, not a step-by-step replay.
 - Voice: the subject of every sentence is the change, never its author. No "I", "me" or "my" anywhere in the body. "I (actually Claude)" is worse than either half: it hands the assignee an account of work they did not do. Authorship is one stated fact in the Agent context section below.
 - Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
-- Flow and topology changes: include separate before-and-after Mermaid `flowchart` blocks with PostHog colors. This includes CI wiring, pipelines, state machines, and request paths. If the change is too trivial for a diagram, explain the omission in Agent context. Use `/writing-pr-descriptions` for the palette and role mapping.
+- Flow and topology changes: include separate before-and-after Mermaid `flowchart` blocks with PostHog colors. This includes CI wiring, pipelines, state machines, and request paths. Use `/writing-pr-descriptions` for the palette and role mapping.
 - Public OSS repo: no internal customers, incidents, or operational metrics.
 - Stack instead of stuffing: if the diff holds two or more separable steps (migration then behavior, rename then rewrite), open a stack rather than one big PR. See AGENTS.md, "Stacked PRs" and /stacking-prs.
 - Simplify before opening: if your agent has a behavior-preserving cleanup pass (Claude Code: `/simplify`), run it on a non-trivial diff before final tests and preflight, since it edits the tree. Skip it for small mechanical changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,6 @@ Examples:
 **Required:** Before creating any PR, read `.github/pull_request_template.md` and use its exact section structure.
 Do not invent a different format.
 **Shape:** invoke `/writing-pr-descriptions` before writing the body. Lead with the effect a person sees rather than the code path behind it, make the body stand alone for a reader who opens no files, and let its size track the change. Then one fact per bullet, sentences under 25 words, active voice, no idioms. A description that got longer as bullets was not cut.
-**Diagrams:** When a PR changes a flow or topology, include branded before-and-after Mermaid `flowchart` blocks. This includes CI wiring, pipelines, state machines, and request paths. Use `/writing-pr-descriptions` for the PostHog palette and role mapping.
 Always fill the `## 🤖 Agent context` section when creating PRs.
 NEVER share sensitive information in a PR description. Users may share sensitive data in an agent session, but those should never surface to a PR description, or comments.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ Examples:
 **Required:** Before creating any PR, read `.github/pull_request_template.md` and use its exact section structure.
 Do not invent a different format.
 **Shape:** invoke `/writing-pr-descriptions` before writing the body. Lead with the effect a person sees rather than the code path behind it, make the body stand alone for a reader who opens no files, and let its size track the change. Then one fact per bullet, sentences under 25 words, active voice, no idioms. A description that got longer as bullets was not cut.
+**Diagrams:** When a PR changes a flow or topology, include branded before-and-after Mermaid `flowchart` blocks. This includes CI wiring, pipelines, state machines, and request paths. If the change is too trivial for a diagram, explain the omission in `## 🤖 Agent context`. Use `/writing-pr-descriptions` for the PostHog palette and role mapping.
 Always fill the `## 🤖 Agent context` section when creating PRs.
 NEVER share sensitive information in a PR description. Users may share sensitive data in an agent session, but those should never surface to a PR description, or comments.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@ Examples:
 **Required:** Before creating any PR, read `.github/pull_request_template.md` and use its exact section structure.
 Do not invent a different format.
 **Shape:** invoke `/writing-pr-descriptions` before writing the body. Lead with the effect a person sees rather than the code path behind it, make the body stand alone for a reader who opens no files, and let its size track the change. Then one fact per bullet, sentences under 25 words, active voice, no idioms. A description that got longer as bullets was not cut.
-**Diagrams:** When a PR changes a flow or topology, include branded before-and-after Mermaid `flowchart` blocks. This includes CI wiring, pipelines, state machines, and request paths. If the change is too trivial for a diagram, explain the omission in `## 🤖 Agent context`. Use `/writing-pr-descriptions` for the PostHog palette and role mapping.
+**Diagrams:** When a PR changes a flow or topology, include branded before-and-after Mermaid `flowchart` blocks. This includes CI wiring, pipelines, state machines, and request paths. Use `/writing-pr-descriptions` for the PostHog palette and role mapping.
 Always fill the `## 🤖 Agent context` section when creating PRs.
 NEVER share sensitive information in a PR description. Users may share sensitive data in an agent session, but those should never surface to a PR description, or comments.
 


### PR DESCRIPTION
## Problem

- Agents can miss required flow diagrams after the detailed rule moved from the PR template into a skill.
- The indirect pointer makes the diagram trigger and PostHog palette easy to skip.

## Changes

```mermaid
flowchart LR
    T["PR template"] --> I["Invoke skill"]
    I --> S["Diagram rule"]
    S --> O["Diagram may be omitted"]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class T phYellow;
    class I phBlue;
    class S phGray;
    class O phRed;
```

```mermaid
flowchart LR
    T["PR template"] --> G["Direct diagram gate"]
    G --> S["Palette and role mapping in skill"]
    S --> D["Branded diagrams"]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class T,D phYellow;
    class G phBlue;
    class S phGray;
```

- The template now states the branded diagram requirement directly.
- The skill checks screenshots, diagrams, and comparison tables separately.

## How did you test this code?

- `hogli lint:skills`
- `hogli ci:preflight --fix`

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- The updated instructions are the documentation for this workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex session directed by Raúl. Skills: `/writing-skills`, `/writing-user-facing-copy`, `/writing-pr-descriptions`, `/shipping-a-pr`, and `/running-ci-preflight`.
- `/simplify` was skipped because this is a small Markdown-only instruction change.