### PR TITLE
fix(canvas): make generated canvases full height

### DIFF
--- a/products/canvas/skills/building-html-canvases/SKILL.md
+++ b/products/canvas/skills/building-html-canvases/SKILL.md
@@ -38,9 +38,10 @@ build pipeline's dependency admission ships.
 ## Styling and theme without Quill
 
 - Size the outermost JSX/HTML element to the iframe viewport with `h-screen` or `height: 100vh`.
-  Do not use `h-full` or `height: 100%` on that root: the iframe's `html`, `body`, and `#root` have
-  no explicit height, so percentage height collapses to the content height. Descendants may use
-  percentage height after the outermost element establishes the viewport height.
+  Do not use `h-full` or `height: 100%` on that root: a published canvas's artifact shell gives
+  its `html`, `body`, and `#root` elements no explicit height, so percentage height collapses to
+  the content height. Descendants may use percentage height after the outermost element establishes
+  the viewport height.
 - Use Tailwind utilities and/or a `<style>` block (keyframes and complex selectors are fine).
 - The host toggles a `.dark` class on the document root when the user's PostHog theme changes.
   Define your colors as CSS variables under `:root { … }` with overrides under `html.dark { … }`,

--- a/products/canvas/skills/building-html-canvases/SKILL.md
+++ b/products/canvas/skills/building-html-canvases/SKILL.md
@@ -37,6 +37,10 @@ build pipeline's dependency admission ships.
 
 ## Styling and theme without Quill
 
+- Size the outermost JSX/HTML element to the iframe viewport with `h-screen` or `height: 100vh`.
+  Do not use `h-full` or `height: 100%` on that root: the iframe's `html`, `body`, and `#root` have
+  no explicit height, so percentage height collapses to the content height. Descendants may use
+  percentage height after the outermost element establishes the viewport height.
 - Use Tailwind utilities and/or a `<style>` block (keyframes and complex selectors are fine).
 - The host toggles a `.dark` class on the document root when the user's PostHog theme changes.
   Define your colors as CSS variables under `:root { … }` with overrides under `html.dark { … }`,

--- a/products/canvas/skills/building-react-quill-canvases/SKILL.md
+++ b/products/canvas/skills/building-react-quill-canvases/SKILL.md
@@ -50,9 +50,9 @@ control or a styled `<div>` standing in for one:
 ## Styling and theme
 
 - Give the canvas's outermost element `h-screen` (`height: 100vh`) so it fills the iframe viewport.
-  Do not use `h-full` there: the host iframe's `html`, `body`, and `#root` have no explicit height,
-  so a percentage root height collapses to content height. Nested elements may use `h-full` once
-  their parent establishes a height.
+  Do not use `h-full` there: a published canvas's artifact shell gives its `html`, `body`, and
+  `#root` elements no explicit height, so a percentage root height collapses to content height.
+  Nested elements may use `h-full` once their parent establishes a height.
 - Style with Tailwind utilities and Quill components; reserve inline `style` for genuinely dynamic
   runtime values (fixed sizes use arbitrary-value utilities like `h-[280px]`).
 - Write specific interface copy. Never use lorem ipsum or placeholder labels in a finished canvas.

--- a/products/canvas/skills/building-react-quill-canvases/SKILL.md
+++ b/products/canvas/skills/building-react-quill-canvases/SKILL.md
@@ -49,6 +49,10 @@ control or a styled `<div>` standing in for one:
 
 ## Styling and theme
 
+- Give the canvas's outermost element `h-screen` (`height: 100vh`) so it fills the iframe viewport.
+  Do not use `h-full` there: the host iframe's `html`, `body`, and `#root` have no explicit height,
+  so a percentage root height collapses to content height. Nested elements may use `h-full` once
+  their parent establishes a height.
 - Style with Tailwind utilities and Quill components; reserve inline `style` for genuinely dynamic
   runtime values (fixed sizes use arbitrary-value utilities like `h-[280px]`).
 - Write specific interface copy. Never use lorem ipsum or placeholder labels in a finished canvas.

