### PR TITLE
fix(data-warehouse): stop reporting first over-budget repartition as failed

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/repartition.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/repartition.py
@@ -106,6 +106,12 @@ class RepartitionBudgetExceededError(Exception):
     is the first attempt or because the resume path rejected the prior checkpoint. The caller needs it
     to tell convergence from a treadmill. `rows_written` alone cannot: a rewrite that restarts every
     run writes hundreds of millions of rows each time and still ends where it began.
+
+    `resumed_from == 0` alone can't tell a genuine first attempt from a treadmill restart, though — both
+    inherit nothing. `had_prior_checkpoint` splits them: True means a checkpoint existed at the start of
+    this attempt (so re-covering ground from row 0 is a restart, not progress), False means there was
+    none to inherit. `checkpoint_saved` records whether this attempt persisted a checkpoint the next run
+    can resume from. A fresh first attempt that saved one is forward progress; the caller sets both.
     """
 
     def __init__(
@@ -115,11 +121,15 @@ class RepartitionBudgetExceededError(Exception):
         rows_written: int = 0,
         resolved: RepartitionTarget | None = None,
         resumed_from: int = 0,
+        had_prior_checkpoint: bool = False,
+        checkpoint_saved: bool = False,
     ) -> None:
         super().__init__(message)
         self.rows_written = rows_written
         self.resolved = resolved
         self.resumed_from = resumed_from
+        self.had_prior_checkpoint = had_prior_checkpoint
+        self.checkpoint_saved = checkpoint_saved
 
 
 class RepartitionSupersededError(Exception):
@@ -1045,6 +1055,10 @@ async def repartition_table_in_place(
                 skip_rows=skip_rows,
             )
         except RepartitionBudgetExceededError as e:
+            # A checkpoint present at the start of this attempt means a resumed_from==0 restart
+            # re-covered ground rather than progressing; its absence means this is a genuine first
+            # attempt. The classifier needs the distinction (see `_handle_budget_exceeded`).
+            e.had_prior_checkpoint = rewrite_checkpoint is not None
             # Checkpoint the half-built temp so the next attempt resumes instead of re-streaming from
             # row 0. Guard with a claim check first: a superseded zombie must not clobber the newer
             # claimant's state (the check raises RepartitionSupersededError, which the caller handles
@@ -1052,6 +1066,7 @@ async def repartition_table_in_place(
             await ensure_claim()
             partial_rows = await _valid_delta_row_count(temp_uri, storage_options)
             if partial_rows:
+                e.checkpoint_saved = True
                 live_version = await asyncio.to_thread(old_delta.version)
                 await asyncio.to_thread(
                     schema.set_repartition_rewrite,

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/repartition_table.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/repartition_table.py
@@ -531,19 +531,24 @@ def _handle_budget_exceeded(
     appended nothing this run is stuck; that one falls through to `_handle_failure` so a rewrite which
     genuinely can't advance in one budget still gives up.
 
-    Progress means this attempt inherited rows and added to them. Neither count alone can say that. A
-    cumulative temp size against a stored high-water mark is not monotonic, because the rewrite
-    restarts from row 0 whenever its checkpoint is discarded (the source's Delta version moved between
-    runs), so a fresh rebuild reading back below an earlier attempt's mark was charged a spurious
-    failure. But the rows written this attempt cannot say it either: a rewrite that restarts every run
-    writes hundreds of millions of rows each time, clears any `> 0` test, and ends exactly where it
-    began. Three schemas sat in that loop for six weeks, each burning a full budget per run and
-    finishing nothing, because the cap could never count to three. `resumed_from` separates them: an
-    attempt that inherited nothing re-covered ground the last one already covered, however much it
-    wrote.
+    Progress means this attempt left the rewrite further along than it found it. Neither row count
+    alone can say that. A cumulative temp size against a stored high-water mark is not monotonic,
+    because the rewrite restarts from row 0 whenever its checkpoint is discarded (the source's Delta
+    version moved between runs), so a fresh rebuild reading back below an earlier attempt's mark was
+    charged a spurious failure. But the rows written this attempt cannot say it either: a rewrite that
+    restarts every run writes hundreds of millions of rows each time, clears any `> 0` test, and ends
+    exactly where it began. Three schemas sat in that loop for six weeks, each burning a full budget per
+    run and finishing nothing, because the cap could never count to three.
+
+    Two shapes count as progress. A resumed attempt that appended rows extended what it inherited. And
+    a genuine first attempt — one with no prior checkpoint to inherit — that persisted a checkpoint the
+    next run resumes from broke new ground, even though `resumed_from` is 0. `had_prior_checkpoint`
+    keeps that first attempt apart from a restart that inherited nothing because it discarded an
+    existing checkpoint: the restart re-covered ground the last attempt already covered, however much it
+    wrote, so only it (and an attempt that saved no checkpoint at all) falls through to `_handle_failure`.
 
     Returns the metric outcome: "superseded" when a newer attempt owns the claim, "progressing" when
-    the rewrite extended what it inherited, otherwise whatever `_handle_failure` returns.
+    the rewrite broke new ground, otherwise whatever `_handle_failure` returns.
     """
     schema.refresh_from_db(fields=["sync_type_config"])
     claim = schema.repartition_claim
