### PR TITLE
fix(tracing): fold unset status into ok in the trace facet rail

### DIFF
--- a/products/tracing/frontend/components/FacetRail/RailFacet.tsx
+++ b/products/tracing/frontend/components/FacetRail/RailFacet.tsx
@@ -5,7 +5,7 @@ import { TRACING_SCENE_VIEWER_ID, tracingFiltersLogic } from 'products/tracing/f
 
 import { Facet } from './Facet'
 import { facetRailLogic } from './facetRailLogic'
-import { FacetConfig, FacetOption, facetSelection, mergeSelectedIntoOptions } from './facets'
+import { FacetConfig, FacetOption, facetSelection, facetValueGroup, mergeSelectedIntoOptions } from './facets'
 import { facetValuesLogic } from './facetValuesLogic'
 
 export interface RailFacetProps {
@@ -50,7 +50,7 @@ export function RailFacet({ facet, id = TRACING_SCENE_VIEWER_ID, hidden }: RailF
         const countByValue = new Map(fetched.map((option) => [option.value, option.count]))
         const options: FacetOption[] = (facet.fixedOptions ?? []).map((option) => ({
             ...option,
-            count: countByValue.get(option.value) ?? 0,
+            count: facetValueGroup(source, option.value).reduce((sum, v) => sum + (countByValue.get(v) ?? 0), 0),
         }))
         return (
             <Facet

--- a/products/tracing/frontend/components/FacetRail/facets.test.ts
+++ b/products/tracing/frontend/components/FacetRail/facets.test.ts
@@ -11,6 +11,7 @@ import {
     facetFilterSelection,
     facetScopeSignature,
     facetSelection,
+    facetValueGroup,
     mergeSelectedIntoOptions,
     resolveFacets,
 } from './facets'
@@ -113,6 +114,38 @@ describe('facets', () => {
         ])('%s', (_, operator, value, expected) => {
             const group = groupWith([{ key: 'status_code', type: PropertyFilterType.Span, operator, value }])
             expect(read(group, STATUS_SOURCE)).toEqual(expected)
+        })
+    })
+
+    describe('facetValueGroup', () => {
+        it.each<[string, FacetSource, string, string[]]>([
+            ['status_code OK folds in Unset', STATUS_SOURCE, '1', ['0', '1']],
+            ['status_code Error is its own singleton', STATUS_SOURCE, '2', ['2']],
+            ['a resource-attribute source passes its value through unchanged', POD_SOURCE, 'pod-a', ['pod-a']],
+        ])('%s', (_, source, value, expected) => {
+            expect(facetValueGroup(source, value)).toEqual(expected)
+        })
+    })
+
+    describe('cycleFacetFilter folds status_code Unset into OK', () => {
+        it('selecting OK ("1") writes both "0" and "1" into the exact filter', () => {
+            const group = cycleFacetFilter(undefined, STATUS_SOURCE, '1')
+            const inner = (group.values[0] as UniversalFiltersGroup).values
+            expect(inner).toEqual([expect.objectContaining({ operator: PropertyOperator.Exact, value: ['0', '1'] })])
+        })
+
+        it('deselecting OK moves both "0" and "1" to the is_not filter, not just "1"', () => {
+            const included = cycleFacetFilter(undefined, STATUS_SOURCE, '1')
+            const excluded = cycleFacetFilter(included, STATUS_SOURCE, '1')
+            expect(facetFilterSelection(excluded, STATUS_SOURCE)).toEqual({ included: [], excluded: ['0', '1'] })
+        })
+
+        it('upgrades a filter with only the pre-fold single digit "1" to the full group on toggle', () => {
+            const legacy = groupWith([
+                { key: 'status_code', type: PropertyFilterType.Span, operator: PropertyOperator.Exact, value: ['1'] },
+            ])
+            const excluded = cycleFacetFilter(legacy, STATUS_SOURCE, '1')
+            expect(facetFilterSelection(excluded, STATUS_SOURCE)).toEqual({ included: [], excluded: ['0', '1'] })
         })
     })
 

--- a/products/tracing/frontend/components/FacetRail/facets.test.ts
+++ b/products/tracing/frontend/components/FacetRail/facets.test.ts
@@ -147,6 +147,31 @@ describe('facets', () => {
             const excluded = cycleFacetFilter(legacy, STATUS_SOURCE, '1')
             expect(facetFilterSelection(excluded, STATUS_SOURCE)).toEqual({ included: [], excluded: ['0', '1'] })
         })
+
+        it.each<[string, PropertyOperator]>([
+            ['included', PropertyOperator.Exact],
+            ['excluded', PropertyOperator.IsNot],
+        ])('reports a pre-fold Unset-only ("0") %s filter against the OK row', (_, operator) => {
+            // Before the fold, Unset was its own row, so a saved view or URL can carry "0" alone. The
+            // OK row has to render it as active, or the first click reads as "select OK" while it
+            // actually cycles the already-active group straight to excluded.
+            const legacy = groupWith([{ key: 'status_code', type: PropertyFilterType.Span, operator, value: ['0'] }])
+            const expected =
+                operator === PropertyOperator.Exact
+                    ? { included: ['1'], excluded: [] }
+                    : { included: [], excluded: ['1'] }
+            expect(facetSelection(legacy, null, STATUS_SOURCE)).toEqual(expected)
+        })
+
+        it('completes a pre-fold Unset-only group when a different row is toggled', () => {
+            // Clicking Error must not leave "0" behind without "1": the rail would show OK selected
+            // while the query dropped every explicitly-OK span.
+            const legacy = groupWith([
+                { key: 'status_code', type: PropertyFilterType.Span, operator: PropertyOperator.Exact, value: ['0'] },
+            ])
+            const group = cycleFacetFilter(legacy, STATUS_SOURCE, '2')
+            expect(facetFilterSelection(group, STATUS_SOURCE)).toEqual({ included: ['0', '1', '2'], excluded: [] })
+        })
     })
 
     describe('facetSelection', () => {

--- a/products/tracing/frontend/components/FacetRail/facets.ts
+++ b/products/tracing/frontend/components/FacetRail/facets.ts
@@ -169,16 +169,17 @@ export function cycleFacetFilter(
     source: FilterGroupFacetSource,
     value: string
 ): UniversalFiltersGroup {
+    const valueGroup = facetValueGroup(source, value)
     const { included, excluded } = facetFilterSelection(group, source)
     let nextIncluded = included
     let nextExcluded = excluded
-    if (included.includes(value)) {
-        nextIncluded = included.filter((v) => v !== value)
-        nextExcluded = excluded.includes(value) ? excluded : [...excluded, value]
-    } else if (excluded.includes(value)) {
-        nextExcluded = excluded.filter((v) => v !== value)
+    if (valueGroup.some((v) => included.includes(v))) {
+        nextIncluded = included.filter((v) => !valueGroup.includes(v))
+        nextExcluded = [...excluded, ...valueGroup.filter((v) => !excluded.includes(v))]
+    } else if (valueGroup.some((v) => excluded.includes(v))) {
+        nextExcluded = excluded.filter((v) => !valueGroup.includes(v))
     } else {
-        nextIncluded = [...included, value]
+        nextIncluded = [...included, ...valueGroup.filter((v) => !included.includes(v))]
     }
 
     const values = innerFilters(group).filter((f) => !isRailFacetFilter(f, source))
@@ -249,12 +250,30 @@ export function facetScopeSignature(facet: FacetConfig, scope: FacetScope): stri
     ])
 }
 
-// OTel span status. Values must stay the digit strings "0"/"1"/"2": breakdown rows arrive
+// A span that never had its status explicitly set carries no distinct meaning from one marked
+// OK, so the rail folds status_code 0 (Unset) into the OK row: selecting, excluding, and counting
+// "1" also reads and writes "0". Keyed on the digit strings the breakdown rows and filter values
+// already use.
+const STATUS_CODE_VALUE_GROUPS: Record<string, string[]> = {
+    '1': ['0', '1'],
+}
+
+/**
+ * The full set of underlying column values a facet click or count should read/write for `value`.
+ * Only status_code's "OK" (folding in "Unset") expands to more than itself; every other facet
+ * value, including status_code's "Error", is its own singleton group.
+ */
+export function facetValueGroup(source: FacetSource, value: string): string[] {
+    if (source.type === 'column' && source.column === 'status_code') {
+        return STATUS_CODE_VALUE_GROUPS[value] ?? [value]
+    }
+    return [value]
+}
+
+// OTel span status. Values must stay the digit strings "1"/"2": breakdown rows arrive
 // stringified (the backend toString()s the Int16 column), so these are what counts key on.
-// Don't switch to the label strings — the server-side filter normaliser treats "OK" as
-// {Unset, OK}, which would silently widen a selection.
+// "Unset" (0) has no separate row; see STATUS_CODE_VALUE_GROUPS above.
 const STATUS_OPTIONS: FacetOption[] = [
-    { value: '0', label: 'Unset', count: 0 },
     { value: '1', label: 'OK', count: 0 },
     { value: '2', label: 'Error', count: 0 },
 ]

--- a/products/tracing/frontend/components/FacetRail/facets.ts
+++ b/products/tracing/frontend/components/FacetRail/facets.ts
@@ -143,6 +143,8 @@ export function facetFilterSelection(
 /**
  * Selection for any facet — routes the service facet to the dedicated serviceNames field
  * (include-only, so nothing is ever excluded there) and everything else to its filterGroup filters.
+ * Column selections are reported against the rows the rail renders, so a folded-away value
+ * (status_code "0") shows up as its group's row instead of as a selection with no row to click.
  */
 export function facetSelection(
     group: UniversalFiltersGroup | undefined,
@@ -154,7 +156,7 @@ export function facetSelection(
             // Empty strings from external state (URL, saved view) would select a value with no visible row.
             return { included: (serviceNames ?? []).filter((v) => v !== ''), excluded: [] }
         }
-        return facetFilterSelection(group, { type: 'column', column: source.column })
+        return facetRowSelection(source, facetFilterSelection(group, { type: 'column', column: source.column }))
     }
     return facetFilterSelection(group, source)
 }
@@ -163,6 +165,7 @@ export function facetSelection(
  * Advance `value` one step through the facet cycle — unchecked → included → excluded → unchecked —
  * returning a new filterGroup. Selection is stored as up to two property filters per key with
  * array values, `exact` and `is_not`; a filter is dropped when its side of the selection empties.
+ * Both sides are written as whole value groups, so no click can leave half of a folded group behind.
  */
 export function cycleFacetFilter(
     group: UniversalFiltersGroup | undefined,
@@ -183,20 +186,22 @@ export function cycleFacetFilter(
     }
 
     const values = innerFilters(group).filter((f) => !isRailFacetFilter(f, source))
-    if (nextIncluded.length > 0) {
+    const nextIncludedValues = expandToValueGroups(source, nextIncluded)
+    const nextExcludedValues = expandToValueGroups(source, nextExcluded)
+    if (nextIncludedValues.length > 0) {
         values.push({
             key: facetFilterKey(source),
             type: facetFilterType(source),
             operator: PropertyOperator.Exact,
-            value: nextIncluded,
+            value: nextIncludedValues,
         })
     }
-    if (nextExcluded.length > 0) {
+    if (nextExcludedValues.length > 0) {
         values.push({
             key: facetFilterKey(source),
             type: facetFilterType(source),
             operator: PropertyOperator.IsNot,
-            value: nextExcluded,
+            value: nextExcludedValues,
         })
     }
     return { type: FilterLogicalOperator.And, values: [{ type: FilterLogicalOperator.And, values }] }
@@ -268,6 +273,40 @@ export function facetValueGroup(source: FacetSource, value: string): string[] {
         return STATUS_CODE_VALUE_GROUPS[value] ?? [value]
     }
     return [value]
+}
+
+// Reverse of STATUS_CODE_VALUE_GROUPS: which row each underlying value is rendered under.
+const STATUS_CODE_ROW_BY_VALUE: Record<string, string> = Object.fromEntries(
+    Object.entries(STATUS_CODE_VALUE_GROUPS).flatMap(([row, values]) => values.map((value) => [value, row]))
+)
+
+/**
+ * The rail row `value` is rendered under: itself for every value except one that was folded away,
+ * which reports the row it folded into. Filters written before the fold (or by hand outside the
+ * rail) can carry status_code "0" on its own, so the OK row has to read as active for it; otherwise
+ * the first click would cycle that already-active group to excluded instead of selecting it.
+ */
+function facetRowValue(source: FacetSource, value: string): string {
+    if (source.type === 'column' && source.column === 'status_code') {
+        return STATUS_CODE_ROW_BY_VALUE[value] ?? value
+    }
+    return value
+}
+
+/** Map a raw filter selection onto the rows the rail renders, deduping values that share a row. */
+function facetRowSelection(source: FacetSource, selection: FacetSelection): FacetSelection {
+    const toRows = (values: string[]): string[] => [...new Set(values.map((v) => facetRowValue(source, v)))]
+    return { included: toRows(selection.included), excluded: toRows(selection.excluded) }
+}
+
+/**
+ * Expand a set of filter values onto whole value groups, so a write always covers every value behind
+ * the rows it touches. Legacy state carrying part of a group (status_code "0" without "1") would
+ * otherwise survive a click on a different row, leaving the rail showing OK while the query drops
+ * explicitly-OK spans.
+ */
+function expandToValueGroups(source: FacetSource, values: string[]): string[] {
+    return [...new Set(values.flatMap((v) => facetValueGroup(source, facetRowValue(source, v))))]
 }
 
 // OTel span status. Values must stay the digit strings "1"/"2": breakdown rows arrive


### PR DESCRIPTION
> [!NOTE]
> Supersedes #83805, whose head was a fork branch, so it could not run the full CI matrix or enter the merge queue. Same two commits, rebased onto master.

## Problem

Someone filtering the trace list by Status could not select "spans that are fine" in one click: the facet rail split that bucket into an Unset row and an OK row, and OK's count only covered the spans whose status was explicitly set.

- OpenTelemetry leaves `status_code` at `0` (Unset) unless a span sets it, and an unset status carries no distinct meaning from `1` (OK).
- The rail rendered Unset, OK, and Error as three independently toggleable rows, so most healthy spans landed under Unset rather than OK.
- The backend already widens the label `"OK"` to `{Unset, OK}` in `translate_span_filter`, but the rail writes raw digit strings, so that widening never fired.

## Changes

- The Status facet lists OK and Error. Unset no longer has its own row.
- OK's count sums the Unset and OK breakdown rows, so it reads as the number of spans that are not errors.
- Selecting OK filters on both digits, and excluding OK writes `status_code ≠ 0,1`. The chip matches the row.
- A saved view or shared URL from the old rail can carry `status_code = 0` alone. The OK row now renders as selected for it, so the first click deselects it instead of jumping to excluded.
- Every write covers whole value groups, so no click leaves half a folded group behind.
- A new `facetValueGroup` helper in `facets.ts` holds the fold. Error, and every other facet, is its own singleton group and behaves as before.
- The fold stays client-side rather than moving to the backend. The rail's displayed counts and selection state then describe the query it actually sends, instead of depending on a widening the rail cannot see happen.

[Status facet folds Unset into OK](https://raw.githubusercontent.com/PostHog/pr-assets/fbf81e677a2acbfb4dd944fa0066b6a848c9d1d8/2026/08/edb59b6d-fc66-4d4b-8824-8d9de075305e.mp4)

## How did you test this code?

New cases in `products/tracing/frontend/components/FacetRail/facets.test.ts` cover four regressions no existing test caught:

- Selecting OK writes only `"1"`, leaving Unset spans out of the result.
- Deselecting OK excludes only `"1"`, so Unset spans stay in an "exclude OK" view.
- A pre-fold filter holding `"0"` alone renders the OK row as unselected, so the first click excludes an already-active group.
- Toggling a different row leaves a partial group behind, showing OK in the rail while the query drops explicitly-OK spans.

The `facets.test.ts` suite was run against this branch after the rebase onto master.

Not re-checked here: the manual pass against a local stack with seeded trace data, recorded in the video above, ran on #83805's head.

The rebase onto master moved the count fold from `FacetRail.tsx` to `RailFacet.tsx`, because #81907 split the rail's fixed-facet rendering into that file. The line is unchanged. The rest of the diff still matches #83805's head.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented by Claude Code in a PostHog Desktop channel task, directed by @frankh. Skills invoked across the sessions: `/writing-pr-descriptions`, `/writing-tests`, `/writing-code-comments`.

Root-caused by tracing how `cycleFacetFilter` and `facetFilterSelection` write raw digit-string filter values, which bypasses the backend's label-based widening in `products/tracing/backend/logic.py`.

Greptile raised a P1 on `facets.ts` against #83805: a filter carrying `status_code "0"` on its own flipped the OK row's first click to excluded. That fix is the second commit here, `read pre-fold unset status filters against the ok row`.

Manual verification used synthetic seeded trace data with invented service names. Nothing in this PR carries material from the agent session that is not already public.

