### PR TITLE
feat(desktop): set any canvas as the home tab

### DIFF
--- a/products/canvas/backend/presentation/views.py
+++ b/products/canvas/backend/presentation/views.py
@@ -1266,6 +1266,29 @@ class CanvasViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         self._report_canvas_action("canvas home provisioned", canvas)
         return Response(CanvasSerializer(canvas).data, status=status.HTTP_201_CREATED)
 
+    @extend_schema(
+        operation_id="canvases_set_home_create",
+        request=None,
+        responses={
+            200: OpenApiResponse(response=CanvasSerializer, description="The caller's new home canvas."),
+            403: OpenApiResponse(description="Home is a viewer surface; sandbox tokens cannot change it."),
+        },
+    )
+    @action(methods=["POST"], detail=True, url_path="set-home")
+    def set_home(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        """Set this canvas as the caller's home canvas."""
+        user = self._request_user()
+        if user is None or self._is_sandbox_authenticated(request):
+            return Response(
+                {"detail": "Home is a viewer surface; sandbox tokens cannot change it."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+        canvas = self.get_object()
+        CanvasHomePreference.objects.for_team(self.team_id).update_or_create(
+            team_id=self.team_id, user=user, defaults={"canvas": canvas}
+        )
+        return Response(CanvasSerializer(canvas).data)
+
     def _lock_home_provisioning(self, user_id: int) -> None:
         """Serialize home provisioning for one user inside the current transaction.
 

--- a/products/canvas/backend/tests/test_grid_layout.py
+++ b/products/canvas/backend/tests/test_grid_layout.py
@@ -403,6 +403,20 @@ class TestHomeProvisioning(GridLayoutAPIBaseTest):
         assert replacement.status_code == status.HTTP_201_CREATED
         assert replacement.json()["id"] != first.json()["id"]
 
+    def test_existing_canvas_can_be_set_as_home(self):
+        original = self._home()
+        replacement_id = self._create_grid()
+
+        selected = self.client.post(f"/api/projects/{self.team.id}/canvases/{replacement_id}/set-home/")
+
+        assert selected.status_code == status.HTTP_200_OK, selected.json()
+        assert selected.json()["id"] == replacement_id
+        assert self._home().json()["id"] == replacement_id
+        with team_scope(self.team.id):
+            preference = CanvasHomePreference.objects.for_team(self.team.id).get(user=self.user)
+            assert str(preference.canvas_id) == replacement_id
+            assert str(preference.canvas_id) != original.json()["id"]
+
     @parameterized.expand([("without_github", False), ("with_github", True)])
     def test_home_seeds_welcome_checklist(self, _name: str, github_connected: bool):
         if github_connected:

--- a/products/canvas/frontend/generated/api.ts
+++ b/products/canvas/frontend/generated/api.ts
@@ -585,6 +585,24 @@ export const canvasesRevertCreate = async (
     })
 }
 
+export const getCanvasesSetHomeCreateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/canvases/${id}/set-home/`
+}
+
+/**
+ * Set this canvas as the caller's home canvas.
+ */
+export const canvasesSetHomeCreate = async (
+    projectId: string,
+    id: string,
+    options?: RequestInit
+): Promise<CanvasApi> => {
+    return apiMutator<CanvasApi>(getCanvasesSetHomeCreateUrl(projectId, id), {
+        ...options,
+        method: 'POST',
+    })
+}
+
 export const getCanvasesSourceRetrieveUrl = (projectId: string, id: string, params?: CanvasesSourceRetrieveParams) => {
     const normalizedParams = new URLSearchParams()
 

--- a/products/canvas/mcp/tools.yaml
+++ b/products/canvas/mcp/tools.yaml
@@ -345,6 +345,9 @@ tools:
     canvases-revert-create:
         operation: canvases_revert_create
         enabled: false
+    canvases-set-home-create:
+        operation: canvases_set_home_create
+        enabled: false
     canvases-state-retrieve:
         operation: canvases_state_retrieve
         enabled: false

--- a/products/desktop/packages/core/src/canvas/dashboardsService.ts
+++ b/products/desktop/packages/core/src/canvas/dashboardsService.ts
@@ -211,6 +211,15 @@ export class DashboardsService {
     return toRecord(api);
   }
 
+  async setHome(id: string): Promise<DashboardRecord> {
+    const api = await this.api.json<ApiCanvas>(
+      `canvases/${encodeURIComponent(id)}/set-home/`,
+      "set home canvas",
+      { method: "POST" },
+    );
+    return toRecord(api);
+  }
+
   // Read a grid canvas's layout document — the head, or a historical version.
   async getLayout(input: {
     id: string;

--- a/products/desktop/packages/core/src/canvas/services.ts
+++ b/products/desktop/packages/core/src/canvas/services.ts
@@ -50,6 +50,7 @@ export interface IDashboardsService {
   }): Promise<DashboardRecord>;
   // Get-or-create the caller's home grid canvas. Idempotent.
   home(): Promise<DashboardRecord>;
+  setHome(id: string): Promise<DashboardRecord>;
   // Read a grid canvas's layout (the head, or a historical version).
   getLayout(input: {
     id: string;

--- a/products/desktop/packages/host-router/src/routers/dashboards.router.ts
+++ b/products/desktop/packages/host-router/src/routers/dashboards.router.ts
@@ -70,6 +70,14 @@ export const dashboardsRouter = router({
     .query(({ ctx }) =>
       ctx.container.get<IDashboardsService>(DASHBOARDS_SERVICE).home(),
     ),
+  setHome: publicProcedure
+    .input(dashboardIdInput)
+    .output(dashboardRecordSchema)
+    .mutation(({ ctx, input }) =>
+      ctx.container
+        .get<IDashboardsService>(DASHBOARDS_SERVICE)
+        .setHome(input.id),
+    ),
   layout: publicProcedure
     .input(canvasLayoutInput)
     .output(canvasLayoutResultSchema)

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
@@ -34,6 +34,7 @@ const actions = {
   togglePin: () => {},
   archive: () => {},
   remove: () => {},
+  setHome: () => {},
 };
 
 function item(overrides: Partial<ChannelItemModel> = {}): ChannelItemModel {
@@ -369,7 +370,8 @@ describe("ChannelItemRow", () => {
     expect(screen.queryByRole("img", { name: "All caught up" })).toBeNull();
   });
 
-  it("gives a canvas the actions it has: pin and delete, not archive or filing", async () => {
+  it("gives a canvas its home, pin, and delete actions", async () => {
+    const setHome = vi.fn();
     const canvas = item({
       key: "canvas:c1",
       kind: "canvas",
@@ -377,7 +379,11 @@ describe("ChannelItemRow", () => {
       title: "Web analytics overview",
     });
     renderInList(
-      <ChannelItemRow actions={actions} isActive={false} item={canvas} />,
+      <ChannelItemRow
+        actions={{ ...actions, setHome }}
+        isActive={false}
+        item={canvas}
+      />,
     );
 
     await userEvent.hover(screen.getByText("Web analytics overview"));
@@ -385,6 +391,13 @@ describe("ChannelItemRow", () => {
     expect(
       await screen.findByRole("button", { name: "Pin" }, { timeout: 2000 }),
     ).not.toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Set as home tab" }),
+    ).not.toBeNull();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Set as home tab" }),
+    );
+    expect(setHome).toHaveBeenCalledWith(canvas);
     expect(screen.getByRole("button", { name: "Delete…" })).not.toBeNull();
     // A canvas can't be archived, filed to a space, or given a command-centre
     // cell, so those items aren't drawn at all rather than drawn dead.

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.tsx
@@ -55,6 +55,7 @@ export interface ChannelItemActions {
   archive: (item: ChannelItemModel) => void;
   /** Canvases only — a task is archived, not deleted. */
   remove: (item: ChannelItemModel) => void;
+  setHome: (item: ChannelItemModel) => void;
 }
 
 // The channel sidebar's own chrome. Deliberately not shared with the Code
@@ -208,6 +209,7 @@ export function ChannelItemRow({
             title: item.title,
             isPinned: item.pinned,
             onTogglePin: () => actions.togglePin(item),
+            onSetHome: () => actions.setHome(item),
             // Confirm first, like the canvas menus in the artifacts grid and
             // the canvas header: the canvas and its history go for everyone.
             onDelete: () => setConfirmDeleteOpen(true),

--- a/products/desktop/packages/ui/src/features/canvas/components/TaskRowMenu.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/TaskRowMenu.tsx
@@ -2,6 +2,7 @@ import {
   ArchiveIcon,
   CaretRightIcon,
   FolderSimpleIcon,
+  HouseIcon,
   PencilSimpleIcon,
   PushPinIcon,
   PushPinSlashIcon,
@@ -52,6 +53,8 @@ export interface TaskRowMenuProps {
   /** Absent where there's no inline rename to open — canvases, for now. */
   onRename?: () => void;
   onTogglePin: () => void;
+  /** Canvases can replace the caller's personal Home tab. */
+  onSetHome?: () => void;
   /** Tasks are archived; canvases are deleted (with an undo window). */
   onArchive?: () => void;
   onDelete?: () => void;
@@ -117,6 +120,12 @@ function TaskRowMenuItems({
         )}
         {menu.isPinned ? "Unpin" : "Pin"}
       </Item>
+      {menu.onSetHome && (
+        <Item onClick={menu.onSetHome}>
+          <HouseIcon size={14} />
+          Set as home tab
+        </Item>
+      )}
       {menu.onRename && (
         <Item onClick={menu.onRename}>
           <PencilSimpleIcon size={14} />

--- a/products/desktop/packages/ui/src/features/canvas/grid/WebsiteHome.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/grid/WebsiteHome.test.tsx
@@ -23,7 +23,9 @@ vi.mock("@posthog/host-router/react", () => ({
 
 // The home canvas itself is another surface's concern; this file is about the
 // query that resolves which canvas Home shows.
-vi.mock("./GridCanvasView", () => ({ GridCanvasView: () => null }));
+vi.mock("@posthog/ui/features/canvas/components/WebsiteDashboard", () => ({
+  WebsiteDashboard: () => null,
+}));
 
 import { WebsiteHome } from "./WebsiteHome";
 

--- a/products/desktop/packages/ui/src/features/canvas/grid/WebsiteHome.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/grid/WebsiteHome.tsx
@@ -12,21 +12,43 @@ import {
   Spinner,
 } from "@posthog/quill";
 import { AUTH_SCOPED_QUERY_META } from "@posthog/ui/features/auth/useCurrentUser";
+import { WebsiteDashboard } from "@posthog/ui/features/canvas/components/WebsiteDashboard";
 import { useCanvasChatPanelStore } from "@posthog/ui/features/canvas/stores/canvasChatPanelStore";
+import {
+  useDashboardEditStore,
+  useIsDashboardEditing,
+} from "@posthog/ui/features/canvas/stores/dashboardEditStore";
 import { useQuery } from "@tanstack/react-query";
-import { useState } from "react";
-import { GridCanvasView } from "./GridCanvasView";
 
-/**
- * The user's home tab: a personal grid canvas, provisioned on first open
- * (idempotent get-or-create) and composed like any other grid canvas — draw a
- * box and describe it.
- */
+function HomeCanvas({ id }: { id: string }) {
+  const editing = useIsDashboardEditing(id);
+  const setEditing = useDashboardEditStore((state) => state.setEditing);
+  const openChat = useCanvasChatPanelStore((state) => state.openChat);
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex shrink-0 items-center justify-between border-(--gray-4) border-b px-4 py-2">
+        <Heading size="lg">Home</Heading>
+        <Button
+          variant={editing ? "primary" : "outline"}
+          size="sm"
+          onClick={() => {
+            if (!editing) openChat();
+            setEditing(id, !editing);
+          }}
+        >
+          {editing ? "Done" : "Edit"}
+        </Button>
+      </div>
+      <div className="relative min-h-0 flex-1">
+        <WebsiteDashboard dashboardId={id} />
+      </div>
+    </div>
+  );
+}
+
 export function WebsiteHome() {
   const trpc = useHostTRPC();
-  const [editing, setEditing] = useState(false);
-  // Entering edit opens the canvas chat dock, like the freeform Edit button.
-  const openChat = useCanvasChatPanelStore((state) => state.openChat);
   const {
     data: home,
     isError,
@@ -86,24 +108,5 @@ export function WebsiteHome() {
       </div>
     );
   }
-  return (
-    <div className="flex h-full flex-col">
-      <div className="flex shrink-0 items-center justify-between border-(--gray-4) border-b px-4 py-2">
-        <Heading size="lg">Home</Heading>
-        <Button
-          variant={editing ? "primary" : "outline"}
-          size="sm"
-          onClick={() => {
-            if (!editing) openChat();
-            setEditing(!editing);
-          }}
-        >
-          {editing ? "Done" : "Edit"}
-        </Button>
-      </div>
-      <div className="relative min-h-0 flex-1">
-        <GridCanvasView canvasId={home.id} interactive={editing} />
-      </div>
-    </div>
-  );
+  return <HomeCanvas id={home.id} />;
 }

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useChannelItems.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useChannelItems.tsx
@@ -63,8 +63,11 @@ export function useChannelItems(channelId: string): {
   const archivedTaskIds = useArchivedTaskIds();
   const { pinnedTaskIds, togglePin } = usePinnedTasks();
   const { archiveTask } = useArchiveTask({ navigateSpace: "website" });
-  const { setPinned: setCanvasPinned, invalidateDashboards } =
-    useDashboardMutations();
+  const {
+    setPinned: setCanvasPinned,
+    setHome,
+    invalidateDashboards,
+  } = useDashboardMutations();
   const client = useOptionalAuthenticatedClient();
   const { data: currentUser, isLoading: viewerLoading } = useCurrentUser({
     client,
@@ -179,6 +182,12 @@ export function useChannelItems(channelId: string): {
           invalidate: invalidateDashboards,
         });
       },
+      setHome: (item) => {
+        if (item.kind !== "canvas") return;
+        setHome(item.id)
+          .then(() => toast.success("Home tab updated"))
+          .catch(() => toast.error("Couldn't update home tab"));
+      },
     }),
     [
       channelId,
@@ -187,6 +196,7 @@ export function useChannelItems(channelId: string): {
       togglePin,
       archiveTask,
       invalidateDashboards,
+      setHome,
     ],
   );
 

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useDashboards.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useDashboards.ts
@@ -196,6 +196,13 @@ export function useDashboardMutations() {
   const setPinned = useMutation(
     trpc.dashboards.setPinned.mutationOptions({ onSuccess: invalidate }),
   );
+  const setHome = useMutation(
+    trpc.dashboards.setHome.mutationOptions({
+      onSuccess: (home) => {
+        queryClient.setQueryData(trpc.dashboards.home.queryKey(), home);
+      },
+    }),
+  );
 
   return {
     // Refresh the canvas queries after a mutation that didn't go through this
@@ -232,6 +239,7 @@ export function useDashboardMutations() {
     // shows in the channel's Pinned menu for every member.
     setPinned: (id: string, pinned: boolean) =>
       setPinned.mutateAsync({ id, pinned }),
+    setHome: (id: string) => setHome.mutateAsync({ id }),
     isCreating: create.isPending,
     isDeleting: remove.isPending,
     isSavingContext: saveContext.isPending,


### PR DESCRIPTION
## Problem

People cannot choose which canvas appears in their personal Home tab.

**Why:** A customizable Home tab keeps the most useful canvas one click away without changing it for teammates.

## Changes

- Canvas rows now offer **Set as home tab** in the right-click menu and hover actions.
- Home immediately shows the selected grid or freeform canvas.
- The backend stores the selection per user and project.

```mermaid
flowchart LR
    A[Open Home] --> B[Provisioned personal canvas]
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phYellow;
    class B phGray;
```

```mermaid
flowchart LR
    A[Right-click canvas] --> B[Set as home tab] --> C[Personal preference] --> D[Open Home]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A,D phYellow;
    class B phBlue;
    class C phGray;
```

Screenshot not included because the local frontend stack could not start without its root workspace dependencies.

## How did you test this code?

- Focused UI tests cover menu visibility, action dispatch, Home caching, and existing channel-item behavior.
- Desktop UI, core, and host-router packages pass typechecking.
- Host-boundary checks and Ruff checks pass.
- The backend behavior test was not run because PostgreSQL was unavailable in this VM.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation changes. The menu label describes the workflow in the product.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented this change with the posthog-desktop, writing-user-facing-copy, improving-drf-endpoints, writing-tests, and writing-pr-descriptions skills.

The implementation reuses the existing per-user home preference and shared canvas renderer. No session-only material appears in public artifacts.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*