### PR TITLE
fix(data-modeling): reuse database during managed DAG sync

### DIFF
--- a/products/data_modeling/backend/logic/saved_query_dag_sync.py
+++ b/products/data_modeling/backend/logic/saved_query_dag_sync.py
@@ -164,6 +164,7 @@ def sync_saved_query_to_dag(
     dag: DAG | None = None,
     allow_managed: bool = False,
     reconcile: bool = True,
+    database: Database | None = None,
 ) -> Node | None:
     """
     Create or update Node and Edges for a SavedQuery.
@@ -181,6 +182,7 @@ def sync_saved_query_to_dag(
         allow_managed: Whether placement into a system-managed DAG is permitted. Only the
             internal managed-viewset sync passes this; user-initiated callers must not, so a
             same-team user can't insert nodes/edges into a managed DAG via the saved-query API.
+        database: An optional prebuilt database to reuse for dependency resolution.
 
     Returns the Node for the SavedQuery, or None if query parsing fails.
     Raises QueryError or CycleDetectionError if the query would create an invalid DAG.
@@ -210,14 +212,15 @@ def sync_saved_query_to_dag(
 
     # Internal DAG sync (no user); bypass warehouse HogQL access control so dependency resolution
     # sees every referenced table/view.
-    database = Database.create_for(team=team, bypass_warehouse_access_control=True)
+    if database is None:
+        database = Database.create_for(team=team, bypass_warehouse_access_control=True)
     # clear previous incoming edges, dependencies may have changed
     Edge.objects.filter(team=team, target=target).delete()
 
     # parse query to extract dependencies and create edges
     try:
         model_name = saved_query.name
-        dependencies = get_parents_from_model_query(team, model_name, model_query)
+        dependencies = get_parents_from_model_query(team, model_name, model_query, database=database)
         for dependency_name in dependencies:
             source = resolve_dependency_to_node(dependency_name, team, database, dag)
             Edge.objects.create(

--- a/products/data_modeling/backend/models/datawarehouse_managed_viewset.py
+++ b/products/data_modeling/backend/models/datawarehouse_managed_viewset.py
@@ -197,7 +197,7 @@ class DataWarehouseManagedViewSet(CreatedMetaFields, UpdatedMetaFields, UUIDTMod
         # creation entirely — no managed DAG is created for that kind.
         if saved_queries_to_schedule:
             managed_dag = DAG.get_or_create_revenue_analytics(self.team)
-            dag_database = Database.create_for(self.team.pk, bypass_warehouse_access_control=True)
+            dag_database = Database.create_for(team=self.team, bypass_warehouse_access_control=True)
             for saved_query in saved_queries_to_schedule:
                 try:
                     # reconcile once after both loops, not once per view

--- a/products/data_modeling/backend/models/datawarehouse_managed_viewset.py
+++ b/products/data_modeling/backend/models/datawarehouse_managed_viewset.py
@@ -197,10 +197,17 @@ class DataWarehouseManagedViewSet(CreatedMetaFields, UpdatedMetaFields, UUIDTMod
         # creation entirely — no managed DAG is created for that kind.
         if saved_queries_to_schedule:
             managed_dag = DAG.get_or_create_revenue_analytics(self.team)
+            dag_database = Database.create_for(self.team.pk, bypass_warehouse_access_control=True)
             for saved_query in saved_queries_to_schedule:
                 try:
                     # reconcile once after both loops, not once per view
-                    sync_saved_query_to_dag(saved_query, dag=managed_dag, allow_managed=True, reconcile=False)
+                    sync_saved_query_to_dag(
+                        saved_query,
+                        dag=managed_dag,
+                        allow_managed=True,
+                        reconcile=False,
+                        database=dag_database,
+                    )
                     # Drop any stale node left in another DAG (e.g. a legacy Default-DAG placement),
                     # unless something there still depends on it (don't orphan a dependent).
                     for stale in Node.objects.filter(team=self.team, saved_query=saved_query).exclude(dag=managed_dag):

--- a/products/data_modeling/backend/models/modeling.py
+++ b/products/data_modeling/backend/models/modeling.py
@@ -460,7 +460,9 @@ def _select_queries_with_scope(
     return result
 
 
-def get_parents_from_model_query(team: Team, model_name: str, model_query: str) -> set[str]:
+def get_parents_from_model_query(
+    team: Team, model_name: str, model_query: str, database: Database | None = None
+) -> set[str]:
     """Get parents from a given query.
 
     The parents of a query are any names in the `FROM` clause of the query.
@@ -474,6 +476,7 @@ def get_parents_from_model_query(team: Team, model_name: str, model_query: str) 
         model_name: The name of the saved query being parsed; used as the
             initial view so cycles back to it are detected.
         model_query: The HogQL query string to parse.
