### PR TITLE
feat(ai-research): sign image fetch requests with web bot auth

### DIFF
--- a/docs/internal/web-bot-auth-key-directory.md
+++ b/docs/internal/web-bot-auth-key-directory.md
@@ -7,7 +7,9 @@ The directory publishes the public keys for `PostHogSessionReplayBot` and signs 
 
 Set `WEB_BOT_AUTH_PRIVATE_KEYS` to a comma-separated list of unencrypted Ed25519 private keys in PKCS8 PEM format.
 Encode PEM line breaks as literal `\n` sequences when the secret store requires a single-line value.
-During key rotation, include the old and new keys until consumers have accepted the new key.
+List the active outbound signing key first.
+During key rotation, add the new key after the active key so that the directory publishes both keys.
+Move the new key to the first position after consumers have accepted it, then remove the old key.
 
 Leave the variable unset outside PostHog Cloud US.
 The endpoint returns `404` when the variable is unset or the deployment is not in the US region.
@@ -18,7 +20,7 @@ PostHog Error Tracking receives a sanitized configuration error, and the endpoin
 
 ## Outbound request signing
 
-The Node.js image fetch lane reads the same variable and signs each outbound request with every configured key.
+The Node.js image fetch lane validates every configured key and signs each outbound request with the first key.
 It signs each redirect hop for that hop's authority.
 The signatures expire after one minute and include a unique 64-byte nonce.
 

--- a/docs/internal/web-bot-auth-key-directory.md
+++ b/docs/internal/web-bot-auth-key-directory.md
@@ -21,7 +21,8 @@ PostHog Error Tracking receives a sanitized configuration error, and the endpoin
 ## Outbound request signing
 
 The Node.js image fetch lane validates every configured key and signs each outbound request with the first key.
