### PR TITLE
feat(desktop): show live pull request status in sessions

### DIFF
--- a/products/desktop/packages/core/src/git/router-schemas.ts
+++ b/products/desktop/packages/core/src/git/router-schemas.ts
@@ -386,6 +386,7 @@ export const getPrDetailsByUrlOutput = z.object({
   draft: z.boolean(),
   headRefName: z.string().nullable(),
   title: z.string().nullable(),
+  author: z.string().nullable(),
 });
 export type PrDetailsByUrlOutput = z.infer<typeof getPrDetailsByUrlOutput>;
 

--- a/products/desktop/packages/host-router/src/routers/git.router.ts
+++ b/products/desktop/packages/host-router/src/routers/git.router.ts
@@ -530,6 +530,7 @@ export const gitRouter = router({
           draft: false,
           headRefName: null,
           title: null,
+          author: null,
         }
       );
     }),

--- a/products/desktop/packages/ui/src/features/editor/components/GithubPrRefChip.test.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/GithubPrRefChip.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+const usePrDetailsMock = vi.hoisted(() => vi.fn());
+const usePrChecksMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@posthog/ui/features/git-interaction/usePrDetails", () => ({
+  usePrDetails: usePrDetailsMock,
+}));
+
+vi.mock("@posthog/ui/features/pr-review/usePrChecks", () => ({
+  usePrChecks: usePrChecksMock,
+}));
+
+import { GithubPrRefChip } from "./GithubPrRefChip";
+
+describe("GithubPrRefChip", () => {
+  it("refreshes lifecycle state and loads CI when its tooltip opens", async () => {
+    const href = "https://github.com/PostHog/posthog/pull/23985";
+    usePrDetailsMock.mockReturnValue({
+      meta: {
+        state: "open",
+        merged: false,
+        draft: true,
+        headRefName: "posthog/status-chip",
+        title: "Show pull request status in sessions",
+        author: "octocat",
+        isLoading: false,
+      },
+      commentThreads: new Map(),
+      commentsLoading: false,
+    });
+    usePrChecksMock.mockReturnValue({
+      data: [
+        {
+          name: "Desktop CI",
+          bucket: "pass",
+          link: null,
+          workflow: null,
+          description: null,
+        },
+      ],
+      isLoading: false,
+    });
+
+    render(
+      <GithubPrRefChip href={href}>PostHog/posthog#23985</GithubPrRefChip>,
+    );
+
+    expect(screen.getByRole("img", { name: "Draft" })).toBeInTheDocument();
+    expect(usePrDetailsMock).toHaveBeenCalledWith(href, {
+      refetchInterval: 30_000,
+    });
+    expect(usePrChecksMock).toHaveBeenCalledWith(null);
+
+    const link = screen.getByText("PostHog/posthog#23985").closest("a");
+    expect(link).not.toBeNull();
+    await userEvent.hover(link as HTMLAnchorElement);
+
+    expect(await screen.findByText("CI passed")).toBeInTheDocument();
+    expect(usePrChecksMock).toHaveBeenCalledWith(href);
+  });
+});

