### PR TITLE
feat(experiments): add breakdown attribution schema changes

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -23271,6 +23271,15 @@
         "ExperimentFunnelMetric": {
             "additionalProperties": false,
             "properties": {
+                "breakdownAttributionType": {
+                    "$ref": "#/definitions/BreakdownAttributionType",
+                    "default": "first_touch",
+                    "description": "How to attribute the breakdown value across funnel steps."
+                },
+                "breakdownAttributionValue": {
+                    "description": "When breakdownAttributionType is `step`, the 0-indexed step to attribute from.",
+                    "type": "integer"
+                },
                 "breakdownFilter": {
                     "$ref": "#/definitions/BreakdownFilter"
                 },
@@ -23350,6 +23359,15 @@
         "ExperimentFunnelMetricTypeProps": {
             "additionalProperties": false,
             "properties": {
+                "breakdownAttributionType": {
+                    "$ref": "#/definitions/BreakdownAttributionType",
+                    "default": "first_touch",
+                    "description": "How to attribute the breakdown value across funnel steps."
+                },
+                "breakdownAttributionValue": {
+                    "description": "When breakdownAttributionType is `step`, the 0-indexed step to attribute from.",
+                    "type": "integer"
+                },
                 "funnel_order_type": {
                     "$ref": "#/definitions/StepOrderValue"
                 },

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -9,6 +9,7 @@ import {
     AnyPersonScopeFilter,
     AnyPropertyFilter,
     BaseMathType,
+    BreakdownAttributionType,
     BreakdownKeyType,
     BreakdownType,
     CalendarHeatmapMathType,
@@ -5225,6 +5226,10 @@ export type ExperimentFunnelMetric = ExperimentMetricBaseProperties & {
     metric_type: ExperimentMetricType.FUNNEL
     series: ExperimentFunnelMetricStep[]
     funnel_order_type?: StepOrderValue
+    /** How to attribute the breakdown value across funnel steps. @default first_touch */
+    breakdownAttributionType?: BreakdownAttributionType
+    /** When breakdownAttributionType is `step`, the 0-indexed step to attribute from. @asType integer */
+    breakdownAttributionValue?: integer
 }
 
 export const isExperimentFunnelMetric = (metric: ExperimentMetric): metric is ExperimentFunnelMetric =>

--- a/frontend/src/queries/validators.js
+++ b/frontend/src/queries/validators.js
@@ -11319,6 +11319,15 @@ function validate86(data, { instancePath = '', parentData, parentDataProperty, r
 const schema101 = {
     additionalProperties: false,
     properties: {
+        breakdownAttributionType: {
+            $ref: '#/definitions/BreakdownAttributionType',
+            default: 'first_touch',
+            description: 'How to attribute the breakdown value across funnel steps.',
+        },
+        breakdownAttributionValue: {
+            description: 'When breakdownAttributionType is `step`, the 0-indexed step to attribute from.',
+            type: 'integer',
+        },
         breakdownFilter: { $ref: '#/definitions/BreakdownFilter' },
         conversion_window: { $ref: '#/definitions/integer' },
         conversion_window_unit: { $ref: '#/definitions/FunnelConversionWindowTimeUnit' },
@@ -11338,8 +11347,9 @@ const schema101 = {
     required: ['kind', 'metric_type', 'series'],
     type: 'object',
 }
-const schema104 = { enum: ['strict', 'unordered', 'ordered'], type: 'string' }
-const schema106 = {
+const schema102 = { enum: ['first_touch', 'last_touch', 'all_events', 'step'], type: 'string' }
+const schema105 = { enum: ['strict', 'unordered', 'ordered'], type: 'string' }
+const schema107 = {
     discriminator: { propertyName: 'kind' },
     oneOf: [
         { $ref: '#/definitions/EventsNode' },
@@ -11491,32 +11501,53 @@ function validate114(data, { instancePath = '', parentData, parentDataProperty, 
                     }
                 }
                 if (_errs1 === errors) {
-                    if (data.breakdownFilter !== undefined) {
+                    if (data.breakdownAttributionType !== undefined) {
+                        let data0 = data.breakdownAttributionType
                         const _errs2 = errors
+                        if (typeof data0 !== 'string') {
+                            validate114.errors = [
+                                {
+                                    instancePath: instancePath + '/breakdownAttributionType',
+                                    schemaPath: '#/definitions/BreakdownAttributionType/type',
+                                    keyword: 'type',
+                                    params: { type: 'string' },
+                                    message: 'must be string',
+                                },
+                            ]
+                            return false
+                        }
                         if (
-                            !validate87(data.breakdownFilter, {
-                                instancePath: instancePath + '/breakdownFilter',
-                                parentData: data,
-                                parentDataProperty: 'breakdownFilter',
-                                rootData,
-                            })
+                            !(
+                                data0 === 'first_touch' ||
+                                data0 === 'last_touch' ||
+                                data0 === 'all_events' ||
+                                data0 === 'step'
+                            )
                         ) {
-                            vErrors = vErrors === null ? validate87.errors : vErrors.concat(validate87.errors)
-                            errors = vErrors.length
+                            validate114.errors = [
+                                {
+                                    instancePath: instancePath + '/breakdownAttributionType',
+                                    schemaPath: '#/definitions/BreakdownAttributionType/enum',
+                                    keyword: 'enum',
+                                    params: { allowedValues: schema102.enum },
+                                    message: 'must be equal to one of the allowed values',
+                                },
+                            ]
+                            return false
                         }
                         var valid0 = _errs2 === errors
                     } else {
                         var valid0 = true
                     }
                     if (valid0) {
-                        if (data.conversion_window !== undefined) {
-                            let data1 = data.conversion_window
-                            const _errs3 = errors
+                        if (data.breakdownAttributionValue !== undefined) {
+                            let data1 = data.breakdownAttributionValue
+                            const _errs5 = errors
                             if (!(typeof data1 == 'number' && !(data1 % 1) && !isNaN(data1) && isFinite(data1))) {
                                 validate114.errors = [
                                     {
-                                        instancePath: instancePath + '/conversion_window',
-                                        schemaPath: '#/definitions/integer/type',
+                                        instancePath: instancePath + '/breakdownAttributionValue',
+                                        schemaPath: '#/properties/breakdownAttributionValue/type',
                                         keyword: 'type',
                                         params: { type: 'integer' },
                                         message: 'must be integer',
@@ -11524,79 +11555,59 @@ function validate114(data, { instancePath = '', parentData, parentDataProperty, 
                                 ]
                                 return false
                             }
-                            var valid0 = _errs3 === errors
+                            var valid0 = _errs5 === errors
                         } else {
                             var valid0 = true
                         }
                         if (valid0) {
-                            if (data.conversion_window_unit !== undefined) {
-                                let data2 = data.conversion_window_unit
-                                const _errs6 = errors
-                                if (typeof data2 !== 'string') {
-                                    validate114.errors = [
-                                        {
-                                            instancePath: instancePath + '/conversion_window_unit',
-                                            schemaPath: '#/definitions/FunnelConversionWindowTimeUnit/type',
-                                            keyword: 'type',
-                                            params: { type: 'string' },
-                                            message: 'must be string',
-                                        },
-                                    ]
-                                    return false
-                                }
+                            if (data.breakdownFilter !== undefined) {
+                                const _errs7 = errors
                                 if (
-                                    !(
-                                        data2 === 'second' ||
-                                        data2 === 'minute' ||
-                                        data2 === 'hour' ||
-                                        data2 === 'day' ||
-                                        data2 === 'week' ||
-                                        data2 === 'month'
-                                    )
+                                    !validate87(data.breakdownFilter, {
+                                        instancePath: instancePath + '/breakdownFilter',
+                                        parentData: data,
+                                        parentDataProperty: 'breakdownFilter',
+                                        rootData,
+                                    })
                                 ) {
-                                    validate114.errors = [
-                                        {
-                                            instancePath: instancePath + '/conversion_window_unit',
-                                            schemaPath: '#/definitions/FunnelConversionWindowTimeUnit/enum',
-                                            keyword: 'enum',
-                                            params: { allowedValues: schema82.enum },
-                                            message: 'must be equal to one of the allowed values',
-                                        },
-                                    ]
-                                    return false
+                                    vErrors = vErrors === null ? validate87.errors : vErrors.concat(validate87.errors)
+                                    errors = vErrors.length
                                 }
-                                var valid0 = _errs6 === errors
+                                var valid0 = _errs7 === errors
                             } else {
                                 var valid0 = true
                             }
                             if (valid0) {
-                                if (data.fingerprint !== undefined) {
-                                    const _errs9 = errors
-                                    if (typeof data.fingerprint !== 'string') {
+                                if (data.conversion_window !== undefined) {
+                                    let data3 = data.conversion_window
+                                    const _errs8 = errors
+                                    if (
+                                        !(typeof data3 == 'number' && !(data3 % 1) && !isNaN(data3) && isFinite(data3))
+                                    ) {
                                         validate114.errors = [
                                             {
-                                                instancePath: instancePath + '/fingerprint',
-                                                schemaPath: '#/properties/fingerprint/type',
+                                                instancePath: instancePath + '/conversion_window',
+                                                schemaPath: '#/definitions/integer/type',
                                                 keyword: 'type',
-                                                params: { type: 'string' },
-                                                message: 'must be string',
+                                                params: { type: 'integer' },
+                                                message: 'must be integer',
                                             },
                                         ]
                                         return false
                                     }
-                                    var valid0 = _errs9 === errors
+                                    var valid0 = _errs8 === errors
                                 } else {
                                     var valid0 = true
                                 }
                                 if (valid0) {
-                                    if (data.funnel_order_type !== undefined) {
-                                        let data4 = data.funnel_order_type
+                                    if (data.conversion_window_unit !== undefined) {
+                                        let data4 = data.conversion_window_unit
                                         const _errs11 = errors
                                         if (typeof data4 !== 'string') {
                                             validate114.errors = [
                                                 {
-                                                    instancePath: instancePath + '/funnel_order_type',
-                                                    schemaPath: '#/definitions/StepOrderValue/type',
+                                                    instancePath: instancePath + '/conversion_window_unit',
+                                                    schemaPath: '#/definitions/FunnelConversionWindowTimeUnit/type',
                                                     keyword: 'type',
                                                     params: { type: 'string' },
                                                     message: 'must be string',
@@ -11604,13 +11615,22 @@ function validate114(data, { instancePath = '', parentData, parentDataProperty, 
                                             ]
                                             return false
                                         }
-                                        if (!(data4 === 'strict' || data4 === 'unordered' || data4 === 'ordered')) {
+                                        if (
+                                            !(
+                                                data4 === 'second' ||
+                                                data4 === 'minute' ||
+                                                data4 === 'hour' ||
+                                                data4 === 'day' ||
+                                                data4 === 'week' ||
+                                                data4 === 'month'
+                                            )
+                                        ) {
                                             validate114.errors = [
                                                 {
-                                                    instancePath: instancePath + '/funnel_order_type',
-                                                    schemaPath: '#/definitions/StepOrderValue/enum',
+                                                    instancePath: instancePath + '/conversion_window_unit',
+                                                    schemaPath: '#/definitions/FunnelConversionWindowTimeUnit/enum',
                                                     keyword: 'enum',
-                                                    params: { allowedValues: schema104.enum },
+                                                    params: { allowedValues: schema82.enum },
                                                     message: 'must be equal to one of the allowed values',
                                                 },
                                             ]
@@ -11621,29 +11641,16 @@ function validate114(data, { instancePath = '', parentData, parentDataProperty, 
                                         var valid0 = true
                                     }
                                     if (valid0) {
-                                        if (data.goal !== undefined) {
-                                            let data5 = data.goal
+                                        if (data.fingerprint !== undefined) {
                                             const _errs14 = errors
-                                            if (typeof data5 !== 'string') {
+                                            if (typeof data.fingerprint !== 'string') {
                                                 validate114.errors = [
                                                     {
-                                                        instancePath: instancePath + '/goal',
-                                                        schemaPath: '#/definitions/ExperimentMetricGoal/type',
+                                                        instancePath: instancePath + '/fingerprint',
+                                                        schemaPath: '#/properties/fingerprint/type',
                                                         keyword: 'type',
                                                         params: { type: 'string' },
                                                         message: 'must be string',
-                                                    },
-                                                ]
-                                                return false
-                                            }
-                                            if (!(data5 === 'increase' || data5 === 'decrease')) {
-                                                validate114.errors = [
-                                                    {
-                                                        instancePath: instancePath + '/goal',
-                                                        schemaPath: '#/definitions/ExperimentMetricGoal/enum',
-                                                        keyword: 'enum',
-                                                        params: { allowedValues: schema83.enum },
-                                                        message: 'must be equal to one of the allowed values',
                                                     },
                                                 ]
                                                 return false
@@ -11653,33 +11660,52 @@ function validate114(data, { instancePath = '', parentData, parentDataProperty, 
                                             var valid0 = true
                                         }
                                         if (valid0) {
-                                            if (data.isSharedMetric !== undefined) {
-                                                const _errs17 = errors
-                                                if (typeof data.isSharedMetric !== 'boolean') {
+                                            if (data.funnel_order_type !== undefined) {
+                                                let data6 = data.funnel_order_type
+                                                const _errs16 = errors
+                                                if (typeof data6 !== 'string') {
                                                     validate114.errors = [
                                                         {
-                                                            instancePath: instancePath + '/isSharedMetric',
-                                                            schemaPath: '#/properties/isSharedMetric/type',
+                                                            instancePath: instancePath + '/funnel_order_type',
+                                                            schemaPath: '#/definitions/StepOrderValue/type',
                                                             keyword: 'type',
-                                                            params: { type: 'boolean' },
-                                                            message: 'must be boolean',
+                                                            params: { type: 'string' },
+                                                            message: 'must be string',
                                                         },
                                                     ]
                                                     return false
                                                 }
-                                                var valid0 = _errs17 === errors
+                                                if (
+                                                    !(
+                                                        data6 === 'strict' ||
+                                                        data6 === 'unordered' ||
+                                                        data6 === 'ordered'
+                                                    )
+                                                ) {
+                                                    validate114.errors = [
+                                                        {
+                                                            instancePath: instancePath + '/funnel_order_type',
+                                                            schemaPath: '#/definitions/StepOrderValue/enum',
+                                                            keyword: 'enum',
+                                                            params: { allowedValues: schema105.enum },
+                                                            message: 'must be equal to one of the allowed values',
+                                                        },
+                                                    ]
+                                                    return false
+                                                }
+                                                var valid0 = _errs16 === errors
                                             } else {
                                                 var valid0 = true
                                             }
                                             if (valid0) {
-                                                if (data.kind !== undefined) {
-                                                    let data7 = data.kind
+                                                if (data.goal !== undefined) {
+                                                    let data7 = data.goal
                                                     const _errs19 = errors
                                                     if (typeof data7 !== 'string') {
                                                         validate114.errors = [
                                                             {
-                                                                instancePath: instancePath + '/kind',
-                                                                schemaPath: '#/properties/kind/type',
+                                                                instancePath: instancePath + '/goal',
+                                                                schemaPath: '#/definitions/ExperimentMetricGoal/type',
                                                                 keyword: 'type',
                                                                 params: { type: 'string' },
                                                                 message: 'must be string',
@@ -11687,14 +11713,14 @@ function validate114(data, { instancePath = '', parentData, parentDataProperty, 
                                                         ]
                                                         return false
                                                     }
-                                                    if ('ExperimentMetric' !== data7) {
+                                                    if (!(data7 === 'increase' || data7 === 'decrease')) {
                                                         validate114.errors = [
                                                             {
-                                                                instancePath: instancePath + '/kind',
-                                                                schemaPath: '#/properties/kind/const',
-                                                                keyword: 'const',
-                                                                params: { allowedValue: 'ExperimentMetric' },
-                                                                message: 'must be equal to constant',
+                                                                instancePath: instancePath + '/goal',
+                                                                schemaPath: '#/definitions/ExperimentMetricGoal/enum',
+                                                                keyword: 'enum',
+                                                                params: { allowedValues: schema83.enum },
+                                                                message: 'must be equal to one of the allowed values',
                                                             },
                                                         ]
                                                         return false
@@ -11704,45 +11730,33 @@ function validate114(data, { instancePath = '', parentData, parentDataProperty, 
                                                     var valid0 = true
                                                 }
                                                 if (valid0) {
-                                                    if (data.metric_type !== undefined) {
-                                                        let data8 = data.metric_type
-                                                        const _errs21 = errors
-                                                        if (typeof data8 !== 'string') {
+                                                    if (data.isSharedMetric !== undefined) {
+                                                        const _errs22 = errors
+                                                        if (typeof data.isSharedMetric !== 'boolean') {
                                                             validate114.errors = [
                                                                 {
-                                                                    instancePath: instancePath + '/metric_type',
-                                                                    schemaPath: '#/properties/metric_type/type',
+                                                                    instancePath: instancePath + '/isSharedMetric',
+                                                                    schemaPath: '#/properties/isSharedMetric/type',
                                                                     keyword: 'type',
-                                                                    params: { type: 'string' },
-                                                                    message: 'must be string',
+                                                                    params: { type: 'boolean' },
+                                                                    message: 'must be boolean',
                                                                 },
                                                             ]
                                                             return false
                                                         }
-                                                        if ('funnel' !== data8) {
-                                                            validate114.errors = [
-                                                                {
-                                                                    instancePath: instancePath + '/metric_type',
-                                                                    schemaPath: '#/properties/metric_type/const',
-                                                                    keyword: 'const',
-                                                                    params: { allowedValue: 'funnel' },
-                                                                    message: 'must be equal to constant',
-                                                                },
-                                                            ]
-                                                            return false
-                                                        }
-                                                        var valid0 = _errs21 === errors
+                                                        var valid0 = _errs22 === errors
                                                     } else {
                                                         var valid0 = true
                                                     }
                                                     if (valid0) {
-                                                        if (data.name !== undefined) {
-                                                            const _errs23 = errors
-                                                            if (typeof data.name !== 'string') {
+                                                        if (data.kind !== undefined) {
+                                                            let data9 = data.kind
+                                                            const _errs24 = errors
+                                                            if (typeof data9 !== 'string') {
                                                                 validate114.errors = [
                                                                     {
-                                                                        instancePath: instancePath + '/name',
-                                                                        schemaPath: '#/properties/name/type',
+                                                                        instancePath: instancePath + '/kind',
+                                                                        schemaPath: '#/properties/kind/type',
                                                                         keyword: 'type',
                                                                         params: { type: 'string' },
                                                                         message: 'must be string',
@@ -11750,109 +11764,94 @@ function validate114(data, { instancePath = '', parentData, parentDataProperty, 
                                                                 ]
                                                                 return false
                                                             }
-                                                            var valid0 = _errs23 === errors
+                                                            if ('ExperimentMetric' !== data9) {
+                                                                validate114.errors = [
+                                                                    {
+                                                                        instancePath: instancePath + '/kind',
+                                                                        schemaPath: '#/properties/kind/const',
+                                                                        keyword: 'const',
+                                                                        params: { allowedValue: 'ExperimentMetric' },
+                                                                        message: 'must be equal to constant',
+                                                                    },
+                                                                ]
+                                                                return false
+                                                            }
+                                                            var valid0 = _errs24 === errors
                                                         } else {
                                                             var valid0 = true
                                                         }
                                                         if (valid0) {
-                                                            if (data.response !== undefined) {
-                                                                let data10 = data.response
-                                                                const _errs25 = errors
-                                                                if (
-                                                                    !(
-                                                                        data10 &&
-                                                                        typeof data10 == 'object' &&
-                                                                        !Array.isArray(data10)
-                                                                    )
-                                                                ) {
+                                                            if (data.metric_type !== undefined) {
+                                                                let data10 = data.metric_type
+                                                                const _errs26 = errors
+                                                                if (typeof data10 !== 'string') {
                                                                     validate114.errors = [
                                                                         {
-                                                                            instancePath: instancePath + '/response',
-                                                                            schemaPath: '#/properties/response/type',
+                                                                            instancePath: instancePath + '/metric_type',
+                                                                            schemaPath: '#/properties/metric_type/type',
                                                                             keyword: 'type',
-                                                                            params: { type: 'object' },
-                                                                            message: 'must be object',
+                                                                            params: { type: 'string' },
+                                                                            message: 'must be string',
                                                                         },
                                                                     ]
                                                                     return false
                                                                 }
-                                                                var valid0 = _errs25 === errors
+                                                                if ('funnel' !== data10) {
+                                                                    validate114.errors = [
+                                                                        {
+                                                                            instancePath: instancePath + '/metric_type',
+                                                                            schemaPath:
+                                                                                '#/properties/metric_type/const',
+                                                                            keyword: 'const',
+                                                                            params: { allowedValue: 'funnel' },
+                                                                            message: 'must be equal to constant',
+                                                                        },
+                                                                    ]
+                                                                    return false
+                                                                }
+                                                                var valid0 = _errs26 === errors
                                                             } else {
                                                                 var valid0 = true
                                                             }
                                                             if (valid0) {
-                                                                if (data.series !== undefined) {
-                                                                    let data11 = data.series
-                                                                    const _errs27 = errors
-                                                                    if (errors === _errs27) {
-                                                                        if (Array.isArray(data11)) {
-                                                                            var valid5 = true
-                                                                            const len0 = data11.length
-                                                                            for (let i0 = 0; i0 < len0; i0++) {
-                                                                                const _errs29 = errors
-                                                                                if (
-                                                                                    !validate116(data11[i0], {
-                                                                                        instancePath:
-                                                                                            instancePath +
-                                                                                            '/series/' +
-                                                                                            i0,
-                                                                                        parentData: data11,
-                                                                                        parentDataProperty: i0,
-                                                                                        rootData,
-                                                                                    })
-                                                                                ) {
-                                                                                    vErrors =
-                                                                                        vErrors === null
-                                                                                            ? validate116.errors
-                                                                                            : vErrors.concat(
-                                                                                                  validate116.errors
-                                                                                              )
-                                                                                    errors = vErrors.length
-                                                                                }
-                                                                                var valid5 = _errs29 === errors
-                                                                                if (!valid5) {
-                                                                                    break
-                                                                                }
-                                                                            }
-                                                                        } else {
-                                                                            validate114.errors = [
-                                                                                {
-                                                                                    instancePath:
-                                                                                        instancePath + '/series',
-                                                                                    schemaPath:
-                                                                                        '#/properties/series/type',
-                                                                                    keyword: 'type',
-                                                                                    params: { type: 'array' },
-                                                                                    message: 'must be array',
-                                                                                },
-                                                                            ]
-                                                                            return false
-                                                                        }
+                                                                if (data.name !== undefined) {
+                                                                    const _errs28 = errors
+                                                                    if (typeof data.name !== 'string') {
+                                                                        validate114.errors = [
+                                                                            {
+                                                                                instancePath: instancePath + '/name',
+                                                                                schemaPath: '#/properties/name/type',
+                                                                                keyword: 'type',
+                                                                                params: { type: 'string' },
+                                                                                message: 'must be string',
+                                                                            },
+                                                                        ]
+                                                                        return false
                                                                     }
-                                                                    var valid0 = _errs27 === errors
+                                                                    var valid0 = _errs28 === errors
                                                                 } else {
                                                                     var valid0 = true
                                                                 }
                                                                 if (valid0) {
-                                                                    if (data.sharedMetricId !== undefined) {
-                                                                        let data13 = data.sharedMetricId
+                                                                    if (data.response !== undefined) {
+                                                                        let data12 = data.response
                                                                         const _errs30 = errors
                                                                         if (
                                                                             !(
-                                                                                typeof data13 == 'number' &&
-                                                                                isFinite(data13)
+                                                                                data12 &&
+                                                                                typeof data12 == 'object' &&
+                                                                                !Array.isArray(data12)
                                                                             )
                                                                         ) {
                                                                             validate114.errors = [
                                                                                 {
                                                                                     instancePath:
-                                                                                        instancePath +
-                                                                                        '/sharedMetricId',
+                                                                                        instancePath + '/response',
                                                                                     schemaPath:
-                                                                                        '#/properties/sharedMetricId/type',
+                                                                                        '#/properties/response/type',
                                                                                     keyword: 'type',
-                                                                                    params: { type: 'number' },
-                                                                                    message: 'must be number',
+                                                                                    params: { type: 'object' },
+                                                                                    message: 'must be object',
                                                                                 },
                                                                             ]
                                                                             return false
@@ -11862,30 +11861,63 @@ function validate114(data, { instancePath = '', parentData, parentDataProperty, 
                                                                         var valid0 = true
                                                                     }
                                                                     if (valid0) {
-                                                                        if (data.uuid !== undefined) {
+                                                                        if (data.series !== undefined) {
+                                                                            let data13 = data.series
                                                                             const _errs32 = errors
-                                                                            if (typeof data.uuid !== 'string') {
-                                                                                validate114.errors = [
-                                                                                    {
-                                                                                        instancePath:
-                                                                                            instancePath + '/uuid',
-                                                                                        schemaPath:
-                                                                                            '#/properties/uuid/type',
-                                                                                        keyword: 'type',
-                                                                                        params: { type: 'string' },
-                                                                                        message: 'must be string',
-                                                                                    },
-                                                                                ]
-                                                                                return false
+                                                                            if (errors === _errs32) {
+                                                                                if (Array.isArray(data13)) {
+                                                                                    var valid6 = true
+                                                                                    const len0 = data13.length
+                                                                                    for (let i0 = 0; i0 < len0; i0++) {
+                                                                                        const _errs34 = errors
+                                                                                        if (
+                                                                                            !validate116(data13[i0], {
+                                                                                                instancePath:
+                                                                                                    instancePath +
+                                                                                                    '/series/' +
+                                                                                                    i0,
+                                                                                                parentData: data13,
+                                                                                                parentDataProperty: i0,
+                                                                                                rootData,
+                                                                                            })
+                                                                                        ) {
+                                                                                            vErrors =
+                                                                                                vErrors === null
+                                                                                                    ? validate116.errors
+                                                                                                    : vErrors.concat(
+                                                                                                          validate116.errors
+                                                                                                      )
+                                                                                            errors = vErrors.length
+                                                                                        }
+                                                                                        var valid6 = _errs34 === errors
+                                                                                        if (!valid6) {
+                                                                                            break
+                                                                                        }
+                                                                                    }
+                                                                                } else {
+                                                                                    validate114.errors = [
+                                                                                        {
+                                                                                            instancePath:
+                                                                                                instancePath +
+                                                                                                '/series',
+                                                                                            schemaPath:
+                                                                                                '#/properties/series/type',
+                                                                                            keyword: 'type',
+                                                                                            params: { type: 'array' },
+                                                                                            message: 'must be array',
+                                                                                        },
+                                                                                    ]
+                                                                                    return false
+                                                                                }
                                                                             }
                                                                             var valid0 = _errs32 === errors
                                                                         } else {
                                                                             var valid0 = true
                                                                         }
                                                                         if (valid0) {
-                                                                            if (data.version !== undefined) {
-                                                                                let data15 = data.version
-                                                                                const _errs34 = errors
+                                                                            if (data.sharedMetricId !== undefined) {
+                                                                                let data15 = data.sharedMetricId
+                                                                                const _errs35 = errors
                                                                                 if (
                                                                                     !(
                                                                                         typeof data15 == 'number' &&
@@ -11896,9 +11928,9 @@ function validate114(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                         {
                                                                                             instancePath:
                                                                                                 instancePath +
-                                                                                                '/version',
+                                                                                                '/sharedMetricId',
                                                                                             schemaPath:
-                                                                                                '#/properties/version/type',
+                                                                                                '#/properties/sharedMetricId/type',
                                                                                             keyword: 'type',
                                                                                             params: { type: 'number' },
                                                                                             message: 'must be number',
@@ -11906,9 +11938,68 @@ function validate114(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                     ]
                                                                                     return false
                                                                                 }
-                                                                                var valid0 = _errs34 === errors
+                                                                                var valid0 = _errs35 === errors
                                                                             } else {
                                                                                 var valid0 = true
+                                                                            }
+                                                                            if (valid0) {
+                                                                                if (data.uuid !== undefined) {
+                                                                                    const _errs37 = errors
+                                                                                    if (typeof data.uuid !== 'string') {
+                                                                                        validate114.errors = [
+                                                                                            {
+                                                                                                instancePath:
+                                                                                                    instancePath +
+                                                                                                    '/uuid',
+                                                                                                schemaPath:
+                                                                                                    '#/properties/uuid/type',
+                                                                                                keyword: 'type',
+                                                                                                params: {
+                                                                                                    type: 'string',
+                                                                                                },
+                                                                                                message:
+                                                                                                    'must be string',
+                                                                                            },
+                                                                                        ]
+                                                                                        return false
+                                                                                    }
+                                                                                    var valid0 = _errs37 === errors
+                                                                                } else {
+                                                                                    var valid0 = true
+                                                                                }
+                                                                                if (valid0) {
+                                                                                    if (data.version !== undefined) {
+                                                                                        let data17 = data.version
+                                                                                        const _errs39 = errors
+                                                                                        if (
+                                                                                            !(
+                                                                                                typeof data17 ==
+                                                                                                    'number' &&
+                                                                                                isFinite(data17)
+                                                                                            )
+                                                                                        ) {
+                                                                                            validate114.errors = [
+                                                                                                {
+                                                                                                    instancePath:
+                                                                                                        instancePath +
+                                                                                                        '/version',
+                                                                                                    schemaPath:
+                                                                                                        '#/properties/version/type',
+                                                                                                    keyword: 'type',
+                                                                                                    params: {
+                                                                                                        type: 'number',
+                                                                                                    },
+                                                                                                    message:
+                                                                                                        'must be number',
+                                                                                                },
+                                                                                            ]
+                                                                                            return false
+                                                                                        }
+                                                                                        var valid0 = _errs39 === errors
+                                                                                    } else {
+                                                                                        var valid0 = true
+                                                                                    }
+                                                                                }
                                                                             }
                                                                         }
                                                                     }
@@ -11942,7 +12033,7 @@ function validate114(data, { instancePath = '', parentData, parentDataProperty, 
     validate114.errors = vErrors
     return errors === 0
 }
-const schema107 = {
+const schema108 = {
     additionalProperties: false,
     properties: {
         breakdownFilter: { $ref: '#/definitions/BreakdownFilter' },
@@ -11966,7 +12057,7 @@ const schema107 = {
     required: ['denominator', 'kind', 'metric_type', 'numerator'],
     type: 'object',
 }
-const schema110 = {
+const schema111 = {
     additionalProperties: false,
     properties: {
         ignore_zeros: { type: 'boolean' },
@@ -12012,7 +12103,7 @@ function validate122(data, { instancePath = '', parentData, parentDataProperty, 
             } else {
                 const _errs1 = errors
                 for (const key0 in data) {
-                    if (!func2.call(schema107.properties, key0)) {
+                    if (!func2.call(schema108.properties, key0)) {
                         validate122.errors = [
                             {
                                 instancePath,
@@ -12932,7 +13023,7 @@ function validate122(data, { instancePath = '', parentData, parentDataProperty, 
     validate122.errors = vErrors
     return errors === 0
 }
-const schema113 = {
+const schema114 = {
     additionalProperties: false,
     properties: {
         breakdownFilter: { $ref: '#/definitions/BreakdownFilter' },
@@ -12996,7 +13087,7 @@ function validate127(data, { instancePath = '', parentData, parentDataProperty, 
             } else {
                 const _errs1 = errors
                 for (const key0 in data) {
-                    if (!func2.call(schema113.properties, key0)) {
+                    if (!func2.call(schema114.properties, key0)) {
                         validate127.errors = [
                             {
                                 instancePath,
@@ -13495,7 +13586,7 @@ function validate127(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                                     keyword: 'enum',
                                                                                                     params: {
                                                                                                         allowedValues:
-                                                                                                            schema113
+                                                                                                            schema114
                                                                                                                 .properties
                                                                                                                 .start_handling
                                                                                                                 .enum,

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -27317,6 +27317,14 @@ class ExperimentFunnelMetricTypeProps(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
+    breakdownAttributionType: BreakdownAttributionType | None = Field(
+        default=BreakdownAttributionType.FIRST_TOUCH,
+        description="How to attribute the breakdown value across funnel steps.",
+    )
+    breakdownAttributionValue: int | None = Field(
+        default=None,
+        description=("When breakdownAttributionType is `step`, the 0-indexed step to attribute from."),
+    )
     funnel_order_type: StepOrderValue | None = None
     metric_type: Literal["funnel"] = "funnel"
     series: list[Annotated[EventsNode | ActionsNode | ExperimentDataWarehouseNode, Field(discriminator="kind")]]
@@ -27781,6 +27789,14 @@ class CalendarHeatmapQuery(BaseModel):
 class ExperimentFunnelMetric(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
+    )
+    breakdownAttributionType: BreakdownAttributionType | None = Field(
+        default=BreakdownAttributionType.FIRST_TOUCH,
+        description="How to attribute the breakdown value across funnel steps.",
+    )
+    breakdownAttributionValue: int | None = Field(
+        default=None,
+        description=("When breakdownAttributionType is `step`, the 0-indexed step to attribute from."),
     )
     breakdownFilter: BreakdownFilter | None = None
     conversion_window: int | None = None

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -6014,6 +6014,10 @@ export interface ExperimentMeanMetricApi {
 export type ExperimentFunnelMetricApiResponse = { [key: string]: unknown } | null
 
 export interface ExperimentFunnelMetricApi {
+    /** How to attribute the breakdown value across funnel steps. */
+    breakdownAttributionType?: BreakdownAttributionTypeApi | null
+    /** When breakdownAttributionType is `step`, the 0-indexed step to attribute from. */
+    breakdownAttributionValue?: number | null
     breakdownFilter?: BreakdownFilterApi | null
     conversion_window?: number | null
     conversion_window_unit?: FunnelConversionWindowTimeUnitApi | null

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -5176,6 +5176,10 @@ export interface ExperimentMeanMetricApi {
 export type ExperimentFunnelMetricApiResponse = { [key: string]: unknown } | null
 
 export interface ExperimentFunnelMetricApi {
+    /** How to attribute the breakdown value across funnel steps. */
+    breakdownAttributionType?: BreakdownAttributionTypeApi | null
+    /** When breakdownAttributionType is `step`, the 0-indexed step to attribute from. */
+    breakdownAttributionValue?: number | null
     breakdownFilter?: BreakdownFilterApi | null
     conversion_window?: number | null
     conversion_window_unit?: FunnelConversionWindowTimeUnitApi | null

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -4754,6 +4754,10 @@ export namespace Schemas {
     export type ExperimentFunnelMetricResponse = { [key: string]: unknown } | null;
 
     export interface ExperimentFunnelMetric {
+      /** How to attribute the breakdown value across funnel steps. */
+      breakdownAttributionType?: BreakdownAttributionType | null;
+      /** When breakdownAttributionType is `step`, the 0-indexed step to attribute from. */
+      breakdownAttributionValue?: number | null;
       breakdownFilter?: BreakdownFilter | null;
       conversion_window?: number | null;
       conversion_window_unit?: FunnelConversionWindowTimeUnit | null;


### PR DESCRIPTION
<!-- This has to stand on its own: a reader who opens no files should still know why the PR is necessary and what it does. Length tracks the change, so a small diff gets a few bullets rather than a full-length body, and a section you have nothing for gets one line or "None". -->

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
<!-- First line: what is different for a person, and who they are. A fix says what breaks; a feature says what someone can now do; a chore says who is blocked. The code path goes underneath. -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Experiment metric breakdowns currently attribute the breakdown value from the exposure event. That differs from insights funnels, where the breakdown is read from funnel events with a configurable attribution mode, and it produces null buckets whenever the exposure event doesn't carry the property.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

This PR adds `breakdownAttributionType` and `breakdownAttributionValue` to the `ExperimentFunnelMetric` type so we can store those values with the metric; no changes are needed for `breakdownLimit` since that value is already stored in the `breakdownFilter`.

We also include all generated files with the new fields.

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->
<!-- Don't recite pass counts for suites CI runs; the checks report those with more authority. Link the evidence instead (run, permalink, error tracking issue), and say what you did not check. Long transcripts go in a <details> block. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

![cat-type-small](https://github.com/user-attachments/assets/19fec63b-4adb-4231-89df-d1e9dcda8751)

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

No agent involved. Schema change was manual while generated code is... well, generated.

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
     - Public artifact: nothing in this PR — code, fixtures and sample data, comments, commit messages, or this description — carries material from the agent session that isn't already public. If the work drew on a customer conversation, ticket, or log, say so here and state that the committed data is invented. Renaming people, hosts, and identifiers does not clear real material; see AGENTS.md "Public open source repo guidance".
-->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way: what changed across the session. The reason the shipped design beats the obvious alternative goes in Changes instead, where a reviewer will actually see it.
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session — that applies to every part of this PR, not just this section.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Voice: the subject of every sentence is the change, never its author. No "I", "me" or "my" anywhere in the body. "I (actually Claude)" is worse than either half: it hands the assignee an account of work they did not do. Authorship is one stated fact in the Agent context section below.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Stack instead of stuffing: if the diff holds two or more separable steps (migration then behavior, rename then rewrite), open a stack rather than one big PR. See AGENTS.md, "Stacked PRs" and /stacking-prs.
- Simplify before opening: if your agent has a behavior-preserving cleanup pass (Claude Code: `/simplify`), run it on a non-trivial diff before final tests and preflight, since it edits the tree. Skip it for small mechanical changes.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- Shape and style: invoke the `/writing-pr-descriptions` skill before writing this body. In short: lead with the effect a person sees rather than the code path behind it, make the body stand alone for a reader who opens no files, size it to the change, link evidence rather than asserting what CI already reports, then hold what's left to one fact per bullet in under 25 words. A body that got longer as bullets was not cut.
-->