### PR TITLE
feat(desktop): mobile remove yourself from reviewers in the inbox list

### DIFF
--- a/products/desktop/apps/mobile/src/features/inbox/components/ReportListRow.tsx
+++ b/products/desktop/apps/mobile/src/features/inbox/components/ReportListRow.tsx
@@ -5,6 +5,7 @@ import { Pressable, View } from "react-native";
 import { PrStatusBadge } from "@/features/tasks/components/PrStatusBadge";
 import { useThemeColors } from "@/lib/theme";
 import { formatReportTimestamp } from "../utils";
+import { SuggestedReviewerAvatarStack } from "./SuggestedReviewerAvatarStack";
 
 interface ReportListRowProps {
   report: SignalReport;
@@ -82,6 +83,7 @@ function ReportListRowComponent({ report, onPress }: ReportListRowProps) {
           <Text className="flex-1 text-[11px] text-gray-9" numberOfLines={1}>
             {timeDisplay}
           </Text>
+          <SuggestedReviewerAvatarStack report={report} />
         </View>
       </View>
 

--- a/products/desktop/apps/mobile/src/features/inbox/components/SuggestedReviewerAvatarStack.test.tsx
+++ b/products/desktop/apps/mobile/src/features/inbox/components/SuggestedReviewerAvatarStack.test.tsx
@@ -1,0 +1,132 @@
+import type {
+  SignalReport,
+  SignalReportArtefactsResponse,
+  SuggestedReviewer,
+} from "@posthog/shared/domain-types";
+import { createElement } from "react";
+import { act, create } from "react-test-renderer";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  currentUserUuid: "user-me" as string | undefined,
+  mutate: vi.fn(),
+  track: vi.fn(),
+}));
+
+vi.mock("@/features/auth", () => ({
+  useUserQuery: () => ({ data: { uuid: mocks.currentUserUuid } }),
+}));
+
+vi.mock("../hooks/useInboxReports", () => ({
+  useInboxReportArtefacts: () => ({ data: artefacts }),
+  useUpdateSuggestedReviewers: () => ({
+    mutate: mocks.mutate,
+    isPending: false,
+  }),
+}));
+
+vi.mock("@/lib/analytics", () => ({
+  ANALYTICS_EVENTS: { INBOX_REPORT_ACTION: "Inbox report action" },
+  computeReportAgeHours: () => 0,
+  useAnalytics: () => ({ track: mocks.track }),
+}));
+
+vi.mock("@/lib/theme", () => ({
+  useThemeColors: () => ({ gray: { 9: "#888" } }),
+}));
+
+// react-native-web's Image touches `window` in a mount effect, which the node
+// test environment lacks. A stub keeps the avatar stack renderable.
+vi.mock("react-native", async () => {
+  const actual = await import("react-native-web");
+  const { createElement } = await import("react");
+  return {
+    ...actual,
+    Image: (props: Record<string, unknown>) => createElement("Image", props),
+  };
+});
+
+import { SuggestedReviewerAvatarStack } from "./SuggestedReviewerAvatarStack";
+
+function reviewer(login: string, uuid: string): SuggestedReviewer {
+  return {
+    github_login: login,
+    github_name: login,
+    relevant_commits: [],
+    user: {
+      id: 1,
+      uuid,
+      email: `${login}@example.com`,
+      first_name: login,
+      last_name: "",
+    },
+  };
+}
+
+const me = reviewer("alice", "user-me");
+const teammate = reviewer("bob", "user-bob");
+const report = { id: "report-1", title: "Checkout failures" } as SignalReport;
+const artefacts: SignalReportArtefactsResponse = {
+  count: 1,
+  results: [
+    {
+      id: "reviewers-1",
+      type: "suggested_reviewers",
+      created_at: "2026-01-01T00:00:00Z",
+      content: [me, teammate],
+    },
+  ],
+};
+
+function mount() {
+  let renderer: ReturnType<typeof create> | null = null;
+  act(() => {
+    renderer = create(createElement(SuggestedReviewerAvatarStack, { report }));
+  });
+  if (!renderer) throw new Error("Renderer not created");
+  return renderer as ReturnType<typeof create>;
+}
+
+function removeButton(renderer: ReturnType<typeof create>) {
+  return renderer.root.findAll(
+    (node) =>
+      node.props.accessibilityLabel === "Remove yourself from reviewers",
+  );
+}
+
+describe("SuggestedReviewerAvatarStack", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.currentUserUuid = "user-me";
+  });
+
+  it.each([
+    ["the current user is a reviewer", "user-me", true],
+    ["the current user is not a reviewer", "user-other", false],
+  ])("is interactive when %s", (_case, currentUserUuid, interactive) => {
+    mocks.currentUserUuid = currentUserUuid;
+    expect(removeButton(mount()).length > 0).toBe(interactive);
+  });
+
+  it("removes the current user and tracks the list action", () => {
+    const renderer = mount();
+    act(() => {
+      removeButton(renderer)[0].props.onPress();
+    });
+
+    expect(mocks.mutate).toHaveBeenCalledWith({
+      artefactId: "reviewers-1",
+      content: [{ github_login: "bob" }],
+      optimisticReviewers: [teammate],
+    });
+    expect(mocks.track).toHaveBeenCalledWith(
+      "Inbox report action",
+      expect.objectContaining({
+        action_type: "remove_suggested_reviewer",
+        surface: "list_row",
+        suggested_reviewer_login: "alice",
+        suggested_reviewer_uuid: "user-me",
+      }),
+    );
+  });
+});

