### PR TITLE
fix(alerts): remove real-time interval flag gate

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -262,7 +262,6 @@ export const FEATURE_FLAGS = {
     ALERTS_15_MINUTE_INTERVAL: 'alerts-15-minute-interval', // owner: #team-analytics-platform, gates 15-minute insight alert interval
     ALERTS_INLINE_NOTIFICATIONS: 'alerts-inline-notifications', // owner: @vdekrijger
     ALERTS_INVESTIGATION_AGENT: 'alerts-investigation-agent', // owner: @andrewm4894, anomaly alerts — investigation agent on firing
-    ALERTS_REAL_TIME_INTERVAL: 'alerts-real-time-interval', // owner: #team-analytics-platform, gates real-time (2-minute) insight alert interval
     AMPLITUDE_BATCH_IMPORT_OPTIONS: 'amplitude-batch-import-options', // owner: #team-ingestion
     ANOMALY_ALERT_GUIDANCE_EXPERIMENT: 'anomaly-alert-guidance',
     APPROVALS: 'approvals', // owner: @yasen-posthog #team-platform-features

--- a/products/alerts/frontend/components/AlertIntervalRow.tsx
+++ b/products/alerts/frontend/components/AlertIntervalRow.tsx
@@ -4,7 +4,6 @@ import { LemonSelect, Tooltip } from '@posthog/lemon-ui'
 
 import { TZLabel } from 'lib/components/TZLabel'
 import { upgradeModalLogic } from 'lib/components/UpgradeModal/upgradeModalLogic'
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { teamLogic } from 'scenes/teamLogic'
 import { userLogic } from 'scenes/userLogic'
@@ -66,7 +65,6 @@ export function AlertIntervalRow({
     const { currentTeam } = useValues(teamLogic)
     const hasHighFrequencyAlertsEntitlement = hasAvailableFeature(AvailableFeature.HIGH_FREQUENCY_ALERTS)
     const hasRealTimeAlertsEntitlement = hasAvailableFeature(AvailableFeature.REAL_TIME_ALERTS)
-    const realTimeAlertsEnabled = useFeatureFlag('ALERTS_REAL_TIME_INTERVAL')
 
     let evaluatedWindow: JSX.Element
     if (!supportsTimeWindow(alertForm.config)) {
@@ -135,8 +133,7 @@ export function AlertIntervalRow({
                             value={value}
                             options={getAlertIntervalOptions(
                                 hasHighFrequencyAlertsEntitlement,
-                                hasRealTimeAlertsEntitlement,
-                                realTimeAlertsEnabled || value === AlertCalculationInterval.REAL_TIME
+                                hasRealTimeAlertsEntitlement
                             )}
                             onChange={(interval) => {
                                 selectAlertCalculationInterval(interval, {

--- a/products/alerts/frontend/components/editAlertModalUtils.tsx
+++ b/products/alerts/frontend/components/editAlertModalUtils.tsx
@@ -74,11 +74,10 @@ export const ALERT_INTERVAL_OPTIONS: AlertCalculationInterval[] = [
 
 export function getAlertIntervalOptions(
     hasHighFrequencyAlertsEntitlement: boolean,
-    hasRealTimeAlertsEntitlement: boolean,
-    showRealTimeOption: boolean
+    hasRealTimeAlertsEntitlement: boolean
 ): Array<{ label: string | JSX.Element; value: AlertCalculationInterval }> {
     const intervals = [
-        ...(showRealTimeOption ? [AlertCalculationInterval.REAL_TIME] : []),
+        AlertCalculationInterval.REAL_TIME,
         AlertCalculationInterval.EVERY_15_MINUTES,
         ...ALERT_INTERVAL_OPTIONS,
     ]


### PR DESCRIPTION
## Problem

- Eligible alert users could access the real-time interval only while a fully rolled-out flag remained active.
- The flag no longer provides a rollout decision.

## Changes

- The interval selector now always includes the real-time option.
- The existing Scale and Enterprise entitlement still controls selection and server-side validation.
- No visible design change; eligible users retain the existing option.

## How did you test this code?

- Type checking covers the removed flag constant and updated interval-option signature.
- Formatting and linting cover the changed frontend files.
- No manual browser test run.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- No matching user-facing documentation mentions the removed rollout flag.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex removed the fully rolled-out alert interval flag gate.
- Skills invoked: /auditing-experiments-flags, /writing-pr-descriptions.
- The retained entitlement check protects access after flag removal.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*