### PR TITLE
fix(data-imports): skip bucket check when botocore rejects the endpoint

### DIFF
--- a/products/data_warehouse/backend/s3.py
+++ b/products/data_warehouse/backend/s3.py
@@ -115,7 +115,20 @@ def get_size_of_folder(path: str) -> float:
 
 
 def ensure_bucket_exists(s3_url: str, s3_key: str, s3_secret: str, s3_endpoint: Optional[str] = None) -> None:
-    s3_client = boto3.client("s3", aws_access_key_id=s3_key, aws_secret_access_key=s3_secret, endpoint_url=s3_endpoint)
+    try:
+        s3_client = boto3.client(
+            "s3", aws_access_key_id=s3_key, aws_secret_access_key=s3_secret, endpoint_url=s3_endpoint
+        )
+    except ValueError as e:
+        # botocore refuses to build a client for endpoint hostnames it deems malformed (e.g. a
+        # container service name containing an underscore), yet delta-rs's object store — which does
+        # the pipeline's actual reads and writes — talks to the same endpoint fine. This bucket check
+        # is a best-effort convenience for local/self-hosted setups where the bucket is provisioned
+        # out of band, so skip it rather than abort the sync; the storage layer surfaces a real error
+        # later if the bucket is genuinely absent.
+        if "Invalid endpoint" in str(e):
+            return
+        raise
 
     parsed = urlparse(s3_url)
     if parsed.scheme != "s3":

--- a/products/data_warehouse/backend/tests/test_s3.py
+++ b/products/data_warehouse/backend/tests/test_s3.py
@@ -123,6 +123,21 @@ class TestEnsureBucketExists(SimpleTestCase):
             ensure_bucket_exists("s3://my-bucket", "key", "secret")
 
     @patch("products.data_warehouse.backend.s3.boto3.client")
+    def test_skips_check_when_botocore_rejects_the_endpoint(self, mock_boto3_client) -> None:
+        # delta-rs accepts endpoints botocore refuses to build a client for (e.g. a service host
+        # with an underscore), so a rejected endpoint must not abort the sync at this pre-check.
+        mock_boto3_client.side_effect = ValueError("Invalid endpoint: http://object_storage:19000")
+
+        ensure_bucket_exists("s3://my-bucket", "key", "secret", "http://object_storage:19000")
+
+    @patch("products.data_warehouse.backend.s3.boto3.client")
+    def test_reraises_unrelated_value_errors(self, mock_boto3_client) -> None:
+        mock_boto3_client.side_effect = ValueError("something else went wrong")
+
+        with self.assertRaises(ValueError):
+            ensure_bucket_exists("s3://my-bucket", "key", "secret")
+
+    @patch("products.data_warehouse.backend.s3.boto3.client")
     def test_reraises_non_404_head_bucket_errors(self, mock_boto3_client) -> None:
         s3_client = MagicMock()
         s3_client.head_bucket.side_effect = _client_error("403")


### PR DESCRIPTION
## Problem

Data-warehouse imports on a self-hosted or containerized setup fail before writing any data when the object-storage endpoint hostname is one botocore rejects. The endpoint is PostHog's own internal storage config (used only under `USE_LOCAL_SETUP`), not a customer value.

- The Delta bucket pre-check builds a raw boto3 client for `settings.OBJECT_STORAGE_ENDPOINT`.
- botocore refuses hostnames it deems malformed, such as a container service name containing an underscore, and raises `ValueError: Invalid endpoint: ...`.
- delta-rs, which does the pipeline's actual reads and writes, talks to that same endpoint fine — so the pre-check is stricter than the storage layer it guards.
- The uncaught error aborts the sync in `ensure_bucket_exists`, surfaced by [error tracking issue 01a01829](https://us.posthog.com/project/2/error_tracking/01a01829-de78-75d0-94a2-3844e1f14c1e).

## Changes

- A sync no longer crashes at the bucket check when botocore rejects the endpoint; the import proceeds and delta-rs handles storage.
- `ensure_bucket_exists` catches the client-construction `ValueError`, returns early when the message is `Invalid endpoint`, and re-raises anything else.
- This check is a best-effort convenience for setups where the bucket is provisioned out of band; skipping it lets the storage layer report a real error later if the bucket is genuinely absent.

## How did you test this code?

Added two cases to `TestEnsureBucketExists` in `products/data_warehouse/backend/tests/test_s3.py`:

- An `Invalid endpoint` `ValueError` from client construction is swallowed, not raised — the regression this PR fixes; no existing case exercised the client-construction path.
- An unrelated `ValueError` still propagates, so the guard is narrow.

Ran the file's suite locally. Not run: the Temporal import pipeline end to end, which needs the dev stack.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking issue in the data-warehouse import pipeline. The `warehouse_sources_*` event properties scoped it to Stripe webhook syncs on the `v2-non-dlt` pipeline, but the failing frame is in shared code (`ensure_bucket_exists`), so the fix lives there and applies to every caller — all of which pass the internal object-storage endpoint under `USE_LOCAL_SETUP`.

Classified as our bug rather than a user/upstream error: the endpoint is internal config that delta-rs accepts, so making it non-retryable would be wrong. Confirmed botocore's underscore-hostname rejection reproduces the exact `ValueError`. Considered making the check itself succeed, but botocore exposes no way to relax endpoint validation, so skipping the best-effort pre-check is the correct scope.

Tools: Claude Code. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
