### PR TITLE
feat(growth): redesign the nav panel product push card

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1401,13 +1401,13 @@ snapshots:
     components-mcp-use-case-card--surveys-create--light:
         hash: v1.k794b7964.693a3cba67de29bb7ecea8b07f3ae05b0201c2785fa2f2d4975e481b6fdc349e.ROQjP-mA4zsLzJifJv9uIKLgwuM0h84NwoFZJ90rSyc
     components-navpanelproductpush--all-products--dark:
-        hash: v1.k794b7964.fb29cbd78a154a52102b09ddfda363b224066d65abeadebee5d74d7bd0197106.L-TFWS6usny3pfuC-UJ6v94m-7elprvCKQEiQu4uia4
+        hash: v1.k794b7964.24e54b2883443ad9a2c5a22bffe7a7870f1ccfd0ea97a2b4e1201c2ba7192623.gIA9Y2g7eZARK8cEyyopNP4lxl5PogVL-6S-jGYZk0w
     components-navpanelproductpush--all-products--light:
-        hash: v1.k794b7964.1ca851e68f3282f393b55cc08c83d14985438bc2c4a358632108dbff9f1f0971.SdrRB9BIGy04vEgIPioVHwDgmv12Mbn-eEL8aUFg_O8
+        hash: v1.k794b7964.bfe2812c6586da7d0c0454f04cb61c468d134b78b7463271549ae314a0dab52c.RUyduXzLwObD97z9SoIFh8-GdIMI3PsDH0by5d-ZdwQ
     components-navpanelproductpush--default-fallback--dark:
-        hash: v1.k794b7964.73c20ea721009efba63d0b347a37dbef0ca34d3d19724c6f5158aadbc138f20e.Aih-CDdZmGHnefWI5954Zgk2lpSJXuVKgluWjrNUOqg
+        hash: v1.k794b7964.020f807f2d17fdf515b84c8800c37e0b6d8b0bda09421fbe1f0d3bcf9aeb23d4.C0OD2Gur0abSVWhBC5aarFDYTYRrudc-F6CjqvjhJ5o
     components-navpanelproductpush--default-fallback--light:
-        hash: v1.k794b7964.c21ed9ee3902f9b0f242e207c5d9d15353b4927f6153d251a35421048c602544.VYc6ozOtCMTbvtt4k9YpZURkEostfdIBq1-WLe6i1WY
+        hash: v1.k794b7964.06ad78d5182a189840a64537f4fffe5aae18b33328c8da550e09227aa506d3af.C5iY4j46abCd6Uf6SVnMZegPSQP9oqMPFb5dSeCdmzo
     components-networkrequest-navigationitem--all-slow--dark:
         hash: v1.k794b7964.d09d9acbf8cb33a45a26cc9fd6e238dd97fa80b5b38c244dab95cd662d085c42.iV22pgH-xBLY-79NVxnPiKvZQ3vbBvZ7uthloHKd9Sc
     components-networkrequest-navigationitem--all-slow--light:
@@ -8497,21 +8497,21 @@ snapshots:
     scenes-other-welcome-dialog--default--light:
         hash: v1.k794b7964.94d0889537f8a4a1345a155d78629fa3e090e1e8830323a77f37557c249ff45d.kPlrU8LIQApctwOYT1bNNhPfH3iynBBs41dZv4PqyzI
     scenes-other-welcome-dialog--empty-organization--dark:
-        hash: v1.k794b7964.9951b983bc53fd0147615d6216e76c8971dafa5fe5f5dcf2f89b076f21d05ac4.xD0q1sDMZaYraoKBg4mlmlnUldBZlVO1PNUkqLXfBuY
+        hash: v1.k794b7964.9324445da230670fa129f51933cbf12208a7bf02b333faa5aa5ef3b488bd127f.jIvaRPb7hDK4CXABpsQQu3Hixs3mSTJ5fUf3oRkDuBM
     scenes-other-welcome-dialog--empty-organization--light:
