### PR TITLE
chore(ci): route schema-only PRs through schema-impact narrowing

### DIFF
--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -383,11 +383,27 @@ jobs:
                         # so they shouldn't trigger the Django/turbo-discover path either.
                         - '!**/*.md'
                         - '!**/*.mdx'
+                        # Generated from frontend/src/queries/schema.json (see the `schema`
+                        # filter below). Excluding them here routes schema-only PRs into
+                        # turbo-discover's schema-impact narrowing instead of the
+                        # all-products legacy path. This cannot skip Django: the
+                        # schemaChanged branch hard-sets run_legacy=true. It also cannot
+                        # hide a hand-edit to the generated files — ci-python.yml
+                        # regenerates schema.py and fails on any diff, and both files stay
+                        # in the `schema` (and `backend`) filters so turbo-discover still
+                        # takes the schema path for them.
+                        - '!posthog/schema.py'
+                        - '!posthog/schema_enums.py'
                       schema:
                         # Tracked separately from `legacy` so turbo-discover can
                         # diff schema.json and narrow the product matrix to
                         # products that import the changed types.
                         - frontend/src/queries/schema.json
+                        # The generated outputs are excluded from `legacy` above; listing
+                        # them here keeps run_legacy=true (full Django) for any schema
+                        # change, including a stray hand-edit to a generated file.
+                        - posthog/schema.py
+                        - posthog/schema_enums.py
                       migrations:
                         - 'docker/clickhouse/**'
                         - 'posthog/migrations/*.py'

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -267,11 +267,27 @@ jobs:
                         # so they shouldn't trigger the Django/turbo-discover path either.
                         - '!**/*.md'
                         - '!**/*.mdx'
+                        # Generated from frontend/src/queries/schema.json (see the `schema`
+                        # filter below). Excluding them here routes schema-only PRs into
+                        # turbo-discover's schema-impact narrowing instead of the
+                        # all-products legacy path. This cannot skip Django: the
+                        # schemaChanged branch hard-sets run_legacy=true. It also cannot
+                        # hide a hand-edit to the generated files — ci-python.yml
+                        # regenerates schema.py and fails on any diff, and both files stay
+                        # in the `schema` (and `backend`) filters so turbo-discover still
+                        # takes the schema path for them.
+                        - '!posthog/schema.py'
+                        - '!posthog/schema_enums.py'
                       schema:
                         # Tracked separately from `legacy` so turbo-discover can
                         # diff schema.json and narrow the product matrix to
                         # products that import the changed types.
                         - frontend/src/queries/schema.json
+                        # The generated outputs are excluded from `legacy` above; listing
+                        # them here keeps run_legacy=true (full Django) for any schema
+                        # change, including a stray hand-edit to a generated file.
+                        - posthog/schema.py
+                        - posthog/schema_enums.py
                       migrations:
                         - 'docker/clickhouse/**'
                         - 'posthog/migrations/*.py'


### PR DESCRIPTION
## TL;DR

Editing the query schema currently reruns every product's test suite. CI already has code that works out which products use the changed types, but a filter quirk means that code never runs. This PR unhides it. Django still always runs on schema changes.

## Problem

- A PR that only edits the query schema runs every product test job on top of the full Django matrix. That is roughly 17 extra jobs per push, several times a day (339 commits touched `schema.json` in the last 90 days).
- turbo-discover has a narrowing path for exactly this case: `schema-impact.js` diffs the changed `schema.json` definitions and maps them to the products that import those types.
- That path is dead code. The regenerated `posthog/schema.py` is committed with every schema change and matches the `legacy` filter's `posthog/**/*`, so `LEGACY_CHANGED=true` takes the all-products branch first.

## Changes

- Schema-only PRs now run the full Django matrix plus only the products that import the changed types, instead of the full Django matrix plus every product job.
- Additive schema changes (new definitions only) now run the full Django matrix with zero product jobs.
- Mechanical: the `.depot/workflows/ci-backend.yml` shadow mirrors the same filter edit.

```diff
 legacy:
   ...
+  - '!posthog/schema.py'
+  - '!posthog/schema_enums.py'
 schema:
   - frontend/src/queries/schema.json
+  - posthog/schema.py
+  - posthog/schema_enums.py
```

> [!NOTE]
> This cannot skip Django. The `schemaChanged` branch in `turbo-discover.js` hard-sets `run_legacy=true`, and the Django job condition keys on that output. It also cannot hide a hand-edit to the generated files: `ci-python.yml` regenerates `schema.py` and fails on any diff, and both generated files stay in the `schema` and `backend` filters.

Before:

```mermaid
flowchart LR
    PR{{schema-only PR}} --> F[legacy paths-filter]
    F -->|generated schema.py matches posthog/**| L[LEGACY_CHANGED=true]
    L --> D[full Django matrix]
    L --> P[all product test jobs]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class PR phYellow;
    class F phBlue;
    class L,P phRed;
    class D phGray;
```

After:

```mermaid
flowchart LR
    PR{{schema-only PR}} --> F[legacy paths-filter]
    F -->|generated files excluded| S[schema filter]
    S --> I[schema-impact.js diffs changed types]
    I -->|modified types| A[full Django matrix + affected products]
    I -->|additive only| B[full Django matrix + no product jobs]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class PR phYellow;
    class F,S,I phBlue;
    class A,B phGray;
```

## How did you test this code?

- `bin/hogli lint:workflows` passes (includes the paths-filter negation-safety check).
- `hogli ci:preflight` flagged the depot shadow drift; the mirror edit resolves it.
- Local simulation of the exact CI script on this tree, with a working-tree `schema.json` edit:

<details>
<summary>turbo-discover simulation runs</summary>

```
LEGACY_CHANGED=false SCHEMA_CHANGED=true TURBO_SCM_BASE=HEAD node .github/scripts/turbo-discover.js
```

Modified an existing definition (`TrendsQuery`):

```
Schema impact: {"kind":"impacting","counts":{"added":0,"modified":1,"removed":0}}
Schema-affected products: ["alerts","analytics-platform","dashboards","data-catalog","demo","endpoints","experiments","product-analytics","web-analytics"]
Run legacy (Django): true
matrix: 4 packed product jobs
```

Added a new definition:

```
Schema impact: {"kind":"additive","counts":{"added":1,"modified":0,"removed":0}}
Run legacy (Django): true
matrix: []
```

</details>

- Not run: `actionlint` locally (binary unavailable in this sandbox); the `ci-lint-workflows` job covers it.
- Not run: a live PR through the dorny filter itself. The excludes follow the existing `!**/*.md` pattern in the same filter list.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The filter comments in the workflow carry the rationale.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Directed by Thomas Obermueller in a PostHog Desktop session (assignee left unset: no verified GitHub handle available in-session).
- Found while investigating CI cost for product-analytics isolation: the narrowing machinery existed but was unreachable on any real schema PR.
- Skills invoked: /authoring-ci-workflows, /writing-pr-descriptions, /diagnosing-ci-and-merge-bottlenecks.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
