### PR TITLE
fix(tasks): stop docker sandbox relaunching agent-server on top of a booting one

### DIFF
--- a/products/tasks/backend/logic/services/docker_sandbox.py
+++ b/products/tasks/backend/logic/services/docker_sandbox.py
@@ -78,6 +78,10 @@ SLIM_IMAGE_NAME = "posthog-sandbox-slim"
 _DOCKERFILE_SHA_LABEL = "com.posthog.sandbox.dockerfile-sha"
 _AGENT_VERSION_LABEL = "com.posthog.sandbox.agent-version"
 AGENT_SERVER_PORT = 47821  # Arbitrary high port unlikely to conflict with dev servers
+# Node + MCP init in a local container can take well over 10s when several sandboxes boot at
+# once (a coordinator tick dispatching a whole scout troop); a short budget makes the Temporal
+# retry relaunch on top of the still-booting first process.
+AGENT_SERVER_LAUNCH_HEALTH_MAX_ATTEMPTS = 120
 # Streamlit sandboxes expose their auth proxy (not the agent-server) on this port; the
 # host-published port maps to it so connect_info can reach the app across processes.
 
@@ -953,7 +957,7 @@ class DockerSandbox(SandboxBase):
         if result.exit_code != 0:
             logger.warning(f"Agent-server process failed to launch in sandbox {self.id}: {result.stderr}")
             return False
-        return self._wait_for_health_check(max_attempts=20)
+        return self._wait_for_health_check(max_attempts=AGENT_SERVER_LAUNCH_HEALTH_MAX_ATTEMPTS)
 
     def _install_gh_guard(self) -> None:
         """Install the gh PATH shim at runtime so it's present regardless of image age.
@@ -1003,6 +1007,17 @@ class DockerSandbox(SandboxBase):
 
         if self._host_port is None:
             raise RuntimeError("Sandbox was not created with port exposure.")
+
+        # A Temporal retry of the start activity lands here with the previous attempt's
+        # process possibly still booting. A second bind on the same port dies with
+        # EADDRINUSE and its fatal handler marks the run failed, so either adopt the
+        # existing server or clear it before launching.
+        if self._agent_server_is_healthy():
+            if wait_for_health:
+                self.wait_for_agent_server_ready(allowed_domains)
+            logger.info(f"Agent-server already healthy in sandbox {self.id}; skipping relaunch")
+            return
+        self._free_agent_server_port()
 
         repo_path: str | None = None
         if repository:
@@ -1210,6 +1225,21 @@ class DockerSandbox(SandboxBase):
         """Poll health endpoint until server is ready (single remote call)."""
 
         return wait_for_health_check(self.execute, self.id, AGENT_SERVER_PORT, max_attempts, poll_interval)
+
+    def _agent_server_is_healthy(self) -> bool:
+        return wait_for_health_check(self.execute, self.id, AGENT_SERVER_PORT, max_attempts=1, poll_interval=0.0)
+
+    def _free_agent_server_port(self) -> None:
+        # `[a]gent-server` matches the server's cmdline but not this command's own bash
+        # wrapper (a bare pattern TERMs the wrapper and the wait/KILL never run). PID 1 in
+        # the container is `tail -f /dev/null`, so the killed process lingers as a zombie;
+        # `-r RSD` keeps the wait from spinning on it.
+        self.execute(
+            "pkill -TERM -f '[a]gent-server' 2>/dev/null || true; "
+            "for _ in $(seq 1 10); do pgrep -r RSD -f '[a]gent-server' >/dev/null || break; sleep 0.5; done; "
+            "pkill -KILL -f '[a]gent-server' 2>/dev/null || true",
+            timeout_seconds=15,
+        )
 
     def read_agent_server_session_init_ms(self) -> int | None:
         return self._read_health_session_init_ms(AGENT_SERVER_PORT)

--- a/products/tasks/backend/logic/services/test_docker_sandbox.py
+++ b/products/tasks/backend/logic/services/test_docker_sandbox.py
@@ -111,6 +111,60 @@ class TestSandboxFactory:
 class TestDockerSandboxUnit:
     """Unit tests that don't require Docker."""
 
