### PR TITLE
feat(experiments): add breakdown attribution UI

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -321,6 +321,7 @@ export const FEATURE_FLAGS = {
     EVENT_MEDIA_PREVIEWS: 'event-media-previews', // owner: @alexlider
     EXPERIMENT_BEHAVIOR_COMPARISON: 'experiment-behavior-comparison', // owner: @mp-hog #team-experiments
     EXPERIMENT_FLAG_CLEANUP_PR: 'experiment-flag-cleanup-pr', // owner: @jurajmajerik #team-experiments
+    EXPERIMENT_METRIC_EVENT_BREAKDOWNS: 'experiment-metric-event-breakdowns', // owner: @rodrigoi #team-experiments
     EXPERIMENT_RECORDINGS_TAB: 'experiment-recordings-tab', // owner: @mp-hog #team-experiments
     EXPERIMENT_SESSION_REPLAYS_SKILL: 'experiment-session-replays-skill', // owner: @rodrigoi #team-experiments
     EXPERIMENTS_DW_AA_TEST: 'experiments-dw-aa-test', // owner: @rodrigoi #team-experiments

--- a/frontend/src/scenes/experiments/MetricBreakdowns/MetricBreakdownAttribution.tsx
+++ b/frontend/src/scenes/experiments/MetricBreakdowns/MetricBreakdownAttribution.tsx
@@ -1,0 +1,72 @@
+import { LemonSelect } from '@posthog/lemon-ui'
+
+import { FUNNEL_STEP_COUNT_LIMIT } from 'scenes/insights/EditorFilters/FunnelsQuerySteps'
+
+import { ExperimentFunnelMetric } from '~/queries/schema/schema-general'
+import { BreakdownAttributionType, StepOrderValue } from '~/types'
+
+export function MetricBreakdownAttribution({
+    metric,
+    onChange,
+}: {
+    metric: ExperimentFunnelMetric
+    onChange: (attributionType: BreakdownAttributionType, attributionValue?: number) => void
+}): JSX.Element {
+    const { funnel_order_type } = metric
+    const stepCount = metric.series?.length || 0
+
+    /**
+     * hardcoded for now, this have to be configured at the metric level.
+     */
+    const breakdownAttributionType = BreakdownAttributionType.FirstTouch
+    const breakdownAttributionValue = 0
+
+    return (
+        <LemonSelect
+            size="small"
+            value={breakdownAttributionType}
+            placeholder="Attribution"
+            options={[
+                { value: BreakdownAttributionType.FirstTouch, label: 'First touchpoint' },
+                { value: BreakdownAttributionType.LastTouch, label: 'Last touchpoint' },
+                { value: BreakdownAttributionType.AllSteps, label: 'All steps' },
+                {
+                    value: BreakdownAttributionType.Step,
+                    label: 'Any step',
+                    hidden: funnel_order_type !== StepOrderValue.UNORDERED,
+                },
+                {
+                    label: 'Specific step',
+                    options: Array(FUNNEL_STEP_COUNT_LIMIT)
+                        .fill(null)
+                        .map((_, stepIndex) => ({
+                            value: `${BreakdownAttributionType.Step}/${stepIndex}`,
+                            label: `Step ${stepIndex + 1}`,
+                            /**
+                             * if the funnel was shortened, an our of range stale selection gets hidden.
+                             * this guard keeps it visible
+                             */
+                            hidden: stepIndex >= stepCount && stepIndex !== breakdownAttributionValue,
+                        })),
+                    hidden: funnel_order_type === StepOrderValue.UNORDERED,
+                },
+            ]}
+            onChange={(value) => {
+                if (!value) {
+                    return
+                }
+                const [attributionType, attributionValue] = value.split('/')
+                /**
+                 * the backend requires a breakdown attribution value for step attribution,
+                 * so "Any step" stores zero.
+                 */
+                onChange(
+                    attributionType as BreakdownAttributionType,
+                    attributionType === BreakdownAttributionType.Step ? parseInt(attributionValue) || 0 : undefined
+                )
+            }}
+            dropdownMaxContentWidth
+            data-attr="experiment-breakdown-attribution"
+        />
+    )
+}

--- a/frontend/src/scenes/experiments/MetricBreakdowns/MetricBreakdownError.tsx
+++ b/frontend/src/scenes/experiments/MetricBreakdowns/MetricBreakdownError.tsx
@@ -1,0 +1,35 @@
+import { ExperimentMetric } from '~/queries/schema/schema-general'
+import { BreakdownAttributionType } from '~/types'
+
+import { MetricBreakdowns } from './MetricBreakdowns'
+
+export type MetricBreakdownErrorProps = {
+    metric: ExperimentMetric
+    isAlternatingRow: boolean
+    onRemoveBreakdown: (index: number) => void
+    onAttributionChange: (attributionType: BreakdownAttributionType, attributionValue?: number) => void
+    onBreakdownLimitChange: (breakdownLimit: number) => void
+}
+
+export function MetricBreakdownError({
+    metric,
+    isAlternatingRow,
+    onRemoveBreakdown,
+    onAttributionChange,
+    onBreakdownLimitChange,
+}: MetricBreakdownErrorProps): JSX.Element {
+    return (
+        <tr data-breakdown-row className="hover:bg-bg-hover group">
+            <td colSpan={7} className={`p-0 border-t border-b ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'}`}>
+                <div className="p-1">
+                    <MetricBreakdowns
+                        metric={metric}
+                        onRemoveBreakdown={onRemoveBreakdown}
+                        onAttributionChange={onAttributionChange}
+                        onBreakdownLimitChange={onBreakdownLimitChange}
+                    />
+                </div>
+            </td>
+        </tr>
+    )
+}

--- a/frontend/src/scenes/experiments/MetricBreakdowns/MetricBreakdownLimit.tsx
+++ b/frontend/src/scenes/experiments/MetricBreakdowns/MetricBreakdownLimit.tsx
@@ -1,0 +1,69 @@
+import { IconInfo } from '@posthog/icons'
+import { LemonSelect } from '@posthog/lemon-ui'
+
+import { Tooltip } from 'lib/lemon-ui/Tooltip'
+
+import { ExperimentMetric } from '~/queries/schema/schema-general'
+
+const DEFAULT_BREAKDOWN_LIMIT = 25
+/**
+ * The backend has no unlimited option, so "Show all" is just a large top-N that covers any
+ * realistic breakdown cardinality.
+ */
+const SHOW_ALL_BREAKDOWN_LIMIT = 1000
+
+const BREAKDOWN_LIMIT_OPTIONS = [
+    { value: 5, label: '5' },
+    { value: 10, label: '10' },
+    { value: 15, label: '15' },
+    { value: 20, label: '20' },
+    { value: 25, label: '25' },
+    { value: SHOW_ALL_BREAKDOWN_LIMIT, label: 'Show all' },
+]
+
+export function MetricBreakdownLimit({
+    metric,
+    onChange,
+}: {
+    metric: ExperimentMetric
+    onChange: (breakdownLimit: number) => void
+}): JSX.Element {
+    const breakdownLimit = metric.breakdownFilter?.breakdown_limit ?? DEFAULT_BREAKDOWN_LIMIT
+
+    /**
+     * This is a protection against manual edits of the metric breakdown limit, in case
+     * a limit is set that does not map to a preset.
+     */
+    const options = BREAKDOWN_LIMIT_OPTIONS.some(({ value }) => value === breakdownLimit)
+        ? BREAKDOWN_LIMIT_OPTIONS
+        : [{ value: breakdownLimit, label: String(breakdownLimit) }, ...BREAKDOWN_LIMIT_OPTIONS]
+
+    return (
+        <div className="flex items-center gap-1">
+            <span className="text-muted">Limit</span>
+            <Tooltip
+                title={
+                    <>
+                        Keeps only the top breakdown values by frequency. The remaining values are grouped together
+                        under "Other". This caps how many breakdown rows the results show. "Show all" raises the cap
+                        high enough to cover any realistic number of values.
+                    </>
+                }
+            >
+                <IconInfo className="text-secondary text-base shrink-0" />
+            </Tooltip>
+            <LemonSelect
+                size="small"
+                value={breakdownLimit}
+                options={options}
+                onChange={(value) => {
+                    if (value != null && value !== breakdownLimit) {
+                        onChange(value)
+                    }
+                }}
+                dropdownMatchSelectWidth={false}
+                data-attr="experiment-breakdown-limit"
+            />
+        </div>
+    )
+}

--- a/frontend/src/scenes/experiments/MetricBreakdowns/MetricBreakdowns.tsx
+++ b/frontend/src/scenes/experiments/MetricBreakdowns/MetricBreakdowns.tsx
@@ -1,0 +1,100 @@
+import { IconInfo } from '@posthog/icons'
+
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
+import { Tooltip } from 'lib/lemon-ui/Tooltip'
+import { BreakdownTag } from 'scenes/insights/filters/BreakdownFilter/BreakdownTag'
+
+import { ExperimentFunnelMetric, ExperimentMetric } from '~/queries/schema/schema-general'
+import { isExperimentFunnelMetric } from '~/queries/schema/schema-general'
+import { BreakdownAttributionType, StepOrderValue } from '~/types'
+
+import { MetricBreakdownAttribution } from './MetricBreakdownAttribution'
+import { MetricBreakdownLimit } from './MetricBreakdownLimit'
+
+/**
+ * Renders the metric's breakdown chips on the left, then (behind the
+ * metric-event-breakdowns flag) the funnel attribution dropdown and the
+ * breakdown limit. Attribution is funnel-only; the limit applies to all types.
+ */
+export function MetricBreakdowns({
+    metric,
+    onRemoveBreakdown,
+    onAttributionChange,
+    onBreakdownLimitChange,
+}: {
+    metric: ExperimentMetric
+    onRemoveBreakdown: (index: number) => void
+    onAttributionChange: (attributionType: BreakdownAttributionType, attributionValue?: number) => void
+    onBreakdownLimitChange: (breakdownLimit: number) => void
+}): JSX.Element {
+    /**
+     * on the frontend, this flag controls whether we show the attribution and limit settings.
+     * these settings are available only for funnels
+     */
+    const metricEventBreakdownsEnabled = useFeatureFlag('EXPERIMENT_METRIC_EVENT_BREAKDOWNS')
+
+    /**
+     * this should collapse into isExperimentFunnelMetric(metric) once enabled
+     */
+    const showAttribution = metricEventBreakdownsEnabled && isExperimentFunnelMetric(metric)
+    /**
+     * all metric tipes will have a breakdown limit
+     */
+    const showLimit = metricEventBreakdownsEnabled
+
+    return (
+        <div className="flex items-center gap-3">
+            <div className="flex items-center gap-2">
+                {metric.breakdownFilter?.breakdowns?.map((breakdown, index) => (
+                    <BreakdownTag
+                        key={index}
+                        breakdown={breakdown.property}
+                        breakdownType={breakdown.type || 'event'}
+                        onClose={() => onRemoveBreakdown(index)}
+                        size="small"
+                    />
+                ))}
+            </div>
+            {showAttribution && (
+                <div className="flex items-center gap-1">
+                    <span className="text-muted">Attribution</span>
+                    <Tooltip
+                        title={
+                            <>
+                                Which funnel step the breakdown value is read from for each user:
+                                <ul className="list-disc pl-4">
+                                    <li>
+                                        <strong>First touchpoint</strong>: value at the user's first step
+                                    </li>
+                                    <li>
+                                        <strong>Last touchpoint</strong>: value at the user's last step
+                                    </li>
+                                    <li>
+                                        <strong>All steps</strong>: behaves like first touchpoint
+                                    </li>
+                                    {(metric as ExperimentFunnelMetric).funnel_order_type ===
+                                    StepOrderValue.UNORDERED ? (
+                                        <li>
+                                            <strong>Any step</strong>: value at any matching step
+                                        </li>
+                                    ) : (
+                                        <li>
+                                            <strong>Specific step</strong>: value at a step you choose
+                                        </li>
+                                    )}
+                                </ul>
+                            </>
+                        }
+                    >
+                        <IconInfo className="text-secondary text-base shrink-0" />
+                    </Tooltip>
+                    <MetricBreakdownAttribution
+                        metric={metric as ExperimentFunnelMetric}
+                        onChange={onAttributionChange}
+                    />
+                </div>
+            )}
+            {showLimit && <MetricBreakdownLimit metric={metric} onChange={onBreakdownLimitChange} />}
+        </div>
+    )
+}

--- a/frontend/src/scenes/experiments/MetricBreakdowns/MetricBreakdowns.tsx
+++ b/frontend/src/scenes/experiments/MetricBreakdowns/MetricBreakdowns.tsx
@@ -64,10 +64,10 @@ export function MetricBreakdowns({
                                 Which funnel step the breakdown value is read from for each user:
                                 <ul className="list-disc pl-4">
                                     <li>
-                                        <strong>First touchpoint</strong>: value at the user's first step
+                                        <strong>First touchpoint</strong>: the first property value seen in any step
                                     </li>
                                     <li>
-                                        <strong>Last touchpoint</strong>: value at the user's last step
+                                        <strong>Last touchpoint</strong>: the last property value seen across all steps
                                     </li>
                                     <li>
                                         <strong>All steps</strong>: The property value must appear on all steps

--- a/frontend/src/scenes/experiments/MetricBreakdowns/MetricBreakdowns.tsx
+++ b/frontend/src/scenes/experiments/MetricBreakdowns/MetricBreakdowns.tsx
@@ -70,7 +70,7 @@ export function MetricBreakdowns({
                                         <strong>Last touchpoint</strong>: value at the user's last step
                                     </li>
                                     <li>
-                                        <strong>All steps</strong>: behaves like first touchpoint
+                                        <strong>All steps</strong>: The property value must appear on all steps
                                     </li>
                                     {(metric as ExperimentFunnelMetric).funnel_order_type ===
                                     StepOrderValue.UNORDERED ? (

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
@@ -14,7 +14,8 @@ import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { humanFriendlyLargeNumber } from 'lib/utils/numbers'
 import { VariantTag } from 'scenes/experiments/ExperimentView/VariantTag'
-import { BreakdownTag } from 'scenes/insights/filters/BreakdownFilter/BreakdownTag'
+import { MetricBreakdownError } from 'scenes/experiments/MetricBreakdowns/MetricBreakdownError'
+import { MetricBreakdowns } from 'scenes/experiments/MetricBreakdowns/MetricBreakdowns'
 import { formatBreakdownLabel } from 'scenes/insights/utils'
 
 import {
@@ -72,34 +73,6 @@ import { GridLines } from './GridLines'
 import { renderTooltipContent } from './MetricRowGroupTooltip'
 import { TimeseriesModal } from './TimeseriesModal'
 import { useAxisScale } from './useAxisScale'
-
-interface BreakdownErrorStateProps {
-    metric: ExperimentMetric
-    isAlternatingRow: boolean
-    onRemoveBreakdown: (index: number) => void
-}
-
-function BreakdownErrorState({ metric, isAlternatingRow, onRemoveBreakdown }: BreakdownErrorStateProps): JSX.Element {
-    return (
-        <tr data-breakdown-row className="hover:bg-bg-hover group">
-            <td colSpan={7} className={`p-0 border-t border-b ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'}`}>
-                <div className="p-1">
-                    <div className="flex items-center gap-2">
-                        {metric.breakdownFilter?.breakdowns?.map((breakdown, index) => (
-                            <BreakdownTag
-                                key={index}
-                                breakdown={breakdown.property}
-                                breakdownType={breakdown.type || 'event'}
-                                onClose={() => onRemoveBreakdown(index)}
-                                size="small"
-                            />
-                        ))}
-                    </div>
-                </div>
-            </td>
-        </tr>
-    )
-}
 
 interface CollapsibleBreakdownSectionProps {
     breakdownResults: any[]
@@ -192,16 +165,13 @@ function CollapsibleBreakdownSection({
                         {
                             key: 'breakdowns',
                             header: (
-                                <div className="flex items-center gap-2">
-                                    {metric.breakdownFilter?.breakdowns?.map((breakdown, index) => (
-                                        <BreakdownTag
-                                            key={index}
-                                            breakdown={breakdown.property}
-                                            breakdownType={breakdown.type || 'event'}
-                                            onClose={() => onRemoveBreakdown(index)}
-                                            size="small"
-                                        />
-                                    ))}
+                                <div onClick={(e) => e.stopPropagation()}>
+                                    <MetricBreakdowns
+                                        metric={metric}
+                                        onRemoveBreakdown={onRemoveBreakdown}
+                                        onAttributionChange={() => {}}
+                                        onBreakdownLimitChange={() => {}}
+                                    />
                                 </div>
                             ),
                             // Render no content (non-expandable disabled header) when recalculating (stale
@@ -221,6 +191,7 @@ function CollapsibleBreakdownSection({
                                                             <tr
                                                                 key={breakdownResult.breakdown_value}
                                                                 className="hover:bg-bg-hover"
+                                                                // eslint-disable-next-line react/forbid-dom-props
                                                                 style={FIXED_HEIGHT_STYLE}
                                                             >
                                                                 <td
@@ -238,6 +209,7 @@ function CollapsibleBreakdownSection({
                                                                 <td
                                                                     colSpan={6}
                                                                     className={`p-3 text-center ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'}`}
+                                                                    // eslint-disable-next-line react/forbid-dom-props
                                                                     style={FIXED_HEIGHT_STYLE}
                                                                 >
                                                                     {isLoading || exposuresLoading ? (
@@ -266,11 +238,13 @@ function CollapsibleBreakdownSection({
                                                             {/* Baseline row */}
                                                             <tr
                                                                 className="hover:bg-bg-hover"
+                                                                // eslint-disable-next-line react/forbid-dom-props
                                                                 style={FIXED_HEIGHT_STYLE}
                                                             >
                                                                 <td
                                                                     className={`w-1/5 border-r p-3 align-top border-b ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'} text-xs`}
                                                                     rowSpan={totalRows}
+                                                                    // eslint-disable-next-line react/forbid-dom-props
                                                                     style={totalRowsHeightStyle}
                                                                 >
                                                                     {formatBreakdownLabel(
@@ -285,6 +259,7 @@ function CollapsibleBreakdownSection({
 
                                                                 <td
                                                                     className={`w-20 pt-1 pl-3 pr-3 pb-1 whitespace-nowrap overflow-hidden ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'}`}
+                                                                    // eslint-disable-next-line react/forbid-dom-props
                                                                     style={FIXED_HEIGHT_STYLE}
                                                                 >
                                                                     <VariantTag variantKey={baselineResult.key} />
@@ -292,6 +267,7 @@ function CollapsibleBreakdownSection({
 
                                                                 <td
                                                                     className={`w-24 pt-1 pl-3 pr-3 pb-1 text-left whitespace-nowrap overflow-hidden ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'}`}
+                                                                    // eslint-disable-next-line react/forbid-dom-props
                                                                     style={FIXED_HEIGHT_STYLE}
                                                                 >
                                                                     <div className="metric-cell">
@@ -304,6 +280,7 @@ function CollapsibleBreakdownSection({
 
                                                                 <td
                                                                     className={`w-20 pt-1 pl-3 pr-3 pb-1 ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'}`}
+                                                                    // eslint-disable-next-line react/forbid-dom-props
                                                                     style={FIXED_HEIGHT_STYLE}
                                                                 >
                                                                     <div />
@@ -311,6 +288,7 @@ function CollapsibleBreakdownSection({
 
                                                                 <td
                                                                     className={`w-20 pt-1 pl-3 pr-3 pb-1 text-center ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'}`}
+                                                                    // eslint-disable-next-line react/forbid-dom-props
                                                                     style={FIXED_HEIGHT_STYLE}
                                                                 >
                                                                     <div />
@@ -319,11 +297,13 @@ function CollapsibleBreakdownSection({
                                                                 {/* Empty Details column for alignment (per-row; variant rows render their own) */}
                                                                 <td
                                                                     className={`w-20 ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'}`}
+                                                                    // eslint-disable-next-line react/forbid-dom-props
                                                                     style={FIXED_HEIGHT_STYLE}
                                                                 />
 
                                                                 <td
                                                                     className={`p-0 align-top text-center relative overflow-hidden ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'}`}
+                                                                    // eslint-disable-next-line react/forbid-dom-props
                                                                     style={FIXED_HEIGHT_STYLE}
                                                                 >
                                                                     {axisRange && axisRange > 0 ? (
@@ -380,6 +360,7 @@ function CollapsibleBreakdownSection({
                                                                         <tr
                                                                             key={`${metric.uuid}-${variant.key}`}
                                                                             className="hover:bg-bg-hover"
+                                                                            // eslint-disable-next-line react/forbid-dom-props
                                                                             style={FIXED_HEIGHT_STYLE}
                                                                             onMouseEnter={(e) =>
                                                                                 handleTooltipMouseEnter(e, variant)
@@ -391,6 +372,7 @@ function CollapsibleBreakdownSection({
                                                                         >
                                                                             <td
                                                                                 className={`w-20 pt-1 pl-3 pr-3 pb-1 whitespace-nowrap overflow-hidden ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'} ${isLastRow ? 'border-b' : ''}`}
+                                                                                // eslint-disable-next-line react/forbid-dom-props
                                                                                 style={{
                                                                                     ...FIXED_HEIGHT_STYLE,
                                                                                     backgroundImage: rowBackgroundImage,
@@ -401,6 +383,7 @@ function CollapsibleBreakdownSection({
 
                                                                             <td
                                                                                 className={`w-24 pt-1 pl-3 pr-3 pb-1 text-left whitespace-nowrap overflow-hidden ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'} ${isLastRow ? 'border-b' : ''}`}
+                                                                                // eslint-disable-next-line react/forbid-dom-props
                                                                                 style={{
                                                                                     ...FIXED_HEIGHT_STYLE,
                                                                                     backgroundImage: rowBackgroundImage,
@@ -419,6 +402,7 @@ function CollapsibleBreakdownSection({
 
                                                                             <td
                                                                                 className={`w-20 pt-1 pl-3 pr-3 pb-1 text-left whitespace-nowrap overflow-hidden ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'} ${isLastRow ? 'border-b' : ''}`}
+                                                                                // eslint-disable-next-line react/forbid-dom-props
                                                                                 style={{
                                                                                     ...FIXED_HEIGHT_STYLE,
                                                                                     backgroundImage: rowBackgroundImage,
@@ -457,6 +441,7 @@ function CollapsibleBreakdownSection({
 
                                                                             <td
                                                                                 className={`w-20 pt-1 pl-3 pr-3 pb-1 text-center whitespace-nowrap overflow-hidden ${!significant ? (isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light') : ''} ${isLastRow ? 'border-b' : ''}`}
+                                                                                // eslint-disable-next-line react/forbid-dom-props
                                                                                 style={{
                                                                                     ...FIXED_HEIGHT_STYLE,
                                                                                     backgroundColor: significant
@@ -481,6 +466,7 @@ function CollapsibleBreakdownSection({
                                                                             {/* Details (empty, for alignment) */}
                                                                             <td
                                                                                 className={`w-20 ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'} ${isLastRow ? 'border-b' : ''}`}
+                                                                                // eslint-disable-next-line react/forbid-dom-props
                                                                                 style={{
                                                                                     ...FIXED_HEIGHT_STYLE,
                                                                                     backgroundImage: rowBackgroundImage,
@@ -773,6 +759,7 @@ export function MetricRowGroup({
                     bg
                 )}
                 rowSpan={skeletonVariantKeys.length}
+                // eslint-disable-next-line react/forbid-dom-props
                 style={getScaledHeightStyle(skeletonVariantKeys.length)}
             >
                 <MetricRetryState retry={metricRetry} />
@@ -781,13 +768,18 @@ export function MetricRowGroup({
 
         return (
             <>
-                <tr className="hover:bg-bg-hover group" style={FIXED_HEIGHT_STYLE}>
+                <tr
+                    className="hover:bg-bg-hover group"
+                    // eslint-disable-next-line react/forbid-dom-props
+                    style={FIXED_HEIGHT_STYLE}
+                >
                     {/* Metric column: real header spanning every variant row, stays interactive while loading */}
                     <td
                         className={`w-1/5 border-r p-3 align-top text-left relative overflow-hidden ${
                             !isLastMetric ? 'border-b' : ''
                         } ${bg}`}
                         rowSpan={skeletonVariantKeys.length}
+                        // eslint-disable-next-line react/forbid-dom-props
                         style={getScaledHeightStyle(skeletonVariantKeys.length)}
                     >
                         <MetricHeader
@@ -816,6 +808,7 @@ export function MetricRowGroup({
                                     bg
                                 )}
                                 rowSpan={skeletonVariantKeys.length}
+                                // eslint-disable-next-line react/forbid-dom-props
                                 style={getScaledHeightStyle(skeletonVariantKeys.length)}
                             >
                                 {/* Reserve the Details button's footprint so the chart column doesn't shift when results land */}
@@ -830,7 +823,12 @@ export function MetricRowGroup({
                 </tr>
 
                 {skeletonVariantKeys.slice(1).map((variantKey, index) => (
-                    <tr key={variantKey} className="hover:bg-bg-hover group" style={FIXED_HEIGHT_STYLE}>
+                    <tr
+                        key={variantKey}
+                        className="hover:bg-bg-hover group"
+                        // eslint-disable-next-line react/forbid-dom-props
+                        style={FIXED_HEIGHT_STYLE}
+                    >
                         <SkeletonResultCells
                             variantKey={variantKey}
                             className={clsx(bg, index === skeletonVariantKeys.length - 2 && 'border-b')}
@@ -848,12 +846,17 @@ export function MetricRowGroup({
 
         return (
             <>
-                <tr className="hover:bg-bg-hover group" style={noResultStateStyle}>
+                <tr
+                    className="hover:bg-bg-hover group"
+                    // eslint-disable-next-line react/forbid-dom-props
+                    style={noResultStateStyle}
+                >
                     {/* Metric column - always visible */}
                     <td
                         className={`w-1/5 border-r p-3 align-top text-left relative overflow-hidden ${
                             !isLastMetric ? 'border-b' : ''
                         } ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'}`}
+                        // eslint-disable-next-line react/forbid-dom-props
                         style={noResultStateStyle}
                     >
                         <MetricHeader
@@ -876,6 +879,7 @@ export function MetricRowGroup({
                         className={`p-3 text-center ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'} ${
                             !isLastMetric ? 'border-b' : ''
                         }`}
+                        // eslint-disable-next-line react/forbid-dom-props
                         style={noResultStateStyle}
                     >
                         <ChartEmptyState
@@ -890,10 +894,12 @@ export function MetricRowGroup({
                     </td>
                 </tr>
                 {metric.breakdownFilter?.breakdowns && metric.breakdownFilter.breakdowns.length > 0 && (
-                    <BreakdownErrorState
+                    <MetricBreakdownError
                         metric={metric}
                         isAlternatingRow={isAlternatingRow}
                         onRemoveBreakdown={onRemoveBreakdown}
+                        onAttributionChange={() => {}}
+                        onBreakdownLimitChange={() => {}}
                     />
                 )}
             </>
@@ -929,6 +935,7 @@ export function MetricRowGroup({
                     <div
                         ref={tooltipRef}
                         className="fixed bg-bg-light border border-border px-3 py-2 rounded-md text-[13px] shadow-md z-[100] min-w-[280px] cursor-pointer hover:border-primary"
+                        // eslint-disable-next-line react/forbid-dom-props
                         style={{
                             left: tooltipState.position.x,
                             top: tooltipState.position.y,
@@ -954,13 +961,17 @@ export function MetricRowGroup({
                     </div>,
                     document.body
                 )}
-
             {/* Baseline row */}
-            <tr className="hover:bg-bg-hover group" style={FIXED_HEIGHT_STYLE}>
+            <tr
+                className="hover:bg-bg-hover group"
+                // eslint-disable-next-line react/forbid-dom-props
+                style={FIXED_HEIGHT_STYLE}
+            >
                 {/* Metric column - with rowspan */}
                 <td
                     className={`w-1/5 border-r p-3 align-top text-left relative overflow-hidden ${!isLastMetric ? 'border-b' : ''} ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'}`}
                     rowSpan={variantResults.length + 1}
+                    // eslint-disable-next-line react/forbid-dom-props
                     style={totalRowsHeightStyle}
                 >
                     <MetricHeader
@@ -982,6 +993,7 @@ export function MetricRowGroup({
                     className={`w-20 pt-1 pl-3 pr-3 pb-1 whitespace-nowrap overflow-hidden ${
                         isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'
                     } ${variantResults.length === 0 ? 'border-b' : ''}`}
+                    // eslint-disable-next-line react/forbid-dom-props
                     style={FIXED_HEIGHT_STYLE}
                 >
                     <VariantTag variantKey={baselineResult.key} />
@@ -992,6 +1004,7 @@ export function MetricRowGroup({
                     className={`w-24 pt-1 pl-3 pr-3 pb-1 text-left whitespace-nowrap overflow-hidden ${
                         isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'
                     } ${variantResults.length === 0 ? 'border-b' : ''}`}
+                    // eslint-disable-next-line react/forbid-dom-props
                     style={FIXED_HEIGHT_STYLE}
                 >
                     <div className="metric-cell">
@@ -1005,6 +1018,7 @@ export function MetricRowGroup({
                     className={`w-20 pt-1 pl-3 pr-3 pb-1 text-left whitespace-nowrap overflow-hidden ${
                         isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'
                     } ${variantResults.length === 0 ? 'border-b' : ''}`}
+                    // eslint-disable-next-line react/forbid-dom-props
                     style={FIXED_HEIGHT_STYLE}
                 >
                     <div />
@@ -1015,6 +1029,7 @@ export function MetricRowGroup({
                     className={`w-20 pt-1 pl-3 pr-3 pb-1 text-center whitespace-nowrap overflow-hidden ${
                         isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'
                     } ${variantResults.length === 0 ? 'border-b' : ''}`}
+                    // eslint-disable-next-line react/forbid-dom-props
                     style={FIXED_HEIGHT_STYLE}
                 >
                     <div />
@@ -1025,6 +1040,7 @@ export function MetricRowGroup({
                     className={`w-20 pt-3 align-top relative overflow-hidden ${
                         isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'
                     } ${variantResults.length === 0 ? 'border-b' : ''}`}
+                    // eslint-disable-next-line react/forbid-dom-props
                     style={FIXED_HEIGHT_STYLE}
                 >
                     {showDetailsModal && (
@@ -1048,6 +1064,7 @@ export function MetricRowGroup({
                     className={`p-0 align-top text-center relative overflow-hidden ${
                         isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'
                     } ${variantResults.length === 0 ? 'border-b' : ''}`}
+                    // eslint-disable-next-line react/forbid-dom-props
                     style={FIXED_HEIGHT_STYLE}
                 >
                     {axisRange && axisRange > 0 ? (
@@ -1075,7 +1092,6 @@ export function MetricRowGroup({
                     )}
                 </td>
             </tr>
-
             {/* Variant rows */}
             {variantResults.map((variant, index) => {
                 const isLastRow = index === variantResults.length - 1
@@ -1096,6 +1112,7 @@ export function MetricRowGroup({
                     <tr
                         key={`${metric.uuid}-${variant.key}`}
                         className="hover:bg-bg-hover group"
+                        // eslint-disable-next-line react/forbid-dom-props
                         style={FIXED_HEIGHT_STYLE}
                         onMouseEnter={(e) => handleTooltipMouseEnter(e, variant)}
                         onMouseLeave={handleTooltipMouseLeave}
@@ -1106,6 +1123,7 @@ export function MetricRowGroup({
                             className={`w-20 pt-1 pl-3 pr-3 pb-1 text-left whitespace-nowrap overflow-hidden ${
                                 isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'
                             } ${isLastRow ? 'border-b' : ''}`}
+                            // eslint-disable-next-line react/forbid-dom-props
                             style={{ ...FIXED_HEIGHT_STYLE, backgroundImage: rowBackgroundImage }}
                         >
                             <VariantTag variantKey={variant.key} />
@@ -1116,6 +1134,7 @@ export function MetricRowGroup({
                             className={`w-24 pt-1 pl-3 pr-3 pb-1 text-left whitespace-nowrap overflow-hidden ${
                                 isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'
                             } ${isLastRow ? 'border-b' : ''}`}
+                            // eslint-disable-next-line react/forbid-dom-props
                             style={{ ...FIXED_HEIGHT_STYLE, backgroundImage: rowBackgroundImage }}
                         >
                             <div className="metric-cell">
@@ -1129,6 +1148,7 @@ export function MetricRowGroup({
                             className={`w-20 pt-1 pl-3 pr-3 pb-1 text-left whitespace-nowrap overflow-hidden ${
                                 isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'
                             } ${isLastRow ? 'border-b' : ''}`}
+                            // eslint-disable-next-line react/forbid-dom-props
                             style={{ ...FIXED_HEIGHT_STYLE, backgroundImage: rowBackgroundImage }}
                         >
                             <div className="flex items-center gap-1">
@@ -1154,6 +1174,7 @@ export function MetricRowGroup({
                             className={`w-20 pt-1 pl-3 pr-3 pb-1 text-center whitespace-nowrap overflow-hidden ${
                                 !significant ? (isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light') : ''
                             } ${isLastRow ? 'border-b' : ''}`}
+                            // eslint-disable-next-line react/forbid-dom-props
                             style={{
                                 ...FIXED_HEIGHT_STYLE,
                                 backgroundColor: significant
@@ -1177,6 +1198,7 @@ export function MetricRowGroup({
                             className={`w-20 ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'} ${
                                 isLastRow ? 'border-b' : ''
                             }`}
+                            // eslint-disable-next-line react/forbid-dom-props
                             style={{ ...FIXED_HEIGHT_STYLE, backgroundImage: rowBackgroundImage }}
                         />
 
@@ -1195,7 +1217,6 @@ export function MetricRowGroup({
                     </tr>
                 )
             })}
-
             {/* Collapsible Breakdown Section. */}
             {(metric.breakdownFilter?.breakdowns?.length ?? 0) > 0 && (
                 <CollapsibleBreakdownSection
@@ -1218,7 +1239,6 @@ export function MetricRowGroup({
                     handleTooltipMouseMove={handleTooltipMouseMove}
                 />
             )}
-
             {timeseriesModalState.variantResult && (
                 <TimeseriesModal
                     isOpen={timeseriesModalState.isOpen}


### PR DESCRIPTION
<!-- This has to stand on its own: a reader who opens no files should still know why the PR is necessary and what it does. Length tracks the change, so a small diff gets a few bullets rather than a full-length body, and a section you have nothing for gets one line or "None". -->

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
<!-- First line: what is different for a person, and who they are. A fix says what breaks; a feature says what someone can now do; a chore says who is blocked. The code path goes underneath. -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Experiment metric breakdowns currently attribute the breakdown value from the exposure event. That diverges from insights funnels, where the breakdown is read off the funnel events with a configurable attribution mode, and it produces null buckets whenever the exposure event doesn't carry the property.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

| new attribution controls on metrics |
| - |
| <img width="1346" height="442" alt="image" src="https://github.com/user-attachments/assets/2b3a5c90-c3cf-405d-81da-d8092bef49d0" /> |

This PR adds the UI components to control breakdown attribution and limit, aligning the UI with Insights.

### Feature gated

Everything renders behind the `experiment-metric-event-breakdowns` flag. The attribution dropdown shows for funnel metrics only; the limit applies to all metric types.

### Attribution control

Attriution is controlled via a `LemonSelect` component, with the same options we provide for insight funnels.

### Breakdown limit control

For all metric types, we allow the user to select a cap on how many property values are shown. Since the backend does not allow for a "Show all", that option uses a unrealistically large number.

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->
<!-- Don't recite pass counts for suites CI runs; the checks report those with more authority. Link the evidence instead (run, permalink, error tracking issue), and say what you did not check. Long transcripts go in a <details> block. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

![cat-type-small](https://github.com/user-attachments/assets/32bf37a4-92fd-4324-903e-6607aaf1da5f)


## Automatic notifications

- [ ] Publish to changelog?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

No agent involved, all home grown code.

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
     - Public artifact: nothing in this PR — code, fixtures and sample data, comments, commit messages, or this description — carries material from the agent session that isn't already public. If the work drew on a customer conversation, ticket, or log, say so here and state that the committed data is invented. Renaming people, hosts, and identifiers does not clear real material; see AGENTS.md "Public open source repo guidance".
-->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way: what changed across the session. The reason the shipped design beats the obvious alternative goes in Changes instead, where a reviewer will actually see it.
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session — that applies to every part of this PR, not just this section.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Voice: the subject of every sentence is the change, never its author. No "I", "me" or "my" anywhere in the body. "I (actually Claude)" is worse than either half: it hands the assignee an account of work they did not do. Authorship is one stated fact in the Agent context section below.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Stack instead of stuffing: if the diff holds two or more separable steps (migration then behavior, rename then rewrite), open a stack rather than one big PR. See AGENTS.md, "Stacked PRs" and /stacking-prs.
- Simplify before opening: if your agent has a behavior-preserving cleanup pass (Claude Code: `/simplify`), run it on a non-trivial diff before final tests and preflight, since it edits the tree. Skip it for small mechanical changes.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- Shape and style: invoke the `/writing-pr-descriptions` skill before writing this body. In short: lead with the effect a person sees rather than the code path behind it, make the body stand alone for a reader who opens no files, size it to the change, link evidence rather than asserting what CI already reports, then hold what's left to one fact per bullet in under 25 words. A body that got longer as bullets was not cut.
-->