### PR TITLE
fix(phai): stop linking artifact IDs as saved insight URLs

### DIFF
--- a/ee/hogai/chat_agent/insights/nodes.py
+++ b/ee/hogai/chat_agent/insights/nodes.py
@@ -192,7 +192,7 @@ class InsightSearchNode(AssistantNode):
             self._evaluation_selections[insight_id] = {"insight": insight, "explanation": explanation}
 
             name = insight["name"] or insight["derived_name"] or "Unnamed"
-            insight_url = build_insight_url(self._team, insight["short_id"])
+            insight_url = build_insight_url(insight["short_id"])
             return f"Selected insight {insight_id}: {name} (url: {insight_url})"
 
         @tool
@@ -618,7 +618,7 @@ class InsightSearchNode(AssistantNode):
             except Exception as e:
                 capture_exception(e)
 
-        insight_url = build_insight_url(self._team, insight["short_id"])
+        insight_url = build_insight_url(insight["short_id"])
         hyperlink_format = f"[{name}]({insight_url})"
 
         summary_parts = [
@@ -829,7 +829,7 @@ class InsightSearchNode(AssistantNode):
                 visualization_messages.append(visualization_message)
 
             insight_name = insight["name"] or insight["derived_name"] or "Unnamed"
-            insight_url = build_insight_url(self._team, insight["short_id"])
+            insight_url = build_insight_url(insight["short_id"])
             insight_hyperlink = f"[{insight_name}]({insight_url})"
             explanations.append(
                 f"- {insight_hyperlink} (Artifact ID: {insight['short_id']}): {selection['explanation']}"

--- a/ee/hogai/chat_agent/query_executor/test/test_nodes.py
+++ b/ee/hogai/chat_agent/query_executor/test/test_nodes.py
@@ -145,7 +145,8 @@ class TestQueryExecutorNode(ClickhouseTestMixin, NonAtomicBaseTest):
         mock_process_query_dict.assert_called_once()  # Query processing started
         msg = cast(AssistantToolCallMessage, new_state.messages[0])
         self.assertIn("Here is the results table of the TrendsQuery insight:", msg.content)
-        self.assertIn(f"Insight ID: {insight.short_id}", msg.content)
+        # The node renders an ephemeral artifact, so the ID is labelled as one and carries no URL
+        self.assertIn(f"Artifact ID: {insight.short_id}", msg.content)
         self.assertIn("Name: test insight", msg.content)
         self.assertIn("Description: test description", msg.content)
         self.assertEqual(msg.type, "tool")

--- a/ee/hogai/context/context.py
+++ b/ee/hogai/context/context.py
@@ -532,7 +532,7 @@ class AssistantContextManager(AssistantContextMixin):
             name=insight.name,
             description=insight.description,
             insight_id=insight.id,
-            # `MaxInsightContext.id` is a saved insight's short_id, so it resolves as a URL
+            # `MaxInsightContext.id` is a saved insight's short_id
             insight_short_id=insight.id,
             dashboard_filters=dashboard_filters,
             filters_override=filters_override,

--- a/ee/hogai/context/context.py
+++ b/ee/hogai/context/context.py
@@ -532,6 +532,8 @@ class AssistantContextManager(AssistantContextMixin):
             name=insight.name,
             description=insight.description,
             insight_id=insight.id,
+            # `MaxInsightContext.id` is a saved insight's short_id, so it resolves as a URL
+            insight_short_id=insight.id,
             dashboard_filters=dashboard_filters,
             filters_override=filters_override,
             variables_override=variables_override,

--- a/ee/hogai/context/dashboard/context.py
+++ b/ee/hogai/context/dashboard/context.py
@@ -66,7 +66,7 @@ class DashboardContext:
         self.name = name
         self.description = description
         self.dashboard_id = dashboard_id
-        self.dashboard_url = build_dashboard_url(team, int(dashboard_id)) if dashboard_id else None
+        self.dashboard_url = build_dashboard_url(int(dashboard_id)) if dashboard_id else None
         self.dashboard_filters = dashboard_filters
         self._semaphore = asyncio.Semaphore(max_concurrent_queries)
 

--- a/ee/hogai/context/dashboard/test/test_context.py
+++ b/ee/hogai/context/dashboard/test/test_context.py
@@ -236,7 +236,7 @@ class TestDashboardContext(BaseTest):
 
         self.assertIn("Dashboard name: Dashboard", result)
         self.assertIn("Dashboard ID: 606", result)
-        self.assertIn(f"Dashboard URL: /project/{self.team.id}/dashboard/606", result)
+        self.assertIn("Dashboard URL: /dashboard/606", result)
 
     async def test_dashboard_url_included_in_format_schema(self):
         dashboard_ctx = DashboardContext(
@@ -249,7 +249,7 @@ class TestDashboardContext(BaseTest):
 
         result = await dashboard_ctx.format_schema()
 
-        self.assertIn(f"Dashboard URL: /project/{self.team.id}/dashboard/12345", result)
+        self.assertIn("Dashboard URL: /dashboard/12345", result)
 
     @patch("ee.hogai.context.insight.context.execute_and_format_query")
     async def test_dashboard_url_included_in_execute_and_format(self, mock_execute):
@@ -273,7 +273,7 @@ class TestDashboardContext(BaseTest):
 
         result = await dashboard_ctx.execute_and_format()
 
-        self.assertIn(f"Dashboard URL: /project/{self.team.id}/dashboard/67890", result)
+        self.assertIn("Dashboard URL: /dashboard/67890", result)
 
     @patch("ee.hogai.context.insight.context.execute_and_format_query")
     async def test_custom_max_concurrent_queries(self, mock_execute):

--- a/ee/hogai/context/insight/context.py
+++ b/ee/hogai/context/insight/context.py
@@ -24,6 +24,9 @@ class InsightContext:
 
     Accepts insight data directly and provides methods to format schema or execute and format results.
     Supports optional dashboard filter/variable overrides before execution.
+
+    `insight_id` is only the identifier shown to the model; `insight_short_id` is the one that resolves to a
+    URL, so an ephemeral artifact passes the former and leaves the latter unset.
     """
 
     def __init__(
@@ -60,7 +63,7 @@ class InsightContext:
     def insight_url(self) -> str | None:
         """Generate insight URL from insight_short_id if available."""
         if self.insight_short_id:
-            return build_insight_url(self.team, self.insight_short_id)
+            return build_insight_url(self.insight_short_id)
         return None
 
     @classmethod

--- a/ee/hogai/context/insight/context.py
+++ b/ee/hogai/context/insight/context.py
@@ -112,7 +112,6 @@ class InsightContext:
             insight_description=self.description,
             query_schema=query_schema,
             results=results,
-            include_url_reminder=self.insight_id is None,
             insight_url=self.insight_url,
         )
 
@@ -126,7 +125,6 @@ class InsightContext:
             insight_id=self.insight_id,
             insight_description=self.description,
             query_schema=query_schema,
-            include_url_reminder=self.insight_id is None,
             insight_url=self.insight_url,
         )
 

--- a/ee/hogai/context/insight/prompts.py
+++ b/ee/hogai/context/insight/prompts.py
@@ -10,7 +10,7 @@ Description: {{{insight_description}}}
 Insight URL: {{{insight_url}}}
 {{/insight_url}}
 {{^insight_url}}
-This insight cannot be accessed via a URL.
+This insight is not saved in the project, so it cannot be accessed via a URL. Any ID above is a conversation-scoped artifact ID, not an insight short ID, so never write it into an `/insights/...` link: that link would 404. If the user wants a permanent link, tell them to click the open insight icon below the chart.
 {{/insight_url}}
 {{#query_schema}}
 
@@ -46,8 +46,7 @@ The current date and time is {{{utc_datetime_display}}} UTC, which is {{{project
 Always add `LIMIT 100` to your queries. The maximum allowed limit is 500 rows. If you need more data, paginate using LIMIT and OFFSET in subsequent queries.
 {{/sql_query}}
 It's expected that the data point for the current period may show a drop in value, as data collection for it is still ongoing. Do not point this out.
-Do not copy the results table as the user sees it in the UI.{{#include_url_reminder}}
-{{/include_url_reminder}}
+Do not copy the results table as the user sees it in the UI.
 {{#has_truncated_values}}
 Some JSON/array values were truncated. You can write a more specific SQL query to explore individual properties or array elements if needed.
 {{/has_truncated_values}}

--- a/ee/hogai/context/insight/prompts.py
+++ b/ee/hogai/context/insight/prompts.py
@@ -1,7 +1,7 @@
 INSIGHT_RESULT_TEMPLATE = """
 Name: {{{insight_name}}}
 {{#insight_id}}
-Insight ID: {{{insight_id}}}
+{{#insight_url}}Insight ID: {{{insight_id}}}{{/insight_url}}{{^insight_url}}Artifact ID: {{{insight_id}}}{{/insight_url}}
 {{/insight_id}}
 {{#insight_description}}
 Description: {{{insight_description}}}
@@ -10,7 +10,7 @@ Description: {{{insight_description}}}
 Insight URL: {{{insight_url}}}
 {{/insight_url}}
 {{^insight_url}}
-This insight is not saved in the project, so it cannot be accessed via a URL. Any ID above is a conversation-scoped artifact ID, not an insight short ID, so never write it into an `/insights/...` link: that link would 404. If the user wants a permanent link, tell them to click the open insight icon below the chart.
+This insight is not saved in the project, so it cannot be accessed via a URL. Any `Artifact ID` above is scoped to this conversation, not an insight short ID, so an `/insights/...` link built from it would 404. If the user wants a saved insight, tell them to open the chart as a new insight from the icon below it and save it from there.
 {{/insight_url}}
 {{#query_schema}}
 

--- a/ee/hogai/context/insight/test/test_context.py
+++ b/ee/hogai/context/insight/test/test_context.py
@@ -301,4 +301,6 @@ class TestInsightContext(BaseTest):
 
         result = await context.execute_and_format()
 
-        self.assertIn("This insight cannot be accessed via a URL.", result)
+        self.assertIn("cannot be accessed via a URL", result)
+        # Without this the model composes `/insights/<artifact id>`, which 404s
+        self.assertIn("`/insights/...` link", result)

--- a/ee/hogai/context/insight/test/test_context.py
+++ b/ee/hogai/context/insight/test/test_context.py
@@ -267,7 +267,7 @@ class TestInsightContext(BaseTest):
         query = AssistantTrendsQuery(series=[AssistantTrendsEventsNode(name="$pageview")])
         context = InsightContext(team=self.team, query=query, user=self.user, insight_short_id="abc123")
 
-        self.assertEqual(context.insight_url, f"/project/{self.team.id}/insights/abc123")
+        self.assertEqual(context.insight_url, "/insights/abc123")
 
     @patch("ee.hogai.context.insight.context.execute_and_format_query")
     async def test_execute_and_format_includes_insight_url(self, mock_execute):
@@ -285,7 +285,8 @@ class TestInsightContext(BaseTest):
 
         result = await context.execute_and_format()
 
-        self.assertIn(f"/project/{self.team.id}/insights/xyz789", result)
+        self.assertIn("/insights/xyz789", result)
+        self.assertIn("Insight ID: display-id", result)
 
     @patch("ee.hogai.context.insight.context.execute_and_format_query")
     async def test_execute_and_format_shows_fallback_when_no_url(self, mock_execute):
@@ -297,10 +298,14 @@ class TestInsightContext(BaseTest):
             query=query,
             user=self.user,
             name="Test Insight",
+            insight_id="cJcS",
         )
 
         result = await context.execute_and_format()
 
         self.assertIn("cannot be accessed via a URL", result)
-        # Without this the model composes `/insights/<artifact id>`, which 404s
-        self.assertIn("`/insights/...` link", result)
+        # An artifact ID under an `Insight ID:` label is what led the model to compose `/insights/cJcS`, which 404s
+        self.assertIn("Artifact ID: cJcS", result)
+        self.assertNotIn("Insight ID:", result)
+        self.assertIn("/insights/", result)
+        self.assertIn("404", result)

--- a/ee/hogai/context/test/test_context.py
+++ b/ee/hogai/context/test/test_context.py
@@ -71,6 +71,9 @@ class TestAssistantContextManager(BaseTest):
         self.assertIn("Description: Daily active users", result)
         self.assertIn("TrendsQuery", result)
         self.assertIn("Trend results: 100 users", result)
+        # A UI-attached insight is saved, so Max gets a real link rather than the unsaved-artifact warning
+        self.assertIn(f"Insight URL: /project/{self.team.id}/insights/123", result)
+        self.assertNotIn("cannot be accessed via a URL", result)
         mock_execute.assert_called_once()
 
     @patch("ee.hogai.context.insight.context.execute_and_format_query")

--- a/ee/hogai/context/test/test_context.py
+++ b/ee/hogai/context/test/test_context.py
@@ -71,10 +71,25 @@ class TestAssistantContextManager(BaseTest):
         self.assertIn("Description: Daily active users", result)
         self.assertIn("TrendsQuery", result)
         self.assertIn("Trend results: 100 users", result)
-        # A UI-attached insight is saved, so Max gets a real link rather than the unsaved-artifact warning
-        self.assertIn(f"Insight URL: /project/{self.team.id}/insights/123", result)
-        self.assertNotIn("cannot be accessed via a URL", result)
         mock_execute.assert_called_once()
+
+    @patch("ee.hogai.context.insight.context.execute_and_format_query")
+    async def test_build_and_execute_insight_links_to_saved_insight(self, mock_execute):
+        mock_execute.return_value = "Trend results: 100 users"
+
+        insight = MaxInsightContext(
+            id="123",
+            name="User Trends",
+            description=None,
+            query=TrendsQuery(series=[EventsNode(event="pageview")]),
+        )
+
+        insight_ctx = self.context_manager._build_insight_context(insight, dashboard_filters=None)
+        result = await self.context_manager._execute_and_format_insight(insight_ctx)
+        assert result is not None
+        # A UI-attached insight is always saved, so Max gets a real link rather than the unsaved-artifact warning
+        self.assertIn("Insight URL: /insights/123", result)
+        self.assertNotIn("cannot be accessed via a URL", result)
 
     @patch("ee.hogai.context.insight.context.execute_and_format_query")
     async def test_build_and_execute_insight_funnel_query(self, mock_execute):

--- a/ee/hogai/tools/task.py
+++ b/ee/hogai/tools/task.py
@@ -95,6 +95,8 @@ TASK_ARTIFACTS_PROMPT = """
 The following artifacts have been generated:
 
 {{{artifacts_list}}}
+
+Artifact IDs are scoped to this conversation and are not insight short IDs. Never write one into an `/insights/...` link: the insight was never saved to the project, so that link would 404.
 """
 
 
@@ -186,7 +188,7 @@ class TaskTool(MaxTool):
                 viz_content = unwrap_visualization_artifact_content(message)
                 if viz_content:
                     artifacts_list_prompt.append(
-                        f"- Insight ID: {message.artifact_id}\nName: {viz_content.name}\nDescription: {viz_content.description}\nQuery: {viz_content.query}"
+                        f"- Artifact ID: {message.artifact_id}\nName: {viz_content.name}\nDescription: {viz_content.description}\nQuery: {viz_content.query}"
                     )
                     continue
                 notebook_content = unwrap_notebook_artifact_content(message)

--- a/ee/hogai/tools/task.py
+++ b/ee/hogai/tools/task.py
@@ -96,7 +96,7 @@ The following artifacts have been generated:
 
 {{{artifacts_list}}}
 
-Artifact IDs are scoped to this conversation and are not insight short IDs. Never write one into an `/insights/...` link: the insight was never saved to the project, so that link would 404.
+Any `Artifact ID` above is scoped to this conversation, not an insight short ID, so an `/insights/...` link built from it would 404. If the user wants a saved insight, tell them to open the chart as a new insight from the icon below it and save it from there.
 """
 
 

--- a/ee/hogai/tools/test/test_task.py
+++ b/ee/hogai/tools/test/test_task.py
@@ -137,8 +137,11 @@ class TestTaskTool(ClickhouseTestMixin, NonAtomicBaseTest):
 
         self.assertIn("Done", result_text)
         self.assertIsNone(artifact)
-        self.assertIn("short_id_123", result_text)
+        self.assertIn("Artifact ID: short_id_123", result_text)
         self.assertIn("Test", result_text)
+        # Labelled as an insight, this handoff had the parent compose `/insights/short_id_123`, which 404s
+        self.assertNotIn("Insight ID:", result_text)
+        self.assertIn("404", result_text)
 
     async def test_arun_impl_dispatches_tool_call_updates(self):
         tool = self._create_tool()

--- a/ee/hogai/tools/upsert_dashboard/test/test_tool.py
+++ b/ee/hogai/tools/upsert_dashboard/test/test_tool.py
@@ -136,7 +136,7 @@ class TestUpsertDashboardTool(BaseTest):
         result, _ = await tool._arun_impl(action)
 
         dashboard = await Dashboard.objects.aget(name="URL Dashboard")
-        expected_url = f"/project/{self.team.id}/dashboard/{dashboard.id}"
+        expected_url = f"/dashboard/{dashboard.id}"
         self.assertIn(f"Dashboard URL: {expected_url}", result)
         self.assertNotIn("/dashboards/", result)
 
@@ -159,7 +159,7 @@ class TestUpsertDashboardTool(BaseTest):
 
         result, _ = await tool._arun_impl(action)
 
-        expected_url = f"/project/{self.team.id}/dashboard/{dashboard.id}"
+        expected_url = f"/dashboard/{dashboard.id}"
         self.assertIn(f"Dashboard URL: {expected_url}", result)
         self.assertNotIn("/dashboards/", result)
 

--- a/ee/hogai/utils/helpers.py
+++ b/ee/hogai/utils/helpers.py
@@ -509,14 +509,18 @@ def cast_assistant_query(
         raise ValueError(f"Unsupported query type: {query.kind}")
 
 
-def build_insight_url(team: Team, id: str) -> str:
-    """Build the URL for an insight."""
-    return f"/project/{team.id}/insights/{id}"
+def build_insight_url(id: str) -> str:
+    """Build the URL for an insight.
+
+    Unprefixed by `/project/<id>`: these URLs are handed to the model, which is instructed to omit
+    that prefix, and the app resolves them against the project the user is already in.
+    """
+    return f"/insights/{id}"
 
 
-def build_dashboard_url(team: Team, id: int) -> str:
-    """Build the URL for a dashboard."""
-    return f"/project/{team.id}/dashboard/{id}"
+def build_dashboard_url(id: int) -> str:
+    """Build the URL for a dashboard. Unprefixed, for the same reason as `build_insight_url`."""
+    return f"/dashboard/{id}"
 
 
 def extract_stream_update(update: Any) -> Any:


### PR DESCRIPTION
## Problem

Max hands users dead links to insights it just made. When someone asks Max to run SQL and it produces a chart, that chart is an ephemeral conversation artifact, not a saved insight. Max then links to it as `/insights/<id>`, and the page shows "Insight not found".

The cause is a labelling mismatch in the prompt. An ephemeral chart's ID is an `AgentArtifact.short_id` (4 characters), but `INSIGHT_RESULT_TEMPLATE` presented it to the model as `Insight ID:`, while the system prompt documents insight URLs as `/insights/<short_id>`. Real insight short IDs are 8 characters, so an artifact ID in that URL can never resolve. The only counter-signal was a single line, "This insight cannot be accessed via a URL", which the model read past.

This was found in a session replay: a user built a lead list with Max, clicked the supporting SQL insight it linked, and hit the not-found page.

## Changes

**The label, which was the actual root cause.** `INSIGHT_RESULT_TEMPLATE` now renders `Artifact ID:` when there is no URL and `Insight ID:` when there is, so the label matches the thing it names. Prose next to a wrong label is exactly what the model read past the first time, so the fix that matches the diagnosis is to fix the label rather than argue with it.

**The fallback copy.** The no-URL branch now tells the user to open the chart as a new insight and save it, which is what the control below the chart actually does: for an ephemeral artifact it routes to `urls.insightNew({query})` under the tooltip "Open as new insight". Earlier copy here promised a permanent link that a single click does not produce, and named an "open insight icon" that is hidden outright while an insight is being edited (`VisualizationArtifact.tsx` sets `openUrl={isEditingInsight ? null : target.url}`).

**Subagent results.** These label the ID as `Artifact ID` rather than `Insight ID`, and carry the same warning; previously that handoff had none. The warning is scoped to `Artifact ID` entries specifically, because the same list interleaves `Notebook ID:` entries and the notebook path *does* persist a real row under the artifact's short id — those links work, and a blanket warning would have Max withhold them.

**UI-attached insights get their real URL.** `_build_insight_context` passed `MaxInsightContext.id` only as `insight_id` and left `insight_short_id` unset, so `insight_url` was always `None` and Max was told a saved insight "cannot be accessed via a URL". It now passes both. Caught by Greptile on the first commit.

**Insight and dashboard URLs lose the `/project/<id>` prefix.** `PROJECT_ORG_USER_CONTEXT_PROMPT` instructs Max that all app URLs must "omit the `/project/:id/` prefix", but `build_insight_url` and `build_dashboard_url` emitted it. The links resolved, so nothing 404'd, but every entity link Max was handed contradicted its own style rule — and the change above makes `Insight URL:` fire for every UI-attached insight for the first time, so it stops being theoretical. Both builders now return `/insights/<short_id>` and `/dashboard/<id>`, and the now-unused `team` argument is gone from both.

**Mechanical:** drops the `include_url_reminder` mustache block. It was empty, and no value was ever passed for it at its only render site, so it rendered nothing either way.

Behavior for genuinely saved insights is otherwise untouched: they still get `Insight ID:` and `Insight URL:` and no warning.

## How did you test this code?

Every branch of the changed templates was rendered through mustache and asserted on:

- artifact, no URL: `Artifact ID:` label, no `Insight ID:` anywhere, warning present
- saved insight with a URL: `Insight ID:` label, link present, no warning
- no ID at all: neither label, warning still coherent
- subagent list as visualizations-only, notebooks-only, and mixed: no `Insight ID:` leaks, warning scoped to the artifact entries
- `QUERY_RESULTS_PROMPT` after the dead-block removal: renders clean, no unresolved mustache tags

Test coverage added where the behaviour previously had none:

- `test_arun_impl_handles_artifact_messages` now asserts the `Artifact ID:` label and the warning; it already rendered this prompt but asserted only on the bare id
- the URL-wiring regression moved out of `test_build_and_execute_insight_trends_query` into its own `test_build_and_execute_insight_links_to_saved_insight`, so the guard is not tied to a trends-specific test
- the no-URL insight test now pins the `Artifact ID` label rather than a fragment of the sentence

Not done: the Django test suite was not run. This sandbox has no synced virtualenv and no Postgres, and `BaseTest` needs a database. Leaving that to CI. No manual testing of Max in a running app.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigation started from a Replay Vision summarizer observation flagging a 404 during an AI Observability self-driving session. Querying the session's events pinned the exact click and the `not_found_shown` event, and the 4-character ID in the URL was the tell that separated an artifact ID from an insight short ID. A neighboring notebook link in the same session worked, which confirmed the asymmetry and is why the subagent warning is scoped rather than blanket.

The later commits came out of a review pass over the first one: the label fix, the corrected CTA copy, the notebook scoping, and the URL prefix alignment were all findings against the original prompt-only diff, verified against the frontend widget and the URL builders before being applied.

A heavier fix was considered and set aside: make the visualization path persist a real saved Insight before any link is built, the way `products/alerts/backend/max_tools.py` already does. That removes the failure entirely rather than instructing the model around it, but it changes what gets written to a project, so it belongs in its own PR.

Public artifact: the diff and this description contain no material from the originating session. No customer names, projects, IDs, or session contents appear in any committed file or in this description.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BLK2ZEUSH/p1786971673255799?thread_ts=1786971673.255799&cid=C0BLK2ZEUSH)*
