### PR TITLE
fix(rbac): keep a project's own default from being overridden

### DIFF
--- a/ee/api/rbac/test/test_access_control.py
+++ b/ee/api/rbac/test/test_access_control.py
@@ -2191,7 +2191,11 @@ class TestAccessControlMembersEndpoint(BaseAccessControlTest):
         # Create another team and set different member override directly in DB
         other_team = Team.objects.create(organization=self.organization, name="Other Team")
         AccessControl.objects.create(
-            team=other_team, resource="project", organization_member=self.user2_membership, access_level="admin"
+            team=other_team,
+            resource="project",
+            resource_id=str(other_team.id),
+            organization_member=self.user2_membership,
+            access_level="admin",
         )
 
         # Request should only return current team's member overrides

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -3492,7 +3492,7 @@ class TestGitHubTeamIntegrationComplete:
     def _sibling_github_integration(self, name: str, installation_id: str, private: bool = False) -> Integration:
         team = Team.objects.create(organization=self.organization, name=name)
         if private:
-            AccessControl.objects.create(team=team, resource="project", access_level="none")
+            AccessControl.objects.create(team=team, resource="project", resource_id=str(team.id), access_level="none")
         return Integration.objects.create(
             team=team,
             kind="github",

--- a/posthog/api/test/test_organization.py
+++ b/posthog/api/test/test_organization.py
@@ -977,7 +977,9 @@ class TestOrganizationSerializer(APIBaseTest):
         [
             (
                 "access_control",
-                lambda self: AccessControl.objects.create(team=self.team, access_level="member", resource="project"),
+                lambda self: AccessControl.objects.create(
+                    team=self.team, access_level="member", resource="project", resource_id=str(self.team.id)
+                ),
             ),
             (
                 "explicit_team_membership",

--- a/posthog/rbac/test/test_user_access_control.py
+++ b/posthog/rbac/test/test_user_access_control.py
@@ -227,6 +227,16 @@ class TestUserAccessControl(BaseUserAccessControlTest):
             is True  # This is the default
         )  # Fix this - need to load all access controls...
 
+    def test_project_default_survives_a_resource_level_project_rule(self):
+        # A rule about "project" written without a resource_id is not a shape the product writes,
+        # and enforcement never reads it. It must not send the walk to the resource tier, which
+        # answers with the built-in project default and would promote everyone to admin
+        self._create_access_control(resource="project", resource_id=self.team.id, access_level="member")
+        self._create_access_control(resource="project", resource_id=None, access_level="none")
+        self._clear_uac_caches()
+
+        assert self.user_access_control.get_user_access_level(self.team) == "member"
+
     def test_ac_object_project_access_control(self):
         # Setup no access by default
         ac = self._create_access_control(resource_id=self.team.id, access_level="none")

--- a/posthog/rbac/user_access_control.py
+++ b/posthog/rbac/user_access_control.py
@@ -1139,6 +1139,13 @@ class UserAccessControl:
             # If there is no team, then there can't be any access controls on this resource
             return False
 
+        # A resource that carries no resource-level controls has no such rules to find, whatever
+        # rows exist. Answering True for one sends the object walk to `access_level_for_resource`,
+        # which returns the built-in default for these resources — that would override the rules
+        # written about the object itself, e.g. a project's own default.
+        if resource in RESOURCES_WITHOUT_RESOURCE_LEVEL_CONTROLS:
+            return False
+
         # Inheriting children (e.g. warehouse_view -> warehouse_objects) intentionally
         # bypass their own resource-level rows: only the parent (umbrella) is consulted.
         # This keeps the AC picker simple — admins configure one umbrella scope instead


### PR DESCRIPTION
## Problem

- Everyone in an organization gets admin access to a project that its administrator closed.
- Both prod US and EU carry the rows that cause this. The count is small, in the single digits per region.
- The cause is an access control row that names the resource `project` and has no `resource_id` (object id).
- Access resolution for a project object leaves the object tier and asks the resource tier.
- The resource tier does not read project rows. It returns the built-in project default, which is `admin`.
- The project's own default row stays unread.
- An explicit member rule or role rule still wins. Only a person who falls back to the default gets the higher level.

## Changes

- A project keeps to its own rules now. Its configured default holds, and its members stay at that level.
- `has_access_levels_for_resource` returns False for `organization`, `project` and `plugin`.
- `access_level_for_resource` already returns the built-in default for those three resources. The gate and the getter agree now.
- Scope limit: this change helps a project that has a correct default row and a malformed row together.
- A project whose only default row is malformed still resolves to `admin`, because it has no readable default. A data repair must correct those rows.
- The write path that creates malformed rows stays open. A separate change must close it.
- Stored rows stay in the database. The resolver ignores them.
- The UI shows no new elements. Only the access level that a project reports can change.

## How did you test this code?

- Added `test_project_default_survives_a_resource_level_project_rule`. It writes a project default row of `member` and a malformed project row. It asserts that resolution returns `member`. On master it returns `admin`.
- Not run locally: the backend suite. The local Postgres container is down, because the host disk is full. CI is the verification here.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

- Found while reviewing the access control settings page on a local instance. A member row showed `Project: Admin`, but the project default was member.
- Confirmed on master, separate from the access control resolution stack, with both rows present.
- Counted the malformed rows in both production app databases through Metabase. The exact figures stay internal, because this repository is public.
- Open question for a reviewer: must the resource-level endpoint refuse `resource: project`?