### PR TITLE
[do not merge] feat(insights): add commands to backfill query from legacy filters

### DIFF
--- a/products/dashboards/backend/management/commands/migrate_dashboard_template_tiles_to_query.py
+++ b/products/dashboards/backend/management/commands/migrate_dashboard_template_tiles_to_query.py
@@ -1,0 +1,63 @@
+from typing import Any
+
+from django.core.management.base import BaseCommand, CommandParser
+
+import structlog
+
+from posthog.schema import InsightVizNode
+
+from posthog.hogql_queries.legacy_compatibility.filter_to_query import filter_to_query
+
+from products.dashboards.backend.models.dashboard_templates import DashboardTemplate
+
+logger = structlog.get_logger(__name__)
+
+
+class Command(BaseCommand):
+    help = (
+        "Convert legacy `filters` tiles on dashboard templates to `query` — the same conversion as "
+        "migration 0530, for templates created since it ran. Dry-run by default; pass --live to write."
+    )
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        parser.add_argument("--live", action="store_true", help="Write changes (default is a read-only report)")
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        live: bool = options["live"]
+        if not live:
+            self.stdout.write(self.style.WARNING("Dry run — pass --live to write"))
+
+        updated_templates = 0
+        converted_tiles = 0
+        errors: dict[str, list[str]] = {}
+
+        for template in DashboardTemplate.objects.exclude(tiles__isnull=True).iterator(chunk_size=100):
+            changed = False
+            for tile in template.tiles or []:
+                if not isinstance(tile, dict) or "filters" not in tile:
+                    continue
+                if not tile.get("query"):
+                    try:
+                        # allow_variables matches migration 0530 — template tiles may carry template variables
+                        source = filter_to_query(tile["filters"], allow_variables=True)
+                        tile["query"] = InsightVizNode(source=source).model_dump(exclude_none=True)
+                    except Exception as e:
+                        errors.setdefault(type(e).__name__, []).append(str(template.id))
+                        continue
+                    converted_tiles += 1
+                # A tile with both keys keeps its query — runtime reads query first, so filters is dead weight.
+                del tile["filters"]
+                changed = True
+            if changed:
+                updated_templates += 1
+                if live:
+                    template.save(update_fields=["tiles"])
+
+        failed = sum(len(ids) for ids in errors.values())
+        verb = "Updated" if live else "Would update"
+        style = self.style.SUCCESS if failed == 0 else self.style.WARNING
+        self.stdout.write(
+            style(f"{verb} {updated_templates} templates ({converted_tiles} tiles converted, {failed} tiles failed)")
+        )
+        for error_type, ids in sorted(errors.items(), key=lambda kv: -len(kv[1])):
+            self.stdout.write(f"  {error_type}: {len(ids)} tiles, template ids e.g. {ids[:5]}")

--- a/products/dashboards/backend/management/commands/test/test_migrate_dashboard_template_tiles_to_query.py
+++ b/products/dashboards/backend/management/commands/test/test_migrate_dashboard_template_tiles_to_query.py
@@ -1,0 +1,46 @@
+from posthog.test.base import BaseTest
+
+from django.core.management import call_command
+
+from products.dashboards.backend.models.dashboard_templates import DashboardTemplate
+
+LEGACY_FILTERS = {"insight": "TRENDS", "events": [{"id": "$pageview", "type": "events", "order": 0}]}
+EXISTING_QUERY = {"kind": "InsightVizNode", "source": {"kind": "TrendsQuery", "series": []}}
+
+
+class TestMigrateDashboardTemplateTilesToQuery(BaseTest):
+    def test_converts_filters_tiles_and_preserves_modern_ones(self):
+        template = DashboardTemplate.objects.create(
+            team=self.team,
+            template_name="mixed",
+            tiles=[
+                {"type": "INSIGHT", "name": "legacy", "filters": LEGACY_FILTERS, "layouts": {}},
+                {"type": "INSIGHT", "name": "both", "filters": LEGACY_FILTERS, "query": EXISTING_QUERY, "layouts": {}},
+                {"type": "TEXT", "body": "hello"},
+            ],
+        )
+
+        call_command("migrate_dashboard_template_tiles_to_query", "--live")
+
+        template.refresh_from_db()
+        assert template.tiles is not None
+        legacy_tile, both_tile, text_tile = template.tiles
+        assert legacy_tile["query"]["kind"] == "InsightVizNode"
+        assert legacy_tile["query"]["source"]["kind"] == "TrendsQuery"
+        assert "filters" not in legacy_tile
+        # A tile that already has a query keeps it verbatim — conversion must not clobber it.
+        assert both_tile["query"] == EXISTING_QUERY
+        assert "filters" not in both_tile
+        assert text_tile == {"type": "TEXT", "body": "hello"}
+
+    def test_dry_run_by_default_writes_nothing(self):
+        template = DashboardTemplate.objects.create(
+            team=self.team, template_name="legacy", tiles=[{"type": "INSIGHT", "filters": LEGACY_FILTERS}]
+        )
+
+        call_command("migrate_dashboard_template_tiles_to_query")
+
+        template.refresh_from_db()
+        assert template.tiles is not None
+        assert "filters" in template.tiles[0]
+        assert "query" not in template.tiles[0]

