### PR TITLE
fix(workflows): keep edits typed while an auto-save is in flight

### DIFF
--- a/products/workflows/frontend/Workflows/workflowLogic.autosave.test.ts
+++ b/products/workflows/frontend/Workflows/workflowLogic.autosave.test.ts
@@ -114,6 +114,46 @@ describe('workflowLogic auto-save', () => {
             expect(logic.values.isAutoSave).toBe(false)
             expect(updateCalls).toBe(1)
         })
+
+        it('keeps edits made while the save request is in flight and saves them next', async () => {
+            jest.useFakeTimers()
+            useMocks({
+                patch: {
+                    '/api/environments/:team_id/hog_flows/:id/': () => {
+                        updateCalls += 1
+                        return [200, { ...workflow, name: 'Edit 1' }]
+                    },
+                },
+            })
+
+            logic.actions.setWorkflowValue('name', 'Edit 1')
+            await expectLogic(logic, () => {
+                logic.actions.markAutoSave(true)
+                logic.actions.saveWorkflow(logic.values.workflow)
+                // Typed while the request is still in flight: the response won't carry it.
+                logic.actions.setWorkflowValue('name', 'Edit 1 and more')
+            }).toDispatchActions(['saveWorkflowSuccess'])
+            expect(updateCalls).toBe(1)
+
+            expect(logic.values.workflow.name).toBe('Edit 1 and more')
+            expect(logic.values.workflowChanged).toBe(true)
+
+            await jest.advanceTimersByTimeAsync(3500)
+            await expectLogic(logic).toDispatchActions(['saveWorkflow', 'saveWorkflowSuccess'])
+            expect(updateCalls).toBe(2)
+        })
+
+        it('does not re-save when nothing changed during the round-trip', async () => {
+            jest.useFakeTimers()
+
+            logic.actions.setWorkflowValue('name', 'Edited')
+            await jest.advanceTimersByTimeAsync(3500)
+            await expectLogic(logic).toDispatchActions(['saveWorkflowSuccess'])
+
+            await jest.advanceTimersByTimeAsync(3500)
+            expect(updateCalls).toBe(1)
+            expect(logic.values.workflowChanged).toBe(false)
+        })
     })
 
     describe('skip cases', () => {

--- a/products/workflows/frontend/Workflows/workflowLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowLogic.ts
@@ -169,6 +169,18 @@ const WORKFLOW_CONTENT_FIELDS = [
     'variables',
 ] as const
 
+// The fields the editor writes through the form. Edits that land while a save is in flight are
+// re-applied from these after the response rebaselines the form, so the round-trip can't drop them.
+const WORKFLOW_EDITABLE_FIELDS = [...WORKFLOW_CONTENT_FIELDS, 'name', 'description'] as const
+
+function pickWorkflowEdits(workflow: HogFlow): Partial<HogFlow> {
+    const result: Record<string, unknown> = {}
+    for (const field of WORKFLOW_EDITABLE_FIELDS) {
+        result[field] = workflow[field]
+    }
+    return result as Partial<HogFlow>
+}
+
 function omitWorkflowContent(workflow: HogFlow): Partial<HogFlow> {
     const result: Record<string, unknown> = { ...workflow }
     for (const field of WORKFLOW_CONTENT_FIELDS) {
@@ -227,6 +239,7 @@ export interface workflowLogicValues {
     workflow: HogFlow
     workflowAllErrors: Record<string, any>
     workflowChanged: boolean
+    workflowEditVersion: number
     workflowErrors: DeepPartialMap<HogFlow, ValidationErrorType>
     workflowHasActionErrors: boolean
     workflowHasErrors: boolean
@@ -3066,6 +3079,15 @@ export const workflowLogic = kea<workflowLogicType>([
                 setAutoSaveEnabled: (_, { enabled }) => enabled,
             },
         ],
+        // Bumped on every form write. A save records the version it captured, so its response can
+        // tell whether the user kept editing while the request was in flight.
+        workflowEditVersion: [
+            0,
+            {
+                setWorkflowValue: (state) => state + 1,
+                setWorkflowValues: (state) => state + 1,
+            },
+        ],
         // Gates when per-field step messages become visible: the action ids that were present at
         // the last save/enable attempt. Every step is validated the whole time (so the node badge
         // and enable-gate work), but a step only shows its messages once the user has tried to
@@ -3441,7 +3463,7 @@ export const workflowLogic = kea<workflowLogicType>([
             (originalWorkflow: HogFlow | null): boolean => !!originalWorkflow?.draft,
         ],
     }),
-    listeners(({ actions, values, props }) => ({
+    listeners(({ actions, values, props, cache }) => ({
         setScheduleStartsAtFromPicker: ({ pickerDate }) => {
             if (!pickerDate) {
                 actions.setScheduleStartsAt(null)
@@ -3635,6 +3657,9 @@ export const workflowLogic = kea<workflowLogicType>([
         loadWorkflowFailure: () => {
             actions.replayDeferredResourceEdited()
         },
+        saveWorkflow: () => {
+            cache.saveEditVersion = values.workflowEditVersion
+        },
         saveWorkflowFailure: () => {
             actions.replayDeferredResourceEdited()
         },
@@ -3745,8 +3770,18 @@ export const workflowLogic = kea<workflowLogicType>([
 
             // A staged save's response carries the live config plus the new draft blob: rebaseline the
             // form on the merged view, or the reset would wipe the just-saved edits off the canvas.
+            const editedDuringSave =
+                cache.saveEditVersion !== undefined && values.workflowEditVersion !== cache.saveEditVersion
+            const editsDuringSave = editedDuringSave ? pickWorkflowEdits(values.workflow) : null
             actions.resetWorkflow(withStagedDraft(originalWorkflow))
             actions.markAutoSave(false)
+            if (editsDuringSave) {
+                // The response only reflects the payload that was sent. Anything typed while it was
+                // in flight (the live email editor writes on every pause) must survive the reset and
+                // stay dirty, or it vanishes from the form and the canvas reloads the stale version.
+                actions.setWorkflowValues(editsDuringSave)
+                actions.autoSaveWorkflow()
+            }
             actions.replayDeferredResourceEdited()
         },
         discardChanges: () => {


### PR DESCRIPTION
## Problem

- Typing in a workflow email step loses text: a few seconds after a pause, the canvas jumps back to an older version and drops the text block you were in.
- Auto-save sends the form, and on the response `saveWorkflowSuccess` resets the form to that response.
- The response only carries what was sent, so anything typed during the round-trip is wiped from the form.
- The email templater then treats the older design as an external edit and reloads it over the open canvas.

https://us.posthog.com/project/2/support/tickets/67560?view=eO1HETSX&page=1

## Changes

- Text typed while an auto-save is in flight now stays on the canvas and is saved by the next auto-save.
- `workflowLogic` counts form writes, records the count when a save starts, and after the response re-applies the in-flight edits on top of the rebaselined form and schedules another save.
- Round-trips with no in-flight edits behave as before.
- Nothing looks different in the UI.

## How did you test this code?

- New test: an edit dispatched while the save request is in flight survives the response, stays dirty, and goes out on the next auto-save. It fails without the fix.
- New test: a clean round-trip does not trigger a redundant second save.
- Not checked: the live Unlayer canvas end to end. The remaining unverified case is a server echo of the design that is not deep-equal to the editor export, which would still reload the canvas on every save.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code. Skills invoked: `/writing-pr-descriptions`. Origin was a support report of the editor dropping sentences after auto-save; no ticket content is in this PR. The root cause was traced statically in `workflowLogic` and `emailTemplaterLogic`; no manual browser testing was done.
