### PR TITLE
feat(replay): prioritize on-demand vision observations

### DIFF
--- a/products/replay_vision/backend/api/prompt_suggestions.py
+++ b/products/replay_vision/backend/api/prompt_suggestions.py
@@ -49,8 +49,8 @@ from products.replay_vision.backend.quota import compute_scanner_budget, quota_s
 from products.replay_vision.backend.scanner_config import scanner_config_error
 from products.replay_vision.backend.temporal.constants import (
     EVALUATE_PROMPT_SUGGESTION_WORKFLOW_NAME,
-    ON_DEMAND_PRIORITY,
     build_evaluate_prompt_suggestion_workflow_id,
+    on_demand_priority,
 )
 from products.replay_vision.backend.temporal.evaluation_types import EvaluatePromptSuggestionInputs
 from products.replay_vision.backend.temporal.metrics import record_scanner_limit_reached
@@ -480,7 +480,7 @@ class ReplayScannerPromptSuggestionViewSet(
                 task_queue=settings.REPLAY_VISION_TASK_QUEUE,
                 execution_timeout=EVALUATE_PROMPT_SUGGESTION_EXECUTION_TIMEOUT,
                 # A user waiting on "test this prompt" ranks with the other user-initiated starts.
-                priority=ON_DEMAND_PRIORITY,
+                priority=on_demand_priority(scanner.team_id),
                 search_attributes=TypedSearchAttributes(
                     search_attributes=[SearchAttributePair(key=POSTHOG_TEAM_ID_KEY, value=scanner.team_id)]
                 ),

--- a/products/replay_vision/backend/api/prompt_suggestions.py
+++ b/products/replay_vision/backend/api/prompt_suggestions.py
@@ -49,6 +49,7 @@ from products.replay_vision.backend.quota import compute_scanner_budget, quota_s
 from products.replay_vision.backend.scanner_config import scanner_config_error
 from products.replay_vision.backend.temporal.constants import (
     EVALUATE_PROMPT_SUGGESTION_WORKFLOW_NAME,
+    ON_DEMAND_PRIORITY,
     build_evaluate_prompt_suggestion_workflow_id,
 )
 from products.replay_vision.backend.temporal.evaluation_types import EvaluatePromptSuggestionInputs
@@ -478,6 +479,8 @@ class ReplayScannerPromptSuggestionViewSet(
                 id=build_evaluate_prompt_suggestion_workflow_id(suggestion.id),
                 task_queue=settings.REPLAY_VISION_TASK_QUEUE,
                 execution_timeout=EVALUATE_PROMPT_SUGGESTION_EXECUTION_TIMEOUT,
+                # A user waiting on "test this prompt" ranks with the other user-initiated starts.
+                priority=ON_DEMAND_PRIORITY,
                 search_attributes=TypedSearchAttributes(
                     search_attributes=[SearchAttributePair(key=POSTHOG_TEAM_ID_KEY, value=scanner.team_id)]
                 ),

--- a/products/replay_vision/backend/api/trigger.py
+++ b/products/replay_vision/backend/api/trigger.py
@@ -9,7 +9,7 @@ from django.conf import settings
 import structlog
 from asgiref.sync import async_to_sync
 from rest_framework.exceptions import Throttled
-from temporalio.common import Priority, SearchAttributePair, TypedSearchAttributes
+from temporalio.common import SearchAttributePair, TypedSearchAttributes
 from temporalio.exceptions import WorkflowAlreadyStartedError
 
 from posthog.exceptions import QuotaLimitExceeded
@@ -38,7 +38,7 @@ from products.replay_vision.backend.temporal.constants import (
     APPLY_SCANNER_WORKFLOW_NAME,
     MAX_IN_FLIGHT_APPLIES_PER_SCANNER,
     MAX_IN_FLIGHT_APPLIES_PER_TEAM,
-    ON_DEMAND_PRIORITY_KEY,
+    ON_DEMAND_PRIORITY,
     PROCESS_VISION_ACTION_EXECUTION_TIMEOUT,
     PROCESS_VISION_ACTION_WORKFLOW_NAME,
     build_apply_scanner_workflow_id,
@@ -199,7 +199,7 @@ def start_apply_scanner_workflow(
             task_queue=settings.REPLAY_VISION_TASK_QUEUE,
             execution_timeout=APPLY_SCANNER_EXECUTION_TIMEOUT,
             # Every caller of this trigger is user-initiated (observe, bulk, inline, retry), so all runs qualify.
-            priority=Priority(priority_key=ON_DEMAND_PRIORITY_KEY),
+            priority=ON_DEMAND_PRIORITY,
             # Stamp the scanner id so on-demand applies count toward the sweep's in-flight cap.
             search_attributes=TypedSearchAttributes(
                 search_attributes=[
@@ -262,7 +262,7 @@ def start_process_vision_action_workflow(
             id=workflow_id,
             task_queue=settings.REPLAY_VISION_TASK_QUEUE,
             execution_timeout=PROCESS_VISION_ACTION_EXECUTION_TIMEOUT,
-            priority=Priority(priority_key=ON_DEMAND_PRIORITY_KEY),
+            priority=ON_DEMAND_PRIORITY,
         )
     except WorkflowAlreadyStartedError as exc:
         if exc.workflow_id != workflow_id:

--- a/products/replay_vision/backend/api/trigger.py
+++ b/products/replay_vision/backend/api/trigger.py
@@ -38,11 +38,11 @@ from products.replay_vision.backend.temporal.constants import (
     APPLY_SCANNER_WORKFLOW_NAME,
     MAX_IN_FLIGHT_APPLIES_PER_SCANNER,
     MAX_IN_FLIGHT_APPLIES_PER_TEAM,
-    ON_DEMAND_PRIORITY,
     PROCESS_VISION_ACTION_EXECUTION_TIMEOUT,
     PROCESS_VISION_ACTION_WORKFLOW_NAME,
     build_apply_scanner_workflow_id,
     build_process_vision_action_workflow_id,
+    on_demand_priority,
 )
 from products.replay_vision.backend.temporal.metrics import record_scanner_limit_reached
 from products.replay_vision.backend.temporal.types import ApplyScannerInputs
@@ -199,7 +199,7 @@ def start_apply_scanner_workflow(
             task_queue=settings.REPLAY_VISION_TASK_QUEUE,
             execution_timeout=APPLY_SCANNER_EXECUTION_TIMEOUT,
             # Every caller of this trigger is user-initiated (observe, bulk, inline, retry), so all runs qualify.
-            priority=ON_DEMAND_PRIORITY,
+            priority=on_demand_priority(scanner.team_id),
             # Stamp the scanner id so on-demand applies count toward the sweep's in-flight cap.
             search_attributes=TypedSearchAttributes(
                 search_attributes=[
@@ -262,7 +262,7 @@ def start_process_vision_action_workflow(
             id=workflow_id,
             task_queue=settings.REPLAY_VISION_TASK_QUEUE,
             execution_timeout=PROCESS_VISION_ACTION_EXECUTION_TIMEOUT,
-            priority=ON_DEMAND_PRIORITY,
+            priority=on_demand_priority(team_id),
         )
     except WorkflowAlreadyStartedError as exc:
         if exc.workflow_id != workflow_id:

--- a/products/replay_vision/backend/api/trigger.py
+++ b/products/replay_vision/backend/api/trigger.py
@@ -9,7 +9,7 @@ from django.conf import settings
 import structlog
 from asgiref.sync import async_to_sync
 from rest_framework.exceptions import Throttled
-from temporalio.common import SearchAttributePair, TypedSearchAttributes
+from temporalio.common import Priority, SearchAttributePair, TypedSearchAttributes
 from temporalio.exceptions import WorkflowAlreadyStartedError
 
 from posthog.exceptions import QuotaLimitExceeded
@@ -38,6 +38,7 @@ from products.replay_vision.backend.temporal.constants import (
     APPLY_SCANNER_WORKFLOW_NAME,
     MAX_IN_FLIGHT_APPLIES_PER_SCANNER,
     MAX_IN_FLIGHT_APPLIES_PER_TEAM,
+    ON_DEMAND_PRIORITY_KEY,
     PROCESS_VISION_ACTION_EXECUTION_TIMEOUT,
     PROCESS_VISION_ACTION_WORKFLOW_NAME,
     build_apply_scanner_workflow_id,
@@ -197,6 +198,8 @@ def start_apply_scanner_workflow(
             id=workflow_id,
             task_queue=settings.REPLAY_VISION_TASK_QUEUE,
             execution_timeout=APPLY_SCANNER_EXECUTION_TIMEOUT,
+            # Every caller of this trigger is user-initiated (observe, bulk, inline, retry), so all runs qualify.
+            priority=Priority(priority_key=ON_DEMAND_PRIORITY_KEY),
             # Stamp the scanner id so on-demand applies count toward the sweep's in-flight cap.
             search_attributes=TypedSearchAttributes(
                 search_attributes=[
@@ -259,6 +262,7 @@ def start_process_vision_action_workflow(
             id=workflow_id,
             task_queue=settings.REPLAY_VISION_TASK_QUEUE,
             execution_timeout=PROCESS_VISION_ACTION_EXECUTION_TIMEOUT,
+            priority=Priority(priority_key=ON_DEMAND_PRIORITY_KEY),
         )
     except WorkflowAlreadyStartedError as exc:
         if exc.workflow_id != workflow_id:

--- a/products/replay_vision/backend/enqueue_claims.py
+++ b/products/replay_vision/backend/enqueue_claims.py
@@ -17,6 +17,8 @@ from products.replay_vision.backend.temporal.constants import (
     MAX_IN_FLIGHT_APPLIES_PER_BACKFILL,
     MAX_IN_FLIGHT_APPLIES_PER_SCANNER,
     MAX_IN_FLIGHT_APPLIES_PER_TEAM,
+    ON_DEMAND_RESERVED_SCANNER_SLOTS,
+    ON_DEMAND_RESERVED_TEAM_SLOTS,
 )
 from products.replay_vision.backend.temporal.metrics import record_enqueue_claim_failure
 
@@ -82,16 +84,20 @@ def try_claim_enqueue_slot(
     scanner_in_flight_rows: int,
     backfill_id: UUID | None = None,
     backfill_in_flight_rows: int = 0,
+    scheduled: bool = False,
 ) -> bool:
     """Atomically claim one enqueue slot against every in-flight cap; True when the scan may start.
 
     Passing `backfill_id` also holds the claim against that backfill's sub-cap, so successive ticks
-    see the slots an earlier tick took before its children persisted their rows.
+    see the slots an earlier tick took before its children persisted their rows. `scheduled` claims
+    stop at the reserved ceilings, so racing scheduled dispatchers cannot eat the on-demand reserve.
     """
+    team_cap = MAX_IN_FLIGHT_APPLIES_PER_TEAM - (ON_DEMAND_RESERVED_TEAM_SLOTS if scheduled else 0)
+    scanner_cap = MAX_IN_FLIGHT_APPLIES_PER_SCANNER - (ON_DEMAND_RESERVED_SCANNER_SLOTS if scheduled else 0)
     keys = [_team_key(team_id), _scanner_key(scanner_id)]
     allowances = [
-        MAX_IN_FLIGHT_APPLIES_PER_TEAM - team_in_flight_rows,
-        MAX_IN_FLIGHT_APPLIES_PER_SCANNER - scanner_in_flight_rows,
+        team_cap - team_in_flight_rows,
+        scanner_cap - scanner_in_flight_rows,
     ]
     if backfill_id is not None:
         keys.append(_backfill_key(backfill_id))
@@ -122,6 +128,7 @@ def claim_enqueue_slot_prefix(
     scanner_in_flight_rows: int,
     backfill_id: UUID | None = None,
     backfill_in_flight_rows: int = 0,
+    scheduled: bool = False,
 ) -> int:
     """Claim slots for an ordered batch, returning how many leading ids were admitted.
 
@@ -142,6 +149,7 @@ def claim_enqueue_slot_prefix(
             scanner_in_flight_rows=scanner_in_flight_rows,
             backfill_id=backfill_id,
             backfill_in_flight_rows=backfill_in_flight_rows,
+            scheduled=scheduled,
         ):
             return admitted
     return len(workflow_ids)

--- a/products/replay_vision/backend/temporal/activities/backfill.py
+++ b/products/replay_vision/backend/temporal/activities/backfill.py
@@ -221,6 +221,7 @@ def find_backfill_candidates_activity(inputs: FindBackfillCandidatesInputs) -> F
         scanner_in_flight_rows=rows["scanner"],
         backfill_id=backfill.id,
         backfill_in_flight_rows=rows["backfill"],
+        scheduled=True,
     )
 
     # The cursor may step over an already-observed session, because nothing will ever need doing for

--- a/products/replay_vision/backend/temporal/constants.py
+++ b/products/replay_vision/backend/temporal/constants.py
@@ -1,6 +1,8 @@
 import datetime as dt
 from uuid import UUID
 
+from temporalio.common import Priority
+
 APPLY_SCANNER_WORKFLOW_NAME = "replay-vision-apply-scanner"
 SWEEP_SCANNER_WORKFLOW_NAME = "replay-vision-sweep-scanner"
 
@@ -12,10 +14,10 @@ SWEEP_SCANNER_WORKFLOW_NAME = "replay-vision-sweep-scanner"
 # row is stranded in `running` until the reaper's cutoff below.
 APPLY_SCANNER_EXECUTION_TIMEOUT = dt.timedelta(minutes=110)
 
-# Task priority for user-initiated applies (1 = highest of 5, default 3): Temporal inherits it into the
+# Task priority for user-initiated starts (1 = highest of 5, default 3): Temporal inherits it into the
 # rasterize-recording child and its rasterization-queue activity, so on-demand runs jump the sweep and
 # backfill backlog on every queue they touch.
-ON_DEMAND_PRIORITY_KEY = 1
+ON_DEMAND_PRIORITY = Priority(priority_key=1)
 
 # A pending/running row is created inside its workflow, and the workflow cannot outlive its execution timeout
 # (which spans Temporal-level retries), so any such row older than the timeout plus a margin for clock skew
@@ -141,19 +143,17 @@ ON_DEMAND_RESERVED_SCANNER_SLOTS = 25
 ON_DEMAND_RESERVED_TEAM_SLOTS = 50
 
 
-def in_flight_headroom(scanner_in_flight: int, team_in_flight: int, *, reserve_for_on_demand: bool = True) -> int:
-    """Dispatch headroom for a sweep tick: the tighter of the per-scanner and per-team caps.
+def in_flight_headroom(scanner_in_flight: int, team_in_flight: int) -> int:
+    """Scheduled-dispatch headroom for a sweep or backfill tick: the tighter of the per-scanner and
+    per-team caps, minus the slots reserved for on-demand admission.
 
     The sweep workflow throttles on this and the count activity records the throttled
     metric from it, so the decision and the metric can't drift apart. Pure, so it is safe
-    inside deterministic workflow code. `reserve_for_on_demand=False` is only for replaying
-    sweep histories recorded before the reserve existed.
+    inside deterministic workflow code.
     """
-    scanner_cap = MAX_IN_FLIGHT_APPLIES_PER_SCANNER - (ON_DEMAND_RESERVED_SCANNER_SLOTS if reserve_for_on_demand else 0)
-    team_cap = MAX_IN_FLIGHT_APPLIES_PER_TEAM - (ON_DEMAND_RESERVED_TEAM_SLOTS if reserve_for_on_demand else 0)
     return min(
-        scanner_cap - scanner_in_flight,
-        team_cap - team_in_flight,
+        MAX_IN_FLIGHT_APPLIES_PER_SCANNER - ON_DEMAND_RESERVED_SCANNER_SLOTS - scanner_in_flight,
+        MAX_IN_FLIGHT_APPLIES_PER_TEAM - ON_DEMAND_RESERVED_TEAM_SLOTS - team_in_flight,
     )
 
 

--- a/products/replay_vision/backend/temporal/constants.py
+++ b/products/replay_vision/backend/temporal/constants.py
@@ -14,10 +14,15 @@ SWEEP_SCANNER_WORKFLOW_NAME = "replay-vision-sweep-scanner"
 # row is stranded in `running` until the reaper's cutoff below.
 APPLY_SCANNER_EXECUTION_TIMEOUT = dt.timedelta(minutes=110)
 
-# Task priority for user-initiated starts (1 = highest of 5, default 3): Temporal inherits it into the
-# rasterize-recording child and its rasterization-queue activity, so on-demand runs jump the sweep and
-# backfill backlog on every queue they touch.
-ON_DEMAND_PRIORITY = Priority(priority_key=1)
+
+def on_demand_priority(team_id: int) -> Priority:
+    """Task priority for user-initiated starts (1 = highest of 5, default 3): Temporal inherits it into
+    the rasterize-recording child and its rasterization-queue activity, so on-demand runs jump the sweep
+    and backfill backlog on every queue they touch. The fairness key shares priority-1 dispatch across
+    teams, so one team's burst cannot starve another team's on-demand work.
+    """
+    return Priority(priority_key=1, fairness_key=str(team_id))
+
 
 # A pending/running row is created inside its workflow, and the workflow cannot outlive its execution timeout
 # (which spans Temporal-level retries), so any such row older than the timeout plus a margin for clock skew

--- a/products/replay_vision/backend/temporal/constants.py
+++ b/products/replay_vision/backend/temporal/constants.py
@@ -12,6 +12,11 @@ SWEEP_SCANNER_WORKFLOW_NAME = "replay-vision-sweep-scanner"
 # row is stranded in `running` until the reaper's cutoff below.
 APPLY_SCANNER_EXECUTION_TIMEOUT = dt.timedelta(minutes=110)
 
+# Task priority for user-initiated applies (1 = highest of 5, default 3): Temporal inherits it into the
+# rasterize-recording child and its rasterization-queue activity, so on-demand runs jump the sweep and
+# backfill backlog on every queue they touch.
+ON_DEMAND_PRIORITY_KEY = 1
+
 # A pending/running row is created inside its workflow, and the workflow cannot outlive its execution timeout
 # (which spans Temporal-level retries), so any such row older than the timeout plus a margin for clock skew
 # and late state writes is provably orphaned.
@@ -130,16 +135,25 @@ COUNT_IN_FLIGHT_APPLIES_TIMEOUT = dt.timedelta(seconds=30)
 CHECK_SCANNER_BUDGET_TIMEOUT = dt.timedelta(seconds=30)
 
 
-def in_flight_headroom(scanner_in_flight: int, team_in_flight: int) -> int:
+# Slots at each cap that scheduled dispatch (sweep, backfill) must leave free, so a user-initiated
+# observe still admits when scheduled work is saturated; on-demand admission checks the full caps.
+ON_DEMAND_RESERVED_SCANNER_SLOTS = 25
+ON_DEMAND_RESERVED_TEAM_SLOTS = 50
+
+
+def in_flight_headroom(scanner_in_flight: int, team_in_flight: int, *, reserve_for_on_demand: bool = True) -> int:
     """Dispatch headroom for a sweep tick: the tighter of the per-scanner and per-team caps.
 
     The sweep workflow throttles on this and the count activity records the throttled
     metric from it, so the decision and the metric can't drift apart. Pure, so it is safe
-    inside deterministic workflow code.
+    inside deterministic workflow code. `reserve_for_on_demand=False` is only for replaying
+    sweep histories recorded before the reserve existed.
     """
+    scanner_cap = MAX_IN_FLIGHT_APPLIES_PER_SCANNER - (ON_DEMAND_RESERVED_SCANNER_SLOTS if reserve_for_on_demand else 0)
+    team_cap = MAX_IN_FLIGHT_APPLIES_PER_TEAM - (ON_DEMAND_RESERVED_TEAM_SLOTS if reserve_for_on_demand else 0)
     return min(
-        MAX_IN_FLIGHT_APPLIES_PER_SCANNER - scanner_in_flight,
-        MAX_IN_FLIGHT_APPLIES_PER_TEAM - team_in_flight,
+        scanner_cap - scanner_in_flight,
+        team_cap - team_in_flight,
     )
 
 

--- a/products/replay_vision/backend/temporal/sweep_workflow.py
+++ b/products/replay_vision/backend/temporal/sweep_workflow.py
@@ -39,6 +39,8 @@ from products.replay_vision.backend.temporal.constants import (
     CHECK_SCANNER_BUDGET_TIMEOUT,
     COUNT_IN_FLIGHT_APPLIES_TIMEOUT,
     FIND_SCANNER_CANDIDATES_TIMEOUT,
+    MAX_IN_FLIGHT_APPLIES_PER_SCANNER,
+    MAX_IN_FLIGHT_APPLIES_PER_TEAM,
     PROCESS_VISION_ACTION_EXECUTION_TIMEOUT,
     PROCESS_VISION_ACTION_WORKFLOW_NAME,
     REFRESH_PROMPT_SUGGESTION_TIMEOUT,
@@ -143,7 +145,10 @@ class SweepScannerWorkflow(PostHogWorkflow):
         if wf.patched("replay-vision-on-demand-reserved-headroom"):
             headroom = in_flight_headroom(scanner_in_flight, team_in_flight)
         else:
-            headroom = in_flight_headroom(scanner_in_flight, team_in_flight, reserve_for_on_demand=False)
+            headroom = min(
+                MAX_IN_FLIGHT_APPLIES_PER_SCANNER - scanner_in_flight,
+                MAX_IN_FLIGHT_APPLIES_PER_TEAM - team_in_flight,
+            )
         if headroom <= 0:
             # At a cap — drain before fetching more. Don't advance the watermark; resume next tick.
             wf.logger.info(

--- a/products/replay_vision/backend/temporal/sweep_workflow.py
+++ b/products/replay_vision/backend/temporal/sweep_workflow.py
@@ -140,8 +140,8 @@ class SweepScannerWorkflow(PostHogWorkflow):
                 retry_policy=common.RetryPolicy(maximum_attempts=1),
             )
             team_in_flight = 0
-        # Patched: a changed headroom can flip a replayed tick between dispatching and returning early,
-        # so pre-deploy sweeps must replay against the un-reserved caps they were recorded with.
+        # Patched: a history recorded without the reserve must replay the un-reserved arithmetic it ran,
+        # or the tick can flip between dispatching and returning early mid-replay.
         if wf.patched("replay-vision-on-demand-reserved-headroom"):
             headroom = in_flight_headroom(scanner_in_flight, team_in_flight)
         else:

--- a/products/replay_vision/backend/temporal/sweep_workflow.py
+++ b/products/replay_vision/backend/temporal/sweep_workflow.py
@@ -138,7 +138,12 @@ class SweepScannerWorkflow(PostHogWorkflow):
                 retry_policy=common.RetryPolicy(maximum_attempts=1),
             )
             team_in_flight = 0
-        headroom = in_flight_headroom(scanner_in_flight, team_in_flight)
+        # Patched: a changed headroom can flip a replayed tick between dispatching and returning early,
+        # so pre-deploy sweeps must replay against the un-reserved caps they were recorded with.
+        if wf.patched("replay-vision-on-demand-reserved-headroom"):
+            headroom = in_flight_headroom(scanner_in_flight, team_in_flight)
+        else:
+            headroom = in_flight_headroom(scanner_in_flight, team_in_flight, reserve_for_on_demand=False)
         if headroom <= 0:
             # At a cap — drain before fetching more. Don't advance the watermark; resume next tick.
             wf.logger.info(

--- a/products/replay_vision/backend/tests/test_api.py
+++ b/products/replay_vision/backend/tests/test_api.py
@@ -10,6 +10,7 @@ from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 
 from parameterized import parameterized
+from temporalio.common import Priority
 from temporalio.exceptions import WorkflowAlreadyStartedError
 
 from posthog.api.tagged_item import set_tags_on_object
@@ -47,6 +48,7 @@ from products.replay_vision.backend.scanner_draft import DraftError, ScannerDraf
 from products.replay_vision.backend.temporal.constants import (
     APPLY_SCANNER_EXECUTION_TIMEOUT,
     APPLY_SCANNER_WORKFLOW_NAME,
+    ON_DEMAND_PRIORITY_KEY,
     build_apply_scanner_workflow_id,
 )
 from products.replay_vision.backend.tests.helpers import (
@@ -2104,6 +2106,7 @@ class TestObserveAction(_VisionAPITestCase):
         self.assertEqual(args[0], APPLY_SCANNER_WORKFLOW_NAME)
         self.assertEqual(kwargs["id"], expected_workflow_id)
         self.assertEqual(kwargs["execution_timeout"], APPLY_SCANNER_EXECUTION_TIMEOUT)
+        self.assertEqual(kwargs["priority"], Priority(priority_key=ON_DEMAND_PRIORITY_KEY))
         inputs = args[1]
         self.assertEqual(inputs.scanner_id, self.scanner.id)
         self.assertEqual(inputs.session_id, "sess-42")

--- a/products/replay_vision/backend/tests/test_api.py
+++ b/products/replay_vision/backend/tests/test_api.py
@@ -47,8 +47,8 @@ from products.replay_vision.backend.scanner_draft import DraftError, ScannerDraf
 from products.replay_vision.backend.temporal.constants import (
     APPLY_SCANNER_EXECUTION_TIMEOUT,
     APPLY_SCANNER_WORKFLOW_NAME,
-    ON_DEMAND_PRIORITY,
     build_apply_scanner_workflow_id,
+    on_demand_priority,
 )
 from products.replay_vision.backend.tests.helpers import (
     create_experiment,
@@ -2105,7 +2105,7 @@ class TestObserveAction(_VisionAPITestCase):
         self.assertEqual(args[0], APPLY_SCANNER_WORKFLOW_NAME)
         self.assertEqual(kwargs["id"], expected_workflow_id)
         self.assertEqual(kwargs["execution_timeout"], APPLY_SCANNER_EXECUTION_TIMEOUT)
-        self.assertEqual(kwargs["priority"], ON_DEMAND_PRIORITY)
+        self.assertEqual(kwargs["priority"], on_demand_priority(self.team.id))
         inputs = args[1]
         self.assertEqual(inputs.scanner_id, self.scanner.id)
         self.assertEqual(inputs.session_id, "sess-42")

--- a/products/replay_vision/backend/tests/test_api.py
+++ b/products/replay_vision/backend/tests/test_api.py
@@ -10,7 +10,6 @@ from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 
 from parameterized import parameterized
-from temporalio.common import Priority
 from temporalio.exceptions import WorkflowAlreadyStartedError
 
 from posthog.api.tagged_item import set_tags_on_object
@@ -48,7 +47,7 @@ from products.replay_vision.backend.scanner_draft import DraftError, ScannerDraf
 from products.replay_vision.backend.temporal.constants import (
     APPLY_SCANNER_EXECUTION_TIMEOUT,
     APPLY_SCANNER_WORKFLOW_NAME,
-    ON_DEMAND_PRIORITY_KEY,
+    ON_DEMAND_PRIORITY,
     build_apply_scanner_workflow_id,
 )
 from products.replay_vision.backend.tests.helpers import (
@@ -2106,7 +2105,7 @@ class TestObserveAction(_VisionAPITestCase):
         self.assertEqual(args[0], APPLY_SCANNER_WORKFLOW_NAME)
         self.assertEqual(kwargs["id"], expected_workflow_id)
         self.assertEqual(kwargs["execution_timeout"], APPLY_SCANNER_EXECUTION_TIMEOUT)
-        self.assertEqual(kwargs["priority"], Priority(priority_key=ON_DEMAND_PRIORITY_KEY))
+        self.assertEqual(kwargs["priority"], ON_DEMAND_PRIORITY)
         inputs = args[1]
         self.assertEqual(inputs.scanner_id, self.scanner.id)
         self.assertEqual(inputs.session_id, "sess-42")

--- a/products/replay_vision/backend/tests/test_backfills.py
+++ b/products/replay_vision/backend/tests/test_backfills.py
@@ -61,6 +61,8 @@ from products.replay_vision.backend.temporal.constants import (
     MAX_IN_FLIGHT_APPLIES_PER_BACKFILL,
     MAX_IN_FLIGHT_APPLIES_PER_SCANNER,
     MAX_IN_FLIGHT_APPLIES_PER_TEAM,
+    ON_DEMAND_RESERVED_SCANNER_SLOTS,
+    ON_DEMAND_RESERVED_TEAM_SLOTS,
     backfill_dispatch_budget,
     build_apply_scanner_workflow_id,
 )
@@ -108,11 +110,12 @@ def _make_backfill(scanner: ReplayScanner, **overrides) -> ReplayScannerBackfill
 @pytest.mark.parametrize(
     "scanner_in_flight,team_in_flight,backfill_in_flight,expected",
     [
-        # One case per cap that can win, plus the fully-saturated floor.
+        # One case per cap that can win, plus the fully-saturated floor. Scheduled dispatch caps
+        # exclude the slots reserved for on-demand admission.
         (0, 0, 0, MAX_IN_FLIGHT_APPLIES_PER_BACKFILL),
         (0, 0, MAX_IN_FLIGHT_APPLIES_PER_BACKFILL, 0),
-        (MAX_IN_FLIGHT_APPLIES_PER_SCANNER - 10, 0, 0, 10),
-        (0, MAX_IN_FLIGHT_APPLIES_PER_TEAM - 5, 0, 5),
+        (MAX_IN_FLIGHT_APPLIES_PER_SCANNER - ON_DEMAND_RESERVED_SCANNER_SLOTS - 10, 0, 0, 10),
+        (0, MAX_IN_FLIGHT_APPLIES_PER_TEAM - ON_DEMAND_RESERVED_TEAM_SLOTS - 5, 0, 5),
     ],
 )
 def test_backfill_dispatch_budget_takes_the_tightest_cap(

--- a/products/replay_vision/backend/tests/test_enqueue_claims.py
+++ b/products/replay_vision/backend/tests/test_enqueue_claims.py
@@ -30,13 +30,14 @@ class TestEnqueueClaims(SimpleTestCase):
     def _flush(self) -> None:
         get_client().delete(_team_key(self.team_id), _scanner_key(self.scanner_id))
 
-    def _claim(self, workflow_id: str, *, team_rows: int = 0, scanner_rows: int = 0) -> bool:
+    def _claim(self, workflow_id: str, *, team_rows: int = 0, scanner_rows: int = 0, scheduled: bool = False) -> bool:
         return try_claim_enqueue_slot(
             team_id=self.team_id,
             scanner_id=self.scanner_id,
             workflow_id=workflow_id,
             team_in_flight_rows=team_rows,
             scanner_in_flight_rows=scanner_rows,
+            scheduled=scheduled,
         )
 
     @parameterized.expand(
@@ -50,6 +51,16 @@ class TestEnqueueClaims(SimpleTestCase):
         with patch(f"products.replay_vision.backend.enqueue_claims.{cap_constant}", 1):
             assert self._claim("wf-1") is True
             assert self._claim("wf-2") is False
+
+    def test_scheduled_claims_stop_at_the_reserved_ceiling(self) -> None:
+        # Racing scheduled dispatchers must not claim into the on-demand reserve; user claims still may.
+        with (
+            patch("products.replay_vision.backend.enqueue_claims.MAX_IN_FLIGHT_APPLIES_PER_TEAM", 2),
+            patch("products.replay_vision.backend.enqueue_claims.ON_DEMAND_RESERVED_TEAM_SLOTS", 1),
+        ):
+            assert self._claim("wf-1", scheduled=True) is True
+            assert self._claim("wf-2", scheduled=True) is False
+            assert self._claim("wf-2") is True
 
     def test_rows_count_against_the_allowance(self) -> None:
         # Persisted in-flight rows consume cap headroom before any claims do.

--- a/products/replay_vision/backend/tests/test_sweep.py
+++ b/products/replay_vision/backend/tests/test_sweep.py
@@ -46,6 +46,8 @@ from products.replay_vision.backend.temporal.activities.refresh_prompt_suggestio
 from products.replay_vision.backend.temporal.constants import (
     MAX_IN_FLIGHT_APPLIES_PER_SCANNER,
     MAX_IN_FLIGHT_APPLIES_PER_TEAM,
+    ON_DEMAND_RESERVED_SCANNER_SLOTS,
+    ON_DEMAND_RESERVED_TEAM_SLOTS,
     SWEEP_READ_BUDGET_BYTES_24H,
     build_process_vision_action_workflow_id,
 )
@@ -1193,13 +1195,33 @@ async def test_child_start_failure_propagates_and_skips_advance() -> None:
         (InFlightApplyCounts(scanner=MAX_IN_FLIGHT_APPLIES_PER_SCANNER, team=0), None),  # scanner cap → throttled
         (InFlightApplyCounts(scanner=MAX_IN_FLIGHT_APPLIES_PER_SCANNER + 10, team=0), None),  # over → throttled
         (InFlightApplyCounts(scanner=0, team=MAX_IN_FLIGHT_APPLIES_PER_TEAM), None),  # team cap → throttled
-        (InFlightApplyCounts(scanner=MAX_IN_FLIGHT_APPLIES_PER_SCANNER - 10, team=0), 10),  # partial scanner headroom
+        (
+            # At the reserved scanner ceiling the sweep throttles even though on-demand still admits.
+            InFlightApplyCounts(scanner=MAX_IN_FLIGHT_APPLIES_PER_SCANNER - ON_DEMAND_RESERVED_SCANNER_SLOTS, team=0),
+            None,
+        ),
+        (
+            # Same for the reserved team ceiling.
+            InFlightApplyCounts(scanner=0, team=MAX_IN_FLIGHT_APPLIES_PER_TEAM - ON_DEMAND_RESERVED_TEAM_SLOTS),
+            None,
+        ),
+        (
+            # Partial scanner headroom below the reserved ceiling.
+            InFlightApplyCounts(
+                scanner=MAX_IN_FLIGHT_APPLIES_PER_SCANNER - ON_DEMAND_RESERVED_SCANNER_SLOTS - 10, team=0
+            ),
+            10,
+        ),
         (
             # Team headroom smaller than scanner headroom → team cap binds the fetch.
-            InFlightApplyCounts(scanner=0, team=MAX_IN_FLIGHT_APPLIES_PER_TEAM - 5),
+            InFlightApplyCounts(scanner=0, team=MAX_IN_FLIGHT_APPLIES_PER_TEAM - ON_DEMAND_RESERVED_TEAM_SLOTS - 5),
             5,
         ),
-        (InFlightApplyCounts(scanner=0, team=0), MAX_IN_FLIGHT_APPLIES_PER_SCANNER),  # idle → full headroom
+        (
+            # Idle → full scheduled headroom, i.e. the scanner cap minus the on-demand reserve.
+            InFlightApplyCounts(scanner=0, team=0),
+            MAX_IN_FLIGHT_APPLIES_PER_SCANNER - ON_DEMAND_RESERVED_SCANNER_SLOTS,
+        ),
     ],
 )
 @pytest.mark.asyncio

--- a/products/replay_vision/backend/tests/test_vision_actions_api.py
+++ b/products/replay_vision/backend/tests/test_vision_actions_api.py
@@ -737,9 +737,9 @@ class TestVisionActionRunNow(_VisionActionAPITestCase):
         self, mock_sync_connect: MagicMock, mock_async_to_sync: MagicMock
     ) -> None:
         from products.replay_vision.backend.temporal.constants import (
-            ON_DEMAND_PRIORITY,
             PROCESS_VISION_ACTION_WORKFLOW_NAME,
             build_process_vision_action_workflow_id,
+            on_demand_priority,
         )
 
         mock_sync_connect.return_value = MagicMock()
@@ -757,7 +757,7 @@ class TestVisionActionRunNow(_VisionActionAPITestCase):
 
         args, kwargs = start_workflow.call_args
         self.assertEqual(args[0], PROCESS_VISION_ACTION_WORKFLOW_NAME)
-        self.assertEqual(kwargs["priority"], ON_DEMAND_PRIORITY)
+        self.assertEqual(kwargs["priority"], on_demand_priority(self.team.id))
         inputs = args[1]
         self.assertEqual(inputs.vision_action_id, action.id)
         self.assertEqual(inputs.mode, "group_summary")

--- a/products/replay_vision/backend/tests/test_vision_actions_api.py
+++ b/products/replay_vision/backend/tests/test_vision_actions_api.py
@@ -737,6 +737,7 @@ class TestVisionActionRunNow(_VisionActionAPITestCase):
         self, mock_sync_connect: MagicMock, mock_async_to_sync: MagicMock
     ) -> None:
         from products.replay_vision.backend.temporal.constants import (
+            ON_DEMAND_PRIORITY,
             PROCESS_VISION_ACTION_WORKFLOW_NAME,
             build_process_vision_action_workflow_id,
         )
@@ -756,6 +757,7 @@ class TestVisionActionRunNow(_VisionActionAPITestCase):
 
         args, kwargs = start_workflow.call_args
         self.assertEqual(args[0], PROCESS_VISION_ACTION_WORKFLOW_NAME)
+        self.assertEqual(kwargs["priority"], ON_DEMAND_PRIORITY)
         inputs = args[1]
         self.assertEqual(inputs.vision_action_id, action.id)
         self.assertEqual(inputs.mode, "group_summary")


### PR DESCRIPTION
## Problem

A user who clicks observe can wait over a minute before their observation starts, and gets a 429 when scheduled work saturates the caps. On-demand, sweep, and backfill runs share one task queue FIFO with no priority, and sweeps regularly exhaust the vision workers' activity slots.

## Changes

- User-initiated starts (observe, bulk, inline, retry, vision-action run-now, prompt-suggestion evaluation) run at Temporal priority 1 (default 3), so they dispatch ahead of queued sweep and backfill work.
- Temporal inherits the priority into the rasterize-recording child and its rasterization-queue activity, so on-demand runs also jump the rasterizer backlog. This intentionally orders them ahead of video exports and Max AI moment renders on that shared queue.
- Sweep and backfill dispatch now hold back slots at both caps (25 of 150 per scanner, 50 of 300 per team). On-demand admission still checks the full caps, so saturated scheduled work can no longer 429 an observe. At full saturation this trims scheduled batch sizes by the reserve.
- Backfill enqueue claims enforce the reserved ceilings atomically in Redis, so racing ticks cannot claim into the reserved band. Sweep dispatch stays counts-based best effort, as before.
- The sweep headroom change sits behind `workflow.patched`; the unpatched branch replays the original un-reserved arithmetic inline. Backfill budgets live in activities and need no gate.

Known gap: a run-now that dedupes onto an already-running sweep-started vision action keeps that run's default priority (pre-existing dedupe behavior).

## How did you test this code?

- Reserved-ceiling cases added to the existing sweep gate test: fails if the reserve is removed and sweeps dispatch into on-demand slots.
- New claim test: a scheduled claim stops at the reserved ceiling while an on-demand claim still admits; catches the claim path ignoring the reserve.
- Priority assertions on the observe and run-now start calls: catch the priority kwarg being dropped.
- Priority inheritance verified against a local Temporal dev server with the prod topology: Python client, parent, and child, plus a Node worker on the repo's `@temporalio` 1.15 for the activity queue. The activity received priority_key 1 set only at the initial start.
- Cloud-side reordering under backlog is Temporal Cloud's Priority GA behavior (server 1.32) and went unchecked locally; a post-deploy spot-check of one observation's rasterize child will confirm it.
- Not fully rerun locally: the final serial suite pass hit shared-test-DB schema drift (`hogflow_templates` column exists); the affected suites passed before the drift, CI covers the rest.

## Automatic notifications

- [ ] Publish changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session. Skills: /writing-tests, /writing-pr-descriptions, /simplify, /code-review, /temporal-query, /prometheus-query. Production queue metrics motivated the change. Review passes moved the legacy headroom arithmetic inline, added the atomic reserved-ceiling claims (Codex finding), and extended priority to the prompt-suggestion start. Priority value and reserve sizes are session judgment calls, kept as plain constants.