### PR TITLE
fix(firebase): skip Firestore collections when the database is in Datastore mode

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/firebase/firebase.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/firebase/firebase.py
@@ -269,8 +269,14 @@ def _request(
     if not response.ok:
         # `raise_for_status` reports status and URL only, so drain a tightly bounded prefix purely
         # to release the connection — the error path never needs a full page's worth of bytes.
-        _read_truncated_body(response, MAX_ERROR_BODY_BYTES)
-        response.raise_for_status()
+        detail_body = _read_truncated_body(response, MAX_ERROR_BODY_BYTES)
+        try:
+            response.raise_for_status()
+        except requests.HTTPError as e:
+            # Google's structured error (status/message) lets callers tell a permanent,
+            # database-configuration failure apart from a transient or unexpected one.
+            e.args = (f"{e.args[0]} ({_error_detail(response, detail_body)})",)
+            raise
 
     raw = _read_capped_body(response, MAX_RESPONSE_BYTES)
     if not raw:
@@ -577,10 +583,12 @@ def get_tables(credentials: FirebaseCredentials) -> list[str]:
         collection_ids = list_collection_ids(api_session, tokens, credentials)
         tables.extend(firestore_table_name(collection_id) for collection_id in collection_ids)
     except requests.HTTPError as e:
-        # A project with no Firestore database answers 404, and a service account without the
-        # Datastore role answers 403. Neither should hide the tables the source can still read.
+        # A project with no Firestore database answers 404, a service account without the
+        # Datastore role answers 403, and a default database provisioned in Datastore mode
+        # (rather than Native mode) answers 400 — the Documents API this source reads is
+        # Native-mode only. None of these should hide the tables the source can still read.
         status = e.response.status_code if e.response is not None else None
-        if status not in (403, 404):
+        if status not in (403, 404) and not (status == 400 and "datastore mode" in str(e).lower()):
             raise
         LOGGER.warning(f"Skipping Firestore collections for Firebase project {credentials.project_id}: {status}")
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/firebase/tests/test_firebase.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/firebase/tests/test_firebase.py
@@ -544,9 +544,38 @@ class TestTableDiscovery:
         with mock.patch(_SESSION_FACTORY, return_value=session.as_session()):
             assert get_tables(credentials()) == [AUTH_USERS_TABLE]
 
-    def test_other_firestore_errors_propagate(self) -> None:
+    def test_datastore_mode_database_does_not_hide_the_other_tables(self) -> None:
         session = FakeSession(
-            request_responses=[FakeResponse(status_code=500, payload={"error": {"status": "INTERNAL"}})],
+            request_responses=[
+                FakeResponse(
+                    status_code=400,
+                    payload={
+                        "error": {
+                            "code": 400,
+                            "status": "FAILED_PRECONDITION",
+                            "message": "The Cloud Firestore API is not available for Firestore in Datastore Mode database.",
+                        }
+                    },
+                )
+            ],
+            post_responses=[FakeResponse(payload=TOKEN_PAYLOAD)],
+        )
+
+        with mock.patch(_SESSION_FACTORY, return_value=session.as_session()):
+            assert get_tables(credentials()) == [AUTH_USERS_TABLE]
+
+    @pytest.mark.parametrize(
+        "status,payload",
+        [
+            (500, {"error": {"status": "INTERNAL"}}),
+            # A 400 for any other reason is a real, actionable failure and must not be conflated
+            # with the Datastore-mode case above just because the status code matches.
+            (400, {"error": {"status": "INVALID_ARGUMENT", "message": "Invalid pageToken."}}),
+        ],
+    )
+    def test_other_firestore_errors_propagate(self, status: int, payload: dict[str, Any]) -> None:
+        session = FakeSession(
+            request_responses=[FakeResponse(status_code=status, payload=payload)],
             post_responses=[FakeResponse(payload=TOKEN_PAYLOAD)],
         )
 


### PR DESCRIPTION
## Problem

Adding a Firebase source fails schema discovery entirely when the project's default database is provisioned in Datastore mode instead of Native mode, even though Auth users and Realtime Database paths are still readable.

Google's Firestore Documents API (`listCollectionIds`, used to enumerate Firestore collections) only works against Native-mode databases. A Datastore-mode database answers every call with `400 Bad Request` / `FAILED_PRECONDITION`, and that error was not recognized, so it propagated and broke the whole schema listing instead of just excluding Firestore.

Surfaced by an error-tracking issue: `HTTPError: 400 Client Error: Bad Request for url: https://firestore.googleapis.com/v1/projects/.../databases/(default)/documents:listCollectionIds`.

## Changes

- `get_tables()` now skips Firestore collections and keeps listing Auth users and Realtime Database paths when the database is in Datastore mode, matching the existing behavior for a missing database (404) or a missing role (403).
- The skip is matched on Google's structured error detail (`FAILED_PRECONDITION` / "Datastore Mode" in the response body), not the bare 400 status code, so an unrelated 400 still surfaces as a real failure.
- `_request()` now appends Google's structured error detail (status and message from the response body) to the raised `HTTPError`, which is what makes that distinction possible. This is mechanical and affects only the exception message text.

## How did you test this code?

Added two test groups to `test_firebase.py`:

- `test_datastore_mode_database_does_not_hide_the_other_tables`: a 400 with a Datastore-mode body still returns Auth users as a table, catching the regression this PR fixes.
- `test_other_firestore_errors_propagate` (parametrized): a 500, and a 400 for an unrelated reason, both still raise — guards against the skip being too broad.

Ran the full `test_firebase.py` suite locally (88 passed).

Not run: mypy (the repo-wide strict run did not finish locally in this session; CI's own mypy job covers it).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None; no user-facing config or workflow changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated and fixed by Claude Code, triaging a live error-tracking issue for the Firebase data-warehouse source. Read the stack trace and captured local variables on the exception event, then used web research to confirm Google's documented behavior that the Firestore Documents API rejects Datastore-mode databases with `FAILED_PRECONDITION`. No skills were invoked beyond the standard `/writing-tests` and `/writing-pr-descriptions` gates for this repo.