--- a/products/product_analytics/backend/legacy_filter_repair.py
+++ b/products/product_analytics/backend/legacy_filter_repair.py
@@ -1,0 +1,464 @@
+"""Repair legacy insight `filters` that `filter_to_query` cannot convert.
+
+The insights this targets do not work today. `filters` was a plain JSON column with no validation,
+so anything could be written to it. The values below were never valid: `/query` validates every
+request against the same generated schema `filter_to_query` uses, so an insight carrying them fails
+at query time. Repairing them is what makes a stored `query` possible.
+
+Two rules decide each value:
+
+- One clear reading — map it (`unique_users` means daily unique users, so `dau`).
+- More than one reading — drop the field so the schema default applies.
+
+Dropping widens an insight: a filter that is gone stops excluding events. That is a real change to
+what the insight reports, which is why every repair is named in the returned list, and why the
+caller records them.
+"""
+
+import copy
+from typing import Any
+
+from posthog.schema import PathType
+
+from posthog.schema_enums import (
+    BaseMathType,
+    CalendarHeatmapMathType,
+    CountPerActorMathType,
+    ExperimentMetricMathType,
+    FunnelConversionWindowTimeUnit,
+    FunnelMathType,
+    FunnelVizType,
+    GroupMathType,
+    IntervalType,
+    Key,
+    PropertyMathType,
+    PropertyOperator,
+    RetentionPeriod,
+    RetentionReference,
+    RetentionType,
+    StepOrderValue,
+)
+
+VALID_MATH: frozenset[str] = frozenset(
+    m.value
+    for enum in (
+        BaseMathType,
+        FunnelMathType,
+        PropertyMathType,
+        CountPerActorMathType,
+        GroupMathType,
+        ExperimentMetricMathType,
+        CalendarHeatmapMathType,
+    )
+    for m in enum
+) | {"hogql"}
+
+# Each alias has exactly one reading. Anything absent from here and from VALID_MATH is dropped.
+MATH_ALIASES: dict[str, str] = {
+    "unique_users": "dau",
+    "unique_user": "dau",
+    "unique_sessions": "unique_session",
+    "wau": "weekly_active",
+    "mau": "monthly_active",
+    "average": "avg",
+    "avg_property": "avg",
+    "avg_per_actor": "avg_count_per_actor",
+    "p50": "median",
+    "p50_property": "median",
+    "p75_property": "p75",
+    "p90_property": "p90",
+    "p95_property": "p95",
+    "p99_property": "p99",
+}
+
+# Display types and list views were written into the `insight` slot. They all describe a trends
+# series; the chart shape lives in `display`, which `clean_display` validates separately.
+INSIGHT_ALIASES: dict[str, str] = {
+    "FUNNEL": "FUNNELS",
+    "TABLE": "TRENDS",
+    "NUMBER": "TRENDS",
+    "PIE": "TRENDS",
+    "BAR": "TRENDS",
+    "HISTOGRAM": "TRENDS",
+    "EVENTS": "TRENDS",
+    "ACTIONS": "TRENDS",
+    "PERSONS": "TRENDS",
+}
+
+VIZ_INSIGHT_TYPES: frozenset[str] = frozenset({"TRENDS", "FUNNELS", "RETENTION", "PATHS", "LIFECYCLE", "STICKINESS"})
+SQL_INSIGHT_TYPES: frozenset[str] = frozenset({"SQL", "HOGQL"})
+
+OPERATOR_ALIASES: dict[str, str] = {
+    "eq": "exact",
+    "is": "exact",
+    "equals": "exact",
+    "contains": "icontains",
+    "not_contains": "not_icontains",
+}
+
+RETENTION_TYPE_ALIASES: dict[str, str] = {"retention": "retention_recurring"}
+RETENTION_REFERENCE_ALIASES: dict[str, str] = {"overall": "total"}
+STEP_ORDER_ALIASES: dict[str, str] = {"sequential": "ordered", "strict_order": "strict"}
+# Plurals of every unit the schema names in the singular.
+TIME_UNIT_ALIASES: dict[str, str] = {f"{u.value}s": u.value for u in FunnelConversionWindowTimeUnit}
+
+_VALID_OPERATORS = frozenset(o.value for o in PropertyOperator)
+_VALID_INTERVALS = frozenset(i.value for i in IntervalType)
+_VALID_PATH_TYPES = frozenset(p.value for p in PathType)
+_VALID_ELEMENT_KEYS = frozenset(k.value for k in Key)
+_VALID_TIME_UNITS = frozenset(u.value for u in FunnelConversionWindowTimeUnit)
+_VALID_STEP_ORDERS = frozenset(s.value for s in StepOrderValue)
+_VALID_FUNNEL_VIZ = frozenset(v.value for v in FunnelVizType)
+_VALID_RETENTION_TYPES = frozenset(r.value for r in RetentionType)
+_VALID_RETENTION_REFERENCES = frozenset(r.value for r in RetentionReference)
+_VALID_RETENTION_PERIODS = frozenset(p.value for p in RetentionPeriod)
+
+# `type` names a property's source table. A value type such as "number" says nothing about the
+# source, and event properties are the overwhelming default, so read it as one.
+PROPERTY_TYPE_ALIASES: dict[str, str] = {"number": "event", "string": "event", "boolean": "event"}
+
+# `_entities` stamps the type from the list an entity sits in, so `events` holds events whatever
+# their own `type` says. Exclusions and retention entities keep their own, and need one to be set.
+ENTITY_LIST_TYPES: dict[str, str | None] = {"events": "events", "actions": "actions", "exclusions": None}
+SINGLE_ENTITY_KEYS = ("target_entity", "returning_entity")
+
+
+def _repair_enum(
+    filters: dict[str, Any],
+    field: str,
+    valid: frozenset[str],
+    aliases: dict[str, str],
+    repairs: list[str],
+    *,
+    title_case: bool = False,
+) -> None:
+    if field not in filters:
+        return
+    value = filters[field]
+    if isinstance(value, str):
+        if value in valid:
+            return
+        candidate = value.title() if title_case else value.lower()
+        target = aliases.get(value) or aliases.get(candidate) or (candidate if candidate in valid else None)
+        if target is not None:
+            filters[field] = target
+            repairs.append(f"{field}:{value}->{target}")
+            return
+    filters.pop(field)
+    repairs.append(f"{field}:dropped")
+
+
+def _repair_int(filters: dict[str, Any], field: str, repairs: list[str]) -> None:
+    value = filters.get(field)
+    if value is None or isinstance(value, int):
+        return
+    try:
+        filters[field] = int(value)
+        repairs.append(f"{field}:coerced-int")
+    except (TypeError, ValueError):
+        filters.pop(field)
+        repairs.append(f"{field}:dropped")
+
+
+def _repair_property(prop: Any, repairs: list[str]) -> dict[str, Any] | None:
+    """Repair one leaf property filter, or return None to drop it."""
+    if not isinstance(prop, dict):
+        repairs.append("property:dropped-not-a-dict")
+        return None
+
+    prop = {**prop}
+
+    # `property` is an older spelling of `key`; without the rename the schema rejects it as unknown.
+    if "property" in prop and "key" not in prop:
+        prop["key"] = prop.pop("property")
+        repairs.append("property.property->key")
+
+    # These never belonged on a property filter and the schema forbids unknown keys.
+    for extra in ("math", "name", "value_is_regex", "event_type"):
+        if extra in prop and prop.get("type") != "behavioral":
+            prop.pop(extra)
+            repairs.append(f"property.{extra}:dropped")
+
+    ptype = prop.get("type")
+    if isinstance(ptype, str) and ptype in PROPERTY_TYPE_ALIASES:
+        prop["type"] = PROPERTY_TYPE_ALIASES[ptype]
+        repairs.append(f"property.type:{ptype}->{prop['type']}")
+
+    # Behavioral and cohort filters carry required fields we cannot reconstruct once they are absent.
+    if prop.get("type") == "behavioral":
+        repairs.append("property:dropped-behavioral")
+        return None
+    if prop.get("type") == "cohort":
+        try:
+            int(prop.get("value"))
+        except (TypeError, ValueError):
+            repairs.append("property:dropped-cohort-without-id")
+            return None
+
+    operator = prop.get("operator")
+    if isinstance(operator, str) and operator not in _VALID_OPERATORS:
+        target = OPERATOR_ALIASES.get(operator)
+        if target is None:
+            prop.pop("operator")
+            repairs.append(f"property.operator:{operator}->default")
+        else:
+            prop["operator"] = target
+            repairs.append(f"property.operator:{operator}->{target}")
+
+    # An element filter can only address the four parts of an element the schema names.
+    if prop.get("type") == "element" and prop.get("key") not in _VALID_ELEMENT_KEYS:
+        repairs.append("property:dropped-unknown-element-key")
+        return None
+
+    if prop.get("key") is None:
+        repairs.append("property:dropped-without-key")
+        return None
+
+    return prop
+
+
+def _repair_property_container(properties: Any, repairs: list[str]) -> Any:
+    """Walk a property list or AND/OR group, repairing leaves and dropping the unrepairable."""
+    if isinstance(properties, dict):
+        if properties.get("type") in ("AND", "OR"):
+            values = properties.get("values")
+            if not isinstance(values, list):
+                repairs.append("properties:dropped-malformed-group")
+                return None
+            cleaned = [c for c in (_repair_property_container(v, repairs) for v in values) if c]
+            if not cleaned:
+                return None
+            return {**properties, "values": cleaned}
+        if _is_old_style_properties(properties):
+            return properties
+        return _repair_property(properties, repairs)
+
+    if isinstance(properties, list):
+        cleaned = [c for c in (_repair_property_container(p, repairs) for p in properties) if c]
+        return cleaned or None
+
+    repairs.append("properties:dropped-unexpected-format")
+    return None
+
+
+def _is_old_style_properties(properties: Any) -> bool:
+    """Mirrors clean_properties.is_old_style_properties, which owns this shape."""
+    return isinstance(properties, dict) and len(properties) == 1 and properties.get("type") not in ("AND", "OR")
+
+
+def _flatten_properties(properties: Any) -> list[dict[str, Any]]:
+    """Collect every leaf property filter, discarding the AND/OR nesting around them."""
+    if isinstance(properties, dict):
+        if properties.get("type") in ("AND", "OR"):
+            return [leaf for value in properties.get("values") or [] for leaf in _flatten_properties(value)]
+        return [properties]
+    if isinstance(properties, list):
+        return [leaf for item in properties for leaf in _flatten_properties(item)]
+    return []
+
+
+def _repair_entity(entity: Any, repairs: list[str], forced_type: str | None = None) -> dict[str, Any] | None:
+    if not isinstance(entity, dict):
+        repairs.append("entity:dropped-not-a-dict")
+        return None
+
+    entity = {**entity}
+
+    etype = forced_type or entity.get("type")
+    if etype not in ("events", "actions", "data_warehouse"):
+        if etype is not None:
+            repairs.append("entity.type->events")
+        etype = "events"
+    # An entity reaching LegacyEntity without a type raises, so always state it.
+    entity["type"] = etype
+
+    entity_id = entity.get("id")
+    if entity["type"] == "actions":
+        try:
+            entity["id"] = int(entity_id)
+        except (TypeError, ValueError):
+            repairs.append("entity:dropped-action-without-id")
+            return None
+    elif isinstance(entity_id, int | float) and not isinstance(entity_id, bool):
+        # An event is addressed by name. A number here is a name that lost its quotes.
+        entity["id"] = str(entity_id)
+        repairs.append("entity.id:coerced-str")
+    elif entity_id is not None and not isinstance(entity_id, str):
+        repairs.append("entity:dropped-unusable-id")
+        return None
+
+    math = entity.get("math")
+    if isinstance(math, str) and math not in VALID_MATH:
+        target = MATH_ALIASES.get(math)
+        if target is None:
+            entity.pop("math", None)
+            repairs.append(f"math:{math}->default")
+        else:
+            entity["math"] = target
+            repairs.append(f"math:{math}->{target}")
+    elif math is not None and not isinstance(math, str):
+        entity.pop("math", None)
+        repairs.append("math:dropped")
+
+    # `{"utm_medium__icontains": "email"}` is the old one-key shape, which clean_properties expands
+    # on its own. Wrapping it in a list would hide it from that check.
+    if "properties" in entity and not _is_old_style_properties(entity["properties"]):
+        cleaned = _repair_property_container(entity["properties"], repairs)
+        # An entity takes a flat list only — clean_entity_properties raises on a nested group.
+        if isinstance(cleaned, dict | list):
+            flat = _flatten_properties(cleaned)
+            if flat != cleaned:
+                repairs.append("entity.properties:flattened")
+            cleaned = flat or None
+        if cleaned is None:
+            entity.pop("properties")
+        else:
+            entity["properties"] = cleaned
+
+    for step_field in ("funnel_from_step", "funnel_to_step"):
+        if step_field in entity:
+            _repair_int(entity, step_field, repairs)
+
+    return entity
+
+
+def normalized_insight_type(filters: dict[str, Any]) -> str | None:
+    """The insight type after case and alias repair, or None when it is not a recognizable one."""
+    raw = filters.get("insight")
+    if raw is None:
+        return "TRENDS"
+    if not isinstance(raw, str):
+        return None
+    upper = raw.upper()
+    resolved = INSIGHT_ALIASES.get(upper, upper)
+    if resolved in VIZ_INSIGHT_TYPES or resolved in SQL_INSIGHT_TYPES:
+        return resolved
+    return None
+
+
+def repair_filters(filters: Any) -> tuple[dict[str, Any], list[str]]:
+    """Return filters `filter_to_query` accepts, plus the name of every repair applied."""
+    repairs: list[str] = []
+    if not isinstance(filters, dict):
+        return {}, ["filters:replaced-non-dict"]
+
+    out = copy.deepcopy(filters)
+
+    raw_insight = out.get("insight")
+    resolved = normalized_insight_type(out)
+    if resolved is None:
+        # `_insight_type` reads the key rather than defaulting when it is present but unusable.
+        out["insight"] = "TRENDS"
+        repairs.append(f"insight:{raw_insight if isinstance(raw_insight, str) else 'malformed'}->TRENDS")
+    elif raw_insight is None and "insight" in out:
+        out["insight"] = "TRENDS"
+        repairs.append("insight:null->TRENDS")
+    elif isinstance(raw_insight, str) and raw_insight != resolved:
+        out["insight"] = resolved
+        repairs.append(f"insight:{raw_insight}->{resolved}")
+
+    for key, forced_type in ENTITY_LIST_TYPES.items():
+        if key not in out:
+            continue
+        raw = out[key]
+        if not isinstance(raw, list):
+            out.pop(key)
+            repairs.append(f"{key}:dropped-not-a-list")
+            continue
+        out[key] = [e for e in (_repair_entity(e, repairs, forced_type) for e in raw) if e]
+
+    for key in SINGLE_ENTITY_KEYS:
+        if key not in out:
+            continue
+        raw = out[key]
+        # A list here is a single entity that was stored wrapped; take the entity back out.
+        if isinstance(raw, list):
+            raw = next((item for item in raw if isinstance(item, dict)), None)
+        repaired = _repair_entity(raw, repairs) if raw is not None else None
+        if repaired is None:
+            out.pop(key)
+            repairs.append(f"{key}:dropped")
+        else:
+            out[key] = repaired
+
+    if "properties" in out:
+        cleaned = _repair_property_container(out["properties"], repairs)
+        if cleaned is None:
+            out.pop("properties")
+        else:
+            out["properties"] = cleaned
+
+    _repair_enum(out, "interval", _VALID_INTERVALS, {}, repairs)
+    _repair_enum(out, "funnel_order_type", _VALID_STEP_ORDERS, STEP_ORDER_ALIASES, repairs)
+    _repair_enum(out, "funnel_viz_type", _VALID_FUNNEL_VIZ, {}, repairs)
+    _repair_enum(out, "funnel_window_interval_unit", _VALID_TIME_UNITS, TIME_UNIT_ALIASES, repairs)
+    _repair_enum(out, "retention_type", _VALID_RETENTION_TYPES, RETENTION_TYPE_ALIASES, repairs)
+    _repair_enum(out, "retention_reference", _VALID_RETENTION_REFERENCES, RETENTION_REFERENCE_ALIASES, repairs)
+    _repair_enum(out, "period", _VALID_RETENTION_PERIODS, {}, repairs, title_case=True)
+    # An unusable breakdown type falls back to "event", which is what `_breakdown_filter` assumes
+    # whenever a breakdown is set without one.
+    _repair_enum(out, "breakdown_type", _valid_breakdown_types(), {}, repairs)
+
+    if "funnel_window_interval" in out:
+        _repair_int(out, "funnel_window_interval", repairs)
+
+    if not isinstance(out.get("layout"), str) and "layout" in out:
+        out.pop("layout")
+        repairs.append("layout:dropped")
+
+    if "compare_to" in out and not isinstance(out["compare_to"], str):
+        out.pop("compare_to")
+        repairs.append("compare_to:dropped")
+
+    breakdown = out.get("breakdown")
+    if breakdown is not None and not isinstance(breakdown, str | int):
+        if isinstance(breakdown, list):
+            kept = [b for b in breakdown if isinstance(b, str | int)]
+            if kept:
+                out["breakdown"] = kept
+            else:
+                out.pop("breakdown")
+                repairs.append("breakdown:dropped")
+        else:
+            out.pop("breakdown")
+            repairs.append("breakdown:dropped")
+
+    # filter_to_query only converts a single breakdown; more than one has no query equivalent.
+    breakdowns = out.get("breakdowns")
+    if isinstance(breakdowns, list) and len(breakdowns) > 1:
+        out.pop("breakdowns")
+        repairs.append("breakdowns:dropped-multiple")
+
+    include_event_types = out.get("include_event_types")
+    if isinstance(include_event_types, list):
+        kept = [t for t in include_event_types if t in _VALID_PATH_TYPES]
+        if len(kept) != len(include_event_types):
+            repairs.append("include_event_types:dropped-unknown")
+        if kept:
+            out["include_event_types"] = kept
+        else:
+            out.pop("include_event_types")
+
+    path_groupings = out.get("path_groupings")
+    if isinstance(path_groupings, list):
+        kept_groupings = [g for g in path_groupings if isinstance(g, str)]
+        if len(kept_groupings) != len(path_groupings):
+            repairs.append("path_groupings:dropped-non-string")
+        if kept_groupings:
+            out["path_groupings"] = kept_groupings
+        else:
+            out.pop("path_groupings")
+
+    for date_field in ("date_from", "date_to"):
+        value = out.get(date_field)
+        if value is not None and not isinstance(value, str):
+            out[date_field] = str(value)
+            repairs.append(f"{date_field}:coerced-str")
+
+    return out, repairs
+
+
+def _valid_breakdown_types() -> frozenset[str]:
+    from posthog.schema import BreakdownType  # noqa: PLC0415 — avoids a schema import cycle at module load
+
+    return frozenset(b.value for b in BreakdownType)

