### PR TITLE
fix(warehouse-sources): retry railway's generic graphql error

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/railway/railway.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/railway/railway.py
@@ -55,6 +55,13 @@ def _raise_for_graphql_errors(payload: dict[str, Any]) -> None:
         # Stable prefix matched by `get_non_retryable_errors` — Railway returns auth failures
         # as HTTP 200 + a GraphQL error, so there is no 401 status to key off.
         raise Exception(f"Railway API error: Not Authorized. GraphQL errors: {messages}")
+    if "Problem processing request" in messages:
+        # Railway's generic internal-error message, also returned as HTTP 200 + a GraphQL error.
+        # Their support forum confirms it's usually a transient backend hiccup, so retry it like
+        # the 429/5xx statuses below rather than aborting the whole sync on the first occurrence.
+        raise RailwayRetryableError(
+            f"Railway API error (retryable): Problem processing request. GraphQL errors: {messages}"
+        )
     raise Exception(f"Railway GraphQL error: {messages}")
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/railway/tests/test_railway.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/railway/tests/test_railway.py
@@ -234,6 +234,13 @@ class TestRailway:
         non_retryable = RailwaySource().get_non_retryable_errors()
         assert any(key in str(exc_info.value) for key in non_retryable)
 
+    def test_problem_processing_request_error_is_retryable(self):
+        # Railway returns this generic message as HTTP 200 + a GraphQL error for what their own
+        # support forum confirms is usually a transient backend hiccup — it must retry like the
+        # 429/5xx statuses below, not abort the sync on the first occurrence.
+        with pytest.raises(RailwayRetryableError):
+            railway._raise_for_graphql_errors({"errors": [{"message": "Problem processing request"}]})
+
     @parameterized.expand([(429,), (500,), (503,)])
     def test_retryable_status_codes(self, status_code):
         session = mock.MagicMock()

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/railway/tests/test_railway_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/railway/tests/test_railway_source.py
@@ -85,6 +85,10 @@ class TestRailwaySource:
             ("rate_limit", "Railway API error (retryable): status=429, retry_after=60"),
             ("server_error", "Railway API error (retryable): status=500, retry_after=None"),
             (
+                "problem_processing_request",
+                "Railway API error (retryable): Problem processing request. GraphQL errors: Problem processing request",
+            ),
+            (
                 "connection_error",
                 "HTTPSConnectionPool(host='backboard.railway.com', port=443): Max retries exceeded with url: "
                 '/graphql/v2 (Caused by ReadTimeoutError("HTTPSConnectionPool'


### PR DESCRIPTION
## Problem

A Railway data warehouse sync aborts immediately when Railway's GraphQL API returns its generic "Problem processing request" error, even though it arrives as part of an HTTP 200 response rather than a 5xx status.
Railway's own support forum confirms this message is usually a transient backend hiccup, not a malformed request.
Surfaced by [error tracking issue 01a017a6](https://us.posthog.com/project/2/error_tracking/01a017a6-4d88-7cc3-bf1f-0ff5dfa01e85): the sync failed three times in under two minutes on the same GraphQL error text.

## Changes

- `_raise_for_graphql_errors` now raises the existing `RailwayRetryableError` for this message, so it retries in-process with backoff the same way HTTP 429/5xx responses already do, instead of failing the sync on the first occurrence.
- The retryable-error catalog already recognizes the `Railway API error (retryable)` prefix this uses, so once the in-process retry budget exhausts, the failure stays out of tracked exception noise the same way other transient errors do.

## How did you test this code?

Added `test_problem_processing_request_error_is_retryable` to `test_railway.py` — catches a regression where this message stops raising `RailwayRetryableError` and instead aborts the sync immediately.
Extended the parameterized `test_retryable_errors_match_transient_failures` in `test_railway_source.py` with the new message format, guarding that it stays recognized as retryable once it reaches the source-level catalog.
Ran the full `railway` test suite locally (35 passed) and `ruff check`/`ruff format`/`mypy` on the changed files, all clean.
Not run: a live sync against Railway's API, since this environment has no Railway credentials.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing docs describe this source's retry behavior.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged directly from the linked error tracking issue: pulled the stack trace, confirmed it resolves entirely within `railway.py`, and cross-referenced Railway's public support forum for what "Problem processing request" typically means.
Read the Stripe source's `get_non_retryable_errors`/`get_retryable_errors` pattern as the reference this change mirrors.
Invoked `/writing-tests` before adding test coverage and `/writing-pr-descriptions` before writing this body.
No open PR (human- or bot-authored) addressed this error.