--- a/products/desktop/packages/ui/src/features/editor/components/GithubPrRefChip.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/GithubPrRefChip.tsx
@@ -1,15 +1,15 @@
 import type { PrCheck } from "@posthog/core/git/router-schemas";
 import {
-  type GithubPrRefDetails,
-  GithubRefChip,
-} from "@posthog/ui/features/editor/components/GithubRefChip";
+  type PrCiStatus,
+  PrRefChip,
+} from "@posthog/ui/features/editor/components/PrRefChip";
 import { usePrDetails } from "@posthog/ui/features/git-interaction/usePrDetails";
 import { usePrChecks } from "@posthog/ui/features/pr-review/usePrChecks";
 import { type ReactElement, type ReactNode, useState } from "react";
 
 function summarizeCiStatus(
   checks: PrCheck[] | null | undefined,
-): GithubPrRefDetails["ciStatus"] {
+): PrCiStatus | null {
   if (!checks || checks.length === 0) return null;
   if (
     checks.some((check) => check.bucket === "fail" || check.bucket === "cancel")
@@ -20,6 +20,7 @@ function summarizeCiStatus(
   return checks.some((check) => check.bucket === "pass") ? "success" : null;
 }
 
+/** A pull request chip wired to live lifecycle and CI state. */
 export function GithubPrRefChip({
   href,
   children,
@@ -29,21 +30,25 @@ export function GithubPrRefChip({
 }): ReactElement {
   const [tooltipOpen, setTooltipOpen] = useState(false);
   const { meta } = usePrDetails(href, { refetchInterval: 30_000 });
+  // CI is the expensive half, so it loads only once someone asks to see it.
   const checksQuery = usePrChecks(tooltipOpen ? href : null);
-  const ciStatus = tooltipOpen
-    ? checksQuery.isLoading
-      ? "loading"
-      : summarizeCiStatus(checksQuery.data)
-    : null;
 
   return (
-    <GithubRefChip
+    <PrRefChip
       href={href}
-      kind="pr"
-      prDetails={{ ...meta, ciStatus }}
       onTooltipOpenChange={setTooltipOpen}
+      details={{
+        state: meta.state,
+        merged: meta.merged,
+        draft: meta.draft,
+        title: meta.title,
+        author: meta.author,
+        isLoading: meta.isLoading,
+        ciStatus: tooltipOpen ? summarizeCiStatus(checksQuery.data) : null,
+        isCiLoading: tooltipOpen && checksQuery.isLoading,
+      }}
     >
       {children}
-    </GithubRefChip>
+    </PrRefChip>
   );
 }

--- a/products/desktop/packages/ui/src/features/editor/components/GithubPrRefChip.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/GithubPrRefChip.tsx
@@ -1,0 +1,49 @@
+import type { PrCheck } from "@posthog/core/git/router-schemas";
+import {
+  type GithubPrRefDetails,
+  GithubRefChip,
+} from "@posthog/ui/features/editor/components/GithubRefChip";
+import { usePrDetails } from "@posthog/ui/features/git-interaction/usePrDetails";
+import { usePrChecks } from "@posthog/ui/features/pr-review/usePrChecks";
+import { type ReactElement, type ReactNode, useState } from "react";
+
+function summarizeCiStatus(
+  checks: PrCheck[] | null | undefined,
+): GithubPrRefDetails["ciStatus"] {
+  if (!checks || checks.length === 0) return null;
+  if (
+    checks.some((check) => check.bucket === "fail" || check.bucket === "cancel")
+  ) {
+    return "failure";
+  }
+  if (checks.some((check) => check.bucket === "pending")) return "pending";
+  return checks.some((check) => check.bucket === "pass") ? "success" : null;
+}
+
+export function GithubPrRefChip({
+  href,
+  children,
+}: {
+  href: string;
+  children: ReactNode;
+}): ReactElement {
+  const [tooltipOpen, setTooltipOpen] = useState(false);
+  const { meta } = usePrDetails(href, { refetchInterval: 30_000 });
+  const checksQuery = usePrChecks(tooltipOpen ? href : null);
+  const ciStatus = tooltipOpen
+    ? checksQuery.isLoading
+      ? "loading"
+      : summarizeCiStatus(checksQuery.data)
+    : null;
+
+  return (
+    <GithubRefChip
+      href={href}
+      kind="pr"
+      prDetails={{ ...meta, ciStatus }}
+      onTooltipOpenChange={setTooltipOpen}
+    >
+      {children}
+    </GithubRefChip>
+  );
+}

--- a/products/desktop/packages/ui/src/features/editor/components/GithubRefChip.stories.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/GithubRefChip.stories.tsx
@@ -10,6 +10,19 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+export const WithoutLiveDetails: Story = {
+  render: () => (
+    <div className="text-[13px]">
+      <GithubRefChip
+        href="https://github.com/example-org/example-repo/pull/101"
+        kind="pr"
+      >
+        example-org/example-repo#101
+      </GithubRefChip>
+    </div>
+  ),
+};
+
 export const LifecycleStates: Story = {
   render: () => (
     <div className="flex flex-wrap items-center gap-3 text-[13px]">

--- a/products/desktop/packages/ui/src/features/editor/components/GithubRefChip.stories.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/GithubRefChip.stories.tsx
@@ -1,0 +1,78 @@
+import { GithubRefChip } from "@posthog/ui/features/editor/components/GithubRefChip";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "Editor/GithubRefChip",
+  component: GithubRefChip,
+  parameters: { layout: "padded" },
+} satisfies Meta<typeof GithubRefChip>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const LifecycleStates: Story = {
+  render: () => (
+    <div className="flex flex-wrap items-center gap-3 text-[13px]">
+      <GithubRefChip
+        href="https://github.com/example-org/example-repo/pull/101"
+        kind="pr"
+        prDetails={{
+          state: "open",
+          merged: false,
+          draft: false,
+          title: "Add account settings",
+          author: "octocat",
+          ciStatus: "success",
+          isLoading: false,
+        }}
+      >
+        example-org/example-repo#101
+      </GithubRefChip>
+      <GithubRefChip
+        href="https://github.com/example-org/example-repo/pull/102"
+        kind="pr"
+        prDetails={{
+          state: "open",
+          merged: false,
+          draft: true,
+          title: "Improve search filters",
+          author: "hubot",
+          ciStatus: "pending",
+          isLoading: false,
+        }}
+      >
+        example-org/example-repo#102
+      </GithubRefChip>
+      <GithubRefChip
+        href="https://github.com/example-org/example-repo/pull/103"
+        kind="pr"
+        prDetails={{
+          state: "closed",
+          merged: false,
+          draft: false,
+          title: "Update billing copy",
+          author: "monalisa",
+          ciStatus: "failure",
+          isLoading: false,
+        }}
+      >
+        example-org/example-repo#103
+      </GithubRefChip>
+      <GithubRefChip
+        href="https://github.com/example-org/example-repo/pull/104"
+        kind="pr"
+        prDetails={{
+          state: "closed",
+          merged: true,
+          draft: false,
+          title: "Fix the sign-up redirect",
+          author: "octocat",
+          ciStatus: "success",
+          isLoading: false,
+        }}
+      >
+        example-org/example-repo#104
+      </GithubRefChip>
+    </div>
+  ),
+};

--- a/products/desktop/packages/ui/src/features/editor/components/GithubRefChip.stories.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/GithubRefChip.stories.tsx
@@ -1,4 +1,8 @@
 import { GithubRefChip } from "@posthog/ui/features/editor/components/GithubRefChip";
+import {
+  PrRefChip,
+  type PrRefDetails,
+} from "@posthog/ui/features/editor/components/PrRefChip";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 const meta = {
@@ -23,69 +27,73 @@ export const WithoutLiveDetails: Story = {
   ),
 };
 
+const LIFECYCLE_CASES: { number: number; details: PrRefDetails }[] = [
+  {
+    number: 101,
+    details: {
+      state: "open",
+      merged: false,
+      draft: false,
+      title: "Add account settings",
+      author: "octocat",
+      isLoading: false,
+      ciStatus: "success",
+      isCiLoading: false,
+    },
+  },
+  {
+    number: 102,
+    details: {
+      state: "open",
+      merged: false,
+      draft: true,
+      title: "Improve search filters",
+      author: "hubot",
+      isLoading: false,
+      ciStatus: "pending",
+      isCiLoading: false,
+    },
+  },
+  {
+    number: 103,
+    details: {
+      state: "closed",
+      merged: false,
+      draft: false,
+      title: "Update billing copy",
+      author: "monalisa",
+      isLoading: false,
+      ciStatus: "failure",
+      isCiLoading: false,
+    },
+  },
+  {
+    number: 104,
+    details: {
+      state: "closed",
+      merged: true,
+      draft: false,
+      title: "Fix the sign-up redirect",
+      author: "octocat",
+      isLoading: false,
+      ciStatus: "success",
+      isCiLoading: false,
+    },
+  },
+];
+
 export const LifecycleStates: Story = {
   render: () => (
     <div className="flex flex-wrap items-center gap-3 text-[13px]">
-      <GithubRefChip
-        href="https://github.com/example-org/example-repo/pull/101"
-        kind="pr"
-        prDetails={{
-          state: "open",
-          merged: false,
-          draft: false,
-          title: "Add account settings",
-          author: "octocat",
-          ciStatus: "success",
-          isLoading: false,
-        }}
-      >
-        example-org/example-repo#101
-      </GithubRefChip>
-      <GithubRefChip
-        href="https://github.com/example-org/example-repo/pull/102"
-        kind="pr"
-        prDetails={{
-          state: "open",
-          merged: false,
-          draft: true,
-          title: "Improve search filters",
-          author: "hubot",
-          ciStatus: "pending",
-          isLoading: false,
-        }}
-      >
-        example-org/example-repo#102
-      </GithubRefChip>
-      <GithubRefChip
-        href="https://github.com/example-org/example-repo/pull/103"
-        kind="pr"
-        prDetails={{
-          state: "closed",
-          merged: false,
-          draft: false,
-          title: "Update billing copy",
-          author: "monalisa",
-          ciStatus: "failure",
-          isLoading: false,
-        }}
-      >
-        example-org/example-repo#103
-      </GithubRefChip>
-      <GithubRefChip
-        href="https://github.com/example-org/example-repo/pull/104"
-        kind="pr"
-        prDetails={{
-          state: "closed",
-          merged: true,
-          draft: false,
-          title: "Fix the sign-up redirect",
-          author: "octocat",
-          ciStatus: "success",
-          isLoading: false,
-        }}
-      >
-        example-org/example-repo#104
-      </GithubRefChip>
+      {LIFECYCLE_CASES.map(({ number, details }) => (
+        <PrRefChip
+          key={number}
+          href={`https://github.com/example-org/example-repo/pull/${number}`}
+          details={details}
+        >
+          {`example-org/example-repo#${number}`}
+        </PrRefChip>
+      ))}
     </div>
   ),
 };
@@ -93,21 +101,21 @@ export const LifecycleStates: Story = {
 export const LoadingDetails: Story = {
   render: () => (
     <div className="text-[13px]">
-      <GithubRefChip
+      <PrRefChip
         href="https://github.com/example-org/example-repo/pull/105"
-        kind="pr"
-        prDetails={{
+        details={{
           state: null,
           merged: false,
           draft: false,
           title: null,
           author: null,
-          ciStatus: "loading",
           isLoading: true,
+          ciStatus: null,
+          isCiLoading: true,
         }}
       >
         example-org/example-repo#105
-      </GithubRefChip>
+      </PrRefChip>
     </div>
   ),
 };

--- a/products/desktop/packages/ui/src/features/editor/components/GithubRefChip.stories.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/GithubRefChip.stories.tsx
@@ -89,3 +89,25 @@ export const LifecycleStates: Story = {
     </div>
   ),
 };
+
+export const LoadingDetails: Story = {
+  render: () => (
+    <div className="text-[13px]">
+      <GithubRefChip
+        href="https://github.com/example-org/example-repo/pull/105"
+        kind="pr"
+        prDetails={{
+          state: null,
+          merged: false,
+          draft: false,
+          title: null,
+          author: null,
+          ciStatus: "loading",
+          isLoading: true,
+        }}
+      >
+        example-org/example-repo#105
+      </GithubRefChip>
+    </div>
+  ),
+};

--- a/products/desktop/packages/ui/src/features/editor/components/GithubRefChip.test.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/GithubRefChip.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 import { GITHUB_REF_URL_ATTR, GithubRefChip } from "./GithubRefChip";
 
@@ -31,38 +30,5 @@ describe("GithubRefChip", () => {
         .closest(`[${GITHUB_REF_URL_ATTR}]`)
         ?.getAttribute(GITHUB_REF_URL_ATTR),
     ).toBe(href);
-  });
-
-  it("shows lifecycle, creator, and CI details for a pull request", async () => {
-    const href = "https://github.com/PostHog/posthog/pull/23985";
-    render(
-      <GithubRefChip
-        href={href}
-        kind="pr"
-        prDetails={{
-          state: "closed",
-          merged: true,
-          draft: false,
-          title: "Show pull request status in sessions",
-          author: "octocat",
-          ciStatus: "success",
-          isLoading: false,
-        }}
-      >
-        PostHog/posthog#23985
-      </GithubRefChip>,
-    );
-
-    expect(screen.getByRole("img", { name: "Merged" })).toBeInTheDocument();
-
-    const link = screen.getByText("PostHog/posthog#23985").closest("a");
-    expect(link).not.toBeNull();
-    await userEvent.hover(link as HTMLAnchorElement);
-
-    expect(
-      await screen.findByText("Show pull request status in sessions"),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Created by @octocat")).toBeInTheDocument();
-    expect(screen.getByText("CI passed")).toBeInTheDocument();
   });
 });

--- a/products/desktop/packages/ui/src/features/editor/components/GithubRefChip.test.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/GithubRefChip.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 import { GITHUB_REF_URL_ATTR, GithubRefChip } from "./GithubRefChip";
 
@@ -30,5 +31,38 @@ describe("GithubRefChip", () => {
         .closest(`[${GITHUB_REF_URL_ATTR}]`)
         ?.getAttribute(GITHUB_REF_URL_ATTR),
     ).toBe(href);
+  });
+
+  it("shows lifecycle, creator, and CI details for a pull request", async () => {
+    const href = "https://github.com/PostHog/posthog/pull/23985";
+    render(
+      <GithubRefChip
+        href={href}
+        kind="pr"
+        prDetails={{
+          state: "closed",
+          merged: true,
+          draft: false,
+          title: "Show pull request status in sessions",
+          author: "octocat",
+          ciStatus: "success",
+          isLoading: false,
+        }}
+      >
+        PostHog/posthog#23985
+      </GithubRefChip>,
+    );
+
+    expect(screen.getByRole("img", { name: "Merged" })).toBeInTheDocument();
+
+    const link = screen.getByText("PostHog/posthog#23985").closest("a");
+    expect(link).not.toBeNull();
+    await userEvent.hover(link as HTMLAnchorElement);
+
+    expect(
+      await screen.findByText("Show pull request status in sessions"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Created by @octocat")).toBeInTheDocument();
+    expect(screen.getByText("CI passed")).toBeInTheDocument();
   });
 });

--- a/products/desktop/packages/ui/src/features/editor/components/GithubRefChip.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/GithubRefChip.tsx
@@ -1,6 +1,17 @@
 import { GithubLogoIcon, GitPullRequestIcon } from "@phosphor-icons/react";
-import { Chip } from "@posthog/quill";
-import type { ReactNode } from "react";
+import {
+  getPrVisualConfig,
+  type PrVisualConfig,
+} from "@posthog/core/git-interaction/prStatus";
+import {
+  Chip,
+  cn,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@posthog/quill";
+import { getPrVisualIcon } from "@posthog/ui/features/git-interaction/prIcon";
+import type { ReactElement, ReactNode } from "react";
 
 /**
  * DOM attribute carrying the chip's GitHub URL. The conversation context menu
@@ -9,25 +20,121 @@ import type { ReactNode } from "react";
  */
 export const GITHUB_REF_URL_ATTR = "data-github-ref-url";
 
+const PR_ICON_TONE_CLASSES: Record<PrVisualConfig["color"], string> = {
+  gray: "text-(--gray-11)",
+  green: "text-(--green-11)",
+  red: "text-(--red-11)",
+  purple: "text-(--purple-11)",
+};
+
+const CI_STATUS_LABELS = {
+  success: "CI passed",
+  failure: "CI needs attention",
+  pending: "CI running",
+  loading: "Loading CI",
+} as const;
+
+export interface GithubPrRefDetails {
+  state: string | null;
+  merged: boolean;
+  draft: boolean;
+  title: string | null;
+  author: string | null;
+  ciStatus: keyof typeof CI_STATUS_LABELS | null;
+  isLoading: boolean;
+}
+
 export function GithubRefChip({
   href,
   kind,
   children,
+  prDetails,
+  onTooltipOpenChange,
 }: {
   href: string;
   kind: "issue" | "pr";
   children: ReactNode;
-}) {
-  const Icon = kind === "pr" ? GitPullRequestIcon : GithubLogoIcon;
-  return (
-    <Chip
+  prDetails?: GithubPrRefDetails;
+  onTooltipOpenChange?: (open: boolean) => void;
+}): ReactElement {
+  const prConfig =
+    prDetails?.state && prDetails.state !== "unknown"
+      ? getPrVisualConfig(prDetails.state, prDetails.merged, prDetails.draft)
+      : null;
+  const Icon =
+    kind === "issue"
+      ? GithubLogoIcon
+      : prConfig
+        ? getPrVisualIcon(prConfig.icon)
+        : GitPullRequestIcon;
+  const statusLabel =
+    prConfig?.label ??
+    (prDetails?.isLoading
+      ? "Loading pull request status"
+      : "Status unavailable. Open in GitHub.");
+
+  const chip = (
+    <a
       {...{ [GITHUB_REF_URL_ATTR]: href }}
-      size="xs"
-      onClick={() => window.open(href, "_blank")}
-      className="cli-file-mention mx-0.5 max-w-full cursor-pointer! whitespace-nowrap pl-1 align-middle active:translate-y-0"
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="mx-0.5 inline-flex max-w-full align-middle no-underline"
     >
-      <Icon size={10} />
-      <span className="min-w-0 truncate">{children}</span>
-    </Chip>
+      <Chip
+        size="xs"
+        className="cli-file-mention max-w-full cursor-pointer! whitespace-nowrap pl-1 active:translate-y-0"
+      >
+        <Icon
+          size={10}
+          weight={kind === "pr" ? "bold" : undefined}
+          className={cn(
+            "shrink-0",
+            prConfig && PR_ICON_TONE_CLASSES[prConfig.color],
+          )}
+          aria-label={kind === "pr" && prDetails ? statusLabel : undefined}
+          aria-hidden={kind === "issue" || !prDetails ? true : undefined}
+          role={kind === "pr" && prDetails ? "img" : undefined}
+        />
+        <span className="min-w-0 truncate">{children}</span>
+      </Chip>
+    </a>
+  );
+
+  if (kind === "issue" || !prDetails) return chip;
+
+  return (
+    <Tooltip onOpenChange={onTooltipOpenChange}>
+      <TooltipTrigger render={chip} />
+      <TooltipContent side="top" className="max-w-80">
+        <div className="flex min-w-0 flex-col gap-1">
+          <div className="flex items-center gap-1.5 font-medium">
+            <Icon
+              size={12}
+              weight="bold"
+              className={cn(
+                "shrink-0",
+                prConfig && PR_ICON_TONE_CLASSES[prConfig.color],
+              )}
+              aria-hidden="true"
+            />
+            <span>{statusLabel}</span>
+          </div>
+          {prDetails.title && (
+            <span className="font-medium text-foreground">
+              {prDetails.title}
+            </span>
+          )}
+          {(prDetails.author || prDetails.ciStatus) && (
+            <span className="flex flex-wrap gap-x-2 text-muted-foreground">
+              {prDetails.author && <span>Created by @{prDetails.author}</span>}
+              {prDetails.ciStatus && (
+                <span>{CI_STATUS_LABELS[prDetails.ciStatus]}</span>
+              )}
+            </span>
+          )}
+        </div>
+      </TooltipContent>
+    </Tooltip>
   );
 }

--- a/products/desktop/packages/ui/src/features/editor/components/GithubRefChip.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/GithubRefChip.tsx
@@ -4,8 +4,9 @@ import {
   type PrVisualConfig,
 } from "@posthog/core/git-interaction/prStatus";
 import {
-  Chip,
+  Button,
   cn,
+  Skeleton,
   Tooltip,
   TooltipContent,
   TooltipTrigger,
@@ -21,18 +22,26 @@ import type { ReactElement, ReactNode } from "react";
 export const GITHUB_REF_URL_ATTR = "data-github-ref-url";
 
 const PR_ICON_TONE_CLASSES: Record<PrVisualConfig["color"], string> = {
-  gray: "text-(--gray-11)",
-  green: "text-(--green-11)",
-  red: "text-(--red-11)",
-  purple: "text-(--purple-11)",
+  gray: "text-(--gray-11) dark:text-(--gray-11)",
+  green: "text-(--green-11) dark:text-(--green-11)",
+  red: "text-(--red-11) dark:text-(--red-11)",
+  purple: "text-(--purple-11) dark:text-(--purple-11)",
 };
+
+/*
+ * Skeletons sit on the tooltip's inverted surface, where quill's --muted fill
+ * reads as a solid block. Tinting the inherited text color keeps them faint in
+ * both themes.
+ */
+const SKELETON_LINE = "h-3 w-24 rounded-xs bg-current/25";
 
 const CI_STATUS_LABELS = {
   success: "CI passed",
   failure: "CI needs attention",
   pending: "CI running",
-  loading: "Loading CI",
 } as const;
+
+export type PrRefCiStatus = keyof typeof CI_STATUS_LABELS | "loading";
 
 export interface GithubPrRefDetails {
   state: string | null;
@@ -40,7 +49,7 @@ export interface GithubPrRefDetails {
   draft: boolean;
   title: string | null;
   author: string | null;
-  ciStatus: keyof typeof CI_STATUS_LABELS | null;
+  ciStatus: PrRefCiStatus | null;
   isLoading: boolean;
 }
 
@@ -67,38 +76,49 @@ export function GithubRefChip({
       : prConfig
         ? getPrVisualIcon(prConfig.icon)
         : GitPullRequestIcon;
-  const statusLabel =
-    prConfig?.label ??
-    (prDetails?.isLoading
-      ? "Loading pull request status"
-      : "Status unavailable. Open in GitHub.");
+  const statusLabel = prConfig?.label ?? "Status unavailable. Open in GitHub.";
+  const isMetaLoading = !prConfig && (prDetails?.isLoading ?? false);
+  // The chip shows the state as an icon only, so the screen reader label has to
+  // carry the loading state the tooltip renders as a skeleton.
+  const iconLabel = isMetaLoading ? "Loading pull request status" : statusLabel;
 
   const chip = (
-    <a
-      {...{ [GITHUB_REF_URL_ATTR]: href }}
-      href={href}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="mx-0.5 inline-flex max-w-full align-middle no-underline"
-    >
-      <Chip
-        size="xs"
-        className="cli-file-mention max-w-full cursor-pointer! whitespace-nowrap pl-1 active:translate-y-0"
-      >
-        <Icon
-          size={10}
-          weight={kind === "pr" ? "bold" : undefined}
-          className={cn(
-            "shrink-0",
-            prConfig && PR_ICON_TONE_CLASSES[prConfig.color],
-          )}
-          aria-label={kind === "pr" && prDetails ? statusLabel : undefined}
-          aria-hidden={kind === "issue" || !prDetails ? true : undefined}
-          role={kind === "pr" && prDetails ? "img" : undefined}
+    <Button
+      variant="outline"
+      size="sm"
+      // The chip is a link, so it keeps link semantics and Base UI must not
+      // expect a native <button>.
+      nativeButton={false}
+      render={
+        <a
+          {...{ [GITHUB_REF_URL_ATTR]: href }}
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
         />
-        <span className="min-w-0 truncate">{children}</span>
-      </Chip>
-    </a>
+      }
+      className="cli-file-mention focus-visible:-outline-offset-1 mx-0.5 max-w-full cursor-pointer! whitespace-nowrap pl-1.5 align-baseline no-underline"
+    >
+      <Icon
+        size={12}
+        weight={kind === "pr" ? "bold" : undefined}
+        className={cn(
+          "shrink-0",
+          prConfig && PR_ICON_TONE_CLASSES[prConfig.color],
+        )}
+        aria-label={kind === "pr" && prDetails ? iconLabel : undefined}
+        aria-hidden={kind === "issue" || !prDetails ? true : undefined}
+        role={kind === "pr" && prDetails ? "img" : undefined}
+      />
+      <span
+        className={cn(
+          "min-w-0 max-w-64 truncate",
+          prConfig && PR_ICON_TONE_CLASSES[prConfig.color],
+        )}
+      >
+        {children}
+      </span>
+    </Button>
   );
 
   if (kind === "issue" || !prDetails) return chip;
@@ -106,30 +126,41 @@ export function GithubRefChip({
   return (
     <Tooltip onOpenChange={onTooltipOpenChange}>
       <TooltipTrigger render={chip} />
-      <TooltipContent side="top" className="max-w-80">
-        <div className="flex min-w-0 flex-col gap-1">
+      <TooltipContent side="top" className="max-w-80 py-2">
+        {/* The tooltip surface is inverted, so its contents inherit that color
+            rather than the page foreground/muted tokens. */}
+        <div className="flex min-w-0 flex-col gap-1.5 text-start">
           <div className="flex items-center gap-1.5 font-medium">
             <Icon
               size={12}
               weight="bold"
-              className={cn(
-                "shrink-0",
-                prConfig && PR_ICON_TONE_CLASSES[prConfig.color],
-              )}
+              className="shrink-0"
               aria-hidden="true"
             />
-            <span>{statusLabel}</span>
+            {isMetaLoading ? (
+              <Skeleton className={SKELETON_LINE} />
+            ) : (
+              <span>{statusLabel}</span>
+            )}
           </div>
-          {prDetails.title && (
-            <span className="font-medium text-foreground">
-              {prDetails.title}
-            </span>
+          {prDetails.title ? (
+            <span className="line-clamp-2 font-medium">{prDetails.title}</span>
+          ) : (
+            isMetaLoading && <Skeleton className={cn(SKELETON_LINE, "w-56")} />
           )}
-          {(prDetails.author || prDetails.ciStatus) && (
-            <span className="flex flex-wrap gap-x-2 text-muted-foreground">
-              {prDetails.author && <span>Created by @{prDetails.author}</span>}
-              {prDetails.ciStatus && (
-                <span>{CI_STATUS_LABELS[prDetails.ciStatus]}</span>
+          {(isMetaLoading || prDetails.author || prDetails.ciStatus) && (
+            <span className="flex flex-wrap items-center gap-x-2 gap-y-1 text-current/70">
+              {isMetaLoading ? (
+                <Skeleton className={cn(SKELETON_LINE, "w-28")} />
+              ) : (
+                prDetails.author && <span>Created by @{prDetails.author}</span>
+              )}
+              {prDetails.ciStatus === "loading" ? (
+                <Skeleton className={cn(SKELETON_LINE, "w-16")} />
+              ) : (
+                prDetails.ciStatus && (
+                  <span>{CI_STATUS_LABELS[prDetails.ciStatus]}</span>
+                )
               )}
             </span>
           )}

--- a/products/desktop/packages/ui/src/features/editor/components/GithubRefChip.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/GithubRefChip.tsx
@@ -1,18 +1,8 @@
+import type { Icon } from "@phosphor-icons/react";
 import { GithubLogoIcon, GitPullRequestIcon } from "@phosphor-icons/react";
-import {
-  getPrVisualConfig,
-  type PrVisualConfig,
-} from "@posthog/core/git-interaction/prStatus";
-import {
-  Button,
-  cn,
-  Skeleton,
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@posthog/quill";
-import { getPrVisualIcon } from "@posthog/ui/features/git-interaction/prIcon";
-import type { ReactElement, ReactNode } from "react";
+import { Button, cn } from "@posthog/quill";
+import type { ComponentProps, ReactElement, ReactNode } from "react";
+import { forwardRef } from "react";
 
 /**
  * DOM attribute carrying the chip's GitHub URL. The conversation context menu
@@ -21,69 +11,33 @@ import type { ReactElement, ReactNode } from "react";
  */
 export const GITHUB_REF_URL_ATTR = "data-github-ref-url";
 
-const PR_ICON_TONE_CLASSES: Record<PrVisualConfig["color"], string> = {
-  gray: "text-(--gray-11) dark:text-(--gray-11)",
-  green: "text-(--green-11) dark:text-(--green-11)",
-  red: "text-(--red-11) dark:text-(--red-11)",
-  purple: "text-(--purple-11) dark:text-(--purple-11)",
-};
-
-/*
- * Skeletons sit on the tooltip's inverted surface, where quill's --muted fill
- * reads as a solid block. Tinting the inherited text color keeps them faint in
- * both themes.
- */
-const SKELETON_LINE = "h-3 w-24 rounded-xs bg-current/25";
-
-const CI_STATUS_LABELS = {
-  success: "CI passed",
-  failure: "CI needs attention",
-  pending: "CI running",
-} as const;
-
-export type PrRefCiStatus = keyof typeof CI_STATUS_LABELS | "loading";
-
-export interface GithubPrRefDetails {
-  state: string | null;
-  merged: boolean;
-  draft: boolean;
-  title: string | null;
-  author: string | null;
-  ciStatus: PrRefCiStatus | null;
-  isLoading: boolean;
+interface GithubRefChipLinkProps
+  extends Omit<ComponentProps<typeof Button>, "children"> {
+  href: string;
+  icon: Icon;
+  /** Names the icon for screen readers. Omit when the icon says nothing extra. */
+  iconLabel?: string;
+  toneClass?: string;
+  children: ReactNode;
 }
 
-export function GithubRefChip({
-  href,
-  kind,
-  children,
-  prDetails,
-  onTooltipOpenChange,
-}: {
-  href: string;
-  kind: "issue" | "pr";
-  children: ReactNode;
-  prDetails?: GithubPrRefDetails;
-  onTooltipOpenChange?: (open: boolean) => void;
-}): ReactElement {
-  const prConfig =
-    prDetails?.state && prDetails.state !== "unknown"
-      ? getPrVisualConfig(prDetails.state, prDetails.merged, prDetails.draft)
-      : null;
-  const Icon =
-    kind === "issue"
-      ? GithubLogoIcon
-      : prConfig
-        ? getPrVisualIcon(prConfig.icon)
-        : GitPullRequestIcon;
-  const statusLabel = prConfig?.label ?? "Status unavailable. Open in GitHub.";
-  const isMetaLoading = !prConfig && (prDetails?.isLoading ?? false);
-  // The chip shows the state as an icon only, so the screen reader label has to
-  // carry the loading state the tooltip renders as a skeleton.
-  const iconLabel = isMetaLoading ? "Loading pull request status" : statusLabel;
-
-  const chip = (
+/**
+ * The chip every GitHub reference renders as: a quill button whose element is
+ * the link itself, so the chip is one thing to click and one thing to tab to.
+ *
+ * Forwards button props and its ref, so a tooltip or menu can drive it through
+ * `render`.
+ */
+export const GithubRefChipLink = forwardRef<
+  HTMLButtonElement,
+  GithubRefChipLinkProps
+>(function GithubRefChipLink(
+  { href, icon: RefIcon, iconLabel, toneClass, children, ...buttonProps },
+  ref,
+) {
+  return (
     <Button
+      ref={ref}
       variant="outline"
       size="sm"
       // The chip is a link, so it keeps link semantics and Base UI must not
@@ -97,75 +51,47 @@ export function GithubRefChip({
           rel="noopener noreferrer"
         />
       }
-      className="cli-file-mention focus-visible:-outline-offset-1 mx-0.5 max-w-full cursor-pointer! whitespace-nowrap pl-1.5 align-baseline no-underline"
+      {...buttonProps}
+      className={cn(
+        "cli-file-mention focus-visible:-outline-offset-1 mx-0.5 max-w-full cursor-pointer! whitespace-nowrap pl-1.5 align-baseline no-underline",
+        buttonProps.className,
+      )}
     >
-      <Icon
+      <RefIcon
         size={12}
-        weight={kind === "pr" ? "bold" : undefined}
-        className={cn(
-          "shrink-0",
-          prConfig && PR_ICON_TONE_CLASSES[prConfig.color],
-        )}
-        aria-label={kind === "pr" && prDetails ? iconLabel : undefined}
-        aria-hidden={kind === "issue" || !prDetails ? true : undefined}
-        role={kind === "pr" && prDetails ? "img" : undefined}
+        weight="bold"
+        className={cn("shrink-0", toneClass)}
+        aria-label={iconLabel}
+        aria-hidden={iconLabel ? undefined : true}
+        role={iconLabel ? "img" : undefined}
       />
-      <span
-        className={cn(
-          "min-w-0 max-w-64 truncate",
-          prConfig && PR_ICON_TONE_CLASSES[prConfig.color],
-        )}
-      >
+      <span className={cn("min-w-0 max-w-64 truncate", toneClass)}>
         {children}
       </span>
     </Button>
   );
+});
 
-  if (kind === "issue" || !prDetails) return chip;
-
+/**
+ * A GitHub reference with no live status behind it: issue links, and stored
+ * mentions that render from saved text rather than from a fetch. `PrRefChip`
+ * is the one that reports a pull request's lifecycle.
+ */
+export function GithubRefChip({
+  href,
+  kind,
+  children,
+}: {
+  href: string;
+  kind: "issue" | "pr";
+  children: ReactNode;
+}): ReactElement {
   return (
-    <Tooltip onOpenChange={onTooltipOpenChange}>
-      <TooltipTrigger render={chip} />
-      <TooltipContent side="top" className="max-w-80 py-2">
-        {/* The tooltip surface is inverted, so its contents inherit that color
-            rather than the page foreground/muted tokens. */}
-        <div className="flex min-w-0 flex-col gap-1.5 text-start">
-          <div className="flex items-center gap-1.5 font-medium">
-            <Icon
-              size={12}
-              weight="bold"
-              className="shrink-0"
-              aria-hidden="true"
-            />
-            {isMetaLoading ? (
-              <Skeleton className={SKELETON_LINE} />
-            ) : (
-              <span>{statusLabel}</span>
-            )}
-          </div>
-          {prDetails.title ? (
-            <span className="line-clamp-2 font-medium">{prDetails.title}</span>
-          ) : (
-            isMetaLoading && <Skeleton className={cn(SKELETON_LINE, "w-56")} />
-          )}
-          {(isMetaLoading || prDetails.author || prDetails.ciStatus) && (
-            <span className="flex flex-wrap items-center gap-x-2 gap-y-1 text-current/70">
-              {isMetaLoading ? (
-                <Skeleton className={cn(SKELETON_LINE, "w-28")} />
-              ) : (
-                prDetails.author && <span>Created by @{prDetails.author}</span>
-              )}
-              {prDetails.ciStatus === "loading" ? (
-                <Skeleton className={cn(SKELETON_LINE, "w-16")} />
-              ) : (
-                prDetails.ciStatus && (
-                  <span>{CI_STATUS_LABELS[prDetails.ciStatus]}</span>
-                )
-              )}
-            </span>
-          )}
-        </div>
-      </TooltipContent>
-    </Tooltip>
+    <GithubRefChipLink
+      href={href}
+      icon={kind === "pr" ? GitPullRequestIcon : GithubLogoIcon}
+    >
+      {children}
+    </GithubRefChipLink>
   );
 }

--- a/products/desktop/packages/ui/src/features/editor/components/MarkdownRenderer.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/MarkdownRenderer.tsx
@@ -1,10 +1,8 @@
 import { isPostHogCodeDeeplink } from "@posthog/shared";
 import { ArtifactRefChip } from "@posthog/ui/features/editor/components/ArtifactRefChip";
 import { EvidenceRefChip } from "@posthog/ui/features/editor/components/EvidenceRefChip";
-import { GithubPrRefChip } from "@posthog/ui/features/editor/components/GithubPrRefChip";
-import { GithubRefChip } from "@posthog/ui/features/editor/components/GithubRefChip";
+import { githubRefChipFor } from "@posthog/ui/features/editor/components/githubRefChipFor";
 import { MessageChartCard } from "@posthog/ui/features/editor/components/MessageChartCard";
-import { parseGithubIssueUrl } from "@posthog/ui/features/message-editor/githubIssueUrl";
 import { CodeBlock } from "@posthog/ui/primitives/CodeBlock";
 import { Divider } from "@posthog/ui/primitives/Divider";
 import { HighlightedCode } from "@posthog/ui/primitives/HighlightedCode";
@@ -178,25 +176,8 @@ export const baseComponents: Components = {
         </ArtifactRefChip>
       );
     }
-    const githubRef = href ? parseGithubIssueUrl(href) : null;
-    if (githubRef) {
-      const isAutoLink = typeof children === "string" && children === href;
-      const label = isAutoLink
-        ? `${githubRef.owner}/${githubRef.repo}#${githubRef.number}`
-        : children;
-      if (githubRef.kind === "pr") {
-        return (
-          <GithubPrRefChip href={githubRef.normalizedUrl}>
-            {label}
-          </GithubPrRefChip>
-        );
-      }
-      return (
-        <GithubRefChip href={githubRef.normalizedUrl} kind="issue">
-          {label}
-        </GithubRefChip>
-      );
-    }
+    const githubChip = githubRefChipFor(href, children);
+    if (githubChip) return githubChip;
     return <ExternalMarkdownLink href={href}>{children}</ExternalMarkdownLink>;
   },
   kbd: ({ children }) => <Kbd>{children}</Kbd>,

--- a/products/desktop/packages/ui/src/features/editor/components/MarkdownRenderer.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/MarkdownRenderer.tsx
@@ -1,6 +1,7 @@
 import { isPostHogCodeDeeplink } from "@posthog/shared";
 import { ArtifactRefChip } from "@posthog/ui/features/editor/components/ArtifactRefChip";
 import { EvidenceRefChip } from "@posthog/ui/features/editor/components/EvidenceRefChip";
+import { GithubPrRefChip } from "@posthog/ui/features/editor/components/GithubPrRefChip";
 import { GithubRefChip } from "@posthog/ui/features/editor/components/GithubRefChip";
 import { MessageChartCard } from "@posthog/ui/features/editor/components/MessageChartCard";
 import { parseGithubIssueUrl } from "@posthog/ui/features/message-editor/githubIssueUrl";
@@ -183,8 +184,15 @@ export const baseComponents: Components = {
       const label = isAutoLink
         ? `${githubRef.owner}/${githubRef.repo}#${githubRef.number}`
         : children;
+      if (githubRef.kind === "pr") {
+        return (
+          <GithubPrRefChip href={githubRef.normalizedUrl}>
+            {label}
+          </GithubPrRefChip>
+        );
+      }
       return (
-        <GithubRefChip href={githubRef.normalizedUrl} kind={githubRef.kind}>
+        <GithubRefChip href={githubRef.normalizedUrl} kind="issue">
           {label}
         </GithubRefChip>
       );

--- a/products/desktop/packages/ui/src/features/editor/components/PrRefChip.test.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/PrRefChip.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { PrRefChip, type PrRefDetails } from "./PrRefChip";
+
+const LOADED: PrRefDetails = {
+  state: "closed",
+  merged: true,
+  draft: false,
+  title: "Show pull request status in sessions",
+  author: "octocat",
+  isLoading: false,
+  ciStatus: "success",
+  isCiLoading: false,
+};
+
+describe("PrRefChip", () => {
+  const href = "https://github.com/PostHog/posthog/pull/23985";
+
+  async function hoverChip(): Promise<void> {
+    const link = screen.getByText("PostHog/posthog#23985").closest("a");
+    expect(link).not.toBeNull();
+    await userEvent.hover(link as HTMLAnchorElement);
+  }
+
+  it("shows lifecycle, creator, and CI details for a pull request", async () => {
+    render(
+      <PrRefChip href={href} details={LOADED}>
+        PostHog/posthog#23985
+      </PrRefChip>,
+    );
+
+    expect(screen.getByRole("img", { name: "Merged" })).toBeInTheDocument();
+
+    await hoverChip();
+
+    expect(
+      await screen.findByText("Show pull request status in sessions"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Created by @octocat")).toBeInTheDocument();
+    expect(screen.getByText("CI passed")).toBeInTheDocument();
+  });
+
+  it("names the loading state while details are on the way", async () => {
+    render(
+      <PrRefChip
+        href={href}
+        details={{
+          state: null,
+          merged: false,
+          draft: false,
+          title: null,
+          author: null,
+          isLoading: true,
+          ciStatus: null,
+          isCiLoading: true,
+        }}
+      >
+        PostHog/posthog#23985
+      </PrRefChip>,
+    );
+
+    expect(
+      screen.getByRole("img", { name: "Loading pull request status" }),
+    ).toBeInTheDocument();
+
+    await hoverChip();
+
+    expect(screen.queryByText("CI passed")).not.toBeInTheDocument();
+  });
+});

--- a/products/desktop/packages/ui/src/features/editor/components/PrRefChip.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/PrRefChip.tsx
@@ -1,0 +1,128 @@
+import { GitPullRequestIcon } from "@phosphor-icons/react";
+import { getPrVisualConfig } from "@posthog/core/git-interaction/prStatus";
+import {
+  cn,
+  Skeleton,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@posthog/quill";
+import { GithubRefChipLink } from "@posthog/ui/features/editor/components/GithubRefChip";
+import { getPrVisualIcon } from "@posthog/ui/features/git-interaction/prIcon";
+import { PR_TONE_TEXT } from "@posthog/ui/features/git-interaction/prTone";
+import type { ReactElement, ReactNode } from "react";
+
+const CI_STATUS_LABELS = {
+  success: "CI passed",
+  failure: "CI needs attention",
+  pending: "CI running",
+} as const;
+
+export type PrCiStatus = keyof typeof CI_STATUS_LABELS;
+
+export interface PrRefDetails {
+  state: string | null;
+  merged: boolean;
+  draft: boolean;
+  title: string | null;
+  author: string | null;
+  isLoading: boolean;
+  ciStatus: PrCiStatus | null;
+  isCiLoading: boolean;
+}
+
+/*
+ * Skeletons sit on the tooltip's inverted surface, where quill's --muted fill
+ * reads as a solid block. Tinting the inherited text color keeps them faint in
+ * both themes.
+ */
+const SKELETON_LINE = "h-3 w-24 rounded-xs bg-current/25";
+
+/**
+ * A pull request chip that reports the PR's lifecycle: a tinted icon on the
+ * chip, and title, creator, and CI status in the hover card. Presentational —
+ * `GithubPrRefChip` supplies the details.
+ */
+export function PrRefChip({
+  href,
+  details,
+  onTooltipOpenChange,
+  children,
+}: {
+  href: string;
+  details: PrRefDetails;
+  onTooltipOpenChange?: (open: boolean) => void;
+  children: ReactNode;
+}): ReactElement {
+  const config =
+    details.state && details.state !== "unknown"
+      ? getPrVisualConfig(details.state, details.merged, details.draft)
+      : null;
+  const isLoading = !config && details.isLoading;
+  const statusLabel = config?.label ?? "Status unavailable. Open in GitHub.";
+  // The chip shows the state as an icon only, so the screen reader label has to
+  // carry the loading state the tooltip renders as a skeleton.
+  const iconLabel = isLoading ? "Loading pull request status" : statusLabel;
+  const StatusIcon = config ? getPrVisualIcon(config.icon) : GitPullRequestIcon;
+  const toneClass = config ? PR_TONE_TEXT[config.color] : undefined;
+
+  return (
+    <Tooltip onOpenChange={onTooltipOpenChange}>
+      <TooltipTrigger
+        render={
+          <GithubRefChipLink
+            href={href}
+            icon={StatusIcon}
+            iconLabel={iconLabel}
+            toneClass={toneClass}
+          >
+            {children}
+          </GithubRefChipLink>
+        }
+      />
+      <TooltipContent side="top" className="max-w-80 py-2">
+        {/* The tooltip surface is inverted, so its contents inherit that color
+            rather than the page foreground/muted tokens. */}
+        <div className="flex min-w-0 flex-col gap-1.5 text-start">
+          <div className="flex items-center gap-1.5 font-medium">
+            <StatusIcon
+              size={12}
+              weight="bold"
+              className="shrink-0"
+              aria-hidden="true"
+            />
+            {isLoading ? (
+              <Skeleton className={SKELETON_LINE} />
+            ) : (
+              <span>{statusLabel}</span>
+            )}
+          </div>
+          {details.title ? (
+            <span className="line-clamp-2 font-medium">{details.title}</span>
+          ) : (
+            isLoading && <Skeleton className={cn(SKELETON_LINE, "w-56")} />
+          )}
+          {(isLoading ||
+            details.author ||
+            details.ciStatus ||
+            details.isCiLoading) && (
+            <span className="flex flex-wrap items-center gap-x-2 gap-y-1 text-current/70">
+              {isLoading ? (
+                <Skeleton className={cn(SKELETON_LINE, "w-28")} />
+              ) : (
+                details.author && <span>Created by @{details.author}</span>
+              )}
+              {details.isCiLoading ? (
+                <Skeleton className={cn(SKELETON_LINE, "w-16")} />
+              ) : (
+                details.ciStatus && (
+                  <span>{CI_STATUS_LABELS[details.ciStatus]}</span>
+                )
+              )}
+            </span>
+          )}
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/products/desktop/packages/ui/src/features/editor/components/githubRefChipFor.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/githubRefChipFor.tsx
@@ -1,0 +1,34 @@
+import { GithubPrRefChip } from "@posthog/ui/features/editor/components/GithubPrRefChip";
+import { GithubRefChip } from "@posthog/ui/features/editor/components/GithubRefChip";
+import { parseGithubIssueUrl } from "@posthog/ui/features/message-editor/githubIssueUrl";
+import type { ReactElement, ReactNode } from "react";
+
+/**
+ * The chip a markdown link to GitHub renders as, or null when the link points
+ * somewhere else. Shared so both markdown renderers route references the same
+ * way.
+ */
+export function githubRefChipFor(
+  href: string | undefined,
+  children: ReactNode,
+): ReactElement | null {
+  const githubRef = href ? parseGithubIssueUrl(href) : null;
+  if (!githubRef) return null;
+
+  // A bare URL reads as noise in a sentence, so it becomes owner/repo#number.
+  const isAutoLink = typeof children === "string" && children === href;
+  const label = isAutoLink
+    ? `${githubRef.owner}/${githubRef.repo}#${githubRef.number}`
+    : children;
+
+  if (githubRef.kind === "pr") {
+    return (
+      <GithubPrRefChip href={githubRef.normalizedUrl}>{label}</GithubPrRefChip>
+    );
+  }
+  return (
+    <GithubRefChip href={githubRef.normalizedUrl} kind="issue">
+      {label}
+    </GithubRefChip>
+  );
+}

--- a/products/desktop/packages/ui/src/features/git-interaction/components/PRBadgeLink.tsx
+++ b/products/desktop/packages/ui/src/features/git-interaction/components/PRBadgeLink.tsx
@@ -1,10 +1,14 @@
 import {
   getPrVisualConfig,
-  type PrVisualConfig,
   parsePrNumber,
 } from "@posthog/core/git-interaction/prStatus";
 import { Button, cn, Spinner } from "@posthog/quill";
 import { getPrVisualIcon } from "../prIcon";
+import {
+  PR_TONE_BORDER,
+  PR_TONE_FILL_COMPACT,
+  prBadgeToneProps,
+} from "../prTone";
 
 interface PRBadgeLinkProps {
   prUrl: string;
@@ -24,51 +28,6 @@ interface PRBadgeLinkProps {
    */
   otherCount?: number;
 }
-
-const COMPACT_COLOR_CLASSES: Record<PrVisualConfig["color"], string> = {
-  gray: "bg-(--gray-3) text-(--gray-11) hover:bg-(--gray-4)",
-  green: "bg-(--green-3) text-(--green-11) hover:bg-(--green-4)",
-  red: "bg-(--red-3) text-(--red-11) hover:bg-(--red-4)",
-  purple: "bg-(--purple-3) text-(--purple-11) hover:bg-(--purple-4)",
-};
-
-/**
- * The PR's lifecycle colour, as classes for a quill button. quill's variants
- * are one neutral palette by design, and this badge's whole job is to say
- * merged from closed from open at a glance — so the tint comes from the Radix
- * token layer, which is what the app's colour scales live in anyway.
- */
-const PR_BADGE_TONE_CLASSES: Record<PrVisualConfig["color"], string> = {
-  gray: "bg-(--gray-3) text-(--gray-11) not-disabled:hover:bg-(--gray-4) not-disabled:hover:text-(--gray-12)",
-  green:
-    "bg-(--green-3) text-(--green-11) not-disabled:hover:bg-(--green-4) not-disabled:hover:text-(--green-12)",
-  red: "bg-(--red-3) text-(--red-11) not-disabled:hover:bg-(--red-4) not-disabled:hover:text-(--red-12)",
-  purple:
-    "bg-(--purple-3) text-(--purple-11) not-disabled:hover:bg-(--purple-4) not-disabled:hover:text-(--purple-12)",
-};
-
-/**
- * How a badge wears its lifecycle state, as props for a quill button. A solid
- * state takes quill's own primary; the rest take their tint.
- *
- * Exported because the dropdown trigger that sits beside the badge in a
- * `ButtonGroup` has to wear the same thing, or the group reads as two controls.
- */
-export function prBadgeToneProps(config: PrVisualConfig): {
-  variant?: "primary";
-  className?: string;
-} {
-  if (config.solid) return { variant: "primary" };
-  return { className: PR_BADGE_TONE_CLASSES[config.color] };
-}
-
-// Divider ahead of the PR-count segment, tinted to the badge's own color.
-const COUNT_DIVIDER_CLASSES: Record<PrVisualConfig["color"], string> = {
-  gray: "border-(--gray-a6)",
-  green: "border-(--green-a6)",
-  red: "border-(--red-a6)",
-  purple: "border-(--purple-a6)",
-};
 
 /**
  * The colored "open this PR on GitHub" badge — styled by the PR's lifecycle
@@ -102,7 +61,7 @@ export function PRBadgeLink({
         rel="noopener noreferrer"
         onClick={(e) => e.stopPropagation()}
         title={stackTitle}
-        className={`inline-flex items-center gap-0.5 rounded px-1 py-0.5 text-[10px] no-underline ${COMPACT_COLOR_CLASSES[config.color]}`}
+        className={`inline-flex items-center gap-0.5 rounded px-1 py-0.5 text-[10px] no-underline ${PR_TONE_FILL_COMPACT[config.color]}`}
       >
         {isPrPending ? (
           <Spinner className="size-2.5" />
@@ -147,9 +106,7 @@ export function PRBadgeLink({
         {prNumber && ` #${prNumber}`}
       </span>
       {otherCount > 0 && (
-        <span
-          className={`border-l pl-2 ${COUNT_DIVIDER_CLASSES[config.color]}`}
-        >
+        <span className={`border-l pl-2 ${PR_TONE_BORDER[config.color]}`}>
           {totalCount}
         </span>
       )}

--- a/products/desktop/packages/ui/src/features/git-interaction/components/TaskActionsMenu.tsx
+++ b/products/desktop/packages/ui/src/features/git-interaction/components/TaskActionsMenu.tsx
@@ -34,6 +34,7 @@ import type { ReactNode } from "react";
 import { toast } from "../../../primitives/toast";
 import { useLocalRepoPath } from "../../workspace/useLocalRepoPath";
 import { getPrActionIcon, getPrVisualIcon } from "../prIcon";
+import { prBadgeToneProps } from "../prTone";
 import { useCloudPrSummaries, useCloudPrUrls } from "../useCloudPrUrl";
 import {
   type GitMenuAction,
@@ -55,7 +56,7 @@ import {
   GitCommitDialog,
   GitPushDialog,
 } from "./GitInteractionDialogs";
-import { PRBadgeLink, prBadgeToneProps } from "./PRBadgeLink";
+import { PRBadgeLink } from "./PRBadgeLink";
 
 interface TaskActionsMenuProps {
   taskId: string;

--- a/products/desktop/packages/ui/src/features/git-interaction/prTone.ts
+++ b/products/desktop/packages/ui/src/features/git-interaction/prTone.ts
@@ -1,0 +1,62 @@
+import type { PrVisualConfig } from "@posthog/core/git-interaction/prStatus";
+
+/**
+ * A pull request's lifecycle color, as classes for the surfaces that wear it.
+ * quill's variants are one neutral palette by design, and these surfaces exist
+ * to say merged from closed from open at a glance, so the tint comes from the
+ * Radix token layer that the app's color scales already live in.
+ *
+ * Tailwind only sees class names it can read in the source, so each map spells
+ * its classes out. Keeping the maps together means a new lifecycle color is one
+ * file to edit rather than five.
+ */
+type PrToneColor = PrVisualConfig["color"];
+
+/** Icon or label tint on an untinted surface. */
+export const PR_TONE_TEXT: Record<PrToneColor, string> = {
+  gray: "text-(--gray-11)",
+  green: "text-(--green-11)",
+  red: "text-(--red-11)",
+  purple: "text-(--purple-11)",
+};
+
+/** Filled badge, for a control that can be disabled. */
+export const PR_TONE_FILL: Record<PrToneColor, string> = {
+  gray: "bg-(--gray-3) text-(--gray-11) not-disabled:hover:bg-(--gray-4) not-disabled:hover:text-(--gray-12)",
+  green:
+    "bg-(--green-3) text-(--green-11) not-disabled:hover:bg-(--green-4) not-disabled:hover:text-(--green-12)",
+  red: "bg-(--red-3) text-(--red-11) not-disabled:hover:bg-(--red-4) not-disabled:hover:text-(--red-12)",
+  purple:
+    "bg-(--purple-3) text-(--purple-11) not-disabled:hover:bg-(--purple-4) not-disabled:hover:text-(--purple-12)",
+};
+
+/** Filled pill for the compact command-center badge, which is a plain anchor. */
+export const PR_TONE_FILL_COMPACT: Record<PrToneColor, string> = {
+  gray: "bg-(--gray-3) text-(--gray-11) hover:bg-(--gray-4)",
+  green: "bg-(--green-3) text-(--green-11) hover:bg-(--green-4)",
+  red: "bg-(--red-3) text-(--red-11) hover:bg-(--red-4)",
+  purple: "bg-(--purple-3) text-(--purple-11) hover:bg-(--purple-4)",
+};
+
+/** Divider inside a filled badge, tinted to the badge's own color. */
+export const PR_TONE_BORDER: Record<PrToneColor, string> = {
+  gray: "border-(--gray-a6)",
+  green: "border-(--green-a6)",
+  red: "border-(--red-a6)",
+  purple: "border-(--purple-a6)",
+};
+
+/**
+ * How a badge wears its lifecycle state, as props for a quill button. A solid
+ * state takes quill's own primary; the rest take their tint.
+ *
+ * Exported because the dropdown trigger that sits beside the badge in a
+ * `ButtonGroup` has to wear the same thing, or the group reads as two controls.
+ */
+export function prBadgeToneProps(config: PrVisualConfig): {
+  variant?: "primary";
+  className?: string;
+} {
+  if (config.solid) return { variant: "primary" };
+  return { className: PR_TONE_FILL[config.color] };
+}

--- a/products/desktop/packages/ui/src/features/git-interaction/usePrActions.ts
+++ b/products/desktop/packages/ui/src/features/git-interaction/usePrActions.ts
@@ -25,6 +25,7 @@ export function usePrActions(prUrl: string | null) {
             ...getOptimisticPrState(variables.action),
             headRefName: prev?.headRefName ?? null,
             title: prev?.title ?? null,
+            author: prev?.author ?? null,
           }),
         );
         // The inbox Pulls list reads PR status from the batched

--- a/products/desktop/packages/ui/src/features/git-interaction/usePrDetails.ts
+++ b/products/desktop/packages/ui/src/features/git-interaction/usePrDetails.ts
@@ -6,6 +6,7 @@ import type { PrCommentThread } from "../code-review/prCommentAnnotations";
 
 interface UsePrDetailsOptions {
   includeComments?: boolean;
+  refetchInterval?: number | false;
 }
 
 function mapPrCommentThreads(
@@ -69,13 +70,14 @@ export function usePrDetails(
   prUrl: string | null,
   options?: UsePrDetailsOptions,
 ) {
-  const { includeComments = false } = options ?? {};
+  const { includeComments = false, refetchInterval = false } = options ?? {};
   const trpc = useHostTRPC();
 
   const metaQuery = useQuery({
     ...trpc.git.getPrDetailsByUrl.queryOptions({ prUrl: prUrl as string }),
     enabled: !!prUrl,
     staleTime: 60_000,
+    refetchInterval,
     placeholderData: (prev) => prev,
     retry: 1,
   });
@@ -100,6 +102,8 @@ export function usePrDetails(
       merged: metaQuery.data?.merged ?? false,
       draft: metaQuery.data?.draft ?? false,
       headRefName: metaQuery.data?.headRefName ?? null,
+      title: metaQuery.data?.title ?? null,
+      author: metaQuery.data?.author ?? null,
       isLoading: metaQuery.isLoading,
     },
     commentThreads,

--- a/products/desktop/packages/ui/src/features/message-editor/components/PromptInput.stories.tsx
+++ b/products/desktop/packages/ui/src/features/message-editor/components/PromptInput.stories.tsx
@@ -341,6 +341,11 @@ export const AllChipTypes: Story = {
         id: "https://github.com/org/repo/issues/123",
         label: "#123 Fix the bug",
       },
+      {
+        type: "github_pr",
+        id: "https://github.com/org/repo/pull/456",
+        label: "org/repo#456",
+      },
       { type: "error", id: "error-1", label: "TypeError: undefined" },
       { type: "experiment", id: "exp-1", label: "new-checkout-flow" },
       { type: "insight", id: "insight-1", label: "Weekly active users" },

--- a/products/desktop/packages/ui/src/features/message-editor/tiptap/MentionChipView.tsx
+++ b/products/desktop/packages/ui/src/features/message-editor/tiptap/MentionChipView.tsx
@@ -16,7 +16,7 @@ import { type NodeViewProps, NodeViewWrapper } from "@tiptap/react";
 import { usePasteUndoStore } from "../pasteUndoStore";
 import type { ChipType, MentionChipAttrs } from "./MentionChipNode";
 
-const chipBase = "group/chip relative top-px active:translate-y-0 pl-1";
+const chipBase = "group/chip relative top-px active:translate-y-0";
 
 const selectedRing = "border-ring/50 ring-[1px] ring-ring/50";
 
@@ -34,9 +34,11 @@ const typeIconMap: Record<ChipType, React.ComponentType<{ size: number }>> = {
 
 function IconCloseButton({
   type,
+  iconSize,
   onRemove,
 }: {
   type: ChipType;
+  iconSize: number;
   onRemove: () => void;
 }) {
   const Icon = typeIconMap[type] || FileTextIcon;
@@ -45,17 +47,20 @@ function IconCloseButton({
     <button
       type="button"
       tabIndex={-1}
-      className="relative inline-flex size-3.5 shrink-0 cursor-pointer items-center justify-center border-none bg-transparent p-0"
+      className={cn(
+        "relative inline-flex shrink-0 cursor-pointer items-center justify-center border-none bg-transparent p-0",
+        iconSize > 10 ? "size-4" : "size-3.5",
+      )}
       onClick={(e) => {
         e.stopPropagation();
         onRemove();
       }}
     >
       <span className="ease pointer-events-none absolute inset-0 flex items-center justify-center opacity-50 transition-opacity duration-150 group-hover/chip:opacity-0 motion-reduce:transition-none">
-        <Icon size={10} />
+        <Icon size={iconSize} />
       </span>
       <span className="ease pointer-events-none absolute inset-0 flex items-center justify-center opacity-0 transition-opacity duration-150 group-hover/chip:opacity-100 motion-reduce:transition-none">
-        <XIcon size={10} />
+        <XIcon size={iconSize} />
       </span>
     </button>
   );
@@ -86,6 +91,7 @@ function DefaultChip({
   const isFile = type === "file";
   const isFolder = type === "folder";
   const isGithubRef = type === "github_issue" || type === "github_pr";
+  const isPr = type === "github_pr";
   const canOpenUrl = isGithubRef && /^https:\/\//.test(id);
 
   // A skill reads as part of the sentence being written, not as an object
@@ -112,12 +118,16 @@ function DefaultChip({
 
   const chipContent = (
     <Chip
-      size="xs"
+      size={isPr ? "sm" : "xs"}
       contentEditable={false}
       onClick={canOpenUrl ? () => window.open(id, "_blank") : undefined}
-      className={`${chipBase} max-w-full whitespace-nowrap ${isGithubRef ? "cursor-pointer!" : "cursor-default! active:translate-y-0!"} ${isCommand ? "cli-slash-command" : "cli-file-mention"} ${selected ? selectedRing : ""}`}
+      className={`${chipBase} ${isPr ? "pl-1.5" : "pl-1"} max-w-full whitespace-nowrap ${isGithubRef ? "cursor-pointer!" : "cursor-default! active:translate-y-0!"} ${isCommand ? "cli-slash-command" : "cli-file-mention"} ${selected ? selectedRing : ""}`}
     >
-      <IconCloseButton type={type as ChipType} onRemove={onRemove} />
+      <IconCloseButton
+        type={type as ChipType}
+        iconSize={isPr ? 12 : 10}
+        onRemove={onRemove}
+      />
       {isGithubRef ? (
         <span className="min-w-0 truncate">{label}</span>
       ) : (

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatMarkdown.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatMarkdown.test.tsx
@@ -12,6 +12,26 @@ vi.mock("../../../../hooks/useAuthenticatedQuery", () => ({
   }),
 }));
 
+vi.mock("@posthog/ui/features/git-interaction/usePrDetails", () => ({
+  usePrDetails: () => ({
+    meta: {
+      state: "open",
+      merged: false,
+      draft: false,
+      headRefName: "posthog/status-chip",
+      title: "Show pull request status in sessions",
+      author: "octocat",
+      isLoading: false,
+    },
+    commentThreads: new Map(),
+    commentsLoading: false,
+  }),
+}));
+
+vi.mock("@posthog/ui/features/pr-review/usePrChecks", () => ({
+  usePrChecks: () => ({ data: [], isLoading: false }),
+}));
+
 import { ChatMarkdown, ChatStreamingMarkdown } from "./ChatMarkdown";
 
 describe("ChatMarkdown", () => {
@@ -40,6 +60,18 @@ Verdict: valid.
     expect(html).toContain("Remote image blocked: internal service");
     expect(html).not.toContain("<img");
     expect(html).not.toContain("http://127.0.0.1/action");
+  });
+
+  it("renders a GitHub pull request with its live status chip", () => {
+    const html = renderToStaticMarkup(
+      <ChatMarkdown content="Review https://github.com/PostHog/posthog/pull/23985" />,
+    );
+
+    expect(html).toContain("PostHog/posthog#23985");
+    expect(html).toContain('aria-label="Open"');
+    expect(html).toContain(
+      'data-github-ref-url="https://github.com/PostHog/posthog/pull/23985"',
+    );
   });
 });
 

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatMarkdown.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatMarkdown.tsx
@@ -12,12 +12,15 @@ import {
 } from "@posthog/quill";
 import { ArtifactRefChip } from "@posthog/ui/features/editor/components/ArtifactRefChip";
 import { EvidenceRefChip } from "@posthog/ui/features/editor/components/EvidenceRefChip";
+import { GithubPrRefChip } from "@posthog/ui/features/editor/components/GithubPrRefChip";
+import { GithubRefChip } from "@posthog/ui/features/editor/components/GithubRefChip";
 import { MessageChartCard } from "@posthog/ui/features/editor/components/MessageChartCard";
 import {
   markOpenLinkDestination,
   parseOpenFence,
   splitMarkdownBlocks,
 } from "@posthog/ui/features/editor/components/splitMarkdownBlocks";
+import { parseGithubIssueUrl } from "@posthog/ui/features/message-editor/githubIssueUrl";
 import {
   BareFileLink,
   hasDirectoryPath,
@@ -98,6 +101,25 @@ const components: Components = {
     if (evidenceTarget) {
       return (
         <EvidenceRefChip target={evidenceTarget}>{children}</EvidenceRefChip>
+      );
+    }
+    const githubRef = href ? parseGithubIssueUrl(href) : null;
+    if (githubRef) {
+      const isAutoLink = typeof children === "string" && children === href;
+      const label = isAutoLink
+        ? `${githubRef.owner}/${githubRef.repo}#${githubRef.number}`
+        : children;
+      if (githubRef.kind === "pr") {
+        return (
+          <GithubPrRefChip href={githubRef.normalizedUrl}>
+            {label}
+          </GithubPrRefChip>
+        );
+      }
+      return (
+        <GithubRefChip href={githubRef.normalizedUrl} kind="issue">
+          {label}
+        </GithubRefChip>
       );
     }
     const link = (

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatMarkdown.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatMarkdown.tsx
@@ -12,15 +12,13 @@ import {
 } from "@posthog/quill";
 import { ArtifactRefChip } from "@posthog/ui/features/editor/components/ArtifactRefChip";
 import { EvidenceRefChip } from "@posthog/ui/features/editor/components/EvidenceRefChip";
-import { GithubPrRefChip } from "@posthog/ui/features/editor/components/GithubPrRefChip";
-import { GithubRefChip } from "@posthog/ui/features/editor/components/GithubRefChip";
+import { githubRefChipFor } from "@posthog/ui/features/editor/components/githubRefChipFor";
 import { MessageChartCard } from "@posthog/ui/features/editor/components/MessageChartCard";
 import {
   markOpenLinkDestination,
   parseOpenFence,
   splitMarkdownBlocks,
 } from "@posthog/ui/features/editor/components/splitMarkdownBlocks";
-import { parseGithubIssueUrl } from "@posthog/ui/features/message-editor/githubIssueUrl";
 import {
   BareFileLink,
   hasDirectoryPath,
@@ -103,25 +101,8 @@ const components: Components = {
         <EvidenceRefChip target={evidenceTarget}>{children}</EvidenceRefChip>
       );
     }
-    const githubRef = href ? parseGithubIssueUrl(href) : null;
-    if (githubRef) {
-      const isAutoLink = typeof children === "string" && children === href;
-      const label = isAutoLink
-        ? `${githubRef.owner}/${githubRef.repo}#${githubRef.number}`
-        : children;
-      if (githubRef.kind === "pr") {
-        return (
-          <GithubPrRefChip href={githubRef.normalizedUrl}>
-            {label}
-          </GithubPrRefChip>
-        );
-      }
-      return (
-        <GithubRefChip href={githubRef.normalizedUrl} kind="issue">
-          {label}
-        </GithubRefChip>
-      );
-    }
+    const githubChip = githubRefChipFor(href, children);
+    if (githubChip) return githubChip;
     const link = (
       <a
         href={href}

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/fileLinkChips.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/fileLinkChips.tsx
@@ -71,7 +71,7 @@ export function InlineFileLink({
         type="button"
         onClick={taskId ? handleClick : undefined}
         disabled={!taskId}
-        className={`m-0 inline border-0 bg-transparent p-0 font-[inherit] text-(--accent-11) text-[length:inherit] ${taskId ? "cursor-pointer underline decoration-(--accent-a8) underline-offset-2 hover:decoration-(--accent-11)" : ""}`}
+        className={`m-0 inline border-0 bg-transparent p-0 font-[inherit] text-[length:inherit] text-foreground ${taskId ? "cursor-pointer underline underline-offset-2" : ""}`}
       >
         {filename}
         {lineSuffix ? `:${lineSuffix}` : ""}

--- a/products/desktop/packages/ui/src/primitives/ArtifactChip.tsx
+++ b/products/desktop/packages/ui/src/primitives/ArtifactChip.tsx
@@ -53,6 +53,7 @@ export function ArtifactChip({
         // the download half out of reach.
         className="min-w-0 shrink"
         variant="outline"
+        size="sm"
       >
         {typeof name === "string" && <FileIcon filename={name} size={12} />}
         <span className="min-w-0 truncate">{label}</span>
@@ -61,7 +62,7 @@ export function ArtifactChip({
       {onDownload && (
         <Tooltip content={downloading ? "Downloading…" : "Download"}>
           <Button
-            size="icon"
+            size="icon-sm"
             variant="outline"
             onClick={onDownload}
             disabled={downloading}

--- a/products/desktop/packages/workspace-server/src/services/git/schemas.ts
+++ b/products/desktop/packages/workspace-server/src/services/git/schemas.ts
@@ -315,6 +315,7 @@ export const getPrDetailsByUrlOutput = z.object({
   draft: z.boolean(),
   headRefName: z.string().nullable(),
   title: z.string().nullable(),
+  author: z.string().nullable(),
 });
 
 export type PrDetailsByUrlOutput = z.infer<typeof getPrDetailsByUrlOutput>;

--- a/products/desktop/packages/workspace-server/src/services/git/service.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/git/service.test.ts
@@ -21,6 +21,26 @@ describe("GitService", () => {
     execGhMock.mockReset();
   });
 
+  it("returns lifecycle and creator details for a pull request", async () => {
+    const details = {
+      state: "open",
+      merged: false,
+      draft: false,
+      headRefName: "posthog/status-chip",
+      title: "Show pull request status in sessions",
+      author: "octocat",
+    };
+    execGhMock.mockResolvedValueOnce(
+      ghResult({ stdout: JSON.stringify(details) }),
+    );
+
+    await expect(
+      new GitService().getPrDetailsByUrl(
+        "https://github.com/PostHog/posthog/pull/23985",
+      ),
+    ).resolves.toEqual(details);
+  });
+
   it("returns no changed files when the remote branch does not exist yet", async () => {
     execGhMock
       .mockResolvedValueOnce(ghResult({ stdout: "main\n" }))

--- a/products/desktop/packages/workspace-server/src/services/git/service.ts
+++ b/products/desktop/packages/workspace-server/src/services/git/service.ts
@@ -1032,7 +1032,7 @@ export class GitService extends TypedEventEmitter<GitCloneEvents> {
         "api",
         `repos/${pr.owner}/${pr.repo}/pulls/${pr.number}`,
         "--jq",
-        "{state,merged,draft,headRefName: .head.ref,title}",
+        "{state,merged,draft,headRefName: .head.ref,title,author: (.user.login // null)}",
       ]);
 
       if (result.exitCode !== 0) {
@@ -1045,6 +1045,7 @@ export class GitService extends TypedEventEmitter<GitCloneEvents> {
         draft: boolean;
         headRefName: string | null;
         title: string | null;
+        author: string | null;
       };
 
       return data;

--- a/products/desktop/packages/workspace-server/src/services/git/service.ts
+++ b/products/desktop/packages/workspace-server/src/services/git/service.ts
@@ -91,7 +91,11 @@ import type {
   SyncOutput,
   UpdatePrByUrlOutput,
 } from "./schemas";
-import { getPrInfoByUrlOutput, prConversationCommentSchema } from "./schemas";
+import {
+  getPrDetailsByUrlOutput,
+  getPrInfoByUrlOutput,
+  prConversationCommentSchema,
+} from "./schemas";
 
 const FETCH_THROTTLE_MS = 30_000;
 /** Max PRs per GraphQL request – stays well under GitHub's complexity ceiling. */
@@ -1039,16 +1043,9 @@ export class GitService extends TypedEventEmitter<GitCloneEvents> {
         return null;
       }
 
-      const data = JSON.parse(result.stdout) as {
-        state: string;
-        merged: boolean;
-        draft: boolean;
-        headRefName: string | null;
-        title: string | null;
-        author: string | null;
-      };
-
-      return data;
+      // The jq expression above and this schema describe one shape, so parse
+      // rather than cast: a GitHub field that moves fails here, not downstream.
+      return getPrDetailsByUrlOutput.parse(JSON.parse(result.stdout));
     } catch {
       return null;
     }


### PR DESCRIPTION
## Problem

People reading session transcripts cannot see whether a referenced pull request is open, draft, closed, or merged without leaving the session.

## Changes

- Session pull request links now show lifecycle-colored status icons.
- The lifecycle status refreshes every 30 seconds while the transcript remains mounted.
- Hovering a pull request shows its title, creator, and CI status.
- CI loads only after hover to avoid background GitHub work.
- Both session markdown renderers now use the same pull request chip.

<img width="1136" height="682" alt="2026-08-20 05 56 19" src="https://github.com/user-attachments/assets/a8eb186f-7841-41b5-bf63-0a54c31c2ba8" />

<img width="1136" height="682" alt="2026-08-20 05 55 53" src="https://github.com/user-attachments/assets/9946e3c0-e69a-41c9-ad54-b96b4e0dca04" />

<img width="1136" height="682" alt="2026-08-20 05 54 45" src="https://github.com/user-attachments/assets/39dc70d7-a4c7-4ceb-b436-25119c8526b3" />


| Before | After |
| --- | --- |
| ![Pull request link without live details](https://raw.githubusercontent.com/PostHog/pr-assets/9af579629fb2461efcbad9abcff70d14903d7ef0/2026/08/182327aa-e8a0-46fd-a4e3-a7ece5a13ce2.png) | ![Lifecycle-colored pull request links with hover details](https://raw.githubusercontent.com/PostHog/pr-assets/871a95fcd41cd69a3daa4f22c3d3d3ad3ade9448/2026/08/79a18a90-e8f9-4974-8c8d-857f9e21c790.png) |

### Chip readability pass

- Pull request chips read at body-text size instead of the 10px extra-small chip.
- The hover card text stays legible. It inherited page colors before, so the title landed foreground-on-foreground and disappeared.
- The hover card shows skeleton lines while details load, in place of the words "Loading CI".
- Artifact chips and their download button sit level with the other session chips.
- Inline file links read as body text with an underline, instead of accent red.
- The chip renders as one quill `Button` with `render={<a />}`, so the link element carries the button styling instead of wrapping it.

| Loading | Loaded |
| --- | --- |
| ![Pull request hover card showing skeleton lines](https://raw.githubusercontent.com/PostHog/pr-assets/a12cb71c0e32c3aed8add5f45e1a1a109975647e/2026/08/d35a33c0-5407-4a43-a75c-d4ae03cb1115.png) | ![Pull request hover card showing status, title, creator, and CI](https://raw.githubusercontent.com/PostHog/pr-assets/370dd6dc74e78af179396aa61692420a6f608059/2026/08/8164ea0c-e011-4e25-bd97-dcf9b1709c80.png) |

## How did you test this code?

- Ran the affected UI tests for status rendering, hover details, markdown links, mentions, and context-menu copying.
- Ran the Git service unit tests and TypeScript checks for UI, core, host-router, and workspace-server.
- Rendered the chip and hover card stories in Storybook with Playwright, in light and dark themes.
- Ran `hogli ci:preflight --strict`.
- The complete workspace-server suite cannot run here because native SQLite bindings are unavailable and integration fixtures invoke blocked unsigned commits.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation change. The behavior is visible in session transcripts and covered by Storybook.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- OpenAI GPT-5.6 implemented the original change with repository tools and Playwright. A public session link was unavailable in the cloud environment.
- Claude Opus 5 made the readability pass on the chips and hover card, verified in Storybook with Playwright.
- Skills invoked: `/writing-ui-components`, `/writing-user-facing-copy`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`, and `/writing-simplified-technical-english`.
- The Storybook examples use invented repositories, titles, and creators.
