### PR TITLE
fix(slack): keep assistant chat available during runs

### DIFF
--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -1725,11 +1725,6 @@ def _handle_assistant_dm_message(
         _notify_missing_slack_scopes(slack, event, missing)
         return ROUTE_HANDLED_LOCALLY
 
-    try:
-        slack.client.assistant_threads_setStatus(channel_id=channel_id, thread_ts=thread_ts, status="Working on it…")
-    except Exception:
-        logger.warning("assistant_set_status_failed", exc_info=True)
-
     # Carry the channel the user was viewing (from assistant_thread_context_changed) so the agent
     # can ground a "look into this" DM in that channel's context.
     viewed = _get_assistant_channel_context(integration.id, channel_id, thread_ts)

--- a/products/slack_app/backend/tests/test_posthog_code_event_handler.py
+++ b/products/slack_app/backend/tests/test_posthog_code_event_handler.py
@@ -1511,7 +1511,7 @@ class TestAssistantEvents(TestCase):
                     "ts": "111.222",
                 }
             )
-            slack_cls.return_value.client.assistant_threads_setStatus.assert_called_once()
+            slack_cls.return_value.client.assistant_threads_setStatus.assert_not_called()
             mock_start.assert_called_once()
 
     def test_dm_message_ignores_bot_and_non_im(self):


### PR DESCRIPTION
## Problem

Slack Assistant Chat users could lose the ability to send an immediate follow-up while a run was active.

The DM handler set the Slack assistant thread status before handing the message to the task workflow. The task run already posts visible progress messages.

## Changes

- The Assistant DM path now starts the task workflow without setting Slack's assistant thread status.
- The handler test now asserts the DM path leaves the assistant status untouched.
- No screenshots: this changes Slack platform state, not rendered PostHog UI.

## How did you test this code?

- `uv run ruff check products/slack_app/backend/api.py products/slack_app/backend/tests/test_posthog_code_event_handler.py`
- Not run: `uv run pytest products/slack_app/backend/tests/test_posthog_code_event_handler.py::TestAssistantEvents::test_dm_message_starts_agent` needs local Postgres, which refused `127.0.0.1:5432`.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs update. This only changes Slack Assistant runtime behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Slack app made this small backend change from a Slack-reported Chat tab follow-up issue. Skills used: `/writing-tests` and `/writing-pr-descriptions`; the frontend guide was checked before the screenshot made the Slack app path clear.

The diff removes the Slack Assistant status call instead of clearing it later. The existing task run progress messages remain the visible working indicator.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1787084208893759)*