--- a/products/product_analytics/backend/management/commands/migrate_insight_filters_to_query.py
+++ b/products/product_analytics/backend/management/commands/migrate_insight_filters_to_query.py
@@ -1,0 +1,124 @@
+from datetime import datetime
+from time import sleep
+from typing import Any
+
+from django.core.management.base import BaseCommand, CommandParser
+from django.db import transaction
+
+import structlog
+
+from posthog.schema import InsightVizNode
+
+from posthog.hogql_queries.legacy_compatibility.filter_to_query import filter_to_query
+
+from products.product_analytics.backend.models.insight import Insight
+
+logger = structlog.get_logger(__name__)
+
+
+class Command(BaseCommand):
+    help = (
+        "Backfill `query` from legacy `filters` on insights that still lack one — the same conversion "
+        "as migration 0545, for rows created since it ran. Empty shells (no query, no filters) convert "
+        "to the default empty trends query they already render as. Dry-run by default; pass --live to "
+        "write. Rows locked by concurrent writers are skipped, so re-run to pick up any remainder."
+    )
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        parser.add_argument("--live", action="store_true", help="Write changes (default is a read-only report)")
+        parser.add_argument("--batch-size", type=int, default=500)
+        parser.add_argument("--sleep-interval", type=float, default=0.1, help="Seconds to sleep between batches")
+        parser.add_argument("--team-id", type=int, help="Only process insights of this team")
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        live: bool = options["live"]
+        batch_size: int = options["batch_size"]
+        sleep_interval: float = options["sleep_interval"]
+        team_id: int | None = options["team_id"]
+
+        # Soft-deleted insights are included: they can be restored from the trash, so they need a query too.
+        # Empty shells (no query, no filters) are included too: filter_to_query({}) yields the same empty
+        # trends query they already render as at read time, so converting them changes nothing visible.
+        base = Insight.objects_including_soft_deleted.filter(query__isnull=True)
+        shells = Insight.objects_including_soft_deleted.filter(query__isnull=True, filters={})
+        if team_id is not None:
+            base = base.filter(team_id=team_id)
+            shells = shells.filter(team_id=team_id)
+
+        total = base.count()
+        self.stdout.write(f"{total} insights without a query")
+        self.stdout.write(f"of which {shells.count()} empty shells (no filters either) — get the default trends query")
+        if not live:
+            self.stdout.write(self.style.WARNING("Dry run — pass --live to write"))
+
+        # Same stamp convention as migration 0545: lets us find rows converted by this run to roll back.
+        migrated_at = str(datetime.now())
+        converted = 0
+        errors: dict[str, list[int]] = {}
+        metadata_errors: dict[str, list[int]] = {}
+        cursor = 0
+
+        while True:
+            with transaction.atomic():
+                batch_qs = (
+                    base.filter(id__gt=cursor)
+                    .order_by("id")
+                    .select_related("team")
+                    .only("id", "filters", "query", "query_metadata", "team")
+                )
+                if live:
+                    batch_qs = batch_qs.select_for_update(skip_locked=True, of=("self",))
+                batch = list(batch_qs[:batch_size])
+                if not batch:
+                    break
+
+                to_update = []
+                for insight in batch:
+                    try:
+                        query = InsightVizNode(source=filter_to_query(insight.filters)).model_dump(exclude_none=True)
+                    except Exception as e:
+                        errors.setdefault(type(e).__name__, []).append(insight.id)
+                        continue
+                    insight.query = query
+                    try:
+                        # bulk_update skips the save() hook that derives this, so derive it here — without it
+                        # a converted insight drops out of the `events` list filter and Max's insight search.
+                        insight.generate_query_metadata()
+                    except Exception as e:
+                        # Best effort: the row still converts, and backfill_insights_query_metadata
+                        # sweeps rows whose metadata stayed null.
+                        logger.warning("query_metadata generation failed", insight_id=insight.id, error=str(e))
+                        metadata_errors.setdefault(type(e).__name__, []).append(insight.id)
+                    insight.filters["migrated_at"] = migrated_at
+                    to_update.append(insight)
+
+                if live and to_update:
+                    # bulk_update bypasses save() and auto_now, so updated_at/last_modified_at stay put and
+                    # "recently modified" orderings don't get churned by a background backfill.
+                    Insight.objects_including_soft_deleted.bulk_update(
+                        to_update, ["query", "filters", "query_metadata"]
+                    )
+                converted += len(to_update)
+                cursor = batch[-1].id
+
+            self.stdout.write(f"...{converted}/{total} converted, cursor at insight id {cursor}")
+            if sleep_interval > 0:
+                sleep(sleep_interval)
+
+        failed = sum(len(ids) for ids in errors.values())
+        verb = "Converted" if live else "Would convert"
+        style = self.style.SUCCESS if failed == 0 else self.style.WARNING
+        self.stdout.write(style(f"{verb} {converted} of {total} insights ({failed} failed)"))
+        for error_type, ids in sorted(errors.items(), key=lambda kv: -len(kv[1])):
+            self.stdout.write(f"  {error_type}: {len(ids)} insights, e.g. {ids[:5]}")
+
+        metadata_failed = sum(len(ids) for ids in metadata_errors.values())
+        if metadata_failed:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"{metadata_failed} converted insights have no query_metadata — "
+                    f"run backfill_insights_query_metadata to sweep them"
+                )
+            )
+            for error_type, ids in sorted(metadata_errors.items(), key=lambda kv: -len(kv[1])):
+                self.stdout.write(f"  {error_type}: {len(ids)} insights, e.g. {ids[:5]}")

