### PR TITLE
feat(desktop): mobile show a run's artifacts in the thread

### DIFF
--- a/products/desktop/apps/mobile/src/app/task/[id].tsx
+++ b/products/desktop/apps/mobile/src/app/task/[id].tsx
@@ -811,6 +811,7 @@ export default function TaskDetailScreen() {
         <TaskSessionView
           events={session?.events ?? []}
           taskId={taskId}
+          runId={task?.latest_run?.id}
           pendingPermissions={session?.pendingPermissions}
           isConnecting={isConnecting}
           isThinking={isThinking}

--- a/products/desktop/apps/mobile/src/features/tasks/components/InlineArtifactCard.tsx
+++ b/products/desktop/apps/mobile/src/features/tasks/components/InlineArtifactCard.tsx
@@ -1,0 +1,174 @@
+import { Text } from "@components/text";
+import { groupRunArtifactVersions } from "@posthog/core/canvas/runArtifactSchemas";
+import { parsePrUrl } from "@posthog/core/inbox/reportPresentation";
+import { readUploadedArtifactName } from "@posthog/core/sessions/inlineArtifacts";
+import type { TaskRunArtifact } from "@posthog/shared";
+import { File as FileIcon, GitPullRequest } from "phosphor-react-native";
+import { useMemo, useState } from "react";
+import { ActivityIndicator, Pressable, View } from "react-native";
+import type { ToolStatus } from "@/features/chat";
+import { openExternalUrl } from "@/lib/openExternalUrl";
+import { useThemeColors } from "@/lib/theme";
+import { useTaskArtifacts } from "../hooks/useTaskArtifacts";
+import { formatArtifactSize } from "../utils/artifactPreview";
+import { ArtifactPreview } from "./ArtifactPreview";
+import { PrDiffStatsBadge } from "./PrDiffStatsBadge";
+import { PrStatusBadge } from "./PrStatusBadge";
+
+function fileKindLabel(name: string): string {
+  const extension = name.includes(".") ? name.split(".").pop() : undefined;
+  return extension && extension.length <= 4 ? extension.toUpperCase() : "File";
+}
+
+function CardRow({
+  icon,
+  title,
+  meta,
+  onPress,
+  accessibilityLabel,
+  trailing,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  meta?: string | null;
+  onPress?: () => void;
+  accessibilityLabel?: string;
+  trailing?: React.ReactNode;
+}) {
+  return (
+    <View className="mx-4 my-1 rounded-lg border border-gray-5 bg-gray-2">
+      <View className="flex-row items-center gap-2.5 py-2 pr-1.5 pl-2">
+        <Pressable
+          className="min-w-0 flex-1 flex-row items-center gap-2.5 active:opacity-70"
+          disabled={!onPress}
+          accessibilityRole="button"
+          accessibilityLabel={accessibilityLabel}
+          onPress={onPress}
+        >
+          <View className="h-8 w-8 shrink-0 items-center justify-center rounded-md bg-gray-4">
+            {icon}
+          </View>
+          <View className="min-w-0 flex-1">
+            <Text
+              className="font-medium text-[13px] text-gray-12"
+              numberOfLines={1}
+            >
+              {title}
+            </Text>
+            {meta ? (
+              <Text className="text-[12px] text-gray-10" numberOfLines={1}>
+                {meta}
+              </Text>
+            ) : null}
+          </View>
+        </Pressable>
+        {trailing ? (
+          <View className="shrink-0 flex-row items-center gap-1">
+            {trailing}
+          </View>
+        ) : null}
+      </View>
+    </View>
+  );
+}
+
+// The manifest only loads once the run is terminal (`enabled`), so an upload
+// mid-run stays in its pending state rather than forcing an eager fetch.
+export function InlineUploadedArtifactCard({
+  toolData,
+  taskId,
+  runId,
+  enabled,
+}: {
+  toolData: { status: ToolStatus; args?: Record<string, unknown> };
+  taskId?: string;
+  runId?: string;
+  enabled: boolean;
+}) {
+  const themeColors = useThemeColors();
+  const [preview, setPreview] = useState<TaskRunArtifact | null>(null);
+  const name = readUploadedArtifactName(toolData.args) ?? "File";
+  const isLoading =
+    toolData.status === "pending" || toolData.status === "running";
+  const isFailed = toolData.status === "error";
+
+  const { data: artifacts } = useTaskArtifacts(
+    taskId,
+    runId,
+    enabled && !isLoading,
+  );
+  const resolved = useMemo(() => {
+    if (!artifacts) return null;
+    return (
+      groupRunArtifactVersions(artifacts).find((group) => group.name === name)
+        ?.latest ?? null
+    );
+  }, [artifacts, name]);
+
+  const size = formatArtifactSize(resolved?.size);
+  const meta = isLoading
+    ? "Uploading…"
+    : isFailed
+      ? "Upload failed"
+      : [fileKindLabel(name), size].filter(Boolean).join(" · ");
+
+  const canOpen = Boolean(resolved?.id && taskId && runId);
+
+  return (
+    <>
+      <CardRow
+        icon={
+          isLoading ? (
+            <ActivityIndicator size="small" color={themeColors.gray[11]} />
+          ) : (
+            <FileIcon
+              size={16}
+              color={isFailed ? themeColors.status.error : themeColors.gray[11]}
+            />
+          )
+        }
+        title={name}
+        meta={meta}
+        accessibilityLabel={`View ${name}`}
+        onPress={canOpen ? () => setPreview(resolved) : undefined}
+      />
+      {preview?.id && taskId && runId ? (
+        <ArtifactPreview
+          taskId={taskId}
+          runId={runId}
+          artifact={preview}
+          onClose={() => setPreview(null)}
+        />
+      ) : null}
+    </>
+  );
+}
+
+/** The pull request a run just opened, drawn in the thread where it happened. */
+export function InlineCreatedPrCard({ url }: { url: string }) {
+  const themeColors = useThemeColors();
+  const parsed = parsePrUrl(url);
+  const ref = parsed ? `${parsed.repoSlug}#${parsed.number}` : "Pull request";
+
+  return (
+    <CardRow
+      icon={
+        <GitPullRequest
+          size={16}
+          weight="bold"
+          color={themeColors.status.success}
+        />
+      }
+      title="Pull request"
+      meta={ref}
+      accessibilityLabel={`Open ${ref} on GitHub`}
+      onPress={() => openExternalUrl(url)}
+      trailing={
+        <>
+          <PrDiffStatsBadge prUrl={url} />
+          <PrStatusBadge prUrl={url} size="sm" hideWhenUnresolved />
+        </>
+      }
+    />
+  );
+}

--- a/products/desktop/apps/mobile/src/features/tasks/components/TaskSessionView.test.tsx
+++ b/products/desktop/apps/mobile/src/features/tasks/components/TaskSessionView.test.tsx
@@ -61,6 +61,13 @@ vi.mock("./TaskArtifacts", () => ({
     createElement("TaskArtifacts", props),
 }));
 
+vi.mock("./InlineArtifactCard", () => ({
+  InlineUploadedArtifactCard: (props: Record<string, unknown>) =>
+    createElement("InlineUploadedArtifactCard", props),
+  InlineCreatedPrCard: (props: Record<string, unknown>) =>
+    createElement("InlineCreatedPrCard", props),
+}));
+
 function renderTaskSessionView(
   props: Parameters<typeof TaskSessionView>[0],
 ): ReturnType<typeof create> {

--- a/products/desktop/apps/mobile/src/features/tasks/components/TaskSessionView.tsx
+++ b/products/desktop/apps/mobile/src/features/tasks/components/TaskSessionView.tsx
@@ -30,7 +30,12 @@ import type {
   SessionNotificationAttachment,
   TerminalStatus,
 } from "../types";
+import { detectInlineArtifact } from "../utils/inlineArtifacts";
 import { CloudMessageAttachment } from "./CloudMessageAttachment";
+import {
+  InlineCreatedPrCard,
+  InlineUploadedArtifactCard,
+} from "./InlineArtifactCard";
 import { PlanApprovalCard } from "./PlanApprovalCard";
 import { PlanStatusBar } from "./PlanStatusBar";
 import { QuestionCard } from "./QuestionCard";
@@ -56,6 +61,7 @@ interface OptimisticUserMessage {
 interface TaskSessionViewProps {
   events: SessionEvent[];
   taskId?: string;
+  runId?: string;
   pendingPermissions?: Record<string, CloudPendingPermissionRequest>;
   isConnecting?: boolean;
   isThinking?: boolean;
@@ -81,6 +87,7 @@ interface ToolData {
   result?: unknown;
   isAgent?: boolean;
   parentToolCallId?: string;
+  meta?: unknown;
 }
 
 interface ParsedMessage {
@@ -184,6 +191,7 @@ function parseSessionNotification(
           args: update.rawInput,
           isAgent,
           parentToolCallId: meta?.parentToolCallId,
+          meta: update._meta,
         },
       };
     }
@@ -199,6 +207,7 @@ function parseSessionNotification(
           args: update.rawInput,
           result: update.rawOutput,
           parentToolCallId: meta?.parentToolCallId,
+          meta: update._meta,
         },
       };
     }
@@ -804,6 +813,7 @@ function ConnectingIndicator() {
 export function TaskSessionView({
   events,
   taskId,
+  runId,
   pendingPermissions,
   isConnecting,
   isThinking,
@@ -994,19 +1004,37 @@ export function TaskSessionView({
           if (item.toolData.isAgent) {
             return <AgentToolCard item={item} onOpenTask={onOpenTask} />;
           }
-          return (
-            <ToolMessage
-              toolName={item.toolData.toolName}
-              rawToolName={item.toolData.rawToolName}
-              kind={deriveToolKind(
-                item.toolData.rawToolName ?? item.toolData.toolName,
-              )}
-              status={item.toolData.status}
-              args={item.toolData.args}
-              result={item.toolData.result}
-              onOpenTask={onOpenTask}
-            />
-          );
+          {
+            const inline = detectInlineArtifact(item.toolData);
+            if (inline?.kind === "upload") {
+              return (
+                <InlineUploadedArtifactCard
+                  toolData={item.toolData}
+                  taskId={taskId}
+                  runId={runId}
+                  enabled={!!terminalStatus}
+                />
+              );
+            }
+            return (
+              <>
+                <ToolMessage
+                  toolName={item.toolData.toolName}
+                  rawToolName={item.toolData.rawToolName}
+                  kind={deriveToolKind(
+                    item.toolData.rawToolName ?? item.toolData.toolName,
+                  )}
+                  status={item.toolData.status}
+                  args={item.toolData.args}
+                  result={item.toolData.result}
+                  onOpenTask={onOpenTask}
+                />
+                {inline?.kind === "pr" && (
+                  <InlineCreatedPrCard url={inline.url} />
+                )}
+              </>
+            );
+          }
         default:
           return null;
       }
@@ -1017,6 +1045,8 @@ export function TaskSessionView({
       pendingPermissions,
       renderAttachment,
       taskId,
+      runId,
+      terminalStatus,
     ],
   );
 

--- a/products/desktop/apps/mobile/src/features/tasks/utils/inlineArtifacts.test.ts
+++ b/products/desktop/apps/mobile/src/features/tasks/utils/inlineArtifacts.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { detectInlineArtifact, type InlineArtifact } from "./inlineArtifacts";
+
+const PR_URL = "https://github.com/PostHog/posthog/pull/82584";
+
+function mcpMeta(tool: string) {
+  return { claudeCode: { toolName: `mcp__github__${tool}` } };
+}
+
+describe("detectInlineArtifact", () => {
+  it("detects an upload_artifact call regardless of status", () => {
+    expect(
+      detectInlineArtifact({
+        meta: {
+          claudeCode: { toolName: "mcp__posthog-code-tools__upload_artifact" },
+        },
+        status: "running",
+        args: { name: "report.csv" },
+      }),
+    ).toEqual({ kind: "upload" });
+  });
+
+  it.each<{
+    name: string;
+    toolData: Parameters<typeof detectInlineArtifact>[0];
+    expected: InlineArtifact | null;
+  }>([
+    {
+      name: "gh pr create",
+      toolData: {
+        meta: { claudeCode: { toolName: "Bash" } },
+        status: "completed",
+        args: { command: "gh pr create --fill" },
+        result: `Creating pull request\n${PR_URL}`,
+      },
+      expected: { kind: "pr", url: PR_URL },
+    },
+    {
+      name: "an MCP create_pull_request tool",
+      toolData: {
+        meta: mcpMeta("create_pull_request"),
+        status: "completed",
+        args: { title: "Fix" },
+        result: { html_url: PR_URL },
+      },
+      expected: { kind: "pr", url: PR_URL },
+    },
+    {
+      // create_pull_request_review contains the creation tool's whole name and
+      // returns the url of the PR it reviewed — not this run's deliverable.
+      name: "reviewing someone else's PR over MCP",
+      toolData: {
+        meta: mcpMeta("create_pull_request_review"),
+        status: "completed",
+        args: { pullNumber: 82584, event: "COMMENT" },
+        result: { html_url: PR_URL },
+      },
+      expected: null,
+    },
+    {
+      // The url sits inside a gh pr comment body, not in a command position.
+      name: "a comment that only mentions creating one",
+      toolData: {
+        meta: { claudeCode: { toolName: "Bash" } },
+        status: "completed",
+        args: {
+          command: `gh pr comment 82584 --body "next time run gh pr create"`,
+        },
+        result: PR_URL,
+      },
+      expected: null,
+    },
+    {
+      name: "reading someone else's PR",
+      toolData: {
+        meta: { claudeCode: { toolName: "Bash" } },
+        status: "completed",
+        args: { command: "gh pr view 82584 --json url" },
+        result: PR_URL,
+      },
+      expected: null,
+    },
+    {
+      name: "a creation still running",
+      toolData: {
+        meta: { claudeCode: { toolName: "Bash" } },
+        status: "running",
+        args: { command: "gh pr create --fill" },
+        result: "",
+      },
+      expected: null,
+    },
+  ])("resolves $name", ({ toolData, expected }) => {
+    expect(detectInlineArtifact(toolData)).toEqual(expected);
+  });
+});

--- a/products/desktop/apps/mobile/src/features/tasks/utils/inlineArtifacts.ts
+++ b/products/desktop/apps/mobile/src/features/tasks/utils/inlineArtifacts.ts
@@ -1,0 +1,29 @@
+import {
+  detectInlineArtifact as detectFromCall,
+  type InlineArtifact,
+} from "@posthog/core/sessions/inlineArtifacts";
+
+export type { InlineArtifact };
+
+export function toolResultText(result: unknown): string {
+  if (typeof result === "string") return result;
+  try {
+    return JSON.stringify(result) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+export function detectInlineArtifact(toolData: {
+  meta?: unknown;
+  status: string;
+  args?: Record<string, unknown>;
+  result?: unknown;
+}): InlineArtifact | null {
+  return detectFromCall({
+    status: toolData.status,
+    meta: toolData.meta,
+    rawInput: toolData.args,
+    getOutputText: () => toolResultText(toolData.result),
+  });
+}

--- a/products/desktop/packages/core/src/sessions/inlineArtifacts.test.ts
+++ b/products/desktop/packages/core/src/sessions/inlineArtifacts.test.ts
@@ -1,0 +1,135 @@
+import { posthogToolMeta } from "@posthog/shared";
+import { describe, expect, it } from "vitest";
+import {
+  isUploadArtifactCall,
+  type PrCreationCandidate,
+  readCreatedPrUrl,
+  readUploadedArtifactName,
+} from "./inlineArtifacts";
+
+const PR_URL = "https://github.com/PostHog/posthog/pull/82584";
+
+function call(
+  overrides: Partial<PrCreationCandidate> & { command?: string },
+): PrCreationCandidate {
+  const { command, ...rest } = overrides;
+  return {
+    status: "completed",
+    meta: posthogToolMeta({ toolName: "Bash" }),
+    rawInput: command === undefined ? {} : { command },
+    outputText: "",
+    ...rest,
+  };
+}
+
+function mcpMeta(tool: string) {
+  return posthogToolMeta({
+    toolName: `mcp__github__${tool}`,
+    mcp: { server: "github", tool },
+  });
+}
+
+describe("inlineArtifacts", () => {
+  it.each([
+    {
+      name: "an explicit download name",
+      input: { path: "/w/out/r.csv", name: "Report.csv" },
+      expected: "Report.csv",
+    },
+    {
+      name: "the file's own name",
+      input: { path: "/w/out/report.csv" },
+      expected: "report.csv",
+    },
+    {
+      name: "a windows path",
+      input: { path: "C:\\work\\report.csv" },
+      expected: "report.csv",
+    },
+    { name: "nothing usable", input: { path: "  " }, expected: null },
+    { name: "a non-object input", input: "report.csv", expected: null },
+  ])("titles an upload from $name", ({ input, expected }) => {
+    expect(readUploadedArtifactName(input)).toBe(expected);
+  });
+
+  it("detects an upload_artifact MCP call", () => {
+    expect(isUploadArtifactCall(mcpMeta("upload_artifact"))).toBe(true);
+    expect(isUploadArtifactCall(mcpMeta("create_pull_request"))).toBe(false);
+  });
+
+  it.each([
+    {
+      name: "gh pr create",
+      call: call({
+        command: "gh pr create --fill",
+        outputText: `Creating pull request\n${PR_URL}`,
+      }),
+      expected: PR_URL,
+    },
+    {
+      name: "an MCP create-pull-request tool",
+      call: call({
+        command: undefined,
+        meta: mcpMeta("create_pull_request"),
+        rawInput: { title: "Fix" },
+        outputText: `{"html_url":"${PR_URL}"}`,
+      }),
+      expected: PR_URL,
+    },
+    {
+      name: "reading someone else's pull request",
+      call: call({
+        command: "gh pr view 82584 --json url",
+        outputText: PR_URL,
+      }),
+      expected: null,
+    },
+    {
+      // `create_pull_request_review` contains the creation tool's whole name
+      // and answers with the url of the PR it reviewed.
+      name: "reviewing someone else's pull request over MCP",
+      call: call({
+        command: undefined,
+        meta: mcpMeta("create_pull_request_review"),
+        rawInput: { pullNumber: 82584, event: "COMMENT" },
+        outputText: `{"html_url":"${PR_URL}"}`,
+      }),
+      expected: null,
+    },
+    {
+      name: "a command that only talks about creating one",
+      call: call({
+        command: `gh pr comment 82584 --body "next time run gh pr create"`,
+        outputText: PR_URL,
+      }),
+      expected: null,
+    },
+    {
+      name: "a creation chained after a push",
+      call: call({
+        command: "git push -u origin work && gh pr create --fill",
+        outputText: PR_URL,
+      }),
+      expected: PR_URL,
+    },
+    {
+      name: "a creation still in flight",
+      call: call({
+        command: "gh pr create --fill",
+        status: "in_progress",
+        outputText: "",
+      }),
+      expected: null,
+    },
+    {
+      name: "a creation that printed no url",
+      call: call({
+        command: "gh pr create --fill",
+        outputText: "pull request create failed",
+      }),
+      expected: null,
+    },
+  ])("reads a created pull request from $name", ({ call, expected }) => {
+    expect(readCreatedPrUrl(call)).toBe(expected);
+  });
+});

--- a/products/desktop/packages/core/src/sessions/inlineArtifacts.ts
+++ b/products/desktop/packages/core/src/sessions/inlineArtifacts.ts
@@ -1,0 +1,92 @@
+import { readMcpToolDescriptor } from "@posthog/shared";
+
+const UPLOAD_ARTIFACT_TOOL = "upload_artifact";
+
+/** The agent's `upload_artifact` call, which delivers a file to the artifacts panel. */
+export function isUploadArtifactCall(meta: unknown): boolean {
+  return readMcpToolDescriptor(meta)?.tool === UPLOAD_ARTIFACT_TOOL;
+}
+
+/** The download name the upload will land under: the given name, else the file's own. */
+export function readUploadedArtifactName(rawInput: unknown): string | null {
+  if (!rawInput || typeof rawInput !== "object") return null;
+  const input = rawInput as { name?: unknown; path?: unknown };
+  if (typeof input.name === "string" && input.name.trim()) {
+    return input.name.trim();
+  }
+  if (typeof input.path === "string" && input.path.trim()) {
+    const segments = input.path.trim().split(/[\\/]/).filter(Boolean);
+    return segments.at(-1) ?? null;
+  }
+  return null;
+}
+
+const PR_URL_PATTERN =
+  /https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/pull\/\d+(?![\w/])/;
+
+// The whole MCP tool name, not a substring: `create_pull_request_review` also
+// returns a PR url but did not create it, so a loose match reads someone else's
+// PR back as this run's deliverable.
+const PR_CREATION_TOOL = /^create[_-]?pull[_-]?request$/i;
+
+// `gh pr create` where a command can start (line start or after a separator).
+// Anywhere else it is being talked about — e.g. inside a `gh pr comment` body —
+// rather than run.
+const GH_PR_CREATE_PATTERN = /(?:^|[\n;|&]\s*)gh\s+pr\s+create\b/;
+
+function readCommand(rawInput: unknown): string {
+  if (!rawInput || typeof rawInput !== "object") return "";
+  const { command } = rawInput as { command?: unknown };
+  if (typeof command === "string") return command;
+  return Array.isArray(command) ? command.join(" ") : "";
+}
+
+function looksLikePrCreation(meta: unknown, rawInput: unknown): boolean {
+  const mcp = readMcpToolDescriptor(meta);
+  if (mcp && PR_CREATION_TOOL.test(mcp.tool)) return true;
+  return GH_PR_CREATE_PATTERN.test(readCommand(rawInput));
+}
+
+// Gated on the call setting out to create a PR rather than on the url alone, so
+// a run that reads, reviews or comments on someone else's PR draws no card.
+function matchesPrCreation(
+  status: string | undefined,
+  meta: unknown,
+  rawInput: unknown,
+): boolean {
+  return status === "completed" && looksLikePrCreation(meta, rawInput);
+}
+
+/** A finished tool call, reduced to what PR-creation detection needs. */
+export interface PrCreationCandidate {
+  status: string | undefined;
+  meta: unknown;
+  rawInput: unknown;
+  outputText: string;
+}
+
+/** The pull request a tool call just opened, or null. */
+export function readCreatedPrUrl(call: PrCreationCandidate): string | null {
+  if (!matchesPrCreation(call.status, call.meta, call.rawInput)) return null;
+  return PR_URL_PATTERN.exec(call.outputText)?.[0] ?? null;
+}
+
+export type InlineArtifact = { kind: "upload" } | { kind: "pr"; url: string };
+
+export interface InlineArtifactCandidate {
+  status: string | undefined;
+  meta: unknown;
+  rawInput: unknown;
+  /** Resolved only for a confirmed PR-creation call, so other rows never pay to build it. */
+  getOutputText: () => string;
+}
+
+/** The deliverable a tool call produced — an uploaded file or an opened PR. */
+export function detectInlineArtifact(
+  call: InlineArtifactCandidate,
+): InlineArtifact | null {
+  if (isUploadArtifactCall(call.meta)) return { kind: "upload" };
+  if (!matchesPrCreation(call.status, call.meta, call.rawInput)) return null;
+  const url = PR_URL_PATTERN.exec(call.getOutputText())?.[0] ?? null;
+  return url ? { kind: "pr", url } : null;
+}

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/inlineArtifacts.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/inlineArtifacts.ts
@@ -1,52 +1,12 @@
-import { readMcpToolDescriptor } from "@posthog/shared";
+import {
+  isUploadArtifactCall,
+  readCreatedPrUrl as readCreatedPrUrlFromCall,
+  readUploadedArtifactName,
+} from "@posthog/core/sessions/inlineArtifacts";
 import { getContentText } from "@posthog/ui/features/sessions/components/session-update/toolCallUtils";
 import type { ToolCall } from "@posthog/ui/features/sessions/types";
 
-const UPLOAD_ARTIFACT_TOOL = "upload_artifact";
-
-/** The agent's `upload_artifact` call, which delivers a file to the artifacts panel. */
-export function isUploadArtifactCall(meta: unknown): boolean {
-  return readMcpToolDescriptor(meta)?.tool === UPLOAD_ARTIFACT_TOOL;
-}
-
-/** The download name the upload will land under: the given name, else the file's own. */
-export function readUploadedArtifactName(rawInput: unknown): string | null {
-  if (!rawInput || typeof rawInput !== "object") return null;
-  const input = rawInput as { name?: unknown; path?: unknown };
-  if (typeof input.name === "string" && input.name.trim()) {
-    return input.name.trim();
-  }
-  if (typeof input.path === "string" && input.path.trim()) {
-    const segments = input.path.trim().split(/[\\/]/).filter(Boolean);
-    return segments.at(-1) ?? null;
-  }
-  return null;
-}
-
-const PR_URL_PATTERN =
-  /https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/pull\/\d+(?![\w/])/;
-
-/**
- * The whole MCP tool name, not a substring of it. `create_pull_request_review`
- * both contains this name and returns the url of the pull request it reviewed,
- * so a loose match reads someone else's PR back as this run's deliverable.
- */
-const PR_CREATION_TOOL = /^create[_-]?pull[_-]?request$/i;
-
-/**
- * `gh pr create` where a command can start: the beginning of the line, or after
- * a separator. Anywhere else it is being talked about rather than run, and the
- * body of a `gh pr comment` is the likeliest place for that.
- */
-const GH_PR_CREATE_PATTERN = /(?:^|[\n;|&]\s*)gh\s+pr\s+create\b/;
-
-/** The shell command a tool call ran, for the tools that carry one. */
-function readCommand(rawInput: unknown): string {
-  if (!rawInput || typeof rawInput !== "object") return "";
-  const { command } = rawInput as { command?: unknown };
-  if (typeof command === "string") return command;
-  return Array.isArray(command) ? command.join(" ") : "";
-}
+export { isUploadArtifactCall, readUploadedArtifactName };
 
 function toolCallOutputText(toolCall: ToolCall): string {
   const content = getContentText(toolCall.content) ?? "";
@@ -54,28 +14,14 @@ function toolCallOutputText(toolCall: ToolCall): string {
   return typeof raw === "string" ? `${content}\n${raw}` : content;
 }
 
-/**
- * Whether the call set out to open a pull request. Two ways in, because a shell
- * that opens one may itself be an MCP tool.
- */
-function looksLikePrCreation(toolCall: ToolCall): boolean {
-  const mcp = readMcpToolDescriptor(toolCall._meta);
-  if (mcp && PR_CREATION_TOOL.test(mcp.tool)) return true;
-  return GH_PR_CREATE_PATTERN.test(readCommand(toolCall.rawInput));
-}
-
-/**
- * The pull request a tool call just opened, or null.
- *
- * Gated on the call setting out to create one rather than on the url alone: a
- * run that reads, reviews or comments on someone else's PR prints the same url,
- * and that PR is not this run's deliverable.
- */
+/** The pull request a tool call just opened, or null. */
 export function readCreatedPrUrl(toolCall: ToolCall): string | null {
-  if (toolCall.status !== "completed") return null;
-  if (!looksLikePrCreation(toolCall)) return null;
-
-  return PR_URL_PATTERN.exec(toolCallOutputText(toolCall))?.[0] ?? null;
+  return readCreatedPrUrlFromCall({
+    status: toolCall.status ?? undefined,
+    meta: toolCall._meta,
+    rawInput: toolCall.rawInput,
+    outputText: toolCallOutputText(toolCall),
+  });
 }
 
 /** Whether a tool call draws an artifact card, which never folds into a tool group. */


### PR DESCRIPTION
## Problem

On the mobile app, a cloud run could produce a file or open a pull request, but the thread that produced it said nothing — the only route to a deliverable was the separate Files surface. This ports the in-thread part of #83157 (desktop) to the React Native app.

## Changes

- An uploaded file draws a card in the thread in place of its tool row. The card stands in for the file while the upload runs, then opens a preview once the run's artifact manifest carries it.
- A pull request the run opened draws a card below the tool call that opened it, showing the PR's diff stats and status and opening GitHub on tap. It reuses the existing `PrStatusBadge` and `PrDiffStatsBadge`.
- Detection treats a PR as created only when the call set out to create one — the `create_pull_request` MCP tool or a `gh pr create` command. A run that reads, reviews, or comments on someone else's PR prints the same url but draws no card.
- The manifest loads only once the run is terminal, matching the Files surface, so a card mid-run stays in its uploading state rather than forcing an eager fetch.
- Mechanical: the pure detection helpers moved to `@posthog/core` so both hosts share them; the desktop wrapper keeps identical behavior.

Left out as desktop-only host mechanics, per the task: the right panel with its attention dot, and the first-run teaching tip that points at it.

This is a visual change, but a mobile screenshot could not be captured in this environment (no simulator or device).

## How did you test this code?

Automated only; the app was not run and no simulator or device was used.

- Core detection tests (`packages/core/src/sessions/inlineArtifacts.test.ts`) cover the two false positives that matter: `create_pull_request_review` and a `gh pr comment` body — both print a PR url that is not a deliverable.
- A mobile detection test (`apps/mobile/src/features/tasks/utils/inlineArtifacts.test.ts`) covers the same false positives plus object-shaped MCP tool results, which mobile stringifies itself before matching.
- Ran the core, ui, and mobile unit suites, the mobile type baseline (`check-mobile-types.mjs`, no new errors), and lint locally.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Port of #83157. Skills invoked: `/writing-tests`, `/simplify`, `/writing-pr-descriptions`.

- The detection logic was lifted into `@posthog/core` rather than reimplemented on mobile, following the `products/desktop` layered architecture (portable logic shared, hosts thin). Desktop keeps a thin wrapper with unchanged behavior.
- `/simplify` folded the artifact classifier into core with a lazily-resolved tool output, so a non-PR tool row never stringifies its result on the chat render path, and replaced a hand-rolled PR-url parser with the shared `parsePrUrl`.
- The card is a native React Native component using the app's theming and touch targets, reusing `ArtifactPreview` and the PR badges; no DOM, Tailwind, or quill was carried over.
- No customer data or session material is in this diff; test fixtures use invented identifiers and reserved example values.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
