### PR TITLE
fix(retention): reject warehouse timestamp columns that aren't dates

### DIFF
--- a/posthog/hogql_queries/insights/retention/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/retention_query_runner.py
@@ -43,6 +43,7 @@ from posthog.hogql_queries.insights.retention.retention_validation_rules import 
     DisallowCumulativeWith24HourWindows,
     DisallowGroupAggregationWithDataWarehouse24HourWindows,
     DisallowPropertyAggregationWith24HourWindows,
+    DisallowUnsupportedDataWarehouseTimestampField,
 )
 from posthog.hogql_queries.insights.utils.breakdowns import (
     ALL_USERS_COHORT_ID,
@@ -149,6 +150,7 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
             DisallowGroupAggregationWithDataWarehouse24HourWindows(),
             DisallowPropertyAggregationWith24HourWindows(),
             DisallowUnsupportedDataWarehouseSettings(),
+            DisallowUnsupportedDataWarehouseTimestampField(),
         )
 
     @cached_property

--- a/posthog/hogql_queries/insights/retention/retention_validation_rules.py
+++ b/posthog/hogql_queries/insights/retention/retention_validation_rules.py
@@ -2,7 +2,11 @@ from rest_framework.exceptions import ValidationError
 
 from posthog.schema import AggregationType, EntityType, RetentionQuery
 
+from posthog.hogql.database.database import Database
+from posthog.hogql.database.models import DateDatabaseField, DateTimeDatabaseField
+
 from posthog.hogql_queries.insights.utils.breakdowns import has_breakdown_filter
+from posthog.hogql_queries.insights.utils.data_warehouse_schema_mixin import resolve_warehouse_field
 from posthog.hogql_queries.validation.validation import QueryValidationContext
 
 
@@ -61,6 +65,41 @@ class DisallowGroupAggregationWithDataWarehouse24HourWindows:
                 "Group aggregation is not supported for 24 hour windows with a data warehouse series.",
                 code=self.code,
             )
+
+
+class DisallowUnsupportedDataWarehouseTimestampField:
+    """Every interval bucket runs the configured timestamp column through toStartOfInterval, so a column that
+    cannot be a datetime fails deep inside ClickHouse, quoting generated SQL the user never wrote. Resolving
+    the column type up front turns that into a 400 naming the column they picked.
+
+    An integer is rejected rather than converted because it could hold seconds, milliseconds or microseconds
+    since the epoch, and guessing wrong shifts every bucket instead of failing."""
+
+    code = "retention_data_warehouse_timestamp_field_unsupported"
+
+    def validate(self, context: QueryValidationContext[RetentionQuery]) -> None:
+        retention_filter = context.query.retentionFilter
+        entities = [
+            entity
+            for entity in (retention_filter.targetEntity, retention_filter.returningEntity)
+            if entity is not None and entity.type == EntityType.DATA_WAREHOUSE
+        ]
+        if not entities:
+            return
+
+        database = Database.create_for(team=context.team, user=context.user)
+        for entity in entities:
+            if not entity.table_name or not entity.timestamp_field:
+                # A half-configured entity raises its own error while building the query.
+                continue
+            field = resolve_warehouse_field(database, entity.table_name, entity.timestamp_field)
+            if not isinstance(field, DateTimeDatabaseField | DateDatabaseField):
+                raise ValidationError(
+                    f"{entity.table_name}.{entity.timestamp_field} can't be used as the retention timestamp, "
+                    "because it isn't a date or datetime column. Pick a different column, "
+                    "or convert this one in a saved query first.",
+                    code=self.code,
+                )
 
 
 class DisallowPropertyAggregationWith24HourWindows:

--- a/posthog/hogql_queries/insights/retention/test/test_retention_data_warehouse.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_data_warehouse.py
@@ -13,6 +13,7 @@ from posthog.test.base import (
 )
 
 from parameterized import parameterized
