### PR TITLE
feat(workflows): reject off-domain custom sender addresses at save time

### DIFF
--- a/posthog/cdp/test/test_validation.py
+++ b/posthog/cdp/test/test_validation.py
@@ -559,12 +559,14 @@ class TestHogFunctionValidation(ClickhouseTestMixin, APIBaseTest, QueryMatchingT
             config={"email": f"sender@{domain}", "name": "Sender", "domain": domain, "verified": True},
         )
 
-    def _validate_email_from(self, from_value, existing_from=None, get_team=True):
+    def _validate_email_from(self, from_value, existing_from=None, get_team=True, cache=None):
         inputs_schema = [{"key": "email", "type": "native_email", "required": True, "templating": "liquid"}]
         value = {"from": from_value, "to": "a@b.com", "subject": "hi", "text": "hi"}
         context_extra = {"existing_email_from": existing_from}
         if get_team:
             context_extra["get_team"] = lambda: self.team
+        if cache is not None:
+            context_extra["email_integration_domain_cache"] = cache
         return validate_inputs(inputs_schema, {"email": {"value": value}}, context_extra=context_extra)
 
     @parameterized.expand(
@@ -619,6 +621,61 @@ class TestHogFunctionValidation(ClickhouseTestMixin, APIBaseTest, QueryMatchingT
                 existing_from={"integrationId": integration.id, "email": "old@evil.com"},
             )
         assert 'is not on the verified domain "posthog.com"' in str(ctx.value.detail)
+
+    def test_email_sender_override_kept_address_with_changed_sender_is_validated(self):
+        # Selecting a different sender re-runs the domain check even when the address is kept.
+        # Grandfathering on the address alone let a sender change save an off-domain pair that
+        # silently falls back at send time - the failure this validation exists to surface.
+        posthog_integration = self._create_email_integration("posthog.com")
+        other_integration = self._create_email_integration("example.dev")
+
+        with pytest.raises(ValidationError) as ctx:
+            self._validate_email_from(
+                {"integrationId": other_integration.id, "email": "community@posthog.com"},
+                existing_from={"integrationId": posthog_integration.id, "email": "community@posthog.com"},
+            )
+        assert 'is not on the verified domain "example.dev"' in str(ctx.value.detail)
+
+    def test_email_sender_override_added_rotation_sender_is_validated(self):
+        # Adding a rotation sender keeps the stored address, so an address-only grandfather
+        # would skip the multi-sender domain loop entirely.
+        posthog_integration = self._create_email_integration("posthog.com")
+        other_integration = self._create_email_integration("example.dev")
+
+        with pytest.raises(ValidationError) as ctx:
+            self._validate_email_from(
+                {
+                    "integrationId": posthog_integration.id,
+                    "integrationIds": [posthog_integration.id, other_integration.id],
+                    "email": "community@posthog.com",
+                },
+                existing_from={"integrationId": posthog_integration.id, "email": "community@posthog.com"},
+            )
+        assert 'is not on the verified domain "example.dev"' in str(ctx.value.detail)
+
+    def test_email_sender_override_grandfathers_either_live_or_draft_value(self):
+        # A raw-API live save is compared against both stored variants: an address unchanged
+        # from the live value must not be blocked because a divergent draft exists.
+        integration = self._create_email_integration()
+
+        self._validate_email_from(
+            {"integrationId": integration.id, "email": "legacy@evil.com"},
+            existing_from=[
+                {"integrationId": integration.id, "email": "legacy@evil.com"},
+                {"integrationId": integration.id, "email": "draft@evil.com"},
+            ],
+        )
+
+    def test_email_sender_domain_lookup_is_cached_per_save(self):
+        # A drip sequence validates one action at a time, so each email step re-queries the
+        # same sender row unless the domain lookup shares a request-scoped cache (mirrors
+        # _message_template_cache).
+        integration = self._create_email_integration()
+        cache: dict = {}
+
+        self._validate_email_from({"integrationId": integration.id, "email": "a@posthog.com"}, cache=cache)
+        with self.assertNumQueries(0):
+            self._validate_email_from({"integrationId": integration.id, "email": "b@posthog.com"}, cache=cache)
 
     def test_email_sender_override_must_be_on_every_rotation_domain(self):
         # Sender rotation picks one integration per send, so a literal address that is off-domain

--- a/posthog/cdp/test/test_validation.py
+++ b/posthog/cdp/test/test_validation.py
@@ -16,19 +16,20 @@ from posthog.cdp.validation import (
     compile_hog,
     generate_template_bytecode,
 )
+from posthog.models.integration import Integration
 
 from products.messaging.backend.api.design_validation import validate_design
 
 from common.hogvm.python.operation import HOGQL_BYTECODE_VERSION
 
 
-def validate_inputs(schema, inputs, function_type="destination", is_dwh_source=False):
+def validate_inputs(schema, inputs, function_type="destination", is_dwh_source=False, context_extra=None):
     serializer = MappingsSerializer(
         data={
             "inputs_schema": schema,
             "inputs": inputs,
         },
-        context={"function_type": function_type, "is_dwh_source": is_dwh_source},
+        context={"function_type": function_type, "is_dwh_source": is_dwh_source, **(context_extra or {})},
     )
     serializer.is_valid(raise_exception=True)
     return serializer.validated_data["inputs"]
@@ -550,6 +551,102 @@ class TestHogFunctionValidation(ClickhouseTestMixin, APIBaseTest, QueryMatchingT
         with pytest.raises(ValidationError) as ctx:
             validate_inputs(inputs_schema, {"email": {"value": value}})
         assert "At most 10 email senders are allowed." in str(ctx.value.detail)
+
+    def _create_email_integration(self, domain="posthog.com"):
+        return Integration.objects.create(
+            team=self.team,
+            kind="email",
+            config={"email": f"sender@{domain}", "name": "Sender", "domain": domain, "verified": True},
+        )
+
+    def _validate_email_from(self, from_value, existing_from=None, get_team=True):
+        inputs_schema = [{"key": "email", "type": "native_email", "required": True, "templating": "liquid"}]
+        value = {"from": from_value, "to": "a@b.com", "subject": "hi", "text": "hi"}
+        context_extra = {"existing_email_from": existing_from}
+        if get_team:
+            context_extra["get_team"] = lambda: self.team
+        return validate_inputs(inputs_schema, {"email": {"value": value}}, context_extra=context_extra)
+
+    @parameterized.expand(
+        [
+            ("off_domain", "sales@evil.com", 'is not on the verified domain "posthog.com"'),
+            ("planted_placeholder", "default@example.com", 'is not on the verified domain "posthog.com"'),
+            ("not_an_email", "not-an-email", "is not a valid email address"),
+            ("address_list", "a@posthog.com, b@posthog.com", "is not a valid email address"),
+        ]
+    )
+    def test_email_literal_sender_override_rejected_at_save(self, _name, address, expected):
+        # A literal override that the runtime would refuse (or silently fall back from) must be
+        # rejected when the workflow is saved, while the author can still act on it.
+        integration = self._create_email_integration()
+
+        with pytest.raises(ValidationError) as ctx:
+            self._validate_email_from({"integrationId": integration.id, "email": address})
+        assert expected in str(ctx.value.detail)
+
+    @parameterized.expand(
+        [
+            ("on_domain", "community@posthog.com"),
+            ("case_insensitive", "Community@PostHog.com"),
+            ("liquid_template", "{{ event.properties.sender }}"),
+            ("hog_template", "{event.properties.sender}"),
+            ("empty_means_integration_default", ""),
+        ]
+    )
+    def test_email_sender_override_accepted_at_save(self, _name, address):
+        integration = self._create_email_integration()
+
+        validated = self._validate_email_from({"integrationId": integration.id, "email": address})
+        assert validated["email"]["value"]["from"]["email"] == address
+
+    def test_email_sender_override_unchanged_stored_value_is_not_revalidated(self):
+        # Workflows written before June 2026 carry a placeholder address the author never typed.
+        # Re-saving one of them must not fail on that stored value; only a newly written address
+        # is held to the domain rule. The stored placeholders are removed by a separate backfill.
+        integration = self._create_email_integration()
+
+        self._validate_email_from(
+            {"integrationId": integration.id, "email": "default@example.com"},
+            existing_from={"integrationId": integration.id, "email": "default@example.com"},
+        )
+
+    def test_email_sender_override_changed_value_is_validated(self):
+        integration = self._create_email_integration()
+
+        with pytest.raises(ValidationError) as ctx:
+            self._validate_email_from(
+                {"integrationId": integration.id, "email": "new@evil.com"},
+                existing_from={"integrationId": integration.id, "email": "old@evil.com"},
+            )
+        assert 'is not on the verified domain "posthog.com"' in str(ctx.value.detail)
+
+    def test_email_sender_override_must_be_on_every_rotation_domain(self):
+        # Sender rotation picks one integration per send, so a literal address that is off-domain
+        # for any of them would make a fraction of sends fall back to a different sender.
+        posthog_integration = self._create_email_integration("posthog.com")
+        other_integration = self._create_email_integration("example.dev")
+
+        with pytest.raises(ValidationError) as ctx:
+            self._validate_email_from(
+                {
+                    "integrationId": posthog_integration.id,
+                    "integrationIds": [posthog_integration.id, other_integration.id],
+                    "email": "community@posthog.com",
+                }
+            )
+        assert 'is not on the verified domain "example.dev"' in str(ctx.value.detail)
+
+    @parameterized.expand(
+        [
+            ("no_team_in_context", False, 1),
+            ("unknown_integration", True, 999999),
+        ]
+    )
+    def test_email_sender_override_skips_when_domain_is_unresolvable(self, _name, get_team, integration_id):
+        # Internal re-saves run without a request (no get_team), and an integration id that does
+        # not resolve has no domain to compare against. Both must not block the save; the runtime
+        # still enforces the domain at send time.
+        self._validate_email_from({"integrationId": integration_id, "email": "sales@evil.com"}, get_team=get_team)
 
     @parameterized.expand(
         [

--- a/posthog/cdp/validation.py
+++ b/posthog/cdp/validation.py
@@ -36,24 +36,40 @@ MAX_WORKFLOW_EMAIL_SENDERS = 10
 FROM_OVERRIDE_EMAIL_REGEX = re.compile(r'^[^\s@"<>,;]+@[^\s@"<>,;]+\.[^\s@"<>,;]+$')
 
 
+def _sender_integration_ids(from_value: dict) -> set[int]:
+    return {
+        integration_id
+        for integration_id in [from_value.get("integrationId"), *(from_value.get("integrationIds") or [])]
+        if isinstance(integration_id, int) and not isinstance(integration_id, bool)
+    }
+
+
 def _validate_email_sender_override(from_value: dict, context: dict) -> None:
     """Reject a literal custom sender address the send path would refuse.
 
     The runtime only sends from an address on the selected integration's verified domain; an
     off-domain override is discarded at send time with a run-log warning the author never sees.
     Catching it at save time puts the error in front of the person who can fix it. Only newly
-    written literals are checked: templated addresses resolve at render time, and values already
-    stored on the workflow are grandfathered so legacy placeholder data (cleaned up by a separate
-    backfill) does not block unrelated edits.
+    written sender configurations are checked: templated addresses resolve at render time, and a
+    value already stored on the workflow (live or draft) is grandfathered so legacy placeholder
+    data (cleaned up by a separate backfill) does not block unrelated edits.
     """
     override = (from_value.get("email") or "").strip()
     # A brace means a Liquid or Hog template that only resolves at send time.
     if not override or "{" in override:
         return
 
-    existing_from = context.get("existing_email_from") or {}
-    if override == (existing_from.get("email") or "").strip():
-        return
+    existing = context.get("existing_email_from") or []
+    # Grandfather only a fully unchanged sender configuration: the address AND the selected
+    # sender set must match a stored variant. Keeping the address while switching senders must
+    # re-check it against the new sender's domain, or the pair silently falls back at send time.
+    for stored in existing if isinstance(existing, list) else [existing]:
+        if not isinstance(stored, dict):
+            continue
+        if override == (stored.get("email") or "").strip() and _sender_integration_ids(
+            from_value
+        ) == _sender_integration_ids(stored):
+            return
 
     get_team = context.get("get_team")
     if get_team is None:
@@ -69,19 +85,25 @@ def _validate_email_sender_override(from_value: dict, context: dict) -> None:
             }
         )
 
-    integration_ids = [
-        integration_id
-        for integration_id in [from_value.get("integrationId"), *(from_value.get("integrationIds") or [])]
-        if isinstance(integration_id, int) and not isinstance(integration_id, bool)
-    ]
+    integration_ids = _sender_integration_ids(from_value)
     if not integration_ids:
         return
 
     override_domain = override.split("@")[1].lower()
-    integrations = Integration.objects.filter(team_id=get_team().id, id__in=integration_ids, kind="email")
-    for integration in integrations:
-        config = integration.config or {}
-        integration_domain = (config.get("domain") or (config.get("email") or "").split("@")[-1]).lower()
+    # An empty cached domain means the id resolved to no email integration for this team; the
+    # save is not blocked on it (there is no domain to compare), matching the uncached behavior.
+    shared_cache = context.get("email_integration_domain_cache")
+    domain_cache: dict[int, str] = shared_cache if isinstance(shared_cache, dict) else {}
+    missing_ids = [integration_id for integration_id in integration_ids if integration_id not in domain_cache]
+    if missing_ids:
+        for integration in Integration.objects.filter(team_id=get_team().id, id__in=missing_ids, kind="email"):
+            config = integration.config or {}
+            domain_cache[integration.id] = (config.get("domain") or (config.get("email") or "").split("@")[-1]).lower()
+        for integration_id in missing_ids:
+            domain_cache.setdefault(integration_id, "")
+
+    for integration_id in sorted(integration_ids):
+        integration_domain = domain_cache.get(integration_id) or ""
         if integration_domain and override_domain != integration_domain:
             raise serializers.ValidationError(
                 {

--- a/posthog/cdp/validation.py
+++ b/posthog/cdp/validation.py
@@ -15,6 +15,7 @@ from posthog.hogql.parser import parse_program, parse_string_template
 from posthog.hogql.visitor import TraversingVisitor
 
 from posthog.cdp.filters import compile_filters_bytecode, compile_filters_expr
+from posthog.models.integration import Integration
 
 from products.cdp.backend.models.hog_functions.hog_function import (
     TYPES_WITH_JAVASCRIPT_SOURCE,
@@ -29,6 +30,67 @@ logger = logging.getLogger(__name__)
 
 CORE_SUPPORTED_FUNCTIONS = {"fetch", "postHogCapture"}
 MAX_WORKFLOW_EMAIL_SENDERS = 10
+
+# Mirrors FROM_OVERRIDE_EMAIL_REGEX in nodejs/src/cdp/services/messaging/email.service.ts, which
+# is what the send path enforces after rendering. Keep the two in sync.
+FROM_OVERRIDE_EMAIL_REGEX = re.compile(r'^[^\s@"<>,;]+@[^\s@"<>,;]+\.[^\s@"<>,;]+$')
+
+
+def _validate_email_sender_override(from_value: dict, context: dict) -> None:
+    """Reject a literal custom sender address the send path would refuse.
+
+    The runtime only sends from an address on the selected integration's verified domain; an
+    off-domain override is discarded at send time with a run-log warning the author never sees.
+    Catching it at save time puts the error in front of the person who can fix it. Only newly
+    written literals are checked: templated addresses resolve at render time, and values already
+    stored on the workflow are grandfathered so legacy placeholder data (cleaned up by a separate
+    backfill) does not block unrelated edits.
+    """
+    override = (from_value.get("email") or "").strip()
+    # A brace means a Liquid or Hog template that only resolves at send time.
+    if not override or "{" in override:
+        return
+
+    existing_from = context.get("existing_email_from") or {}
+    if override == (existing_from.get("email") or "").strip():
+        return
+
+    get_team = context.get("get_team")
+    if get_team is None:
+        # No request context (internal re-saves, direct construction); the send path still
+        # enforces the domain.
+        return
+
+    if not FROM_OVERRIDE_EMAIL_REGEX.match(override):
+        raise serializers.ValidationError(
+            {
+                "input": f'The custom sender address "{override}" is not a valid email address. '
+                "Use a single address like sender@yourdomain.com, or a template that resolves to one."
+            }
+        )
+
+    integration_ids = [
+        integration_id
+        for integration_id in [from_value.get("integrationId"), *(from_value.get("integrationIds") or [])]
+        if isinstance(integration_id, int) and not isinstance(integration_id, bool)
+    ]
+    if not integration_ids:
+        return
+
+    override_domain = override.split("@")[1].lower()
+    integrations = Integration.objects.filter(team_id=get_team().id, id__in=integration_ids, kind="email")
+    for integration in integrations:
+        config = integration.config or {}
+        integration_domain = (config.get("domain") or (config.get("email") or "").split("@")[-1]).lower()
+        if integration_domain and override_domain != integration_domain:
+            raise serializers.ValidationError(
+                {
+                    "input": f'The custom sender address "{override}" is not on the verified domain '
+                    f'"{integration_domain}" of the selected sender. Use an address on that domain, '
+                    "or select a different sender."
+                }
+            )
+
 
 PRODUCT_ASYNC_FUNCTIONS: set[str] = set()
 
@@ -503,6 +565,8 @@ class InputsItemSerializer(serializers.Serializer):
                         raise serializers.ValidationError(
                             {"input": "Expected 'from.integrationIds' to be a list of Integration IDs."}
                         )
+
+                _validate_email_sender_override(from_value, self.context)
 
             if isinstance(value.get("html"), str) and value["html"] and not value.get("design"):
                 # Programmatically authored emails often supply html without a design, which the

--- a/products/workflows/backend/api/hog_flow.py
+++ b/products/workflows/backend/api/hog_flow.py
@@ -737,6 +737,22 @@ def _should_validate_strictly(context: dict, is_draft: Optional[bool]) -> bool:
     return source is not None and source != EventSource.WEB
 
 
+def _existing_email_from_by_action(instance: "HogFlow") -> dict[str, dict]:
+    """Stored email sender overrides keyed by action id, draft actions winning over live ones."""
+    result: dict[str, dict] = {}
+    draft = instance.draft if isinstance(instance.draft, dict) else {}
+    for actions in (instance.actions, draft.get("actions")):
+        for stored_action in actions or []:
+            if not isinstance(stored_action, dict) or not stored_action.get("id"):
+                continue
+            email_input = ((stored_action.get("config") or {}).get("inputs") or {}).get("email")
+            value = email_input.get("value") if isinstance(email_input, dict) else None
+            from_value = value.get("from") if isinstance(value, dict) else None
+            if isinstance(from_value, dict):
+                result[stored_action["id"]] = from_value
+    return result
+
+
 def _event_config_has_event_or_action(event_config: dict) -> bool:
     # An "events to wait for" / conversion entry that targets neither events nor actions compiles to
     # always-true bytecode and would fire on every incoming event. Action-based entries (events empty,
@@ -1248,6 +1264,13 @@ class HogFlowActionSerializer(serializers.Serializer):
                         # {"secret": true} marker recovers the stored value instead of wiping it.
                         "encrypted_inputs": (self.context.get("existing_encrypted_inputs") or {}).get(data.get("id"))
                         or {},
+                        # Team plus this action's stored sender override, so a literal custom
+                        # sender address is checked against the integration's verified domain at
+                        # save time, while an unchanged stored value is grandfathered.
+                        "get_team": self.context.get("get_team"),
+                        "existing_email_from": (self.context.get("existing_action_email_from") or {}).get(
+                            data.get("id")
+                        ),
                     },
                 )
 
@@ -1989,6 +2012,10 @@ class HogFlowSerializer(HogFlowMinimalSerializer):
         # Must be set before super() runs, since the nested action serializers validate inside it.
         if instance is not None:
             self.context["existing_encrypted_inputs"] = existing_secret_map(instance, template_cache={})
+            # Stored sender overrides, keyed by action id, so child action validation only holds
+            # newly written custom sender addresses to the verified-domain rule. Draft wins over
+            # live for the same reason as secrets: it is the value the client last saw.
+            self.context["existing_action_email_from"] = _existing_email_from_by_action(instance)
 
         # Warehouse-table triggers are row-scoped: step inputs may use the `{record.x}` alias for the
         # synced row. Flag it before child action validation so function-input compilation rewrites it.

--- a/products/workflows/backend/api/hog_flow.py
+++ b/products/workflows/backend/api/hog_flow.py
@@ -737,9 +737,14 @@ def _should_validate_strictly(context: dict, is_draft: Optional[bool]) -> bool:
     return source is not None and source != EventSource.WEB
 
 
-def _existing_email_from_by_action(instance: "HogFlow") -> dict[str, dict]:
-    """Stored email sender overrides keyed by action id, draft actions winning over live ones."""
-    result: dict[str, dict] = {}
+def _existing_email_from_by_action(instance: "HogFlow") -> dict[str, list[dict]]:
+    """Stored email sender overrides keyed by action id, live and draft variants both kept.
+
+    Which variant a save should be compared against depends on how the request routes (a
+    builder save targets the draft, a raw API write targets live), so validation grandfathers
+    a value matching either - both are values already stored on the workflow.
+    """
+    result: dict[str, list[dict]] = {}
     draft = instance.draft if isinstance(instance.draft, dict) else {}
     for actions in (instance.actions, draft.get("actions")):
         for stored_action in actions or []:
@@ -749,7 +754,7 @@ def _existing_email_from_by_action(instance: "HogFlow") -> dict[str, dict]:
             value = email_input.get("value") if isinstance(email_input, dict) else None
             from_value = value.get("from") if isinstance(value, dict) else None
             if isinstance(from_value, dict):
-                result[stored_action["id"]] = from_value
+                result.setdefault(stored_action["id"], []).append(from_value)
     return result
 
 
@@ -1270,6 +1275,11 @@ class HogFlowActionSerializer(serializers.Serializer):
                         "get_team": self.context.get("get_team"),
                         "existing_email_from": (self.context.get("existing_action_email_from") or {}).get(
                             data.get("id")
+                        ),
+                        # Request-scoped: a drip sequence's steps share senders, and the actions
+                        # list validates one action at a time (mirrors _message_template_cache).
+                        "email_integration_domain_cache": self.context.setdefault(
+                            "_email_integration_domain_cache", {}
                         ),
                     },
                 )

--- a/products/workflows/backend/api/test/test_hog_flow.py
+++ b/products/workflows/backend/api/test/test_hog_flow.py
@@ -19,6 +19,7 @@ from posthog.constants import AvailableFeature
 from posthog.event_usage import EventSource
 from posthog.models import Organization, OrganizationMembership, Team, User
 from posthog.models.activity_logging.activity_log import ActivityLog
+from posthog.models.integration import Integration
 from posthog.models.personal_api_key import PersonalAPIKey
 from posthog.models.utils import generate_random_token_personal, hash_key_value
 from posthog.test.fixtures import create_app_metric2
@@ -312,6 +313,51 @@ class TestHogFlowAPI(APIBaseTest):
         detail = response.json()["detail"]
         for fragment in fragments:
             assert fragment in detail, (fragment, detail)
+
+    def test_literal_off_domain_sender_override_is_rejected_at_save(self):
+        # The domain rule lived only in the send path, so a bad literal address saved fine and
+        # every send then fell back to the integration's sender with a run-log warning the
+        # author never saw. The save is where the author can still act on it.
+        sync_template_to_db(_email_function_template())
+        integration = Integration.objects.create(
+            team=self.team,
+            kind="email",
+            config={"email": "sender@posthog.com", "name": "Sender", "domain": "posthog.com", "verified": True},
+        )
+        inputs = _valid_email_inputs()
+        inputs["email"]["value"]["from"] = {"integrationId": integration.id, "email": "sales@evil.com"}
+        hog_flow, action = self._create_hog_flow_with_action({"inputs": inputs})
+        action["type"] = "function_email"
+
+        response = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow, HTTP_X_POSTHOG_CLIENT="mcp")
+
+        assert response.status_code == 400, response.json()
+        assert 'is not on the verified domain "posthog.com"' in response.json()["detail"]
+
+    def test_stored_off_domain_sender_override_survives_a_resave(self):
+        # Workflows written before June 2026 carry a placeholder address the author never typed.
+        # Re-sending the stored graph unchanged must not fail on it, or every edit to an affected
+        # workflow is blocked until the placeholder backfill has run.
+        sync_template_to_db(_email_function_template())
+        integration = Integration.objects.create(
+            team=self.team,
+            kind="email",
+            config={"email": "sender@posthog.com", "name": "Sender", "domain": "posthog.com", "verified": True},
+        )
+        inputs = _valid_email_inputs()
+        inputs["email"]["value"]["from"] = {"integrationId": integration.id, "email": "default@example.com"}
+        hog_flow, action = self._create_hog_flow_with_action({"template_id": "template-email", "inputs": inputs})
+        action["type"] = "function_email"
+        stored = HogFlow.objects.create(
+            team=self.team, name="Legacy flow", actions=hog_flow["actions"], status=HogFlow.State.ACTIVE
+        )
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/hog_flows/{stored.id}",
+            {"actions": hog_flow["actions"]},
+        )
+
+        assert response.status_code == 200, response.json()
 
     def test_fixed_template_id_is_inferred_from_step_type(self):
         # template_id on fixed-template steps is a constant of the step type; omitting the


