### PR TITLE
chore(tests): reuse warehouse e2e Temporal worker

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/tests/e2e/test_end_to_end.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/tests/e2e/test_end_to_end.py
@@ -3,6 +3,7 @@ import json
 import uuid
 import functools
 import contextlib
+from collections.abc import AsyncIterator
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta
 from typing import Any, Optional, cast
@@ -334,6 +335,33 @@ def mock_customer_io_client():
         yield set_response
 
 
+def _create_worker(activity_environment: WorkflowEnvironment, activity_executor: ThreadPoolExecutor) -> Worker:
+    return Worker(
+        activity_environment.client,
+        task_queue=settings.DATA_WAREHOUSE_TASK_QUEUE,
+        workflows=[
+            ExternalDataJobWorkflow,
+            CDPProducerJobWorkflow,
+            DuckLakeCopyDataImportsWorkflow,
+            DuckLakeRegisterDataImportsWorkflow,
+            PostImportWorkflow,
+        ],
+        activities=ACTIVITIES + DUCKLAKE_ACTIVITIES,  # type: ignore
+        workflow_runner=UnsandboxedWorkflowRunner(),
+        activity_executor=activity_executor,
+        max_concurrent_activities=50,
+        debug_mode=True,  # turn off sandbox/deadlock detector
+    )
+
+
+@pytest_asyncio.fixture(scope="module", loop_scope="module")
+async def warehouse_workflow_environment() -> AsyncIterator[WorkflowEnvironment]:
+    with ThreadPoolExecutor(max_workers=50) as activity_executor:
+        async with await WorkflowEnvironment.start_time_skipping() as activity_environment:
+            async with _create_worker(activity_environment, activity_executor):
+                yield activity_environment
+
+
 @pytest_asyncio.fixture(autouse=True)
 async def minio_client():
     """Manage an S3 client to interact with a MinIO bucket.
@@ -365,6 +393,7 @@ async def _run(
     sync_type_config: Optional[dict] = None,
     billable: Optional[bool] = None,
     ignore_assertions: Optional[bool] = False,
+    activity_environment: Optional[WorkflowEnvironment] = None,
 ):
     source = await sync_to_async(ExternalDataSource.objects.create)(
         source_id=uuid.uuid4(),
@@ -403,7 +432,7 @@ async def _run(
             "products.warehouse_sources.backend.temporal.data_imports.metrics.get_producer"
         ) as mock_app_metrics_producer_cls,
     ):
-        await _execute_run(workflow_id, inputs, mock_data_response)
+        await _execute_run(workflow_id, inputs, mock_data_response, activity_environment)
 
         # In v3 mode, the job is still RUNNING after the workflow (consumer marks it COMPLETED),
         # so we need to query without status filter to get the job_id for the replay.
@@ -547,7 +576,41 @@ async def _replay_v3_consumer(team_id: int, schema_id, job_id: str | None = None
     _pg_queue_replay.clear()
 
 
-async def _execute_run(workflow_id: str, inputs: ExternalDataWorkflowInputs, mock_data_response):
+async def _execute_workflow(
+    activity_environment: WorkflowEnvironment, workflow_id: str, inputs: ExternalDataWorkflowInputs
+) -> None:
+    await activity_environment.client.execute_workflow(
+        ExternalDataJobWorkflow.run,
+        inputs,
+        id=workflow_id,
+        task_queue=settings.DATA_WAREHOUSE_TASK_QUEUE,
+        retry_policy=RetryPolicy(maximum_attempts=1),
+    )
+
+    # The load-dependent post-import steps run in an abandoned child, so
+    # assertions on its side effects (e.g. storage_delta_mib) would race
+    # worker shutdown — await it before leaving the worker context. Absent
+    # on paths that never start it (V3 consumer-owned, non-completed jobs).
+    job = await sync_to_async(
+        ExternalDataJob.objects.filter(team_id=inputs.team_id, schema_id=inputs.external_data_schema_id)
+        .order_by("-created_at")
+        .first
+    )()
+    if job is not None:
+        handle = activity_environment.client.get_workflow_handle(build_post_import_workflow_id(str(job.id)))
+        try:
+            await handle.result()
+        except RPCError as e:
+            if e.status != RPCStatusCode.NOT_FOUND:
+                raise
+
+
+async def _execute_run(
+    workflow_id: str,
+    inputs: ExternalDataWorkflowInputs,
+    mock_data_response: Any,
+    activity_environment: Optional[WorkflowEnvironment] = None,
+) -> None:
     def mock_paginate(
         class_self,
         path: str = "",
@@ -650,47 +713,13 @@ async def _execute_run(workflow_id: str, inputs: ExternalDataWorkflowInputs, moc
                 )
             )
 
-        async with await WorkflowEnvironment.start_time_skipping() as activity_environment:
-            async with Worker(
-                activity_environment.client,
-                task_queue=settings.DATA_WAREHOUSE_TASK_QUEUE,
-                workflows=[
-                    ExternalDataJobWorkflow,
-                    CDPProducerJobWorkflow,
-                    DuckLakeCopyDataImportsWorkflow,
-                    DuckLakeRegisterDataImportsWorkflow,
-                    PostImportWorkflow,
-                ],
-                activities=ACTIVITIES + DUCKLAKE_ACTIVITIES,  # type: ignore
-                workflow_runner=UnsandboxedWorkflowRunner(),
-                activity_executor=ThreadPoolExecutor(max_workers=50),
-                max_concurrent_activities=50,
-                debug_mode=True,  # turn off sandbox/deadlock detector
-            ):
-                await activity_environment.client.execute_workflow(
-                    ExternalDataJobWorkflow.run,
-                    inputs,
-                    id=workflow_id,
-                    task_queue=settings.DATA_WAREHOUSE_TASK_QUEUE,
-                    retry_policy=RetryPolicy(maximum_attempts=1),
-                )
-
-                # The load-dependent post-import steps run in an abandoned child, so
-                # assertions on its side effects (e.g. storage_delta_mib) would race
-                # worker shutdown — await it before leaving the worker context. Absent
-                # on paths that never start it (V3 consumer-owned, non-completed jobs).
-                job = await sync_to_async(
-                    ExternalDataJob.objects.filter(team_id=inputs.team_id, schema_id=inputs.external_data_schema_id)
-                    .order_by("-created_at")
-                    .first
-                )()
-                if job is not None:
-                    handle = activity_environment.client.get_workflow_handle(build_post_import_workflow_id(str(job.id)))
-                    try:
-                        await handle.result()
-                    except RPCError as e:
-                        if e.status != RPCStatusCode.NOT_FOUND:
-                            raise
+        if activity_environment is not None:
+            await _execute_workflow(activity_environment, workflow_id, inputs)
+        else:
+            with ThreadPoolExecutor(max_workers=50) as activity_executor:
+                async with await WorkflowEnvironment.start_time_skipping() as isolated_environment:
+                    async with _create_worker(isolated_environment, activity_executor):
+                        await _execute_workflow(isolated_environment, workflow_id, inputs)
 
 
 _STRIPE_JOB_INPUTS: dict[str, str | dict[str, str]] = {
@@ -727,7 +756,9 @@ _STRIPE_JOB_INPUTS: dict[str, str | dict[str, str]] = {
         ),
     ],
 )
-async def test_stripe_source(team, mock_stripe_client, request, schema_name, table_name, fixture_name):
+async def test_stripe_source(
+    team, mock_stripe_client, request, schema_name, table_name, fixture_name, warehouse_workflow_environment
+):
     fixture_data = request.getfixturevalue(fixture_name)
     await _run(
         team=team,
@@ -736,6 +767,7 @@ async def test_stripe_source(team, mock_stripe_client, request, schema_name, tab
         source_type="Stripe",
         job_inputs=_STRIPE_JOB_INPUTS,
         mock_data_response=fixture_data["data"],
+        activity_environment=warehouse_workflow_environment,
     )
 
 
@@ -786,7 +818,9 @@ _ZENDESK_JOB_INPUTS: dict[str, str | dict[str, str]] = {
         ),
     ],
 )
-async def test_zendesk_source(team, request, schema_name, table_name, fixture_name, fixture_data_key):
+async def test_zendesk_source(
+    team, request, schema_name, table_name, fixture_name, fixture_data_key, warehouse_workflow_environment
+):
     fixture_data = request.getfixturevalue(fixture_name)
     await _run(
         team=team,
@@ -795,6 +829,7 @@ async def test_zendesk_source(team, request, schema_name, table_name, fixture_na
         source_type="Zendesk",
         job_inputs=_ZENDESK_JOB_INPUTS,
         mock_data_response=fixture_data[fixture_data_key],
+        activity_environment=warehouse_workflow_environment,
     )
 
 
@@ -823,7 +858,15 @@ async def test_paddle_source(team, mock_paddle_client, request, schema_name, tab
     )
 
 
-async def _run_customer_io(team, schema_name, table_name, mock_data, mock_customer_io_client, payload):
+async def _run_customer_io(
+    team,
+    schema_name,
+    table_name,
+    mock_data,
+    mock_customer_io_client,
+    payload,
+    activity_environment: Optional[WorkflowEnvironment] = None,
+):
     mock_customer_io_client(payload)
     await _run(
         team=team,
@@ -832,6 +875,7 @@ async def _run_customer_io(team, schema_name, table_name, mock_data, mock_custom
         source_type="CustomerIO",
         job_inputs={"app_api_key": "test-key", "region": "us"},
         mock_data_response=mock_data,
+        activity_environment=activity_environment,
     )
 
 
@@ -853,7 +897,14 @@ async def _run_customer_io(team, schema_name, table_name, mock_data, mock_custom
     ],
 )
 async def test_customer_io_source(
-    team, mock_customer_io_client, request, schema_name, table_name, fixture_name, fixture_data_key
+    team,
+    mock_customer_io_client,
+    request,
+    schema_name,
+    table_name,
+    fixture_name,
+    fixture_data_key,
+    warehouse_workflow_environment,
 ):
     fixture_data = request.getfixturevalue(fixture_name)
     await _run_customer_io(
@@ -863,6 +914,7 @@ async def test_customer_io_source(
         mock_data=fixture_data[fixture_data_key],
         mock_customer_io_client=mock_customer_io_client,
         payload=fixture_data,
+        activity_environment=warehouse_workflow_environment,
     )
 
 


### PR DESCRIPTION
before:235 seconds.
after: 55 seconds.

> 🤖 Posted by an automated coding agent.

## Problem

Warehouse source E2E cases repeatedly start the same Temporal test server, worker, activity registry, and thread pool.

The Stripe, Zendesk, and Customer.io matrices pay this setup for all 64 parameter cases.

## Changes

- The three source families share one module-scoped time-skipping environment and worker.
- Other E2E tests keep their isolated Temporal environment.
- Every parameter case, pipeline mode, database fixture, and workflow assertion remains.
- Shared execution recorded 55.4 call seconds across all 64 cases locally.

## How did you test this code?

- Ran representative NonDLT and V3 cases from all three source families together.
- Ran all 64 selected parameter cases twice with one shared worker.
- The full selection passed in about 171 seconds on the repeated run.
- Ran Ruff, repository-wide mypy, and `hogli ci:preflight --fix`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This change only adjusts test infrastructure.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi implemented this change with repository shell tools and CI trace analysis. It used `/writing-tests`, `/writing-code-comments`, and `/writing-pr-descriptions`.

The first version of the local test database lacked required PostgreSQL extensions. Validation used a fresh no-migrations database with `ltree`, `pgcrypto`, and `pg_trgm` enabled.
