### PR TITLE
fix(ai-research): rename the image fetcher bot

### DIFF
--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/image-fetcher.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/image-fetcher.test.ts
@@ -46,6 +46,22 @@ describe('HttpImageFetcher', () => {
         fetchStreamedMock.mockReset()
     })
 
+    it('identifies every request as PostHogImageFetcherBot', async () => {
+        fetchStreamedMock.mockResolvedValue(image(PNG, 'image/png'))
+
+        await fetcher().fetch('https://cdn.example.com/a.png', OPTIONS)
+
+        expect(fetchStreamedMock).toHaveBeenCalledWith(
+            'https://cdn.example.com/a.png',
+            expect.objectContaining({
+                headers: expect.objectContaining({
+                    'user-agent':
+                        'PostHogImageFetcherBot/1.0 (+https://posthog.com/docs/ai-research/image-fetcher-bot)',
+                }),
+            })
+        )
+    })
+
     it('returns the bytes of an image whose payload matches its declared type', async () => {
         fetchStreamedMock.mockResolvedValue(image(PNG, 'image/png; charset=binary'))
 

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/image-fetcher.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/image-fetcher.ts
@@ -75,7 +75,7 @@ export interface ImageFetcher {
     fetch(url: string, options: ImageFetchOptions): Promise<ImageFetchResult>
 }
 
-const USER_AGENT = 'PostHogSessionReplayBot/1.0 (+https://posthog.com/docs/session-replay/image-bot)'
+const USER_AGENT = 'PostHogImageFetcherBot/1.0 (+https://posthog.com/docs/ai-research/image-fetcher-bot)'
 
 const REQUEST_HEADERS: Record<string, string> = {
     'user-agent': USER_AGENT,


### PR DESCRIPTION
## Problem

Site owners need a stable bot name and public documentation URL when they inspect or block image fetch requests.

The current name ties the bot to Session Replay even though AI research owns the image fetcher.

## Changes

- The image fetcher sends `PostHogImageFetcherBot/1.0 (+https://posthog.com/docs/ai-research/image-fetcher-bot)`.
- A focused test protects the complete public user-agent contract.
- This change has no visual effect in the PostHog app.

## How did you test this code?

- A focused Jest test verifies the complete user agent on an outbound request.
- ESLint, Prettier, the full Node TypeScript check, and `ci:preflight` pass locally.
- Not tested against a live image origin because the request boundary has unit coverage.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- [PostHog/posthog.com#19574](https://github.com/PostHog/posthog.com/pull/19574) moves the public documentation and redirects the old URL.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex changed the public bot identity and added a regression test.

Skills invoked: `/writing-tests`, `/writing-user-facing-copy`, `/writing-pr-descriptions`, `/yeet`, and Simplified Technical English.