### PR TITLE
fix(notifications): show batch exports in the pipeline picker

### DIFF
--- a/frontend/src/scenes/settings/user/pipelineNotificationsLogic.test.ts
+++ b/frontend/src/scenes/settings/user/pipelineNotificationsLogic.test.ts
@@ -1,3 +1,5 @@
+import { MOCK_DEFAULT_ORGANIZATION, MOCK_DEFAULT_TEAM } from 'lib/api.mock'
+
 import { expectLogic } from 'kea-test-utils'
 
 import { organizationLogic } from 'scenes/organizationLogic'
@@ -30,13 +32,12 @@ describe('pipelineNotificationsLogic', () => {
         userLogic.mount()
         organizationLogic.mount()
         organizationLogic.actions.loadCurrentOrganizationSuccess({
-            id: 'org-1',
-            name: 'Org',
+            ...MOCK_DEFAULT_ORGANIZATION,
             teams: [
-                { id: 1, name: 'Project A' },
-                { id: 2, name: 'Project B' },
+                { ...MOCK_DEFAULT_TEAM, id: 1, name: 'Project A' },
+                { ...MOCK_DEFAULT_TEAM, id: 2, name: 'Project B' },
             ],
-        } as any)
+        })
         logic = pipelineNotificationsLogic()
         logic.mount()
     })

--- a/frontend/src/scenes/settings/user/pipelineNotificationsLogic.test.ts
+++ b/frontend/src/scenes/settings/user/pipelineNotificationsLogic.test.ts
@@ -1,0 +1,65 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { organizationLogic } from 'scenes/organizationLogic'
+import { userLogic } from 'scenes/userLogic'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+
+import { pipelineNotificationsLogic } from './pipelineNotificationsLogic'
+
+describe('pipelineNotificationsLogic', () => {
+    let logic: ReturnType<typeof pipelineNotificationsLogic.build>
+
+    beforeEach(() => {
+        useMocks({
+            get: {
+                '/api/projects/:team_id/hog_functions/': { results: [], next: null },
+                '/api/projects/:team_id/pipeline_destination_configs/': { results: [], next: null },
+                '/api/projects/1/batch_exports/': {
+                    results: [{ id: 'be-1', name: 'Nightly export', team_id: 1 }],
+                    next: null,
+                },
+                '/api/projects/2/batch_exports/': {
+                    results: [{ id: 'be-2', name: 'Hourly export', team_id: 2 }],
+                    next: null,
+                },
+            },
+        })
+        initKeaTests()
+        userLogic.mount()
+        organizationLogic.mount()
+        organizationLogic.actions.loadCurrentOrganizationSuccess({
+            id: 'org-1',
+            name: 'Org',
+            teams: [
+                { id: 1, name: 'Project A' },
+                { id: 2, name: 'Project B' },
+            ],
+        } as any)
+        logic = pipelineNotificationsLogic()
+        logic.mount()
+    })
+
+    it('lists the batch exports of every project', async () => {
+        logic.actions.loadPipelines()
+        await expectLogic(logic).toDispatchActions(['loadPipelinesSuccess'])
+
+        expect(logic.values.pipelines).toEqual([
+            expect.objectContaining({
+                id: 'batch_export:be-1',
+                name: 'Nightly export',
+                kind: 'batch_export',
+                teamId: 1,
+                teamName: 'Project A',
+            }),
+            expect.objectContaining({
+                id: 'batch_export:be-2',
+                name: 'Hourly export',
+                kind: 'batch_export',
+                teamId: 2,
+                teamName: 'Project B',
+            }),
+        ])
+    })
+})

--- a/frontend/src/scenes/settings/user/pipelineNotificationsLogic.ts
+++ b/frontend/src/scenes/settings/user/pipelineNotificationsLogic.ts
@@ -108,8 +108,6 @@ export const pipelineNotificationsLogic = kea<pipelineNotificationsLogicType>([
                         return []
                     }
 
-                    const teamNamesById = new Map(org.teams.map((t) => [t.id, t.name]))
-
                     const perTeamItems = await Promise.all(
                         org.teams.map(async (team): Promise<PipelineItem[]> => {
                             const items: PipelineItem[] = []
@@ -153,29 +151,31 @@ export const pipelineNotificationsLogic = kea<pipelineNotificationsLogicType>([
                             } catch (e) {
                                 console.warn(`Failed to load plugin destinations for team ${team.id}`, e)
                             }
+                            try {
+                                const initial: PaginatedBatchExportListApi = await batchExportsList(String(team.id), {
+                                    limit: 100,
+                                })
+                                const bes: BatchExportApi[] = [
+                                    ...initial.results,
+                                    ...(await api.loadPaginatedResults<BatchExportApi>(initial.next ?? null)),
+                                ]
+                                for (const be of bes) {
+                                    items.push({
+                                        id: `batch_export:${be.id}`,
+                                        name: displayName(be.name),
+                                        kind: 'batch_export',
+                                        teamId: team.id,
+                                        teamName: team.name,
+                                    })
+                                }
+                            } catch (e) {
+                                console.warn(`Failed to load batch exports for team ${team.id}`, e)
+                            }
                             return items
                         })
                     )
 
-                    let batchExportItems: PipelineItem[] = []
-                    try {
-                        const initial: PaginatedBatchExportListApi = await batchExportsList(org.id, { limit: 100 })
-                        const bes: BatchExportApi[] = [
-                            ...initial.results,
-                            ...(await api.loadPaginatedResults<BatchExportApi>(initial.next ?? null)),
-                        ]
-                        batchExportItems = bes.map<PipelineItem>((be) => ({
-                            id: `batch_export:${be.id}`,
-                            name: displayName(be.name),
-                            kind: 'batch_export',
-                            teamId: be.team_id,
-                            teamName: teamNamesById.get(be.team_id) ?? '',
-                        }))
-                    } catch (e) {
-                        console.warn('Failed to load batch exports', e)
-                    }
-
-                    const items = [...perTeamItems.flat(), ...batchExportItems]
+                    const items = perTeamItems.flat()
                     return items.sort(
                         (a, b) =>
                             a.teamName.localeCompare(b.teamName) ||


### PR DESCRIPTION
## Problem

A member cannot mute failure emails for a batch export. The per-pipeline picker in notification settings never lists them, so only destinations and transformations can be muted.

## Changes

- Fetch each project's batch exports alongside its other pipelines, so they appear in the picker.
- How it works: the request passed an organization ID to a project-scoped path, 404ed, and a catch turned the failure into a console warning.

## How did you test this code?

- 1 frontend logic test added, covering batch exports listed per project.
- The test was confirmed to fail against the current code and pass with the fix.
- Agent-authored; only the automated test above was run.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code. Skills invoked: `/writing-tests`, `/creating-pull-requests`.
- Found while building #83851, and split out so it can land on its own while that feature is redesigned.
- The organization-wide batch export route has no generated client function, so the call moved into the existing per-project loop rather than hand-rolling a URL.