### PR TITLE
fix(managed-warehouse): scale query error ratio axis as a fraction

### DIFF
--- a/frontend/src/scenes/data-warehouse/scene/MonitoringTab.tsx
+++ b/frontend/src/scenes/data-warehouse/scene/MonitoringTab.tsx
@@ -312,7 +312,7 @@ const HistoricalMonitoringCharts = memo(function HistoricalMonitoringCharts({
                         description="Share of queries that returned an error"
                         responses={monitoringSeries}
                         metrics={[{ metric: 'error_ratio', fallbackLabel: 'Errors' }]}
-                        yAxis={{ format: 'percentage' }}
+                        yAxis={{ format: 'percentage_scaled' }}
                         valueFormatter={(value) => percentage(value)}
                         loading={initialLoading}
                     />


### PR DESCRIPTION
## Problem

On the Data warehouse monitoring tab, the query error ratio chart's y-axis reads 100x too low: during an error spike the axis showed 0.3% while the tooltip showed 31.83% for the same point.

The series reports `error_ratio` as a 0-1 fraction. The tooltip formatter (`percentage()` from `lib/utils/numbers`) multiplies by 100, but the y-axis used quill-charts' `percentage` format, which expects values already on a 0-100 scale.

## Changes

- The y-axis now uses the `percentage_scaled` format, which takes 0-1 fractions, so the axis and tooltip agree.
- One-line change; nothing else on the tab is affected.

## How did you test this code?

Traced both formatters: quill-charts documents `percentage` as 0-100 and `percentage_scaled` as 0-1 ([y-formatters.ts](https://github.com/PostHog/posthog/blob/master/packages/quill/packages/charts/src/utils/y-formatters.ts)), and the upstream metric is a plain rate ratio. Not run: the app against a live warehouse, since the fix only swaps a documented format constant.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session: traced the unit mismatch from a screenshot to the two formatters, confirmed the upstream metric is a fraction, and applied the one-line format swap. Skills invoked: /writing-pr-descriptions.
