### PR TITLE
fix(frontend): stop reporting unmount aborts as query failures

### DIFF
--- a/products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic.test.ts
+++ b/products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic.test.ts
@@ -66,6 +66,7 @@ describe('logsViewerDataLogic', () => {
 
         it.each([
             ['new query started', 'exact match for NEW_QUERY_STARTED_ERROR_MESSAGE'],
+            ['unmounting component', 'exact match for UNMOUNTING_ERROR_MESSAGE'],
             ['Fetch is aborted', 'Safari abort message'],
             ['The operation was aborted', 'alternative abort message'],
             ['ABORTED', 'uppercase abort'],

--- a/products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic.ts
@@ -53,6 +53,7 @@ const DEFAULT_LIVE_TAIL_POLL_INTERVAL_MS = 1000
 const DEFAULT_LOGS_PAGE_SIZE: number = 250
 export const DEFAULT_INITIAL_LOGS_LIMIT = null as number | null
 const NEW_QUERY_STARTED_ERROR_MESSAGE = 'new query started' as const
+const UNMOUNTING_ERROR_MESSAGE = 'unmounting component' as const
 
 // Parse cache keyed on log object identity — leak-free by construction (entries die with their
 // logs) and shared across logic instances. Parsing is pure per object, so cached entries are
@@ -84,9 +85,13 @@ function classifyQueryError(error: unknown): { error_type: string; status_code: 
     return { error_type: 'unknown', status_code: statusCode }
 }
 
+// kea-loaders reduces a rejection to its message, so an aborted request arrives here as the reason
+// text we passed to `abort()`. Neither of our reasons contains "abort", so both need matching by
+// name: an unmatched one is treated as a genuine failure, which toasts the user and fires a
+// `logs query failed` capture for a request that was cancelled on purpose.
 function isUserInitiatedError(error: unknown): boolean {
     const errorStr = String(error).toLowerCase()
-    return error === NEW_QUERY_STARTED_ERROR_MESSAGE || errorStr.includes('abort')
+    return error === NEW_QUERY_STARTED_ERROR_MESSAGE || error === UNMOUNTING_ERROR_MESSAGE || errorStr.includes('abort')
 }
 
 const stringifyLogAttributes = (attributes: Record<string, any>): Record<string, string> => {
@@ -1284,11 +1289,15 @@ export const logsViewerDataLogic = kea<logsViewerDataLogicType>([
         beforeUnmount: () => {
             actions.setLiveTailRunning(false)
             actions.cancelInProgressLiveTail(null)
+            // Abort with an `AbortError`, never a bare string: `fetch` rejects with the reason
+            // exactly as given, and `handleFetch` only re-throws it untouched when it is a real
+            // `AbortError`. A string reason falls through and gets relabelled as an `ApiError`, so
+            // tearing the viewer down looks like a failed request in the console.
             if (values.logsAbortController) {
-                values.logsAbortController.abort('unmounting component')
+                values.logsAbortController.abort(new DOMException(UNMOUNTING_ERROR_MESSAGE, 'AbortError'))
             }
             if (values.sparklineAbortController) {
-                values.sparklineAbortController.abort('unmounting component')
+                values.sparklineAbortController.abort(new DOMException(UNMOUNTING_ERROR_MESSAGE, 'AbortError'))
             }
         },
     })),

--- a/products/tracing/frontend/tracingDataLogic.test.ts
+++ b/products/tracing/frontend/tracingDataLogic.test.ts
@@ -9,7 +9,7 @@ import { resumeKeaLoadersErrors, silenceKeaLoadersErrors } from '~/initKea'
 import { AggregatedSpanRow } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
 
-import { NEW_QUERY_STARTED_ERROR_MESSAGE, tracingDataLogic } from './tracingDataLogic'
+import { NEW_QUERY_STARTED_ERROR_MESSAGE, UNMOUNTING_ERROR_MESSAGE, tracingDataLogic } from './tracingDataLogic'
 import { tracingFiltersLogic } from './tracingFiltersLogic'
 import type { Span } from './types'
 
@@ -363,6 +363,28 @@ describe('tracingDataLogic', () => {
                 fail(logic, 'boom')
                 expect(loadingValue(logic)).toBe(false)
                 apiSpy.mockRestore()
+            }
+        )
+    })
+
+    describe('cancelled requests', () => {
+        // A superseded query and a scene teardown both abort whatever is in flight. Neither is a
+        // fault the user can act on, so neither may reach them as a toast or land in error
+        // telemetry as a failed tracing query.
+        it.each([NEW_QUERY_STARTED_ERROR_MESSAGE, UNMOUNTING_ERROR_MESSAGE])(
+            'does not report "%s" as a query failure',
+            (reason) => {
+                silenceKeaLoadersErrors()
+                const toastSpy = jest.spyOn(lemonToast, 'error').mockReturnValue(undefined as any)
+                const captureSpy = jest.spyOn(posthog, 'capture').mockReturnValue(undefined as any)
+                logic = mountWithSpans([])
+
+                logic.actions.fetchSpansFailure(reason)
+
+                expect(toastSpy).not.toHaveBeenCalled()
+                expect(captureSpy).not.toHaveBeenCalledWith('tracing query failed', expect.anything())
+                toastSpy.mockRestore()
+                captureSpy.mockRestore()
             }
         )
     })

--- a/products/tracing/frontend/tracingDataLogic.ts
+++ b/products/tracing/frontend/tracingDataLogic.ts
@@ -78,10 +78,15 @@ const DEFAULT_PAGE_SIZE = 100
 const OPERATIONS_AGGREGATION_LIMIT = 5000
 export const PREFETCH_SPANS = 20
 export const NEW_QUERY_STARTED_ERROR_MESSAGE = 'new query started' as const
+export const UNMOUNTING_ERROR_MESSAGE = 'unmounting component' as const
 
+// kea-loaders reduces a rejection to its message, so an aborted request arrives here as the reason
+// text we passed to `abort()`. Neither of our reasons contains "abort", so both need matching by
+// name: an unmatched one is treated as a genuine failure, which toasts the user and fires a
+// `tracing query failed` capture for a request that was cancelled on purpose.
 export function isUserInitiatedError(error: unknown): boolean {
     const errorStr = String(error).toLowerCase()
-    return error === NEW_QUERY_STARTED_ERROR_MESSAGE || errorStr.includes('abort')
+    return error === NEW_QUERY_STARTED_ERROR_MESSAGE || error === UNMOUNTING_ERROR_MESSAGE || errorStr.includes('abort')
 }
 
 // A ts hint (from a shared/cold link) bounds the lookup tightly around the trace instead of the
@@ -1483,43 +1488,49 @@ export const tracingDataLogic = kea<tracingDataLogicType>([
         },
         cancelInProgressSpans: ({ controller }) => {
             if (values.spansAbortController !== null) {
-                values.spansAbortController.abort(NEW_QUERY_STARTED_ERROR_MESSAGE)
+                values.spansAbortController.abort(new DOMException(NEW_QUERY_STARTED_ERROR_MESSAGE, 'AbortError'))
             }
             actions.setSpansAbortController(controller)
         },
         cancelInProgressSparkline: ({ controller }) => {
             if (values.sparklineAbortController !== null) {
-                values.sparklineAbortController.abort(NEW_QUERY_STARTED_ERROR_MESSAGE)
+                values.sparklineAbortController.abort(new DOMException(NEW_QUERY_STARTED_ERROR_MESSAGE, 'AbortError'))
             }
             actions.setSparklineAbortController(controller)
         },
         cancelInProgressMatchingCounts: ({ controller }) => {
             if (values.matchingCountsAbortController !== null) {
-                values.matchingCountsAbortController.abort(NEW_QUERY_STARTED_ERROR_MESSAGE)
+                values.matchingCountsAbortController.abort(
+                    new DOMException(NEW_QUERY_STARTED_ERROR_MESSAGE, 'AbortError')
+                )
             }
             actions.setMatchingCountsAbortController(controller)
         },
         cancelInProgressDurationHistogram: ({ controller }) => {
             if (values.durationHistogramAbortController !== null) {
-                values.durationHistogramAbortController.abort(NEW_QUERY_STARTED_ERROR_MESSAGE)
+                values.durationHistogramAbortController.abort(
+                    new DOMException(NEW_QUERY_STARTED_ERROR_MESSAGE, 'AbortError')
+                )
             }
             actions.setDurationHistogramAbortController(controller)
         },
         cancelInProgressLatencyHeatmap: ({ controller }) => {
             if (values.latencyHeatmapAbortController !== null) {
-                values.latencyHeatmapAbortController.abort(NEW_QUERY_STARTED_ERROR_MESSAGE)
+                values.latencyHeatmapAbortController.abort(
+                    new DOMException(NEW_QUERY_STARTED_ERROR_MESSAGE, 'AbortError')
+                )
             }
             actions.setLatencyHeatmapAbortController(controller)
         },
         cancelInProgressAggregation: ({ controller }) => {
             if (values.aggregationAbortController !== null) {
-                values.aggregationAbortController.abort(NEW_QUERY_STARTED_ERROR_MESSAGE)
+                values.aggregationAbortController.abort(new DOMException(NEW_QUERY_STARTED_ERROR_MESSAGE, 'AbortError'))
             }
             actions.setAggregationAbortController(controller)
         },
         cancelInProgressSpanTree: ({ controller }) => {
             if (values.spanTreeAbortController !== null) {
-                values.spanTreeAbortController.abort(NEW_QUERY_STARTED_ERROR_MESSAGE)
+                values.spanTreeAbortController.abort(new DOMException(NEW_QUERY_STARTED_ERROR_MESSAGE, 'AbortError'))
             }
             actions.setSpanTreeAbortController(controller)
         },
@@ -1566,26 +1577,30 @@ export const tracingDataLogic = kea<tracingDataLogicType>([
 
     events(({ values }) => ({
         beforeUnmount: () => {
+            // Abort with an `AbortError`, never a bare string: `fetch` rejects with the reason
+            // exactly as given, and `handleFetch` only re-throws it untouched when it is a real
+            // `AbortError`. A string reason falls through and gets relabelled as an `ApiError`, so
+            // tearing the scene down looks like a failed request in the console.
             if (values.spansAbortController) {
-                values.spansAbortController.abort('unmounting component')
+                values.spansAbortController.abort(new DOMException(UNMOUNTING_ERROR_MESSAGE, 'AbortError'))
             }
             if (values.sparklineAbortController) {
-                values.sparklineAbortController.abort('unmounting component')
+                values.sparklineAbortController.abort(new DOMException(UNMOUNTING_ERROR_MESSAGE, 'AbortError'))
             }
             if (values.matchingCountsAbortController) {
-                values.matchingCountsAbortController.abort('unmounting component')
+                values.matchingCountsAbortController.abort(new DOMException(UNMOUNTING_ERROR_MESSAGE, 'AbortError'))
             }
             if (values.durationHistogramAbortController) {
-                values.durationHistogramAbortController.abort('unmounting component')
+                values.durationHistogramAbortController.abort(new DOMException(UNMOUNTING_ERROR_MESSAGE, 'AbortError'))
             }
             if (values.latencyHeatmapAbortController) {
-                values.latencyHeatmapAbortController.abort('unmounting component')
+                values.latencyHeatmapAbortController.abort(new DOMException(UNMOUNTING_ERROR_MESSAGE, 'AbortError'))
             }
             if (values.spanTreeAbortController) {
-                values.spanTreeAbortController.abort('unmounting component')
+                values.spanTreeAbortController.abort(new DOMException(UNMOUNTING_ERROR_MESSAGE, 'AbortError'))
             }
             if (values.aggregationAbortController) {
-                values.aggregationAbortController.abort('unmounting component')
+                values.aggregationAbortController.abort(new DOMException(UNMOUNTING_ERROR_MESSAGE, 'AbortError'))
             }
         },
     })),


### PR DESCRIPTION
## Problem

Leaving the Traces page while a query is in flight shows the user a red "Failed to load traces: unmounting component" toast for a request they cancelled by navigating away.

- Both viewers abort their in-flight requests on teardown with a bare string reason.
- `fetch` rejects with that reason exactly as given, and a string has no `name`, so the `AbortError` check in [`handleFetch`](https://github.com/PostHog/posthog/blob/master/frontend/src/lib/api.ts#L7511) does not match.
- The abort falls through and gets relabelled as an `ApiError`, which surfaces in the console as `Error: unmounting component` with a fetch stack.
- `isUserInitiatedError` then sees the reason text, which contains neither "abort" nor the superseded-query reason, so it treats the teardown as a real failure.
- The same failure path fires a `tracing query failed` or `logs query failed` capture, so error telemetry counts navigations as broken queries.

## Changes

- Navigating away from Traces or Logs mid-query no longer toasts the user.
- The console no longer records the teardown as a failed request, so session recordings of the app stop showing phantom errors.
- Teardown aborts now pass `new DOMException(reason, 'AbortError')`, which `handleFetch` re-throws untouched. This matches what the metrics viewer and the logs cancel path already do.
- `isUserInitiatedError` matches the unmount reason by name, alongside the existing superseded-query reason.
- Mechanical: the seven tracing cancel sites move to the same `DOMException` form for consistency. Their reason text already matched by name, so their behavior is unchanged.

No UI was added or restyled, so there is nothing to screenshot. The visible difference is a toast that no longer appears.

## How did you test this code?

- Added one parameterized case to each logic test. It catches the regression where a scene or viewer teardown reaches the user as a toast and lands in telemetry as a failed query, which no existing case covered.
- Ran the two affected Jest suites locally, and confirmed the new tracing case fails against the old guard with `Failed to load traces: unmounting component`.
- Ran the frontend typecheck and Oxlint over the changed files.
- Not run: the rest of the frontend suite, and any browser check. This sandbox has no running app.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude Code) at the request of a PostHog staff member in the linked Slack thread. Left unassigned because their GitHub handle was not verified in that session, so the owning team should assign the driver.

The work started from a Replay Vision summary that reported a UI rendering glitch, then split into three separate causes: a replay stylesheet capture artifact, a Kea scene double-unmount, and this one. Only this one is in scope here. The scene double-unmount guard in `sceneLogic` is a plausible follow-up, but it is defensive rather than a root-cause fix, so it is deliberately left out.

An alternative fix was to add the unmount reason to the string allowlist alone. That suppresses the toast but leaves the abort relabelled as an `ApiError`, so the console error remains. Both halves are needed.

Skills invoked: `/writing-code-comments`, `/writing-tests`, `/writing-pr-descriptions`.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BLK2ZEUSH/p1787058113261719?thread_ts=1787058113.261719&cid=C0BLK2ZEUSH)*