+        database: An optional prebuilt database to reuse for dependency resolution.
     """
     hogql_query = parse_select(model_query)
     context = HogQLContext(
@@ -481,6 +484,7 @@ def get_parents_from_model_query(team: Team, model_name: str, model_query: str) 
         team=team,
         enable_select_queries=True,
     )
+    context.database = database
     if context.database is None:
         # Internal DAG parsing (no user); bypass warehouse HogQL access control so parent-table
         # resolution sees every referenced table/view.

--- a/products/data_modeling/backend/test/test_saved_query_dag_sync.py
+++ b/products/data_modeling/backend/test/test_saved_query_dag_sync.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 from parameterized import parameterized
 
+from posthog.hogql.database.database import Database
 from posthog.hogql.errors import QueryError
 
 from products.data_modeling.backend.logic.saved_query_dag_sync import (
@@ -108,8 +109,11 @@ class TestSyncSavedQueryToDag(BaseTest):
             query={"query": "SELECT * FROM events", "kind": "HogQLQuery"},
         )
 
-        node = sync_saved_query_to_dag(saved_query)
+        database = Database.create_for(team=self.team, bypass_warehouse_access_control=True)
+        with mock.patch("posthog.hogql.database.database.Database.create_for") as mock_database_create:
+            node = sync_saved_query_to_dag(saved_query, database=database)
 
+        mock_database_create.assert_not_called()
         events_node = Node.objects.filter(
             team=self.team,
             dag__name=DEFAULT_DAG_NAME,

--- a/products/data_modeling/backend/tests/test_managed_viewset_providers.py
+++ b/products/data_modeling/backend/tests/test_managed_viewset_providers.py
@@ -1,6 +1,7 @@
 from posthog.test.base import BaseTest
 from unittest.mock import AsyncMock, Mock, patch
 
+from posthog.hogql.database.database import Database
 from posthog.hogql.database.models import IntegerDatabaseField
 
 from products.data_modeling.backend.facade.managed_viewset_hooks import (
@@ -28,6 +29,7 @@ SERVICE = "products.data_warehouse.backend.logic.data_load.saved_query_service"
 GET_V2_DAG_IDS = "products.data_modeling.backend.schedule.get_v2_scheduled_dag_ids"
 RECONCILE = "products.data_modeling.backend.logic.schedule_reconcile"
 NODE_MAT = "products.data_modeling.backend.logic.node_materialization"
+SYNC_SAVED_QUERY_TO_DAG = "products.data_modeling.backend.logic.saved_query_dag_sync.sync_saved_query_to_dag"
 
 
 def _no_schedules():
@@ -80,6 +82,24 @@ class TestManagedViewSetProviders(BaseTest):
         # materialization, nor get a managed (revenue-analytics) DAG.
         mock_schedule.assert_not_called()
         self.assertFalse(DAG.objects.filter(team=self.team, name=REVENUE_ANALYTICS_DAG_NAME).exists())
+
+    @patch(SCHEDULE_MATERIALIZATION)
+    @patch(SYNC_SAVED_QUERY_TO_DAG)
+    @patch("posthog.hogql.database.database.Database.create_for", wraps=Database.create_for)
+    def test_sync_views_reuses_database_for_dag_dependencies(
+        self, mock_database_create, mock_sync_saved_query_to_dag, _mock_schedule
+    ):
+        views = [_fake_view(name=f"provided_view_{index}") for index in range(3)]
+        with patch.dict(_expected_views_providers, clear=True):
+            register_expected_views_provider(KIND, lambda team: views)
+
+            viewset = self._viewset()
+            viewset.sync_views()
+
+        self.assertEqual(mock_database_create.call_count, 2)
+        self.assertEqual(mock_sync_saved_query_to_dag.call_count, len(views))
+        dag_databases = [call.kwargs["database"] for call in mock_sync_saved_query_to_dag.call_args_list]
+        self.assertTrue(all(database is dag_databases[0] for database in dag_databases))
 
     @patch(SCHEDULE_MATERIALIZATION)
     def test_sync_views_is_idempotent(self, _):

--- a/products/warehouse_sources/backend/tests/api/test_external_data_source.py
+++ b/products/warehouse_sources/backend/tests/api/test_external_data_source.py
@@ -8279,6 +8279,8 @@ class TestExternalDataSource(APIBaseTest):
                     [200, 201],
                     f"Expected acceptance for valid prefix '{prefix}'",
                 )
+                source = ExternalDataSource.objects.get(id=response.json()["id"])
+                self.assertEqual(source.prefix, prefix)
 
 
 class TestCreateWebhook(APIBaseTest):


### PR DESCRIPTION
> 🤖 Posted by an automated coding agent.

## Problem

Creating a warehouse source rebuilds the complete HogQL database tree for every managed revenue view and again for each dependency scan.

The six-prefix API test spent 15.51 seconds creating six sources. Real source creation pays the same repeated work.

## Changes

- Managed view sync builds one fresh database after all expected views are saved.
- DAG node creation and parent resolution reuse that database for every view.
- Other DAG sync callers keep their existing behavior through optional parameters.
- The prefix API test still creates all six sources and now checks exact stored values.
- The six-prefix API test fell from 15.51 to 10.14 seconds locally.

```mermaid
flowchart TD
    A[Managed view sync] --> B[Build database for external tables]
    A --> C[Save expected views]
    C --> D{Each managed view}
    D --> E[Build database for DAG node]
    E --> F[Build database for parent scan]

    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phYellow;
    class B,C,E,F phBlue;
    class D phGray;
```

```mermaid
flowchart TD
    A[Managed view sync] --> B[Build database for external tables]
    A --> C[Save expected views]
    C --> D[Build one post-save DAG database]
    D --> E{Each managed view}
    E --> F[Create DAG node and resolve parents]

    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phYellow;
    class B,C,D,F phBlue;
    class E phGray;
```

## How did you test this code?

- Added a managed-view test that catches rebuilding the database per DAG view.
- Strengthened an existing DAG dependency test to require the supplied database.
- Kept all six API source creations and asserted each prefix round-trips through PostgreSQL.
- Ran the managed-view, DAG sync, and prefix API suites together.
- Ran Ruff, repository-wide mypy, and `hogli ci:preflight --fix`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Existing API behavior and the documented workflow remain unchanged.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi implemented this change with repository shell tools, cProfile, and py-spy. It used `/improving-drf-endpoints`, `/writing-tests`, `/writing-code-comments`, and `/writing-pr-descriptions`.

A narrower serializer-context change and a test-only scheduling mock were measured and discarded because neither improved wall time.