### PR DESCRIPTION
## Problem

A customer who types an off-domain custom sender address in a workflow email step saves it without any error. Every send then ignores the address and falls back to the integration's sender, with only a run-log warning (#84891).

- Before #84891 the same stored address failed every send outright, which is how legacy placeholder data broke sending for hundreds of workflows.
- #84891 noted that authoring-time validation is the right place for this signal and that it did not exist yet. This PR adds it.

## Changes

- Saving a workflow email step with a literal custom sender address off the selected sender's verified domain now fails. The error names the address and the domain, and suggests fixing the address or picking a different sender.
- A literal address that is not a valid single email address is rejected the same way.
- Templated addresses (`{{ ... }}` or `{ ... }`) skip the check. They only resolve at send time, where the domain rule still applies.
- With sender rotation, a literal address must be on the verified domain of every selected sender. An off-domain rotation pick would otherwise silently fall back for a fraction of sends.
- Only new or changed addresses validate. A stored value re-sent unchanged is grandfathered, so workflows carrying the legacy `default@example.com` placeholder stay editable until the backfill removes it.
- The check runs where saves already validate strictly: non-draft saves, and all saves from programmatic clients. Web UI drafts stay lenient mid-edit, unchanged.
- Rejected alternative: validating on every save regardless of prior value. That blocks every edit to the ~330 workflows that still store the placeholder the old sender picker wrote.

Nothing changes visually. The new error surfaces through the existing save error path.

## How did you test this code?

- New serializer cases in `posthog/cdp/test/test_validation.py` cover the reject matrix (off-domain, placeholder, malformed, address list), the accept matrix (on-domain, case-insensitive, templated, empty), grandfathering of unchanged values, rotation across two domains, and the skip paths (no request context, unknown integration). No existing test exercised any save-time domain rule; all of these passed before this PR only because the rule did not exist.
- Two API tests in `products/workflows/backend/api/test/test_hog_flow.py` guard the context threading: a create with an off-domain literal returns 400, and a re-save of a stored off-domain value returns 200. The serializer tests pass context by hand, so only these catch a regression that drops the `get_team` / stored-sender threading in the workflow serializer.
- Confirmed the reject-path tests fail with the validation removed.
- Ran: both touched test files in full, ruff, and repo-wide mypy.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No doc under `docs/` describes the email step sender.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (Fable 5) in Claude Code, directed by the assignee. Skills invoked: `/improving-drf-endpoints`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-code-comments`, `/writing-pr-descriptions`. Follow-up to the validation gap #84891 documented; tests were written first and confirmed red before the implementation. All committed sample data is invented (`example.com` / `evil.com` style addresses only).
