### PR TITLE
feat(engineering-analytics): align URL routes

### DIFF
--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -140,20 +140,20 @@ export const productRoutes: Record<string, [string, string]> = {
     '/endpoints': ['EndpointsScene', 'endpoints'],
     '/endpoints/:name': ['EndpointScene', 'endpoint'],
     '/engineering-analytics/overview': ['EngineeringAnalytics', 'engineeringAnalytics'],
-    '/engineering-analytics/pull-requests': ['EngineeringAnalytics', 'engineeringAnalyticsPullRequestList'],
+    '/engineering-analytics/pulls': ['EngineeringAnalytics', 'engineeringAnalyticsPullRequestList'],
     '/engineering-analytics/workflows': ['EngineeringAnalytics', 'engineeringAnalyticsWorkflows'],
     '/engineering-analytics/test-health': ['EngineeringAnalytics', 'engineeringAnalyticsTestHealth'],
     '/engineering-analytics/teams': ['EngineeringAnalytics', 'engineeringAnalyticsTeams'],
     '/engineering-analytics/teams/:ownerTeam': ['EngineeringAnalyticsTeam', 'engineeringAnalyticsTeam'],
-    '/engineering-analytics/repos/:repoOwner/:repoName/pull-requests/:number': [
+    '/engineering-analytics/:repoOwner/:repoName/pulls/:number': [
         'EngineeringAnalyticsPullRequest',
         'engineeringAnalyticsPullRequest',
     ],
-    '/engineering-analytics/repos/:repoOwner/:repoName/actions/runs/:runId': [
+    '/engineering-analytics/:repoOwner/:repoName/workflow-runs/:runId': [
         'EngineeringAnalyticsWorkflowRun',
         'engineeringAnalyticsWorkflowRun',
     ],
-    '/engineering-analytics/repos/:repoOwner/:repoName/actions/workflows/:workflowName': [
+    '/engineering-analytics/:repoOwner/:repoName/workflows/:workflowName': [
         'EngineeringAnalyticsWorkflowRuns',
         'engineeringAnalyticsWorkflowRuns',
     ],
@@ -1172,18 +1172,18 @@ export const productUrls = {
         return combineUrl('/endpoints', { tab: 'usage', ...searchParams }).url
     },
     engineeringAnalytics: (): string => '/engineering-analytics/overview',
-    engineeringAnalyticsPullRequestList: (): string => '/engineering-analytics/pull-requests',
+    engineeringAnalyticsPullRequestList: (): string => '/engineering-analytics/pulls',
     engineeringAnalyticsWorkflows: (): string => '/engineering-analytics/workflows',
     engineeringAnalyticsTestHealth: (): string => '/engineering-analytics/test-health',
     engineeringAnalyticsTeams: (): string => '/engineering-analytics/teams',
     engineeringAnalyticsTeam: (ownerTeam: string): string =>
         `/engineering-analytics/teams/${encodeURIComponent(ownerTeam)}`,
     engineeringAnalyticsPullRequest: (repoOwner: string, repoName: string, number: number | string): string =>
-        `/engineering-analytics/repos/${encodeURIComponent(repoOwner)}/${encodeURIComponent(repoName)}/pull-requests/${number}`,
+        `/engineering-analytics/${encodeURIComponent(repoOwner)}/${encodeURIComponent(repoName)}/pulls/${number}`,
     engineeringAnalyticsWorkflowRun: (repoOwner: string, repoName: string, runId: number | string): string =>
-        `/engineering-analytics/repos/${encodeURIComponent(repoOwner)}/${encodeURIComponent(repoName)}/actions/runs/${runId}`,
+        `/engineering-analytics/${encodeURIComponent(repoOwner)}/${encodeURIComponent(repoName)}/workflow-runs/${runId}`,
     engineeringAnalyticsWorkflowRuns: (repoOwner: string, repoName: string, workflowName: string): string =>
-        `/engineering-analytics/repos/${encodeURIComponent(repoOwner)}/${encodeURIComponent(repoName)}/actions/workflows/${encodeURIComponent(workflowName)}`,
+        `/engineering-analytics/${encodeURIComponent(repoOwner)}/${encodeURIComponent(repoName)}/workflows/${encodeURIComponent(workflowName)}`,
     engineeringAnalyticsAuthor: (handle: string): string =>
         `/engineering-analytics/authors/${encodeURIComponent(handle)}`,
     errorTracking: (params = {}): string => combineUrl('/error_tracking', params).url,

--- a/products/engineering_analytics/backend/management/commands/seed_engineering_analytics.py
+++ b/products/engineering_analytics/backend/management/commands/seed_engineering_analytics.py
@@ -1054,7 +1054,7 @@ class Command(BaseCommand):
             )
         )
         self.stdout.write(
-            f"Multi-push demo PR: /project/{team.pk}/engineering-analytics/repos/{SEED_REPOSITORY}/pull-requests/{_DEMO_PR_NUMBER}"
+            f"Multi-push demo PR: /project/{team.pk}/engineering-analytics/{SEED_REPOSITORY}/pulls/{_DEMO_PR_NUMBER}"
         )
 
     def _load_fixture(self, fixture_dir: Path, filename: str) -> list[dict[str, Any]]:

--- a/products/engineering_analytics/manifest.tsx
+++ b/products/engineering_analytics/manifest.tsx
@@ -58,26 +58,23 @@ export const manifest: ProductManifest = {
             iconType: 'health',
         },
     },
-    // Detail paths follow GitHub's REST-API shape (repos/:owner/:repo/pull-requests/:n, .../actions/runs/:id)
-    // — a repos/ prefix that keeps them clear of the tab routes and readable collection nouns. Cross-repo
-    // aggregates stay at the product root. Provider lives on the data (RepoRef.provider), so these url
-    // builders are the single place to branch verbs for a future provider (e.g. GitLab).
+    // Repository paths follow GitHub's owner/repo shape while using provider-neutral, plural resource names.
     routes: {
         '/engineering-analytics/overview': ['EngineeringAnalytics', 'engineeringAnalytics'],
-        '/engineering-analytics/pull-requests': ['EngineeringAnalytics', 'engineeringAnalyticsPullRequestList'],
+        '/engineering-analytics/pulls': ['EngineeringAnalytics', 'engineeringAnalyticsPullRequestList'],
         '/engineering-analytics/workflows': ['EngineeringAnalytics', 'engineeringAnalyticsWorkflows'],
         '/engineering-analytics/test-health': ['EngineeringAnalytics', 'engineeringAnalyticsTestHealth'],
         '/engineering-analytics/teams': ['EngineeringAnalytics', 'engineeringAnalyticsTeams'],
         '/engineering-analytics/teams/:ownerTeam': ['EngineeringAnalyticsTeam', 'engineeringAnalyticsTeam'],
-        '/engineering-analytics/repos/:repoOwner/:repoName/pull-requests/:number': [
+        '/engineering-analytics/:repoOwner/:repoName/pulls/:number': [
             'EngineeringAnalyticsPullRequest',
             'engineeringAnalyticsPullRequest',
         ],
-        '/engineering-analytics/repos/:repoOwner/:repoName/actions/runs/:runId': [
+        '/engineering-analytics/:repoOwner/:repoName/workflow-runs/:runId': [
             'EngineeringAnalyticsWorkflowRun',
             'engineeringAnalyticsWorkflowRun',
         ],
-        '/engineering-analytics/repos/:repoOwner/:repoName/actions/workflows/:workflowName': [
+        '/engineering-analytics/:repoOwner/:repoName/workflows/:workflowName': [
             'EngineeringAnalyticsWorkflowRuns',
             'engineeringAnalyticsWorkflowRuns',
         ],
@@ -93,18 +90,18 @@ export const manifest: ProductManifest = {
     },
     urls: {
         engineeringAnalytics: (): string => '/engineering-analytics/overview',
-        engineeringAnalyticsPullRequestList: (): string => '/engineering-analytics/pull-requests',
+        engineeringAnalyticsPullRequestList: (): string => '/engineering-analytics/pulls',
         engineeringAnalyticsWorkflows: (): string => '/engineering-analytics/workflows',
         engineeringAnalyticsTestHealth: (): string => '/engineering-analytics/test-health',
         engineeringAnalyticsTeams: (): string => '/engineering-analytics/teams',
         engineeringAnalyticsTeam: (ownerTeam: string): string =>
             `/engineering-analytics/teams/${encodeURIComponent(ownerTeam)}`,
         engineeringAnalyticsPullRequest: (repoOwner: string, repoName: string, number: number | string): string =>
-            `/engineering-analytics/repos/${encodeURIComponent(repoOwner)}/${encodeURIComponent(repoName)}/pull-requests/${number}`,
+            `/engineering-analytics/${encodeURIComponent(repoOwner)}/${encodeURIComponent(repoName)}/pulls/${number}`,
         engineeringAnalyticsWorkflowRun: (repoOwner: string, repoName: string, runId: number | string): string =>
-            `/engineering-analytics/repos/${encodeURIComponent(repoOwner)}/${encodeURIComponent(repoName)}/actions/runs/${runId}`,
+            `/engineering-analytics/${encodeURIComponent(repoOwner)}/${encodeURIComponent(repoName)}/workflow-runs/${runId}`,
         engineeringAnalyticsWorkflowRuns: (repoOwner: string, repoName: string, workflowName: string): string =>
-            `/engineering-analytics/repos/${encodeURIComponent(repoOwner)}/${encodeURIComponent(repoName)}/actions/workflows/${encodeURIComponent(workflowName)}`,
+            `/engineering-analytics/${encodeURIComponent(repoOwner)}/${encodeURIComponent(repoName)}/workflows/${encodeURIComponent(workflowName)}`,
         engineeringAnalyticsAuthor: (handle: string): string =>
             `/engineering-analytics/authors/${encodeURIComponent(handle)}`,
     },


### PR DESCRIPTION
## Problem

Engineering analytics URLs use REST-style and GitHub-branded segments that make repository pages less familiar and workflows provider-specific.

## Changes

- Pull pages now use the plural `pulls` resource name.
- Repository routes now place the owner and repository directly after the product prefix.
- Workflow routes now use provider-neutral plural resource names.
- This URL-only change has no visual difference, so no screenshot applies.

## How did you test this code?

- `pnpm --filter=@posthog/frontend fix` passed.
- `git diff --check` passed.
- The frontend typecheck could not run because required workspace packages were not built in this checkout.
- Repository preflight could not start because `bin/hogli` requires an unavailable `python` executable.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented the requested route mapping with PostHog code tools. The `writing-pr-descriptions` skill shaped this description.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*