### PR TITLE
chore(cdp): remove the dead cyclotron v1 database url config

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -136,7 +136,6 @@ export PERSONS_DB_WRITER_URL=${PERSONS_DB_WRITER_URL:-$PERSONS_DATABASE_URL}
 export PERSONS_DB_READER_URL=${PERSONS_DB_READER_URL:-$PERSONS_READONLY_DATABASE_URL}
 export BEHAVIORAL_COHORTS_DATABASE_URL=${BEHAVIORAL_COHORTS_DATABASE_URL:-postgres://posthog:posthog@${PGHOST:-db}:${PGPORT:-5432}/behavioral_cohorts}
 export FLAGS_READ_STORE_DATABASE_URL=${FLAGS_READ_STORE_DATABASE_URL:-postgres://posthog:posthog@${PGHOST:-db}:${PGPORT:-5432}/flags_read_store}
-export CYCLOTRON_DATABASE_URL=${CYCLOTRON_DATABASE_URL:-postgres://posthog:posthog@${PGHOST:-db}:${PGPORT:-5432}/cyclotron}
 export CYCLOTRON_NODE_DATABASE_URL=${CYCLOTRON_NODE_DATABASE_URL:-postgres://posthog:posthog@${PGHOST:-db}:${PGPORT:-5432}/cyclotron_node}
 
 # Clean up orphaned dev processes left behind by a previous unclean shutdown.

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -217,7 +217,6 @@ services:
             CDP_VALKEY_HOST: valkey
             CDP_VALKEY_PORT: 6379
             ENCRYPTION_SALT_KEYS: $ENCRYPTION_SALT_KEYS
-            CYCLOTRON_DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
             PERSONS_DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
             BEHAVIORAL_COHORTS_DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
             OTEL_EXPORTER_OTLP_ENDPOINT: ''

--- a/nodejs/jest.setup-env.ts
+++ b/nodejs/jest.setup-env.ts
@@ -6,7 +6,7 @@ import { brotliDecompressSync } from 'zlib'
 // from an environment where NODE_ENV or DEBUG is already set (IDE test runners,
 // debuggers, flox exports DEBUG=1), `determineNodeEnv()` resolves to dev and
 // every config default (DATABASE_URL, PERSONS_DATABASE_URL, CLICKHOUSE_DATABASE,
-// CYCLOTRON_DATABASE_URL, ...) points at the real dev databases — which
+// CYCLOTRON_NODE_DATABASE_URL, ...) points at the real dev databases — which
 // destructive test helpers would then wipe. Force the test environment so the
 // defaults always resolve to their test_* counterparts. Explicitly exported
 // *_DATABASE_URL variables still win; tests/helpers/database-guard.ts catches

--- a/nodejs/src/cdp/config.ts
+++ b/nodejs/src/cdp/config.ts
@@ -120,7 +120,6 @@ export type CdpConfig = ClickhouseConfig & {
     CDP_EMAIL_TRACKING_URL: string
 
     // Cyclotron (CDP job queue)
-    CYCLOTRON_DATABASE_URL: string
     CYCLOTRON_SHARD_DEPTH_LIMIT: number
     CYCLOTRON_NODE_DATABASE_URL?: string
     // SES (Workflows email sending)
@@ -287,9 +286,6 @@ export function getDefaultCdpConfig(): CdpConfig {
         CDP_EMAIL_TRACKING_URL: 'http://localhost:8010',
 
         // Cyclotron
-        CYCLOTRON_DATABASE_URL: isTestEnv()
-            ? 'postgres://posthog:posthog@localhost:5432/test_cyclotron'
-            : 'postgres://posthog:posthog@localhost:5432/cyclotron',
         CYCLOTRON_SHARD_DEPTH_LIMIT: 1000000,
         CYCLOTRON_NODE_DATABASE_URL: isTestEnv()
             ? 'postgres://posthog:posthog@localhost:5432/test_cyclotron_node'

--- a/nodejs/src/cdp/rerun/rerun-e2e.test.ts
+++ b/nodejs/src/cdp/rerun/rerun-e2e.test.ts
@@ -149,7 +149,6 @@ describe('CDP hog invocation rerun e2e', () => {
         hub.CDP_FETCH_RETRIES = 0
         hub.CDP_FETCH_BACKOFF_BASE_MS = 1
         hub.CDP_CYCLOTRON_COMPRESS_KAFKA_DATA = true
-        hub.CYCLOTRON_DATABASE_URL = 'postgres://posthog:posthog@localhost:5432/test_cyclotron'
         hub.CYCLOTRON_NODE_DATABASE_URL = NODE_DB_URL
         hub.HOG_INVOCATION_RESULTS_ENABLED = true
 

--- a/nodejs/tests/service-e2e/rust-ingestion-consumer.test.ts
+++ b/nodejs/tests/service-e2e/rust-ingestion-consumer.test.ts
@@ -557,7 +557,6 @@ function testDependencyEnv(): NodeJS.ProcessEnv {
         PERSONS_DATABASE_URL: `${POSTGRES_URL}/test_persons`,
         PERSONS_READONLY_DATABASE_URL: `${POSTGRES_URL}/test_persons`,
         BEHAVIORAL_COHORTS_DATABASE_URL: `${POSTGRES_URL}/test_behavioral_cohorts`,
-        CYCLOTRON_DATABASE_URL: `${POSTGRES_URL}/test_cyclotron`,
         CYCLOTRON_NODE_DATABASE_URL: `${POSTGRES_URL}/test_cyclotron_node`,
         KAFKA_HOSTS: 'localhost:9092',
         KAFKA_PRODUCER_METADATA_BROKER_LIST: 'localhost:9092',

--- a/products/tasks/backend/sandbox/images/bake-posthog-dev-stack.sh
+++ b/products/tasks/backend/sandbox/images/bake-posthog-dev-stack.sh
@@ -250,7 +250,6 @@ bin/migrate --scope=clickhouse
 log "running rust-driven migrations"
 # Same connection URLs bin/start derives for these scopes; the rust/bin migrators
 # otherwise default to localhost with per-store host/user envs.
-export CYCLOTRON_DATABASE_URL="${CYCLOTRON_DATABASE_URL:-postgres://posthog:posthog@db:5432/cyclotron}"
 export CYCLOTRON_NODE_DATABASE_URL="${CYCLOTRON_NODE_DATABASE_URL:-postgres://posthog:posthog@db:5432/cyclotron_node}"
 export BEHAVIORAL_COHORTS_DATABASE_URL="${BEHAVIORAL_COHORTS_DATABASE_URL:-postgres://posthog:posthog@db:5432/behavioral_cohorts}"
 export FLAGS_READ_STORE_DATABASE_URL="${FLAGS_READ_STORE_DATABASE_URL:-postgres://posthog:posthog@db:5432/flags_read_store}"


### PR DESCRIPTION
## Problem

`CYCLOTRON_DATABASE_URL` is the connection string for the cyclotron **V1** database, which no longer exists in any environment — the clusters were destroyed on 2026-08-14 ([PostHog/posthog-cloud-infra#9984](https://github.com/PostHog/posthog-cloud-infra/pull/9984)).

The setting outlived its last reader. `job-queue-postgres.ts` was the only code that used it, and that went in [#78160](https://github.com/PostHog/posthog/pull/78160). Since then the field has been declared and defaulted on every CDP process, and exported by `bin/start` and the dev-stack bake script, pointing at a database that isn't there. Anyone reading the config would reasonably assume V1 is still wired up.

## Changes

Remove the setting and everything that fed it:

- `nodejs/src/cdp/config.ts` — the `CYCLOTRON_DATABASE_URL` type member and its default
- `bin/start` and `products/tasks/backend/sandbox/images/bake-posthog-dev-stack.sh` — the local-dev exports. `bin/migrate --scope=cyclotron` only runs the V2 migrator now, so neither export had an effect
- `docker-compose.hobby.yml` — the env entry on the hobby app
- `rerun-e2e.test.ts` and `rust-ingestion-consumer.test.ts` — assignments that would no longer typecheck
- `jest.setup-env.ts` — a comment listing config defaults that point at real dev databases; swapped the V1 example for `CYCLOTRON_NODE_DATABASE_URL`

**`CYCLOTRON_SHARD_DEPTH_LIMIT` stays.** It reads as V1 from the name, but `job-queue-postgres-v2.ts` uses it. All other `CYCLOTRON_NODE_*` settings are V2 and untouched.

## How did you test this code?

I am an agent. Automated checks I ran locally:

- **`pnpm --filter=@posthog/nodejs typescript:check` passes with 0 errors** (exit 0), after building the `@posthog/hogvm` and `@posthog/replay-anonymizer` napi packages that a fresh worktree lacks. For a removed config field this is the check that matters: any remaining reader or assignment would fail to compile.
- Repo-wide `grep` for `CYCLOTRON_DATABASE_URL` returns nothing.
- `bash -n` on `bin/start` and the bake script, and a YAML parse of `docker-compose.hobby.yml`.

`rerun-e2e.test.ts` (one of the files edited) fails 3/3 locally — **but it fails identically on `origin/master`** in a separate worktree, same suite and same count, so it is pre-existing and needs infra this local stack does not fully provide, not a consequence of this change.

**Not verified:** I did not run `rust-ingestion-consumer.test.ts` (service-e2e, needs the full stack) and did not build any container image. No production code path reads this setting, so the blast radius is config surface only.

## 🤖 Agent context

Authored by Claude (Claude Code), directed by @dmarchuk. Final code cleanup of the cyclotron V1 decommission, after [#83200](https://github.com/PostHog/posthog/pull/83200) removed the Rust crates and napi binding, and [PostHog/charts#14427](https://github.com/PostHog/charts/pull/14427) removed the V1 janitor state file.

Kept separate from [#83200](https://github.com/PostHog/posthog/pull/83200) deliberately: that diff was already ~6k lines and touched production Dockerfiles, so config plumbing was left for a change that is easy to read on its own.

Worth a reviewer's eye on one judgement call: `CYCLOTRON_SHARD_DEPTH_LIMIT` was a near-miss deletion. Its name matches the V1 sharding vocabulary, but it is consumed by the V2 queue, so it stays.