-        hash: v1.k794b7964.eb441c3b4223d47e62b1ad8f39138d27b4621e5c059ed4b8bcd90dee3fc7ee8d.CuE1WUVJAOt82qzcXB6UwIyUCLHw5Gu_NYnTrmgYlFk
+        hash: v1.k794b7964.6a0c8b6ebb92d1906513350ec2032a618a365767f090ad7f601050549486da16.KAlCXZL7Kf0kVpFz4c850yN4zW6eKXMCciXpcIDPtV4
     scenes-other-welcome-dialog--no-inviter--dark:
         hash: v1.k794b7964.7b34aac52fe0499a37f5971ccf76a25e12cde19e7c3e6f2f779802111fb99cd7.pF2gizxUDboEBZD4sG2K5U7GkIqm-yX_Ch6gtey_Mng
     scenes-other-welcome-dialog--no-inviter--light:
         hash: v1.k794b7964.f766cbd27b7bc11b50ce42602ca2fcab11fa005e795aad0d66e6f67e627570d2.M3CFGWAqq3ebMX5h9Rlb9cCCOBUfhrdc86fQexL6-MA
     scenes-other-welcome-dialog--provisioned--dark:
-        hash: v1.k794b7964.ca1f1c0c19f2b721c8a57b8ab8527214aa231c3557caedcf392b4f7f531a267b.fd-faV75IyRDiQaarDTPWOAU3fiQYfGTgwg-1kAqZ88
+        hash: v1.k794b7964.f2c3d2da5c26ff0d4e4883583589df344c65b8d6b58ae37ef5c4792c02b5d026.G7Cluv7BykKb0ZB6ox1bq_ETjWtz13E0kNhkGxqV-ao
     scenes-other-welcome-dialog--provisioned--light:
-        hash: v1.k794b7964.4241f0cd5107adba6f5385cad103712e340ab458747b0936107c9a85e0c9f423.L5KqvkCuIdvMTJ4AknHk45IwOt-XgmGYjBmeDA_Bkuc
+        hash: v1.k794b7964.7bc96d4f26a15090c0e0822f013065ffbf00a22f0edda8572b12c01a531fe6dc.x21M2rAOPxoCSK84EZ-zyIs4Mvpl_BEBXhi33H3UJzw
     scenes-other-welcome-flagshipproductscard--default--dark:
-        hash: v1.k794b7964.d3a26ab7dedc62599bcc213bc25209189a39ec87e2472821d79dec3d5062d38d.DJtX4EJhBeB0ZjyBmXhQK3F1oZ1BK1Nm7TU4bH0RXnE
+        hash: v1.k794b7964.6851560ee74f548c534d5cca9da3f4130b8246bde9d7fd55e2a488b9796776e9.gxmuoqSgNubqjgDwXDAI-4YD0l4yMr4us4kdAc9gcaQ
     scenes-other-welcome-flagshipproductscard--default--light:
-        hash: v1.k794b7964.358a8cb872b3bc97b9f8844bb29bf00638879dc17dd20d5e93479d59b4064d36.YYXK42rCO__vp0IfRMrfGQyICVpArFGBiHNY7Ka1JNY
+        hash: v1.k794b7964.9810dedb36d0fb0dfe89ba8fd57aa27370e4961c268c5da91fb43afdcb5465d7.Eu1Q6DWylPXCKEIbi9oks2v6lS9n_udV2AeY2-4_spo
     scenes-other-welcome-installprogresscard--default--dark:
         hash: v1.k794b7964.b321aa0af8cd6635d3746c0f22e768f1ef0ed4a56210e219babebd1c38896890.2f7pqD-CII2Cb_5O9oo_SAA4A-hzd2n42nThxggLws8
     scenes-other-welcome-installprogresscard--default--light:

--- a/frontend/src/lib/components/NavPanelAdvertisement/navPanelAdShared.tsx
+++ b/frontend/src/lib/components/NavPanelAdvertisement/navPanelAdShared.tsx
@@ -27,81 +27,34 @@ export function isCampaignPayload(value: unknown): value is CampaignPayload {
     )
 }
 
