### PR TITLE
fix(signals): route skill-tagged scout runs to the ai-gateway

### DIFF
--- a/products/desktop/packages/agent/src/utils/gateway.test.ts
+++ b/products/desktop/packages/agent/src/utils/gateway.test.ts
@@ -281,6 +281,69 @@ describe("resolveGatewayTarget", () => {
     ).toBe(true);
   });
 
+  it("routes a skill-qualified scout stage via the plain product entry", () => {
+    expect(
+      resolveGatewayTarget({
+        product: "signals",
+        aiStage: "scout:web-analytics",
+        posthogHost: PY_HOST,
+        env: SIGNALS_ENV,
+      }),
+    ).toEqual({ baseUrl: GO, isAiGateway: true, aiProduct: "signals_scout" });
+  });
+
+  it("routes only the listed skill via a skill-qualified entry", () => {
+    const env = {
+      AI_GATEWAY_URL: GO,
+      AI_GATEWAY_PRODUCTS: "signals_scout:web-analytics",
+    };
+    expect(
+      resolveGatewayTarget({
+        product: "signals",
+        aiStage: "scout:web-analytics",
+        posthogHost: PY_HOST,
+        env,
+      }),
+    ).toEqual({ baseUrl: GO, isAiGateway: true, aiProduct: "signals_scout" });
+    expect(
+      resolveGatewayTarget({
+        product: "signals",
+        aiStage: "scout:logs",
+        posthogHost: PY_HOST,
+        env,
+      }),
+    ).toEqual({
+      baseUrl: "https://gateway.us.posthog.com/signals",
+      isAiGateway: false,
+      aiProduct: "signals_scout",
+    });
+  });
+
+  it("does not let a skill-qualified entry route the bare scout stage", () => {
+    expect(
+      resolveGatewayTarget({
+        product: "signals",
+        aiStage: "scout",
+        posthogHost: PY_HOST,
+        env: {
+          AI_GATEWAY_URL: GO,
+          AI_GATEWAY_PRODUCTS: "signals_scout:web-analytics",
+        },
+      }).isAiGateway,
+    ).toBe(false);
+  });
+
+  it("routes the custom stage when signals_custom is listed", () => {
+    expect(
+      resolveGatewayTarget({
+        product: "signals",
+        aiStage: "custom",
+        posthogHost: PY_HOST,
+        env: { AI_GATEWAY_URL: GO, AI_GATEWAY_PRODUCTS: "signals_custom" },
+      }),
+    ).toEqual({ baseUrl: GO, isAiGateway: true, aiProduct: "signals_custom" });
+  });
+
   it("honours an LLM_GATEWAY_URL override on the unrouted path", () => {
     expect(
       resolveGatewayTarget({
@@ -301,7 +364,15 @@ describe("resolveAiProduct", () => {
     ["research", "signals_research"],
     ["implementation", "signals_implementation"],
     ["repo_selection", "signals_repo_selection"],
+    ["custom", "signals_custom"],
   ])("maps the signals %s stage to %s", (aiStage, expected) => {
+    expect(resolveAiProduct({ product: "signals", aiStage })).toBe(expected);
+  });
+
+  it.each([
+    ["scout:web-analytics", "signals_scout"],
+    ["scout:customer-analytics-billing-and-usage", "signals_scout"],
+  ])("maps the skill-qualified %s stage to %s", (aiStage, expected) => {
     expect(resolveAiProduct({ product: "signals", aiStage })).toBe(expected);
   });
 

--- a/products/desktop/packages/agent/src/utils/gateway.test.ts
+++ b/products/desktop/packages/agent/src/utils/gateway.test.ts
@@ -333,15 +333,22 @@ describe("resolveGatewayTarget", () => {
     ).toBe(false);
   });
 
-  it("routes the custom stage when signals_custom is listed", () => {
+  it("routes the custom_agent stage when signals_custom_agent is listed", () => {
     expect(
       resolveGatewayTarget({
         product: "signals",
-        aiStage: "custom",
+        aiStage: "custom_agent",
         posthogHost: PY_HOST,
-        env: { AI_GATEWAY_URL: GO, AI_GATEWAY_PRODUCTS: "signals_custom" },
+        env: {
+          AI_GATEWAY_URL: GO,
+          AI_GATEWAY_PRODUCTS: "signals_custom_agent",
+        },
       }),
-    ).toEqual({ baseUrl: GO, isAiGateway: true, aiProduct: "signals_custom" });
+    ).toEqual({
+      baseUrl: GO,
+      isAiGateway: true,
+      aiProduct: "signals_custom_agent",
+    });
   });
 
   it("honours an LLM_GATEWAY_URL override on the unrouted path", () => {
@@ -364,7 +371,7 @@ describe("resolveAiProduct", () => {
     ["research", "signals_research"],
     ["implementation", "signals_implementation"],
     ["repo_selection", "signals_repo_selection"],
-    ["custom", "signals_custom"],
+    ["custom_agent", "signals_custom_agent"],
   ])("maps the signals %s stage to %s", (aiStage, expected) => {
     expect(resolveAiProduct({ product: "signals", aiStage })).toBe(expected);
   });

--- a/products/desktop/packages/agent/src/utils/gateway.ts
+++ b/products/desktop/packages/agent/src/utils/gateway.ts
@@ -95,7 +95,18 @@ const SIGNALS_STAGE_PRODUCTS = new Set([
   "research",
   "implementation",
   "repo_selection",
+  "custom",
 ]);
+
+/**
+ * Scout runs qualify their stage with the skill (`scout:web-analytics`) for
+ * per-scout cost attribution. The product stays `signals_scout`.
+ */
+const SCOUT_STAGE_PREFIX = "scout:";
+
+function signalsStage(aiStage: string): string {
+  return aiStage.startsWith(SCOUT_STAGE_PREFIX) ? "scout" : aiStage;
+}
 
 /**
  * The `ai_product` value sent to the Go gateway, which has no product route and
@@ -113,8 +124,11 @@ export function resolveAiProduct({
   product: GatewayProduct;
   aiStage?: string | null;
 }): string {
-  if (product === "signals" && aiStage && SIGNALS_STAGE_PRODUCTS.has(aiStage)) {
-    return `signals_${aiStage}`;
+  if (product === "signals" && aiStage) {
+    const stage = signalsStage(aiStage);
+    if (SIGNALS_STAGE_PRODUCTS.has(stage)) {
+      return `signals_${stage}`;
+    }
   }
   return product;
 }
@@ -146,6 +160,10 @@ export interface GatewayTarget {
  * Both must be set: an unlisted product, or a listed one with no URL, stays on
  * the Python gateway. Migration is therefore opt-in per product, and clearing
  * either value rolls everything back.
+ *
+ * Scout entries may qualify by skill (`signals_scout:web-analytics`), matching
+ * only runs of that skill, so the scout fleet can migrate in batches. A plain
+ * `signals_scout` entry matches every skill.
  */
 export function resolveGatewayTarget({
   product,
@@ -160,9 +178,14 @@ export function resolveGatewayTarget({
 }): GatewayTarget {
   const aiProduct = resolveAiProduct({ product, aiStage });
   const aiGatewayUrl = (env.AI_GATEWAY_URL ?? "").trim();
+  const routedProducts = parseAiGatewayProducts(env.AI_GATEWAY_PRODUCTS);
+  const skillQualified = aiStage?.startsWith(SCOUT_STAGE_PREFIX)
+    ? `${aiProduct}:${aiStage.slice(SCOUT_STAGE_PREFIX.length)}`
+    : null;
   const routed =
     aiGatewayUrl !== "" &&
-    parseAiGatewayProducts(env.AI_GATEWAY_PRODUCTS).has(aiProduct);
+    (routedProducts.has(aiProduct) ||
+      (skillQualified !== null && routedProducts.has(skillQualified)));
 
   if (routed) {
     return {

--- a/products/desktop/packages/agent/src/utils/gateway.ts
+++ b/products/desktop/packages/agent/src/utils/gateway.ts
@@ -95,7 +95,7 @@ const SIGNALS_STAGE_PRODUCTS = new Set([
   "research",
   "implementation",
   "repo_selection",
-  "custom",
+  "custom_agent",
 ]);
 
 /**

--- a/products/signals/backend/custom_agent/base.py
+++ b/products/signals/backend/custom_agent/base.py
@@ -680,7 +680,7 @@ Return only a JSON object matching this schema. Do not include markdown fences o
                 context=context,
                 step_name=label,
                 origin_product=tasks_facade.TaskOriginProduct.SIGNAL_REPORT,
-                ai_stage="custom_agent",
+                ai_stage=STEP_CUSTOM_AGENT,
                 internal=True,
             )
             self._session = session

--- a/products/signals/backend/custom_agent/base.py
+++ b/products/signals/backend/custom_agent/base.py
@@ -680,7 +680,7 @@ Return only a JSON object matching this schema. Do not include markdown fences o
                 context=context,
                 step_name=label,
                 origin_product=tasks_facade.TaskOriginProduct.SIGNAL_REPORT,
-                ai_stage="custom",
+                ai_stage="custom_agent",
                 internal=True,
             )
             self._session = session

--- a/products/signals/backend/custom_agent/base.py
+++ b/products/signals/backend/custom_agent/base.py
@@ -680,6 +680,7 @@ Return only a JSON object matching this schema. Do not include markdown fences o
                 context=context,
                 step_name=label,
                 origin_product=tasks_facade.TaskOriginProduct.SIGNAL_REPORT,
+                ai_stage="custom",
                 internal=True,
             )
             self._session = session

--- a/products/signals/backend/test/test_custom_agent_gateway_stage.py
+++ b/products/signals/backend/test/test_custom_agent_gateway_stage.py
@@ -12,10 +12,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from asgiref.sync import async_to_sync
 
+import products.signals.backend.temporal.custom_agent  # noqa: F401  (warms the base<->temporal import cycle so standalone collection works)
 from products.signals.backend.agent_runtime import STEP_CUSTOM_AGENT, AgentRuntime
-from products.signals.backend.artefact_schemas import (
-    CodeReference,  # noqa: F401  (fully initializes the package before base)
-)
 from products.signals.backend.custom_agent.base import CustomSignalAgent
 
 
@@ -24,7 +22,7 @@ def test_send_raw_stamps_custom_agent_stage():
     agent._session = None
     agent.team_id = 123
     agent.user_id = 456
-    agent.repository = None
+    agent._resolved_repository = None
     agent.model = "claude-sonnet-4-6"
 
     start_raw = AsyncMock(return_value=(MagicMock(), "ok"))

--- a/products/signals/backend/test/test_custom_agent_gateway_stage.py
+++ b/products/signals/backend/test/test_custom_agent_gateway_stage.py
@@ -1,12 +1,6 @@
-"""Pins the custom-agent sandbox run's ai_stage stamp.
-
-The stamp is what gives custom-agent LLM spend a stage (and, via the agent
-server, the `signals_custom_agent` product) instead of landing unlabelled under
-broad `signals`. It must also stay equal to STEP_CUSTOM_AGENT so
-`signals-pipeline-models` payload authors can target the vocabulary they see in
-LLM analytics. Deleting the kwarg keeps every other suite green, so this test
-is the only thing that fails on a silent revert.
-"""
+"""Pins the custom-agent run's ai_stage stamp: it must equal STEP_CUSTOM_AGENT so
+`signals-pipeline-models` payload authors target the vocabulary they see in LLM
+analytics. Deleting the kwarg keeps every other suite green."""
 
 from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/products/signals/backend/test/test_custom_agent_gateway_stage.py
+++ b/products/signals/backend/test/test_custom_agent_gateway_stage.py
@@ -1,0 +1,48 @@
+"""Pins the custom-agent sandbox run's ai_stage stamp.
+
+The stamp is what gives custom-agent LLM spend a stage (and, via the agent
+server, the `signals_custom_agent` product) instead of landing unlabelled under
+broad `signals`. It must also stay equal to STEP_CUSTOM_AGENT so
+`signals-pipeline-models` payload authors can target the vocabulary they see in
+LLM analytics. Deleting the kwarg keeps every other suite green, so this test
+is the only thing that fails on a silent revert.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from asgiref.sync import async_to_sync
+
+from products.signals.backend.agent_runtime import STEP_CUSTOM_AGENT, AgentRuntime
+from products.signals.backend.artefact_schemas import (
+    CodeReference,  # noqa: F401  (fully initializes the package before base)
+)
+from products.signals.backend.custom_agent.base import CustomSignalAgent
+
+
+def test_send_raw_stamps_custom_agent_stage():
+    agent = CustomSignalAgent.__new__(CustomSignalAgent)
+    agent._session = None
+    agent.team_id = 123
+    agent.user_id = 456
+    agent.repository = None
+    agent.model = "claude-sonnet-4-6"
+
+    start_raw = AsyncMock(return_value=(MagicMock(), "ok"))
+    with (
+        patch(
+            "products.signals.backend.custom_agent.base.get_or_create_signals_sandbox_env",
+            return_value="env-id",
+        ),
+        patch(
+            "products.signals.backend.custom_agent.base.resolve_agent_runtime",
+            return_value=AgentRuntime(),
+        ),
+        patch(
+            "products.signals.backend.custom_agent.base.MultiTurnSession.start_raw",
+            start_raw,
+        ),
+    ):
+        result = async_to_sync(agent._send_raw)("prompt", label="step-1")
+
+    assert result == "ok"
+    assert start_raw.call_args.kwargs["ai_stage"] == STEP_CUSTOM_AGENT

--- a/products/signals/backend/test/test_custom_agent_log_artefacts.py
+++ b/products/signals/backend/test/test_custom_agent_log_artefacts.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, patch
 from asgiref.sync import async_to_sync
 from pydantic import BaseModel
 
+import products.signals.backend.temporal.custom_agent  # noqa: F401  (warms the base<->temporal import cycle so standalone collection works)
 from products.signals.backend.artefact_schemas import ArtefactContentValidationError, CodeReference, NoteArtefact
 from products.signals.backend.custom_agent.base import NO_REPO, CustomSignalAgent
 from products.signals.backend.custom_agent.persistence import (


### PR DESCRIPTION
## Problem

Scout runs never reach the Go ai-gateway, even in dev where routing is enabled. Since per-scout cost attribution landed, scout runs tag `ai_stage` as `scout:<skill>`, but the sandbox gateway routing matches stages exactly against `scout`, so every scout run resolves to the broad `signals` product, misses the `AI_GATEWAY_PRODUCTS` allowlist, and stays on the Python gateway. Custom signal agents pass no stage at all and show up as `(unlabelled)` in LLM analytics.

## Changes

Fixes the stage matching and adds a batching knob for the prod cutover.

- `resolveAiProduct` treats any `scout:<skill>` stage as the scout stage, so scout runs resolve to **`signals_scout`** and route wherever it is allowlisted.
- **`AI_GATEWAY_PRODUCTS`** now also accepts skill-qualified entries (`signals_scout:web-analytics`) that route only that skill, so the scout fleet can migrate in batches instead of all skills at once. A plain `signals_scout` entry still routes every skill.
- Custom signal agents (`start_raw`) stamp `ai_stage="custom_agent"`, resolving to **`signals_custom_agent`** and matching the `signals-pipeline-models` step key: attribution is fixed immediately, routing stays opt-in via the allowlist.

**Inert in prod**: routing only changes where `SANDBOX_AI_GATEWAY_URL` + `SANDBOX_AI_GATEWAY_PRODUCTS` are set, which today is dev only.

## How did you test this code?

Unit tests in `gateway.test.ts`: skill-qualified stages resolve to `signals_scout`, a qualified allowlist entry routes only its skill (sibling skills and the bare `scout` stage stay on Python), and `signals_custom_agent` routes when listed. A Python test pins the `start_raw` stage kwarg against silent reverts. Not verified here: an end-to-end dev scout run on the Go path, which needs this deployed first.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (Fable 5), directed by Brandon; `pr-descriptions` skill used for this description. Requires human review.