-It signs each redirect hop for that hop's authority.
+It signs each redirect hop for the GET method, authority, full target URI, and `Signature-Agent` header.
+This prevents use of the signature for another method, path, or query.
 The signatures expire after one minute and include a unique 64-byte nonce.
 
 The request uses the structured-string `Signature-Agent` format in [Cloudflare's current verifier](https://developers.cloudflare.com/bots/reference/bot-verification/web-bot-auth/).

--- a/docs/internal/web-bot-auth-key-directory.md
+++ b/docs/internal/web-bot-auth-key-directory.md
@@ -15,3 +15,12 @@ The endpoint returns `404` when the variable is unset or the deployment is not i
 When the variable is present, each production ASGI worker schedules validation on a daemon thread during lifespan startup.
 An empty or invalid value does not stop startup.
 PostHog Error Tracking receives a sanitized configuration error, and the endpoint returns `503` without exposing key material.
+
+## Outbound request signing
+
+The Node.js image fetch lane reads the same variable and signs each outbound request with every configured key.
+It signs each redirect hop for that hop's authority.
+The signatures expire after one minute and include a unique 64-byte nonce.
+
+The request uses the structured-string `Signature-Agent` format in [Cloudflare's current verifier](https://developers.cloudflare.com/bots/reference/bot-verification/web-bot-auth/).
+It includes the parameters required by the [current Web Bot Auth protocol draft](https://datatracker.ietf.org/doc/draft-meunier-webbotauth-httpsig-protocol/).

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/image-fetcher.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/image-fetcher.test.ts
@@ -38,7 +38,7 @@ function image(bytes: Buffer, contentType: string, extraHeaders: Record<string, 
     return respond(200, { 'content-type': contentType, ...extraHeaders }, { bytes, overLimit: false })
 }
 
-const NOOP_SIGNER: WebBotAuthRequestSigner = { headersFor: () => ({}) }
+const NOOP_SIGNER: WebBotAuthRequestSigner = { headersForGet: () => ({}) }
 /** Everything public by default, so a test that cares about the policy says so. */
 const fetcher = (
     policy: Partial<RedirectPolicy> = {},
@@ -138,14 +138,14 @@ describe('HttpImageFetcher', () => {
         fetchStreamedMock
             .mockResolvedValueOnce(respond(302, { location: 'https://images.example.net/moved.png' }))
             .mockResolvedValueOnce(image(PNG, 'image/png'))
-        const headersFor = jest
+        const headersForGet = jest
             .fn()
             .mockReturnValueOnce({ signature: 'first-hop-signature' })
             .mockReturnValueOnce({ signature: 'second-hop-signature' })
 
-        await fetcher({}, { headersFor }).fetch('https://cdn.example.com/a.png', OPTIONS)
+        await fetcher({}, { headersForGet }).fetch('https://cdn.example.com/a.png', OPTIONS)
 
-        expect(headersFor.mock.calls).toEqual([
+        expect(headersForGet.mock.calls).toEqual([
             ['https://cdn.example.com/a.png'],
             ['https://images.example.net/moved.png'],
         ])

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/image-fetcher.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/image-fetcher.test.ts
@@ -1,6 +1,7 @@
 import { ResolutionError, SecureRequestError, StreamedResponse, fetchStreamed } from '~/common/utils/request'
 
 import { HttpImageFetcher, ImageFetchOptions, RedirectPolicy } from './image-fetcher'
+import { WebBotAuthRequestSigner } from './web-bot-auth'
 
 jest.mock('~/common/utils/request', () => ({
     ...jest.requireActual('~/common/utils/request'),
@@ -37,9 +38,13 @@ function image(bytes: Buffer, contentType: string, extraHeaders: Record<string, 
     return respond(200, { 'content-type': contentType, ...extraHeaders }, { bytes, overLimit: false })
 }
 
+const NOOP_SIGNER: WebBotAuthRequestSigner = { headersFor: () => ({}) }
 /** Everything public by default, so a test that cares about the policy says so. */
-const fetcher = (policy: Partial<RedirectPolicy> = {}): HttpImageFetcher =>
-    new HttpImageFetcher({ maxUrlLength: 2048, isPublicHost: () => true, ...policy })
+const fetcher = (
+    policy: Partial<RedirectPolicy> = {},
+    webBotAuthSigner: WebBotAuthRequestSigner = NOOP_SIGNER
+): HttpImageFetcher =>
+    new HttpImageFetcher({ maxUrlLength: 2048, isPublicHost: () => true, ...policy }, webBotAuthSigner)
 
 describe('HttpImageFetcher', () => {
     beforeEach(() => {
@@ -127,6 +132,25 @@ describe('HttpImageFetcher', () => {
 
         expect(result).toMatchObject({ outcome: 'ok', redirects: 1 })
         expect(fetchStreamedMock.mock.calls[1][0]).toBe('https://cdn.example.com/moved.png')
+    })
+
+    it('signs each redirect hop for its target URL', async () => {
+        fetchStreamedMock
+            .mockResolvedValueOnce(respond(302, { location: 'https://images.example.net/moved.png' }))
+            .mockResolvedValueOnce(image(PNG, 'image/png'))
+        const headersFor = jest
+            .fn()
+            .mockReturnValueOnce({ signature: 'first-hop-signature' })
+            .mockReturnValueOnce({ signature: 'second-hop-signature' })
+
+        await fetcher({}, { headersFor }).fetch('https://cdn.example.com/a.png', OPTIONS)
+
+        expect(headersFor.mock.calls).toEqual([
+            ['https://cdn.example.com/a.png'],
+            ['https://images.example.net/moved.png'],
+        ])
+        expect(fetchStreamedMock.mock.calls[0][1].headers).toMatchObject({ signature: 'first-hop-signature' })
+        expect(fetchStreamedMock.mock.calls[1][1].headers).toMatchObject({ signature: 'second-hop-signature' })
     })
 
     it.each([

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/image-fetcher.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/image-fetcher.ts
@@ -154,7 +154,7 @@ export class HttpImageFetcher implements ImageFetcher {
     }
 
     private async hop(url: string, timeoutMs: number, maxBytes: number): Promise<HopResult> {
-        const headers = { ...REQUEST_HEADERS, ...this.webBotAuthSigner.headersFor(url) }
+        const headers = { ...REQUEST_HEADERS, ...this.webBotAuthSigner.headersForGet(url) }
         const response = await fetchStreamed(url, { headers, timeoutMs })
         const status = response.status
 

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/image-fetcher.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/image-fetcher.ts
@@ -1,5 +1,7 @@
 import { InvalidRequestError, ResolutionError, SecureRequestError, fetchStreamed } from '~/common/utils/request'
 
+import { WebBotAuthRequestSigner } from './web-bot-auth'
+
 /**
  * The raster set the anonymizer keeps on a collected ref, so a fetched image and an inline one reach
  * the scrub lane as the same kind of thing.
@@ -88,15 +90,18 @@ const REQUEST_HEADERS: Record<string, string> = {
 const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308])
 
 /**
- * This sends no credential of any kind: no cookie, no `Authorization`, and no `Referer`. This lane
- * must not reach an image behind a login, and a `Referer` would tell the origin which page of the
- * customer's site the image sat on.
+ * This sends no user credential: no cookie, no `Authorization`, and no `Referer`. This lane must not
+ * reach an image behind a login, and a `Referer` would tell the origin which page of the customer's
+ * site the image sat on. Web Bot Auth identifies PostHog as the operator of the request.
  *
  * Every refusal is an outcome rather than a throw. This runs inside a Kafka batch, one URL at a
  * time, and a throw would abandon the URLs after it in the same batch.
  */
 export class HttpImageFetcher implements ImageFetcher {
-    constructor(private readonly policy: RedirectPolicy) {}
+    constructor(
+        private readonly policy: RedirectPolicy,
+        private readonly webBotAuthSigner: WebBotAuthRequestSigner
+    ) {}
 
     public async fetch(url: string, options: ImageFetchOptions): Promise<ImageFetchResult> {
         const deadlineMs = Date.now() + options.timeoutMs
@@ -149,7 +154,8 @@ export class HttpImageFetcher implements ImageFetcher {
     }
 
     private async hop(url: string, timeoutMs: number, maxBytes: number): Promise<HopResult> {
-        const response = await fetchStreamed(url, { headers: REQUEST_HEADERS, timeoutMs })
+        const headers = { ...REQUEST_HEADERS, ...this.webBotAuthSigner.headersFor(url) }
+        const response = await fetchStreamed(url, { headers, timeoutMs })
         const status = response.status
 
         if (REDIRECT_STATUSES.has(status)) {

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/web-bot-auth.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/web-bot-auth.test.ts
@@ -70,7 +70,7 @@ describe('Web Bot Auth request signing', () => {
         verifySignedHeaders(url, headers, keyPair.publicKey, 'sig1')
     })
 
-    it('signs with every configured key during rotation', () => {
+    it('signs with the first configured key during rotation', () => {
         const firstKeyPair = generateEd25519KeyPair()
         const secondKeyPair = generateEd25519KeyPair()
         const signer = createWebBotAuthRequestSigner(
@@ -81,12 +81,18 @@ describe('Web Bot Auth request signing', () => {
         const headers = signer.headersFor(url)
 
         verifySignedHeaders(url, headers, firstKeyPair.publicKey, 'sig1')
-        verifySignedHeaders(url, headers, secondKeyPair.publicKey, 'sig2')
+        expect(headers['signature-input']).not.toContain(keyId(secondKeyPair.publicKey))
+        expect(headers.signature).not.toContain('sig2=')
     })
 
     it.each([
         ['an empty value', '', 'must contain at least one'],
         ['a malformed key', 'not a PEM', 'entry 1 could not be loaded'],
+        [
+            'a malformed non-active key',
+            `${generateEd25519KeyPair().privateKeyPem},not a PEM`,
+            'entry 2 could not be loaded',
+        ],
         [
             'a non-Ed25519 key',
             generateKeyPairSync('rsa', { modulusLength: 2048 })

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/web-bot-auth.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/web-bot-auth.test.ts
@@ -23,7 +23,14 @@ function keyId(publicKey: KeyObject): string {
     return createHash('sha256').update(canonicalJwk).digest('base64url')
 }
 
-function verifySignedHeaders(url: string, headers: Record<string, string>, publicKey: KeyObject, label: string): void {
+function expectSignedHeadersToVerify(
+    method: string,
+    url: string,
+    headers: Record<string, string>,
+    publicKey: KeyObject,
+    label: string,
+    expectedResult = true
+): void {
     const signatureInput = headers['signature-input'].split(', ').find((member) => member.startsWith(`${label}=`))
     const signature = headers.signature.split(', ').find((member) => member.startsWith(`${label}=`))
     if (!signatureInput || !signature) {
@@ -32,7 +39,7 @@ function verifySignedHeaders(url: string, headers: Record<string, string>, publi
 
     const parameters = signatureInput.slice(label.length + 1)
     const parametersMatch = parameters.match(
-        /^\("@authority" "signature-agent"\);created=(\d+);keyid="([^"]+)";alg="ed25519";expires=(\d+);nonce="([^"]+)";tag="web-bot-auth"$/
+        /^\("@method" "@authority" "@target-uri" "signature-agent"\);created=(\d+);keyid="([^"]+)";alg="ed25519";expires=(\d+);nonce="([^"]+)";tag="web-bot-auth"$/
     )
     if (!parametersMatch) {
         throw new Error(`Invalid ${label} parameters`)
@@ -42,12 +49,16 @@ function verifySignedHeaders(url: string, headers: Record<string, string>, publi
     expect(Number(expires) - Number(created)).toBe(60)
     expect(Buffer.from(nonce, 'base64url')).toHaveLength(64)
 
+    const targetUrl = new URL(url)
+    targetUrl.hash = ''
     const signatureBase =
-        `"@authority": ${new URL(url).host}\n` +
+        `"@method": ${method}\n` +
+        `"@authority": ${targetUrl.host}\n` +
+        `"@target-uri": ${targetUrl.toString()}\n` +
         `"signature-agent": ${SIGNATURE_AGENT}\n` +
         `"@signature-params": ${parameters}`
     const signatureBytes = Buffer.from(signature.slice(`${label}=:`.length, -1), 'base64')
-    expect(verifySignature(null, Buffer.from(signatureBase), publicKey, signatureBytes)).toBe(true)
+    expect(verifySignature(null, Buffer.from(signatureBase), publicKey, signatureBytes)).toBe(expectedResult)
 }
 
 describe('Web Bot Auth request signing', () => {
@@ -64,10 +75,22 @@ describe('Web Bot Auth request signing', () => {
         const signer = createWebBotAuthRequestSigner(keyPair.privateKeyPem)
         const url = 'https://cdn.example.com/image.png?size=large'
 
-        const headers = signer.headersFor(url)
+        const headers = signer.headersForGet(url)
 
         expect(headers['signature-agent']).toBe(SIGNATURE_AGENT)
-        verifySignedHeaders(url, headers, keyPair.publicKey, 'sig1')
+        expectSignedHeadersToVerify('GET', url, headers, keyPair.publicKey, 'sig1')
+    })
+
+    it.each([
+        ['a different method', 'POST', 'https://cdn.example.com/image.png?size=large'],
+        ['a different path', 'GET', 'https://cdn.example.com/other.png?size=large'],
+        ['a different query', 'GET', 'https://cdn.example.com/image.png?size=small'],
+    ])('does not verify for %s', (_name, method, replayUrl) => {
+        const keyPair = generateEd25519KeyPair()
+        const signer = createWebBotAuthRequestSigner(keyPair.privateKeyPem)
+        const headers = signer.headersForGet('https://cdn.example.com/image.png?size=large')
+
+        expectSignedHeadersToVerify(method, replayUrl, headers, keyPair.publicKey, 'sig1', false)
     })
 
     it('signs with the first configured key during rotation', () => {
@@ -78,9 +101,9 @@ describe('Web Bot Auth request signing', () => {
         )
         const url = 'https://cdn.example.com/image.png'
 
-        const headers = signer.headersFor(url)
+        const headers = signer.headersForGet(url)
 
-        verifySignedHeaders(url, headers, firstKeyPair.publicKey, 'sig1')
+        expectSignedHeadersToVerify('GET', url, headers, firstKeyPair.publicKey, 'sig1')
         expect(headers['signature-input']).not.toContain(keyId(secondKeyPair.publicKey))
         expect(headers.signature).not.toContain('sig2=')
     })

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/web-bot-auth.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/web-bot-auth.test.ts
@@ -1,0 +1,100 @@
+import { KeyObject, createHash, generateKeyPairSync, verify as verifySignature } from 'node:crypto'
+
+import { createWebBotAuthRequestSigner } from './web-bot-auth'
+
+const SIGNATURE_AGENT = '"https://us.posthog.com/.well-known/http-message-signatures-directory"'
+
+type TestKeyPair = {
+    privateKeyPem: string
+    publicKey: KeyObject
+}
+
+function generateEd25519KeyPair(): TestKeyPair {
+    const { privateKey, publicKey } = generateKeyPairSync('ed25519')
+    return {
+        privateKeyPem: privateKey.export({ format: 'pem', type: 'pkcs8' }).toString(),
+        publicKey,
+    }
+}
+
+function keyId(publicKey: KeyObject): string {
+    const jwk = publicKey.export({ format: 'jwk' })
+    const canonicalJwk = JSON.stringify({ crv: jwk.crv, kty: jwk.kty, x: jwk.x })
+    return createHash('sha256').update(canonicalJwk).digest('base64url')
+}
+
+function verifySignedHeaders(url: string, headers: Record<string, string>, publicKey: KeyObject, label: string): void {
+    const signatureInput = headers['signature-input'].split(', ').find((member) => member.startsWith(`${label}=`))
+    const signature = headers.signature.split(', ').find((member) => member.startsWith(`${label}=`))
+    if (!signatureInput || !signature) {
+        throw new Error(`Missing ${label}`)
+    }
+
+    const parameters = signatureInput.slice(label.length + 1)
+    const parametersMatch = parameters.match(
+        /^\("@authority" "signature-agent"\);created=(\d+);keyid="([^"]+)";alg="ed25519";expires=(\d+);nonce="([^"]+)";tag="web-bot-auth"$/
+    )
+    if (!parametersMatch) {
+        throw new Error(`Invalid ${label} parameters`)
+    }
+    const [, created, actualKeyId, expires, nonce] = parametersMatch
+    expect(actualKeyId).toBe(keyId(publicKey))
+    expect(Number(expires) - Number(created)).toBe(60)
+    expect(Buffer.from(nonce, 'base64url')).toHaveLength(64)
+
+    const signatureBase =
+        `"@authority": ${new URL(url).host}\n` +
+        `"signature-agent": ${SIGNATURE_AGENT}\n` +
+        `"@signature-params": ${parameters}`
+    const signatureBytes = Buffer.from(signature.slice(`${label}=:`.length, -1), 'base64')
+    expect(verifySignature(null, Buffer.from(signatureBase), publicKey, signatureBytes)).toBe(true)
+}
+
+describe('Web Bot Auth request signing', () => {
+    beforeEach(() => {
+        jest.useFakeTimers().setSystemTime(new Date('2026-08-19T08:00:00Z'))
+    })
+
+    afterEach(() => {
+        jest.useRealTimers()
+    })
+
+    it('creates a Cloudflare-compatible signature with current protocol parameters', () => {
+        const keyPair = generateEd25519KeyPair()
+        const signer = createWebBotAuthRequestSigner(keyPair.privateKeyPem)
+        const url = 'https://cdn.example.com/image.png?size=large'
+
+        const headers = signer.headersFor(url)
+
+        expect(headers['signature-agent']).toBe(SIGNATURE_AGENT)
+        verifySignedHeaders(url, headers, keyPair.publicKey, 'sig1')
+    })
+
+    it('signs with every configured key during rotation', () => {
+        const firstKeyPair = generateEd25519KeyPair()
+        const secondKeyPair = generateEd25519KeyPair()
+        const signer = createWebBotAuthRequestSigner(
+            `${firstKeyPair.privateKeyPem},${secondKeyPair.privateKeyPem.replaceAll('\n', '\\n')}`
+        )
+        const url = 'https://cdn.example.com/image.png'
+
+        const headers = signer.headersFor(url)
+
+        verifySignedHeaders(url, headers, firstKeyPair.publicKey, 'sig1')
+        verifySignedHeaders(url, headers, secondKeyPair.publicKey, 'sig2')
+    })
+
+    it.each([
+        ['an empty value', '', 'must contain at least one'],
+        ['a malformed key', 'not a PEM', 'entry 1 could not be loaded'],
+        [
+            'a non-Ed25519 key',
+            generateKeyPairSync('rsa', { modulusLength: 2048 })
+                .privateKey.export({ format: 'pem', type: 'pkcs8' })
+                .toString(),
+            'entry 1 is not an Ed25519 private key',
+        ],
+    ])('rejects %s', (_name, privateKeyPems, expectedError) => {
+        expect(() => createWebBotAuthRequestSigner(privateKeyPems)).toThrow(expectedError)
+    })
+})

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/web-bot-auth.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/web-bot-auth.ts
@@ -3,6 +3,7 @@ import { KeyObject, createHash, createPrivateKey, createPublicKey, randomBytes, 
 const SIGNATURE_AGENT_URL = 'https://us.posthog.com/.well-known/http-message-signatures-directory'
 const SIGNATURE_AGENT_HEADER = JSON.stringify(SIGNATURE_AGENT_URL)
 const SIGNATURE_LIFETIME_SECONDS = 60
+const REQUEST_METHOD = 'GET'
 
 type SigningKey = {
     privateKey: KeyObject
@@ -10,7 +11,7 @@ type SigningKey = {
 }
 
 export interface WebBotAuthRequestSigner {
-    headersFor(url: string): Record<string, string>
+    headersForGet(url: string): Record<string, string>
 }
 
 export function createWebBotAuthRequestSigner(commaSeparatedPrivateKeyPems: string): WebBotAuthRequestSigner {
@@ -26,16 +27,21 @@ export function createWebBotAuthRequestSigner(commaSeparatedPrivateKeyPems: stri
 class Ed25519WebBotAuthRequestSigner implements WebBotAuthRequestSigner {
     constructor(private readonly signingKey: SigningKey) {}
 
-    public headersFor(url: string): Record<string, string> {
-        const authority = new URL(url).host
+    public headersForGet(url: string): Record<string, string> {
+        const targetUrl = new URL(url)
+        targetUrl.hash = ''
+        const authority = targetUrl.host
+        const targetUri = targetUrl.toString()
         const created = Math.floor(Date.now() / 1000)
         const expires = created + SIGNATURE_LIFETIME_SECONDS
         const nonce = randomBytes(64).toString('base64url')
         const parameters =
-            `("@authority" "signature-agent");created=${created};keyid="${this.signingKey.keyId}";` +
+            `("@method" "@authority" "@target-uri" "signature-agent");created=${created};keyid="${this.signingKey.keyId}";` +
             `alg="ed25519";expires=${expires};nonce="${nonce}";tag="web-bot-auth"`
         const signatureBase =
+            `"@method": ${REQUEST_METHOD}\n` +
             `"@authority": ${authority}\n` +
+            `"@target-uri": ${targetUri}\n` +
             `"signature-agent": ${SIGNATURE_AGENT_HEADER}\n` +
             `"@signature-params": ${parameters}`
 

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/web-bot-auth.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/web-bot-auth.ts
@@ -1,0 +1,80 @@
+import { KeyObject, createHash, createPrivateKey, createPublicKey, randomBytes, sign } from 'node:crypto'
+
+const SIGNATURE_AGENT_URL = 'https://us.posthog.com/.well-known/http-message-signatures-directory'
+const SIGNATURE_AGENT_HEADER = JSON.stringify(SIGNATURE_AGENT_URL)
+const SIGNATURE_LIFETIME_SECONDS = 60
+
+type SigningKey = {
+    privateKey: KeyObject
+    keyId: string
+}
+
+export interface WebBotAuthRequestSigner {
+    headersFor(url: string): Record<string, string>
+}
+
+export function createWebBotAuthRequestSigner(commaSeparatedPrivateKeyPems: string): WebBotAuthRequestSigner {
+    const privateKeyPems = commaSeparatedPrivateKeyPems.split(',')
+    if (privateKeyPems.length === 1 && privateKeyPems[0].trim() === '') {
+        throw new Error('WEB_BOT_AUTH_PRIVATE_KEYS must contain at least one Ed25519 private key')
+    }
+
+    const signingKeys = privateKeyPems.map((privateKeyPem, index) => loadSigningKey(privateKeyPem, index + 1))
+    return new Ed25519WebBotAuthRequestSigner(signingKeys)
+}
+
+class Ed25519WebBotAuthRequestSigner implements WebBotAuthRequestSigner {
+    constructor(private readonly signingKeys: SigningKey[]) {}
+
+    public headersFor(url: string): Record<string, string> {
+        const authority = new URL(url).host
+        const created = Math.floor(Date.now() / 1000)
+        const expires = created + SIGNATURE_LIFETIME_SECONDS
+        const signatureInputs: string[] = []
+        const signatures: string[] = []
+
+        for (const [index, signingKey] of this.signingKeys.entries()) {
+            const label = `sig${index + 1}`
+            const nonce = randomBytes(64).toString('base64url')
+            const parameters =
+                `("@authority" "signature-agent");created=${created};keyid="${signingKey.keyId}";` +
+                `alg="ed25519";expires=${expires};nonce="${nonce}";tag="web-bot-auth"`
+            const signatureBase =
+                `"@authority": ${authority}\n` +
+                `"signature-agent": ${SIGNATURE_AGENT_HEADER}\n` +
+                `"@signature-params": ${parameters}`
+
+            signatureInputs.push(`${label}=${parameters}`)
+            signatures.push(
+                `${label}=:${sign(null, Buffer.from(signatureBase), signingKey.privateKey).toString('base64')}:`
+            )
+        }
+
+        return {
+            // Cloudflare rejects the dictionary form from newer drafts, so use the compatible structured string.
+            'signature-agent': SIGNATURE_AGENT_HEADER,
+            'signature-input': signatureInputs.join(', '),
+            signature: signatures.join(', '),
+        }
+    }
+}
+
+function loadSigningKey(privateKeyPem: string, keyIndex: number): SigningKey {
+    let privateKey: KeyObject
+    try {
+        privateKey = createPrivateKey(privateKeyPem.trim().replaceAll('\\n', '\n'))
+    } catch {
+        throw new Error(`WEB_BOT_AUTH_PRIVATE_KEYS entry ${keyIndex} could not be loaded`)
+    }
+    if (privateKey.asymmetricKeyType !== 'ed25519') {
+        throw new Error(`WEB_BOT_AUTH_PRIVATE_KEYS entry ${keyIndex} is not an Ed25519 private key`)
+    }
+
+    const publicJwk = createPublicKey(privateKey).export({ format: 'jwk' })
+    if (publicJwk.kty !== 'OKP' || publicJwk.crv !== 'Ed25519' || !publicJwk.x) {
+        throw new Error(`WEB_BOT_AUTH_PRIVATE_KEYS entry ${keyIndex} has an invalid public key`)
+    }
+    const canonicalJwk = JSON.stringify({ crv: publicJwk.crv, kty: publicJwk.kty, x: publicJwk.x })
+    const keyId = createHash('sha256').update(canonicalJwk).digest('base64url')
+    return { privateKey, keyId }
+}

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/web-bot-auth.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/web-bot-auth.ts
@@ -20,41 +20,30 @@ export function createWebBotAuthRequestSigner(commaSeparatedPrivateKeyPems: stri
     }
 
     const signingKeys = privateKeyPems.map((privateKeyPem, index) => loadSigningKey(privateKeyPem, index + 1))
-    return new Ed25519WebBotAuthRequestSigner(signingKeys)
+    return new Ed25519WebBotAuthRequestSigner(signingKeys[0])
 }
 
 class Ed25519WebBotAuthRequestSigner implements WebBotAuthRequestSigner {
-    constructor(private readonly signingKeys: SigningKey[]) {}
+    constructor(private readonly signingKey: SigningKey) {}
 
     public headersFor(url: string): Record<string, string> {
         const authority = new URL(url).host
         const created = Math.floor(Date.now() / 1000)
         const expires = created + SIGNATURE_LIFETIME_SECONDS
-        const signatureInputs: string[] = []
-        const signatures: string[] = []
-
-        for (const [index, signingKey] of this.signingKeys.entries()) {
-            const label = `sig${index + 1}`
-            const nonce = randomBytes(64).toString('base64url')
-            const parameters =
-                `("@authority" "signature-agent");created=${created};keyid="${signingKey.keyId}";` +
-                `alg="ed25519";expires=${expires};nonce="${nonce}";tag="web-bot-auth"`
-            const signatureBase =
-                `"@authority": ${authority}\n` +
-                `"signature-agent": ${SIGNATURE_AGENT_HEADER}\n` +
-                `"@signature-params": ${parameters}`
-
-            signatureInputs.push(`${label}=${parameters}`)
-            signatures.push(
-                `${label}=:${sign(null, Buffer.from(signatureBase), signingKey.privateKey).toString('base64')}:`
-            )
-        }
+        const nonce = randomBytes(64).toString('base64url')
+        const parameters =
+            `("@authority" "signature-agent");created=${created};keyid="${this.signingKey.keyId}";` +
+            `alg="ed25519";expires=${expires};nonce="${nonce}";tag="web-bot-auth"`
+        const signatureBase =
+            `"@authority": ${authority}\n` +
+            `"signature-agent": ${SIGNATURE_AGENT_HEADER}\n` +
+            `"@signature-params": ${parameters}`
 
         return {
             // Cloudflare rejects the dictionary form from newer drafts, so use the compatible structured string.
             'signature-agent': SIGNATURE_AGENT_HEADER,
-            'signature-input': signatureInputs.join(', '),
-            signature: signatures.join(', '),
+            'signature-input': `sig1=${parameters}`,
+            signature: `sig1=:${sign(null, Buffer.from(signatureBase), this.signingKey.privateKey).toString('base64')}:`,
         }
     }
 }

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/config.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/config.ts
@@ -69,6 +69,9 @@ export type MlMirrorConfig = {
      */
     SESSION_RECORDING_ML_URL_PRODUCER_ENABLED: boolean
 
+    // US-only, PEM, multiple keys allowed (comma-separated)
+    WEB_BOT_AUTH_PRIVATE_KEYS: string
+
     /**
      * While true the fetch lane sends no outbound request. It reads the topic, dedupes, writes the
      * ledger and reports the metrics, which is the phase 0 measurement: how many requests the
@@ -242,6 +245,7 @@ export function getDefaultMlMirrorConfig(): MlMirrorConfig {
         SESSION_RECORDING_ML_IMAGE_SCRUB_PRODUCER_ENABLED: false,
         SESSION_RECORDING_ML_URL_COLLECTION_ENABLED: false,
         SESSION_RECORDING_ML_URL_PRODUCER_ENABLED: false,
+        WEB_BOT_AUTH_PRIVATE_KEYS: '',
         SESSION_RECORDING_ML_IMAGE_FETCH_DRY_RUN: true,
         SESSION_RECORDING_ML_IMAGE_FETCH_GROUP_ID: 'session-replay-ml-image-fetch',
         SESSION_RECORDING_ML_IMAGE_FETCH_BATCH_SIZE: 500,

--- a/nodejs/src/servers/ingestion-session-replay-ml-image-fetch-server.ts
+++ b/nodejs/src/servers/ingestion-session-replay-ml-image-fetch-server.ts
@@ -18,6 +18,7 @@ import { HostBudget } from '~/ingestion/pipelines/sessionreplay/ml-mirror-image-
 import { HttpImageFetcher } from '~/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/image-fetcher'
 import { assertUrlPolicyLoaded } from '~/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/politeness-key'
 import { UrlFetchConsumer } from '~/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/url-fetch-consumer'
+import { createWebBotAuthRequestSigner } from '~/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/web-bot-auth'
 import { resolveMlMirrorRedisConnection } from '~/ingestion/pipelines/sessionreplay/ml-mirror/config'
 import { createProducerRegistry } from '~/ingestion/pipelines/sessionreplay/outputs/producer-registry'
 import { INGESTION_SESSIONREPLAY_ML_IMAGE_FETCH_PRODUCER } from '~/ingestion/pipelines/sessionreplay/shared/outputs/producer-config'
@@ -72,6 +73,7 @@ export function buildFetchRunner(
     config: IngestionSessionReplayMlMirrorServerConfig,
     publisher: FrontierPublisher
 ): FetchRunner {
+    const webBotAuthSigner = createWebBotAuthRequestSigner(config.WEB_BOT_AUTH_PRIVATE_KEYS)
     const budget = new HostBudget({
         requestsPerSecond: config.SESSION_RECORDING_ML_IMAGE_FETCH_REQUESTS_PER_SECOND,
         burst: config.SESSION_RECORDING_ML_IMAGE_FETCH_BURST,
@@ -82,12 +84,15 @@ export function buildFetchRunner(
         maxTrackedDomains: config.SESSION_RECORDING_ML_IMAGE_FETCH_MAX_TRACKED_DOMAINS,
     })
     return new FetchRunner(
-        new HttpImageFetcher({
-            maxUrlLength: MAX_REDIRECT_URL_LENGTH,
-            // The crate's rule, so a redirect target meets the check the collector already applied
-            // to the first candidate rather than a second answer to the same question.
-            isPublicHost: (host) => getAnonymizer().isPublicHost(host),
-        }),
+        new HttpImageFetcher(
+            {
+                maxUrlLength: MAX_REDIRECT_URL_LENGTH,
+                // The crate's rule, so a redirect target meets the check the collector already applied
+                // to the first candidate rather than a second answer to the same question.
+                isPublicHost: (host) => getAnonymizer().isPublicHost(host),
+            },
+            webBotAuthSigner
+        ),
         budget,
         {
             maxConcurrentPerDomain: config.SESSION_RECORDING_ML_IMAGE_FETCH_MAX_CONCURRENT_PER_DOMAIN,


### PR DESCRIPTION
## Problem

Sites that verify automated traffic cannot distinguish the PostHog image fetch lane from an impersonator.

[#83235](https://github.com/PostHog/posthog/pull/83235) hosts the public key directory, but it leaves outbound image requests unsigned.

## Changes

- The image fetcher signs each request with Ed25519 Web Bot Auth headers.
- Each redirect hop receives a new signature for its GET method, authority, and full target URI.
- The first configured key signs each request during rotation.
- Each signature expires after one minute and includes a unique 64-byte nonce.
- The fetch runner rejects empty, malformed, encrypted, or non-Ed25519 keys.
- Cloudflare receives its compatible quoted `Signature-Agent` value plus the current protocol parameters.

### Before

```mermaid
flowchart LR
    F{{"Image fetch lane"}} -->|"Unsigned HTTPS GET"| O["Image origin"]
    D["Key directory from #83235"] -. "Not referenced" .-> F
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class F phBlue;
    class O phRed;
    class D phGray;
```

### After

```mermaid
flowchart LR
    K["Configured PEM keys"] --> V["Validate every key"]
    V --> S["Sign with the first key"]
    F{{"Image fetch lane"}} --> S
    S -->|"Signed HTTPS GET"| O["Image origin"]
    O -. "Verify public key" .-> D["PostHog key directory"]
    O -->|"Redirect"| S
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class F,V,S phBlue;
    class O,D phRed;
    class K phGray;
```

## How did you test this code?

- Focused Jest tests verify the wire format, request scope, signatures, key rotation, PEM parsing, and redirect re-signing.
- ESLint checked every changed TypeScript file.
- The Node.js TypeScript check passed after building the required workspace type packages.
- [Cloudflare live validation](https://crawltest.com/cdn-cgi/web-bot-auth) returned the documented unknown-key `401` for an ephemeral signature covering `@method`, `@authority`, and `@target-uri`.
- Not checked: a deployed request with the production key. The image-fetch deployment remains in dry-run mode.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- The internal guide now covers outbound signing, rotation, redirect handling, and protocol compatibility.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented and reviewed the signing boundary. The signature covers the GET method and full target URI. The request keeps Cloudflare's compatible quoted header.

Skills invoked: `/ingestion-pipeline-doctor-nodejs`, `/security-audit`, `/writing-tests`, `/writing-code-comments`, `/writing-user-facing-copy`, `/writing-pr-descriptions`, `/stacking-prs`, and Simplified Technical English.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*