### PR TITLE
fix(mysql): give MySQL connect failures an actionable error message

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
@@ -178,7 +178,19 @@ class MySQLSource(SQLSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatabase
 
     def get_non_retryable_errors(self) -> dict[str, str | None]:
         return {
-            "Can't connect to MySQL server on": None,
+            # pymysql collapses every connect-level failure (wrong host/port, closed firewall,
+            # unreachable host, a connect timeout that outlasts the in-process retry budget) into
+            # error 2003, "Can't connect to MySQL server on '<host>' (<os detail>)". Non-retryable
+            # for the same reason as the Postgres source's connect-timeout entry: a persistently
+            # unreachable host won't recover on retry. Give the actionable reachability guidance the
+            # raw driver tuple lacks; the volatile host/os-detail are excluded from the match. The
+            # create-time `_VALIDATE_CONNECTION_HINTS` above stay more granular.
+            "Can't connect to MySQL server on": (
+                "PostHog couldn't connect to your MySQL server. Check that the host and port are "
+                "correct and that the database is reachable from the public internet, with PostHog's "
+                "egress IP addresses allowed through your firewall. For a database that can't be "
+                "exposed publicly, use the SSH tunnel option, then re-enable the sync."
+            ),
             "No primary key defined for table": (
                 "This table needs a primary key to sync incrementally, but none is set. Choose a primary "
                 "key for the table in its sync settings, or switch it to full table replication, then "

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -1882,6 +1882,25 @@ class TestMySQLSourceNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
+            "(2003, \"Can't connect to MySQL server on 'db.example.com' (timed out)\")",
+            "(2003, \"Can't connect to MySQL server on 'db.example.com' ([Errno 111] Connection refused)\")",
+        ],
+    )
+    def test_cannot_connect_surfaces_actionable_message(self, source, error_msg):
+        # A persistent connect failure is non-retryable, but the customer must get reachability
+        # guidance rather than the raw pymysql (2003, ...) tuple. Guards against reverting the
+        # umbrella message back to None.
+        non_retryable = source.get_non_retryable_errors()
+        friendly = next(
+            (message for pattern, message in non_retryable.items() if pattern in error_msg),
+            None,
+        )
+        assert friendly is not None, f"Connect failure should surface a friendly message: {error_msg}"
+        assert "SSH tunnel" in friendly
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
             "Cannot build decimal array from values",
             "ValueError: Cannot build decimal array from values",
         ],


### PR DESCRIPTION
## Problem

A customer whose MySQL sync can't reach the database saw the raw pymysql driver tuple `(2003, "Can't connect to MySQL server on '<host>' (timed out)")` as the sync's error. It gives no next step. pymysql collapses every connect-level failure (wrong host or port, closed firewall, unreachable host, a connect timeout that outlasts the in-process retry budget) into error 2003. The sync path already classified 2003 as non-retryable, but mapped it to `None`, so the driver tuple is what reached `latest_error`.

## Changes

- A MySQL source that can't connect now shows: check the host and port, confirm the database is reachable with PostHog's egress IPs allowed through the firewall, and use the SSH tunnel option for a database that can't be exposed publicly.
- The message comes from the `"Can't connect to MySQL server on"` entry in `get_non_retryable_errors`, changed from `None` to that copy. Retryability is unchanged; the key already existed, so nothing new is classified.
- The wording mirrors the Postgres source's connect-timeout message and MySQL's own create-time validation hints, so the guidance a customer gets at setup and at sync time now match.

## How did you test this code?

Added two cases to `TestMySQLSourceNonRetryableErrors` (timeout and refused variants of the 2003 tuple) asserting the umbrella entry resolves to an actionable, non-`None` message. This guards against reverting it to `None`, which no existing test caught — the others only assert the key is classified non-retryable, not that a customer-readable message is stored.

Ran the `TestMySQLSourceNonRetryableErrors` class locally (64 cases) and `ruff` over both files. Not run: the full warehouse-sources suite (no database in this sandbox).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by an agent triaging a batch of data-warehouse sync failure classes. This PR addresses one class: MySQL connect failures surfacing a raw driver tuple. Skills invoked: `/writing-user-facing-copy` (the error message), `/writing-tests` (the added cases), `/writing-pr-descriptions` (this body). The umbrella 2003 key was chosen over adding granular per-cause keys because it already exists as the non-retryable classifier and covers timeout, refused, and unreachable alike; the create-time `_VALIDATE_CONNECTION_HINTS` stay more granular. Retryability was deliberately left unchanged — a persistently unreachable host won't recover on retry, matching the Postgres source's treatment.

The example error that motivated this was a real production value; no customer host, identifier, or data appears in the diff, tests, or this description (the test uses `db.example.com`).

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