+from rest_framework.exceptions import ValidationError
 
 from posthog.hogql_queries.actors_query_runner import ActorsQueryRunner
 from posthog.hogql_queries.insights.retention.retention_query_runner import RetentionQueryRunner
@@ -252,6 +253,50 @@ class TestRetentionDataWarehouse(ClickhouseTestMixin, APIBaseTest):
             "targetEntity": entity("signed_up"),
             "returningEntity": entity("renewed"),
         }
+
+    def _activity_table_with_timestamp_type(self, column_type: str, occurred_at: list[object]) -> str:
+        person_ids = self._create_people()
+        suffix = "".join(c for c in column_type.lower() if c.isalnum())
+        return self._create_data_warehouse_table(
+            filename=f"warehouse_activity_ts_{suffix}.csv",
+            table_name=f"warehouse_activity_ts_{suffix}",
+            header=["id", "person_id", "activity_type", "occurred_at"],
+            rows=[
+                [1, person_ids["user-1"], "signed_up", occurred_at[0]],
+                [2, person_ids["user-2"], "signed_up", occurred_at[1]],
+                [3, person_ids["user-1"], "renewed", occurred_at[2]],
+                [4, person_ids["user-2"], "renewed", occurred_at[3]],
+            ],
+            table_columns={
+                "id": "Int64",
+                "person_id": "UUID",
+                "activity_type": "String",
+                "occurred_at": column_type,
+            },
+        )
+
+    @parameterized.expand(
+        [
+            ("integer", "Int64", [1735722000, 1735725600, 1735815600, 1735905600]),
+            (
+                "string",
+                "String",
+                ["2025-01-01 09:00:00", "2025-01-01 10:00:00", "2025-01-02 12:00:00", "2025-01-03 12:00:00"],
+            ),
+        ]
+    )
+    def test_non_datetime_timestamp_field_is_rejected(self, _name: str, column_type: str, occurred_at: list[object]):
+        # Both types reach toStartOfInterval and fail inside ClickHouse without this check, quoting
+        # generated SQL rather than naming the column the user picked.
+        table = self._activity_table_with_timestamp_type(column_type, occurred_at)
+
+        with self.assertRaisesMessage(ValidationError, "isn't a date or datetime column"):
+            self.run_query(
+                query={
+                    "dateRange": {"date_from": "2025-01-01T00:00:00Z", "date_to": "2025-01-05T00:00:00Z"},
+                    "retentionFilter": self._activity_retention_filter(table),
+                }
+            )
 
     @snapshot_clickhouse_queries
     def test_retention_data_warehouse_breakdown_by_warehouse_column(self):

--- a/posthog/hogql_queries/insights/utils/data_warehouse_schema_mixin.py
+++ b/posthog/hogql_queries/insights/utils/data_warehouse_schema_mixin.py
@@ -6,6 +6,17 @@ from posthog.hogql.database.models import DatabaseField, Table
 from posthog.hogql_queries.insights.query_context import QueryContextProtocol
 
 
+def resolve_warehouse_field(database: Database, table_name: str, field_name: str) -> DatabaseField:
+    table = database.get_table(table_name)
+    field = table.fields.get(field_name)
+    if field is None:
+        raise ValidationError(detail=f"Unknown field {table_name}.{field_name}")
+    if isinstance(field, Table):
+        raise ValidationError(detail=f"{table_name}.{field_name} points to a table, not a field")
+    assert isinstance(field, DatabaseField)
+    return field
+
+
 class DataWarehouseSchemaMixin(QueryContextProtocol):
     _hogql_database: Database | None = None
 
@@ -21,11 +32,4 @@ class DataWarehouseSchemaMixin(QueryContextProtocol):
         return self._hogql_database
 
     def get_warehouse_field(self, table_name: str, field_name: str) -> DatabaseField:
