### PR TITLE
perf(warehouse-sources): push the issues scan floor into the tag-values read

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_warehouse_parent.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_warehouse_parent.py
@@ -350,3 +350,51 @@ def test_resolve_rejects_unfilterable_tables_so_callers_fall_back(
 
     with pytest.raises(WarehouseParentTableNotFoundError, match=match):
         _patched_resolve(uri, row_filter=bad_filter)
+
+
+def test_row_filter_tightens_to_an_absolute_floor(tmp_path: Path) -> None:
+    # The incremental caller passes its watermark so the scan stops reading issues it would
+    # only discard per row. The tighter of the two floors has to win, or an incremental run
+    # keeps paying for the whole snapshot.
+    uri = _write_parent_table_with_ages(tmp_path, "string")
+    watermark = datetime.now(UTC) - timedelta(days=2)
+
+    pages = _patched_reader(
+        uri,
+        columns=["id"],
+        page_size=10,
+        row_filter=ParentRowFilter(field="lastSeen", not_older_than=timedelta(days=90), not_before=watermark),
+    )
+
+    # "fresh" is 5 days old, so the watermark excludes it where the 90-day window would not.
+    assert {row["id"] for page in pages for row in page} == {"no_signal"}
+
+
+@parameterized.expand(
+    [
+        ("relative_only", timedelta(days=90), None, False, -90),
+        ("absolute_only", None, timedelta(days=2), False, -2),
+        ("absolute_is_tighter", timedelta(days=90), timedelta(days=2), False, -2),
+        ("relative_is_tighter", timedelta(days=1), timedelta(days=30), False, -1),
+        ("naive_absolute_is_read_as_utc", None, timedelta(days=2), True, -2),
+    ]
+)
+def test_parent_row_filter_floor_picks_the_tighter_bound(
+    _name, not_older_than, not_before_ago, naive, expected_days
+) -> None:
+    now = datetime.now(UTC)
+    not_before = None
+    if not_before_ago is not None:
+        not_before = now - not_before_ago
+        if naive:
+            not_before = not_before.replace(tzinfo=None)
+
+    floor = ParentRowFilter(field="lastSeen", not_older_than=not_older_than, not_before=not_before).floor(now)
+
+    assert floor == now + timedelta(days=expected_days)
+
+
+def test_parent_row_filter_rejects_a_filter_with_no_floor() -> None:
+    # Silently scanning everything is the failure this whole field exists to prevent.
+    with pytest.raises(ValueError, match="not_older_than"):
+        ParentRowFilter(field="lastSeen")

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/typing.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/typing.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 from typing import Any, Literal, NotRequired, Optional, TypedDict
 
 from requests import Session
@@ -59,10 +59,29 @@ class ParentRowFilter:
     stopped listing long ago. `field` is the parent's API field name; rows where it is NULL
     are kept, matching the per-row cutoff the Sentry tag-values iterator established.
     Omit the filter only for parents whose API genuinely returns the full collection.
+
+    `not_older_than` is the vendor's list window, relative to scan time. `not_before` is an
+    absolute floor a caller already computed, typically an incremental watermark, which lets
+    a child skip parents it has processed before instead of reading and discarding them.
+    Setting both floors the scan at whichever is tighter; at least one is required.
     """
 
     field: str
-    not_older_than: timedelta
+    not_older_than: timedelta | None = None
+    not_before: datetime | None = None
+
+    def __post_init__(self) -> None:
+        if self.not_older_than is None and self.not_before is None:
+            raise ValueError("ParentRowFilter needs not_older_than, not_before, or both")
+
+    def floor(self, now: datetime) -> datetime:
+        """The earliest value of `field` a row may carry and still be scanned."""
+        floors = [] if self.not_older_than is None else [now - self.not_older_than]
+        if self.not_before is not None:
+            # A naive floor can't be compared against the timezone-aware scan time, and the
+            # API timestamps this tracks are UTC.
+            floors.append(self.not_before if self.not_before.tzinfo else self.not_before.replace(tzinfo=UTC))
+        return max(floors)
 
 
 class PaginatorTypeConfig(TypedDict, total=True):

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/warehouse_parent.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/warehouse_parent.py
@@ -89,7 +89,7 @@ def _row_filter_expression(
     """
     physical = _physical_columns_by_api_name(delta_table, parent_name, [row_filter.field])[row_filter.field]
     field_type = pyarrow_schema_from_arrow_exportable(delta_table.schema()).field(physical).type
-    cutoff = dt.datetime.now(dt.UTC) - row_filter.not_older_than
+    cutoff = row_filter.floor(dt.datetime.now(dt.UTC))
 
     cutoff_scalar: pa.Scalar
     if pa.types.is_timestamp(field_type):

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/sentry.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/sentry.py
@@ -33,6 +33,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.res
     Endpoint,
     EndpointResource,
     IncrementalConfig,
+    ParentRowFilter,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.sync_window import SyncWindow
@@ -40,6 +41,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.typ
 from products.warehouse_sources.backend.temporal.data_imports.sources.sentry.settings import (
     ALLOWED_SENTRY_API_BASE_URLS,
     DEFAULT_SENTRY_API_BASE_URL,
+    ISSUES_PARENT_ROW_FILTER,
     PROJECT_STAT_NAMES,
     REQUIRED_SENTRY_SCOPES,
     SENTRY_ENDPOINTS,
@@ -400,10 +402,26 @@ def _skip_rows_on_stale_issue_404(
         raise
 
 
-def _issues_parent_columns(cutoff_last_seen: Any) -> list[str]:
-    # lastSeen is only projected when an incremental cutoff needs it — a parent whose column
-    # selection dropped it can still drive full-refresh children.
-    return ["id", "lastSeen"] if cutoff_last_seen is not None else ["id"]
+# lastSeen carries the scan floor, so it is always projected. A parent whose column selection
+# dropped it fails the eager resolve check and drives this child from the API instead.
+_ISSUES_PARENT_COLUMNS = ["id", "lastSeen"]
+
+
+def _issues_parent_row_filter(cutoff_last_seen: datetime | None) -> ParentRowFilter:
+    """Floor for the issues scan: Sentry's list window, tightened by the incremental cutoff.
+
+    The cutoff half is pure I/O: it turns the per-row skip below into a predicate the parquet
+    reader applies, so an incremental run stops reading issues it would only discard. The
+    per-row check stays the authority, and the floor is never tighter than it.
+
+    The window half is the same constant `issue_events` and `issue_hashes` use, so all three
+    children fan out over one row set instead of each bounding the parent differently. It does
+    drop issues this iterator used to yield, in the two cases where the per-row check bounded
+    nothing: a full refresh (no cutoff at all) and a watermark older than the window. Those are
+    issues Sentry's own listing no longer returns, so the API path never fanned out over them
+    either.
+    """
+    return dataclasses.replace(ISSUES_PARENT_ROW_FILTER, not_before=cutoff_last_seen)
 
 
 def _usable_resume_state(
@@ -460,9 +478,10 @@ def _iter_issue_tag_values_rows(
             for page in iter_parent_pages_from_warehouse(
                 table=issues_table,
                 parent_name="issues",
-                columns=_issues_parent_columns(cutoff_last_seen),
+                columns=_ISSUES_PARENT_COLUMNS,
                 page_size=100,
                 schema_name="issue_tag_values",
+                row_filter=_issues_parent_row_filter(cutoff_last_seen),
             )
             for row in page
         )
@@ -1272,8 +1291,9 @@ def sentry_source(
                 team_id=team_id,
                 source_id=source_id,
                 parent_name="issues",
-                required_columns=_issues_parent_columns(_parse_datetime_value(incremental_last_seen_max)),
+                required_columns=_ISSUES_PARENT_COLUMNS,
                 schema_name="issue_tag_values",
+                row_filter=_issues_parent_row_filter(_parse_datetime_value(incremental_last_seen_max)),
             )
         if resumable_source_manager is not None and resumable_source_manager.can_resume():
             # The pipeline reads this same Redis state to pick replace-vs-append for chunk 0,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/tests/test_sentry.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/tests/test_sentry.py
@@ -19,6 +19,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.sentry.sen
     SentryResumeConfig,
     SentryStatsSummaryRejectedError,
     _custom_endpoint_rows,
+    _issues_parent_row_filter,
     _normalize_api_base_url,
     _normalize_organization_slug,
     _parse_next_link,
@@ -969,6 +970,51 @@ class TestIssueTagValuesResumable:
 
     @parameterized.expand(
         [
+            # An incremental run floors at its watermark, which is tighter than the window.
+            ("incremental_run", "2026-08-01T00:00:00Z", datetime(2026, 8, 1, tzinfo=UTC)),
+            # A full refresh has no watermark, so only Sentry's list window bounds the scan.
+            ("full_refresh", None, None),
+        ]
+    )
+    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.sentry.sentry.make_tracked_session")
+    @patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.warehouse_parent.resolve_parent_table_ref",
+        return_value=ParentTableRef(uri="s3://bucket/team_123_sentry_x/issues", version=3),
+    )
+    @patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.warehouse_parent.iter_parent_pages_from_warehouse",
+        return_value=iter([[{"id": "100", "lastSeen": "2026-08-17T00:00:00Z"}]]),
+    )
+    def test_warehouse_scan_is_floored_by_the_watermark_and_the_list_window(
+        self, _name, watermark, expected_floor, mock_reader, _mock_resolve, mock_get
+    ) -> None:
+        # Without a floor the scan reads every issue ever synced and discards most of them
+        # per row, which is the fan-out inflation the config-driven children already fixed.
+        mock_get.return_value.get.side_effect = lambda url, **kwargs: _response([])
+
+        resp = sentry_source(
+            auth_token="token",
+            organization_slug="acme",
+            api_base_url="https://sentry.io",
+            endpoint="issue_tag_values",
+            team_id=123,
+            job_id="job-id",
+            source_id="source-1",
+            use_warehouse_parent=True,
+            should_use_incremental_field=watermark is not None,
+            db_incremental_field_last_value=watermark,
+        )
+        list(cast(Any, resp.items()))
+
+        row_filter = mock_reader.call_args.kwargs["row_filter"]
+        assert row_filter.field == "lastSeen"
+        floor = row_filter.floor(datetime.now(UTC))
+        if expected_floor is None:
+            expected_floor = datetime.now(UTC) - timedelta(days=SENTRY_RETENTION_DAYS)
+        assert abs(floor - expected_floor) < timedelta(seconds=5)
+
+    @parameterized.expand(
+        [
             # Written over the API listing, read by a warehouse run.
             ("api_checkpoint_in_warehouse_run", None, True),
             # Written over a different pinned version than this run resolved (parent re-synced).
@@ -1903,9 +1949,11 @@ class TestWarehouseParentReuse:
         mock_reader.assert_called_once_with(
             table=ParentTableRef(uri="s3://bucket/team_123_sentry_x/issues", version=3),
             parent_name="issues",
-            columns=["id"],
+            # lastSeen is always projected because it carries the scan floor.
+            columns=["id", "lastSeen"],
             page_size=100,
             schema_name="issue_tag_values",
+            row_filter=_issues_parent_row_filter(None),
         )
 
     @patch("products.warehouse_sources.backend.temporal.data_imports.sources.sentry.sentry.make_tracked_session")


### PR DESCRIPTION
## Problem

- Syncing Sentry `issue_tag_values` reads every issue in the parent snapshot, then discards most of them one row at a time in Python. A production run on a large source scanned 16,992 issues to use a fraction of them.
- The same run also fans out unbounded when it has no incremental cutoff. A full refresh, or a watermark older than Sentry's list window, walks issues the API path never lists. That is the row inflation [#84360](https://github.com/PostHog/posthog/pull/84360) fixed for `issue_events` and `issue_hashes`, still present in the third child.

## Changes

- `ParentRowFilter` gains `not_before`, an absolute floor beside the existing relative window. `floor()` returns whichever is tighter, so one filter can carry both bounds.
- `issue_tag_values` now passes a filter built from the shared `ISSUES_PARENT_ROW_FILTER` plus its incremental cutoff, so the parquet reader skips those issues instead of the iterator reading and dropping them.
- All three Sentry children now bound the parent by the same constant, so one source no longer fans out over three different row sets.
- `lastSeen` is always projected, because the floor needs it. A parent missing that column fails the eager resolve check and drives the child from the API, which is the existing fallback.

> [!NOTE]
> The cutoff half is pure I/O: it never drops a row the per-row check would have kept, and that check stays the authority. The window half does change behavior, in exactly the two cases where the per-row check bounded nothing — a full refresh, and a watermark older than the window. Those issues are outside Sentry's listing, so the API path never fanned out over them either.

## How did you test this code?

- `test_warehouse_scan_is_floored_by_the_watermark_and_the_list_window` covers an incremental run and a full refresh. Catches the filter not reaching the reader, which is how the original unbounded scan shipped, and a floor that picks the looser bound.
- `test_row_filter_tightens_to_an_absolute_floor` proves the pushdown against a real Delta table: with a 2-day watermark the 5-day-old row is not scanned.
- `test_parent_row_filter_floor_picks_the_tighter_bound` covers relative-only, absolute-only, either side tighter, and a naive datetime. Catches a max/min inversion, which would silently over- or under-fetch.
- `test_parent_row_filter_rejects_a_filter_with_no_floor` guards the field's whole purpose: a filter that bounds nothing.
- `test_issue_tag_values_reads_issues_from_warehouse` updated for the always-projected `lastSeen` and the new argument.
- Not run: a production run of the changed path. `issue_tag_values` on the one enabled project next syncs after this would deploy.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. `.agents/skills/implementing-warehouse-sources/SKILL.md` already carries the row-set parity rule this follows.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found by reading the row-count log after [#84360](https://github.com/PostHog/posthog/pull/84360) deployed: the filtered children reported bounded scans while `issue_tag_values` still reported the full snapshot. Reviewing that path surfaced the second, larger gap, that its unbounded case was never bounded at all. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
