### PR TITLE
fix(warehouse-sources): guide users when CDC setup hits a read-only database

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/adapter.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/adapter.py
@@ -65,6 +65,15 @@ def _slot_setup_error_message(exc: Exception) -> str:
             "Either grant it replication access, or switch these tables to Incremental sync "
             "instead of CDC. Incremental needs only SELECT permission."
         )
+    # A read replica or read-only standby rejects the CREATE PUBLICATION that CDC needs.
+    if "in a read-only transaction" in message:
+        return (
+            f"Failed to create replication slot: {exc} "
+            "CDC has to create a replication slot and publication, which only a writable primary "
+            "database allows. This connection points at a read replica or read-only standby. "
+            "Connect to the primary database, or switch these tables to Incremental sync, which "
+            "needs only SELECT."
+        )
     return f"Failed to create replication slot: {exc}"
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/tests/test_adapter.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/tests/test_adapter.py
@@ -185,6 +185,11 @@ class TestSlotSetupErrorMessage:
         error = _slot_setup_error_message(Exception("ERROR: must be superuser or replication role"))
         assert "Incremental sync" in error
 
+    def test_read_only_transaction_error_points_at_primary(self) -> None:
+        error = _slot_setup_error_message(Exception("cannot execute CREATE PUBLICATION in a read-only transaction"))
+        assert "primary database" in error
+        assert "Incremental sync" in error
+
     def test_non_permission_error_keeps_raw_message_only(self) -> None:
         error = _slot_setup_error_message(RuntimeError("connection reset"))
         assert error == "Failed to create replication slot: connection reset"


### PR DESCRIPTION
## Problem

A user connecting a Postgres data warehouse source with CDC sync sees the setup fail with a raw database error: "Failed to create replication slot: cannot execute CREATE PUBLICATION in a read-only transaction". The message names no cause and no fix, so the user is stuck.

The error means the connection points at a read replica or read-only standby. CDC has to create a replication slot and publication, which only a writable primary allows.

## Changes

- The CDC setup failure now tells the user their connection points at a read replica or read-only standby, and to connect to the primary database or switch the tables to Incremental sync.
- The read-only case joins the existing permission-error branch in `_slot_setup_error_message`; other failures still surface the raw driver text.

This is a backend copy change. No UI changed.

## How did you test this code?

Added one case to `TestSlotSetupErrorMessage` in `test_adapter.py`: it feeds a read-only-transaction exception and asserts the message points at the primary database and Incremental sync. It guards the regression where that failure fell through to the raw psycopg text. No existing case covered the read-only path.

Ran that test class locally: 4 passed. Did not run the database-backed suites.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude Code (Opus 4.8) while reviewing anonymized data-warehouse onboarding session summaries for recurring friction. One theme was a Postgres CDC connection failing against a read-only database with an unhelpful raw error.

Skills invoked: /writing-user-facing-copy, /writing-tests, /writing-pr-descriptions.

The message mirrors the tone and structure of the adjacent permission-error branch, which already points read-blocked users at Incremental sync. No sync behavior or schema changed.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