--- a/products/desktop/apps/mobile/src/features/inbox/components/SuggestedReviewerAvatarStack.tsx
+++ b/products/desktop/apps/mobile/src/features/inbox/components/SuggestedReviewerAvatarStack.tsx
@@ -1,0 +1,125 @@
+import { Text } from "@components/text";
+import { toSuggestedReviewerWriteContent } from "@posthog/core/inbox/artefacts";
+import { selectSuggestedReviewersArtefact } from "@posthog/core/inbox/reportArtefacts";
+import type { SignalReport } from "@posthog/shared/domain-types";
+import { ActivityIndicator, Image, Pressable, View } from "react-native";
+import { useUserQuery } from "@/features/auth";
+import {
+  ANALYTICS_EVENTS,
+  computeReportAgeHours,
+  useAnalytics,
+} from "@/lib/analytics";
+import { useThemeColors } from "@/lib/theme";
+import {
+  useInboxReportArtefacts,
+  useUpdateSuggestedReviewers,
+} from "../hooks/useInboxReports";
+
+const MAX_VISIBLE = 4;
+const OVERLAP = { marginLeft: -6 };
+
+interface SuggestedReviewerAvatarStackProps {
+  report: SignalReport;
+}
+
+export function SuggestedReviewerAvatarStack({
+  report,
+}: SuggestedReviewerAvatarStackProps) {
+  const themeColors = useThemeColors();
+  const { data: me } = useUserQuery();
+  const { data: artefacts } = useInboxReportArtefacts(report.id, {
+    staleTime: 5 * 60 * 1000,
+    refetchInterval: false,
+  });
+  const { mutate: updateReviewers, isPending } = useUpdateSuggestedReviewers(
+    report.id,
+  );
+  const analytics = useAnalytics();
+
+  const reviewerArtefact = selectSuggestedReviewersArtefact(
+    artefacts?.results ?? [],
+  );
+  const reviewers = (reviewerArtefact?.content ?? []).filter(
+    (reviewer) => reviewer.github_login,
+  );
+  if (reviewers.length === 0) {
+    return null;
+  }
+
+  const currentReviewer = reviewers.find(
+    (reviewer) => reviewer.user?.uuid === me?.uuid,
+  );
+  const visible = reviewers.slice(0, MAX_VISIBLE);
+  const overflow = reviewers.length - visible.length;
+
+  const stack = (
+    <View className="flex-row items-center">
+      {visible.map((reviewer, index) => (
+        <Image
+          key={reviewer.github_login}
+          source={{
+            uri: `https://github.com/${reviewer.github_login}.png?size=48`,
+          }}
+          className="h-6 w-6 rounded-full border-2 border-background bg-gray-4"
+          style={index > 0 ? OVERLAP : undefined}
+        />
+      ))}
+      {overflow > 0 ? (
+        <View
+          className="h-6 min-w-6 items-center justify-center rounded-full border-2 border-background bg-gray-3 px-1"
+          style={OVERLAP}
+        >
+          <Text className="font-semibold text-[10px] text-gray-11">
+            +{overflow}
+          </Text>
+        </View>
+      ) : null}
+    </View>
+  );
+
+  if (!currentReviewer || !reviewerArtefact) {
+    return stack;
+  }
+
+  const removeSelf = () => {
+    const next = reviewerArtefact.content.filter(
+      (reviewer) => reviewer.user?.uuid !== me?.uuid,
+    );
+    analytics.track(ANALYTICS_EVENTS.INBOX_REPORT_ACTION, {
+      report_id: report.id,
+      report_title: report.title ?? null,
+      report_age_hours: computeReportAgeHours(report.created_at),
+      priority: report.priority ?? null,
+      actionability: report.actionability ?? null,
+      action_type: "remove_suggested_reviewer",
+      surface: "list_row",
+      is_bulk: false,
+      bulk_size: 1,
+      rank: 0,
+      list_size: 0,
+      suggested_reviewer_login: currentReviewer.github_login || undefined,
+      suggested_reviewer_uuid: currentReviewer.user?.uuid,
+    });
+    updateReviewers({
+      artefactId: reviewerArtefact.id,
+      content: toSuggestedReviewerWriteContent(next),
+      optimisticReviewers: next,
+    });
+  };
+
+  return (
+    <Pressable
+      onPress={removeSelf}
+      disabled={isPending}
+      hitSlop={8}
+      accessibilityRole="button"
+      accessibilityLabel="Remove yourself from reviewers"
+      className="flex-row items-center gap-1.5 py-1 active:opacity-70"
+    >
+      {stack}
+      {isPending ? (
+        <ActivityIndicator size="small" color={themeColors.gray[9]} />
+      ) : null}
+    </Pressable>
+  );
+}

