### PR TITLE
fix(data-warehouse): widen copy-files retry budget for zombie compaction races

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/tests/test_util.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/tests/test_util.py
@@ -149,6 +149,34 @@ class TestPrepareS3FilesForQuerying:
         assert cp_file.await_count == util_module._COPY_FILES_MAX_ATTEMPTS
         assert refresh_file_uris.await_count == util_module._COPY_FILES_MAX_ATTEMPTS - 1
 
+    async def test_retry_backoff_outlasts_documented_worst_case_compaction_time(self):
+        # A zombie compact+vacuum pass can keep deleting source files for as long as its own
+        # rewrite takes - documented up to ~45s for a pathological table in
+        # core/delta/maintenance.py. Regression for the retry budget silently falling back under
+        # that documented worst case (it did: 4 attempts only covered ~14s of backoff).
+        cp_file = AsyncMock(side_effect=FileNotFoundError("s3://bucket/job/my_table/part-0.parquet"))
+        s3 = _fake_s3(_cp_file=cp_file)
+        refresh_file_uris = AsyncMock(return_value=["s3://bucket/job/my_table/part-0.parquet"])
+        sleeps: list[float] = []
+
+        async def _record_sleep(seconds: float) -> None:
+            sleeps.append(seconds)
+
+        with (
+            patch.object(util_module, "aget_s3_client", return_value=_FakeS3CM(s3)),
+            patch("asyncio.sleep", side_effect=_record_sleep),
+        ):
+            with pytest.raises(FileNotFoundError):
+                await prepare_s3_files_for_querying(
+                    folder_path="job",
+                    table_name="my_table",
+                    file_uris=["s3://bucket/job/my_table/part-0.parquet"],
+                    delete_existing=False,
+                    refresh_file_uris=refresh_file_uris,
+                )
+
+        assert sum(sleeps) > 45
+
     async def test_propagates_vanished_source_file_without_refresh_callback(self):
         # Callers that don't pass refresh_file_uris keep today's behavior: the race still
         # surfaces as an error instead of being retried blindly.

--- a/products/warehouse_sources/backend/temporal/data_imports/util.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/util.py
@@ -66,9 +66,11 @@ S3_DELETE_TIME_BUFFER = 600
 
 # A zombie compaction+vacuum pass (a heartbeat-timed-out activity attempt still running) can keep
 # deleting source files for as long as its own rewrite takes - documented up to ~45s for a
-# fragmented table in core/delta/maintenance.py - which can outlive a single retry. Bound the retries
-# with backoff instead, mirroring _purge_s3_prefix's approach to the same class of race.
-_COPY_FILES_MAX_ATTEMPTS = 4
+# fragmented table in core/delta/maintenance.py, before vacuum even starts - which can outlive a
+# single retry. Bound the retries with backoff instead, mirroring _purge_s3_prefix's approach to
+# the same class of race. 6 attempts gives ~62s of cumulative backoff (2+4+8+16+32s), comfortably
+# past that documented worst case; 4 attempts (~14s) wasn't.
+_COPY_FILES_MAX_ATTEMPTS = 6
 
 
 def is_posthog_team(team_id: int) -> bool:


### PR DESCRIPTION
## Problem

A data warehouse sync can fail after every retry with a `FileNotFoundError` while publishing a table's queryable S3 files, even though the code already retries this exact race. Surfaced by an [error tracking issue](https://us.posthog.com/project/2/error_tracking/01a016e3-c773-7be0-8e37-2e83cf265dab) on a sync's post-load step.

- A concurrent compact+vacuum pass on the same Delta table (e.g. a zombie attempt outliving a heartbeat timeout) can delete a source parquet file between listing it and copying it.
- The retry loop in `prepare_s3_files_for_querying` exists for exactly this race, but its backoff totaled only ~14 seconds.
- `core/delta/maintenance.py` documents compaction alone taking up to ~45 seconds for a pathological table, so the retry budget gave up before the race it was built to survive could resolve.

## Changes

- Raises `_COPY_FILES_MAX_ATTEMPTS` from 4 to 6 in `products/warehouse_sources/backend/temporal/data_imports/util.py`, extending cumulative backoff from ~14s to ~62s.
- Updates the constant's comment to state the new headroom against the documented worst case.

## How did you test this code?

- Added `test_retry_backoff_outlasts_documented_worst_case_compaction_time` in `test_util.py`, asserting the cumulative backoff exceeds 45 seconds. This fails on the prior 4-attempt budget (~14s) and passes with the new one.
- Ran `products/warehouse_sources/backend/temporal/data_imports/tests/test_util.py` locally: 18 passed.
- Ran `ruff check --fix`, `ruff format`, and `mypy` on the changed files: clean.
- Not run: a live reproduction against S3/Delta Lake, since the race requires a concurrent compaction pass that isn't practical to simulate outside the unit test.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via the PostHog error-tracking MCP tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`, `execute-sql`) to pull the stack trace and batch context, then traced the code path through `batch_consumer.py`, `load/processor.py`, `common/load.py`, and `util.py`. The `/writing-tests` and `/writing-pr-descriptions` skills were invoked before writing the regression test and this description, respectively.