### PR TITLE
feat(surveys): expose survey response archives as a system table

### DIFF
--- a/posthog/hogql/database/schema/system.py
+++ b/posthog/hogql/database/schema/system.py
@@ -1086,7 +1086,7 @@ insight_variables: PostgresTable = PostgresTable(
     postgres_table_name="posthog_insightvariable",
     description="Reusable insight/dashboard template variables; one row per variable.",
     fields={
-        "id": IntegerDatabaseField(name="id", description="Variable id."),
+        "id": UUIDDatabaseField(name="id", description="Variable id (UUID)."),
         "team_id": IntegerDatabaseField(name="team_id"),
         "name": StringDatabaseField(name="name", description="Display name of the variable."),
         "type": StringDatabaseField(name="type", description="Variable type, e.g. 'String', 'Number', 'List', 'Date'."),

--- a/posthog/hogql/database/schema/system.py
+++ b/posthog/hogql/database/schema/system.py
@@ -1205,7 +1205,7 @@ surveys: PostgresTable = PostgresTable(
     access_control_creator_id_field="created_by_id",
     description="In-app surveys; one row per survey, including its questions and display configuration.",
     fields={
-        "id": IntegerDatabaseField(name="id", description="Survey id."),
+        "id": UUIDDatabaseField(name="id", description="Survey id (UUID)."),
         "team_id": IntegerDatabaseField(name="team_id"),
         "name": StringDatabaseField(name="name", description="Survey name."),
         "type": StringDatabaseField(name="type", description="Survey delivery type, e.g. 'popover', 'api', 'widget'."),

--- a/posthog/hogql/database/schema/system.py
+++ b/posthog/hogql/database/schema/system.py
@@ -1224,6 +1224,25 @@ surveys: PostgresTable = PostgresTable(
     },
 )
 
+survey_response_archives: PostgresTable = PostgresTable(
+    name="survey_response_archives",
+    postgres_table_name="posthog_surveyresponsearchive",
+    access_scope="survey",
+    access_control_id_field="survey_id",
+    description="Archived survey responses; one row per response hidden from survey results. Survey responses themselves are events, so join response_uuid to events.uuid.",
+    fields={
+        "id": UUIDDatabaseField(name="id", description="Archive record UUID."),
+        "team_id": IntegerDatabaseField(name="team_id"),
+        "survey_id": UUIDDatabaseField(
+            name="survey_id", description="Survey the archived response belongs to; joins to surveys.id."
+        ),
+        "response_uuid": UUIDDatabaseField(
+            name="response_uuid", description="UUID of the event holding the response; joins to events.uuid."
+        ),
+        "archived_at": DateTimeDatabaseField(name="archived_at", description="When the response was archived."),
+    },
+)
+
 teams: PostgresTable = PostgresTable(
     name="teams",
     postgres_table_name="posthog_team",
@@ -2873,6 +2892,7 @@ class SystemTables(TableNode):
         "_ticket_assignee_roles": TableNode(name="_ticket_assignee_roles", table=ticket_assignee_roles, hidden=True),
         "support_tickets": TableNode(name="support_tickets", table=support_tickets),
         "surveys": TableNode(name="surveys", table=surveys),
+        "survey_response_archives": TableNode(name="survey_response_archives", table=survey_response_archives),
         "_task_public_channels": TableNode(name="_task_public_channels", table=task_public_channels, hidden=True),
         "task_runs": TableNode(name="task_runs", table=task_runs),
         "tags": TableNode(name="tags", table=tags),

--- a/posthog/hogql/database/schema/test/test_system_tables.py
+++ b/posthog/hogql/database/schema/test/test_system_tables.py
@@ -50,7 +50,7 @@ from products.logs.backend.models import LogsAlertConfiguration, LogsView
 from products.notebooks.backend.models import Notebook, ResourceNotebook
 from products.product_analytics.backend.models.insight import Insight
 from products.product_analytics.backend.models.insight_variable import InsightVariable
-from products.surveys.backend.models import Survey
+from products.surveys.backend.models import Survey, SurveyResponseArchive
 from products.warehouse_sources.backend.facade.models import (
     DataWarehouseTable as DataWarehouseTableModel,
     ExternalDataJob,
@@ -675,6 +675,14 @@ def _create_survey(team: Team, label: str) -> Survey:
     return Survey.objects.create(team=team, name=f"survey_{label}", type="popover")
 
 
+def _create_survey_response_archive(team: Team, label: str) -> SurveyResponseArchive:
+    return SurveyResponseArchive.objects.create(
+        team=team,
+        survey=_create_survey(team, f"archived_{label}"),
+        response_uuid=uuid.uuid4(),
+    )
+
+
 def _create_public_task_channel(team: Team, label: str):
     Channel = apps.get_model("tasks", "Channel")
 
@@ -860,6 +868,7 @@ SYSTEM_TABLE_FACTORIES = [
     ("session_recordings", _create_session_recording),
     ("source_schemas", _create_source_schema),
     ("support_tickets", _create_support_ticket),
+    ("survey_response_archives", _create_survey_response_archive),
     ("surveys", _create_survey),
     ("_task_public_channels", _create_public_task_channel),
     ("tags", _create_tag),

--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -10227,7 +10227,7 @@
                   "name": "id",
                   "schema_valid": true,
                   "table": null,
-                  "type": "integer"
+                  "type": "string"
               },
               "name": {
                   "chain": null,
@@ -20506,7 +20506,7 @@
                   "name": "id",
                   "schema_valid": true,
                   "table": null,
-                  "type": "integer"
+                  "type": "string"
               },
               "name": {
                   "chain": null,

--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -8363,7 +8363,7 @@
                   "name": "id",
                   "schema_valid": true,
                   "table": null,
-                  "type": "integer"
+                  "type": "string"
               },
               "name": {
                   "chain": null,
@@ -18642,7 +18642,7 @@
                   "name": "id",
                   "schema_valid": true,
                   "table": null,
-                  "type": "integer"
+                  "type": "string"
               },
               "name": {
                   "chain": null,

--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -10315,6 +10315,55 @@
           "row_count": null,
           "type": "system"
       },
+      "system.survey_response_archives": {
+          "certification": null,
+          "fields": {
+              "id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "id",
+                  "id": null,
+                  "name": "id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "survey_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "survey_id",
+                  "id": null,
+                  "name": "survey_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "response_uuid": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "response_uuid",
+                  "id": null,
+                  "name": "response_uuid",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "archived_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "archived_at",
+                  "id": null,
+                  "name": "archived_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              }
+          },
+          "id": "system.survey_response_archives",
+          "name": "system.survey_response_archives",
+          "row_count": null,
+          "type": "system"
+      },
       "system.task_runs": {
           "certification": null,
           "fields": {
@@ -20542,6 +20591,55 @@
           },
           "id": "system.surveys",
           "name": "system.surveys",
+          "row_count": null,
+          "type": "system"
+      },
+      "system.survey_response_archives": {
+          "certification": null,
+          "fields": {
+              "id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "id",
+                  "id": null,
+                  "name": "id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "survey_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "survey_id",
+                  "id": null,
+                  "name": "survey_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "response_uuid": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "response_uuid",
+                  "id": null,
+                  "name": "response_uuid",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "archived_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "archived_at",
+                  "id": null,
+                  "name": "archived_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              }
+          },
+          "id": "system.survey_response_archives",
+          "name": "system.survey_response_archives",
           "row_count": null,
           "type": "system"
       },

--- a/posthog/hogql/database/test/test_postgres_table.py
+++ b/posthog/hogql/database/test/test_postgres_table.py
@@ -4,7 +4,7 @@ from typing import Literal
 from posthog.test.base import BaseTest
 
 from django.apps import apps
-from django.db.models import ForeignKey, Model
+from django.db.models import ForeignKey, Model, UUIDField
 from django.test import SimpleTestCase
 from django.urls import get_resolver
 
@@ -429,6 +429,32 @@ class TestPostgresTablePrimaryKey(BaseTest):
             f"system.{table_name} has access_scope='{table.access_scope}' "
             f"but no single-column primary key (composite PK). "
             f"Object-level access control requires a single-column PK."
+        )
+
+
+class TestPostgresTableIdFieldType(SimpleTestCase):
+    """A UUID primary key must never be declared as an integer.
+
+    The declared type is what `system.information_schema` and the SQL editor report, and what the
+    resolver keys its UUID-literal validation off — so an integer declaration on a UUID column
+    misdocuments joins between system tables and swallows the friendly HogQL error for
+    `WHERE id = 'not-a-uuid'`, leaving a raw ClickHouse CANNOT_PARSE_UUID instead."""
+
+    @parameterized.expand(ALL_POSTGRES_SYSTEM_TABLES)
+    def test_uuid_pk_is_not_declared_as_an_integer(self, table_name: str, table: PostgresTable) -> None:
+        if not isinstance(table.fields.get("id"), IntegerDatabaseField):
+            return
+
+        model = _model_by_pg_table().get(table.postgres_table_name)
+        if model is None:
+            return
+
+        pk = model._meta.pk
+        self.assertNotIsInstance(
+            pk,
+            UUIDField,
+            f"system.{table_name}.id is declared as IntegerDatabaseField, but {model.__name__}'s "
+            f"primary key is a UUID column. Use UUIDDatabaseField.",
         )
 
 

--- a/products/posthog_ai/skills/querying-posthog-data/references/models-surveys.md
+++ b/products/posthog_ai/skills/querying-posthog-data/references/models-surveys.md
@@ -69,9 +69,27 @@ Column | Type | Nullable | Description
 
 - **Feature Flags**: Multiple flag relationships via `system.feature_flags`
 - **Insight**: `linked_insight_id` -> `system.insights.id`
+- **Archived responses**: `system.survey_response_archives.survey_id` -> `system.surveys.id`
 
 ### Important Notes
 
 - Survey name must be unique per team
 - Internal flags (`targeting_flag`, `internal_targeting_flag`, `internal_response_sampling_flag`) are auto-managed
 - `linked_flag` is user-managed and optional
+
+## SurveyResponseArchive (`system.survey_response_archives`)
+
+Survey responses are stored as events, so archiving one is recorded in Postgres instead. One row per archived (hidden) response.
+
+### Columns
+
+Column | Type | Nullable | Description
+`id` | uuid | NOT NULL | Primary key (UUID)
+`survey_id` | uuid | NOT NULL | FK to `system.surveys.id`
+`response_uuid` | uuid | NOT NULL | UUID of the event representing the response — join to `events.uuid`
+`archived_at` | timestamp with tz | NOT NULL | When the response was archived
+
+### Important Notes
+
+- To exclude archived responses from a survey's results, anti-join the survey events against this table on `events.uuid = survey_response_archives.response_uuid`
+- `(team_id, response_uuid)` is unique


### PR DESCRIPTION
## Problem

Survey responses live as events, so "archived" (hidden) responses are tracked in a separate Postgres table rather than in ClickHouse. That table wasn't exposed to HogQL, so anyone querying survey responses in SQL — an insight, a saved query, or the AI agent — silently counted responses the survey UI hides.

## Changes

- Adds `system.survey_response_archives`, backed by `posthog_surveyresponsearchive`, exposing `id`, `survey_id`, `response_uuid`, and `archived_at`.
- Scoped to the `survey` access scope with `access_control_id_field="survey_id"`: rows are children of a Survey, not the access-controlled object themselves, so object-level denials on a survey have to filter the FK.
- Documents the table and the anti-join pattern (`events.uuid = survey_response_archives.response_uuid`) in the surveys query reference.
- Fixes two tables that declared a UUID primary key as an integer (`system.surveys`, `system.insight_variables`). The wrong type reached schema introspection and suppressed the friendly HogQL error on an invalid UUID literal. Emitted SQL is unchanged.

No ClickHouse migration is involved — `PostgresTable` reads live via ClickHouse's `postgresql(...)` table function.

## How did you test this code?

Automated tests only; the agent could not run them locally (no Python environment or database available in this session), so CI is the evidence.

Two tests were added:

- A factory for the new table in `SYSTEM_TABLE_FACTORIES` (`test_system_tables.py`). The existing coverage guard requires one, and the parameterized isolation test it feeds proves a team cannot read another team's archive rows through the federated read.
- `TestPostgresTableIdFieldType` in `test_postgres_table.py`, which fails any `PostgresTable` declaring `id` as `IntegerDatabaseField` when the Django model's primary key is a `UUIDField`. This catches the defect fixed above, which had already recurred across two tables.

The rest of the change is covered by the existing system-table contract tests, which assert the access-scope, `access_control_id_field`, creator-field, and single-column-PK rules for every registered table.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code (PostHog Desktop), with `/writing-tests` invoked before adding the two tests.

Two decisions worth flagging. First, access-control shape: archive rows aren't Survey objects, so `access_control_creator_id_field` is deliberately left unset and `access_control_id_field` points at the parent FK — the inverse of how `system.surveys` itself is declared. Second, review feedback on the mistyped `id` column was applied beyond the one table it was filed against, since the same mistake already existed elsewhere; the guard test is what keeps it from returning.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