-        table = self.hogql_database.get_table(table_name)
-        field = table.fields.get(field_name)
-        if field is None:
-            raise ValidationError(detail=f"Unknown field {table_name}.{field_name}")
-        if isinstance(field, Table):
-            raise ValidationError(detail=f"{table_name}.{field_name} points to a table, not a field")
-        assert isinstance(field, DatabaseField)
-        return field
+        return resolve_warehouse_field(self.hogql_database, table_name, field_name)


### PR DESCRIPTION
## TL;DR

Point retention at a data warehouse table whose timestamp column stores a number instead of a date, and it crashed with a wall of ClickHouse SQL. Now it says which column is wrong.

Follows #84458, which fixed a different crash in the same feature.

## Problem

- Retention on a warehouse table errors out when the chosen timestamp column is not a date or datetime.
- The user sees `Illegal type Int64 of 1st argument of function toStartOfInterval`, followed by the whole generated query.
- Nothing in that message names the column they picked.
- Every interval bucket wraps the column in `toStartOfInterval`, so a column that can't be a datetime fails inside ClickHouse.
- String columns fail identically. Retention has never supported either type.
- Warehouse sources produce these columns routinely: an integer `created_at` holding a unix epoch is common.
- Every warehouse retention fixture used `DateTime64(3, 'UTC')`, so no test covered it.

## Changes

- The user now gets a 400 naming the column they picked, and what to do about it, instead of a ClickHouse type error quoting generated SQL.
- A new `DisallowUnsupportedDataWarehouseTimestampField` validation rule resolves the column's type before the query is built.
- Integers are rejected rather than converted. The value could be seconds, milliseconds or microseconds since the epoch, and guessing wrong shifts every cohort silently instead of failing.
- Mechanical: `resolve_warehouse_field` moves out of `DataWarehouseSchemaMixin` into a function the rule can reuse. Funnels still reaches it through the mixin, unchanged.

Funnels checks this inside its timestamp expression builder. A validation rule fits better here for two reasons:

- Retention's builders have unit tests that construct AST with no live warehouse schema, by design. Putting a schema lookup in `entity_timestamp_field` broke five of them.
- Validation runs before expression building, so a half-configured entity still reports its own more specific error first.

The rule generates no SQL, so every existing snapshot is untouched.

> [!NOTE]
> Strings are rejected here rather than wrapped in `toDateTime`. Funnels accepts them; retention never has, so this is not a regression, and a clear 400 beats the current crash. Supporting them needs the builder to read the schema, which is the coupling described above. Better as its own change.

## How did you test this code?

Two new parameterized cases in `test_retention_data_warehouse.py`, one per column type. Both fail without the rule, with the error from the report:

```
Illegal type Int64  ... of function toStartOfInterval
Illegal type String ... of function toStartOfInterval
```

No existing test covered a non-datetime timestamp column, so neither case is redundant.

`posthog/hogql_queries/insights/retention/test/` passes with all 56 snapshots unchanged. That includes the five AST-only builder tests that the rejected expression-builder approach broke, which is the guard that this version stays out of query building.

Not done: no manual check in a running app.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with PostHog Code (Claude Opus 5). Skills invoked: `/writing-tests`, `/writing-user-facing-copy`, `/writing-pr-descriptions`.

Found while manually testing the retention warehouse rollout: an insight failed with the ClickHouse type error above. The first suspicion was the actor-id bug fixed in #84458, but that error came from the timestamp column instead, so it needed its own change.

The first implementation followed funnels and did the check inside `entity_timestamp_field`. That coupled expression building to a live warehouse schema and broke the builder unit tests that deliberately avoid one, so it moved to a validation rule. Checking whether string columns worked before this change decided the scope: they crashed too, so rejecting them is a strict improvement rather than a removed feature.

A second, separate problem surfaced during diagnosis and is not addressed here: the column picker pre-fills defaults by matching column names without checking their types, which is how an integer column got selected as a timestamp in the first place. That fix is frontend-only and will be its own PR.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
