### PR TITLE
fix(ci): pass the run purpose to vr run complete

### DIFF
--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -784,26 +784,26 @@ jobs:
               run: cd vr-cli/products/visual_review/cli && npm ci && npm run build
 
             - name: Complete Visual Review run
+              # Pass the same --purpose vr-setup created the run with. The backend reports zero
+              # unresolved on an observe run however many snapshots drifted, so without the flag
+              # the CLI cannot tell a clean tracking run from a drifting one and reports neither.
+              # With it, drift becomes a warning annotation naming the identifiers and the command
+              # still exits 0, so the run stays non-gating without the finding being dropped.
+              # That signal matters because an identifier drifting on master without being approved
+              # or quarantined reds the next PR that renders it.
+              #
+              # No exit-code branching: an observe run cannot exit 1, so every non-zero exit here
+              # is a real failure (exit 1 unresolved on a review run, exit 2 CLI error) and reds CI.
               env:
                   VR_TOKEN: ${{ secrets.VR_API_TOKEN }}
-                  # Master pushes and merge-queue branches create the run with --purpose observe
-                  # (tracking-only), because neither has a PR whose reviewer could approve a diff.
+                  RUN_ID: ${{ needs.vr-setup.outputs.run_id }}
                   VR_OBSERVE: ${{ github.event_name == 'push' || needs.changes.outputs.merge_queue == 'true' }}
               run: |
-                  status=0
-                  node vr-cli/products/visual_review/cli/dist/cli/src/index.js run complete \
-                    --run-id "${{ needs.vr-setup.outputs.run_id }}" \
-                    --baseline frontend/snapshots.yml \
-                    --token "$VR_TOKEN" || status=$?
-
-                  # `vr run complete` exits 1 for unresolved visual changes and 2 when the CLI
-                  # itself failed (auth, network, timeout, backend processing). Only the former
-                  # is expected on an observe run, so exit 2 still reds CI everywhere.
-                  if [ "$status" -eq 1 ] && [ "$VR_OBSERVE" = 'true' ]; then
-                      echo "Observe run: visual changes recorded, not gating."
-                      exit 0
+                  args=(--run-id "$RUN_ID" --baseline frontend/snapshots.yml --token "$VR_TOKEN")
+                  if [ "$VR_OBSERVE" = 'true' ]; then
+                      args+=(--purpose observe)
                   fi
-                  exit "$status"
+                  node vr-cli/products/visual_review/cli/dist/cli/src/index.js run complete "${args[@]}"
 
     calculate-running-time:
         name: Calculate running time


### PR DESCRIPTION
## Problem

A snapshot that drifts on master stays invisible until it reds an unrelated PR.
#77815 taught `vr run complete` to report that drift, but only when told the run purpose, and the workflow never passes it.

This is the workflow half of #77815, split out after its merge-queue run failed.

- The complete job builds the VR CLI from the base branch, not the PR branch.
- Passing `--purpose` before the CLI change is on master fails the queue run with `unknown option '--purpose'` ([failing job](https://github.com/PostHog/posthog/actions/runs/31692665704/job/94425868340)).
- PR CI cannot catch this, because the flag is only added on observe runs (master pushes and `trunk-merge/**`).

> [!WARNING]
> Merge only after #77815. Enqueued before it, this PR fails the same way.

## Changes

- The complete step passes `--purpose observe` on master pushes and `trunk-merge/**`, matching what `vr-setup` created the run with.
- The exit-1 tolerance branch is gone: an observe run cannot exit 1, so every non-zero exit is a real failure and reds CI.

## How did you test this code?

- The hunk is byte-identical to the one already reviewed on #77815 before the split.
- `bin/hogli lint:workflows` via `ci:preflight` on push: 0 failures.
- Not run: an observe run end to end. This PR's own merge-queue run is the first real exercise of the flag.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. #77815 carries the README correction.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude (Claude Code) diagnosed #77815's repeated merge-queue failures: the new workflow flag reached a CLI built from master, which did not know it. The human asked for the split; Claude moved the workflow hunk here unchanged and reverted it on #77815.

Skills invoked: `/writing-pr-descriptions`, `posthog:triaging-visual-review-runs`.
