### PR TITLE
feat(cdp): reject behavioral filters in realtime function filters

### DIFF
--- a/posthog/cdp/test/test_validation.py
+++ b/posthog/cdp/test/test_validation.py
@@ -690,6 +690,36 @@ class TestHogFunctionValidation(ClickhouseTestMixin, APIBaseTest, QueryMatchingT
             ],
         }
 
+    # Behavioral filters compile to a ClickHouse subquery over events history, which neither
+    # bytecode (per-event) nor transpiled JS (in-browser) filters can evaluate
+    @parameterized.expand(
+        [
+            ("destination_global_properties", "destination", "properties"),
+            ("site_destination_global_properties", "site_destination", "properties"),
+            ("destination_event_properties", "destination", "event_properties"),
+        ]
+    )
+    def test_validate_filters_rejects_behavioral_properties(self, _name, function_type, placement):
+        behavioral_property = {
+            "type": "behavioral",
+            "value": "performed_event",
+            "key": "$pageview",
+            "event_type": "events",
+            "time_value": 30,
+            "time_interval": "day",
+        }
+        event = {"id": "$pageview", "type": "events", "name": "$pageview", "order": 0}
+        if placement == "properties":
+            filters = {"events": [event], "properties": [behavioral_property]}
+        else:
+            filters = {"events": [{**event, "properties": [behavioral_property]}]}
+
+        serializer = HogFunctionFiltersSerializer(
+            data=filters, context={**self.filters_context, "function_type": function_type}
+        )
+        assert not serializer.is_valid()
+        assert "behavioral" in str(serializer.errors).lower()
+
     def test_validate_filters_person_updates_only_allows_properties(self):
         filters = {
             "source": "person-updates",

--- a/posthog/cdp/validation.py
+++ b/posthog/cdp/validation.py
@@ -662,6 +662,21 @@ class InputsSerializer(serializers.DictField):
         # Unlike standard dict validation we are iterating the schema - not the inputs
 
 
+def _contains_behavioral_property(filters: dict) -> bool:
+    """Behavioral ("performed event") property filters compile to a ClickHouse subquery over events
+    history, which realtime function filters (bytecode per-event, or JS transpiled into the browser)
+    can never evaluate."""
+    entities = (filters.get("events") or []) + (filters.get("actions") or []) + (filters.get("data_warehouse") or [])
+    property_lists = [filters.get("properties") or []] + [
+        entity.get("properties") or [] for entity in entities if isinstance(entity, dict)
+    ]
+    return any(
+        isinstance(prop, dict) and prop.get("type") == "behavioral"
+        for property_list in property_lists
+        for prop in property_list
+    )
+
+
 class HogFunctionFiltersSerializer(serializers.Serializer):
     source = serializers.ChoiceField(
         choices=["events", "person-updates", "data-warehouse-table"], required=False, default="events"
@@ -686,6 +701,12 @@ class HogFunctionFiltersSerializer(serializers.Serializer):
 
         # Ensure data is initialized as an empty dict if it's None
         data = data or {}
+
+        if _contains_behavioral_property(data):
+            raise serializers.ValidationError(
+                "Behavioral (performed event) filters can't be evaluated in realtime functions. "
+                "Use a cohort to filter on past behavior."
+            )
 
         if function_type == "transformation_log":
             # Filter bytecode is compiled against event-shaped globals, which log records

--- a/products/feature_flags/backend/test/test_filters_validation.py
+++ b/products/feature_flags/backend/test/test_filters_validation.py
@@ -315,6 +315,9 @@ class TestRejectSerdeUnsafeFilters(SimpleTestCase):
             ("property_type_not_string", {"groups": [{"properties": [{"key": "k", "type": 1}]}]}),
             # Rust has no `event` variant, so one of these fails the team's whole cached set.
             ("property_type_event", {"groups": [{"properties": [{"key": "k", "type": "event"}]}]}),
+            # `behavioral` is a real insight filter type, but Rust flag matching has no variant
+            # for it (it can't evaluate events history) — it must stay rejected here.
+            ("property_type_behavioral", {"groups": [{"properties": [{"key": "$pageview", "type": "behavioral"}]}]}),
             ("property_type_missing", {"groups": [{"properties": [{"key": "k"}]}]}),
             ("property_empty", {"groups": [{"properties": [{}]}]}),
             ("property_key_missing", {"groups": [{"properties": [{"type": "person"}]}]}),


### PR DESCRIPTION
## Problem

A behavioral property filter on a site destination or site app would throw a `TypeError` in the visitor's browser.

- #83738 adds the `behavioral` filter type, which only ClickHouse can evaluate.
- Filter JSON is a shared vocabulary, so the same shape reaches hog function filters.
- Site destinations and site apps transpile their filters to JS that runs in the browser. That path has no subquery guard.
- It accepts the filter, emits the query AST as a JS object literal, then calls `.includes()` on it. An object has no `.includes`.
- The guard is inert until #83738 lands. This can merge first and close the gap before anything can produce a behavioral filter.

## Changes

- Rejects behavioral properties in hog function filters when the function is saved, in global and per-event filter properties.
- The bytecode path already failed, but only through a generic "select queries are not allowed" compile error. It now gets the same clear message.
- Feature flags already reject the type through their Rust serde allowlist, so no flag code changed.

## How did you test this code?

- `posthog/cdp/test/test_validation.py`: rejection across `destination` and `site_destination`, and both filter placements. No existing test covered a subquery reaching the transpiled path.
- `products/feature_flags/backend/test/test_filters_validation.py`: one case pins `behavioral` as serde-unsafe. Allowlisting it without a Rust `PropertyType` variant fails deserialization of the team's whole cached flag set.
- Verified the browser failure on the #83738 branch with the guard removed. Compiling a behavioral filter through the transpiled path produced JS calling `.includes()` on an object literal. Not reproducible on master, where the filter type does not compile.
- Both suites need migrations enabled. `--no-migrations` cannot create the `ltree` extension they use.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The behavior a user sees is an error message on a filter that never worked.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Desktop task). Skills read: `writing-pr-descriptions`, `writing-tests`, `stacking-prs`.

The guard first appeared as #83739, stacked on #83738, and that PR is now closed.
A stack lands bottom-first, so the stacked version would have put #83738 on master with the transpiled path unguarded until the layer above followed.
Targeting master directly inverts the order, because the guard does nothing until the filter type exists.

Folding it into #83738 was the plan. The signed-commit tooling refused to commit to that branch, reporting it as a protected base branch, so the guard became its own PR.