--- a/products/product_analytics/backend/management/commands/migrate_insight_filters_to_query.py
+++ b/products/product_analytics/backend/management/commands/migrate_insight_filters_to_query.py
@@ -7,21 +7,75 @@ from django.db import transaction
 
 import structlog
 
-from posthog.schema import InsightVizNode
+from posthog.schema import InsightVizNode, QuerySchemaRoot
 
 from posthog.hogql_queries.legacy_compatibility.filter_to_query import filter_to_query
 
+from products.product_analytics.backend.legacy_filter_repair import (
+    SQL_INSIGHT_TYPES,
+    normalized_insight_type,
+    repair_filters,
+)
 from products.product_analytics.backend.models.insight import Insight
 
 logger = structlog.get_logger(__name__)
+
+REPAIRS_KEY = "migration_repairs"
+
+
+def sql_query_from_filters(filters: dict[str, Any]) -> dict[str, Any] | None:
+    """Build the query for a SQL insight, which keeps its SQL in `filters` instead of a query node."""
+    raw = filters.get("query")
+    if isinstance(raw, dict):
+        if raw.get("kind"):
+            return raw
+        raw = raw.get("query")
+    if isinstance(raw, str) and raw.strip():
+        return {"kind": "DataVisualizationNode", "source": {"kind": "HogQLQuery", "query": raw}}
+    return None
+
+
+def validated(query: dict[str, Any]) -> dict[str, Any]:
+    """Reject anything /query would reject, so a stored query is always one that can run."""
+    QuerySchemaRoot.model_validate(query)
+    return query
+
+
+def _convert(filters: dict[str, Any]) -> dict[str, Any]:
+    return InsightVizNode(source=filter_to_query(filters)).model_dump(exclude_none=True)
+
+
+def query_from_filters(filters: Any) -> tuple[dict[str, Any], list[str]]:
+    """Convert legacy filters, repairing them only when they cannot convert as they stand.
+
+    Returns the query and the name of every repair applied. Raises when even repaired filters fail.
+    """
+    filters = filters if isinstance(filters, dict) else {}
+
+    if normalized_insight_type(filters) in SQL_INSIGHT_TYPES:
+        sql_query = sql_query_from_filters(filters)
+        if sql_query is None:
+            raise ValueError("SQL insight without a usable query")
+        return validated(sql_query), ["insight:sql"]
+
+    try:
+        return validated(_convert(filters)), []
+    except Exception:
+        repaired, repairs = repair_filters(filters)
+        # A second failure propagates, and the caller reports it against the original row.
+        return validated(_convert(repaired)), repairs
 
 
 class Command(BaseCommand):
     help = (
         "Backfill `query` from legacy `filters` on insights that still lack one — the same conversion "
-        "as migration 0545, for rows created since it ran. Empty shells (no query, no filters) convert "
-        "to the default empty trends query they already render as. Dry-run by default; pass --live to "
-        "write. Rows locked by concurrent writers are skipped, so re-run to pick up any remainder."
+        "as migration 0545, for rows created since it ran. Filters that cannot convert are repaired "
+        "first: `filters` was never validated, so it holds values the schema does not accept, which "
+        "means those insights fail at query time today. A repair maps a value when it has one clear "
+        "reading and drops it to the schema default when it does not. Empty shells (no query, no "
+        "filters) convert to the default empty trends query they already render as. Dry-run by "
+        "default; pass --live to write. Rows locked by concurrent writers are skipped, so re-run to "
+        "pick up any remainder."
     )
 
     def add_arguments(self, parser: CommandParser) -> None:
@@ -29,13 +83,76 @@ class Command(BaseCommand):
         parser.add_argument("--batch-size", type=int, default=500)
         parser.add_argument("--sleep-interval", type=float, default=0.1, help="Seconds to sleep between batches")
         parser.add_argument("--team-id", type=int, help="Only process insights of this team")
+        parser.add_argument(
+            "--no-repair",
+            action="store_true",
+            help="Convert only filters that already convert, and report the rest as failures",
+        )
+        parser.add_argument(
+            "--rollback",
+            metavar="STAMP",
+            help=(
+                "Undo one run: clear `query` on the insights it stamped with this exact `migrated_at`. "
+                "List the stamps with --list-stamps. Scoped to a single run on purpose, because "
+                "clearing every stamped row would also undo migration 0545."
+            ),
+        )
+        parser.add_argument(
+            "--list-stamps", action="store_true", help="Show each `migrated_at` stamp and how many rows carry it"
+        )
 
     def handle(self, *args: Any, **options: Any) -> None:
-        live: bool = options["live"]
-        batch_size: int = options["batch_size"]
-        sleep_interval: float = options["sleep_interval"]
         team_id: int | None = options["team_id"]
 
+        if options["list_stamps"]:
+            self._list_stamps(team_id)
+            return
+        if options["rollback"]:
+            self._rollback(options["rollback"], team_id, options["live"])
+            return
+
+        self._backfill(
+            live=options["live"],
+            batch_size=options["batch_size"],
+            sleep_interval=options["sleep_interval"],
+            team_id=team_id,
+            repair=not options["no_repair"],
+        )
+
+    def _stamped(self, team_id: int | None):
+        qs = Insight.objects_including_soft_deleted.filter(filters__has_key="migrated_at")
+        return qs.filter(team_id=team_id) if team_id is not None else qs
+
+    def _list_stamps(self, team_id: int | None) -> None:
+        counts: dict[str, int] = {}
+        for filters in self._stamped(team_id).values_list("filters", flat=True).iterator(chunk_size=500):
+            stamp = (filters or {}).get("migrated_at")
+            if stamp:
+                counts[str(stamp)] = counts.get(str(stamp), 0) + 1
+        if not counts:
+            self.stdout.write("No stamped insights")
+            return
+        self.stdout.write(f"{len(counts)} stamps:")
+        for stamp, count in sorted(counts.items()):
+            self.stdout.write(f"  {count:>6}  {stamp}")
+
+    def _rollback(self, stamp: str, team_id: int | None, live: bool) -> None:
+        batch = list(self._stamped(team_id).filter(filters__migrated_at=stamp).only("id", "filters", "query"))
+        self.stdout.write(f"{len(batch)} insights stamped {stamp!r}")
+        if not live:
+            self.stdout.write(self.style.WARNING("Dry run — pass --live to write"))
+            return
+        for insight in batch:
+            insight.query = None
+            insight.query_metadata = None
+            insight.filters.pop("migrated_at", None)
+            insight.filters.pop(REPAIRS_KEY, None)
+        Insight.objects_including_soft_deleted.bulk_update(batch, ["query", "filters", "query_metadata"])
+        self.stdout.write(self.style.SUCCESS(f"Reverted {len(batch)} insights"))
+
+    def _backfill(
+        self, *, live: bool, batch_size: int, sleep_interval: float, team_id: int | None, repair: bool
+    ) -> None:
         # Soft-deleted insights are included: they can be restored from the trash, so they need a query too.
         # Empty shells (no query, no filters) are included too: filter_to_query({}) yields the same empty
         # trends query they already render as at read time, so converting them changes nothing visible.
@@ -51,9 +168,11 @@ class Command(BaseCommand):
         if not live:
             self.stdout.write(self.style.WARNING("Dry run — pass --live to write"))
 
-        # Same stamp convention as migration 0545: lets us find rows converted by this run to roll back.
+        # Same stamp convention as migration 0545, and unique per run so --rollback can target this one.
         migrated_at = str(datetime.now())
         converted = 0
+        repaired_count = 0
+        repair_counts: dict[str, int] = {}
         errors: dict[str, list[int]] = {}
         metadata_errors: dict[str, list[int]] = {}
         cursor = 0
@@ -75,7 +194,10 @@ class Command(BaseCommand):
                 to_update = []
                 for insight in batch:
                     try:
-                        query = InsightVizNode(source=filter_to_query(insight.filters)).model_dump(exclude_none=True)
+                        if repair:
+                            query, repairs = query_from_filters(insight.filters)
+                        else:
+                            query, repairs = validated(_convert(insight.filters or {})), []
                     except Exception as e:
                         errors.setdefault(type(e).__name__, []).append(insight.id)
                         continue
@@ -89,7 +211,15 @@ class Command(BaseCommand):
                         # sweeps rows whose metadata stayed null.
                         logger.warning("query_metadata generation failed", insight_id=insight.id, error=str(e))
                         metadata_errors.setdefault(type(e).__name__, []).append(insight.id)
+                    if not isinstance(insight.filters, dict):
+                        insight.filters = {}
                     insight.filters["migrated_at"] = migrated_at
+                    if repairs:
+                        repaired_count += 1
+                        # Recorded on the row so a repaired insight stays findable for review.
+                        insight.filters[REPAIRS_KEY] = repairs
+                        for name in repairs:
+                            repair_counts[name] = repair_counts.get(name, 0) + 1
                     to_update.append(insight)
 
                 if live and to_update:
@@ -109,8 +239,18 @@ class Command(BaseCommand):
         verb = "Converted" if live else "Would convert"
         style = self.style.SUCCESS if failed == 0 else self.style.WARNING
         self.stdout.write(style(f"{verb} {converted} of {total} insights ({failed} failed)"))
+        if live and converted:
+            self.stdout.write(f"Stamp for this run (pass to --rollback to undo it): {migrated_at!r}")
         for error_type, ids in sorted(errors.items(), key=lambda kv: -len(kv[1])):
             self.stdout.write(f"  {error_type}: {len(ids)} insights, e.g. {ids[:5]}")
+
+        if repaired_count:
+            self.stdout.write(
+                f"{repaired_count} insights needed a repair first — their filters held values the schema "
+                f"does not accept, so they could not run before either:"
+            )
+            for name, count in sorted(repair_counts.items(), key=lambda kv: -kv[1]):
+                self.stdout.write(f"  {count:>5}  {name}")
 
         metadata_failed = sum(len(ids) for ids in metadata_errors.values())
         if metadata_failed:

--- a/products/product_analytics/backend/management/commands/test/test_migrate_insight_filters_to_query.py
+++ b/products/product_analytics/backend/management/commands/test/test_migrate_insight_filters_to_query.py
@@ -78,7 +78,8 @@ class TestMigrateInsightFiltersToQuery(BaseTest):
         assert query_insight.query == existing_query
 
     def test_conversion_error_skips_row_and_continues_across_batches(self):
-        bad = Insight.objects.create(team=self.team, filters={"insight": "TRENDS", "events": 42})
+        # A SQL insight keeps its SQL in `filters`; without it there is nothing to build a query from.
+        bad = Insight.objects.create(team=self.team, filters={"insight": "SQL"})
         good = Insight.objects.create(team=self.team, filters=TREND_FILTERS)
         soft_deleted = Insight.objects.create(team=self.team, deleted=True, filters=TREND_FILTERS)
 
@@ -91,3 +92,69 @@ class TestMigrateInsightFiltersToQuery(BaseTest):
         assert "migrated_at" not in bad.filters
         assert good.query is not None
         assert soft_deleted.query is not None
+
+    @parameterized.expand(
+        [
+            ("plain_sql", "select 1", "select 1"),
+            (
+                "nested_query_node",
+                {"kind": "DataVisualizationNode", "source": {"kind": "HogQLQuery", "query": "s"}},
+                "s",
+            ),
+        ]
+    )
+    def test_converts_sql_insights_to_a_sql_query(self, _name, stored_query, expected_sql):
+        insight = Insight.objects.create(team=self.team, filters={"insight": "SQL", "query": stored_query})
+
+        self._run(live=True)
+
+        insight.refresh_from_db()
+        assert insight.query is not None
+        assert insight.query["kind"] == "DataVisualizationNode"
+        assert insight.query["source"]["query"] == expected_sql
+
+    def test_repairs_filters_that_cannot_convert_and_records_what_changed(self):
+        # `unique_users` was never a valid math value, so this insight fails at query time today.
+        insight = Insight.objects.create(
+            team=self.team,
+            filters={"insight": "TRENDS", "events": [{"id": "$pageview", "order": 0, "math": "unique_users"}]},
+        )
+
+        self._run(live=True)
+
+        insight.refresh_from_db()
+        assert insight.query["source"]["series"][0]["math"] == "dau"
+        assert insight.filters["migration_repairs"] == ["math:unique_users->dau"]
+
+    def test_no_repair_leaves_unconvertible_rows_alone(self):
+        insight = Insight.objects.create(
+            team=self.team,
+            filters={"insight": "TRENDS", "events": [{"id": "$pageview", "order": 0, "math": "unique_users"}]},
+        )
+
+        self._run(live=True, no_repair=True)
+
+        insight.refresh_from_db()
+        assert insight.query is None
+        assert "migrated_at" not in insight.filters
+
+    def test_rollback_reverts_only_the_run_with_the_given_stamp(self):
+        # Migration 0545 stamped its own rows with the same key. Rolling back every stamped row would
+        # undo that migration too, so a rollback has to be scoped to one run's stamp.
+        from_0545 = Insight.objects.create(
+            team=self.team, filters={**TREND_FILTERS, "migrated_at": "2024-08-22 12:00:00"}, query={"kind": "old"}
+        )
+        this_run = Insight.objects.create(team=self.team, filters=TREND_FILTERS)
+
+        self._run(live=True)
+        this_run.refresh_from_db()
+        stamp = this_run.filters["migrated_at"]
+
+        call_command("migrate_insight_filters_to_query", live=True, rollback=stamp, sleep_interval=0)
+
+        this_run.refresh_from_db()
+        from_0545.refresh_from_db()
+        assert this_run.query is None
+        assert "migrated_at" not in this_run.filters
+        assert from_0545.query == {"kind": "old"}
+        assert from_0545.filters["migrated_at"] == "2024-08-22 12:00:00"

--- a/products/product_analytics/backend/management/commands/test/test_migrate_insight_filters_to_query.py
+++ b/products/product_analytics/backend/management/commands/test/test_migrate_insight_filters_to_query.py
@@ -1,0 +1,93 @@
+from posthog.test.base import BaseTest
+
+from django.core.management import call_command
+
+from parameterized import parameterized
+
+from products.product_analytics.backend.models.insight import Insight
+
+TREND_FILTERS = {"insight": "TRENDS", "events": [{"id": "$pageview", "type": "events", "order": 0}]}
+
+
+class TestMigrateInsightFiltersToQuery(BaseTest):
+    def _run(self, **kwargs) -> None:
+        call_command("migrate_insight_filters_to_query", sleep_interval=0, **kwargs)
+
+    @parameterized.expand(
+        [
+            ("trend", TREND_FILTERS, "TrendsQuery", ["$pageview"]),
+            (
+                "funnel",
+                {
+                    "insight": "FUNNELS",
+                    "events": [
+                        {"id": "$pageview", "type": "events", "order": 0},
+                        {"id": "user signed up", "type": "events", "order": 1},
+                    ],
+                },
+                "FunnelsQuery",
+                ["$pageview", "user signed up"],
+            ),
+            # Migration 0545 required an `insight` key and skipped rows without one; the command must not.
+            (
+                "no_insight_key",
+                {"events": [{"id": "$pageview", "type": "events", "order": 0}]},
+                "TrendsQuery",
+                ["$pageview"],
+            ),
+        ]
+    )
+    def test_converts_legacy_filters(self, _name, filters, expected_source_kind, expected_events):
+        insight = Insight.objects.create(team=self.team, filters=filters)
+
+        self._run(live=True)
+
+        insight.refresh_from_db()
+        assert insight.query is not None
+        assert insight.query["kind"] == "InsightVizNode"
+        assert insight.query["source"]["kind"] == expected_source_kind
+        assert "migrated_at" in insight.filters
+        # bulk_update skips the save() hook that derives metadata, so the command derives it. Without that,
+        # a converted insight drops out of the `events` list filter and Max's insight search.
+        assert insight.query_metadata is not None
+        assert sorted(insight.query_metadata["events"]) == sorted(expected_events)
+
+    def test_dry_run_by_default_writes_nothing(self):
+        insight = Insight.objects.create(team=self.team, filters=TREND_FILTERS)
+
+        self._run()
+
+        insight.refresh_from_db()
+        assert insight.query is None
+        assert "migrated_at" not in insight.filters
+
+    def test_converts_empty_shells_and_leaves_query_insights_untouched(self):
+        shell = Insight.objects.create(team=self.team)
+        existing_query = {"kind": "InsightVizNode", "source": {"kind": "TrendsQuery", "series": []}}
+        query_insight = Insight.objects.create(team=self.team, query=existing_query)
+
+        self._run(live=True)
+
+        shell.refresh_from_db()
+        query_insight.refresh_from_db()
+        # Shells must land on the same empty trends query they rendered as before, not on some real series.
+        assert shell.query is not None
+        assert shell.query["source"]["kind"] == "TrendsQuery"
+        assert shell.query["source"]["series"] == []
+        assert "migrated_at" in shell.filters
+        assert query_insight.query == existing_query
+
+    def test_conversion_error_skips_row_and_continues_across_batches(self):
+        bad = Insight.objects.create(team=self.team, filters={"insight": "TRENDS", "events": 42})
+        good = Insight.objects.create(team=self.team, filters=TREND_FILTERS)
+        soft_deleted = Insight.objects.create(team=self.team, deleted=True, filters=TREND_FILTERS)
+
+        self._run(live=True, batch_size=1)
+
+        bad.refresh_from_db()
+        good.refresh_from_db()
+        soft_deleted.refresh_from_db()
+        assert bad.query is None
+        assert "migrated_at" not in bad.filters
+        assert good.query is not None
+        assert soft_deleted.query is not None