--- a/products/canvas/skills/building-react-quill-canvases/references/starter-scaffold.md
+++ b/products/canvas/skills/building-react-quill-canvases/references/starter-scaffold.md
@@ -77,7 +77,8 @@ export default function Canvas() {
   }, [win, nonce])
 
   return (
-    <div className="flex flex-col gap-4 p-6">
+    // The canvas root must resolve height against the iframe viewport.
+    <div className="flex h-screen flex-col gap-4 overflow-y-auto p-6">
       <div className="flex items-center justify-between">
         <Heading size="xl" className="mb-4">
           Canvas

--- a/products/canvas/skills/composing-grid-canvases/SKILL.md
+++ b/products/canvas/skills/composing-grid-canvases/SKILL.md
@@ -73,9 +73,10 @@ Start from the complete, buildable project in [references/component-example.md](
 
 - **Design responsively.** Give the component's root `h-screen` so it fills the placement iframe's
   viewport, and adapt the layout to any size the user drags: a 2×1 placement is a glanceable tile;
-  a 6×4 is a full app surface. Do not use `h-full` on the root: the iframe's `html`, `body`, and
-  `#root` elements have no explicit height, so `height: 100%` collapses to the content height.
-  Render usefully at `minW`×`minH`, and treat `config` as the only per-placement input.
+  a 6×4 is a full app surface. Do not use `h-full` on the root: a published component's artifact
+  shell gives its `html`, `body`, and `#root` elements no explicit height, so `height: 100%`
+  collapses to the content height. Render usefully at `minW`×`minH`, and treat `config` as the only
+  per-placement input.
 
 Publish and wait for the build like any canvas — a component with no ready build cannot go live on
 a grid.

--- a/products/canvas/skills/composing-grid-canvases/SKILL.md
+++ b/products/canvas/skills/composing-grid-canvases/SKILL.md
@@ -71,9 +71,11 @@ Start from the complete, buildable project in [references/component-example.md](
   `additionalProperties`, `items`, `enum`, `const`, `minimum`, `maximum`, `minLength`, `maxLength`,
   `minItems`, `maxItems`, `format`. No `$ref`, no `pattern` — validation rejects them.
 
-- **Design responsively.** Fill 100% of the box's width and height, and adapt the layout to any
-  size the user drags: a 2×1 placement is a glanceable tile; a 6×4 is a full app surface. Render
-  usefully at `minW`×`minH`, and treat `config` as the only per-placement input.
+- **Design responsively.** Give the component's root `h-screen` so it fills the placement iframe's
+  viewport, and adapt the layout to any size the user drags: a 2×1 placement is a glanceable tile;
+  a 6×4 is a full app surface. Do not use `h-full` on the root: the iframe's `html`, `body`, and
+  `#root` elements have no explicit height, so `height: 100%` collapses to the content height.
+  Render usefully at `minW`×`minH`, and treat `config` as the only per-placement input.
 
 Publish and wait for the build like any canvas — a component with no ready build cannot go live on
 a grid.

--- a/products/canvas/skills/composing-grid-canvases/references/component-example.md
+++ b/products/canvas/skills/composing-grid-canvases/references/component-example.md
@@ -143,4 +143,4 @@ export default function WelcomeChecklist() {
 - `ph` is a host-injected global — never import it, and feature-detect optional surfaces like `ph.state` so the widget degrades instead of crashing on an older runtime.
 - Loading state renders a skeleton, never a blank; every async access has a `.catch` that lands in a renderable state.
 - Fill the placement iframe viewport (`h-screen`) and let content scroll; `h-full` cannot resolve
-  on the root because the iframe shell has no explicit height.
+  on the root because the published artifact shell has no explicit height.

--- a/products/canvas/skills/composing-grid-canvases/references/component-example.md
+++ b/products/canvas/skills/composing-grid-canvases/references/component-example.md
@@ -99,7 +99,8 @@ export default function WelcomeChecklist() {
   const done = checked ? ITEMS.filter((item) => checked[item.id]).length : 0
 
   return (
-    <div className="flex h-full flex-col gap-2 overflow-y-auto p-3">
+    // The component root must resolve height against its placement iframe viewport.
+    <div className="flex h-screen flex-col gap-2 overflow-y-auto p-3">
       <div className="flex items-baseline justify-between gap-2">
         <Text weight="medium">Welcome to PostHog</Text>
         {checked ? (
@@ -141,4 +142,5 @@ export default function WelcomeChecklist() {
 - Imports only from the platform allowlist (`react`, `@posthog/quill`, `lucide-react`, `recharts`, `dayjs`).
 - `ph` is a host-injected global — never import it, and feature-detect optional surfaces like `ph.state` so the widget degrades instead of crashing on an older runtime.
 - Loading state renders a skeleton, never a blank; every async access has a `.catch` that lands in a renderable state.
-- Fill 100% of the box (`h-full`) and let content scroll; the user controls the placement's size.
+- Fill the placement iframe viewport (`h-screen`) and let content scroll; `h-full` cannot resolve
+  on the root because the iframe shell has no explicit height.


### PR DESCRIPTION
## Problem

Canvas components generated from the skills can collapse to content height and leave empty space inside grid placements.

**Why:** Component roots used percentage height without a height-bearing iframe ancestor.

## Changes

- Generated React and HTML canvases now size their root against the iframe viewport.
- Component guidance explains why percentage height fails at the root.
- Starter examples use viewport height and preserve scrolling.

## How did you test this code?

- `uv run python products/posthog_ai/scripts/build_skills.py --lint`
- Full rendering was not run because the local Postgres and Redis services were unavailable.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The canvas-building skills and their reference scaffolds contain the documentation update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex made this change with the `writing-skills`, `writing-code-comments`, and `writing-pr-descriptions` skills. The comments preserve the non-obvious iframe sizing constraint.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*