### PR TITLE
fix(cymbal): flush the SDK in the posthog capture test wait loop

### DIFF
--- a/rust/cymbal/tests/posthog_capture.rs
+++ b/rust/cymbal/tests/posthog_capture.rs
@@ -84,8 +84,12 @@ async fn pipeline_failure_is_captured_as_posthog_exception(db: PgPool) {
         reqwest::StatusCode::INTERNAL_SERVER_ERROR
     );
 
-    // The capture is fire-and-forget; wait for it to reach the mock server.
+    // The capture is fire-and-forget, and the SDK only buffers it: one event
+    // never reaches `flush_at`, so delivery would otherwise wait on the 5s
+    // `flush_interval_ms`. Flush every turn so this waits on the spawned send
+    // rather than racing that interval.
     for _ in 0..100 {
+        posthog_rs::flush().await;
         if capture.hits_async().await > 0 {
             break;
         }


### PR DESCRIPTION
## Problem

An engineer with a PR in the Trunk merge queue loses their place when this cymbal test flakes, and every entry behind them restarts CI.

- The test polls 100 times at 50ms for the captured `$exception` to reach its mock server, a 5000ms budget.
- One event never reaches the SDK's `flush_at` of 100, so delivery waits on the 5000ms `flush_interval_ms` default.
- Both deadlines fall on the same instant.
- The loop wins on iteration 99 of 100, so any delay over 50ms loses it.
- The failure signature is zero requests at the mock server, including the catch-all mock.

Refs #84781, which lists this test and asks each owning team for a root-cause deflake. The `retries` mitigation described there is not on master.

## Changes

- The wait loop calls `posthog_rs::flush()` on each turn, so it waits on the spawned send rather than the flush interval.
- `flush()` returns once the worker has attempted delivery of everything queued before the call, so the loop now exits on the first or second turn.

## How did you test this code?

Ran the test locally against Postgres and Redpanda containers. 20 consecutive passes with the fix, at 2.8s per run against 7.8s before it.

The margin was measured rather than inferred. A scratch test in `common-posthog` reproduced the buffered capture in isolation and ran the same loop shape:

<details>
<summary>Measured margin, 5 runs</summary>

```
iterations used: 99/100
first hit at:    Some(5.019074949s)
loop exited at:  5.019075039s
SLACK: 90ns (loop had 1 iterations to spare)
```

A separate run confirmed the mechanism: 4.95s of polling saw 0 requests, then `flush()` delivered in 6.9ms.
</details>

Not checked: the CI failure itself never reproduced locally. This sandbox has one CPU, so runner contention could not be simulated. The fix rests on the measured one-iteration margin plus the matching CI signature.

No new test. The change removes a race in an existing test's wait loop.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app from a [Slack thread](https://posthog.slack.com/archives/C09ADEV3AJD/p1787083500838049) about queue evictions on two unrelated PRs. Investigating those turned up this test as one cause.

Skills invoked: `/writing-tests`, `/fixing-flaky-tests`, `/writing-pr-descriptions`.

Raising the poll budget past 5s was the first option considered and rejected: it keeps the test waiting on a timer it does not control and leaves the same race one runner generation later. Flushing removes the dependency on the interval instead.

Nothing here draws on non-public material. The CI figures come from this repo's GitHub Actions runs and issue #84781.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09ADEV3AJD/p1787083500838049)*
