### PR TITLE
fix(replay): remove redundant per-row ResizeObserver in inspector list

### DIFF
--- a/frontend/src/scenes/session-recordings/player/inspector/components/PlayerInspectorListItem.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/PlayerInspectorListItem.tsx
@@ -1,8 +1,6 @@
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
-import { FunctionComponent, isValidElement, memo, useEffect, useRef } from 'react'
-import { useDebouncedCallback } from 'use-debounce'
-import useResizeObserver from 'use-resize-observer'
+import { FunctionComponent, isValidElement, memo, useRef } from 'react'
 
 import {
     BaseIcon,
@@ -48,8 +46,6 @@ import {
 import { ItemAppState, ItemAppStateDetail, ItemConsoleLog, ItemConsoleLogDetail } from './ItemConsoleLog'
 import { ItemDoctor, ItemDoctorDetail } from './ItemDoctor'
 import { ItemEvent, ItemEventDetail, ItemEventMenu } from './ItemEvent'
-
-const PLAYER_INSPECTOR_LIST_ITEM_MARGIN = 1
 
 interface IconAndDescription {
     Icon: FunctionComponent | undefined
@@ -379,53 +375,22 @@ const ListItemDetail = memo(function ListItemDetail({
 export const PlayerInspectorListItem = memo(function PlayerInspectorListItem({
     item,
     index,
-    onLayout,
     groupCount,
     groupedItems,
 }: {
     item: InspectorListItem
     index: number
-    onLayout?: (layout: { width: number; height: number }) => void
     groupCount?: number
     groupedItems?: InspectorListItem[]
 }): JSX.Element {
     const hoverRef = useRef<HTMLDivElement>(null)
+    const ref = useRef<HTMLDivElement>(null)
 
     const { logicProps } = useValues(sessionRecordingPlayerLogic)
 
     const { expandedItems } = useValues(playerInspectorLogic(logicProps))
 
     const isExpanded = expandedItems.includes(index)
-
-    const onLayoutDebounced = useDebouncedCallback(onLayout ?? (() => {}), 500)
-    const { ref, width, height } = useResizeObserver({})
-
-    const totalHeight = height ? height + PLAYER_INSPECTOR_LIST_ITEM_MARGIN : height
-
-    // Height changes should lay out immediately but width ones (browser resize can be much slower)
-    useEffect(
-        () => {
-            if (!onLayout || !width || !totalHeight) {
-                return
-            }
-            onLayoutDebounced({ width, height: totalHeight })
-        },
-        // purposefully only triggering on width
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-        [width]
-    )
-
-    useEffect(
-        () => {
-            if (!onLayout || !width || !totalHeight) {
-                return
-            }
-            onLayout({ width, height: totalHeight })
-        },
-        // purposefully only triggering on total height
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-        [totalHeight]
-    )
 
     const isHovering = useIsHovering(hoverRef)
 


### PR DESCRIPTION
## Problem

Session Replay's Inspector panel virtualizes its row list with `react-window`, which already manages dynamic row heights via a single shared `ResizeObserver` instance (`useDynamicRowHeight` → `observeRowElements`). Each row (`PlayerInspectorListItem`) *also* independently created its own separate `ResizeObserver` via an `onLayout` callback prop — but nothing in the codebase passes `onLayout` anymore, so this was dead code left over from before the `react-window` migration.

With `overscanCount: 20`, that meant dozens of standalone `ResizeObserver` instances could be alive at once on a busy session, each competing for the browser's per-frame resize-notification budget. Many independent observers (vs. one observer watching many targets) is a known trigger for `ResizeObserver loop completed with undelivered notifications`, and we've seen this error reported on the replay Inspector panel, including on sessions long/heavy enough that it visibly stalls the tab.

## Changes

- Removed the dead `useResizeObserver` call, `onLayout` prop, `onLayoutDebounced`, and both associated effects from `PlayerInspectorListItem.tsx` (confirmed via repo-wide search: no caller passes `onLayout`).
- Replaced the `ref` (previously returned by `useResizeObserver`) with a plain `useRef`, since the outer `<div>` still needs one.
- Removed now-unused imports (`useResizeObserver`, `useDebouncedCallback`) and the now-dead `PLAYER_INSPECTOR_LIST_ITEM_MARGIN` constant.
- Row height measurement is unaffected — it's still handled entirely by `react-window`'s own `useDynamicRowHeight`, which was already the correct, single-shared-instance implementation.

No screenshots, since this is a pure dead-code removal with no visual change.

## How did you test this code?

I'm an agent (see LLM context below), so to be precise about what was actually run:
- `pnpm --filter=@posthog/frontend typescript:check` — zero errors attributable to the changed file.
- `oxlint` on the changed file — 0 warnings/errors.
- Existing jest suite for `session-recordings/player/inspector` — the suites unrelated to an unbuilt workspace package in this checkout pass; the others fail on an unrelated, pre-existing module-resolution gap in this fresh clone.
- Repo-wide grep confirming `onLayout` has zero remaining callers.
- I did **not** visually verify in a browser or Storybook (no browser tooling available in my environment) — reviewers should sanity-check the `Components/PlayerInspector` story renders identically, since that's the one place with an existing visual snapshot covering this component.

## Publish to changelog?
no

## Docs update
Not applicable — internal implementation detail, no user-facing behavior change.

## 🤖 LLM context
Authored by an AI agent (Claude, via PostHog Desktop) while investigating a Session Replay freeze report. Traced the freeze to a duplicate/dead resize-observation code path in the Inspector panel's row component and removed it. Verified with `tsc`, `oxlint`, and the existing jest suite in a fresh clone; did not have browser/Chromatic access to visually confirm — flagged above for human review.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*