### PR TITLE
fix(desktop/perf): compact buffered tool updates

### DIFF
--- a/products/desktop/packages/core/src/sessions/sessionEventBatching.test.ts
+++ b/products/desktop/packages/core/src/sessions/sessionEventBatching.test.ts
@@ -32,6 +32,34 @@ function chunkText(event: AcpMessage): string {
   return params.update.content.text;
 }
 
+function toolUpdate(
+  toolCallId: string,
+  fields: Record<string, unknown>,
+): AcpMessage {
+  return {
+    ts: 1,
+    message: {
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: {
+        sessionId: RUN_ID,
+        update: {
+          sessionUpdate: "tool_call_update",
+          toolCallId,
+          ...fields,
+        },
+      },
+    },
+  } as unknown as AcpMessage;
+}
+
+function updateFields(event: AcpMessage): Record<string, unknown> {
+  return (
+    (event.message as { params?: { update?: Record<string, unknown> } }).params
+      ?.update ?? {}
+  );
+}
+
 function createHarness() {
   const sessions: Record<string, AgentSession> = {
     [RUN_ID]: {
@@ -189,6 +217,31 @@ describe("streamed event batching", () => {
     // A single flush tick drains the whole burst, in arrival order.
     vi.advanceTimersByTime(FLUSH_MS);
     expect(h.events().map(chunkText)).toEqual(["a", "b", "c"]);
+  });
+
+  it("stores one merged snapshot for buffered updates to the same tool call", () => {
+    const h = createHarness();
+
+    h.emit(toolUpdate("tool-1", { rawInput: { command: "ls" } }));
+    h.emit(
+      toolUpdate("tool-1", {
+        rawInput: { command: "ls -la" },
+        title: "List files",
+      }),
+    );
+    h.emit(toolUpdate("tool-1", { status: "completed", rawOutput: "done" }));
+
+    vi.advanceTimersByTime(FLUSH_MS);
+
+    expect(h.events()).toHaveLength(1);
+    expect(updateFields(h.events()[0])).toEqual({
+      sessionUpdate: "tool_call_update",
+      toolCallId: "tool-1",
+      rawInput: { command: "ls -la" },
+      title: "List files",
+      status: "completed",
+      rawOutput: "done",
+    });
   });
 
   it("flushes buffered events synchronously on teardown", () => {

--- a/products/desktop/packages/core/src/sessions/sessionService.ts
+++ b/products/desktop/packages/core/src/sessions/sessionService.ts
@@ -100,6 +100,7 @@ import {
   resolveAllowAlwaysUpgradeMode,
 } from "./permissionResponse";
 import {
+  collapseSupersededToolCallUpdates,
   convertStoredEntriesToEvents,
   createUserShellExecuteEvent,
   extractPromptText,
@@ -2753,7 +2754,7 @@ export class SessionService {
     const batches = this.pendingSessionEvents;
     this.pendingSessionEvents = new Map();
     for (const [taskRunId, events] of batches) {
-      for (const acpMsg of events) {
+      for (const acpMsg of collapseSupersededToolCallUpdates(events)) {
         this.applySessionEvent(taskRunId, acpMsg);
       }
     }
@@ -2765,7 +2766,7 @@ export class SessionService {
     const events = this.pendingSessionEvents.get(taskRunId);
     if (!events) return;
     this.pendingSessionEvents.delete(taskRunId);
-    for (const acpMsg of events) {
+    for (const acpMsg of collapseSupersededToolCallUpdates(events)) {
       this.applySessionEvent(taskRunId, acpMsg);
     }
   }

--- a/products/desktop/packages/ui/src/features/sessions/sessionServiceHost.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/sessionServiceHost.test.ts
@@ -400,6 +400,7 @@ vi.mock("@posthog/core/sessions/sessionEvents", async () => {
     typeof import("@posthog/core/sessions/sessionEvents")
   >("@posthog/core/sessions/sessionEvents");
   return {
+    collapseSupersededToolCallUpdates: actual.collapseSupersededToolCallUpdates,
     convertStoredEntriesToEvents: mockConvertStoredEntriesToEvents,
     createUserPromptEvent: vi.fn((prompt, ts) => ({
       type: "acp_message",


### PR DESCRIPTION
## Problem

Long tool calls can make PostHog Desktop use extra renderer memory because every streamed tool snapshot enters transcript state.

Transcript hydration already collapses superseded tool updates. Live event buffers did not.

## Changes

- Live tool streams now merge superseded snapshots within each 16 ms event buffer before updating renderer state.
- Each merged update keeps earlier fields and uses the latest value for repeated fields.
- The transcript looks the same.

Before:

```mermaid
flowchart LR
    Buffer[Session event buffer] --> First[Tool snapshot 1]
    Buffer --> Second[Tool snapshot 2]
    Buffer --> Third[Tool snapshot 3]
    First --> Store[Renderer transcript state]
    Second --> Store
    Third --> Store
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class Buffer phYellow;
    class First,Second,Third phBlue;
    class Store phGray;
```

After:

```mermaid
flowchart LR
    Buffer[Session event buffer] --> Merge[Merge snapshots by tool call]
    Merge --> Store[Renderer transcript state]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class Buffer phYellow;
    class Merge phBlue;
    class Store phGray;
```

## How did you test this code?

The session batching test now catches snapshots that remain duplicated or lose fields during the merge.

Ran the `@posthog/core` test suite and typecheck. Ran Desktop Biome lint, the host boundary check, and `hogli ci:preflight --fix`.

Not run: a manual Electron session with a long tool call.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This change only affects internal event buffering.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

An OpenAI coding agent used repository shell and edit tools. It invoked `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`, and `/writing-simplified-technical-english`.

This PR takes the remaining bounded part of transcript compaction after cloud transcript paging shipped in #82988. The test data is invented.
