### PR TITLE
feat(warehouse-sources): promote App Store Connect source to beta

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/app_store_connect/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/app_store_connect/source.py
@@ -57,7 +57,7 @@ class AppStoreConnectSource(ResumableSource[AppStoreConnectSourceConfig, AppStor
             name=SchemaExternalDataSourceType.APP_STORE_CONNECT,
             category=DataWarehouseSourceCategory.ANALYTICS,
             label="Apple (App Store Connect)",
-            releaseStatus=ReleaseStatus.ALPHA,
+            releaseStatus=ReleaseStatus.BETA,
             keywords=["app store", "ios", "apple", "mobile analytics"],
             caption="""Pull your App Store apps, versions, builds, reviews and sales reports into the PostHog Data warehouse.
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/app_store_connect/tests/test_app_store_connect_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/app_store_connect/tests/test_app_store_connect_source.py
@@ -51,12 +51,12 @@ class TestAppStoreConnectSource:
     def test_source_type(self) -> None:
         assert AppStoreConnectSource().source_type == ExternalDataSourceType.APPSTORECONNECT
 
-    def test_source_is_visible_and_labelled_alpha(self) -> None:
+    def test_source_is_visible_and_labelled_beta(self) -> None:
         config = AppStoreConnectSource().get_source_config
 
         # `unreleasedSource` hides a source from users entirely; a finished source must not set it.
         assert not config.unreleasedSource
-        assert config.releaseStatus == ReleaseStatus.ALPHA
+        assert config.releaseStatus == ReleaseStatus.BETA
         assert config.category == DataWarehouseSourceCategory.ANALYTICS
         assert config.docsUrl is not None
 


### PR DESCRIPTION
## Problem

Teams connecting the Apple (App Store Connect) data-warehouse source saw it labelled alpha, signalling it was new and lightly tested. The source has since proven stable enough for a beta label.

- Used by 51 teams over the last 7 days (beta needs 30+).
- Import error rate of 2.1% over the last 7 days (beta needs under 5%).

## Changes

- Set `releaseStatus` to `ReleaseStatus.BETA` on the App Store Connect source config.
- Updated the source test to assert the beta status.
- No connector behaviour, schema, or sync logic changed. This is a status promotion only.

## How did you test this code?

- Ran `test_app_store_connect_source.py::TestAppStoreConnectSource::test_source_is_visible_and_labelled_beta`; it passes.
- The test asserts the config reports `ReleaseStatus.BETA` and stays visible (no `unreleasedSource`), catching a regression that reverts the promotion.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The label is not part of the user-facing source doc.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Invoked `/implementing-warehouse-sources` to confirm where the release status lives and `/writing-pr-descriptions` for this body. The change is a one-value flip from alpha to beta plus its test. Searched open PRs (excluding `app/posthog`) by source name, `releaseStatus`, and promote terms, and scanned the maintainer's own open PRs; found no duplicate promotion.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