--- a/products/product_analytics/backend/tests/test_legacy_filter_repair.py
+++ b/products/product_analytics/backend/tests/test_legacy_filter_repair.py
@@ -1,0 +1,250 @@
+from typing import Any
+
+from django.test import SimpleTestCase
+
+from parameterized import parameterized
+
+from posthog.schema import InsightVizNode, QuerySchemaRoot
+
+from posthog.hogql_queries.legacy_compatibility.filter_to_query import filter_to_query
+
+from products.product_analytics.backend.legacy_filter_repair import repair_filters
+
+# Filters that already convert. Repair must leave the resulting query byte-identical: an alias that
+# is too eager would silently rewrite insights that work.
+ALREADY_VALID: list[tuple[str, dict]] = [
+    ("trends", {"insight": "TRENDS", "events": [{"id": "$pageview", "type": "events", "order": 0}]}),
+    ("base_math", {"insight": "TRENDS", "events": [{"id": "a", "order": 0, "math": "dau"}]}),
+    ("property_math", {"insight": "TRENDS", "events": [{"id": "a", "order": 0, "math": "p95", "math_property": "x"}]}),
+    (
+        "group_math",
+        {"insight": "TRENDS", "events": [{"id": "a", "order": 0, "math": "unique_group", "math_group_type_index": 0}]},
+    ),
+    # Converts and validates without its companion field, so repair has no business touching it.
+    ("group_math_without_index", {"insight": "TRENDS", "events": [{"id": "a", "order": 0, "math": "unique_group"}]}),
+    ("hogql_math_without_expression", {"insight": "TRENDS", "events": [{"id": "a", "order": 0, "math": "hogql"}]}),
+    (
+        "funnels",
+        {
+            "insight": "FUNNELS",
+            "events": [{"id": "a", "order": 0}, {"id": "b", "order": 1}],
+            "funnel_order_type": "strict",
+        },
+    ),
+    (
+        "retention",
+        {
+            "insight": "RETENTION",
+            "period": "Week",
+            "retention_type": "retention_first_time",
+            "target_entity": {"id": "a", "type": "events"},
+        },
+    ),
+    ("paths", {"insight": "PATHS", "include_event_types": ["$pageview", "custom_event"], "step_limit": 5}),
+    ("lifecycle", {"insight": "LIFECYCLE", "events": [{"id": "a", "order": 0}], "toggledLifecycles": ["new"]}),
+    ("stickiness", {"shown_as": "Stickiness", "events": [{"id": "a", "order": 0}]}),
+    ("breakdown", {"insight": "TRENDS", "breakdown": "$browser", "breakdown_type": "event", "events": [{"id": "a"}]}),
+    (
+        "entity_properties",
+        {
+            "insight": "TRENDS",
+            "events": [{"id": "a", "properties": [{"key": "x", "value": "1", "operator": "exact", "type": "event"}]}],
+        },
+    ),
+    (
+        "old_style_properties",
+        {"insight": "TRENDS", "events": [{"id": "a", "properties": {"utm_medium__icontains": "email"}}]},
+    ),
+    (
+        "cohort",
+        {"insight": "TRENDS", "properties": [{"key": "id", "value": 42, "type": "cohort"}], "events": [{"id": "a"}]},
+    ),
+    ("actions", {"insight": "TRENDS", "actions": [{"id": 12, "type": "actions", "order": 0}]}),
+    ("empty_shell", {}),
+]
+
+# Values `filters` accepted because the column was never validated. Each case is (name, broken
+# filters, the repair we expect), and every one must end up convertible.
+REPAIRABLE: list[tuple[str, Any, str]] = [
+    (
+        "math_alias",
+        {"insight": "TRENDS", "events": [{"id": "a", "order": 0, "math": "unique_users"}]},
+        "math:unique_users->dau",
+    ),
+    (
+        "math_percentile_alias",
+        {"insight": "TRENDS", "events": [{"id": "a", "order": 0, "math": "p50", "math_property": "x"}]},
+        "math:p50->median",
+    ),
+    (
+        "math_ambiguous_dropped",
+        {"insight": "TRENDS", "events": [{"id": "a", "order": 0, "math": "last_value", "math_property": "x"}]},
+        "math:last_value->default",
+    ),
+    (
+        "insight_case_variant",
+        {"insight": "FUNNEL", "events": [{"id": "a", "order": 0}, {"id": "b", "order": 1}]},
+        "insight:FUNNEL->FUNNELS",
+    ),
+    (
+        "insight_display_type",
+        {"insight": "NUMBER", "display": "BoldNumber", "events": [{"id": "a", "order": 0}]},
+        "insight:NUMBER->TRENDS",
+    ),
+    ("insight_null", {"insight": None, "events": [{"id": "a", "order": 0}]}, "insight:null->TRENDS"),
+    ("insight_unhashable", {"insight": ["TRENDS"], "events": [{"id": "a", "order": 0}]}, "insight:malformed->TRENDS"),
+    (
+        "event_id_number",
+        {"insight": "TRENDS", "events": [{"id": 123, "order": 0, "type": "events"}]},
+        "entity.id:coerced-str",
+    ),
+    ("interval_unknown", {"insight": "TRENDS", "interval": "total", "events": [{"id": "a"}]}, "interval:dropped"),
+    (
+        "funnel_order_alias",
+        {"insight": "FUNNELS", "funnel_order_type": "sequential", "events": [{"id": "a"}, {"id": "b"}]},
+        "funnel_order_type:sequential->ordered",
+    ),
+    (
+        "funnel_window_unit_plural",
+        {"insight": "FUNNELS", "funnel_window_interval_unit": "seconds", "events": [{"id": "a"}]},
+        "funnel_window_interval_unit:seconds->second",
+    ),
+    (
+        "retention_type_alias",
+        {"insight": "RETENTION", "retention_type": "retention"},
+        "retention_type:retention->retention_recurring",
+    ),
+    ("retention_period_case", {"insight": "RETENTION", "period": "week"}, "period:week->Week"),
+    (
+        "breakdown_type_unknown",
+        {"insight": "TRENDS", "breakdown": "x", "breakdown_type": "feature", "events": [{"id": "a"}]},
+        "breakdown_type:dropped",
+    ),
+    (
+        "path_types_unknown",
+        {"insight": "PATHS", "include_event_types": ["$pageview", "some_event_name"]},
+        "include_event_types:dropped-unknown",
+    ),
+    (
+        "property_key_spelled_property",
+        {
+            "insight": "TRENDS",
+            "properties": [{"operator": "exact", "property": "$browser", "value": "Chrome"}],
+            "events": [{"id": "a"}],
+        },
+        "property.property->key",
+    ),
+    (
+        "property_operator_alias",
+        {
+            "insight": "TRENDS",
+            "events": [{"id": "a", "properties": [{"key": "x", "value": "1", "operator": "eq", "type": "event"}]}],
+        },
+        "property.operator:eq->exact",
+    ),
+    (
+        "property_bare_string",
+        {"insight": "TRENDS", "properties": ["not-a-filter"], "events": [{"id": "a"}]},
+        "properties:dropped-unexpected-format",
+    ),
+    (
+        "property_unknown_element_key",
+        {
+            "insight": "FUNNELS",
+            "events": [{"id": "a", "properties": [{"key": "nope", "value": "x", "type": "element"}]}],
+        },
+        "property:dropped-unknown-element-key",
+    ),
+    (
+        "entity_properties_nested_group",
+        {
+            "insight": "FUNNELS",
+            "events": [
+                {
+                    "id": "a",
+                    "properties": {
+                        "type": "AND",
+                        "values": [{"type": "AND", "values": [{"key": "x", "value": "1", "type": "event"}]}],
+                    },
+                }
+            ],
+        },
+        "entity.properties:flattened",
+    ),
+    (
+        "exclusion_step_string",
+        {
+            "insight": "FUNNELS",
+            "events": [{"id": "a"}, {"id": "b"}],
+            "exclusions": [{"id": "c", "funnel_from_step": "0", "funnel_to_step": "1"}],
+        },
+        "funnel_from_step:coerced-int",
+    ),
+    ("date_from_number", {"insight": "TRENDS", "date_from": -7, "events": [{"id": "a"}]}, "date_from:coerced-str"),
+    (
+        "multi_breakdown",
+        {"insight": "FUNNELS", "breakdowns": [{"property": "a"}, {"property": "b"}], "events": [{"id": "a"}]},
+        "breakdowns:dropped-multiple",
+    ),
+    ("events_not_a_list", {"insight": "TRENDS", "events": None}, "events:dropped-not-a-list"),
+    ("filters_not_a_dict", None, "filters:replaced-non-dict"),
+]
+
+
+def convert(filters: dict) -> dict:
+    return InsightVizNode(source=filter_to_query(filters)).model_dump(exclude_none=True)
+
+
+class TestLegacyFilterRepair(SimpleTestCase):
+    @parameterized.expand(ALREADY_VALID)
+    def test_leaves_convertible_filters_alone(self, _name: str, filters: dict) -> None:
+        repaired, repairs = repair_filters(filters)
+
+        assert repairs == []
+        assert convert(repaired) == convert(filters)
+
+    @parameterized.expand(REPAIRABLE)
+    def test_repairs_filters_that_cannot_convert(self, _name: str, filters: Any, expected_repair: str) -> None:
+        # Each case has to actually be broken, or it is not testing the repair.
+        with self.assertRaises(Exception):
+            convert(filters)
+
+        repaired, repairs = repair_filters(filters)
+
+        assert expected_repair in repairs
+        # A stored query that /query would reject is no better than no query at all.
+        QuerySchemaRoot.model_validate(convert(repaired))
+
+    def test_keeps_the_series_when_repairing_one_of_its_events(self) -> None:
+        filters = {
+            "insight": "TRENDS",
+            "events": [
+                {"id": "kept", "order": 0, "type": "events"},
+                {"id": "repaired", "order": 1, "type": "events", "math": "unique_users"},
+            ],
+        }
+
+        repaired, _ = repair_filters(filters)
+
+        series = convert(repaired)["source"]["series"]
+        assert [s["event"] for s in series] == ["kept", "repaired"]
+        assert series[1]["math"] == "dau"
+
+    def test_drops_only_the_unrepairable_property(self) -> None:
+        filters = {
+            "insight": "TRENDS",
+            "events": [
+                {
+                    "id": "a",
+                    "properties": [
+                        {"key": "kept", "value": "1", "operator": "exact", "type": "event"},
+                        {"key": "dropped", "type": "behavioral", "value": "performed_event"},
+                    ],
+                }
+            ],
+        }
+
+        repaired, repairs = repair_filters(filters)
+
+        assert "property:dropped-behavioral" in repairs
+        assert [p["key"] for p in repaired["events"][0]["properties"]] == ["kept"]


