### PR TITLE
feat(cdp): trigger destinations from group updates

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -270,6 +270,7 @@ export const FEATURE_FLAGS = {
     BILLING_ALERTS: 'billing-alerts', // owner: #team-billing, gates the Billing > Alerts tab
     CDP_ACTIVITY_LOG_NOTIFICATIONS: 'cdp-activity-log-notifications', // owner: #team-workflows-cdp
     CDP_DWH_TABLE_SOURCE: 'cdp-dwh-table-source', // owner: #team-workflows-cdp
+    CDP_GROUP_UPDATES: 'cdp-group-updates', // owner: #team-workflows-cdp
     CDP_HOG_SOURCES: 'cdp-hog-sources', // owner #team-workflows-cdp
     CDP_NEW_PRICING: 'cdp-new-pricing', // owner: #team-workflows
     CDP_PERSON_UPDATES: 'cdp-person-updates', // owner: #team-workflows-cdp

--- a/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
@@ -190,7 +190,7 @@ export function sanitizeConfiguration(data: HogFunctionConfigurationType): HogFu
     const filters = data.filters ?? {}
     filters.source = filters.source ?? 'events'
 
-    if (filters.source === 'person-updates' || Array.isArray(data?.mappings)) {
+    if (filters.source === 'person-updates' || filters.source === 'group-updates' || Array.isArray(data?.mappings)) {
         // Ensure we aren't passing in values that aren't supported
         delete filters.actions
         delete filters.events

--- a/frontend/src/scenes/hog-functions/filters/HogFunctionFilters.tsx
+++ b/frontend/src/scenes/hog-functions/filters/HogFunctionFilters.tsx
@@ -114,6 +114,7 @@ export function HogFunctionFilters({
     const isTransformation = type === 'transformation'
     const isDataWarehouse = configuration?.filters?.source === 'data-warehouse-table'
     const cdpPersonUpdatesEnabled = useFeatureFlag('CDP_PERSON_UPDATES')
+    const cdpGroupUpdatesEnabled = useFeatureFlag('CDP_GROUP_UPDATES')
     const cdpDwhTableSourceEnabled = useFeatureFlag('CDP_DWH_TABLE_SOURCE')
 
     // The table matcher's column suggestions read from databaseTableListLogic, which isn't loaded
@@ -182,7 +183,9 @@ export function HogFunctionFilters({
 
     // NOTE: Mappings won't work for person updates currently as they are totally event based...
     const showSourcePicker =
-        (cdpPersonUpdatesEnabled || cdpDwhTableSourceEnabled) && type === 'destination' && !useMapping
+        (cdpPersonUpdatesEnabled || cdpGroupUpdatesEnabled || cdpDwhTableSourceEnabled) &&
+        type === 'destination' &&
+        !useMapping
     const showEventMatchers =
         !useMapping && ['events', 'data-warehouse-table'].includes(configuration?.filters?.source ?? 'events')
 
@@ -206,6 +209,8 @@ export function HogFunctionFilters({
                             <br />
                             <b>Person updates</b> will trigger whenever a Person is created, updated or deleted.
                             <br />
+                            <b>Group updates</b> will trigger whenever a group's properties are updated.
+                            <br />
                             <b>Warehouse table</b> will trigger whenever a new row is synced into a data warehouse
                             table.
                         </>
@@ -218,6 +223,9 @@ export function HogFunctionFilters({
                                     { value: 'events', label: 'Events' },
                                     ...(cdpPersonUpdatesEnabled
                                         ? [{ value: 'person-updates', label: 'Person updates' }]
+                                        : []),
+                                    ...(cdpGroupUpdatesEnabled
+                                        ? [{ value: 'group-updates', label: 'Group updates' }]
                                         : []),
                                     ...(cdpDwhTableSourceEnabled
                                         ? [{ value: 'data-warehouse-table', label: 'Warehouse table' }]

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -7295,7 +7295,7 @@ export type CyclotronJobFilterPropertyFilter =
     | FlagPropertyFilter
 
 export interface CyclotronJobFiltersType {
-    source?: 'events' | 'person-updates' | 'data-warehouse-table'
+    source?: 'events' | 'person-updates' | 'group-updates' | 'data-warehouse-table'
     events?: CyclotronJobFilterEvents[]
     data_warehouse?: CyclotronJobFilterDataWarehouse[]
     actions?: CyclotronJobFilterActions[]

--- a/nodejs/src/capabilities.ts
+++ b/nodejs/src/capabilities.ts
@@ -12,6 +12,7 @@ import { PluginServerCapabilities, PluginServerMode, stringToPluginServerMode } 
 export const CAPABILITIES_CDP: PluginServerCapabilities = {
     cdpProcessedEvents: true,
     cdpPersonUpdates: true,
+    cdpGroupUpdates: true,
     cdpInternalEvents: true,
     cdpCyclotronWorker: true,
     cdpApi: true,
@@ -114,6 +115,10 @@ export function getPluginServerCapabilities(
         case PluginServerMode.cdp_person_updates:
             return {
                 cdpPersonUpdates: true,
+            }
+        case PluginServerMode.cdp_group_updates:
+            return {
+                cdpGroupUpdates: true,
             }
         case PluginServerMode.cdp_internal_events:
             return {

--- a/nodejs/src/cdp/consumers/cdp-group-updates.consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-group-updates.consumer.test.ts
@@ -1,0 +1,154 @@
+import { createMockJobQueue } from '../../../tests/helpers/mocks/job-queue.mock'
+import '../../../tests/helpers/mocks/producer.mock'
+
+import { GroupReadRepository } from '~/common/groups/repositories/group-repository.interface'
+import { closeHub, createHub } from '~/common/utils/db/hub'
+import { forSnapshot } from '~/tests/helpers/snapshots'
+
+import { createCdpConsumerDeps } from '../../../tests/helpers/cdp'
+import { getFirstTeam, resetTestDatabase, updateOrganizationAvailableFeatures } from '../../../tests/helpers/sql'
+import { ClickhouseGroup, Hub, Team } from '../../types'
+import { HOG_EXAMPLES, HOG_FILTERS_EXAMPLES, HOG_INPUTS_EXAMPLES } from '../_tests/examples'
+import { insertHogFunction as _insertHogFunction, createHogFunction, createKafkaMessage } from '../_tests/fixtures'
+import { GroupsManagerService } from '../services/managers/groups-manager.service'
+import { HogFunctionType } from '../types'
+import { CdpGroupUpdatesConsumer } from './cdp-group-updates.consumer'
+
+describe('CDP Group Updates Consumer', () => {
+    let processor: CdpGroupUpdatesConsumer
+    let hub: Hub
+    let team: Team
+    let hogFunction: HogFunctionType
+
+    const createClickhouseGroup = (teamId: number, data: Partial<ClickhouseGroup> = {}): ClickhouseGroup => ({
+        team_id: teamId,
+        group_type_index: 0,
+        group_key: 'acme-inc',
+        created_at: '2025-01-01 00:00:00',
+        group_properties: JSON.stringify({ name: 'Acme Inc' }),
+        ...data,
+    })
+
+    const insertHogFunction = async (hogFunction: Partial<HogFunctionType>) => {
+        const item = await _insertHogFunction(hub.postgres, team.id, hogFunction)
+        // Trigger the reload that django would do
+        processor['hogFunctionManager']['onHogFunctionsReloaded'](team.id, [item.id])
+        return item
+    }
+
+    beforeEach(async () => {
+        await resetTestDatabase()
+        hub = await createHub({
+            SITE_URL: 'http://localhost:8000',
+        })
+        team = await getFirstTeam(hub.postgres)
+        await updateOrganizationAvailableFeatures(hub.postgres, team.organization_id, [
+            { key: 'group_analytics', name: 'Group Analytics' },
+        ])
+        hub.teamManager['lazyLoader'].clear()
+
+        const mockJobQueue = createMockJobQueue()
+        processor = new CdpGroupUpdatesConsumer(hub, createCdpConsumerDeps(hub), mockJobQueue)
+        await processor.start()
+
+        const mockGroupRepository: GroupReadRepository = {
+            fetchGroupsByKeys: jest.fn().mockResolvedValue([]),
+            fetchGroupTypesByTeamIds: jest.fn().mockResolvedValue({
+                [team.id]: [{ group_type: 'organization', group_type_index: 0 }],
+            }),
+            fetchGroupTypesByProjectIds: jest.fn().mockResolvedValue({}),
+        }
+        processor['groupsManager'] = new GroupsManagerService(hub.teamManager, mockGroupRepository)
+
+        hogFunction = createHogFunction({
+            // Inputs must not reference `person` - a group update has no person to resolve
+            ...HOG_EXAMPLES.simple_return_object,
+            ...HOG_INPUTS_EXAMPLES.none,
+            ...HOG_FILTERS_EXAMPLES.no_filters,
+            type: 'destination',
+        })
+
+        hogFunction.filters = { ...hogFunction.filters, source: 'group-updates' }
+        await insertHogFunction(hogFunction)
+    })
+
+    afterEach(async () => {
+        await processor.stop()
+        await closeHub(hub)
+    })
+
+    describe('_parseKafkaBatch', () => {
+        it('should ignore invalid message', async () => {
+            const events = await processor._parseKafkaBatch([createKafkaMessage({})])
+            expect(events).toHaveLength(0)
+        })
+
+        it('should ignore message with no team', async () => {
+            const events = await processor._parseKafkaBatch([createKafkaMessage(createClickhouseGroup(999999))])
+            expect(events).toHaveLength(0)
+        })
+
+        it('should ignore message for an unknown group type index', async () => {
+            const events = await processor._parseKafkaBatch([
+                createKafkaMessage(createClickhouseGroup(team.id, { group_type_index: 3 })),
+            ])
+            expect(events).toHaveLength(0)
+        })
+
+        it('should key the group by its type name so group property filters resolve', async () => {
+            const events = await processor._parseKafkaBatch([
+                createKafkaMessage(createClickhouseGroup(team.id), { timestamp: 1735693261000 }),
+            ])
+
+            expect(events).toHaveLength(1)
+            expect(forSnapshot(events[0])).toMatchInlineSnapshot(`
+                {
+                  "event": {
+                    "distinct_id": "acme-inc",
+                    "elements_chain": "",
+                    "event": "$group_updated",
+                    "properties": {},
+                    "timestamp": "2025-01-01T01:01:01.000Z",
+                    "url": "http://localhost:8000/project/2/groups/0/acme-inc",
+                    "uuid": "<REPLACED-UUID-0>",
+                  },
+                  "groups": {
+                    "organization": {
+                      "id": "acme-inc",
+                      "index": 0,
+                      "properties": {
+                        "name": "Acme Inc",
+                      },
+                      "type": "organization",
+                      "url": "http://localhost:8000/project/2/groups/0/acme-inc",
+                    },
+                  },
+                  "project": {
+                    "id": 2,
+                    "name": "TEST PROJECT",
+                    "url": "http://localhost:8000/project/2",
+                  },
+                }
+            `)
+        })
+    })
+
+    describe('processing', () => {
+        it('should only run hog functions that are filtering for group updates', async () => {
+            const hogFunctionEvents = createHogFunction({
+                ...HOG_EXAMPLES.simple_fetch,
+                ...HOG_INPUTS_EXAMPLES.simple_fetch,
+                ...HOG_FILTERS_EXAMPLES.no_filters,
+                type: 'destination',
+            })
+
+            await insertHogFunction(hogFunctionEvents)
+
+            const events = await processor._parseKafkaBatch([createKafkaMessage(createClickhouseGroup(team.id))])
+            const result = await processor.processBatch(events)
+
+            expect(result.invocations).toHaveLength(1)
+            expect(result.invocations[0].functionId).toEqual(hogFunction.id)
+        })
+    })
+})

--- a/nodejs/src/cdp/consumers/cdp-group-updates.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-group-updates.consumer.ts
@@ -1,0 +1,181 @@
+import { Message } from 'node-rdkafka'
+
+import { KAFKA_GROUPS } from '~/common/config/kafka-topics'
+import { KafkaConsumerInterface, createKafkaConsumer } from '~/common/kafka/consumer'
+import { instrumentFn, instrumented } from '~/common/tracing/tracing-utils'
+import { parseJSON } from '~/common/utils/json-parse'
+import { logger } from '~/common/utils/logger'
+import { captureException } from '~/common/utils/posthog'
+import { UUIDT } from '~/common/utils/utils'
+
+import { ClickhouseGroup, HealthCheckResult, PluginsServerConfig, Team } from '../../types'
+import { HogFunctionInvocationPipeline } from '../services/hog-function-invocation-pipeline.service'
+import { JobQueue } from '../services/job-queue/job-queue.interface'
+import { CyclotronJobInvocation, HogFunctionInvocationGlobals, HogFunctionTypeType } from '../types'
+import { CdpConsumerBase, CdpConsumerBaseDeps } from './cdp-base.consumer'
+import { counterParseError } from './metrics'
+
+export class CdpGroupUpdatesConsumer extends CdpConsumerBase {
+    protected name = 'CdpGroupUpdatesConsumer'
+    protected hogTypes: HogFunctionTypeType[] = ['destination']
+
+    protected hogQueue: JobQueue
+    protected kafkaConsumer: KafkaConsumerInterface
+    private hogFunctionPipeline: HogFunctionInvocationPipeline
+
+    constructor(config: PluginsServerConfig, deps: CdpConsumerBaseDeps, hogQueue: JobQueue) {
+        super(config, deps)
+        this.hogQueue = hogQueue
+        this.kafkaConsumer = createKafkaConsumer({
+            groupId: 'cdp-group-updates-consumer',
+            topic: KAFKA_GROUPS,
+        })
+        this.hogFunctionPipeline = new HogFunctionInvocationPipeline(config, {
+            hogFunctionManager: this.hogFunctionManager,
+            hogInputsService: this.hogInputsService,
+            hogWatcher: this.hogWatcher,
+            hogWatcherMirror: this.hogWatcherMirror,
+            hogMasker: this.hogMasker,
+            hogFunctionMonitoringService: this.hogFunctionMonitoringService,
+            quotaLimiting: deps.quotaLimiting,
+            redis: this.redis,
+            valkeyShadow: this.valkeyShadow,
+        })
+    }
+
+    public async processBatch(
+        invocationGlobals: HogFunctionInvocationGlobals[]
+    ): Promise<{ backgroundTask: Promise<any>; invocations: CyclotronJobInvocation[] }> {
+        if (!invocationGlobals.length) {
+            return { backgroundTask: Promise.resolve(), invocations: [] }
+        }
+
+        const invocationsToBeQueued = await this.hogFunctionPipeline.buildInvocations(invocationGlobals, {
+            hogTypes: this.hogTypes,
+            filterFn: (fn) => fn.filters?.source === 'group-updates',
+        })
+
+        return {
+            backgroundTask: Promise.all([
+                instrumentFn({ key: 'cdp.background_task.queue_invocations', sendException: false }, () =>
+                    this.hogQueue.queueInvocations(invocationsToBeQueued)
+                ),
+                instrumentFn({ key: 'cdp.background_task.monitoring_flush', sendException: false }, async () => {
+                    try {
+                        await this.hogFunctionMonitoringService.flush()
+                    } catch (err) {
+                        captureException(err)
+                        logger.error('🔴', 'Error producing queued messages for monitoring', { err })
+                    }
+                }),
+            ]),
+            invocations: invocationsToBeQueued,
+        }
+    }
+
+    @instrumented('cdpConsumer.handleEachBatch.parseKafkaMessages')
+    public async _parseKafkaBatch(messages: Message[]): Promise<HogFunctionInvocationGlobals[]> {
+        const globals: HogFunctionInvocationGlobals[] = []
+        await Promise.all(
+            messages.map(async (message) => {
+                try {
+                    const data = parseJSON(message.value!.toString()) as ClickhouseGroup
+
+                    const [teamHogFunctions, team] = await Promise.all([
+                        this.hogFunctionManager.getHogFunctionsForTeam(data.team_id, this.hogTypes),
+                        this.deps.teamManager.getTeam(data.team_id),
+                    ])
+
+                    const filteredHogFunctions = teamHogFunctions.filter((fn) => fn.filters?.source === 'group-updates')
+
+                    if (!filteredHogFunctions.length || !team) {
+                        return
+                    }
+
+                    // Group property filters compile against `groups.<type>`, so a group we can't
+                    // name can't be filtered on - drop it rather than invoke with a mislabelled group.
+                    const groupType = await this.groupsManager.getGroupTypeName(data.team_id, data.group_type_index)
+                    if (!groupType) {
+                        return
+                    }
+
+                    globals.push(
+                        convertClickhouseGroupToInvocationGlobals(
+                            data,
+                            team,
+                            groupType,
+                            new Date(message.timestamp ?? Date.now()).toISOString(),
+                            this.config.SITE_URL
+                        )
+                    )
+                } catch (e) {
+                    logger.error('Error parsing message', e)
+                    counterParseError.labels({ error: e.message }).inc()
+                }
+            })
+        )
+
+        return globals
+    }
+
+    public override async start(): Promise<void> {
+        await super.start()
+        await this.hogQueue.startAsProducer()
+        await this.kafkaConsumer.connect(async (messages) => {
+            logger.info('🔁', `${this.name} - handling batch`, { size: messages.length })
+            return await instrumentFn('cdpConsumer.handleEachBatch', async () => {
+                const invocationGlobals = await this._parseKafkaBatch(messages)
+                const { backgroundTask } = await this.processBatch(invocationGlobals)
+                return { backgroundTask }
+            })
+        })
+    }
+
+    public override async stop(): Promise<void> {
+        logger.info('💤', 'Stopping consumer...')
+        await this.kafkaConsumer.disconnect()
+        await this.hogQueue.stopProducer()
+        await super.stop()
+    }
+
+    public isHealthy(): HealthCheckResult {
+        return this.kafkaConsumer.isHealthy()
+    }
+}
+
+function convertClickhouseGroupToInvocationGlobals(
+    data: ClickhouseGroup,
+    team: Team,
+    groupType: string,
+    timestamp: string,
+    siteUrl: string
+): HogFunctionInvocationGlobals {
+    const projectUrl = `${siteUrl}/project/${team.id}`
+    const groupUrl = `${projectUrl}/groups/${data.group_type_index}/${encodeURIComponent(data.group_key)}`
+
+    return {
+        project: {
+            id: team.id,
+            name: team.name,
+            url: projectUrl,
+        },
+        event: {
+            uuid: new UUIDT().toString(),
+            event: '$group_updated',
+            distinct_id: data.group_key,
+            properties: {},
+            timestamp,
+            url: groupUrl,
+            elements_chain: '',
+        },
+        groups: {
+            [groupType]: {
+                id: data.group_key,
+                type: groupType,
+                index: data.group_type_index,
+                url: groupUrl,
+                properties: parseJSON(data.group_properties),
+            },
+        },
+    }
+}

--- a/nodejs/src/cdp/services/managers/groups-manager.service.ts
+++ b/nodejs/src/cdp/services/managers/groups-manager.service.ts
@@ -51,6 +51,11 @@ export class GroupsManagerService {
         this.groupPropertiesLoader.clear()
     }
 
+    public async getGroupTypeName(teamId: number, groupTypeIndex: number): Promise<string | null> {
+        const typeMapping = await this.groupTypesLoader.get(String(teamId))
+        return Object.entries(typeMapping ?? {}).find(([, index]) => index === groupTypeIndex)?.[0] ?? null
+    }
+
     /**
      * Loads groups for a given team and event, returning the groups record.
      * Can be used directly when a full globals object isn't available (e.g. hogflow worker).

--- a/nodejs/src/cdp/types.ts
+++ b/nodejs/src/cdp/types.ts
@@ -45,7 +45,7 @@ export type HogFunctionMasking = {
 }
 
 export interface HogFunctionFilters {
-    source?: 'events' | 'person-updates' | 'data-warehouse-table' // Special case to identify what kind of thing this filters on
+    source?: 'events' | 'person-updates' | 'group-updates' | 'data-warehouse-table' // Special case to identify what kind of thing this filters on
     events?: HogFunctionFilterEvent[]
     actions?: HogFunctionFilterAction[]
     properties?: Record<string, any>[] // Global property filters that apply to all events

--- a/nodejs/src/common/config.ts
+++ b/nodejs/src/common/config.ts
@@ -44,6 +44,7 @@ export enum PluginServerMode {
     recordings_blob_ingestion_v2_ml_image_fetch_retry = 'recordings-blob-ingestion-v2-ml-image-fetch-retry',
     cdp_processed_events = 'cdp-processed-events',
     cdp_person_updates = 'cdp-person-updates',
+    cdp_group_updates = 'cdp-group-updates',
     cdp_data_warehouse_events = 'cdp-data-warehouse-events',
     cdp_internal_events = 'cdp-internal-events',
     cdp_cyclotron_worker = 'cdp-cyclotron-worker',

--- a/nodejs/src/server.ts
+++ b/nodejs/src/server.ts
@@ -30,6 +30,7 @@ import { CdpCyclotronWorkerHogFlow } from './cdp/consumers/cdp-cyclotron-worker-
 import { CdpCyclotronWorker } from './cdp/consumers/cdp-cyclotron-worker.consumer'
 import { CdpDatawarehouseEventsConsumer } from './cdp/consumers/cdp-data-warehouse-events.consumer'
 import { CdpEventsConsumer } from './cdp/consumers/cdp-events.consumer'
+import { CdpGroupUpdatesConsumer } from './cdp/consumers/cdp-group-updates.consumer'
 import { CdpHogflowSubscriptionMatcherConsumer } from './cdp/consumers/cdp-hogflow-subscription-matcher.consumer'
 import { CdpInternalEventsConsumer } from './cdp/consumers/cdp-internal-event.consumer'
 import { CdpLegacyEventsConsumer } from './cdp/consumers/cdp-legacy-event.consumer'
@@ -94,6 +95,7 @@ export class PluginServer implements NodeServer {
             capabilities.cdpDataWarehouseEvents ||
             capabilities.cdpInternalEvents ||
             capabilities.cdpPersonUpdates ||
+            capabilities.cdpGroupUpdates ||
             capabilities.cdpLegacyOnEvent ||
             capabilities.cdpApi ||
             capabilities.cdpCyclotronWorker ||
@@ -201,6 +203,14 @@ export class PluginServer implements NodeServer {
         if (capabilities.cdpPersonUpdates) {
             serviceLoaders.push(async () => {
                 const consumer = new CdpPersonUpdatesConsumer(this.config, cdpDeps!, kafkaQueue)
+                await consumer.start()
+                return consumer.service
+            })
+        }
+
+        if (capabilities.cdpGroupUpdates) {
+            serviceLoaders.push(async () => {
+                const consumer = new CdpGroupUpdatesConsumer(this.config, cdpDeps!, kafkaQueue)
                 await consumer.start()
                 return consumer.service
             })

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -140,6 +140,7 @@ export interface PluginServerCapabilities {
     cdpProcessedEvents?: boolean
     cdpDataWarehouseEvents?: boolean
     cdpPersonUpdates?: boolean
+    cdpGroupUpdates?: boolean
     cdpInternalEvents?: boolean
     cdpLegacyOnEvent?: boolean
     cdpCyclotronWorkerBatchResolve?: boolean

--- a/posthog/cdp/validation.py
+++ b/posthog/cdp/validation.py
@@ -675,7 +675,7 @@ class InputsSerializer(serializers.DictField):
 
 class HogFunctionFiltersSerializer(serializers.Serializer):
     source = serializers.ChoiceField(
-        choices=["events", "person-updates", "data-warehouse-table"], required=False, default="events"
+        choices=["events", "person-updates", "group-updates", "data-warehouse-table"], required=False, default="events"
     )  # type: ignore
     actions = serializers.ListField(child=serializers.DictField(), required=False)
     events = serializers.ListField(child=serializers.DictField(), required=False)
@@ -717,8 +717,8 @@ class HogFunctionFiltersSerializer(serializers.Serializer):
             # Don't allow events or actions for person-updates
             data.pop("data_warehouse", None)
 
-        if data.get("source") == "person-updates":
-            # Don't allow events or actions for person-updates
+        if data.get("source") in ("person-updates", "group-updates"):
+            # Neither source carries an event, so event/action matchers can never match
             data.pop("events", None)
             data.pop("actions", None)
             data.pop("data_warehouse", None)

--- a/products/cdp/frontend/generated/api.schemas.ts
+++ b/products/cdp/frontend/generated/api.schemas.ts
@@ -328,6 +328,7 @@ export interface InputsSchemaItemApi {
 /**
  * * `events` - events
  * * `person-updates` - person-updates
+ * * `group-updates` - group-updates
  * * `data-warehouse-table` - data-warehouse-table
  */
 export type HogFunctionFiltersSourceEnumApi =
@@ -336,6 +337,7 @@ export type HogFunctionFiltersSourceEnumApi =
 export const HogFunctionFiltersSourceEnumApi = {
     Events: 'events',
     PersonUpdates: 'person-updates',
+    GroupUpdates: 'group-updates',
     DataWarehouseTable: 'data-warehouse-table',
 } as const
 

--- a/products/cdp/frontend/generated/api.zod.ts
+++ b/products/cdp/frontend/generated/api.zod.ts
@@ -119,9 +119,9 @@ export const HogFunctionsCreateBody = /* @__PURE__ */ zod.object({
     filters: zod
         .object({
             source: zod
-                .enum(['events', 'person-updates', 'data-warehouse-table'])
+                .enum(['events', 'person-updates', 'group-updates', 'data-warehouse-table'])
                 .describe(
-                    '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                    '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                 )
                 .default(hogFunctionsCreateBodyFiltersOneSourceDefault),
             actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
@@ -226,9 +226,9 @@ export const HogFunctionsCreateBody = /* @__PURE__ */ zod.object({
                 filters: zod
                     .object({
                         source: zod
-                            .enum(['events', 'person-updates', 'data-warehouse-table'])
+                            .enum(['events', 'person-updates', 'group-updates', 'data-warehouse-table'])
                             .describe(
-                                '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                                '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                             )
                             .default(hogFunctionsCreateBodyMappingsItemFiltersSourceDefault),
                         actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
@@ -376,9 +376,9 @@ export const HogFunctionsUpdateBody = /* @__PURE__ */ zod.object({
     filters: zod
         .object({
             source: zod
-                .enum(['events', 'person-updates', 'data-warehouse-table'])
+                .enum(['events', 'person-updates', 'group-updates', 'data-warehouse-table'])
                 .describe(
-                    '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                    '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                 )
                 .default(hogFunctionsUpdateBodyFiltersOneSourceDefault),
             actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
@@ -483,9 +483,9 @@ export const HogFunctionsUpdateBody = /* @__PURE__ */ zod.object({
                 filters: zod
                     .object({
                         source: zod
-                            .enum(['events', 'person-updates', 'data-warehouse-table'])
+                            .enum(['events', 'person-updates', 'group-updates', 'data-warehouse-table'])
                             .describe(
-                                '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                                '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                             )
                             .default(hogFunctionsUpdateBodyMappingsItemFiltersSourceDefault),
                         actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
@@ -633,9 +633,9 @@ export const HogFunctionsPartialUpdateBody = /* @__PURE__ */ zod.object({
     filters: zod
         .object({
             source: zod
-                .enum(['events', 'person-updates', 'data-warehouse-table'])
+                .enum(['events', 'person-updates', 'group-updates', 'data-warehouse-table'])
                 .describe(
-                    '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                    '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                 )
                 .default(hogFunctionsPartialUpdateBodyFiltersOneSourceDefault),
             actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
@@ -740,9 +740,9 @@ export const HogFunctionsPartialUpdateBody = /* @__PURE__ */ zod.object({
                 filters: zod
                     .object({
                         source: zod
-                            .enum(['events', 'person-updates', 'data-warehouse-table'])
+                            .enum(['events', 'person-updates', 'group-updates', 'data-warehouse-table'])
                             .describe(
-                                '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                                '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                             )
                             .default(hogFunctionsPartialUpdateBodyMappingsItemFiltersSourceDefault),
                         actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
@@ -894,9 +894,9 @@ export const HogFunctionsEnableBackfillsCreateBody = /* @__PURE__ */ zod.object(
     filters: zod
         .object({
             source: zod
-                .enum(['events', 'person-updates', 'data-warehouse-table'])
+                .enum(['events', 'person-updates', 'group-updates', 'data-warehouse-table'])
                 .describe(
-                    '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                    '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                 )
                 .default(hogFunctionsEnableBackfillsCreateBodyFiltersOneSourceDefault),
             actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
@@ -1007,9 +1007,9 @@ export const HogFunctionsEnableBackfillsCreateBody = /* @__PURE__ */ zod.object(
                 filters: zod
                     .object({
                         source: zod
-                            .enum(['events', 'person-updates', 'data-warehouse-table'])
+                            .enum(['events', 'person-updates', 'group-updates', 'data-warehouse-table'])
                             .describe(
-                                '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                                '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                             )
                             .default(hogFunctionsEnableBackfillsCreateBodyMappingsItemFiltersSourceDefault),
                         actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
@@ -1236,9 +1236,9 @@ export const HogFunctionsInvocationsCreateBody = /* @__PURE__ */ zod.object({
             filters: zod
                 .object({
                     source: zod
-                        .enum(['events', 'person-updates', 'data-warehouse-table'])
+                        .enum(['events', 'person-updates', 'group-updates', 'data-warehouse-table'])
                         .describe(
-                            '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                            '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                         )
                         .default(hogFunctionsInvocationsCreateBodyConfigurationOneFiltersOneSourceDefault),
                     actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
@@ -1349,9 +1349,9 @@ export const HogFunctionsInvocationsCreateBody = /* @__PURE__ */ zod.object({
                         filters: zod
                             .object({
                                 source: zod
-                                    .enum(['events', 'person-updates', 'data-warehouse-table'])
+                                    .enum(['events', 'person-updates', 'group-updates', 'data-warehouse-table'])
                                     .describe(
-                                        '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                                        '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                                     )
                                     .default(
                                         hogFunctionsInvocationsCreateBodyConfigurationOneMappingsItemFiltersSourceDefault

--- a/products/workflows/frontend/generated/api.schemas.ts
+++ b/products/workflows/frontend/generated/api.schemas.ts
@@ -68,6 +68,7 @@ export const OnErrorEnumApi = {
 /**
  * * `events` - events
  * * `person-updates` - person-updates
+ * * `group-updates` - group-updates
  * * `data-warehouse-table` - data-warehouse-table
  */
 export type HogFunctionFiltersSourceEnumApi =
@@ -76,6 +77,7 @@ export type HogFunctionFiltersSourceEnumApi =
 export const HogFunctionFiltersSourceEnumApi = {
     Events: 'events',
     PersonUpdates: 'person-updates',
+    GroupUpdates: 'group-updates',
     DataWarehouseTable: 'data-warehouse-table',
 } as const
 

--- a/products/workflows/frontend/generated/api.zod.ts
+++ b/products/workflows/frontend/generated/api.zod.ts
@@ -93,9 +93,9 @@ export const HogFlowTemplatesCreateBody = /* @__PURE__ */ zod
                         .union([
                             zod.object({
                                 source: zod
-                                    .enum(['events', 'person-updates', 'data-warehouse-table'])
+                                    .enum(['events', 'person-updates', 'group-updates', 'data-warehouse-table'])
                                     .describe(
-                                        '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                                        '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                                     )
                                     .default(hogFlowTemplatesCreateBodyActionsItemFiltersOneSourceDefault),
                                 actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
@@ -215,9 +215,9 @@ export const HogFlowTemplatesUpdateBody = /* @__PURE__ */ zod
                         .union([
                             zod.object({
                                 source: zod
-                                    .enum(['events', 'person-updates', 'data-warehouse-table'])
+                                    .enum(['events', 'person-updates', 'group-updates', 'data-warehouse-table'])
                                     .describe(
-                                        '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                                        '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                                     )
                                     .default(hogFlowTemplatesUpdateBodyActionsItemFiltersOneSourceDefault),
                                 actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
@@ -343,9 +343,9 @@ export const HogFlowTemplatesPartialUpdateBody = /* @__PURE__ */ zod
                             .union([
                                 zod.object({
                                     source: zod
-                                        .enum(['events', 'person-updates', 'data-warehouse-table'])
+                                        .enum(['events', 'person-updates', 'group-updates', 'data-warehouse-table'])
                                         .describe(
-                                            '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                                            '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                                         )
                                         .default(hogFlowTemplatesPartialUpdateBodyActionsItemFiltersOneSourceDefault),
                                     actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
@@ -452,9 +452,9 @@ export const HogFlowsCreateBody = /* @__PURE__ */ zod
                                 filters: zod
                                     .object({
                                         source: zod
-                                            .enum(['events', 'person-updates', 'data-warehouse-table'])
+                                            .enum(['events', 'person-updates', 'group-updates', 'data-warehouse-table'])
                                             .describe(
-                                                '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                                                '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                                             )
                                             .default(hogFlowsCreateBodyConversionOneEventsItemFiltersOneSourceDefault),
                                         actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
@@ -556,9 +556,9 @@ export const HogFlowsCreateBody = /* @__PURE__ */ zod
                         .union([
                             zod.object({
                                 source: zod
-                                    .enum(['events', 'person-updates', 'data-warehouse-table'])
+                                    .enum(['events', 'person-updates', 'group-updates', 'data-warehouse-table'])
                                     .describe(
-                                        '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                                        '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                                     )
                                     .default(hogFlowsCreateBodyActionsItemFiltersOneSourceDefault),
                                 actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
@@ -609,9 +609,14 @@ export const HogFlowsCreateBody = /* @__PURE__ */ zod
                                                 .union([
                                                     zod.object({
                                                         source: zod
-                                                            .enum(['events', 'person-updates', 'data-warehouse-table'])
+                                                            .enum([
+                                                                'events',
+                                                                'person-updates',
+                                                                'group-updates',
+                                                                'data-warehouse-table',
+                                                            ])
                                                             .describe(
-                                                                '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                                                                '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                                                             )
                                                             .default(
                                                                 hogFlowsCreateBodyActionsItemConfigTwoConditionFiltersOneSourceDefault
@@ -655,10 +660,11 @@ export const HogFlowsCreateBody = /* @__PURE__ */ zod
                                                                 .enum([
                                                                     'events',
                                                                     'person-updates',
+                                                                    'group-updates',
                                                                     'data-warehouse-table',
                                                                 ])
                                                                 .describe(
-                                                                    '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                                                                    '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                                                                 )
                                                                 .default(
                                                                     hogFlowsCreateBodyActionsItemConfigTwoEventsItemFiltersOneSourceDefault
@@ -796,9 +802,9 @@ export const HogFlowsUpdateBody = /* @__PURE__ */ zod
                                 filters: zod
                                     .object({
                                         source: zod
-                                            .enum(['events', 'person-updates', 'data-warehouse-table'])
+                                            .enum(['events', 'person-updates', 'group-updates', 'data-warehouse-table'])
                                             .describe(
-                                                '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                                                '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                                             )
                                             .default(hogFlowsUpdateBodyConversionOneEventsItemFiltersOneSourceDefault),
                                         actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
@@ -900,9 +906,9 @@ export const HogFlowsUpdateBody = /* @__PURE__ */ zod
                         .union([
                             zod.object({
                                 source: zod
-                                    .enum(['events', 'person-updates', 'data-warehouse-table'])
+                                    .enum(['events', 'person-updates', 'group-updates', 'data-warehouse-table'])
                                     .describe(
-                                        '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                                        '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                                     )
                                     .default(hogFlowsUpdateBodyActionsItemFiltersOneSourceDefault),
                                 actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
@@ -953,9 +959,14 @@ export const HogFlowsUpdateBody = /* @__PURE__ */ zod
                                                 .union([
                                                     zod.object({
                                                         source: zod
-                                                            .enum(['events', 'person-updates', 'data-warehouse-table'])
+                                                            .enum([
+                                                                'events',
+                                                                'person-updates',
+                                                                'group-updates',
+                                                                'data-warehouse-table',
+                                                            ])
                                                             .describe(
-                                                                '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                                                                '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                                                             )
                                                             .default(
                                                                 hogFlowsUpdateBodyActionsItemConfigTwoConditionFiltersOneSourceDefault
@@ -999,10 +1010,11 @@ export const HogFlowsUpdateBody = /* @__PURE__ */ zod
                                                                 .enum([
                                                                     'events',
                                                                     'person-updates',
+                                                                    'group-updates',
                                                                     'data-warehouse-table',
                                                                 ])
                                                                 .describe(
-                                                                    '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                                                                    '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                                                                 )
                                                                 .default(
                                                                     hogFlowsUpdateBodyActionsItemConfigTwoEventsItemFiltersOneSourceDefault
@@ -1143,9 +1155,9 @@ export const HogFlowsPartialUpdateBody = /* @__PURE__ */ zod
                                 filters: zod
                                     .object({
                                         source: zod
-                                            .enum(['events', 'person-updates', 'data-warehouse-table'])
+                                            .enum(['events', 'person-updates', 'group-updates', 'data-warehouse-table'])
                                             .describe(
-                                                '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                                                '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                                             )
                                             .default(
                                                 hogFlowsPartialUpdateBodyConversionOneEventsItemFiltersOneSourceDefault
@@ -1249,9 +1261,9 @@ export const HogFlowsPartialUpdateBody = /* @__PURE__ */ zod
                         .union([
                             zod.object({
                                 source: zod
-                                    .enum(['events', 'person-updates', 'data-warehouse-table'])
+                                    .enum(['events', 'person-updates', 'group-updates', 'data-warehouse-table'])
                                     .describe(
-                                        '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                                        '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                                     )
                                     .default(hogFlowsPartialUpdateBodyActionsItemFiltersOneSourceDefault),
                                 actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
@@ -1302,9 +1314,14 @@ export const HogFlowsPartialUpdateBody = /* @__PURE__ */ zod
                                                 .union([
                                                     zod.object({
                                                         source: zod
-                                                            .enum(['events', 'person-updates', 'data-warehouse-table'])
+                                                            .enum([
+                                                                'events',
+                                                                'person-updates',
+                                                                'group-updates',
+                                                                'data-warehouse-table',
+                                                            ])
                                                             .describe(
-                                                                '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                                                                '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                                                             )
                                                             .default(
                                                                 hogFlowsPartialUpdateBodyActionsItemConfigTwoConditionFiltersOneSourceDefault
@@ -1348,10 +1365,11 @@ export const HogFlowsPartialUpdateBody = /* @__PURE__ */ zod
                                                                 .enum([
                                                                     'events',
                                                                     'person-updates',
+                                                                    'group-updates',
                                                                     'data-warehouse-table',
                                                                 ])
                                                                 .describe(
-                                                                    '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                                                                    '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                                                                 )
                                                                 .default(
                                                                     hogFlowsPartialUpdateBodyActionsItemConfigTwoEventsItemFiltersOneSourceDefault
@@ -1734,9 +1752,14 @@ export const HogFlowsInvocationsCreateBody = /* @__PURE__ */ zod.object({
                                     filters: zod
                                         .object({
                                             source: zod
-                                                .enum(['events', 'person-updates', 'data-warehouse-table'])
+                                                .enum([
+                                                    'events',
+                                                    'person-updates',
+                                                    'group-updates',
+                                                    'data-warehouse-table',
+                                                ])
                                                 .describe(
-                                                    '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                                                    '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                                                 )
                                                 .default(
                                                     hogFlowsInvocationsCreateBodyConfigurationOneConversionOneEventsItemFiltersOneSourceDefault
@@ -1847,9 +1870,9 @@ export const HogFlowsInvocationsCreateBody = /* @__PURE__ */ zod.object({
                             .union([
                                 zod.object({
                                     source: zod
-                                        .enum(['events', 'person-updates', 'data-warehouse-table'])
+                                        .enum(['events', 'person-updates', 'group-updates', 'data-warehouse-table'])
                                         .describe(
-                                            '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                                            '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                                         )
                                         .default(
                                             hogFlowsInvocationsCreateBodyConfigurationOneActionsItemFiltersOneSourceDefault
@@ -1905,10 +1928,11 @@ export const HogFlowsInvocationsCreateBody = /* @__PURE__ */ zod.object({
                                                                 .enum([
                                                                     'events',
                                                                     'person-updates',
+                                                                    'group-updates',
                                                                     'data-warehouse-table',
                                                                 ])
                                                                 .describe(
-                                                                    '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                                                                    '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                                                                 )
                                                                 .default(
                                                                     hogFlowsInvocationsCreateBodyConfigurationOneActionsItemConfigTwoConditionFiltersOneSourceDefault
@@ -1952,10 +1976,11 @@ export const HogFlowsInvocationsCreateBody = /* @__PURE__ */ zod.object({
                                                                     .enum([
                                                                         'events',
                                                                         'person-updates',
+                                                                        'group-updates',
                                                                         'data-warehouse-table',
                                                                     ])
                                                                     .describe(
-                                                                        '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                                                                        '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                                                                     )
                                                                     .default(
                                                                         hogFlowsInvocationsCreateBodyConfigurationOneActionsItemConfigTwoEventsItemFiltersOneSourceDefault
@@ -2354,9 +2379,9 @@ export const HogFlowsBulkDeleteCreateBody = /* @__PURE__ */ zod
                                 filters: zod
                                     .object({
                                         source: zod
-                                            .enum(['events', 'person-updates', 'data-warehouse-table'])
+                                            .enum(['events', 'person-updates', 'group-updates', 'data-warehouse-table'])
                                             .describe(
-                                                '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                                                '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                                             )
                                             .default(
                                                 hogFlowsBulkDeleteCreateBodyConversionOneEventsItemFiltersOneSourceDefault
@@ -2460,9 +2485,9 @@ export const HogFlowsBulkDeleteCreateBody = /* @__PURE__ */ zod
                         .union([
                             zod.object({
                                 source: zod
-                                    .enum(['events', 'person-updates', 'data-warehouse-table'])
+                                    .enum(['events', 'person-updates', 'group-updates', 'data-warehouse-table'])
                                     .describe(
-                                        '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                                        '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                                     )
                                     .default(hogFlowsBulkDeleteCreateBodyActionsItemFiltersOneSourceDefault),
                                 actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
@@ -2513,9 +2538,14 @@ export const HogFlowsBulkDeleteCreateBody = /* @__PURE__ */ zod
                                                 .union([
                                                     zod.object({
                                                         source: zod
-                                                            .enum(['events', 'person-updates', 'data-warehouse-table'])
+                                                            .enum([
+                                                                'events',
+                                                                'person-updates',
+                                                                'group-updates',
+                                                                'data-warehouse-table',
+                                                            ])
                                                             .describe(
-                                                                '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                                                                '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                                                             )
                                                             .default(
                                                                 hogFlowsBulkDeleteCreateBodyActionsItemConfigTwoConditionFiltersOneSourceDefault
@@ -2559,10 +2589,11 @@ export const HogFlowsBulkDeleteCreateBody = /* @__PURE__ */ zod
                                                                 .enum([
                                                                     'events',
                                                                     'person-updates',
+                                                                    'group-updates',
                                                                     'data-warehouse-table',
                                                                 ])
                                                                 .describe(
-                                                                    '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                                                                    '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                                                                 )
                                                                 .default(
                                                                     hogFlowsBulkDeleteCreateBodyActionsItemConfigTwoEventsItemFiltersOneSourceDefault

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -39218,6 +39218,7 @@ export namespace Schemas {
     /**
      * * `events` - events
      * * `person-updates` - person-updates
+     * * `group-updates` - group-updates
      * * `data-warehouse-table` - data-warehouse-table
      */
     export type HogFunctionFiltersSourceEnum = typeof HogFunctionFiltersSourceEnum[keyof typeof HogFunctionFiltersSourceEnum];
@@ -39226,6 +39227,7 @@ export namespace Schemas {
     export const HogFunctionFiltersSourceEnum = {
       Events: 'events',
       PersonUpdates: 'person-updates',
+      GroupUpdates: 'group-updates',
       DataWarehouseTable: 'data-warehouse-table',
     } as const;
 

--- a/services/mcp/src/generated/cdp_functions/api.ts
+++ b/services/mcp/src/generated/cdp_functions/api.ts
@@ -139,9 +139,9 @@ export const HogFunctionsCreateBody = /* @__PURE__ */ zod.object({
     filters: zod
         .object({
             source: zod
-                .enum(['events', 'person-updates', 'data-warehouse-table'])
+                .enum(['events', 'person-updates', 'group-updates', 'data-warehouse-table'])
                 .describe(
-                    '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                    '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                 )
                 .default(hogFunctionsCreateBodyFiltersOneSourceDefault),
             actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
@@ -234,9 +234,9 @@ export const HogFunctionsCreateBody = /* @__PURE__ */ zod.object({
                 filters: zod
                     .object({
                         source: zod
-                            .enum(['events', 'person-updates', 'data-warehouse-table'])
+                            .enum(['events', 'person-updates', 'group-updates', 'data-warehouse-table'])
                             .describe(
-                                '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                                '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                             )
                             .default(hogFunctionsCreateBodyMappingsItemFiltersSourceDefault),
                         actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
@@ -386,9 +386,9 @@ export const HogFunctionsPartialUpdateBody = /* @__PURE__ */ zod.object({
     filters: zod
         .object({
             source: zod
-                .enum(['events', 'person-updates', 'data-warehouse-table'])
+                .enum(['events', 'person-updates', 'group-updates', 'data-warehouse-table'])
                 .describe(
-                    '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                    '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                 )
                 .default(hogFunctionsPartialUpdateBodyFiltersOneSourceDefault),
             actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
@@ -481,9 +481,9 @@ export const HogFunctionsPartialUpdateBody = /* @__PURE__ */ zod.object({
                 filters: zod
                     .object({
                         source: zod
-                            .enum(['events', 'person-updates', 'data-warehouse-table'])
+                            .enum(['events', 'person-updates', 'group-updates', 'data-warehouse-table'])
                             .describe(
-                                '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                                '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                             )
                             .default(hogFunctionsPartialUpdateBodyMappingsItemFiltersSourceDefault),
                         actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
@@ -738,9 +738,9 @@ export const HogFunctionsInvocationsCreateBody = /* @__PURE__ */ zod.object({
             filters: zod
                 .object({
                     source: zod
-                        .enum(['events', 'person-updates', 'data-warehouse-table'])
+                        .enum(['events', 'person-updates', 'group-updates', 'data-warehouse-table'])
                         .describe(
-                            '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                            '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                         )
                         .default(hogFunctionsInvocationsCreateBodyConfigurationOneFiltersOneSourceDefault),
                     actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
@@ -851,9 +851,9 @@ export const HogFunctionsInvocationsCreateBody = /* @__PURE__ */ zod.object({
                         filters: zod
                             .object({
                                 source: zod
-                                    .enum(['events', 'person-updates', 'data-warehouse-table'])
+                                    .enum(['events', 'person-updates', 'group-updates', 'data-warehouse-table'])
                                     .describe(
-                                        '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                                        '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                                     )
                                     .default(
                                         hogFunctionsInvocationsCreateBodyConfigurationOneMappingsItemFiltersSourceDefault

--- a/services/mcp/src/generated/error_tracking_alerts/api.ts
+++ b/services/mcp/src/generated/error_tracking_alerts/api.ts
@@ -139,9 +139,9 @@ export const HogFunctionsCreateBody = /* @__PURE__ */ zod.object({
     filters: zod
         .object({
             source: zod
-                .enum(['events', 'person-updates', 'data-warehouse-table'])
+                .enum(['events', 'person-updates', 'group-updates', 'data-warehouse-table'])
                 .describe(
-                    '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                    '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                 )
                 .default(hogFunctionsCreateBodyFiltersOneSourceDefault),
             actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
@@ -234,9 +234,9 @@ export const HogFunctionsCreateBody = /* @__PURE__ */ zod.object({
                 filters: zod
                     .object({
                         source: zod
-                            .enum(['events', 'person-updates', 'data-warehouse-table'])
+                            .enum(['events', 'person-updates', 'group-updates', 'data-warehouse-table'])
                             .describe(
-                                '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                                '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                             )
                             .default(hogFunctionsCreateBodyMappingsItemFiltersSourceDefault),
                         actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
@@ -377,9 +377,9 @@ export const HogFunctionsPartialUpdateBody = /* @__PURE__ */ zod.object({
     filters: zod
         .object({
             source: zod
-                .enum(['events', 'person-updates', 'data-warehouse-table'])
+                .enum(['events', 'person-updates', 'group-updates', 'data-warehouse-table'])
                 .describe(
-                    '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                    '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                 )
                 .default(hogFunctionsPartialUpdateBodyFiltersOneSourceDefault),
             actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
@@ -472,9 +472,9 @@ export const HogFunctionsPartialUpdateBody = /* @__PURE__ */ zod.object({
                 filters: zod
                     .object({
                         source: zod
-                            .enum(['events', 'person-updates', 'data-warehouse-table'])
+                            .enum(['events', 'person-updates', 'group-updates', 'data-warehouse-table'])
                             .describe(
-                                '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                                '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                             )
                             .default(hogFunctionsPartialUpdateBodyMappingsItemFiltersSourceDefault),
                         actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),

--- a/services/mcp/src/generated/workflows/api.ts
+++ b/services/mcp/src/generated/workflows/api.ts
@@ -108,9 +108,9 @@ export const HogFlowsCreateBody = /* @__PURE__ */ zod
                                 filters: zod
                                     .object({
                                         source: zod
-                                            .enum(['events', 'person-updates', 'data-warehouse-table'])
+                                            .enum(['events', 'person-updates', 'group-updates', 'data-warehouse-table'])
                                             .describe(
-                                                '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                                                '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                                             )
                                             .default(hogFlowsCreateBodyConversionOneEventsItemFiltersOneSourceDefault),
                                         actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
@@ -212,9 +212,9 @@ export const HogFlowsCreateBody = /* @__PURE__ */ zod
                         .union([
                             zod.object({
                                 source: zod
-                                    .enum(['events', 'person-updates', 'data-warehouse-table'])
+                                    .enum(['events', 'person-updates', 'group-updates', 'data-warehouse-table'])
                                     .describe(
-                                        '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                                        '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                                     )
                                     .default(hogFlowsCreateBodyActionsItemFiltersOneSourceDefault),
                                 actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
@@ -265,9 +265,14 @@ export const HogFlowsCreateBody = /* @__PURE__ */ zod
                                                 .union([
                                                     zod.object({
                                                         source: zod
-                                                            .enum(['events', 'person-updates', 'data-warehouse-table'])
+                                                            .enum([
+                                                                'events',
+                                                                'person-updates',
+                                                                'group-updates',
+                                                                'data-warehouse-table',
+                                                            ])
                                                             .describe(
-                                                                '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                                                                '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                                                             )
                                                             .default(
                                                                 hogFlowsCreateBodyActionsItemConfigTwoConditionFiltersOneSourceDefault
@@ -311,10 +316,11 @@ export const HogFlowsCreateBody = /* @__PURE__ */ zod
                                                                 .enum([
                                                                     'events',
                                                                     'person-updates',
+                                                                    'group-updates',
                                                                     'data-warehouse-table',
                                                                 ])
                                                                 .describe(
-                                                                    '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                                                                    '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                                                                 )
                                                                 .default(
                                                                     hogFlowsCreateBodyActionsItemConfigTwoEventsItemFiltersOneSourceDefault
@@ -454,9 +460,9 @@ export const HogFlowsPartialUpdateBody = /* @__PURE__ */ zod
                                 filters: zod
                                     .object({
                                         source: zod
-                                            .enum(['events', 'person-updates', 'data-warehouse-table'])
+                                            .enum(['events', 'person-updates', 'group-updates', 'data-warehouse-table'])
                                             .describe(
-                                                '\* `events` - events\n\* `person-updates` - person-updates\n\* `data-warehouse-table` - data-warehouse-table'
+                                                '\* `events` - events\n\* `person-updates` - person-updates\n\* `group-updates` - group-updates\n\* `data-warehouse-table` - data-warehouse-table'
                                             )
                                             .default(
                                                 hogFlowsPartialUpdateBodyConversionOneEventsItemFiltersOneSourceDefault

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/cdp-functions-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/cdp-functions-create.json
@@ -70,8 +70,8 @@
                 },
                 "source": {
                     "default": "events",
-                    "description": "* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table",
-                    "enum": ["events", "person-updates", "data-warehouse-table"],
+                    "description": "* `events` - events\n* `person-updates` - person-updates\n* `group-updates` - group-updates\n* `data-warehouse-table` - data-warehouse-table",
+                    "enum": ["events", "person-updates", "group-updates", "data-warehouse-table"],
                     "type": "string"
                 }
             },
@@ -249,8 +249,8 @@
                                     },
                                     "source": {
                                         "default": "events",
-                                        "description": "* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table",
-                                        "enum": ["events", "person-updates", "data-warehouse-table"],
+                                        "description": "* `events` - events\n* `person-updates` - person-updates\n* `group-updates` - group-updates\n* `data-warehouse-table` - data-warehouse-table",
+                                        "enum": ["events", "person-updates", "group-updates", "data-warehouse-table"],
                                         "type": "string"
                                     }
                                 },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/cdp-functions-invocations-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/cdp-functions-invocations-create.json
@@ -217,8 +217,8 @@
                         },
                         "source": {
                             "default": "events",
-                            "description": "* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table",
-                            "enum": ["events", "person-updates", "data-warehouse-table"],
+                            "description": "* `events` - events\n* `person-updates` - person-updates\n* `group-updates` - group-updates\n* `data-warehouse-table` - data-warehouse-table",
+                            "enum": ["events", "person-updates", "group-updates", "data-warehouse-table"],
                             "type": "string"
                         },
                         "transpiled": {}
@@ -419,8 +419,13 @@
                                             },
                                             "source": {
                                                 "default": "events",
-                                                "description": "* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table",
-                                                "enum": ["events", "person-updates", "data-warehouse-table"],
+                                                "description": "* `events` - events\n* `person-updates` - person-updates\n* `group-updates` - group-updates\n* `data-warehouse-table` - data-warehouse-table",
+                                                "enum": [
+                                                    "events",
+                                                    "person-updates",
+                                                    "group-updates",
+                                                    "data-warehouse-table"
+                                                ],
                                                 "type": "string"
                                             },
                                             "transpiled": {}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/cdp-functions-partial-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/cdp-functions-partial-update.json
@@ -76,8 +76,8 @@
                 },
                 "source": {
                     "default": "events",
-                    "description": "* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table",
-                    "enum": ["events", "person-updates", "data-warehouse-table"],
+                    "description": "* `events` - events\n* `person-updates` - person-updates\n* `group-updates` - group-updates\n* `data-warehouse-table` - data-warehouse-table",
+                    "enum": ["events", "person-updates", "group-updates", "data-warehouse-table"],
                     "type": "string"
                 }
             },
@@ -259,8 +259,8 @@
                                     },
                                     "source": {
                                         "default": "events",
-                                        "description": "* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table",
-                                        "enum": ["events", "person-updates", "data-warehouse-table"],
+                                        "description": "* `events` - events\n* `person-updates` - person-updates\n* `group-updates` - group-updates\n* `data-warehouse-table` - data-warehouse-table",
+                                        "enum": ["events", "person-updates", "group-updates", "data-warehouse-table"],
                                         "type": "string"
                                     }
                                 },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/error-tracking-alerts-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/error-tracking-alerts-create.json
@@ -70,8 +70,8 @@
                 },
                 "source": {
                     "default": "events",
-                    "description": "* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table",
-                    "enum": ["events", "person-updates", "data-warehouse-table"],
+                    "description": "* `events` - events\n* `person-updates` - person-updates\n* `group-updates` - group-updates\n* `data-warehouse-table` - data-warehouse-table",
+                    "enum": ["events", "person-updates", "group-updates", "data-warehouse-table"],
                     "type": "string"
                 }
             },
@@ -249,8 +249,8 @@
                                     },
                                     "source": {
                                         "default": "events",
-                                        "description": "* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table",
-                                        "enum": ["events", "person-updates", "data-warehouse-table"],
+                                        "description": "* `events` - events\n* `person-updates` - person-updates\n* `group-updates` - group-updates\n* `data-warehouse-table` - data-warehouse-table",
+                                        "enum": ["events", "person-updates", "group-updates", "data-warehouse-table"],
                                         "type": "string"
                                     }
                                 },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/error-tracking-alerts-partial-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/error-tracking-alerts-partial-update.json
@@ -76,8 +76,8 @@
                 },
                 "source": {
                     "default": "events",
-                    "description": "* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table",
-                    "enum": ["events", "person-updates", "data-warehouse-table"],
+                    "description": "* `events` - events\n* `person-updates` - person-updates\n* `group-updates` - group-updates\n* `data-warehouse-table` - data-warehouse-table",
+                    "enum": ["events", "person-updates", "group-updates", "data-warehouse-table"],
                     "type": "string"
                 }
             },
@@ -259,8 +259,8 @@
                                     },
                                     "source": {
                                         "default": "events",
-                                        "description": "* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table",
-                                        "enum": ["events", "person-updates", "data-warehouse-table"],
+                                        "description": "* `events` - events\n* `person-updates` - person-updates\n* `group-updates` - group-updates\n* `data-warehouse-table` - data-warehouse-table",
+                                        "enum": ["events", "person-updates", "group-updates", "data-warehouse-table"],
                                         "type": "string"
                                     }
                                 },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/workflows-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/workflows-create.json
@@ -75,10 +75,11 @@
                                                             },
                                                             "source": {
                                                                 "default": "events",
-                                                                "description": "* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table",
+                                                                "description": "* `events` - events\n* `person-updates` - person-updates\n* `group-updates` - group-updates\n* `data-warehouse-table` - data-warehouse-table",
                                                                 "enum": [
                                                                     "events",
                                                                     "person-updates",
+                                                                    "group-updates",
                                                                     "data-warehouse-table"
                                                                 ],
                                                                 "type": "string"
@@ -157,10 +158,11 @@
                                                                 },
                                                                 "source": {
                                                                     "default": "events",
-                                                                    "description": "* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table",
+                                                                    "description": "* `events` - events\n* `person-updates` - person-updates\n* `group-updates` - group-updates\n* `data-warehouse-table` - data-warehouse-table",
                                                                     "enum": [
                                                                         "events",
                                                                         "person-updates",
+                                                                        "group-updates",
                                                                         "data-warehouse-table"
                                                                     ],
                                                                     "type": "string"
@@ -257,8 +259,8 @@
                                     },
                                     "source": {
                                         "default": "events",
-                                        "description": "* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table",
-                                        "enum": ["events", "person-updates", "data-warehouse-table"],
+                                        "description": "* `events` - events\n* `person-updates` - person-updates\n* `group-updates` - group-updates\n* `data-warehouse-table` - data-warehouse-table",
+                                        "enum": ["events", "person-updates", "group-updates", "data-warehouse-table"],
                                         "type": "string"
                                     },
                                     "transpiled": {}
@@ -387,8 +389,13 @@
                                             },
                                             "source": {
                                                 "default": "events",
-                                                "description": "* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table",
-                                                "enum": ["events", "person-updates", "data-warehouse-table"],
+                                                "description": "* `events` - events\n* `person-updates` - person-updates\n* `group-updates` - group-updates\n* `data-warehouse-table` - data-warehouse-table",
+                                                "enum": [
+                                                    "events",
+                                                    "person-updates",
+                                                    "group-updates",
+                                                    "data-warehouse-table"
+                                                ],
                                                 "type": "string"
                                             },
                                             "transpiled": {}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/workflows-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/workflows-update.json
@@ -64,8 +64,13 @@
                                             },
                                             "source": {
                                                 "default": "events",
-                                                "description": "* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table",
-                                                "enum": ["events", "person-updates", "data-warehouse-table"],
+                                                "description": "* `events` - events\n* `person-updates` - person-updates\n* `group-updates` - group-updates\n* `data-warehouse-table` - data-warehouse-table",
+                                                "enum": [
+                                                    "events",
+                                                    "person-updates",
+                                                    "group-updates",
+                                                    "data-warehouse-table"
+                                                ],
                                                 "type": "string"
                                             },
                                             "transpiled": {}


### PR DESCRIPTION
## Problem

A team that models accounts as groups cannot react when a group's properties change. Destinations trigger on events and on person updates only.

- The `clickhouse_groups` Kafka topic already carries every group upsert, including the group's full properties.
- No CDP consumer reads that topic.

## Changes

- A destination can now choose "Group updates" as its source and run whenever a `$groupidentify` updates a group. The `cdp-group-updates` flag gates the option.
- `CdpGroupUpdatesConsumer` reads `clickhouse_groups` and queues destinations whose `filters.source` is `group-updates`. It mirrors `CdpPersonUpdatesConsumer`.
- The consumer exposes the updated group as `groups.<type>`, so existing group property filters resolve against `group_N.properties` with no filter-compilation change.
- Group properties come from the Kafka payload, so no group lookup runs per message.
- The consumer drops a group whose type index has no name for the team. A mislabelled key would silently stop every group property filter from matching.
- Saving a group-updates destination strips event and action matchers, as person-updates already does.
- Mechanical: the `cdp-group-updates` plugin server mode and capability, the new serializer choice, and the regenerated API types.

> [!NOTE]
> Nothing consumes the topic in production until charts run a pod with `PLUGIN_SERVER_MODE=cdp-group-updates`. The capability is on by default in local dev.

> [!NOTE]
> A group update carries no person. A destination whose inputs template `{person}` fails to build its inputs on this source, the same way it does on the warehouse-table source.

## How did you test this code?

- `nodejs/src/cdp/consumers/cdp-group-updates.consumer.test.ts` adds 5 cases. The parse case pins the globals key to the group type name: if it regressed to the index or the group key, every group property filter would stop matching, and no existing test covers that.
- One case drops a message whose group type index the team does not map.
- `posthog/cdp/test/test_validation.py` ran locally against the new `group-updates` choice.
- Not checked: no run against a live plugin server or a real `clickhouse_groups` message. The consumer has never processed production data.
- No screenshot: the only visible change is one extra option in the existing Source dropdown, which needs the flag to appear.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No published doc covers the destination source picker.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code (Opus 5). Skills invoked: `/writing-tests`, `/writing-user-facing-copy`, `/writing-pr-descriptions`.

Two decisions shaped the consumer. The group type name comes from the mapping `GroupsManagerService` already caches, through a new `getGroupTypeName` method, rather than a fresh query per message. Properties come from the Kafka payload rather than a group lookup, since the payload is the row that was just written.

The work started on the `posthog/workflows-github-event-trigger` branch and moved to a branch off master, since it shares no code with that stack.
