### PR TITLE
feat(desktop): add emoji autocomplete to comments

### DIFF
--- a/docs/internal/slack-local-setup-guide.md
+++ b/docs/internal/slack-local-setup-guide.md
@@ -112,6 +112,7 @@ oauth_config:
       - channels:history
       - groups:history
       - chat:write
+      - emoji:read
       - canvases:write
       - files:write
       - reactions:write

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -48966,6 +48966,7 @@
                 "chat:write",
                 "chat:write.customize",
                 "commands",
+                "emoji:read",
                 "files:read",
                 "files:write",
                 "groups:history",

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5547,6 +5547,7 @@ export enum SlackIntegrationScope {
     CHAT_WRITE = 'chat:write',
     CHAT_WRITE_CUSTOMIZE = 'chat:write.customize',
     COMMANDS = 'commands',
+    EMOJI_READ = 'emoji:read',
     FILES_READ = 'files:read',
     FILES_WRITE = 'files:write',
     GROUPS_HISTORY = 'groups:history',

--- a/posthog/api/comments.py
+++ b/posthog/api/comments.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, cast
 
 from django.core import exceptions as django_exceptions
+from django.core.cache import cache
 from django.db import transaction
 from django.db.models import Q, QuerySet
 from django.utils import timezone
@@ -94,6 +95,22 @@ STALE_SLACK_RESERVATION_GRACE = timedelta(minutes=2)
 RESERVED_ITEM_CONTEXT_KEYS = frozenset(
     {"from_slack", "slack_synced_ts", "slack_message_ts", "slack_author_name", "slack_author_avatar"}
 )
+SLACK_EMOJI_READ_SCOPE = "emoji:read"
+
+
+def _resolve_slack_emoji_url(name: str, emoji_by_name: dict[str, Any], seen: set[str] | None = None) -> str | None:
+    value = emoji_by_name.get(name)
+    if not isinstance(value, str):
+        return None
+    if value.startswith("https://"):
+        return value
+    if not value.startswith("alias:"):
+        return None
+    seen = {*seen, name} if seen else {name}
+    alias = value.removeprefix("alias:")
+    if alias in seen:
+        return None
+    return _resolve_slack_emoji_url(alias, emoji_by_name, seen)
 
 
 def _release_slack_reservation(slack_thread: "CommentSlackThread") -> None:
@@ -585,6 +602,18 @@ class CommentListQueryParamsSerializer(serializers.Serializer):
     )
 
 
