### PR TITLE
fix(experiments): tighten the flag cleanup agent prompt

### DIFF
--- a/products/experiments/backend/flag_cleanup.py
+++ b/products/experiments/backend/flag_cleanup.py
@@ -139,7 +139,7 @@ def build_cleanup_prompt(experiment: Experiment, flag_key: str, plan: CleanupPla
             "## Rules",
             "- For the kept variant: keep that branch's body, delete the surrounding flag check and the other branches.",
             "- Boolean-style checks: keep the enabled path's body and drop the if-check (and any else branch).",
-            "- If the kept branch renders nothing or does nothing, delete it entirely, including the component or helper it calls and their call sites. Do not leave a no-op mounted.",
+            "- If the kept branch renders nothing or does nothing, delete it entirely, including any component or helper that nothing else uses once the branch is gone. Do not leave a no-op mounted.",
             "- Remove the now-dead code you create: orphaned branches, unused imports, unused helpers.",
             "- Code only. Do NOT change the flag in PostHog, and do NOT touch unrelated code.",
             "- If the correct path is genuinely ambiguous at a site, leave it unchanged and list it in the PR description for a human to review.",

--- a/products/experiments/backend/flag_cleanup.py
+++ b/products/experiments/backend/flag_cleanup.py
@@ -133,16 +133,20 @@ def build_cleanup_prompt(experiment: Experiment, flag_key: str, plan: CleanupPla
             f'Search the repo for the flag key "{flag_key}" and for PostHog SDK calls that read flags, e.g.:',
             f"  {FLAG_SDK_CALLS}",
             "Cover every language used in the repo (JS/TS, Python, Go, Ruby, PHP, etc.).",
+            "If the search finds no references to the flag at all, stop: do not open a pull request.",
+            "Finish with a short note saying the codebase has no references to this flag, so the flag can simply be deleted in PostHog.",
             "",
             "## Rules",
             "- For the kept variant: keep that branch's body, delete the surrounding flag check and the other branches.",
             "- Boolean-style checks: keep the enabled path's body and drop the if-check (and any else branch).",
+            "- If the kept branch renders nothing or does nothing, delete it entirely, including the component or helper it calls and their call sites. Do not leave a no-op mounted.",
             "- Remove the now-dead code you create: orphaned branches, unused imports, unused helpers.",
             "- Code only. Do NOT change the flag in PostHog, and do NOT touch unrelated code.",
             "- If the correct path is genuinely ambiguous at a site, leave it unchanged and list it in the PR description for a human to review.",
             "",
             "## Output",
             f'Open a draft pull request titled "{title}". In the description, summarise what you removed and anything you left for manual review.',
+            'Describe the outcome accurately: when the baseline is kept because the experiment lost or was inconclusive, say the change was rolled back. Do not describe the kept variant as having "won".',
         ]
     )
     return title, description


### PR DESCRIPTION
## Problem

Three prompt quality issues surfaced while dogfooding the experiment flag cleanup agent:

- When the repo had zero references to the flag, the agent paused in its chat thread asking whether to open an empty PR.
- In #78094 the agent kept the surviving branch's component mounted even though it renders nothing.
- In #73152 the PR body said "control won" when the experiment had lost and control simply stayed as the baseline.

## Changes

Three additions to the cleanup prompt in `flag_cleanup.py`:

- No references found: stop, do not open a PR, report that the flag can simply be deleted in PostHog.
- If the kept branch renders nothing or does nothing, delete it entirely including its call sites.
- Describe a rollback as a rollback, not as the kept variant having won.

## How did you test this code?

Prompt text only, no logic changes. Existing `test_flag_cleanup.py` suite passes (9 tests). No new tests added: pinning prompt prose with string matches would not catch a real regression.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored in a Claude Code session directed by @jurajmajerik. Each prompt addition maps to a concrete failure observed in a dogfood run (linked PRs above). Verified with ruff and the existing unit tests.