--- a/products/desktop/apps/mobile/src/features/inbox/hooks/useInboxReports.ts
+++ b/products/desktop/apps/mobile/src/features/inbox/hooks/useInboxReports.ts
@@ -184,7 +184,10 @@ export function useAvailableSuggestedReviewers(options?: {
   });
 }
 
-export function useInboxReportArtefacts(reportId: string | null) {
+export function useInboxReportArtefacts(
+  reportId: string | null,
+  options?: { staleTime?: number; refetchInterval?: number | false },
+) {
   const { projectId, oauthAccessToken } = useAuthStore();
 
   return useQuery<SignalReportArtefactsResponse>({
@@ -196,8 +199,9 @@ export function useInboxReportArtefacts(reportId: string | null) {
     enabled: !!projectId && !!oauthAccessToken && !!reportId,
     // The log is a live work record — agents append artefacts while a report
     // is open, so refresh it gently rather than trusting the default staleTime.
-    staleTime: 10_000,
-    refetchInterval: 20_000,
+    // List rows pass a calmer profile: reviewer suggestions rarely change mid-scroll.
+    staleTime: options?.staleTime ?? 10_000,
+    refetchInterval: options?.refetchInterval ?? 20_000,
   });
 }
 
@@ -282,7 +286,7 @@ export function useUpdateSuggestedReviewers(reportId: string) {
       }
     },
     onSettled: () => {
-      queryClient.invalidateQueries({ queryKey });
+      queryClient.invalidateQueries({ queryKey: inboxKeys.all });
     },
   });
 }


### PR DESCRIPTION
## Problem

A mobile inbox user who is a suggested reviewer on a report could only take themselves off it by opening the report and using the detail screen. The inbox list rows showed no reviewers at all, so there was no way to act from the list.

This ports the desktop feature in #84151 to the React Native app.

## Changes

- Inbox list rows now show a stack of suggested-reviewer avatars (up to four, with a `+N` overflow badge).
- When the signed-in user is one of the suggested reviewers, the stack becomes a touch target that removes them, with an optimistic update and a spinner while the write is in flight.
- When the user is not a reviewer, or there is no artefact to write back to, the stack renders as plain non-interactive avatars and a tap falls through to open the report.
- Removing yourself fires the `remove_suggested_reviewer` action with the reviewer login and uuid on the `list_row` surface, matching the detail screen.
- Mechanical: the reviewer-write mutation now invalidates the whole inbox cache on settle (was artefacts-only), so the list and the report reconcile after a list-row edit.
- Mechanical: `useInboxReportArtefacts` takes an optional fetch profile; the list row passes a 5-minute stale window and no polling, so scrolling the inbox does not start a 20-second poll per visible row.

Shared logic reuses `selectSuggestedReviewersArtefact` and `toSuggestedReviewerWriteContent` from `@posthog/core`; no `packages/core` or `packages/ui` code changed.

No screenshot: this environment has no simulator or device to render the React Native app, so the visual result was not captured.

## How did you test this code?

- Added `SuggestedReviewerAvatarStack.test.tsx` (3 cases): the remove control appears only when the current user is a reviewer; pressing it calls the mutation with self filtered out of the write content; pressing it fires the `remove_suggested_reviewer` analytics action with the login and uuid. These guard the reviewer-match gate and the write/analytics payload that a refactor could silently break.
- Ran locally in `products/desktop`: `pnpm --filter @posthog/mobile test` (full suite), `pnpm --filter @posthog/mobile typecheck` (baseline check, no new errors), `pnpm --filter @posthog/mobile lint`.
- Not done: no running-app verification, so interaction and layout were not observed live.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. Skills invoked: `/writing-user-facing-copy`, `/writing-tests`, `/simplify`, `/writing-pr-descriptions`.

Decisions along the way:
- Scoped the interactive stack to the active inbox list row (`ReportListRow`), the direct analog of the desktop list card. The swipe/Tinder view was left alone because a remove control inside its pan-responder card conflicts with swipe gestures.
- Kept the analytics call inline (mirroring `TinderView`) rather than routing through `useInboxEngagementTracker`, whose per-mount open/close lifecycle would fire spurious events for every visible row.
- After `/simplify` flagged a per-row artefact fetch with a 20-second poll, added the calmer fetch profile so the list surface does not poll per row, matching desktop's low-frequency list fetch.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
