### PR TITLE
chore(ci): stop the shellcheck job hanging on apt

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -13,8 +13,18 @@ jobs:
         name: shellcheck
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+            # The runner image ships shellcheck, so this is a fallback for when it
+            # doesn't. apt has no retries and a 120s per-fetch timeout by default;
+            # an unresponsive mirror once held this job past its timeout, and the
+            # merge queue reads a cancelled required check as a failure.
             - name: Install shellcheck
-              run: sudo apt update && sudo apt install -y shellcheck
+              run: |
+                  if command -v shellcheck >/dev/null; then
+                      shellcheck --version
+                      exit 0
+                  fi
+                  sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 update
+                  sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 install -y shellcheck
             - name: Check secrets scripts
               run: cd bin && shellcheck deploy-hobby
 

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -13,10 +13,10 @@ jobs:
         name: shellcheck
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-            # The runner image ships shellcheck, so this is a fallback for when it
-            # doesn't. apt has no retries and a 120s per-fetch timeout by default;
-            # an unresponsive mirror once held this job past its timeout, and the
-            # merge queue reads a cancelled required check as a failure.
+            # The runner image ships shellcheck, so apt is only a fallback. apt has
+            # no retries and a 120s per-fetch timeout by default, and a stalled
+            # mirror can hold this job past its timeout, which the merge queue
+            # reads as a failed required check.
             - name: Install shellcheck
               run: |
                   if command -v shellcheck >/dev/null; then


### PR DESCRIPTION
## Problem

- A PR can get kicked out of the Trunk merge queue by a slow Ubuntu mirror, with nothing in the PR to fix.
- The `shellcheck` job runs `apt update && apt install shellcheck` on every PR, on a 5 minute job timeout.
- apt has no retries and a 120 second per-fetch timeout by default, so one stalled mirror holds the job until the timeout fires.
- GitHub reports a timed-out job as `cancelled`, and Trunk reads a cancelled required check as a failure. Example: [queue run kicked for PR #84370](https://github.com/PostHog/posthog/actions/runs/32227379438/job/95989776453).

## Changes

- The install step now exits early when shellcheck is already on the runner, which is the case on the `ubuntu-24.04` image (it ships `shellcheck 0.9.0-1`, the same apt package).
- The apt fallback runs with `Acquire::Retries=3` and `Acquire::http::Timeout=30`, so a stalled fetch fails fast instead of eating the job timeout.
- No user-visible change. Mechanical CI change only.

## How did you test this code?

- `bin/hogli lint:workflows` and `actionlint` pass locally.
- The early-exit path is what this PR's own `shellcheck` check exercises; the apt fallback path is not exercised by CI and went unchecked here.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code, directed by the assignee. Skills invoked: `/merging-prs` (where the queue kick surfaced), `/authoring-ci-workflows`, `/writing-pr-descriptions`. Root-caused from the cancelled queue run's job log (apt stuck on the Azure mirror, then the job timeout). Checked the runner image README to confirm shellcheck is preinstalled before making the install conditional.