@@ -552,7 +557,12 @@ def _handle_budget_exceeded(
         return "superseded"
 
     pending = schema.repartition_pending or pending or {}
-    if error.resumed_from > 0 and error.rows_written > 0:
+    resumed_and_advanced = error.resumed_from > 0 and error.rows_written > 0
+    # A first attempt inherits nothing, so `resumed_from` is 0, but saving a fresh checkpoint the next
+    # run resumes from is still forward progress. Only a restart that discarded an existing checkpoint
+    # (`had_prior_checkpoint`) re-covered ground already covered — that one is the treadmill to stop.
+    fresh_and_checkpointed = not error.had_prior_checkpoint and error.checkpoint_saved
+    if resumed_and_advanced or fresh_and_checkpointed:
         # Forward progress this attempt: keep the checkpoint and reset the failure counter — a rewrite
         # still advancing is not the doomed one the cap exists to stop. The next run resumes from the
         # checkpoint rather than giving up.

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_repartition_table.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_repartition_table.py
@@ -298,6 +298,47 @@ class TestBudgetExhaustion:
         assert "warehouse_repartition_failed" not in emitted
         assert "warehouse_repartition_skipped" in emitted
 
+    @patch(f"{MODULE}.capture_exception")
+    @patch(f"{MODULE}.capture_repartition_event")
+    @patch(f"{MODULE}.HeartbeaterSync")
+    @patch(f"{MODULE}.repartition_table_in_place", new_callable=AsyncMock)
+    @patch(f"{MODULE}.DeltaTableRef")
+    @patch(f"{MODULE}.is_auto_repartition_enabled", return_value=True)
+    @patch(f"{MODULE}.ExternalDataJob")
+    @patch(f"{MODULE}.ExternalDataSchema")
+    def test_first_over_budget_attempt_that_checkpoints_is_progress_not_a_failure(
+        self,
+        mock_schema_model: MagicMock,
+        _mock_job_model: MagicMock,
+        _mock_enabled: MagicMock,
+        _mock_helper_cls: MagicMock,
+        mock_repartition: AsyncMock,
+        _mock_heartbeater: MagicMock,
+        mock_capture_event: MagicMock,
+        mock_capture_exception: MagicMock,
+    ) -> None:
+        # The first over-budget attempt on a large table inherits no checkpoint, so resumed_from is 0,
+        # but it persisted a fresh checkpoint the next run resumes from. That is forward progress, not
+        # the treadmill the cap exists to stop: it must not emit a failure event, report to error
+        # tracking, or burn an attempt (had_prior_checkpoint distinguishes it from a discarding restart).
+        schema = _schema(name="public.usages", s3_folder_name="usages", pending={**PENDING_TARGET, "attempts": 0})
+        mock_schema_model.objects.select_related.return_value.get.return_value = schema
+        mock_repartition.side_effect = RepartitionBudgetExceededError(
+            "out of budget", rows_written=162_000_000, resumed_from=0, had_prior_checkpoint=False, checkpoint_saved=True
+        )
+
+        _maybe_repartition_table(
+            RepartitionActivityInputs(team_id=TEAM_ID, schema_id=SCHEMA_ID, job_id=JOB_ID, source_id=SOURCE_ID),
+            MagicMock(),
+        )
+
+        emitted = [c.args[0] for c in mock_capture_event.call_args_list]
+        assert "warehouse_repartition_failed" not in emitted
+        mock_capture_exception.assert_not_called()
+        schema.clear_repartition_pending.assert_not_called()
+        schema.stamp_last_repartition_at.assert_not_called()
+        assert schema.set_repartition_pending.call_args.args[0]["attempts"] == 0
+
     @parameterized.expand([("below_max", 0, False), ("reaching_max", 2, True)])
     @patch(f"{MODULE}.capture_exception")
     @patch(f"{MODULE}.capture_repartition_event")
@@ -321,11 +362,11 @@ class TestBudgetExhaustion:
         _mock_capture_event: MagicMock,
         _mock_capture_exception: MagicMock,
     ) -> None:
