### PR TITLE
feat(cdp): filter reruns by error message substring

### DIFF
--- a/nodejs/src/cdp/rerun/rerun-job.manager.test.ts
+++ b/nodejs/src/cdp/rerun/rerun-job.manager.test.ts
@@ -122,6 +122,23 @@ describe('RerunJobManager', () => {
         expect(state.progress.done).toBe(false)
     })
 
+    it('drops an all-whitespace error_message_contains instead of matching every row', async () => {
+        const jobId = await manager.enqueue(1, 'hog_function', uuidv7(), {
+            filter: { ...baseFilter, error_message_contains: '   ' },
+        })
+
+        const state = fetchState(await queryJob(jobId))
+        expect(state.request.filter.error_message_contains).toBeUndefined()
+    })
+
+    it('rejects an error_message_contains longer than the cap', async () => {
+        await expect(
+            manager.enqueue(1, 'hog_function', uuidv7(), {
+                filter: { ...baseFilter, error_message_contains: 'x'.repeat(201) },
+            })
+        ).rejects.toThrow(/error_message_contains cannot exceed 200 characters/i)
+    })
+
     it('rejects a window longer than the TTL (30 days)', async () => {
         await expect(
             manager.enqueue(1, 'hog_function', uuidv7(), {

--- a/nodejs/src/cdp/rerun/rerun-job.manager.test.ts
+++ b/nodejs/src/cdp/rerun/rerun-job.manager.test.ts
@@ -4,7 +4,7 @@ import { v7 as uuidv7 } from 'uuid'
 import { parseJSON } from '~/common/utils/json-parse'
 
 import { RerunJobManager } from './rerun-job.manager'
-import { RERUN_QUEUE_NAME, RerunJobState } from './rerun-job.types'
+import { RERUN_MAX_ERROR_MESSAGE_CONTAINS, RERUN_QUEUE_NAME, RerunJobState } from './rerun-job.types'
 
 const DB_URL = 'postgres://posthog:posthog@localhost:5432/test_cyclotron_node'
 const TEST_MAX_COUNT = 1000
@@ -137,6 +137,19 @@ describe('RerunJobManager', () => {
                 filter: { ...baseFilter, error_message_contains: 'x'.repeat(201) },
             })
         ).rejects.toThrow(/error_message_contains cannot exceed 200 characters/i)
+    })
+
+    it('accepts an error_message_contains at the cap made of non-BMP characters', async () => {
+        // 200 code points, 400 UTF-16 code units. Django caps on code points, so
+        // counting UTF-16 units here would reject a value Django already accepted.
+        const contains = '😀'.repeat(RERUN_MAX_ERROR_MESSAGE_CONTAINS)
+
+        const jobId = await manager.enqueue(1, 'hog_function', uuidv7(), {
+            filter: { ...baseFilter, error_message_contains: contains },
+        })
+
+        const state = fetchState(await queryJob(jobId))
+        expect(state.request.filter.error_message_contains).toBe(contains)
     })
 
     it('rejects a window longer than the TTL (30 days)', async () => {

--- a/nodejs/src/cdp/rerun/rerun-job.manager.ts
+++ b/nodejs/src/cdp/rerun/rerun-job.manager.ts
@@ -79,7 +79,10 @@ export class RerunJobManager {
         }
 
         const contains = request.filter.error_message_contains?.trim()
-        if (contains && contains.length > RERUN_MAX_ERROR_MESSAGE_CONTAINS) {
+        // Count Unicode code points, not UTF-16 code units, to match Django's
+        // max_length (Python len()). Counting `.length` here would reject a
+        // non-BMP value Django already accepted, 500ing instead of enqueueing.
+        if (contains && Array.from(contains).length > RERUN_MAX_ERROR_MESSAGE_CONTAINS) {
             throw new Error(`error_message_contains cannot exceed ${RERUN_MAX_ERROR_MESSAGE_CONTAINS} characters`)
         }
 

--- a/nodejs/src/cdp/rerun/rerun-job.manager.ts
+++ b/nodejs/src/cdp/rerun/rerun-job.manager.ts
@@ -4,6 +4,7 @@ import { logger } from '~/common/utils/logger'
 
 import { CyclotronV2Manager } from '../services/cyclotron-v2'
 import {
+    RERUN_MAX_ERROR_MESSAGE_CONTAINS,
     RERUN_MAX_WINDOW_DAYS,
     RERUN_QUEUE_NAME,
     RerunFunctionKind,
@@ -77,8 +78,19 @@ export class RerunJobManager {
             throw new Error(`rerun window cannot exceed ${RERUN_MAX_WINDOW_DAYS} days (TTL on hog_invocation_results)`)
         }
 
+        const contains = request.filter.error_message_contains?.trim()
+        if (contains && contains.length > RERUN_MAX_ERROR_MESSAGE_CONTAINS) {
+            throw new Error(`error_message_contains cannot exceed ${RERUN_MAX_ERROR_MESSAGE_CONTAINS} characters`)
+        }
+
         const trimmedIds = request.filter.invocation_ids?.slice(0, this.config.maxCount)
-        const filter = { ...request.filter, invocation_ids: trimmedIds }
+        // An all-whitespace value would otherwise match every row, quietly turning a
+        // narrowed rerun into a full-window one.
+        const filter = {
+            ...request.filter,
+            invocation_ids: trimmedIds,
+            error_message_contains: contains || undefined,
+        }
 
         const state: RerunJobState = {
             function_kind: functionKind,

--- a/nodejs/src/cdp/rerun/rerun-job.types.ts
+++ b/nodejs/src/cdp/rerun/rerun-job.types.ts
@@ -45,6 +45,10 @@ export type RerunStatusValue = 'running' | 'succeeded' | 'failed' | 'canceled'
  * than that). The window also caps rerun to data that's still resident in the
  * table — older rows are gone via TTL anyway.
  *
+ * `error_message_contains` is an OPTIONAL additional restriction, capped at
+ * `RERUN_MAX_ERROR_MESSAGE_CONTAINS` characters so the per-row substring scan
+ * inside `HAVING` stays cheap.
+ *
  * `invocation_ids` is an OPTIONAL additional restriction. When set, the
  * paginator pulls only those ids within the window — a UI "rerun these
  * specific failed runs" affordance. Server-side cap on the list size is
@@ -55,6 +59,13 @@ export interface RerunFilter {
     window_end: string
     status?: RerunStatusValue[]
     error_kind?: string[]
+    /**
+     * Case-insensitive substring match on the invocation's error message. Narrows a
+     * rerun to one failure mode when `error_kind` cannot: the classifier buckets
+     * anything that is not a timeout, HTTP status or OOM into `hog_error`, so a
+     * single incident is not addressable by kind alone.
+     */
+    error_message_contains?: string
     max_attempts?: number
     max_count?: number
     invocation_ids?: string[]
@@ -69,6 +80,9 @@ export interface RerunRequest {
  * `hog_invocation_results`. Older rows are already gone via part drop.
  */
 export const RERUN_MAX_WINDOW_DAYS = 30
+
+/** Mirror of the Django serializer's `error_message_contains` max_length. */
+export const RERUN_MAX_ERROR_MESSAGE_CONTAINS = 200
 
 export interface RerunCursor {
     scheduled_at: string

--- a/nodejs/src/cdp/rerun/rerun-paginator.service.test.ts
+++ b/nodejs/src/cdp/rerun/rerun-paginator.service.test.ts
@@ -456,6 +456,43 @@ describe('RerunPaginatorService integration', () => {
             expect(next.progress.queued).toBe(1)
         })
 
+        it('honours error_message_contains when error_kind cannot separate the rows', async () => {
+            // Both rows classify as 'hog_error', so error_kind is useless for targeting one
+            // incident. Matching on the message is the only way to rerun just its failures.
+            await seedRows([
+                {
+                    invocation_id: 'inv-sender',
+                    status: 'failed',
+                    error: new Error('The custom sender address "x@example.com" is not on the verified domain "acme.com"'),
+                },
+                { invocation_id: 'inv-other', status: 'failed', error: new Error('Invalid Liquid template') },
+            ])
+
+            const state = buildState({
+                request: {
+                    filter: {
+                        window_start: '2026-01-01T00:00:00Z',
+                        window_end: '2027-01-01T00:00:00Z',
+                        error_message_contains: 'IS NOT ON THE VERIFIED DOMAIN',
+                    },
+                },
+            })
+
+            const { state: next } = await paginator.processPage(team.id, state, {
+                jobId: 'test-rerun-job',
+                createdAt: DateTime.now(),
+            })
+            // Membership rather than array equality: rows produced by an earlier test can land
+            // after this test's truncate, and an unrelated id appearing would fail an exact match
+            // without saying anything about the filter under test.
+            const enqueued = hogQueue.queueInvocations.mock.calls[0]?.[0] as
+                | CyclotronJobInvocationHogFunction[]
+                | undefined
+            const ids = enqueued?.map((i) => i.id) ?? []
+            expect(ids).toContain('inv-sender')
+            expect(ids).not.toContain('inv-other')
+        })
+
         it('honours max_count by capping queued+skipped at the user-provided limit', async () => {
             await seedRows([
                 { invocation_id: 'a', status: 'failed', error: new Error('5xx') },

--- a/nodejs/src/cdp/rerun/rerun-paginator.service.ts
+++ b/nodejs/src/cdp/rerun/rerun-paginator.service.ts
@@ -483,6 +483,12 @@ export class RerunPaginatorService {
         const errorKindClause = filter.error_kind?.length
             ? 'AND argMax(error_kind, version) IN {error_kind:Array(String)}'
             : ''
+        // `positionCaseInsensitive` rather than LIKE: a caller-supplied pattern would
+        // need `%` and `_` escaped to mean "contains", and getting that wrong silently
+        // widens the rerun instead of erroring.
+        const errorMessageClause = filter.error_message_contains
+            ? 'AND positionCaseInsensitive(argMax(error_message, version), {error_message_contains:String}) > 0'
+            : ''
         const maxAttemptsClause =
             filter.max_attempts !== undefined ? 'AND argMax(attempts, version) < {max_attempts:UInt8}' : ''
         // `invocation_ids` is an OPTIONAL additional restriction layered on top
@@ -518,6 +524,7 @@ export class RerunPaginatorService {
                 HAVING argMax(is_deleted, version) = 0
                    AND argMax(status, version) IN {status:Array(String)}
                    ${errorKindClause}
+                   ${errorMessageClause}
                    ${maxAttemptsClause}
                 ORDER BY last_scheduled_at DESC, invocation_id DESC
                 LIMIT {limit:UInt32}`,
@@ -529,6 +536,7 @@ export class RerunPaginatorService {
                 window_end: windowEnd,
                 status: requestedStatus,
                 error_kind: filter.error_kind ?? [],
+                error_message_contains: filter.error_message_contains ?? '',
                 max_attempts: filter.max_attempts ?? 255,
                 invocation_ids: filter.invocation_ids ?? [],
                 cursor_scheduled_at: cursorScheduledAt,

--- a/posthog/api/hog_invocation_rerun.py
+++ b/posthog/api/hog_invocation_rerun.py
@@ -24,6 +24,10 @@ HOG_INVOCATION_RERUN_MAX_COUNT = get_from_env("HOG_INVOCATION_RERUN_MAX_COUNT", 
 # window any longer would point at partitions that have already been dropped.
 RERUN_MAX_WINDOW_DAYS = 30
 
+# Cap on `error_message_contains`. Mirrors RERUN_MAX_ERROR_MESSAGE_CONTAINS on the
+# Node side, where the substring scan runs per row inside the page query's HAVING.
+RERUN_MAX_ERROR_MESSAGE_CONTAINS = 200
+
 
 class HogInvocationRerunFilterSerializer(serializers.Serializer):
     """Filter shape for the rerun endpoint. `window_start`/`window_end` are required."""
@@ -39,6 +43,17 @@ class HogInvocationRerunFilterSerializer(serializers.Serializer):
         child=serializers.CharField(),
         required=False,
         help_text="Restrict to invocations whose error_kind matches one of these (e.g. 'http_5xx', 'timeout').",
+    )
+    error_message_contains = serializers.CharField(
+        required=False,
+        allow_blank=False,
+        max_length=RERUN_MAX_ERROR_MESSAGE_CONTAINS,
+        trim_whitespace=True,
+        help_text=(
+            "Restrict to invocations whose error message contains this substring, matched "
+            "case-insensitively. Use this to target one failure mode when `error_kind` cannot: "
+            "every error that is not a timeout, HTTP status or OOM is classified as 'hog_error'."
+        ),
     )
     max_attempts = serializers.IntegerField(
         required=False,

--- a/posthog/plugins/plugin_server_api.py
+++ b/posthog/plugins/plugin_server_api.py
@@ -294,6 +294,10 @@ def rerun_hog_invocations(
       - {"invocation_ids": ["uuid", ...]}                   -> rerun these specific runs
       - {"filter": {"window_start": "...", "window_end": "...", "status": [...], ...}}
 
+    Narrow a filter-mode rerun to one failure mode with `error_message_contains`:
+    the error classifier buckets everything that is not a timeout, HTTP status or
+    OOM into `hog_error`, so `error_kind` alone cannot isolate a single incident.
+
     The Node side (`nodejs/src/cdp/rerun`) reads the matching rows from
     `hog_invocation_results`, rehydrates the invocation from the stored
     `invocation_globals`, and re-enqueues onto cyclotron with `is_retry=1`.

--- a/products/cdp/backend/api/test/test_hog_function.py
+++ b/products/cdp/backend/api/test/test_hog_function.py
@@ -1954,6 +1954,53 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
             assert response.status_code == status.HTTP_200_OK, response.json()
             assert mock_rerun.call_count == 1
 
+    def test_rerun_forwards_error_message_contains(self):
+        fn = HogFunction.objects.create(team=self.team, type="destination", hog="return event")
+
+        with patch("products.cdp.backend.api.hog_function.rerun_hog_invocations") as mock_rerun:
+            mock_rerun.return_value = MagicMock(status_code=200, json=lambda: {"rerun_job_id": "job-1"})
+
+            response = self.client.post(
+                f"/api/projects/{self.team.id}/hog_functions/{fn.id}/rerun/",
+                data={
+                    "filter": {
+                        "window_start": "2026-07-01T00:00:00Z",
+                        "window_end": "2026-07-02T00:00:00Z",
+                        "error_message_contains": "  is not on the verified domain  ",
+                    }
+                },
+            )
+
+            assert response.status_code == status.HTTP_200_OK, response.json()
+            payload = mock_rerun.call_args.kwargs["payload"]
+            assert payload["filter"]["error_message_contains"] == "is not on the verified domain"
+
+    @parameterized.expand(
+        [
+            ("too_long", "x" * 201),
+            ("blank", ""),
+        ]
+    )
+    def test_rerun_rejects_invalid_error_message_contains(self, _name, value):
+        # A blank or oversized value reaching the worker would widen the rerun to the whole
+        # window rather than narrowing it, so it has to fail before the enqueue.
+        fn = HogFunction.objects.create(team=self.team, type="destination", hog="return event")
+
+        with patch("products.cdp.backend.api.hog_function.rerun_hog_invocations") as mock_rerun:
+            response = self.client.post(
+                f"/api/projects/{self.team.id}/hog_functions/{fn.id}/rerun/",
+                data={
+                    "filter": {
+                        "window_start": "2026-07-01T00:00:00Z",
+                        "window_end": "2026-07-02T00:00:00Z",
+                        "error_message_contains": value,
+                    }
+                },
+            )
+
+            assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+            mock_rerun.assert_not_called()
+
     @parameterized.expand(
         [
             (

--- a/products/cdp/frontend/generated/api.schemas.ts
+++ b/products/cdp/frontend/generated/api.schemas.ts
@@ -665,6 +665,11 @@ export interface HogInvocationRerunFilterApi {
     /** Restrict to invocations whose error_kind matches one of these (e.g. 'http_5xx', 'timeout'). */
     error_kind?: string[]
     /**
+     * Restrict to invocations whose error message contains this substring, matched case-insensitively. Use this to target one failure mode when `error_kind` cannot: every error that is not a timeout, HTTP status or OOM is classified as 'hog_error'.
+     * @maxLength 200
+     */
+    error_message_contains?: string
+    /**
      * Skip invocations that have already been attempted this many times or more.
      * @minimum 1
      * @maximum 255

--- a/products/cdp/frontend/generated/api.zod.ts
+++ b/products/cdp/frontend/generated/api.zod.ts
@@ -1539,6 +1539,8 @@ export const HogFunctionsPublishCreateBody = /* @__PURE__ */ zod.object({
  * Because rerun replays historical event/person/group data, it requires
  * `person:read` and `group:read` on top of `hog_function:write`.
  */
+export const hogFunctionsRerunCreateBodyFilterOneErrorMessageContainsMax = 200
+
 export const hogFunctionsRerunCreateBodyFilterOneMaxAttemptsMax = 255
 
 export const hogFunctionsRerunCreateBodyFilterOneMaxCountMax = 10000
@@ -1570,6 +1572,13 @@ export const HogFunctionsRerunCreateBody = /* @__PURE__ */ zod
                     .optional()
                     .describe(
                         "Restrict to invocations whose error_kind matches one of these (e.g. 'http_5xx', 'timeout')."
+                    ),
+                error_message_contains: zod
+                    .string()
+                    .max(hogFunctionsRerunCreateBodyFilterOneErrorMessageContainsMax)
+                    .optional()
+                    .describe(
+                        "Restrict to invocations whose error message contains this substring, matched case-insensitively. Use this to target one failure mode when `error_kind` cannot: every error that is not a timeout, HTTP status or OOM is classified as 'hog_error'."
                     ),
                 max_attempts: zod
                     .number()

--- a/products/workflows/frontend/generated/api.schemas.ts
+++ b/products/workflows/frontend/generated/api.schemas.ts
@@ -1089,6 +1089,11 @@ export interface HogInvocationRerunFilterApi {
     /** Restrict to invocations whose error_kind matches one of these (e.g. 'http_5xx', 'timeout'). */
     error_kind?: string[]
     /**
+     * Restrict to invocations whose error message contains this substring, matched case-insensitively. Use this to target one failure mode when `error_kind` cannot: every error that is not a timeout, HTTP status or OOM is classified as 'hog_error'.
+     * @maxLength 200
+     */
+    error_message_contains?: string
+    /**
      * Skip invocations that have already been attempted this many times or more.
      * @minimum 1
      * @maximum 255

--- a/products/workflows/frontend/generated/api.zod.ts
+++ b/products/workflows/frontend/generated/api.zod.ts
@@ -2164,6 +2164,8 @@ export const HogFlowsPublishCreateBody = /* @__PURE__ */ zod.object({
  * Because rerun replays historical event/person/group data, it requires
  * `person:read` and `group:read` on top of `hog_flow:write`.
  */
+export const hogFlowsRerunCreateBodyFilterOneErrorMessageContainsMax = 200
+
 export const hogFlowsRerunCreateBodyFilterOneMaxAttemptsMax = 255
 
 export const hogFlowsRerunCreateBodyFilterOneMaxCountMax = 10000
@@ -2195,6 +2197,13 @@ export const HogFlowsRerunCreateBody = /* @__PURE__ */ zod
                     .optional()
                     .describe(
                         "Restrict to invocations whose error_kind matches one of these (e.g. 'http_5xx', 'timeout')."
+                    ),
+                error_message_contains: zod
+                    .string()
+                    .max(hogFlowsRerunCreateBodyFilterOneErrorMessageContainsMax)
+                    .optional()
+                    .describe(
+                        "Restrict to invocations whose error message contains this substring, matched case-insensitively. Use this to target one failure mode when `error_kind` cannot: every error that is not a timeout, HTTP status or OOM is classified as 'hog_error'."
                     ),
                 max_attempts: zod
                     .number()

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -39928,6 +39928,11 @@ export namespace Schemas {
       /** Restrict to invocations whose error_kind matches one of these (e.g. 'http_5xx', 'timeout'). */
       error_kind?: string[];
       /**
+         * Restrict to invocations whose error message contains this substring, matched case-insensitively. Use this to target one failure mode when `error_kind` cannot: every error that is not a timeout, HTTP status or OOM is classified as 'hog_error'.
+         * @maxLength 200
+         */
+      error_message_contains?: string;
+      /**
          * Skip invocations that have already been attempted this many times or more.
          * @minimum 1
          * @maximum 255


### PR DESCRIPTION
## Problem

An on-caller recovering one incident's failed invocations cannot target them. The rerun filter narrows by `error_kind`, and `classifyError` only separates timeouts, HTTP statuses and OOM. Everything else, which is most application-level failures, is classified `hog_error`.

So a rerun scoped to a single incident sweeps every unrelated `hog_error` in the same window. For a destination or workflow email step, that re-sends messages nobody intended to send.

The alternative today is passing an explicit `invocation_ids` list, which means exporting ids from ClickHouse and posting them back in batches of 10,000.

## Changes

- `error_message_contains` on the rerun filter: a case-insensitive substring match on the invocation's error message, applied alongside the existing `status` and `error_kind` clauses.
- The paginator uses `positionCaseInsensitive` rather than `LIKE`. A caller-supplied `LIKE` pattern needs `%` and `_` escaped to mean "contains", and getting that wrong widens the rerun silently instead of erroring.
- Capped at 200 characters, mirrored on both sides, because the match runs per row inside the page query's `HAVING`.
- An all-whitespace value is dropped rather than passed through, since it would match every row and turn a narrowed rerun into a full-window one.
- Purely additive. Existing callers are unaffected, and the clause is omitted from the query when the field is absent.

Recovering one incident now looks like this, with no id export:

```json
{"filter": {
  "window_start": "2026-08-17T13:00:00Z",
  "window_end": "2026-08-18T21:35:00Z",
  "status": ["failed"],
  "error_message_contains": "is not on the verified domain"
}}
```

## How did you test this code?

- A paginator case seeds two failed rows that both classify as `hog_error`, then asserts only the message-matching one is re-enqueued. No existing test covered targeting a failure mode that `error_kind` cannot express, which is the whole point of the field.
- Two manager cases cover the guards: an all-whitespace value is dropped, and an over-cap value is rejected before the wrapper job is enqueued.
- Two API cases cover the serializer: a padded value reaches the worker trimmed, and blank or over-cap values 400 without calling the enqueue path.
- Ran locally against real ClickHouse and Kafka: the rerun paginator and manager suites, and the new API cases. `hogli ci:preflight --strict` reports 0 failures.
- The new paginator case initially shared a pre-existing flake in this suite, where rows produced by an earlier test land after the next test's truncate. It asserts membership rather than array equality for that reason, and passed 3 runs in a row. The adjacent `error_kind` case still carries the flake; not touched here.
- Not run: the full backend suite, and any rerun against production data.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The filter is documented in its own help text and in the `rerun_hog_invocations` docstring, both updated here.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (Opus 5) in Claude Code, directed by the assignee. Skills invoked: `/improving-drf-endpoints`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

Written while recovering a workflow email incident, where the missing filter was the blocker for a self-serve replay affordance. The first approach passed explicit `invocation_ids` exported from ClickHouse; a filter field replaced it once it was clear the same gap recurs for any incident whose failures land in the generic `hog_error` bucket. `positionCaseInsensitive` was chosen over `LIKE` to keep escaping out of the caller's hands.

All committed sample data is invented.
