### PR TITLE
fix(workflows): tolerate unusable email sender overrides

### DIFF
--- a/nodejs/src/cdp/services/messaging/email.service.test.ts
+++ b/nodejs/src/cdp/services/messaging/email.service.test.ts
@@ -328,13 +328,18 @@ describe('EmailService', () => {
                 ['a list of addresses', 'a@posthog.com, b@posthog.com'],
                 ['an RFC-822 formatted address', '"Name" <a@posthog.com>'],
                 ['a value that is not an email address', 'not-an-email'],
-            ])('rejects %s without calling SES', async (_desc, email) => {
+            ])('discards %s and sends from the integration sender', async (_desc, email) => {
                 invocation.queueParameters = createEmailParams({
                     from: { integrationId: 1, email },
                 })
                 const result = await service.executeSendEmail(invocation)
-                expect(result.error).toContain(`"${email}"`)
-                expect(sendEmailSpy).not.toHaveBeenCalled()
+                // Failing the send would break every step still carrying the placeholder address
+                // an old sender picker wrote, so an unusable override degrades to the integration's
+                // own sender. The unverified address must never reach the provider either way.
+                expect(result.error).toBeUndefined()
+                const sentCommand = sendEmailSpy.mock.calls[0][0] as { input: any }
+                expect(sentCommand.input.FromEmailAddress).toBe('"Test User" <test@posthog.com>')
+                expect(result.logs.some((log) => log.level === 'warn' && log.message.includes(email))).toBe(true)
             })
         })
         describe('email sending', () => {

--- a/nodejs/src/cdp/services/messaging/email.service.ts
+++ b/nodejs/src/cdp/services/messaging/email.service.ts
@@ -230,7 +230,7 @@ export class EmailService {
                 )
             }
 
-            const from = this.resolveFromSender(integration, params.from)
+            const from = this.resolveFromSender(integration, params.from, addLog)
 
             // Single choke point for the suppression check — every send path lands here regardless
             // of whether the invocation came from a workflow action or an email destination hog
@@ -480,7 +480,8 @@ export class EmailService {
 
     private resolveFromSender(
         integration: IntegrationType,
-        from: CyclotronInvocationQueueParametersEmailType['from']
+        from: CyclotronInvocationQueueParametersEmailType['from'],
+        addLog: ReturnType<typeof createAddLogFunction>
     ): { email: string; name: string } {
         if (!integration.config.verified) {
             throw new Error('The selected email integration domain is not verified')
@@ -495,25 +496,34 @@ export class EmailService {
         const overrideName = from.name ? sanitizeFromName(from.name) : ''
 
         return {
-            email: this.resolveFromEmailAddress(integration, from.email?.trim()),
+            email: this.resolveFromEmailAddress(integration, from.email?.trim(), addLog),
             name: overrideName || integration.config.name,
         }
     }
 
-    private resolveFromEmailAddress(integration: IntegrationType, overrideEmail: string | undefined): string {
+    // An unusable override degrades to the integration's own sender rather than failing the send.
+    // Steps authored before mid-2026 carry a placeholder address written by an old sender picker,
+    // so throwing here fails sends whose author never typed an address at all.
+    private resolveFromEmailAddress(
+        integration: IntegrationType,
+        overrideEmail: string | undefined,
+        addLog: ReturnType<typeof createAddLogFunction>
+    ): string {
         if (!overrideEmail) {
             return integration.config.email
         }
 
         if (!FROM_OVERRIDE_EMAIL_REGEX.test(overrideEmail)) {
-            throw new Error(
-                `The custom sender address "${overrideEmail}" is not a valid email address. Fix the From address in the workflow's email step so it resolves to a single valid address.`
+            addLog(
+                'warn',
+                `Ignoring the custom sender address "${overrideEmail}": it is not a valid email address. Sending from ${integration.config.email} instead. Fix the From address in the workflow's email step so it resolves to a single valid address.`
             )
+            return integration.config.email
         }
 
         // Verification is domain-level (the DNS records cover the whole domain), so any address
         // on the integration's domain is exactly as verified as the integration's own address.
-        // Anything off-domain must fail: allowing it would let a workflow send as a domain the
+        // Anything off-domain is discarded: honoring it would let a workflow send as a domain the
         // team never proved ownership of.
         const integrationDomain: string = (
             integration.config.domain ??
@@ -522,9 +532,11 @@ export class EmailService {
         ).toLowerCase()
         const overrideDomain = overrideEmail.split('@')[1].toLowerCase()
         if (!integrationDomain || overrideDomain !== integrationDomain) {
-            throw new Error(
-                `The custom sender address "${overrideEmail}" is not on the verified domain "${integrationDomain}" of the selected sender. Use an address on that domain, or select a different sender in the workflow's email step.`
+            addLog(
+                'warn',
+                `Ignoring the custom sender address "${overrideEmail}": it is not on the verified domain "${integrationDomain}" of the selected sender. Sending from ${integration.config.email} instead. Use an address on that domain, or select a different sender in the workflow's email step.`
             )
+            return integration.config.email
         }
 
         return overrideEmail


### PR DESCRIPTION
## Problem

Workflow email steps configured in the app before June 2026 fail every send, and the author never typed the address that breaks them.

- The email step's sender picker read `integration.config.email_address` to prefill `from.email`. That key does not exist on an email integration, so the `?? 'default@example.com'` fallback persisted on every sender pick. Introduced in #35984, removed in #60438, never backfilled.
- The stored value was inert for a year. The runtime overwrote `from.email` with the integration's address, and after #60438 it ignored the field.
- #83059 made `from.email` load-bearing. `resolveFromEmailAddress` throws when the address sits outside the integration's verified domain, so a stored placeholder kills the send before the provider call.
- The editor reveals the placeholder as a custom sender address, so the step looks deliberately misconfigured to its owner.

Both regions are affected. The failure rate stepped up on the #83059 deploy and has held since.

## Changes

- An unusable sender override now falls back to the integration's stored sender instead of failing the send.
- The run log gets a warning naming the discarded address and the address used in its place.
- The domain guarantee is unchanged. An address outside the verified domain still never reaches the provider.
- The empty-override path already fell back, so this makes an unusable value behave like an absent one.
- Rejected alternative: reverting #83059. Sender rotation (#83356) now shares `resolveFromSender`, so a revert conflicts and withdraws a shipped feature to correct stored data.
- Rejected alternative: special-casing the `default@example.com` literal. A general fallback also covers off-domain values written by API and agent callers.

A backfill to strip the placeholder from stored workflows is worth doing separately. It is not needed to restore sending.

> [!NOTE]
> An off-domain override no longer surfaces as a send failure. Authoring-time validation is the right place for that signal, and it does not exist yet.

## How did you test this code?

Reproduced the failure on the local dev stack, then confirmed the fix against the same steps: a real event through capture, the real CDP worker, and a maildev-backed email integration verified on `posthog.com`.

Setup: cloned a local email workflow and set `from` to `{integrationId, email: "default@example.com"}`, the exact shape the old sender picker stored.

Before the fix, from `log_entries`:

```
error  The custom sender address "default@example.com" is not on the verified domain
       "posthog.com" of the selected sender.
error  Workflow encountered an error at [Action:action_function_email_...]
```

The maildev inbox stayed empty and `app_metrics2` recorded `email_failed`.

After the fix, same stored data and same event:

```
warn   Ignoring the custom sender address "default@example.com": it is not on the verified
       domain "posthog.com" of the selected sender. Sending from daniel.l@posthog.com instead.
info   Email sent to qa-recipient@posthog.com from Daniel L <daniel.l@posthog.com>
```

The message arrived with `From: daniel.l@posthog.com` and the metric moved to `email_sent`.

Each override below was written to the database, triggered by a captured event, and read back out of maildev:

| Stored `from.email` | Delivered | `From:` header |
| --- | --- | --- |
| `default@example.com` | yes | `daniel.l@posthog.com` |
| `community@posthog.com` | yes | `community@posthog.com` |
| `not-an-email` | yes | `daniel.l@posthog.com` |
| `sales@evil.com` | yes | `daniel.l@posthog.com` |

The five rewritten jest cases catch a regression no existing test covered: an override the author never set must not fail the send, and an unverified domain must still not reach the provider. They previously asserted the opposite for the first half.

Not checked: the SES transport. Sender resolution runs before the provider switch, so the local run exercises the same code path, and the SES identity assertions stay at the jest level rather than a live send. No screenshot, because no rendered surface changes.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No doc under `docs/` describes the email step sender.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (Opus 5) in Claude Code, directed by the assignee. Skills invoked: `/posthog-local-e2e-qa`, `/writing-user-facing-copy`, `/writing-pr-descriptions`.

The investigation started from a report that sends had broken without a config change, and worked backwards through the three PRs above. Production metrics fixed the start time to the #83059 deploy and showed both regions moving together, which ruled out #83356 as the trigger. The fix moved from matching the placeholder literal to a general fallback once the same failure mode showed up for any off-domain value.

The local repro data is invented: a cloned workflow, a test recipient address, and the placeholder literal from this repository's own git history.