-        # This attempt inherited nothing: the resume path discarded the checkpoint, so it re-streamed
-        # from row 0 and covered ground the last attempt already covered. It writes 230M rows doing it,
-        # which clears any "did this attempt write anything" test and resets the failure counter. Three
-        # schemas looped that way for six weeks, each burning a full budget per run and converging on
-        # nothing, because the cap could never count to three.
+        # This attempt inherited nothing because the resume path discarded a checkpoint that existed at
+        # its start, so it re-streamed from row 0 and covered ground the last attempt already covered. It
+        # writes 230M rows doing it, which clears any "did this attempt write anything" test and resets
+        # the failure counter. Three schemas looped that way for six weeks, each burning a full budget
+        # per run and converging on nothing, because the cap could never count to three.
         schema = _schema(
             name="public.usages",
             s3_folder_name="usages",
@@ -334,7 +375,7 @@ class TestBudgetExhaustion:
         )
         mock_schema_model.objects.select_related.return_value.get.return_value = schema
         mock_repartition.side_effect = RepartitionBudgetExceededError(
-            "out of budget", rows_written=230_000_000, resumed_from=0
+            "out of budget", rows_written=230_000_000, resumed_from=0, had_prior_checkpoint=True, checkpoint_saved=True
         )
 
         _maybe_repartition_table(


### PR DESCRIPTION
## Problem

A data-warehouse source whose table is too large to repartition in one activity budget shows up in `warehouse_repartition_failed` telemetry on its very first over-budget attempt, even though that attempt made real progress. The failure is also reported to error tracking and burns one of the table's three finite attempts.

- The rewrite streams a table into a new partition scheme and checkpoints its progress when it runs out of budget, so the next run resumes instead of restarting.
- The first attempt inherits no checkpoint, so `resumed_from` is 0.
- `_handle_budget_exceeded` treated any `resumed_from == 0` attempt as a stall, so a first attempt that wrote and checkpointed hundreds of millions of rows was classified as a failure.

## Changes

- The first over-budget attempt that persists a checkpoint now stands down as `progressing`: no `warehouse_repartition_failed` event, no error-tracking report, no burned attempt.
- `RepartitionBudgetExceededError` carries two new facts the classifier needs: `had_prior_checkpoint` (a checkpoint existed at the start of this attempt) and `checkpoint_saved` (this attempt persisted one). The caller sets both.
- The treadmill guard is unchanged in effect. A restart that discarded an existing checkpoint has `had_prior_checkpoint` set, so it still counts a failed attempt and still gives up after the cap. It gives up one attempt later than before, because the genuine first attempt no longer counts.
- Mechanical: docstrings on the error class and `_handle_budget_exceeded` updated to describe the first-attempt case.

## How did you test this code?

- Added `test_first_over_budget_attempt_that_checkpoints_is_progress_not_a_failure`: a fresh attempt (`resumed_from=0`, no prior checkpoint, checkpoint saved) must not emit a failure event, report to error tracking, or burn an attempt. No existing case covered a first attempt with a saved checkpoint.
- Updated `test_restarted_rewrite_burns_an_attempt_however_many_rows_it_wrote` to set `had_prior_checkpoint=True`, matching the discarding-restart scenario it is named for, so it still exercises the treadmill guard.
- Ran the repartition activity suite and the core repartition suite locally; both pass. Not run: the controller suite's database-backed cases, because this sandbox has no Postgres.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triage of a `warehouse_repartition_failed` mode (`RepartitionBudgetExceededError`, proactive trigger, two large tables, no terminal failures). Traced the emit site and the budget-exceeded classifier, found the first-attempt false positive, and fixed the classification.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

Related but distinct: [#83139](https://github.com/PostHog/posthog/pull/83139) fixes the treadmill root cause (a schema's own merge bumps the Delta version and discards the checkpoint every run) by holding imports so the checkpoint survives. That does not address the first-attempt misclassification, which fires even when the checkpoint would survive. The two changes are complementary.

No material from the agent session appears here. Table names, paths, and row counts from the triage input were treated as sensitive and kept out of the code, tests, and this description.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
