### PR TITLE
fix(desktop): make shared sessions read-only

### DIFF
--- a/products/desktop/packages/core/src/pi-runtime/piSessionAccess.test.ts
+++ b/products/desktop/packages/core/src/pi-runtime/piSessionAccess.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { canPromptPiSession } from "./piSessionAccess";
+
+describe("canPromptPiSession", () => {
+  it.each([
+    ["the session owner", "owner", "owner", true],
+    ["another user", "owner", "viewer", false],
+    ["a viewer whose identity is loading", "owner", undefined, false],
+    ["a session without an owner", undefined, "viewer", true],
+  ])("allows %s to prompt: %s", (_case, ownerUuid, userUuid, expected) => {
+    expect(canPromptPiSession(ownerUuid, userUuid)).toBe(expected);
+  });
+});

--- a/products/desktop/packages/core/src/pi-runtime/piSessionAccess.ts
+++ b/products/desktop/packages/core/src/pi-runtime/piSessionAccess.ts
@@ -1,0 +1,6 @@
+export function canPromptPiSession(
+  taskAuthorUuid: string | undefined,
+  currentUserUuid: string | undefined,
+): boolean {
+  return !taskAuthorUuid || taskAuthorUuid === currentUserUuid;
+}

--- a/products/desktop/packages/ui/src/features/pi-sessions/PiSessionView.tsx
+++ b/products/desktop/packages/ui/src/features/pi-sessions/PiSessionView.tsx
@@ -13,6 +13,7 @@ import {
   createEmptyPiExtensionTaskState,
   type PiExtensionTaskState,
 } from "@posthog/core/pi-runtime/piExtensionStore";
+import { canPromptPiSession } from "@posthog/core/pi-runtime/piSessionAccess";
 import {
   PiOperationError,
   type PiSessionController,
@@ -68,6 +69,7 @@ import {
   getPiPendingConfig,
   usePiPendingConfigStore,
 } from "./piPendingConfigStore";
+import { ReadOnlySessionNotice } from "./ReadOnlySessionNotice";
 
 const log = logger.scope("pi-session-view");
 
@@ -476,6 +478,10 @@ export function PiSessionView({ task, isCloud }: PiSessionViewProps) {
     currentUser?.uuid && task.created_by?.uuid
       ? currentUser.uuid === task.created_by.uuid
       : undefined;
+  const promptDisabledForOwnership = !canPromptPiSession(
+    task.created_by?.uuid,
+    currentUser?.uuid,
+  );
   const piSessionController = useService<PiSessionController>(
     PI_SESSION_CONTROLLER,
   );
@@ -723,7 +729,9 @@ export function PiSessionView({ task, isCloud }: PiSessionViewProps) {
             )}
           </>
         )}
-        {mcpPermission ? (
+        {promptDisabledForOwnership ? (
+          <ReadOnlySessionNotice />
+        ) : mcpPermission ? (
           isMcpPermissionResponding ? (
             <Skeleton className="h-24 w-full" />
           ) : (

--- a/products/desktop/packages/ui/src/features/pi-sessions/ReadOnlySessionNotice.stories.tsx
+++ b/products/desktop/packages/ui/src/features/pi-sessions/ReadOnlySessionNotice.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ReadOnlySessionNotice } from "./ReadOnlySessionNotice";
+
+const meta = {
+  title: "Features/Pi sessions/ReadOnlySessionNotice",
+  component: ReadOnlySessionNotice,
+  decorators: [
+    (Story) => (
+      <div className="mx-auto w-full max-w-3xl p-4">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof ReadOnlySessionNotice>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/products/desktop/packages/ui/src/features/pi-sessions/ReadOnlySessionNotice.tsx
+++ b/products/desktop/packages/ui/src/features/pi-sessions/ReadOnlySessionNotice.tsx
@@ -1,0 +1,11 @@
+import { Text } from "@posthog/quill";
+
+export function ReadOnlySessionNotice() {
+  return (
+    <div className="rounded-md border border-border bg-muted px-3 py-4 text-center">
+      <Text className="text-muted-foreground">
+        You can view this session, but only its owner can send messages.
+      </Text>
+    </div>
+  );
+}


### PR DESCRIPTION
## Problem

People viewing another user’s session in a public space see an active composer, although they cannot send messages to that session.

## Changes

- Another user’s session now replaces the composer and permission controls with a read-only notice.
- Sessions owned by the current user remain writable.
- Legacy sessions without an owner remain writable.

| Before | After |
| --- | --- |
| ![Before: another user sees an active session composer](https://raw.githubusercontent.com/PostHog/pr-assets/6e09d229178f332e37a3926f7f22b73c6635fcd8/2026/08/aa5464e2-7c8b-4519-a886-39c0e66f6f1e.png) | ![After: another user sees a read-only session notice](https://raw.githubusercontent.com/PostHog/pr-assets/f4c5577b70ed12434e3c36fdeabbbb6d68576ed6/2026/08/ebcba6c5-d1ed-4e96-a64c-a5477ed087ca.png) |

## How did you test this code?

- The ownership regression test covers owners, other users, loading identities, and ownerless sessions.
- The affected core and UI tests, typechecks, lint, formatting, preflight, and Storybook build pass.
- Storybook renders verified both states shown above.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation update is needed because the change only corrects an existing permission state.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented and verified the change with the /posthog-desktop, /writing-user-facing-copy, /storybook-stories, and /writing-pr-descriptions skills.

The screenshots use invented Storybook content and contain no session-derived customer data.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*