### PR DESCRIPTION
> [!WARNING]
> Do not merge. These two commands are one-off backfills meant to be copied into a toolbox and run from there. The PR exists so the code gets read, tested by CI, and kept in one place.

The production fix that used to sit alongside them is now [#89051](https://github.com/PostHog/posthog/pull/89051).

## Problem

Insights created with legacy `filters` and no `query` still exist, and every read converts them on the fly through `filter_to_query`.

- Migration 0545 (insights) and migration 0530 (dashboard template tiles) each backfilled once in 2024 and never ran again, so every row created since stays unconverted.
- The read-time conversion machinery cannot be removed while any row lacks a `query`.
- Nobody sees this today. It blocks the people removing the legacy `filters` format.

## Changes

Nothing changes for anyone until someone runs a command with `--live`. Both are dry-run by default.

- `migrate_insight_filters_to_query` reruns the 0545 conversion over insights that still need one, stamping `filters.migrated_at` so a run can be found and rolled back. `--team-id`, `--batch-size` and `--sleep-interval` control scope and pace.
- Unlike 0545, a row without a `filters.insight` key converts too, to the default trends query it already renders as. Empty shells with neither `query` nor `filters` get that same query.
- Soft-deleted insights convert as well, since restoring one has to yield a working query.
- The command derives `query_metadata` in the batch loop. `bulk_update` skips the `save()` hook that normally derives it, and an insight without it drops out of the insight list's event filter and out of Max's insight search. A metadata failure does not block the conversion; the run reports how many rows the sweep still has to pick up.
- Writes go through `bulk_update`, so `updated_at` and `last_modified_at` stay put and a background backfill does not churn "recently modified" orderings.
- Rows held by a concurrent writer are skipped rather than waited on, so a run needs repeating once to sweep the remainder.
- `migrate_dashboard_template_tiles_to_query` reruns the 0530 conversion over dashboard templates. It converts legacy `filters` tiles with `allow_variables`, strips the `filters` key, and never overwrites a tile that already has a query.

## How did you test this code?

`test_migrate_insight_filters_to_query.py`, each case tied to a regression:

- Trend, funnel, and no-`insight`-key conversion. Catches the queryset regressing to 0545's `filters__insight` requirement, which would silently skip rows.
- Dry run by default writes nothing. Catches an inverted `--live` gate mutating rows on a report run.
- Shells land on the empty-series trends query and query-bearing rows stay untouched. Catches shells getting a real series, and the queryset widening into converted rows.
- A raising filters blob skips only that row, with `--batch-size=1`. Catches one bad row aborting the run or stalling the cursor.
- Soft-deleted rows convert. Catches a switch to the default manager, which excludes them.
- A converted row carries the query's events in `query_metadata`. Catches the backfill leaving metadata null.

`test_migrate_dashboard_template_tiles_to_query.py`: a legacy tile converts and loses its `filters` key while a tile with an existing query keeps it verbatim, and a dry run writes nothing.

Both files ran locally against the dev stack. Neither command has run against production data.

Not run locally: repo-wide mypy. CI covers it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Internal operations commands.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted), directed by Thomas Obermüller.

- Authored in PostHog Desktop across several sessions. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- Design choice: dry-run by default with an explicit `--live`, unlike the sibling `backfill_insights_query_metadata` command's opt-in `--dry-run`. The default posture for a bulk writer should be read-only.
- Scope moved across the session. Empty shells were skipped first and converted after a decision; the template command was added once the data traced daily shell creation back to `filters`-shaped template tiles.
- The commands live under their owning products because a `posthog/`-level command would have added model-crossing entries for product-owned models.
- Known remnant, not addressed here: `ensure_migration_defaults.py` still seeds the default template with `filters`-shaped tiles. It keeps working through runtime conversion and has to be rewritten before `filter_to_query` can be deleted.
- Test fixtures are invented. No session material is in the code, tests, or this description.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