+/** Where the hog sits along the card's bottom edge, so each illustration can be framed on its own terms. */
+export interface HoggieOffset {
+    /** Horizontal center of the hog, as a percentage of the card's width. 0 is the left edge, 100 the right. */
+    x?: number
+    /** Share of the hog's own height hidden below the card's bottom edge. */
+    y?: number
+}
+
 export interface ProductPushDisplay {
-    /** Hoggie illustration shown in the promo card's hero image (a PNG, via `pngHoggie`) */
+    /** Hoggie illustration shown at the bottom of the promo card (a PNG, via `pngHoggie`) */
     Hoggie: React.ComponentType<AssetSvgProps>
-    /** Product brand color driving the hero's geometric background */
+    /** Product brand color, used for the title and - mixed down - its highlight */
     accentColor: string
     /** Default promo copy, used when the campaign has no custom reason text */
     tagline: string
+    /** Overrides the default framing of `Hoggie`, for illustrations that sit off-balance in their own bounds */
+    hoggieOffset?: HoggieOffset
 }
 
-// Playful scattered shapes behind the hoggie, tinted white over the product's brand color
-function GeometricPattern(): JSX.Element {
-    return (
-        <svg
-            className="absolute inset-0 h-full w-full text-white"
-            viewBox="0 0 232 96"
-            preserveAspectRatio="xMidYMid slice"
-            aria-hidden="true"
-        >
-            <circle cx="26" cy="22" r="11" fill="currentColor" opacity="0.25" />
-            <circle cx="204" cy="66" r="17" fill="none" stroke="currentColor" strokeWidth="3" opacity="0.3" />
-            <rect
-                x="176"
-                y="10"
-                width="15"
-                height="15"
-                rx="2"
-                transform="rotate(18 183 17)"
-                fill="currentColor"
-                opacity="0.2"
-            />
-            <polygon points="64,10 75,30 53,30" fill="currentColor" opacity="0.3" />
-            <path
-                d="M8 62 l7 -8 7 8 7 -8 7 8"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                opacity="0.35"
-            />
-            <circle cx="118" cy="14" r="4" fill="currentColor" opacity="0.35" />
-            <path
-                d="M148 78 h12 M154 72 v12"
-                stroke="currentColor"
-                strokeWidth="3"
-                strokeLinecap="round"
-                opacity="0.3"
-            />
-            <circle cx="52" cy="78" r="6" fill="none" stroke="currentColor" strokeWidth="2.5" opacity="0.25" />
-            <rect
-                x="96"
-                y="70"
-                width="10"
-                height="10"
-                transform="rotate(-12 101 75)"
-                fill="currentColor"
-                opacity="0.18"
-            />
-            <polygon
-                points="206,18 214,32 198,32"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2.5"
-                strokeLinejoin="round"
-                opacity="0.3"
-            />
-        </svg>
-    )
-}
+const DEFAULT_HOGGIE_OFFSET: Required<HoggieOffset> = { x: 50, y: 22 }
 
 /**
- * Presentational product "hog + text" hero: a Hoggie illustration over the product's brand-tinted
- * geometric background, with a title and blurb below. Shared by the nav advertisement card and the
- * welcome dialog's flagship-products showcase so both read as one visual. ``topRight`` is an optional
- * slot for an overlay control (e.g. a dismiss button); the welcome showcase leaves it empty.
+ * Presentational product "text + hog" promo: the product name highlighted in its brand color, a
+ * blurb, and a Hoggie illustration running off the card's bottom edge. Shared by the nav
+ * advertisement card and the welcome dialog's flagship-products showcase so both read as one
+ * visual. The illustration is clipped by the caller's `overflow-hidden`. ``topRight`` is an
+ * optional slot for a control next to the title (e.g. a dismiss button); the welcome showcase
+ * leaves it empty.
  */
 export function ProductHogHero({
     hero,
@@ -114,22 +67,36 @@ export function ProductHogHero({
     text: React.ReactNode
     topRight?: JSX.Element
 }): JSX.Element {
+    const { x, y } = { ...DEFAULT_HOGGIE_OFFSET, ...hero.hoggieOffset }
+
     return (
-        <>
-            <div
-                className="relative flex h-24 items-center justify-center"
-                style={{ backgroundColor: hero.accentColor }}
-            >
-                <GeometricPattern />
-                <hero.Hoggie className="relative h-20 w-auto" aria-hidden="true" />
-                <div className="absolute inset-x-0 bottom-0 h-10 bg-gradient-to-b from-transparent to-surface-primary" />
-                {topRight ? <div className="absolute top-1 right-1">{topRight}</div> : null}
+        <div className="flex flex-col gap-1 px-2 pt-2">
+            <div className="flex items-start justify-between gap-1">
+                <strong
+                    className="rounded-sm px-1 py-px text-sm leading-tight"
+                    style={{
+                        // Pulled towards the theme's text color so pale brand accents stay legible on
+                        // light backgrounds and dark ones on the dark theme, without losing their hue.
+                        color: `color-mix(in srgb, ${hero.accentColor} 78%, var(--color-text-primary))`,
+                        backgroundColor: `color-mix(in srgb, ${hero.accentColor} 18%, transparent)`,
+                    }}
+                >
+                    {title}
+                </strong>
+                {topRight}
             </div>
-            <div className="flex flex-col gap-1 px-2 pt-0.5 pb-2">
-                <strong className="text-sm leading-tight">{title}</strong>
-                <p className="mb-0 text-secondary">{text}</p>
+            <p className="mb-0 text-secondary">{text}</p>
+            {/* Pulled out of the card's horizontal padding so `x` is a share of the full card width */}
+            <div className="relative -mx-2 -mt-1 h-32">
+                {/* Oversized rather than nudged down, so the part `y` hides below the edge does not
+                    open an equal gap above the hog. */}
+                <hero.Hoggie
+                    className="absolute top-0 w-auto max-w-none"
+                    style={{ left: `${x}%`, height: `${100 / (1 - y / 100)}%`, transform: 'translateX(-50%)' }}
+                    aria-hidden="true"
+                />
             </div>
-        </>
+        </div>
     )
 }
 
@@ -152,11 +119,10 @@ export function AdvertisementCard({
 
     const dismissButton = (
         <LemonButton
-            icon={<IconX className={hero ? 'text-white' : 'text-muted'} />}
+            icon={<IconX className="text-muted" />}
             tooltip="Dismiss"
             tooltipPlacement="right"
             size="xxsmall"
-            className={hero ? 'bg-black/20 hover:bg-black/30' : undefined}
             onClick={(e) => {
                 e.preventDefault()
                 e.stopPropagation()

--- a/frontend/src/lib/components/NavPanelAdvertisement/navPanelProductPushDisplay.ts
+++ b/frontend/src/lib/components/NavPanelAdvertisement/navPanelProductPushDisplay.ts
@@ -1,14 +1,14 @@
 import * as chart from '@posthog/brand/hoggies/png/chart'
-import * as codeBubble from '@posthog/brand/hoggies/png/code-bubble'
 import * as cursor from '@posthog/brand/hoggies/png/cursor'
 import * as director from '@posthog/brand/hoggies/png/director'
 import * as experiment from '@posthog/brand/hoggies/png/experiment'
 import * as judge from '@posthog/brand/hoggies/png/judge'
 import * as megaphone from '@posthog/brand/hoggies/png/megaphone'
 import * as noir from '@posthog/brand/hoggies/png/noir-1'
+import * as officeWorker from '@posthog/brand/hoggies/png/office-worker'
 import * as panic from '@posthog/brand/hoggies/png/panic'
 import * as phoneCall from '@posthog/brand/hoggies/png/phone-call'
-import * as puzzle from '@posthog/brand/hoggies/png/puzzle'
+import * as research from '@posthog/brand/hoggies/png/research'
 import * as robot from '@posthog/brand/hoggies/png/robot'
 import * as trafficController from '@posthog/brand/hoggies/png/traffic-controller'
 import * as wizard from '@posthog/brand/hoggies/png/wizard-1'
@@ -21,16 +21,16 @@ import { ProductKey } from '~/queries/schema/schema-general'
 import type { ProductPushDisplay } from './navPanelAdShared'
 
 const HedgehogChart = pngHoggie(chart)
-const HedgehogCodeBubble = pngHoggie(codeBubble)
 const HedgehogCursor = pngHoggie(cursor)
 const HedgehogDirector = pngHoggie(director)
 const HedgehogExperiment = pngHoggie(experiment)
 const HedgehogJudge = pngHoggie(judge)
 const HedgehogMegaphone = pngHoggie(megaphone)
 const HedgehogNoir = pngHoggie(noir)
+const HedgehogOfficeWorker = pngHoggie(officeWorker)
 const HedgehogPanic = pngHoggie(panic)
 const HedgehogPhoneCall = pngHoggie(phoneCall)
-const HedgehogPuzzle = pngHoggie(puzzle)
+const HedgehogResearch = pngHoggie(research)
 const HedgehogRobot = pngHoggie(robot)
 const HedgehogTrafficController = pngHoggie(trafficController)
 const HedgehogWizard = pngHoggie(wizard)
@@ -52,72 +52,85 @@ export const PRODUCT_PUSH_DISPLAY: Partial<Record<ProductKey, ProductPushDisplay
         accentColor: 'var(--color-product-product-analytics-light)',
         tagline:
             'Insights, funnels, trends, and retention - understand exactly what users do in your product, with the events you already send.',
+        hoggieOffset: { x: 42 },
     },
     [ProductKey.WEB_ANALYTICS]: {
         Hoggie: HedgehogCursor,
         accentColor: 'var(--color-product-web-analytics-light)',
         tagline:
             'Visitors, pageviews, and conversions on one simple dashboard. Like GA, without the pain - and no extra setup, ready for you to use.',
+        hoggieOffset: { x: 72, y: 12 },
     },
     [ProductKey.SESSION_REPLAY]: {
         Hoggie: HedgehogDirector,
         accentColor: 'var(--color-product-session-replay-light)',
         tagline:
             'Lights, camera, action - watch real users move through your product and see exactly where they get stuck.',
+        hoggieOffset: { x: 65, y: 32 },
     },
     [ProductKey.ERROR_TRACKING]: {
         Hoggie: HedgehogPanic,
         accentColor: 'var(--color-product-error-tracking-light)',
         tagline:
             'Catch exceptions before your users tweet about them - errors grouped, triaged, and linked to the sessions that hit them.',
+        hoggieOffset: { x: 30 },
     },
     [ProductKey.FEATURE_FLAGS]: {
         Hoggie: HedgehogTrafficController,
         accentColor: 'var(--color-product-feature-flags-light)',
         tagline: 'Ship to 1% before you ship to everyone. Roll out, target, and roll back - no redeploys needed.',
+        hoggieOffset: { x: 72 },
     },
     [ProductKey.EXPERIMENTS]: {
         Hoggie: HedgehogExperiment,
         accentColor: 'var(--color-product-experiments-light)',
         tagline: 'Stop debating, start testing. Run A/B tests on real users and let the data settle the argument.',
+        hoggieOffset: { x: 62 },
     },
     [ProductKey.CONVERSATIONS]: {
         Hoggie: HedgehogPhoneCall,
         accentColor: 'var(--color-product-support-light)',
         tagline:
             'Talk to users right inside your product, with their session and event history next to every conversation.',
+        hoggieOffset: { x: 77 },
     },
     [ProductKey.DATA_WAREHOUSE]: {
-        Hoggie: HedgehogCodeBubble,
+        Hoggie: HedgehogOfficeWorker,
         accentColor: 'var(--color-product-data-warehouse-light)',
         tagline:
             'Query everything with SQL - your product events plus warehouse sources like Stripe, HubSpot, and Postgres.',
+        hoggieOffset: { x: 65, y: 6 },
     },
     [ProductKey.AI_OBSERVABILITY]: {
         Hoggie: HedgehogRobot,
         accentColor: 'var(--color-product-llm-analytics-light)',
         tagline:
             "Traces, costs, and latency for every LLM call - know what your AI is doing, and what it's costing you.",
+        hoggieOffset: { x: 54 },
     },
     [ProductKey.LLM_CLUSTERS]: {
-        Hoggie: HedgehogPuzzle,
+        Hoggie: HedgehogResearch,
         accentColor: 'var(--color-product-llm-clusters-light)',
         tagline: 'Thousands of AI conversations, automatically grouped into patterns you can actually act on.',
+        hoggieOffset: { x: 20 },
     },
     [ProductKey.LLM_EVALUATIONS]: {
         Hoggie: HedgehogJudge,
         accentColor: 'var(--color-product-llm-evaluations-light)',
         tagline: 'Grade your LLM outputs at scale and catch regressions before your users do.',
+        hoggieOffset: { x: 73 },
     },
     [ProductKey.LLM_PROMPTS]: {
         Hoggie: HedgehogWizard,
         accentColor: 'var(--color-product-llm-analytics-light)',
         tagline: 'Version, test, and ship prompt changes without redeploying your app. A little magic, fully tracked.',
+        hoggieOffset: { x: 82 },
     },
     [ProductKey.LOGS]: {
         Hoggie: HedgehogNoir,
         accentColor: 'var(--color-product-logs-light)',
         tagline: 'Search every log line alongside your product data - no mystery goes unsolved.',
+        hoggieOffset: { x: 75 },
     },
     [ProductKey.WORKFLOWS]: {
         Hoggie: HedgehogWorkflows,


### PR DESCRIPTION
## Problem

Anyone who gets a product suggestion in the nav sidebar sees it on a card with a saturated brand-color banner and a scattered-shapes SVG behind the hedgehog. The design team replaced that layout with a flat card: the product name highlighted in its brand color, the blurb under it, and the hedgehog running off the bottom edge.

## Changes

- The push card now shows the product name as a colored highlight on a flat surface, with the hedgehog cropped by the card's bottom edge.
- The colored banner, its geometric SVG pattern, and the fade-to-surface gradient are gone.
- The title color and its highlight both derive from the product accent through `color-mix`, so a new product needs one color rather than a matching set.
- The title mixes in 22% of `--color-text-primary`, which flips per theme. Without that step the amber and teal accents fail to read on the light theme.
- Each product can set `hoggieOffset` to frame its own illustration. `x` places the hedgehog across the card, `y` sets how much of it the bottom edge hides.
- The hedgehog scales up rather than translating down. Translating opened a gap above it as tall as the crop, which is what made the deeply cropped cards look loose.
- The welcome dialog's flagship products showcase shares `ProductHogHero`, so it takes the same layout.
- Mechanical: the dismiss button drops its white-on-scrim variant, which existed only to sit on the colored banner.

Dark theme:

![nav panel product push, dark theme](https://raw.githubusercontent.com/PostHog/pr-assets/34cbb3b63ff03e826a60446b9c0ab1af49702d78/2026/08/5e2de8c7-2e01-4fc4-8f62-b98e1eb675cf.png)

Light theme:

![nav panel product push, light theme](https://raw.githubusercontent.com/PostHog/pr-assets/881db81f451b0346a61519330f98dd41d75fb295/2026/08/32620365-6abe-42ba-b0c9-709272ac65fc.png)

## How did you test this code?

- Rendered `Components/NavPanelProductPush` in Storybook at the 232px sidebar width, in both themes, for all 14 products and the fallback.
- Compared each rendered card against the design mock by detecting the card grid and each illustration's ink bounding box. Every product lands within 1.3 percentage points of the mock's horizontal position.
- The gap between the blurb and the hedgehog fell from a mean of 30px to a mean of 11px across the 14 cards.
- No new tests. The change is presentational, and no existing test asserts on this markup.

> [!NOTE]
> Not run: the visual regression suite. `frontend/snapshots.yml` holds baselines for `components-navpanelproductpush--all-products` and `components-navpanelproductpush--default-fallback`. Both change here and need regenerating.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code (Opus 5). Skills invoked: `/writing-ui-components`, `/writing-pr-descriptions`.

The offsets were not chosen by eye. An early pass positioned every hedgehog centered, which the design mock does not do. The mock was then measured programmatically, per card, and the rendered output measured the same way until the two agreed. Four products were moved off those measured values afterwards on the reviewer's direction: product analytics, feature flags, LLM clusters, and logs.

The gap above each hedgehog started as a spacing question and turned out to be structural. The first implementation cropped the illustration with `translateY`, which pushes the artwork down and opens an equal gap above it, so the deeper the crop the worse the gap. Sizing the illustration up against a fixed window removes the coupling and keeps the meaning of `y` intact.

`ProductHogHero` is shared with the welcome dialog rather than forked, matching the intent recorded in its existing comment. The residual gap above some hedgehogs comes from transparent padding baked into the PNG assets, which no layout change can remove.
