### PR TITLE
fix(warehouse-sources): stop reporting exhausted-retry BuildBetter 5xx/429 as tracked errors

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/buildbetter/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/buildbetter/source.py
@@ -61,6 +61,13 @@ class BuildBetterSource(ResumableSource[BuildBetterSourceConfig, BuildBetterResu
             "webhook authentication request failed": "BuildBetter authentication failed. Please check your API key.",
         }
 
+    def get_retryable_errors(self) -> set[str]:
+        # `execute`'s own tenacity retry already retries a 5xx or 429 (raised as
+        # BuildBetterRetryableError) up to 5 attempts; once that budget exhausts, Temporal retries
+        # the whole activity from the saved pagination checkpoint, so the failure is transient and
+        # self-recovering rather than tracked-exception-worthy.
+        return {"BuildBetter: server error", "BuildBetter: rate limited"}
+
     def get_schemas(
         self,
         config: BuildBetterSourceConfig,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/buildbetter/test_buildbetter.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/buildbetter/test_buildbetter.py
@@ -268,3 +268,19 @@ class TestBuildBetterSourceNonRetryableErrors:
     def test_does_not_match_transient_errors(self, _name: str, other_error: str) -> None:
         non_retryable_errors = self.source.get_non_retryable_errors()
         assert not any(key in other_error for key in non_retryable_errors)
+
+
+class TestBuildBetterSourceRetryableErrors:
+    def setup_method(self) -> None:
+        self.source = BuildBetterSource()
+
+    @parameterized.expand(
+        [
+            ("server_error_502", "BuildBetter: server error 502"),
+            ("server_error_503", "BuildBetter: server error 503"),
+            ("rate_limited", "BuildBetter: rate limited"),
+        ]
+    )
+    def test_matches_exhausted_internal_retries(self, _name: str, observed_error: str) -> None:
+        retryable_errors = self.source.get_retryable_errors()
+        assert any(pattern in observed_error for pattern in retryable_errors)


### PR DESCRIPTION
## Problem

A BuildBetter sync that hits a 502 from BuildBetter's API gets reported to error tracking as a fresh exception ([issue](https://us.posthog.com/project/2/error_tracking/01a017bd-c8f0-7523-940a-1401dad0bcad)), even though the request loop already retried it five times internally and Temporal keeps retrying the whole sync afterward.

## Changes

- `BuildBetterSource` now implements `get_retryable_errors()`, matching "BuildBetter: server error" and "BuildBetter: rate limited".
- Once the source's own tenacity retries for a 5xx or 429 are exhausted, the shared import pipeline (`import_data_sync.py`) logs the failure as a warning and lets Temporal retry the activity, instead of reporting it as a tracked exception.
- This mirrors the existing pattern already used by Stripe, Langfuse, Mailchimp, and roughly 30 other sources for the same "already retried internally, self-recovering" case.

## How did you test this code?

Added `TestBuildBetterSourceRetryableErrors`, parameterized over 502, 503, and rate-limit messages, asserting each matches `get_retryable_errors()` - the case that was previously unhandled.

Ran the full `test_buildbetter.py` suite locally: 18 passed. Ran `ruff check` and `ruff format --check` on the changed files.

Not run: no end-to-end sync against a live BuildBetter workspace.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error tracking issue reported by webhook. Investigated the stack trace, the `BuildBetterRetryableError` retry loop in `buildbetter.py`, and the shared `import_data_sync.py` error-routing logic to find the missing `get_retryable_errors()` hook, then cross-checked the fix against Langfuse's and Stripe's equivalent implementations for the same pattern.