+class CommentEmojiSerializer(serializers.Serializer):
+    name = serializers.CharField(help_text="Slack shortcode without surrounding colons.")
+    url = serializers.URLField(help_text="HTTPS image URL for the custom emoji.")
+
+
+class CommentEmojiListResponseSerializer(serializers.Serializer):
+    results = CommentEmojiSerializer(
+        many=True,
+        help_text="Custom emoji available from Slack workspaces connected to this project.",
+    )
+
+
 class CommentSlackThreadSerializer(serializers.ModelSerializer):
     created_by = UserBasicSerializer(
         read_only=True, allow_null=True, help_text="User who mirrored the discussion. Null if since deleted."
@@ -983,6 +1012,45 @@ class CommentViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.ModelV
         count = queryset.count()
 
         return Response({"count": count})
+
+    @extend_schema(
+        request=None,
+        responses={200: CommentEmojiListResponseSerializer},
+        description="List custom emoji from Slack workspaces connected to this project.",
+    )
+    @action(methods=["GET"], detail=False, required_scopes=["comment:read", "integration:read"])
+    def emojis(self, request: Request, **kwargs: Any) -> Response:
+        emoji_urls: dict[str, str] = {}
+        integrations = Integration.objects.filter(team_id=self.team_id, kind="slack").order_by("id")
+
+        for integration in integrations:
+            slack = SlackIntegration(integration)
+            if slack.missing_scopes({SLACK_EMOJI_READ_SCOPE}):
+                continue
+
+            cache_key = f"comment-emojis/{integration.id}"
+            cached_emojis: object = cache.get(cache_key)
+            emoji_by_name = cast(dict[str, Any], cached_emojis) if isinstance(cached_emojis, dict) else None
+            if emoji_by_name is None:
+                try:
+                    response = slack.client.emoji_list()
+                    response_emojis: object = response.get("emoji", {})
+                except SlackApiError:
+                    logger.warning("comment_emoji_list_failed", integration_id=integration.id)
+                    continue
+                if not isinstance(response_emojis, dict):
+                    continue
+                emoji_by_name = cast(dict[str, Any], response_emojis)
+                cache.set(cache_key, emoji_by_name, 60 * 60)
+
+            for name in sorted(emoji_by_name):
+                if name in emoji_urls:
+                    continue
+                url = _resolve_slack_emoji_url(name, emoji_by_name)
+                if url:
+                    emoji_urls[name] = url
+
+        return Response({"results": [{"name": name, "url": url} for name, url in emoji_urls.items()]})
 
     @extend_schema(
         request=None,

--- a/posthog/api/test/test_comments.py
+++ b/posthog/api/test/test_comments.py
@@ -11,7 +11,7 @@ from django.utils import timezone
 from parameterized import parameterized
 from rest_framework import status
 
-from posthog.models import User
+from posthog.models import Integration, User
 from posthog.models.activity_logging.activity_log import ActivityLog
 from posthog.models.comment import Comment
 from posthog.models.comment.utils import build_comment_item_url, extract_plain_text_from_rich_content
@@ -76,6 +76,57 @@ class TestComments(APIBaseTest, QueryMatchingTest):
             artifacts=[{"id": "artifact-1", "name": "report.md", "type": "output"}],
         )
         return task
+
+    @mock.patch("posthog.api.comments.SlackIntegration")
+    def test_comment_emojis_resolve_slack_aliases_and_skip_unscoped_integrations(
+        self, slack_integration: mock.Mock
+    ) -> None:
+        scoped = Integration.objects.create(
+            team=self.team,
+            kind="slack",
+            integration_id="T_SCOPED",
+            config={"scope": "emoji:read"},
+        )
+        Integration.objects.create(
+            team=self.team,
+            kind="slack",
+            integration_id="T_UNSCOPED",
+            config={"scope": "chat:write"},
+        )
+        emoji_list = mock.Mock(
+            return_value={
+                "emoji": {
+                    "hedgehog": "https://emoji.slack-edge.com/hedgehog.png",
+                    "hog": "alias:hedgehog",
+                    "loop_a": "alias:loop_b",
+                    "loop_b": "alias:loop_a",
+                }
+            }
+        )
+
+        def build_slack(integration: Integration) -> mock.Mock:
+            slack = mock.Mock()
+            slack.missing_scopes.return_value = set() if integration.id == scoped.id else {"emoji:read"}
+            slack.client.emoji_list = emoji_list
+            return slack
+
+        slack_integration.side_effect = build_slack
+
+        response = self.client.get(f"/api/projects/{self.team.id}/comments/emojis/")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {
+            "results": [
+                {"name": "hedgehog", "url": "https://emoji.slack-edge.com/hedgehog.png"},
+                {"name": "hog", "url": "https://emoji.slack-edge.com/hedgehog.png"},
+            ]
+        }
+        emoji_list.assert_called_once_with()
+
+        scoped_client = self._sandbox_task_comment_client(scopes="comment:read")
+        forbidden = scoped_client.get(f"/api/projects/{self.team.id}/comments/emojis/")
+        assert forbidden.status_code == status.HTTP_403_FORBIDDEN
+        assert "integration:read" in forbidden.json()["detail"]
 
     def test_task_artifact_comments_require_a_visible_owning_task(self) -> None:
         task = self._task_artifact_target()

--- a/posthog/models/test/test_integration_model.py
+++ b/posthog/models/test/test_integration_model.py
@@ -93,7 +93,14 @@ def test_slack_oauth_requests_the_recently_approved_scopes_on_every_instance():
 
     requested = set(POSTHOG_SLACK_SCOPE.split(","))
 
-    assert {"assistant:write", "im:history", "canvases:write", "files:write", "channels:manage"} <= requested
+    assert {
+        "assistant:write",
+        "im:history",
+        "canvases:write",
+        "files:write",
+        "channels:manage",
+        "emoji:read",
+    } <= requested
 
 
 class TestIntegrationModel(BaseTest):

--- a/posthog/schema_enums.py
+++ b/posthog/schema_enums.py
@@ -3804,6 +3804,7 @@ class SlackIntegrationScope(StrEnum):
     CHAT_WRITE = "chat:write"
     CHAT_WRITE_CUSTOMIZE = "chat:write.customize"
     COMMANDS = "commands"
+    EMOJI_READ = "emoji:read"
     FILES_READ = "files:read"
     FILES_WRITE = "files:write"
     GROUPS_HISTORY = "groups:history"

--- a/products/desktop/packages/api-client/src/generated.ts
+++ b/products/desktop/packages/api-client/src/generated.ts
@@ -4380,6 +4380,16 @@ export namespace Schemas {
     source_comment?: (string | null) | undefined;
     completed_at?: (string | null) | undefined;
   };
+  export type CommentEmoji = {
+    /** Slack shortcode without surrounding colons. */
+    name: string;
+    /** HTTPS image URL for the custom emoji. */
+    url: string;
+  };
+  export type CommentEmojiListResponse = {
+    /** Custom emoji available from Slack workspaces connected to this project. */
+    results: Array<CommentEmoji>;
+  };
   export type CompareItem = { label: string; value: string };
   export type ConclusionEnum = "won" | "lost" | "inconclusive" | "stopped_early" | "invalid";
   export type ConditionalFormattingRule = {
@@ -18530,6 +18540,15 @@ export namespace Endpoints {
     };
     responses: { 200: unknown };
   };
+  export type get_Comments_emojis_retrieve = {
+    method: "GET";
+    path: "/api/projects/{project_id}/comments/emojis/";
+    requestFormat: "json";
+    parameters: {
+      path: { project_id: string };
+    };
+    responses: { 200: Schemas.CommentEmojiListResponse };
+  };
   export type get_Conversations_tickets_list = {
     method: "GET";
     path: "/api/projects/{project_id}/conversations/tickets/";
@@ -25898,6 +25917,7 @@ export type EndpointByMethod = {
     "/api/projects/{project_id}/comments/{id}/": Endpoints.get_Comments_retrieve;
     "/api/projects/{project_id}/comments/{id}/thread/": Endpoints.get_Comments_thread_retrieve;
     "/api/projects/{project_id}/comments/count/": Endpoints.get_Comments_count_retrieve;
+    "/api/projects/{project_id}/comments/emojis/": Endpoints.get_Comments_emojis_retrieve;
     "/api/projects/{project_id}/conversations/tickets/": Endpoints.get_Conversations_tickets_list;
     "/api/projects/{project_id}/conversations/tickets/{id}/": Endpoints.get_Conversations_tickets_retrieve;
     "/api/projects/{project_id}/conversations/tickets/unread_count/": Endpoints.get_Conversations_tickets_unread_count_retrieve;

--- a/products/desktop/packages/api-client/src/posthog-client.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.ts
@@ -271,6 +271,8 @@ export type ResourceComment = Omit<Schemas.Comment, "version"> & {
   version?: number;
 };
 
+export type CommentEmoji = Schemas.CommentEmoji;
+
 export interface CreateResourceCommentRequest {
   scope: CommentScope;
   itemId: string;
@@ -3428,6 +3430,15 @@ export class PostHogAPIClient {
       { scope, itemId, returned: comments.length },
     );
     return comments;
+  }
+
+  async getCommentEmojis(): Promise<CommentEmoji[]> {
+    const teamId = await this.getTeamId();
+    const response = await this.api.get(
+      "/api/projects/{project_id}/comments/emojis/",
+      { path: { project_id: String(teamId) } },
+    );
+    return response.results;
   }
 
   async createResourceComment(

--- a/products/desktop/packages/ui/package.json
+++ b/products/desktop/packages/ui/package.json
@@ -85,6 +85,7 @@
     "canvas-confetti": "^1.9.4",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "emojilib": "4.0.2",
     "framer-motion": "^12.26.2",
     "fuse.js": "^7.1.0",
     "fzf": "^0.5.2",

--- a/products/desktop/packages/ui/src/features/canvas/components/CommentEmojiProvider.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/CommentEmojiProvider.tsx
@@ -1,0 +1,27 @@
+import type { CommentEmoji } from "@posthog/api-client/posthog-client";
+import { useCommentEmojis } from "@posthog/ui/features/canvas/hooks/useCommentEmojis";
+import {
+  createContext,
+  type ReactElement,
+  type ReactNode,
+  useContext,
+} from "react";
+
+const CommentEmojiContext = createContext<CommentEmoji[]>([]);
+
+export function CommentEmojiProvider({
+  children,
+}: {
+  children: ReactNode;
+}): ReactElement {
+  const { data: emojis = [] } = useCommentEmojis();
+  return (
+    <CommentEmojiContext.Provider value={emojis}>
+      {children}
+    </CommentEmojiContext.Provider>
+  );
+}
+
+export function useCommentEmojiList(): CommentEmoji[] {
+  return useContext(CommentEmojiContext);
+}

--- a/products/desktop/packages/ui/src/features/canvas/components/EmojiSuggestionGrid.stories.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/EmojiSuggestionGrid.stories.tsx
@@ -1,0 +1,78 @@
+import type { EmojiSuggestion } from "@posthog/ui/features/canvas/utils/emojiSuggestions";
+import type { Meta, StoryObj } from "@storybook/react";
+import { type ReactElement, useState } from "react";
+import { EmojiSuggestionGrid } from "./EmojiSuggestionGrid";
+
+const suggestions: EmojiSuggestion[] = [
+  {
+    id: "unicode:👋",
+    name: "wave",
+    keywords: ["wave", "hello"],
+    insertion: "👋",
+    emoji: "👋",
+  },
+  {
+    id: "unicode:🎉",
+    name: "tada",
+    keywords: ["tada", "party"],
+    insertion: "🎉",
+    emoji: "🎉",
+  },
+  {
+    id: "unicode:🔥",
+    name: "fire",
+    keywords: ["fire"],
+    insertion: "🔥",
+    emoji: "🔥",
+  },
+  {
+    id: "unicode:🚀",
+    name: "rocket",
+    keywords: ["rocket"],
+    insertion: "🚀",
+    emoji: "🚀",
+  },
+  {
+    id: "unicode:❤️",
+    name: "heart",
+    keywords: ["heart"],
+    insertion: "❤️",
+    emoji: "❤️",
+  },
+  {
+    id: "unicode:👍",
+    name: "thumbs_up",
+    keywords: ["thumbs_up", "+1"],
+    insertion: "👍",
+    emoji: "👍",
+  },
+];
+
+const meta = {
+  title: "Canvas/Emoji suggestion grid",
+  component: EmojiSuggestionGrid,
+  decorators: [
+    (Story): ReactElement => (
+      <div className="relative mt-64 w-80">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof EmojiSuggestionGrid>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: (): ReactElement => {
+    const [highlightedIndex, setHighlightedIndex] = useState(0);
+    return (
+      <EmojiSuggestionGrid
+        suggestions={suggestions}
+        highlightedIndex={highlightedIndex}
+        onHighlight={setHighlightedIndex}
+        onSelect={() => undefined}
+      />
+    );
+  },
+};

--- a/products/desktop/packages/ui/src/features/canvas/components/EmojiSuggestionGrid.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/EmojiSuggestionGrid.tsx
@@ -1,0 +1,84 @@
+import { Autocomplete as BaseAutocomplete } from "@base-ui/react/autocomplete";
+import {
+  Autocomplete,
+  AutocompleteItem,
+  AutocompleteList,
+} from "@posthog/quill";
+import type { EmojiSuggestion } from "@posthog/ui/features/canvas/utils/emojiSuggestions";
+import type { ReactElement } from "react";
+
+const COLUMN_COUNT = 6;
+
+export function EmojiSuggestionGrid({
+  suggestions,
+  highlightedIndex,
+  onHighlight,
+  onSelect,
+  registerItem,
+}: {
+  suggestions: EmojiSuggestion[];
+  highlightedIndex: number;
+  onHighlight: (index: number) => void;
+  onSelect: (suggestion: EmojiSuggestion) => void;
+  registerItem?: (index: number, element: HTMLElement | null) => void;
+}): ReactElement {
+  const rows: EmojiSuggestion[][] = [];
+  for (let index = 0; index < suggestions.length; index += COLUMN_COUNT) {
+    rows.push(suggestions.slice(index, index + COLUMN_COUNT));
+  }
+
+  return (
+    <div className="absolute bottom-full left-0 z-50 mb-1 w-64 overflow-hidden rounded-md border border-border bg-card shadow-lg">
+      <Autocomplete
+        inline
+        grid
+        mode="none"
+        items={suggestions}
+        itemToStringValue={(suggestion) => suggestion.name}
+      >
+        <AutocompleteList
+          aria-label="Choose an emoji"
+          className="max-h-56 space-y-1 overflow-y-auto"
+        >
+          {rows.map((row, rowIndex) => (
+            <BaseAutocomplete.Row
+              key={row[0]?.id ?? rowIndex}
+              className="grid grid-cols-6 gap-1"
+            >
+              {row.map((suggestion, columnIndex) => {
+                const index = rowIndex * COLUMN_COUNT + columnIndex;
+                return (
+                  <AutocompleteItem
+                    key={suggestion.id}
+                    value={suggestion}
+                    nativeButton
+                    ref={(element) => registerItem?.(index, element)}
+                    aria-label={`:${suggestion.name}:`}
+                    data-attr="comment-emoji-suggestion"
+                    title={`:${suggestion.name}:`}
+                    onMouseDown={(event) => event.preventDefault()}
+                    onMouseEnter={() => onHighlight(index)}
+                    onClick={() => onSelect(suggestion)}
+                    className={`h-8 justify-center px-0 text-lg ${
+                      index === highlightedIndex ? "bg-fill-selected" : ""
+                    }`}
+                  >
+                    {suggestion.imageUrl ? (
+                      <img
+                        src={suggestion.imageUrl}
+                        alt=""
+                        className="size-5 object-contain"
+                      />
+                    ) : (
+                      suggestion.emoji
+                    )}
+                  </AutocompleteItem>
+                );
+              })}
+            </BaseAutocomplete.Row>
+          ))}
+        </AutocompleteList>
+      </Autocomplete>
+    </div>
+  );
+}

--- a/products/desktop/packages/ui/src/features/canvas/components/MentionComposer.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/MentionComposer.tsx
@@ -2,7 +2,7 @@ import { RobotIcon } from "@phosphor-icons/react";
 import { Avatar, AvatarFallback, InputGroup } from "@posthog/quill";
 import type { UserBasic } from "@posthog/shared/domain-types";
 import { UserAvatar } from "@posthog/ui/features/auth/UserAvatar";
-import { useCommentEmojis } from "@posthog/ui/features/canvas/hooks/useCommentEmojis";
+import { useCommentEmojiList } from "@posthog/ui/features/canvas/components/CommentEmojiProvider";
 import {
   type EmojiSuggestion,
   filterEmojiSuggestions,
@@ -93,7 +93,7 @@ export function MentionComposer({
   // Esc hides the popup until the current trigger exits; a new trigger re-arms it.
   const [dismissed, setDismissed] = useState(false);
   const [emojiDismissed, setEmojiDismissed] = useState(false);
-  const { data: customEmojis = [] } = useCommentEmojis();
+  const customEmojis = useCommentEmojiList();
 
   const open = !!session && !dismissed && session.items.length > 0;
   const emojiOpen =
@@ -111,30 +111,46 @@ export function MentionComposer({
   // The suggestion plugin's callbacks close over refs so they always see the
   // latest props and popup state.
   const membersRef = useRef(members);
-  membersRef.current = members;
   const customEmojisRef = useRef(customEmojis);
-  customEmojisRef.current = customEmojis;
   const allowAgentMentionRef = useRef(allowAgentMention);
-  allowAgentMentionRef.current = allowAgentMention;
   const onValueChangeRef = useRef(onValueChange);
-  onValueChangeRef.current = onValueChange;
   const onSubmitRef = useRef(onSubmit);
-  onSubmitRef.current = onSubmit;
   const onMentionInsertRef = useRef(onMentionInsert);
-  onMentionInsertRef.current = onMentionInsert;
   const openRef = useRef(open);
-  openRef.current = open;
   const emojiOpenRef = useRef(emojiOpen);
-  emojiOpenRef.current = emojiOpen;
   const sessionRef = useRef(session);
-  sessionRef.current = session;
   const emojiSessionRef = useRef(emojiSession);
-  emojiSessionRef.current = emojiSession;
   const highlightedRef = useRef(highlightedIndex);
-  highlightedRef.current = highlightedIndex;
   const highlightedEmojiRef = useRef(highlightedEmojiIndex);
-  highlightedEmojiRef.current = highlightedEmojiIndex;
   const lastValueRef = useRef(value);
+
+  useEffect(() => {
+    membersRef.current = members;
+    customEmojisRef.current = customEmojis;
+    allowAgentMentionRef.current = allowAgentMention;
+    onValueChangeRef.current = onValueChange;
+    onSubmitRef.current = onSubmit;
+    onMentionInsertRef.current = onMentionInsert;
+    openRef.current = open;
+    emojiOpenRef.current = emojiOpen;
+    sessionRef.current = session;
+    emojiSessionRef.current = emojiSession;
+    highlightedRef.current = highlightedIndex;
+    highlightedEmojiRef.current = highlightedEmojiIndex;
+  }, [
+    allowAgentMention,
+    customEmojis,
+    emojiOpen,
+    emojiSession,
+    highlightedEmojiIndex,
+    highlightedIndex,
+    members,
+    onMentionInsert,
+    onSubmit,
+    onValueChange,
+    open,
+    session,
+  ]);
 
   const editor = useEditor(
     {

--- a/products/desktop/packages/ui/src/features/canvas/components/MentionComposer.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/MentionComposer.tsx
@@ -2,6 +2,11 @@ import { RobotIcon } from "@phosphor-icons/react";
 import { Avatar, AvatarFallback, InputGroup } from "@posthog/quill";
 import type { UserBasic } from "@posthog/shared/domain-types";
 import { UserAvatar } from "@posthog/ui/features/auth/UserAvatar";
+import { useCommentEmojis } from "@posthog/ui/features/canvas/hooks/useCommentEmojis";
+import {
+  type EmojiSuggestion,
+  filterEmojiSuggestions,
+} from "@posthog/ui/features/canvas/utils/emojiSuggestions";
 import {
   type ComposerMentionCandidate,
   contentToDoc,
@@ -9,11 +14,15 @@ import {
   filterComposerMentionCandidates,
 } from "@posthog/ui/features/canvas/utils/mentionComposer";
 import { userDisplayName } from "@posthog/ui/features/canvas/utils/userDisplay";
+import { Extension } from "@tiptap/core";
 import Mention, { type MentionNodeAttrs } from "@tiptap/extension-mention";
 import Placeholder from "@tiptap/extension-placeholder";
+import { PluginKey } from "@tiptap/pm/state";
 import { EditorContent, useEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
+import Suggestion from "@tiptap/suggestion";
 import { type ReactNode, useEffect, useRef, useState } from "react";
+import { EmojiSuggestionGrid } from "./EmojiSuggestionGrid";
 import "./mention-chip.css";
 import "./mention-composer.css";
 
@@ -48,6 +57,13 @@ interface SuggestionSession {
   command: (candidate: ComposerMentionCandidate) => void;
 }
 
+interface EmojiSuggestionSession {
+  items: EmojiSuggestion[];
+  command: (candidate: EmojiSuggestion) => void;
+}
+
+const EMOJI_SUGGESTION_PLUGIN_KEY = new PluginKey("commentEmojiSuggestion");
+
 /**
  * The thread composer: a rich text area that opens an @-mention typeahead over
  * the org's members. Selecting a member inserts an inline chip — rendered the
@@ -68,22 +84,36 @@ export function MentionComposer({
   children,
 }: MentionComposerProps) {
   const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const emojiItemRefs = useRef<(HTMLElement | null)[]>([]);
   const [session, setSession] = useState<SuggestionSession | null>(null);
+  const [emojiSession, setEmojiSession] =
+    useState<EmojiSuggestionSession | null>(null);
   const [selectedIndex, setSelectedIndex] = useState(0);
-  // Esc hides the popup until the current trigger exits; a new `@` re-arms it.
+  const [selectedEmojiIndex, setSelectedEmojiIndex] = useState(0);
+  // Esc hides the popup until the current trigger exits; a new trigger re-arms it.
   const [dismissed, setDismissed] = useState(false);
+  const [emojiDismissed, setEmojiDismissed] = useState(false);
+  const { data: customEmojis = [] } = useCommentEmojis();
 
   const open = !!session && !dismissed && session.items.length > 0;
+  const emojiOpen =
+    !!emojiSession && !emojiDismissed && emojiSession.items.length > 0;
   // The list can shrink while a lower row is selected (members filter down).
   const highlightedIndex = Math.min(
     selectedIndex,
     Math.max(0, (session?.items.length ?? 0) - 1),
+  );
+  const highlightedEmojiIndex = Math.min(
+    selectedEmojiIndex,
+    Math.max(0, (emojiSession?.items.length ?? 0) - 1),
   );
 
   // The suggestion plugin's callbacks close over refs so they always see the
   // latest props and popup state.
   const membersRef = useRef(members);
   membersRef.current = members;
+  const customEmojisRef = useRef(customEmojis);
+  customEmojisRef.current = customEmojis;
   const allowAgentMentionRef = useRef(allowAgentMention);
   allowAgentMentionRef.current = allowAgentMention;
   const onValueChangeRef = useRef(onValueChange);
@@ -94,10 +124,16 @@ export function MentionComposer({
   onMentionInsertRef.current = onMentionInsert;
   const openRef = useRef(open);
   openRef.current = open;
+  const emojiOpenRef = useRef(emojiOpen);
+  emojiOpenRef.current = emojiOpen;
   const sessionRef = useRef(session);
   sessionRef.current = session;
+  const emojiSessionRef = useRef(emojiSession);
+  emojiSessionRef.current = emojiSession;
   const highlightedRef = useRef(highlightedIndex);
   highlightedRef.current = highlightedIndex;
+  const highlightedEmojiRef = useRef(highlightedEmojiIndex);
+  highlightedEmojiRef.current = highlightedEmojiIndex;
   const lastValueRef = useRef(value);
 
   const editor = useEditor(
@@ -119,6 +155,99 @@ export function MentionComposer({
           link: false,
         }),
         Placeholder.configure({ placeholder: placeholder ?? "" }),
+        Extension.create({
+          name: "commentEmojiSuggestion",
+          addProseMirrorPlugins() {
+            return [
+              Suggestion({
+                pluginKey: EMOJI_SUGGESTION_PLUGIN_KEY,
+                editor: this.editor,
+                char: ":",
+                startOfLine: false,
+                allowSpaces: false,
+                allow: ({ state, range }) => {
+                  const before = state.doc.textBetween(
+                    Math.max(0, range.from - 1),
+                    range.from,
+                  );
+                  return before === "" || /\s/.test(before);
+                },
+                items: ({ query }) =>
+                  filterEmojiSuggestions(query, customEmojisRef.current),
+                command: ({ editor: e, range, props }) => {
+                  const emoji = props as unknown as EmojiSuggestion;
+                  e.chain()
+                    .focus()
+                    .insertContentAt(range, emoji.insertion)
+                    .run();
+                },
+                render: () => ({
+                  onStart: (props) => {
+                    setEmojiDismissed(false);
+                    setSelectedEmojiIndex(0);
+                    setEmojiSession({
+                      items: props.items as unknown as EmojiSuggestion[],
+                      command: (candidate) =>
+                        props.command(
+                          candidate as unknown as Record<string, unknown>,
+                        ),
+                    });
+                  },
+                  onUpdate: (props) => {
+                    setSelectedEmojiIndex(0);
+                    setEmojiSession({
+                      items: props.items as unknown as EmojiSuggestion[],
+                      command: (candidate) =>
+                        props.command(
+                          candidate as unknown as Record<string, unknown>,
+                        ),
+                    });
+                  },
+                  onKeyDown: ({ event }) => {
+                    if (event.key === "Escape" && emojiSessionRef.current) {
+                      setEmojiDismissed(true);
+                      return true;
+                    }
+                    if (!emojiOpenRef.current) return false;
+                    const items = emojiSessionRef.current?.items ?? [];
+                    let next: number | null = null;
+                    if (event.key === "ArrowRight") {
+                      next = highlightedEmojiRef.current + 1;
+                    } else if (event.key === "ArrowLeft") {
+                      next = highlightedEmojiRef.current - 1;
+                    } else if (event.key === "ArrowDown") {
+                      next = highlightedEmojiRef.current + 6;
+                    } else if (event.key === "ArrowUp") {
+                      next = highlightedEmojiRef.current - 6;
+                    }
+                    if (next !== null) {
+                      const bounded = Math.max(
+                        0,
+                        Math.min(items.length - 1, next),
+                      );
+                      setSelectedEmojiIndex(bounded);
+                      emojiItemRefs.current[bounded]?.scrollIntoView({
+                        block: "nearest",
+                      });
+                      return true;
+                    }
+                    if (event.key === "Enter" || event.key === "Tab") {
+                      const candidate = items[highlightedEmojiRef.current];
+                      if (candidate)
+                        emojiSessionRef.current?.command(candidate);
+                      return true;
+                    }
+                    return false;
+                  },
+                  onExit: () => {
+                    setEmojiSession(null);
+                    setEmojiDismissed(false);
+                  },
+                }),
+              }),
+            ];
+          },
+        }),
         Mention.configure({
           renderHTML: ({ node }) => [
             "span",
@@ -214,7 +343,7 @@ export function MentionComposer({
         // Runs before the suggestion plugin's handler, so defer to it while
         // the popup is open.
         handleKeyDown: (_view, event) => {
-          if (openRef.current) return false;
+          if (openRef.current || emojiOpenRef.current) return false;
           if (event.key === "Enter" && !event.shiftKey) {
             event.preventDefault();
             onSubmitRef.current();
@@ -242,6 +371,17 @@ export function MentionComposer({
 
   return (
     <div className="relative">
+      {emojiOpen && emojiSession && (
+        <EmojiSuggestionGrid
+          suggestions={emojiSession.items}
+          highlightedIndex={highlightedEmojiIndex}
+          onHighlight={setSelectedEmojiIndex}
+          onSelect={emojiSession.command}
+          registerItem={(index, element) => {
+            emojiItemRefs.current[index] = element;
+          }}
+        />
+      )}
       {open && session && (
         <div className="absolute inset-x-0 bottom-full z-50 mb-1 flex flex-col overflow-hidden rounded-md border border-border bg-card text-[13px] text-foreground shadow-lg">
           <div

--- a/products/desktop/packages/ui/src/features/canvas/components/MentionText.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/MentionText.test.tsx
@@ -12,8 +12,8 @@ vi.mock("@posthog/ui/router/navigationBridge", () => ({
   navigateToChannelTask: vi.fn(),
 }));
 
-vi.mock("@posthog/ui/features/canvas/hooks/useCommentEmojis", () => ({
-  useCommentEmojis: () => ({ data: commentEmojis }),
+vi.mock("@posthog/ui/features/canvas/components/CommentEmojiProvider", () => ({
+  useCommentEmojiList: () => commentEmojis,
 }));
 
 vi.mock("@posthog/ui/utils/urls", () => ({

--- a/products/desktop/packages/ui/src/features/canvas/components/MentionText.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/MentionText.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MentionText } from "./MentionText";
 
 const navigateToChannelDashboard = vi.fn();
+const commentEmojis = vi.hoisted(() => [] as { name: string; url: string }[]);
 
 vi.mock("@posthog/ui/router/navigationBridge", () => ({
   navigateToChannel: vi.fn(),
@@ -11,12 +12,17 @@ vi.mock("@posthog/ui/router/navigationBridge", () => ({
   navigateToChannelTask: vi.fn(),
 }));
 
+vi.mock("@posthog/ui/features/canvas/hooks/useCommentEmojis", () => ({
+  useCommentEmojis: () => ({ data: commentEmojis }),
+}));
+
 vi.mock("@posthog/ui/utils/urls", () => ({
   getPostHogUrl: (path: string) => `https://us.posthog.com${path}`,
 }));
 
 beforeEach(() => {
   vi.clearAllMocks();
+  commentEmojis.length = 0;
 });
 
 describe("MentionText", () => {
@@ -79,6 +85,20 @@ describe("MentionText", () => {
 
     expect(defaultAllowed).toBe(true);
     expect(navigateToChannelDashboard).not.toHaveBeenCalled();
+  });
+
+  it("renders a Slack custom emoji shortcode as its image", () => {
+    commentEmojis.push({
+      name: "party_parrot",
+      url: "https://emoji.slack-edge.com/parrot.gif",
+    });
+
+    render(<MentionText content="Ship it :party_parrot:" />);
+
+    expect(screen.getByAltText(":party_parrot:")).toHaveAttribute(
+      "src",
+      "https://emoji.slack-edge.com/parrot.gif",
+    );
   });
 
   it("inherits the surrounding message text size", () => {

--- a/products/desktop/packages/ui/src/features/canvas/components/MentionText.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/MentionText.tsx
@@ -11,6 +11,8 @@ import type { MentionChip } from "@posthog/core/message-editor/content";
 import { xmlToContent } from "@posthog/core/message-editor/content";
 import { Chip } from "@posthog/quill";
 import { splitMentionSegments } from "@posthog/shared";
+import { useCommentEmojis } from "@posthog/ui/features/canvas/hooks/useCommentEmojis";
+import { splitCustomEmojiSegments } from "@posthog/ui/features/canvas/utils/emojiSuggestions";
 import { splitLinkSegments } from "@posthog/ui/features/canvas/utils/linkify";
 import { GithubRefChip } from "@posthog/ui/features/editor/components/GithubRefChip";
 import { parseGithubIssueUrl } from "@posthog/ui/features/message-editor/githubIssueUrl";
@@ -23,6 +25,7 @@ type RenderSegment =
   | { type: "link"; text: string; href: string }
   | { type: "agent"; text: string }
   | { type: "mention"; name: string; email: string }
+  | { type: "customEmoji"; name: string; url: string }
   | { type: "chip"; chip: MentionChip };
 
 const chipIcons = {
@@ -82,6 +85,7 @@ export function MentionText({
   currentUserEmail?: string | null;
   className?: string;
 }) {
+  const { data: customEmojis = [] } = useCommentEmojis();
   // Key each segment by its character offset — stable for a given content.
   const segments = useMemo(() => {
     let offset = 0;
@@ -107,6 +111,15 @@ export function MentionText({
         push({ type: "text", text: text.slice(cursor) }, text.length - cursor);
       }
     };
+    const pushCustomEmojis = (text: string) => {
+      for (const segment of splitCustomEmojiSegments(text, customEmojis)) {
+        if (segment.type === "customEmoji") {
+          push(segment, segment.name.length + 2);
+        } else {
+          pushAgentMentions(segment.text);
+        }
+      }
+    };
     const pushMentions = (text: string) => {
       for (const segment of splitMentionSegments(text)) {
         if (segment.type === "mention") {
@@ -115,7 +128,7 @@ export function MentionText({
             segment.text.length,
           );
         } else {
-          pushAgentMentions(segment.text);
+          pushCustomEmojis(segment.text);
         }
       }
     };
@@ -133,7 +146,7 @@ export function MentionText({
       }
     }
     return entries;
-  }, [content]);
+  }, [content, customEmojis]);
   const selfEmail = currentUserEmail?.toLowerCase();
   return (
     <span className={className}>
@@ -146,6 +159,17 @@ export function MentionText({
             <span key={key} className={mentionChipClass}>
               {segment.text}
             </span>
+          );
+        }
+        if (segment.type === "customEmoji") {
+          return (
+            <img
+              key={key}
+              src={segment.url}
+              alt={`:${segment.name}:`}
+              title={`:${segment.name}:`}
+              className="mx-0.5 inline-block size-4 object-contain align-text-bottom"
+            />
           );
         }
         if (segment.type === "mention") {

--- a/products/desktop/packages/ui/src/features/canvas/components/MentionText.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/MentionText.tsx
@@ -11,7 +11,7 @@ import type { MentionChip } from "@posthog/core/message-editor/content";
 import { xmlToContent } from "@posthog/core/message-editor/content";
 import { Chip } from "@posthog/quill";
 import { splitMentionSegments } from "@posthog/shared";
-import { useCommentEmojis } from "@posthog/ui/features/canvas/hooks/useCommentEmojis";
+import { useCommentEmojiList } from "@posthog/ui/features/canvas/components/CommentEmojiProvider";
 import { splitCustomEmojiSegments } from "@posthog/ui/features/canvas/utils/emojiSuggestions";
 import { splitLinkSegments } from "@posthog/ui/features/canvas/utils/linkify";
 import { GithubRefChip } from "@posthog/ui/features/editor/components/GithubRefChip";
@@ -85,7 +85,7 @@ export function MentionText({
   currentUserEmail?: string | null;
   className?: string;
 }) {
-  const { data: customEmojis = [] } = useCommentEmojis();
+  const customEmojis = useCommentEmojiList();
   // Key each segment by its character offset — stable for a given content.
   const segments = useMemo(() => {
     let offset = 0;

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useCommentEmojis.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useCommentEmojis.ts
@@ -1,0 +1,16 @@
+import type { CommentEmoji } from "@posthog/api-client/posthog-client";
+import {
+  getAuthIdentity,
+  useAuthStateValue,
+} from "@posthog/ui/features/auth/store";
+import { useAuthenticatedQuery } from "@posthog/ui/hooks/useAuthenticatedQuery";
+import type { UseQueryResult } from "@tanstack/react-query";
+
+export function useCommentEmojis(): UseQueryResult<CommentEmoji[], Error> {
+  const authIdentity = useAuthStateValue(getAuthIdentity);
+  return useAuthenticatedQuery(
+    ["comment-emojis", authIdentity],
+    (client) => client.getCommentEmojis(),
+    { staleTime: 60 * 60 * 1_000, retry: false },
+  );
+}

--- a/products/desktop/packages/ui/src/features/canvas/utils/emojiSuggestions.test.ts
+++ b/products/desktop/packages/ui/src/features/canvas/utils/emojiSuggestions.test.ts
@@ -1,0 +1,45 @@
+import type { CommentEmoji } from "@posthog/api-client/posthog-client";
+import { describe, expect, it } from "vitest";
+import {
+  filterEmojiSuggestions,
+  splitCustomEmojiSegments,
+} from "./emojiSuggestions";
+
+const customEmojis: CommentEmoji[] = [
+  { name: "party_parrot", url: "https://emoji.slack-edge.com/parrot.gif" },
+];
+
+describe("emojiSuggestions", () => {
+  it.each([
+    ["wave", "👋"],
+    ["waving_hand", "👋"],
+    ["+1", "👍"],
+  ])("finds the Unicode emoji for the %s shortcode", (query, expected) => {
+    expect(filterEmojiSuggestions(query, [])[0]?.insertion).toBe(expected);
+  });
+
+  it("includes Slack custom emoji and keeps its shortcode as the insertion", () => {
+    expect(filterEmojiSuggestions("party_par", customEmojis)[0]).toMatchObject({
+      name: "party_parrot",
+      insertion: ":party_parrot:",
+      imageUrl: "https://emoji.slack-edge.com/parrot.gif",
+    });
+  });
+
+  it("replaces only known custom shortcodes when rendering comment text", () => {
+    expect(
+      splitCustomEmojiSegments(
+        "Ship it :party_parrot: but keep :unknown:",
+        customEmojis,
+      ),
+    ).toEqual([
+      { type: "text", text: "Ship it " },
+      {
+        type: "customEmoji",
+        name: "party_parrot",
+        url: "https://emoji.slack-edge.com/parrot.gif",
+      },
+      { type: "text", text: " but keep :unknown:" },
+    ]);
+  });
+});

--- a/products/desktop/packages/ui/src/features/canvas/utils/emojiSuggestions.ts
+++ b/products/desktop/packages/ui/src/features/canvas/utils/emojiSuggestions.ts
@@ -1,0 +1,104 @@
+import type { CommentEmoji } from "@posthog/api-client/posthog-client";
+import emojiKeywords from "emojilib";
+
+export interface EmojiSuggestion {
+  id: string;
+  name: string;
+  keywords: string[];
+  insertion: string;
+  emoji?: string;
+  imageUrl?: string;
+}
+
+export type EmojiTextSegment =
+  | { type: "text"; text: string }
+  | { type: "customEmoji"; name: string; url: string };
+
+const MAX_RESULTS = 48;
+
+const standardEmojiSuggestions: EmojiSuggestion[] = Object.entries(
+  emojiKeywords,
+).map(([emoji, keywords]) => ({
+  id: `unicode:${emoji}`,
+  name: keywords[0] ?? emoji,
+  keywords,
+  insertion: emoji,
+  emoji,
+}));
+
+function matchScore(suggestion: EmojiSuggestion, query: string): number | null {
+  const aliases = [suggestion.name, ...suggestion.keywords].map((keyword) =>
+    keyword.toLowerCase(),
+  );
+  const exactIndex = aliases.indexOf(query);
+  if (exactIndex >= 0) return exactIndex;
+  const prefixIndex = aliases.findIndex((alias) => alias.startsWith(query));
+  if (prefixIndex >= 0) return 100 + prefixIndex;
+  const inclusionIndex = aliases.findIndex((alias) => alias.includes(query));
+  if (inclusionIndex >= 0) return 200 + inclusionIndex;
+  return null;
+}
+
+export function filterEmojiSuggestions(
+  query: string,
+  customEmojis: CommentEmoji[],
+): EmojiSuggestion[] {
+  const normalizedQuery = query
+    .replace(/^:+|:+$/g, "")
+    .trim()
+    .toLowerCase()
+    .replaceAll("-", "_");
+  if (!normalizedQuery) return [];
+
+  const customSuggestions: EmojiSuggestion[] = customEmojis.map((emoji) => ({
+    id: `slack:${emoji.name}`,
+    name: emoji.name,
+    keywords: [emoji.name],
+    insertion: `:${emoji.name}:`,
+    imageUrl: emoji.url,
+  }));
+
+  return [...customSuggestions, ...standardEmojiSuggestions]
+    .map((suggestion) => ({
+      suggestion,
+      score: matchScore(suggestion, normalizedQuery),
+    }))
+    .filter(
+      (match): match is { suggestion: EmojiSuggestion; score: number } =>
+        match.score !== null,
+    )
+    .sort(
+      (left, right) =>
+        left.score - right.score ||
+        left.suggestion.name.localeCompare(right.suggestion.name),
+    )
+    .slice(0, MAX_RESULTS)
+    .map(({ suggestion }) => suggestion);
+}
+
+export function splitCustomEmojiSegments(
+  text: string,
+  customEmojis: CommentEmoji[],
+): EmojiTextSegment[] {
+  const emojiByName = new Map(
+    customEmojis.map((emoji) => [emoji.name.toLowerCase(), emoji]),
+  );
+  const segments: EmojiTextSegment[] = [];
+  let cursor = 0;
+
+  for (const match of text.matchAll(/:([a-zA-Z0-9_+-]{1,100}):/g)) {
+    const start = match.index ?? 0;
+    const emoji = emojiByName.get(match[1].toLowerCase());
+    if (!emoji) continue;
+    if (start > cursor) {
+      segments.push({ type: "text", text: text.slice(cursor, start) });
+    }
+    segments.push({ type: "customEmoji", name: emoji.name, url: emoji.url });
+    cursor = start + match[0].length;
+  }
+
+  if (cursor < text.length) {
+    segments.push({ type: "text", text: text.slice(cursor) });
+  }
+  return segments.length > 0 ? segments : [{ type: "text", text }];
+}

--- a/products/desktop/packages/ui/src/features/sessions/components/CommentComposer.integration.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/CommentComposer.integration.test.tsx
@@ -1,8 +1,36 @@
 import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@posthog/ui/features/canvas/hooks/useCommentEmojis", () => ({
+  useCommentEmojis: () => ({ data: [] }),
+}));
+
 import { CommentComposer } from "./CommentComposer";
 
 describe("CommentComposer submission", () => {
+  it("opens emoji autocomplete from a shortcode and inserts the selected emoji", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    const { container } = render(
+      <CommentComposer
+        value=""
+        onValueChange={onValueChange}
+        onSubmit={vi.fn()}
+        members={[]}
+        placeholder="Comment"
+      />,
+    );
+    const editor = container.querySelector(".ProseMirror");
+    expect(editor).not.toBeNull();
+
+    (editor as HTMLElement).focus();
+    await user.keyboard(":wav");
+    await user.click(await screen.findByLabelText(":waving_hand:"));
+
+    expect(onValueChange).toHaveBeenLastCalledWith("👋");
+  });
+
   it.each(["enter", "send"] as const)(
     "submits the current comment with %s",
     (input) => {

--- a/products/desktop/packages/ui/src/features/sessions/components/CommentComposer.integration.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/CommentComposer.integration.test.tsx
@@ -2,8 +2,8 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
-vi.mock("@posthog/ui/features/canvas/hooks/useCommentEmojis", () => ({
-  useCommentEmojis: () => ({ data: [] }),
+vi.mock("@posthog/ui/features/canvas/components/CommentEmojiProvider", () => ({
+  useCommentEmojiList: () => [],
 }));
 
 import { CommentComposer } from "./CommentComposer";

--- a/products/desktop/packages/ui/src/shell/App.tsx
+++ b/products/desktop/packages/ui/src/shell/App.tsx
@@ -13,6 +13,7 @@ import { InviteCodeScreen } from "@posthog/ui/features/auth/components/InviteCod
 import { ScopeReauthPrompt } from "@posthog/ui/features/auth/components/ScopeReauthPrompt";
 import { useAuthSession } from "@posthog/ui/features/auth/useAuthSession";
 import { useIsOrgAdmin } from "@posthog/ui/features/auth/useOrgRole";
+import { CommentEmojiProvider } from "@posthog/ui/features/canvas/components/CommentEmojiProvider";
 import { CanvasGenerationToaster } from "@posthog/ui/features/canvas/freeform/useCanvasGenerationToasts";
 import { AddDirectoryDialog } from "@posthog/ui/features/folder-picker/AddDirectoryDialog";
 import { ErrorDetailsDialog } from "@posthog/ui/features/notifications/ErrorDetailsDialog";
@@ -234,7 +235,9 @@ function App({ devToolbar }: AppProps) {
         <div className="flex h-screen flex-col">
           <div className="relative min-h-0 flex-1 overflow-hidden">
             {isAuthenticated ? (
-              <AnimatePresence mode="wait">{content}</AnimatePresence>
+              <CommentEmojiProvider>
+                <AnimatePresence mode="wait">{content}</AnimatePresence>
+              </CommentEmojiProvider>
             ) : (
               content
             )}

--- a/products/desktop/pnpm-lock.yaml
+++ b/products/desktop/pnpm-lock.yaml
@@ -1463,6 +1463,9 @@ importers:
       cmdk:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      emojilib:
+        specifier: 4.0.2
+        version: 4.0.2
       framer-motion:
         specifier: ^12.26.2
         version: 12.31.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -10596,6 +10599,9 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  emojilib@4.0.2:
+    resolution: {integrity: sha512-8sP3sfAi861cNaFFp7RmyKi4S26K34ZKy4si75ojUW627AIVBHhMSu2SFJo3YRoK66YWnbysIbOk/d48uEqtKQ==}
 
   empathic@2.0.0:
     resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
@@ -25511,6 +25517,8 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  emojilib@4.0.2: {}
 
   empathic@2.0.0: {}
 

--- a/products/platform_features/frontend/generated/api.schemas.ts
+++ b/products/platform_features/frontend/generated/api.schemas.ts
@@ -949,6 +949,18 @@ export interface CommentSlackThreadApi {
     readonly created_by: UserBasicApi | null
 }
 
+export interface CommentEmojiApi {
+    /** Slack shortcode without surrounding colons. */
+    name: string
+    /** HTTPS image URL for the custom emoji. */
+    url: string
+}
+
+export interface CommentEmojiListResponseApi {
+    /** Custom emoji available from Slack workspaces connected to this project. */
+    results: CommentEmojiApi[]
+}
+
 export interface PinnedSceneTabApi {
     /** Stable identifier for the tab. Generated client-side; safe to omit on create. */
     id?: string

--- a/products/platform_features/frontend/generated/api.ts
+++ b/products/platform_features/frontend/generated/api.ts
@@ -21,6 +21,7 @@ import type {
     ChangeRequestRejectApi,
     ChangeRequestsListParams,
     CommentApi,
+    CommentEmojiListResponseApi,
     CommentSlackThreadApi,
     CommentsListParams,
     ListParams,
@@ -1085,6 +1086,23 @@ export const getCommentsCountRetrieveUrl = (projectId: string) => {
 
 export const commentsCountRetrieve = async (projectId: string, options?: RequestInit): Promise<void> => {
     return apiMutator<void>(getCommentsCountRetrieveUrl(projectId), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getCommentsEmojisRetrieveUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/comments/emojis/`
+}
+
+/**
+ * List custom emoji from Slack workspaces connected to this project.
+ */
+export const commentsEmojisRetrieve = async (
+    projectId: string,
+    options?: RequestInit
+): Promise<CommentEmojiListResponseApi> => {
+    return apiMutator<CommentEmojiListResponseApi>(getCommentsEmojisRetrieveUrl(projectId), {
         ...options,
         method: 'GET',
     })

--- a/products/platform_features/mcp/tools.yaml
+++ b/products/platform_features/mcp/tools.yaml
@@ -309,6 +309,9 @@ tools:
     comments-destroy:
         operation: comments_destroy
         enabled: false
+    comments-emojis-retrieve:
+        operation: comments_emojis_retrieve
+        enabled: false
     comments-list:
         operation: comments_list
         enabled: true

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -17149,6 +17149,18 @@ export namespace Schemas {
       source_comment?: string | null;
     }
 
+    export interface CommentEmoji {
+      /** Slack shortcode without surrounding colons. */
+      name: string;
+      /** HTTPS image URL for the custom emoji. */
+      url: string;
+    }
+
+    export interface CommentEmojiListResponse {
+      /** Custom emoji available from Slack workspaces connected to this project. */
+      results: CommentEmoji[];
+    }
+
     export interface CommentError {
       /** Human-readable explanation of what went wrong. */
       detail: string;


### PR DESCRIPTION
## Problem

People writing comments cannot search for emoji by shortcode or use their Slack workspace's custom emoji.

## Changes

- Typing a shortcode such as `:wave` opens a six-column emoji grid with keyboard navigation.
- Selecting a Unicode emoji replaces the shortcode with the emoji character.
- Selecting a Slack custom emoji keeps its `:name:` shortcode and renders the matching image in comments.
- A cached comments endpoint merges custom emoji from connected Slack workspaces and resolves Slack aliases.
- The endpoint requires both comment and integration read access.

> [!WARNING]
> The new `emoji:read` scope makes existing Slack connections request reauthorization. Confirm Slack app approval before rollout.

**Before**

```mermaid
flowchart LR
    A[Comment composer] --> B[Plain text only]
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phYellow;
    class B phGray;
```

**After**

```mermaid
flowchart LR
    A[Comment composer] --> B[Emoji autocomplete]
    B --> C[Unicode emoji data]
    B --> D[Cached Slack emoji API]
    D --> E[Connected Slack workspaces]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phYellow;
    class B phBlue;
    class C phGray;
    class D,E phRed;
```

![emoji-grid](https://raw.githubusercontent.com/PostHog/pr-assets/3167667cc2d6cb9168aa4775ba7d16eff24eeb35/2026/08/0d8f0e7b-5640-4918-bc7b-97856940ca39.png)

## How did you test this code?

- Vitest covers shortcode lookup, custom emoji rendering, and composer insertion.
- Pytest covers Slack aliases, missing scopes, and endpoint authorization.
- TypeScript checks passed for the Desktop UI and API client packages.
- Repository-wide mypy passed.
- The Desktop Storybook build passed, and Chromium rendered the emoji grid story.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- The local Slack setup guide now includes the `emoji:read` scope.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- The pi coding agent implemented and verified this change with repository tools.
- Skills used: `/writing-ui-components`, `/writing-user-facing-copy`, `/writing-tests`, `/improving-drf-endpoints`, `/adopting-generated-api-types`, `/writing-code-comments`, and `/writing-pr-descriptions`.
- The implementation uses Base UI's grid autocomplete pattern and the existing Quill autocomplete styling.