+    @pytest.fixture(autouse=True)
+    def _fresh_container(self):
+        # Launch tests mock `execute` to succeed, which would read as "server already
+        # healthy" and short-circuit start_agent_server before the command is built.
+        with (
+            patch.object(DockerSandbox, "_agent_server_is_healthy", return_value=False),
+            patch.object(DockerSandbox, "_free_agent_server_port"),
+        ):
+            yield
+
+    def test_start_agent_server_skips_relaunch_when_already_healthy(self) -> None:
+        sandbox = DockerSandbox.__new__(DockerSandbox)
+        sandbox._container_id = "abc123"
+        sandbox.id = "abc123"
+        sandbox.config = SandboxConfig(name="test")
+        sandbox._host_port = 12345
+
+        with (
+            patch.object(sandbox, "is_running", return_value=True),
+            patch.object(sandbox, "_agent_server_is_healthy", return_value=True),
+            patch.object(sandbox, "wait_for_agent_server_ready") as wait_for_ready,
+            patch.object(sandbox, "_free_agent_server_port") as mock_free,
+            patch.object(sandbox, "execute") as mock_execute,
+        ):
+            sandbox.start_agent_server("PostHog/posthog", "task-123", "run-456", "background")
+
+        wait_for_ready.assert_called_once_with(None)
+        mock_free.assert_not_called()
+        mock_execute.assert_not_called()
+
+    def test_start_agent_server_frees_port_before_relaunch(self) -> None:
+        sandbox = DockerSandbox.__new__(DockerSandbox)
+        sandbox._container_id = "abc123"
+        sandbox.id = "abc123"
+        sandbox.config = SandboxConfig(name="test")
+        sandbox._host_port = 12345
+        calls: list[str] = []
+
+        with (
+            patch.object(sandbox, "is_running", return_value=True),
+            patch.object(sandbox, "write_file"),
+            patch.object(sandbox, "_agent_server_is_healthy", return_value=False),
+            patch.object(sandbox, "_free_agent_server_port", side_effect=lambda: calls.append("free")),
+            patch.object(sandbox, "_wait_for_health_check", return_value=True),
+            patch.object(sandbox, "execute") as mock_execute,
+        ):
+            mock_execute.side_effect = lambda command, **kwargs: (
+                calls.append("launch") if "./node_modules/.bin/agent-server" in command else None,
+                MagicMock(exit_code=0, stdout="", stderr=""),
+            )[1]
+            sandbox.start_agent_server("PostHog/posthog", "task-123", "run-456", "background")
+
+        assert calls == ["free", "launch"]
+
     @pytest.mark.parametrize(
         "command",
         [

--- a/products/tasks/backend/logic/services/tests/test_docker_sandbox.py
+++ b/products/tasks/backend/logic/services/tests/test_docker_sandbox.py
@@ -39,6 +39,8 @@ def test_wait_for_agent_server_ready_timeout_is_retryable_and_not_captured(sandb
 def test_start_agent_server_health_check_timeout_is_retryable_and_not_captured(sandbox: DockerSandbox):
     with (
         patch.object(sandbox, "is_running", return_value=True),
+        patch.object(sandbox, "_agent_server_is_healthy", return_value=False),
+        patch.object(sandbox, "_free_agent_server_port"),
         patch.object(sandbox, "write_file"),
         patch.object(sandbox, "_build_agent_server_command", return_value="run-agent-server"),
         patch.object(sandbox, "_launch_and_check", return_value=False),


### PR DESCRIPTION
## Problem

- A local task run (any Docker-sandbox run, including every locally dispatched scout) fails with `EADDRINUSE :::47821` even though its agent-server came up fine.
- The launch health check gives the server 10 seconds. Node and MCP init in a local container takes 8 to 12 seconds alone, and longer when a coordinator tick boots a whole troop.
- The Temporal retry of `start_agent_server` then launches a second agent-server in the same container. Its bind fails and its fatal handler marks the run failed.

## Changes

- `DockerSandbox.start_agent_server` adopts an already-healthy server instead of relaunching, and otherwise frees the port before it launches. This mirrors what `ModalSandbox` already does.
- The launch health check budget rises from 20 attempts to 120, the same order as Modal.
- The port-freeing command uses the `[a]gent-server` pattern so `pkill` does not TERM its own bash wrapper, and `pgrep -r RSD` so the wait does not spin on the zombie that PID 1 (`tail -f /dev/null`) never reaps.

## How did you test this code?

- New unit tests: `start_agent_server` skips the launch when the server is already healthy, and frees the port before launching when it is not. Neither path existed before.
- Manually on a local stack: one solo scout run and three concurrent runs all completed; before the change the concurrent case failed with `EADDRINUSE`.
- Not run: the Docker-backed integration tests.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5). Root cause found while debugging local scout runs from the scouts-work session; the fix was written and verified locally on 2026-08-18, then pushed on request. Skills invoked: `/writing-pr-descriptions`.
