### PR TITLE
fix(error-tracking): restore issue property filter editing

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
@@ -111,7 +111,7 @@ export const SEARCH_QUERY_DEBOUNCE_MS = 500
  *  matched another is the bug class this file guards against), so they share
  *  this single derivation rather than repeating it. */
 function entryValue(entry: MenuFilterEntry): string {
-    return String(entry.group.getValue?.(entry.item) ?? entry.name)
+    return String(entry.canonicalValue ?? entry.group.getValue?.(entry.item) ?? entry.name)
 }
 
 /** Identity for an entry's underlying definition — source group + value.

--- a/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
@@ -48,7 +48,7 @@ import { getCoreFilterDefinition } from '~/taxonomy/helpers'
 import { AnyPropertyFilter, EventDefinition } from '~/types'
 
 import { useTaxonomicFilterContext } from '../headless/context'
-import { recentTaxonomicFiltersLogic } from '../recentTaxonomicFiltersLogic'
+import { hasRecentContext, recentTaxonomicFiltersLogic } from '../recentTaxonomicFiltersLogic'
 import { taxonomicFilterPinnedPropertiesLogic } from '../taxonomicFilterPinnedPropertiesLogic'
 import { isQuickFilterItem, META_GROUP_TYPES, TaxonomicDefinitionTypes, TaxonomicFilterGroupType } from '../types'
 import { filterPinnedForContext, filterRecentsForContext } from '../utils/suggestedContextFilters'
@@ -388,7 +388,10 @@ export function TaxonomicFilterMenu({
             const mergedItem = extra
                 ? ({ ...(entry.item as unknown as object), ...extra } as unknown as TaxonomicDefinitionTypes)
                 : entry.item
-            const itemValue = entry.group.getValue?.(mergedItem) ?? null
+            const itemValue =
+                (hasRecentContext(mergedItem) ? mergedItem._recentContext.sourceValue : undefined) ??
+                entry.group.getValue?.(mergedItem) ??
+                null
             hadCommitRef.current = true
             posthog.capture('taxonomic filter menu item selected', {
                 groupType: entry.group.type,

--- a/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
@@ -48,9 +48,15 @@ import { getCoreFilterDefinition } from '~/taxonomy/helpers'
 import { AnyPropertyFilter, EventDefinition } from '~/types'
 
 import { useTaxonomicFilterContext } from '../headless/context'
-import { hasRecentContext, recentTaxonomicFiltersLogic } from '../recentTaxonomicFiltersLogic'
+import { recentTaxonomicFiltersLogic } from '../recentTaxonomicFiltersLogic'
 import { taxonomicFilterPinnedPropertiesLogic } from '../taxonomicFilterPinnedPropertiesLogic'
-import { isQuickFilterItem, META_GROUP_TYPES, TaxonomicDefinitionTypes, TaxonomicFilterGroupType } from '../types'
+import {
+    isQuickFilterItem,
+    META_GROUP_TYPES,
+    TaxonomicDefinitionTypes,
+    TaxonomicFilterGroupType,
+    TaxonomicFilterValue,
+} from '../types'
 import { filterPinnedForContext, filterRecentsForContext } from '../utils/suggestedContextFilters'
 import { MenuFilterCombobox } from './Combobox'
 import { MenuFilterDwhConfig } from './DwhFlow'
@@ -388,10 +394,7 @@ export function TaxonomicFilterMenu({
             const mergedItem = extra
                 ? ({ ...(entry.item as unknown as object), ...extra } as unknown as TaxonomicDefinitionTypes)
                 : entry.item
-            const itemValue =
-                (hasRecentContext(mergedItem) ? mergedItem._recentContext.sourceValue : undefined) ??
-                entry.group.getValue?.(mergedItem) ??
-                null
+            const itemValue = entry.group.getValue?.(mergedItem) ?? entry.canonicalValue ?? null
             hadCommitRef.current = true
             posthog.capture('taxonomic filter menu item selected', {
                 groupType: entry.group.type,
@@ -847,10 +850,10 @@ interface ShortcutItem {
     // this branch was in flight; consumers (this menu) read whichever
     // shape exists. See `taxonomicFilterPinnedPropertiesLogic` /
     // `recentTaxonomicFiltersLogic`.
-    _pinnedContext?: { sourceGroupType?: TaxonomicFilterGroupType; value?: unknown }
+    _pinnedContext?: { sourceGroupType?: TaxonomicFilterGroupType; value?: TaxonomicFilterValue }
     _recentContext?: {
         sourceGroupType?: TaxonomicFilterGroupType
-        sourceValue?: unknown
+        sourceValue?: TaxonomicFilterValue
         propertyFilter?: AnyPropertyFilter
     }
 }
@@ -905,8 +908,8 @@ function mapShortcutItems(items: ShortcutItem[], groups: TaxonomicFilterGroup[])
             // Recent stores the value under `sourceValue`, pinned under
             // `value`. Read whichever side exists.
             const sourceValue =
-                (ctx as { sourceValue?: unknown } | undefined)?.sourceValue ??
-                (ctx as { value?: unknown } | undefined)?.value
+                (ctx as { sourceValue?: TaxonomicFilterValue } | undefined)?.sourceValue ??
+                (ctx as { value?: TaxonomicFilterValue } | undefined)?.value
             const group = resolveShortcutGroup(item, sourceType, sourceValue, groups)
             if (!group) {
                 return null
@@ -917,6 +920,7 @@ function mapShortcutItems(items: ShortcutItem[], groups: TaxonomicFilterGroup[])
                 item: item as TaxonomicDefinitionTypes,
                 group,
                 name,
+                ...(sourceValue != null ? { canonicalValue: sourceValue } : {}),
                 friendlyLabel: getCoreFilterDefinition(name, group.type)?.label,
                 ...(recentPropertyFilter
                     ? { recentPropertyFilter, recentLabel: formatPropertyLabel(recentPropertyFilter, {}) }

--- a/frontend/src/lib/components/TaxonomicFilter/menu/types.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/types.ts
@@ -22,6 +22,7 @@ export interface MenuFilterEntry {
     item: TaxonomicDefinitionTypes
     group: TaxonomicFilterGroup
     name: string
+    canonicalValue?: TaxonomicFilterValue
     friendlyLabel?: string
     recentPropertyFilter?: AnyPropertyFilter
     recentLabel?: string

--- a/frontend/src/models/propertyDefinitionsModel.test.ts
+++ b/frontend/src/models/propertyDefinitionsModel.test.ts
@@ -491,35 +491,56 @@ describe('the property definitions model', () => {
         })
     })
 
-    describe('log_entry property values', () => {
-        it('returns local options for log_entry/level without a network request', async () => {
-            let networkCalled = false
+    describe('local property values', () => {
+        it.each([
+            [
+                'log_entry/level',
+                PropertyDefinitionType.LogEntry,
+                'level',
+                [
+                    { id: 0, name: 'info' },
+                    { id: 1, name: 'warn' },
+                    { id: 2, name: 'error' },
+                ],
+            ],
+            [
+                'resource/severity',
+                PropertyDefinitionType.Resource,
+                'severity',
+                [
+                    { id: 0, name: 'low' },
+                    { id: 1, name: 'medium' },
+                    { id: 2, name: 'high' },
+                    { id: 3, name: 'critical' },
+                ],
+            ],
+        ] as const)(
+            'returns local options for %s without a network request',
+            async (_, type, propertyKey, expectedValues) => {
+                let networkCalled = false
 
-            useMocks({
-                get: {
-                    '/api/log_entry/values': () => {
-                        networkCalled = true
-                        return [200, { results: [], refreshing: false }]
+                useMocks({
+                    get: {
+                        [`/api/${type}/values`]: () => {
+                            networkCalled = true
+                            return [200, { results: [], refreshing: false }]
+                        },
                     },
-                },
-            })
-
-            await expectLogic(logic, () => {
-                logic.actions.loadPropertyValues({
-                    endpoint: undefined,
-                    type: PropertyDefinitionType.LogEntry,
-                    propertyKey: 'level',
-                    newInput: undefined,
                 })
-            }).toFinishAllListeners()
 
-            expect(networkCalled).toBe(false)
-            expect(logic.values.options['level'].values).toEqual([
-                { id: 0, name: 'info' },
-                { id: 1, name: 'warn' },
-                { id: 2, name: 'error' },
-            ])
-        })
+                await expectLogic(logic, () => {
+                    logic.actions.loadPropertyValues({
+                        endpoint: undefined,
+                        type,
+                        propertyKey,
+                        newInput: undefined,
+                    })
+                }).toFinishAllListeners()
+
+                expect(networkCalled).toBe(false)
+                expect(logic.values.options[propertyKey].values).toEqual(expectedValues)
+            }
+        )
 
         it('does not fetch from a nonexistent endpoint for log_entry properties without local options', async () => {
             let networkCalled = false

--- a/frontend/src/models/propertyDefinitionsModel.ts
+++ b/frontend/src/models/propertyDefinitionsModel.ts
@@ -80,6 +80,12 @@ const localOptions: Record<string, PropValue[]> = {
         { id: 1, name: 'warn' },
         { id: 2, name: 'error' },
     ],
+    'resource/severity': [
+        { id: 0, name: 'low' },
+        { id: 1, name: 'medium' },
+        { id: 2, name: 'high' },
+        { id: 3, name: 'critical' },
+    ],
 }
 
 export type FormatPropertyValueForDisplayFunction = (

--- a/products/error_tracking/backend/logic/__init__.py
+++ b/products/error_tracking/backend/logic/__init__.py
@@ -298,30 +298,33 @@ def get_issue_assignment(assignment_id: UUID | str) -> ErrorTrackingIssueAssignm
 
 
 def get_issue_values(team_id: int, key: str | None, value: str | None) -> list[str]:
-    if not key or not value:
+    if not key:
         return []
+
+    if key == "severity":
+        severities = [severity.value for severity in ErrorTrackingIssue.Severity]
+        return [severity for severity in severities if not value or value.lower() in severity.lower()]
 
     queryset = ErrorTrackingIssue.objects.filter(team_id=team_id)
 
     if key == "name":
+        if value:
+            queryset = queryset.filter(name__icontains=value)
         return [
             issue_name
-            for issue_name in queryset.filter(name__icontains=value).values_list("name", flat=True)
+            for issue_name in queryset.order_by("name").values_list("name", flat=True).distinct()[:100]
             if issue_name is not None
         ]
 
     if key == "issue_description":
+        if value:
+            queryset = queryset.filter(description__icontains=value)
         return [
             issue_description
-            for issue_description in queryset.filter(description__icontains=value).values_list("description", flat=True)
+            for issue_description in queryset.order_by("description")
+            .values_list("description", flat=True)
+            .distinct()[:100]
             if issue_description is not None
-        ]
-
-    if key == "severity":
-        return [
-            severity
-            for severity in queryset.filter(severity__icontains=value).values_list("severity", flat=True).distinct()
-            if severity is not None
         ]
 
     return []

--- a/products/error_tracking/backend/test/test_facade_api.py
+++ b/products/error_tracking/backend/test/test_facade_api.py
@@ -165,8 +165,15 @@ class TestErrorTrackingFacadeAPI(BaseTest):
             ["name", "name", "checkout", ["Checkout timeout", "Checkout type error"]],
             ["issue_description", "issue_description", "timeout", ["A timeout during payment"]],
             ["severity", "severity", "hi", ["high"]],
+            ["empty_name_search", "name", None, ["Checkout timeout", "Checkout type error"]],
+            [
+                "empty_description_search",
+                "issue_description",
+                None,
+                ["A timeout during payment", "Type mismatch in checkout"],
+            ],
+            ["empty_severity_search", "severity", None, ["low", "medium", "high", "critical"]],
             ["missing_key", None, "timeout", []],
-            ["missing_value", "name", None, []],
             ["unknown_key", "unknown", "checkout", []],
         ]
     )

--- a/products/error_tracking/frontend/components/IssueFilters/FilterGroup.test.tsx
+++ b/products/error_tracking/frontend/components/IssueFilters/FilterGroup.test.tsx
@@ -1,8 +1,11 @@
 import '@testing-library/jest-dom'
 
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { BindLogic, Provider } from 'kea'
+
+import { recentTaxonomicFiltersLogic } from 'lib/components/TaxonomicFilter/recentTaxonomicFiltersLogic'
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
@@ -170,5 +173,83 @@ describe('FilterGroup', () => {
         expect(screen.queryByText('New filter…')).not.toBeInTheDocument()
 
         logic.unmount()
+    })
+
+    it('opens the value editor and adds a pill when custom controls initially have no filters', async () => {
+        const logic = issueFiltersLogic({ logicKey: LOGIC_KEY })
+        logic.mount()
+
+        render(
+            <Provider>
+                <BindLogic logic={issueFiltersLogic} props={{ logicKey: LOGIC_KEY }}>
+                    <FilterGroup
+                        renderControls={({ filterPicker, activeFilters }) => (
+                            <>
+                                {filterPicker}
+                                {activeFilters}
+                            </>
+                        )}
+                    />
+                </BindLogic>
+            </Provider>
+        )
+
+        await userEvent.click(screen.getByText('Add filter'))
+        await userEvent.click(await screen.findByText('Issue severity'))
+
+        const valueEditor = (await screen.findByText('Enter value...')).closest('.Popover')
+        await waitFor(() => expect(valueEditor).toHaveClass('Popover--enter-active'))
+        expect(screen.getByTestId('error-tracking-active-filters')).toHaveTextContent('Issue severity')
+
+        const inner = logic.values.filterGroup.values[0] as UniversalFiltersGroup
+        expect(inner.values).toContainEqual(
+            expect.objectContaining({ key: 'severity', type: PropertyFilterType.ErrorTrackingIssue })
+        )
+
+        logic.unmount()
+    })
+
+    it('opens the value editor and adds a pill for a recent issue property', async () => {
+        const recents = recentTaxonomicFiltersLogic.build()
+        recents.mount()
+        recents.actions.clearRecentFilters()
+        recents.actions.recordRecentFilter({
+            groupType: TaxonomicFilterGroupType.ErrorTrackingIssues,
+            groupName: 'Issues',
+            value: 'severity',
+            item: { name: 'severity' },
+        })
+
+        const logic = issueFiltersLogic({ logicKey: LOGIC_KEY })
+        logic.mount()
+
+        render(
+            <Provider>
+                <BindLogic logic={issueFiltersLogic} props={{ logicKey: LOGIC_KEY }}>
+                    <FilterGroup
+                        renderControls={({ filterPicker, activeFilters }) => (
+                            <>
+                                {filterPicker}
+                                {activeFilters}
+                            </>
+                        )}
+                    />
+                </BindLogic>
+            </Provider>
+        )
+
+        await userEvent.click(screen.getByText('Add filter'))
+        const recentIssueRow = Array.from(
+            document.querySelectorAll<HTMLElement>('[data-slot="taxonomic-filter-menu-row"]')
+        ).find((row) => row.textContent?.includes('Issue severity') && row.textContent.includes('Recent'))
+        expect(recentIssueRow).toBeInTheDocument()
+        await userEvent.click(recentIssueRow as HTMLElement)
+
+        const valueEditor = (await screen.findByText('Enter value...')).closest('.Popover')
+        await waitFor(() => expect(valueEditor).toHaveClass('Popover--enter-active'))
+        expect(screen.getByTestId('error-tracking-active-filters')).toHaveTextContent('Issue severity')
+
+        logic.unmount()
+        recents.unmount()
     })
 })

--- a/products/error_tracking/frontend/components/IssueFilters/FilterGroup.tsx
+++ b/products/error_tracking/frontend/components/IssueFilters/FilterGroup.tsx
@@ -55,7 +55,6 @@ export const FilterGroup = ({
                 iconOnly={iconOnly}
                 filterAddedFromPreview={filterAddedFromPreview}
                 renderControls={renderControls}
-                hasActiveFilters={displayGroup.values.length > 0}
             />
         </UniversalFilters>
     )
@@ -68,7 +67,6 @@ const FilterControls = ({
     iconOnly = false,
     filterAddedFromPreview = 0,
     renderControls,
-    hasActiveFilters = false,
 }: {
     taxonomicGroupTypes?: TaxonomicFilterGroupType[]
     nested?: boolean
@@ -76,7 +74,6 @@ const FilterControls = ({
     iconOnly?: boolean
     filterAddedFromPreview?: number
     renderControls?: (controls: { filterPicker: ReactNode; activeFilters: ReactNode }) => ReactNode
-    hasActiveFilters?: boolean
 }): JSX.Element => {
     const filterRow = (
         <div className={`relative flex shrink-0 items-center ${activeFiltersInline ? 'gap-2' : 'gap-1'}`}>
@@ -104,7 +101,7 @@ const FilterControls = ({
                             <FilterPicker taxonomicGroupTypes={taxonomicGroupTypes} iconOnly={iconOnly} />
                         </div>
                     ),
-                    activeFilters: hasActiveFilters ? (
+                    activeFilters: (
                         <UniversalFilterGroup
                             taxonomicGroupTypes={taxonomicGroupTypes}
                             filterAddedFromPreview={filterAddedFromPreview}
@@ -112,7 +109,7 @@ const FilterControls = ({
                             className="flex w-full flex-wrap items-center gap-1"
                             dataAttr="error-tracking-active-filters"
                         />
-                    ) : null,
+                    ),
                 })}
             </>
         )


### PR DESCRIPTION
## Problem

Error tracking users can select an issue property, but the picker can fail to add its filter or open the value editor.

Recent issue properties can also lose their canonical key, while empty value searches return no suggestions.

## Changes

- Keep active filters mounted so a new property pill can open its editor immediately.
- Resolve recent issue properties from their canonical source value.
- Return up to 100 issue names or descriptions before users type.
- Show the fixed severity values immediately.
- Screenshot not included because this changes picker behavior without changing the layout.

## How did you test this code?

- Extended `FilterGroup` tests to cover base and recent property selection with immediate editor opening.
- Extended property model tests to cover fixed severity suggestions without a request.
- Extended facade tests to cover empty searches and fixed severity values.
- Ran targeted Jest and pytest suites.
- Ran `hogli ci:preflight --fix` successfully.
- TypeScript checking remains blocked by unrelated missing local and generated modules.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs update. This restores existing filter behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I used the pi coding agent. I invoked `/error-tracking`, `/modifying-taxonomic-filter`, `/writing-tests`, `/writing-ui-components`, `/writing-user-facing-copy`, `/improving-drf-endpoints`, `/querying-local-postgres`, `/run-posthog`, `/running-ci-preflight`, and `/writing-pr-descriptions`.

The implementation expanded from filter selection to include empty-search suggestions and fixed severity values. No private source material appears in the PR.
