### PR TITLE
chore(ai-research): own ml mirror pipelines

### DIFF
--- a/nodejs/src/owners.yaml
+++ b/nodejs/src/owners.yaml
@@ -10,6 +10,6 @@ rules:
     - match: '/ingestion/pipelines/sessionreplay/'
       owners: [team-replay, team-ingestion]
     - match: '/ingestion/pipelines/sessionreplay/ml-mirror-*/'
-      owners: ai-research
+      owners: [ai-research, team-ingestion]
     - match: '/session-replay/recording-rasterizer/'
       owners: team-replay

--- a/nodejs/src/owners.yaml
+++ b/nodejs/src/owners.yaml
@@ -9,7 +9,9 @@ rules:
       owners: team-ingestion
     - match: '/ingestion/pipelines/sessionreplay/'
       owners: [team-replay, team-ingestion]
-    - match: '/ingestion/pipelines/sessionreplay/ml-mirror-*/'
+    - match:
+          - '/ingestion/pipelines/sessionreplay/ml-mirror/'
+          - '/ingestion/pipelines/sessionreplay/ml-mirror-*/'
       owners: [ai-research, team-ingestion]
     - match: '/session-replay/recording-rasterizer/'
       owners: team-replay

--- a/nodejs/src/owners.yaml
+++ b/nodejs/src/owners.yaml
@@ -9,5 +9,7 @@ rules:
       owners: team-ingestion
     - match: '/ingestion/pipelines/sessionreplay/'
       owners: [team-replay, team-ingestion]
+    - match: '/ingestion/pipelines/sessionreplay/ml-mirror-*/'
+      owners: ai-research
     - match: '/session-replay/recording-rasterizer/'
       owners: team-replay


### PR DESCRIPTION
## Problem

AI Research changes to the ML mirror pipelines currently route ownership to Session Replay and Ingestion.

## Changes

- Set AI Research as the primary owner and keep Ingestion as a secondary owner.
- Match the bare `ml-mirror` folder and current or future `ml-mirror-*` folders.
- This internal change has no user-visible effect.

## How did you test this code?

- The resolver maps the bare folder and all three hyphenated folders to AI Research and Ingestion.
- Ran: `owners:lint nodejs/src/owners.yaml` and `hogli ci:preflight --fix`.
- Not run to completion: `owners:fmt` stops on a pre-existing assertion outside this rule.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This ownership-only change does not affect product documentation.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex made the change with `/gh-address-comments`, `/establishing-code-ownership`, `/writing-pr-descriptions`, GitHub `/yeet`, and ASD-STE100. The user selected AI Research and Ingestion as owners.