### PR TITLE
fix: mcp impersonation skip cred review

### DIFF
--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -344,7 +344,7 @@ class TestUserAPI(APIBaseTest):
         assert response.status_code == 200
         assert response.json()["requires_credential_review"] is expected
 
-    def test_requires_credential_review_skipped_when_impersonating(self):
+    def test_requires_credential_review_skipped_when_impersonating_via_session(self):
         User.objects.filter(pk=self.user.pk).update(credentials_reviewed_at=None)
         PersonalAPIKey.objects.create(
             user=self.user,
@@ -352,8 +352,40 @@ class TestUserAPI(APIBaseTest):
             secure_value=hash_key_value("phx_test_value_impersonated"),
             scopes=["*"],
         )
-        with patch("posthog.api.user.is_impersonated_session", return_value=True):
+        with patch("posthog.helpers.impersonation.is_impersonated_session", return_value=True):
             response = self.client.get("/api/users/@me/")
+        assert response.status_code == 200
+        assert response.json()["requires_credential_review"] is False
+
+    def test_requires_credential_review_skipped_when_impersonating_via_oauth_token(self):
+        User.objects.filter(pk=self.user.pk).update(credentials_reviewed_at=None)
+        PersonalAPIKey.objects.create(
+            user=self.user,
+            label="Test key",
+            secure_value=hash_key_value("phx_test_value_impersonated_oauth"),
+            scopes=["*"],
+        )
+        staff = User.objects.create_user(email="staff@example.com", password="x", first_name="Staff", is_staff=True)
+        app = OAuthApplication.objects.create(
+            name="MCP client",
+            client_id="test_impersonation_client_id",
+            client_type=OAuthApplication.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
+            redirect_uris="https://example.com/callback",
+            algorithm="RS256",
+            user=self.user,
+        )
+        token = OAuthAccessToken.objects.create(
+            user=self.user,
+            application=app,
+            token="pha_test_impersonated_access_token",
+            scope="user:read",
+            expires=timezone.now() + timedelta(hours=1),
+            scoped_teams=[self.team.id],
+            impersonated_by=staff,
+        )
+        self.client.logout()
+        response = self.client.get("/api/users/@me/", headers={"authorization": f"Bearer {token.token}"})
         assert response.status_code == 200
         assert response.json()["requires_credential_review"] is False
 

--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -344,6 +344,19 @@ class TestUserAPI(APIBaseTest):
         assert response.status_code == 200
         assert response.json()["requires_credential_review"] is expected
 
+    def test_requires_credential_review_skipped_when_impersonating(self):
+        User.objects.filter(pk=self.user.pk).update(credentials_reviewed_at=None)
+        PersonalAPIKey.objects.create(
+            user=self.user,
+            label="Test key",
+            secure_value=hash_key_value("phx_test_value_impersonated"),
+            scopes=["*"],
+        )
+        with patch("posthog.api.user.is_impersonated_session", return_value=True):
+            response = self.client.get("/api/users/@me/")
+        assert response.status_code == 200
+        assert response.json()["requires_credential_review"] is False
+
     def test_requires_credential_review_unverified_passkey(self):
         # Unverified passkeys are the realistic pre-claim attack artifact - a partner
         # session can register a credential without ever completing verification.

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -90,6 +90,7 @@ from posthog.helpers.email_utils import (
     reject_plus_addressed_email,
     validate_display_name,
 )
+from posthog.helpers.impersonation import is_impersonated
 from posthog.helpers.session_cache import SessionCache
 from posthog.helpers.two_factor_session import has_passkeys, set_two_factor_verified_in_session
 from posthog.helpers.verified_domain_enforcement import VERIFIED_DOMAIN_REQUIRED_ERROR, resolve_login_organization
@@ -458,8 +459,7 @@ class UserSerializer(serializers.ModelSerializer):
         if instance.credentials_reviewed_at is not None:
             return False
         # impersonating users shouldn't bounced into the credential review screen
-        request = self.context.get("request")
-        if request is not None and is_impersonated_session(request):
+        if is_impersonated(self.context.get("request")):
             return False
         if PersonalAPIKey.objects.filter(user=instance).exists():
             return True

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -457,6 +457,10 @@ class UserSerializer(serializers.ModelSerializer):
     def get_requires_credential_review(self, instance: User) -> bool:
         if instance.credentials_reviewed_at is not None:
             return False
+        # impersonating users shouldn't bounced into the credential review screen
+        request = self.context.get("request")
+        if request is not None and is_impersonated_session(request):
+            return False
         if PersonalAPIKey.objects.filter(user=instance).exists():
             return True
         if WebauthnCredential.objects.filter(user=instance).exists():


### PR DESCRIPTION
## Problem

- Staff who impersonate a user land on the credential review screen instead of the app.
- The screen shows for any user with an unreviewed personal API key, passkey, or third-party OAuth token.
- Since #84974 counts live OAuth refresh tokens, every user with a connected MCP client now triggers it, so impersonation hits the screen almost every time.
- The review is for the account owner to acknowledge their own credentials. An operator should neither see it nor dismiss it on the owner's behalf.

## Changes

- `requires_credential_review` on `/api/users/@me/` is now `false` whenever the request is an impersonated session, so the frontend redirect never fires for operators.
- No change for non-impersonated users.

## How did you test this code?

- New test `test_requires_credential_review_skipped_when_impersonating`: user with an unreviewed personal API key, impersonated session, flag must be false. No existing test covered the impersonation path.
- Existing `requires_credential_review` tests pass unchanged.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5) in VS Code. Skills invoked: /writing-pr-descriptions. The agent traced the report to #84974 widening the credential review gate, then added the impersonation short-circuit and test.
