### PR TITLE
fix(insights): reject behavioral properties in action steps

### DIFF
--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -1614,6 +1614,9 @@ def steps_to_expr(steps: list[ActionStepJSON], team: Team, events_alias: Optiona
             exprs.append(expr)
 
         if step.properties:
+            # An action referencing itself here would re-enter action_to_expr until Python's recursion limit.
+            if any(isinstance(prop, dict) and prop.get("type") == "behavioral" for prop in step.properties):
+                raise QueryError("Action steps can't filter on behavioral properties")
             exprs.append(property_to_expr(step.properties, team))
 
         if len(exprs) == 1:

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -2122,6 +2122,19 @@ class TestProperty(BaseTest):
             ),
         )
 
+    def test_behavioral_property_in_action_step_raises(self):
+        # Compiling one would re-enter action_to_expr until Python's recursion limit
+        action = Action.objects.create(team=self.team, steps_json=[{"event": "$pageview"}])
+        action.steps_json = [
+            {
+                "event": "$pageview",
+                "properties": [self._behavioral_filter(event_type="actions", key=str(action.pk))],
+            }
+        ]
+        action.save()
+        with self.assertRaises(QueryError):
+            action_to_expr(action)
+
 
 class TestPropertyIsSetIsNotSetWithData(APIBaseTest):
     # Sentinel to indicate a property should not be included in the event


### PR DESCRIPTION
## Problem

A crafted action makes every query that touches it fail to compile.

- An action step property is an arbitrary `dict`, so it can hold a behavioral filter naming the action it lives on.
- `steps_to_expr` compiles step properties through `property_to_expr`, which routes a behavioral filter with `event_type: "actions"` back into `action_to_expr`.
- A self-referencing action recursed until Python raised `RecursionError`. Reproduced locally.
- Any query using the action broke, not only queries that use a behavioral filter.

## Changes

- Rejects behavioral properties where action step properties are compiled.
- That cuts the only edge re-entering `action_to_expr`, so cycles spanning several actions are covered too.
- The check sits below the feature flag gate, so it holds whichever way the flag resolves.
- Nesting a behavioral filter inside another one's `event_filters` stays allowed. That payload is a finite tree, it compiles, and it reads as "events by a person who also did X".

## How did you test this code?

- `posthog/hogql/test/test_property.py`: an action whose step property names that action now raises instead of recursing. Without the fix the same case raises `RecursionError`.
- 262 cases across `test_property.py` and `posthog/cdp/test/test_validation.py` pass with migrations enabled.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Desktop task). Skills invoked: /writing-tests, /writing-pr-descriptions.

Raised by `veria-ai` on #83738. Its mechanism was right and its suggested patch was not: the patch guarded `event_filters`, while the cycle runs through action step properties. Applying that patch verbatim left the `RecursionError` in place, and it also rejected `event_filters` nesting, which compiles correctly today. Both checked by reproducing each case before and after.

Lands on #83738's branch because the branch it fixes is not on master yet.
