### PR TITLE
chore: Add issue dismiss and new "enabled but no data" state to health overview 

### DIFF
--- a/frontend/src/scenes/web-analytics/health/HealthStatusTab.tsx
+++ b/frontend/src/scenes/web-analytics/health/HealthStatusTab.tsx
@@ -1,16 +1,22 @@
 import { useActions, useValues } from 'kea'
 
 import { IconRefresh } from '@posthog/icons'
-import { LemonBanner, LemonButton, LemonSkeleton } from '@posthog/lemon-ui'
+import { LemonBanner, LemonButton, LemonSkeleton, LemonSwitch } from '@posthog/lemon-ui'
 
 import { HealthCheckSection } from './components/HealthCheckSection'
-import { HealthCheck } from './healthCheckTypes'
+import { HealthCheck, HealthCheckStatus } from './healthCheckTypes'
 import { webAnalyticsHealthLogic } from './webAnalyticsHealthLogic'
 
 export function HealthStatusTab(): JSX.Element {
-    const { overallHealthStatus, checksByCategory, healthIssuesLoading, refreshDisabledReason } =
-        useValues(webAnalyticsHealthLogic)
-    const { refreshHealthChecks, trackSectionToggled } = useActions(webAnalyticsHealthLogic)
+    const {
+        overallHealthStatus,
+        checksByCategory,
+        healthIssuesLoading,
+        refreshDisabledReason,
+        hasDismissedChecks,
+        showDismissed,
+    } = useValues(webAnalyticsHealthLogic)
+    const { refreshHealthChecks, trackSectionToggled, setShowDismissed } = useActions(webAnalyticsHealthLogic)
 
     return (
         <div className="mt-4 space-y-4 max-w-4xl">
@@ -23,6 +29,18 @@ export function HealthStatusTab(): JSX.Element {
                 loading={healthIssuesLoading}
                 refreshDisabledReason={refreshDisabledReason}
             />
+
+            {hasDismissedChecks && (
+                <div className="flex justify-end">
+                    <LemonSwitch
+                        label="Show dismissed"
+                        checked={showDismissed}
+                        onChange={setShowDismissed}
+                        size="small"
+                        data-attr="web-analytics-health-show-dismissed"
+                    />
+                </div>
+            )}
 
             <div className="space-y-3">
                 <HealthCheckSection
@@ -51,7 +69,7 @@ export function HealthStatusTab(): JSX.Element {
 }
 
 interface OverallHealthBannerProps {
-    status: 'success' | 'warning' | 'error' | 'loading'
+    status: HealthCheckStatus
     summary: string
     passedCount: number
     totalCount: number
@@ -78,7 +96,7 @@ function OverallHealthBanner({
         )
     }
 
-    const bannerType = status === 'success' ? 'success' : status === 'error' ? 'error' : 'warning'
+    const bannerType = status === 'success' || status === 'info' ? 'success' : status === 'error' ? 'error' : 'warning'
 
     return (
         <LemonBanner type={bannerType}>

--- a/frontend/src/scenes/web-analytics/health/components/HealthCheckItem.tsx
+++ b/frontend/src/scenes/web-analytics/health/components/HealthCheckItem.tsx
@@ -1,7 +1,7 @@
 import { useActions } from 'kea'
 
-import { IconCheck, IconWarning, IconX } from '@posthog/icons'
-import { LemonButton, LemonSkeleton } from '@posthog/lemon-ui'
+import { IconCheck, IconEllipsis, IconInfo, IconWarning, IconX } from '@posthog/icons'
+import { LemonButton, LemonMenu, LemonSkeleton, LemonTag } from '@posthog/lemon-ui'
 
 import { Link } from 'lib/lemon-ui/Link'
 import { isExternalLink } from 'lib/utils/url'
@@ -14,7 +14,8 @@ interface HealthCheckItemProps {
 }
 
 export function HealthCheckItem({ check }: HealthCheckItemProps): JSX.Element {
-    const { trackActionClicked } = useActions(webAnalyticsHealthLogic)
+    const { trackActionClicked, setIssueDismissed } = useActions(webAnalyticsHealthLogic)
+    const issueId = check.issueId
 
     const handleActionClick = (): void => {
         trackActionClicked(check.id, check.category, check.status, check.urgent ?? false)
@@ -22,7 +23,11 @@ export function HealthCheckItem({ check }: HealthCheckItemProps): JSX.Element {
     }
 
     return (
-        <div className="flex items-start gap-3 p-3 rounded border border-primary/10 bg-surface-primary">
+        <div
+            className={`flex items-start gap-3 p-3 rounded border border-primary/10 bg-surface-primary ${
+                check.dismissed ? 'opacity-60' : ''
+            }`}
+        >
             <StatusIcon status={check.status} urgent={check.urgent} />
             <div className="flex-1 min-w-0">
                 <div className="flex items-center gap-2">
@@ -31,6 +36,7 @@ export function HealthCheckItem({ check }: HealthCheckItemProps): JSX.Element {
                     ) : (
                         <span className="font-medium">{check.title}</span>
                     )}
+                    {check.dismissed && <LemonTag type="muted">Dismissed</LemonTag>}
                     {check.docsUrl && (
                         <Link to={check.docsUrl} target="_blank" className="text-xs text-muted">
                             Docs
@@ -41,7 +47,7 @@ export function HealthCheckItem({ check }: HealthCheckItemProps): JSX.Element {
                     {check.status === 'loading' ? <LemonSkeleton className="w-32 h-4" /> : check.description}
                 </div>
             </div>
-            {check.action && (
+            {check.action && !check.dismissed && (
                 <div className="flex-shrink-0">
                     {check.action.to ? (
                         <LemonButton
@@ -60,6 +66,25 @@ export function HealthCheckItem({ check }: HealthCheckItemProps): JSX.Element {
                             {check.action.label}
                         </LemonButton>
                     ) : null}
+                </div>
+            )}
+            {issueId && (
+                <div className="flex-shrink-0">
+                    <LemonMenu
+                        items={[
+                            check.dismissed
+                                ? { label: 'Restore', onClick: () => setIssueDismissed(issueId, false) }
+                                : { label: 'Dismiss', onClick: () => setIssueDismissed(issueId, true) },
+                        ]}
+                    >
+                        <LemonButton
+                            type="tertiary"
+                            size="small"
+                            icon={<IconEllipsis />}
+                            aria-label="Issue options"
+                            data-attr="web-analytics-health-issue-menu"
+                        />
+                    </LemonMenu>
                 </div>
             )}
         </div>
@@ -82,6 +107,12 @@ function StatusIcon({ status, urgent }: { status: HealthCheckStatus; urgent?: bo
             return (
                 <div className="w-6 h-6 rounded-full bg-success-highlight flex items-center justify-center flex-shrink-0">
                     <IconCheck className="text-success w-4 h-4" />
+                </div>
+            )
+        case 'info':
+            return (
+                <div className="w-6 h-6 rounded-full bg-fill-info-secondary flex items-center justify-center flex-shrink-0">
+                    <IconInfo className="text-info w-4 h-4" />
                 </div>
             )
         case 'warning':

--- a/frontend/src/scenes/web-analytics/health/components/HealthCheckSection.tsx
+++ b/frontend/src/scenes/web-analytics/health/components/HealthCheckSection.tsx
@@ -36,9 +36,10 @@ export function HealthCheckSection({
     onToggle,
 }: HealthCheckSectionProps): JSX.Element {
     const config = CATEGORY_CONFIG[category]
-    const passedCount = checks.filter((c) => c.status === 'success').length
-    const totalCount = checks.length
-    const hasIssues = checks.some((c) => c.status === 'warning' || c.status === 'error')
+    const counted = checks.filter((c) => !c.dismissed)
+    const passedCount = counted.filter((c) => c.status === 'success' || c.status === 'info').length
+    const totalCount = counted.length
+    const hasIssues = counted.some((c) => c.status === 'warning' || c.status === 'error')
 
     const handleChange = (activeKey: HealthCheckCategory | null): void => {
         onToggle?.(category, activeKey === category)

--- a/frontend/src/scenes/web-analytics/health/healthCheckTypes.ts
+++ b/frontend/src/scenes/web-analytics/health/healthCheckTypes.ts
@@ -1,4 +1,4 @@
-export type HealthCheckStatus = 'success' | 'warning' | 'error' | 'loading'
+export type HealthCheckStatus = 'success' | 'info' | 'warning' | 'error' | 'loading'
 
 export type HealthCheckCategory = 'events' | 'configuration' | 'performance'
 
@@ -17,6 +17,8 @@ export interface HealthCheck {
     action?: HealthCheckAction
     docsUrl?: string
     urgent?: boolean
+    issueId?: string
+    dismissed?: boolean
 }
 
 export interface OverallHealthStatus {

--- a/frontend/src/scenes/web-analytics/health/webAnalyticsHealthLogic.ts
+++ b/frontend/src/scenes/web-analytics/health/webAnalyticsHealthLogic.ts
@@ -2,6 +2,7 @@ import { MakeLogicType, actions, afterMount, connect, kea, listeners, path, redu
 import { loaders } from 'kea-loaders'
 
 import api, { ApiError } from 'lib/api'
+import { healthSummaryLogic } from 'lib/components/HelpMenu/healthSummaryLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
@@ -40,6 +41,7 @@ interface WebHealthCheckConfig {
     title: string
     passingDescription: string
     failingDescription: string
+    infoDescription?: string
     passingAction?: HealthCheckAction
     failingAction?: HealthCheckAction
     docsUrl?: string
@@ -139,9 +141,11 @@ const WEB_HEALTH_CHECKS: WebHealthCheckConfig[] = [
         passingDescription: 'LCP, INP, and CLS are being tracked. You can monitor your real user experience!',
         failingDescription:
             'Core Web Vitals (LCP, INP, CLS) measure real user experience. Google uses these metrics for search ranking.',
-        passingAction: { label: 'View Web Vitals', to: '/web/web-vitals' },
+        infoDescription:
+            "Web vitals is enabled. We haven't received any $web_vitals events yet, which can take a few minutes after enabling. If it persists, check that you're on a recent posthog-js version.",
+        passingAction: { label: 'View web vitals', to: '/web/web-vitals' },
         failingAction: {
-            label: 'Enable Web Vitals',
+            label: 'Enable web vitals',
             to: urls.settings('environment-web-analytics', 'web-vitals-autocapture'),
         },
         docsUrl: 'https://posthog.com/docs/web-analytics/web-vitals',
@@ -155,6 +159,7 @@ export interface webAnalyticsHealthLogicValues {
     activeIssuesByKind: Record<string, HealthIssue>
     allChecks: HealthCheck[]
     checksByCategory: Record<HealthCheckCategory, HealthCheck[]>
+    hasDismissedChecks: boolean
     hasIssues: boolean
     hasUrgentIssues: boolean
     healthIssues: HealthIssuesResponse | null
@@ -163,6 +168,7 @@ export interface webAnalyticsHealthLogicValues {
     now: number
     overallHealthStatus: OverallHealthStatus
     refreshDisabledReason: string | null
+    showDismissed: boolean
     urgentFailedChecks: HealthCheck[]
 }
 
@@ -246,8 +252,18 @@ export interface webAnalyticsHealthLogicActions {
     setNextRefreshAvailableAt: (timestamp: number | null) => {
         timestamp: number | null
     }
+    setIssueDismissed: (
+        id: string,
+        dismissed: boolean
+    ) => {
+        dismissed: boolean
+        id: string
+    }
     setNow: (now: number) => {
         now: number
+    }
+    setShowDismissed: (show: boolean) => {
+        show: boolean
     }
     startCooldownCountdown: () => {
         value: true
@@ -283,9 +299,11 @@ export interface webAnalyticsHealthLogicMeta {
             activeIssuesByKind: Record<string, HealthIssue>,
             healthIssuesLoading: boolean,
             healthIssues: HealthIssuesResponse | null,
-            featureFlags: FeatureFlagsSet
+            featureFlags: FeatureFlagsSet,
+            showDismissed: boolean
         ) => HealthCheck[]
         checksByCategory: (allChecks: HealthCheck[]) => Record<HealthCheckCategory, HealthCheck[]>
+        hasDismissedChecks: (activeIssuesByKind: Record<string, HealthIssue>) => boolean
         overallHealthStatus: (allChecks: HealthCheck[]) => OverallHealthStatus
         hasIssues: (overallHealthStatus: OverallHealthStatus) => boolean
         urgentFailedChecks: (allChecks: HealthCheck[]) => HealthCheck[]
@@ -336,6 +354,8 @@ export const webAnalyticsHealthLogic = kea<webAnalyticsHealthLogicType>([
         setNextRefreshAvailableAt: (timestamp: number | null) => ({ timestamp }),
         setNow: (now: number) => ({ now }),
         startCooldownCountdown: true,
+        setIssueDismissed: (id: string, dismissed: boolean) => ({ id, dismissed }),
+        setShowDismissed: (show: boolean) => ({ show }),
     }),
 
     reducers({
@@ -352,6 +372,12 @@ export const webAnalyticsHealthLogic = kea<webAnalyticsHealthLogicType>([
                 setNow: (_, { now }) => now,
             },
         ],
+        showDismissed: [
+            false,
+            {
+                setShowDismissed: (_, { show }) => show,
+            },
+        ],
     }),
 
     loaders(({ values }) => ({
@@ -359,7 +385,7 @@ export const webAnalyticsHealthLogic = kea<webAnalyticsHealthLogicType>([
             __default: null as HealthIssuesResponse | null,
             loadHealthIssues: async (): Promise<HealthIssuesResponse> => {
                 return await api.get<HealthIssuesResponse>(
-                    `api/projects/${values.currentTeamIdStrict}/health_issues/?status=active&dismissed=false`
+                    `api/projects/${values.currentTeamIdStrict}/health_issues/?status=active`
                 )
             },
         },
@@ -378,55 +404,68 @@ export const webAnalyticsHealthLogic = kea<webAnalyticsHealthLogicType>([
         ],
 
         allChecks: [
-            (s) => [s.activeIssuesByKind, s.healthIssuesLoading, s.healthIssues, s.featureFlags],
+            (s) => [s.activeIssuesByKind, s.healthIssuesLoading, s.healthIssues, s.featureFlags, s.showDismissed],
             (
                 activeIssuesByKind: Record<string, HealthIssue>,
                 loading: boolean,
                 healthIssues: HealthIssuesResponse | null,
-                featureFlags: FeatureFlagsSet
+                featureFlags: FeatureFlagsSet,
+                showDismissed: boolean
             ): HealthCheck[] => {
                 const enabledChecks = featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_PATH_CLEANING_SUGGESTIONS]
                     ? WEB_HEALTH_CHECKS
                     : WEB_HEALTH_CHECKS.filter((config) => config.kind !== 'path_cleaning_suggestions')
-                return enabledChecks.map((config) => {
-                    // Show loading only on the first load (no data yet), like the rest of the health UI.
-                    if (loading && !healthIssues) {
-                        return {
-                            id: config.id,
-                            category: config.category,
-                            title: config.title,
-                            description: 'Checking...',
-                            status: 'loading' as HealthCheckStatus,
+                return enabledChecks
+                    .map((config): HealthCheck | null => {
+                        // Show loading only on the first load (no data yet), like the rest of the health UI.
+                        if (loading && !healthIssues) {
+                            return {
+                                id: config.id,
+                                category: config.category,
+                                title: config.title,
+                                description: 'Checking...',
+                                status: 'loading' as HealthCheckStatus,
+                            }
                         }
-                    }
 
-                    const issue = activeIssuesByKind[config.kind]
-                    if (!issue) {
+                        const issue = activeIssuesByKind[config.kind]
+                        if (!issue) {
+                            return {
+                                id: config.id,
+                                category: config.category,
+                                title: config.title,
+                                description: config.passingDescription,
+                                status: 'success' as HealthCheckStatus,
+                                action: config.passingAction,
+                                docsUrl: config.docsUrl,
+                                urgent: config.urgent,
+                            }
+                        }
+
+                        if (issue.dismissed && !showDismissed) {
+                            return null
+                        }
+
+                        // Critical backend severity surfaces as an error, info as a neutral note (e.g. web
+                        // vitals enabled but no events yet), everything else as a warning.
+                        const status: HealthCheckStatus =
+                            issue.severity === 'critical' ? 'error' : issue.severity === 'info' ? 'info' : 'warning'
+                        const description =
+                            (status === 'info' ? config.infoDescription : undefined) ?? config.failingDescription
                         return {
                             id: config.id,
                             category: config.category,
                             title: config.title,
-                            description: config.passingDescription,
-                            status: 'success' as HealthCheckStatus,
-                            action: config.passingAction,
+                            description,
+                            status,
+                            action: status === 'info' ? undefined : config.failingAction,
                             docsUrl: config.docsUrl,
-                            urgent: config.urgent,
+                            urgent: status === 'info' || issue.dismissed ? false : config.urgent,
+                            issueId: issue.id,
+                            dismissed: issue.dismissed,
                         }
-                    }
-
-                    // Critical backend severity surfaces as an error, everything else as a warning.
-                    const status: HealthCheckStatus = issue.severity === 'critical' ? 'error' : 'warning'
-                    return {
-                        id: config.id,
-                        category: config.category,
-                        title: config.title,
-                        description: config.failingDescription,
-                        status,
-                        action: config.failingAction,
-                        docsUrl: config.docsUrl,
-                        urgent: config.urgent,
-                    }
-                })
+                    })
+                    .filter((check): check is HealthCheck => check !== null)
             },
         ],
 
@@ -439,14 +478,23 @@ export const webAnalyticsHealthLogic = kea<webAnalyticsHealthLogicType>([
             }),
         ],
 
+        hasDismissedChecks: [
+            (s) => [s.activeIssuesByKind],
+            (activeIssuesByKind: Record<string, HealthIssue>): boolean =>
+                WEB_HEALTH_CHECKS.some((config) => activeIssuesByKind[config.kind]?.dismissed),
+        ],
+
         overallHealthStatus: [
             (s) => [s.allChecks],
             (allChecks: HealthCheck[]): OverallHealthStatus => {
-                const passedCount = allChecks.filter((check) => check.status === 'success').length
-                const warningCount = allChecks.filter((check) => check.status === 'warning').length
-                const errorCount = allChecks.filter((check) => check.status === 'error').length
-                const loadingCount = allChecks.filter((check) => check.status === 'loading').length
-                const totalCount = allChecks.length
+                const counted = allChecks.filter((check) => !check.dismissed)
+                const passedCount = counted.filter(
+                    (check) => check.status === 'success' || check.status === 'info'
+                ).length
+                const warningCount = counted.filter((check) => check.status === 'warning').length
+                const errorCount = counted.filter((check) => check.status === 'error').length
+                const loadingCount = counted.filter((check) => check.status === 'loading').length
+                const totalCount = counted.length
 
                 let status: HealthCheckStatus
                 let summary: string
@@ -621,6 +669,15 @@ export const webAnalyticsHealthLogic = kea<webAnalyticsHealthLogicType>([
                 status,
                 is_urgent: isUrgent,
             })
+        },
+        setIssueDismissed: async ({ id, dismissed }) => {
+            try {
+                await api.update(`api/projects/${values.currentTeamIdStrict}/health_issues/${id}/`, { dismissed })
+                actions.loadHealthIssues()
+                healthSummaryLogic.actions.loadHealthSummary()
+            } catch {
+                lemonToast.error(dismissed ? 'Failed to dismiss issue' : 'Failed to restore issue')
+            }
         },
     })),
 

--- a/frontend/src/scenes/web-analytics/health/webAnalyticsHealthLogic.ts
+++ b/frontend/src/scenes/web-analytics/health/webAnalyticsHealthLogic.ts
@@ -249,15 +249,15 @@ export interface webAnalyticsHealthLogicActions {
     refreshHealthChecks: (isManual?: boolean) => {
         isManual: boolean
     }
-    setNextRefreshAvailableAt: (timestamp: number | null) => {
-        timestamp: number | null
-    }
     setIssueDismissed: (
         id: string,
         dismissed: boolean
     ) => {
         dismissed: boolean
         id: string
+    }
+    setNextRefreshAvailableAt: (timestamp: number | null) => {
+        timestamp: number | null
     }
     setNow: (now: number) => {
         now: number

--- a/posthog/models/team/team.py
+++ b/posthog/models/team/team.py
@@ -1229,6 +1229,18 @@ def reevaluate_authorized_urls_health(sender, instance: Team, **kwargs):
     transaction.on_commit(lambda: evaluate_health_check_for_team.delay("authorized_urls", team_id))
 
 
+@mutable_receiver(post_save, sender=Team)
+def reevaluate_web_vitals_health(sender, instance: Team, **kwargs):
+    update_fields = kwargs.get("update_fields")
+    if update_fields is not None and "autocapture_web_vitals_opt_in" not in update_fields:
+        return
+
+    from posthog.tasks.health_checks import evaluate_health_check_for_team
+
+    team_id = instance.id
+    transaction.on_commit(lambda: evaluate_health_check_for_team.delay("web_vitals", team_id))
+
+
 def check_is_feature_available_for_team(team_id: int, feature_key: str, current_usage: Optional[int] = None):
     available_product_features: Optional[list[dict[str, str]]] = (
         Team.objects.select_related("organization")

--- a/posthog/test/setup_receivers_baseline.txt
+++ b/posthog/test/setup_receivers_baseline.txt
@@ -134,6 +134,7 @@ post_save:posthog.models.remote_config.team_saved
 post_save:posthog.models.team.extensions.register_team_extension_signal.<locals>.receiver_func
 post_save:posthog.models.team.team.put_team_in_cache_on_save
 post_save:posthog.models.team.team.reevaluate_authorized_urls_health
+post_save:posthog.models.team.team.reevaluate_web_vitals_health
 post_save:posthog.storage.gateway_credential_signal_handlers._reproject_on_access_control_change
 post_save:posthog.storage.gateway_credential_signal_handlers._reproject_on_membership_save
 post_save:posthog.storage.gateway_credential_signal_handlers._reproject_on_role_membership_change

--- a/products/web_analytics/backend/temporal/health_checks/web_vitals.py
+++ b/products/web_analytics/backend/temporal/health_checks/web_vitals.py
@@ -1,5 +1,6 @@
 from posthog.dags.common.owners import JobOwners
 from posthog.models.health_issue import HealthIssue
+from posthog.models.team import Team
 from posthog.temporal.health_checks.detectors import CLICKHOUSE_BATCH_EXECUTION_POLICY
 from posthog.temporal.health_checks.framework import (
     _SEVERITY_WEIGHT,
@@ -23,6 +24,9 @@ GROUP BY team_id
 HAVING countIf(event = '$pageview') > 0
    AND countIf(event = '$web_vitals') = 0
 """
+
+WEB_VITALS_STATE_NOT_ENABLED = "not_enabled"
+WEB_VITALS_STATE_NO_DATA_YET = "no_data_yet"
 
 
 class WebVitalsCheck(HealthCheck):
@@ -50,6 +54,12 @@ class WebVitalsCheck(HealthCheck):
 
     @classmethod
     def render_alert(cls, issue: HealthIssue) -> AlertContent:
+        if issue.payload.get("state") == WEB_VITALS_STATE_NO_DATA_YET:
+            return AlertContent(
+                title="Web vitals enabled, no events yet",
+                summary=issue.payload.get("reason", "Web vitals is enabled but no $web_vitals events have arrived yet"),
+                link="/web/health",
+            )
         return AlertContent(
             title="No web vitals events",
             summary=issue.payload.get("reason", "$web_vitals events are not being received"),
@@ -58,6 +68,8 @@ class WebVitalsCheck(HealthCheck):
 
     @classmethod
     def render_signal(cls, issue: HealthIssue) -> SignalContent | None:
+        if issue.payload.get("state") == WEB_VITALS_STATE_NO_DATA_YET:
+            return None
         title = "No web vitals events"
         summary = issue.payload.get("reason", "$web_vitals events are not being received.")
         return SignalContent(
@@ -78,16 +90,27 @@ class WebVitalsCheck(HealthCheck):
             lookback_days=WEB_VITALS_LOOKBACK_DAYS,
         )
 
+        flagged_team_ids = [team_id for (team_id,) in rows]
+        if not flagged_team_ids:
+            return {}
+
+        opted_in_team_ids = set(
+            Team.objects.filter(
+                id__in=flagged_team_ids,
+                autocapture_web_vitals_opt_in=True,
+            ).values_list("id", flat=True)
+        )
+
         issues: dict[int, list[HealthCheckResult]] = {}
-        for (team_id,) in rows:
+        for team_id in flagged_team_ids:
+            if team_id in opted_in_team_ids:
+                severity, state = HealthIssue.Severity.INFO, WEB_VITALS_STATE_NO_DATA_YET
+                reason = f"Web vitals is enabled but no $web_vitals events have arrived in the last {WEB_VITALS_LOOKBACK_DAYS} days"
+            else:
+                severity, state = HealthIssue.Severity.WARNING, WEB_VITALS_STATE_NOT_ENABLED
+                reason = f"Team has $pageview events but no $web_vitals events in last {WEB_VITALS_LOOKBACK_DAYS} days"
             issues[team_id] = [
-                HealthCheckResult(
-                    severity=HealthIssue.Severity.WARNING,
-                    payload={
-                        "reason": f"Team has $pageview events but no $web_vitals events in last {WEB_VITALS_LOOKBACK_DAYS} days"
-                    },
-                    hash_keys=[],
-                )
+                HealthCheckResult(severity=severity, payload={"state": state, "reason": reason}, hash_keys=[])
             ]
 
         return issues

--- a/products/web_analytics/backend/test/test_authorized_urls.py
+++ b/products/web_analytics/backend/test/test_authorized_urls.py
@@ -71,7 +71,7 @@ class TestAuthorizedUrlsSignal(BaseTest):
             self.team.app_urls = ["https://example.com"]
             self.team.save()
 
-        mock_task.delay.assert_called_with("authorized_urls", self.team.id)
+        mock_task.delay.assert_any_call("authorized_urls", self.team.id)
 
     @patch("posthog.tasks.health_checks.evaluate_health_check_for_team")
     def test_task_not_dispatched_before_commit(self, mock_task):


### PR DESCRIPTION
<!-- This has to stand on its own: a reader who opens no files should still know why the PR is necessary and what it does. Length tracks the change, so a small diff gets a few bullets rather than a full-length body, and a section you have nothing for gets one line or "None". -->

## Problem
Users wanted a way to dismiss issues that they can't fix. They were also confused why web vitals was enabled but the issue was still present. 
<!-- Who are we building for, what are their needs, why is this important? -->
<!-- First line: what is different for a person, and who they are. A fix says what breaks; a feature says what someone can now do; a chore says who is blocked. The code path goes underneath. -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Adds a new dismiss feature and differentiates between no enabled and enabled but no data has been seen 

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->
<!-- Don't recite pass counts for suites CI runs; the checks report those with more authority. Link the evidence instead (run, permalink, error tracking issue), and say what you did not check. Long transcripts go in a <details> block. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
     - Public artifact: nothing in this PR — code, fixtures and sample data, comments, commit messages, or this description — carries material from the agent session that isn't already public. If the work drew on a customer conversation, ticket, or log, say so here and state that the committed data is invented. Renaming people, hosts, and identifiers does not clear real material; see AGENTS.md "Public open source repo guidance".
-->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way: what changed across the session. The reason the shipped design beats the obvious alternative goes in Changes instead, where a reviewer will actually see it.
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session — that applies to every part of this PR, not just this section.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Voice: the subject of every sentence is the change, never its author. No "I", "me" or "my" anywhere in the body. "I (actually Claude)" is worse than either half: it hands the assignee an account of work they did not do. Authorship is one stated fact in the Agent context section below.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Flow and topology changes: include separate before-and-after Mermaid `flowchart` blocks with PostHog colors. This includes CI wiring, pipelines, state machines, and request paths. Use `/writing-pr-descriptions` for the palette and role mapping.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Stack instead of stuffing: if the diff holds two or more separable steps (migration then behavior, rename then rewrite), open a stack rather than one big PR. See AGENTS.md, "Stacked PRs" and /stacking-prs.
- Simplify before opening: if your agent has a behavior-preserving cleanup pass (Claude Code: `/simplify`), run it on a non-trivial diff before final tests and preflight, since it edits the tree. Skip it for small mechanical changes.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- Shape and style: invoke the `/writing-pr-descriptions` skill before writing this body. In short: lead with the effect a person sees rather than the code path behind it, make the body stand alone for a reader who opens no files, size it to the change, link evidence rather than asserting what CI already reports, then hold what's left to one fact per bullet in under 25 words. A body that got longer as bullets was not cut.
-->
