### PR TITLE
fix(devex): stop dagster CI replaying migrations twice on a schema cache miss

### DIFF
--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -410,9 +410,9 @@ jobs:
               with:
                   path: schema.sql.gz
                   # Prefer the shared content key; fall back to the exact merge-base SHA key.
-                  key: force-cache-miss-${{ github.run_id }}
+                  key: ${{ needs.changes.outputs.schema_migrations_key || needs.changes.outputs.schema_cache_key }}
                   restore-keys: |
-                      force-cache-miss-nothing-is-saved-under-this-
+                      ${{ needs.changes.outputs.schema_cache_key }}
 
             - name: Prime test_posthog from cached schema
               # Treat cache problems as misses; the migrate step below rebuilds the DB

--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -414,34 +414,45 @@ jobs:
                   restore-keys: |
                       ${{ needs.changes.outputs.schema_cache_key }}
 
-            - name: Prime test_posthog and posthog from cached schema (PR)
-              # Primes both test_posthog (used by pytest --reuse-db) and the prod-style
-              # posthog db (read by migrate_clickhouse → InstanceSetting). pytest's
-              # keepdb=True path layers any PR-added migrations on top.
-              # On cache miss, fall through to a full migrate so migrate_clickhouse works.
+            - name: Prime test_posthog from cached schema
+              # Treat cache problems as misses; the migrate step below rebuilds the DB
+              # whenever this one reports restored=false.
+              id: prime-schema
               if: ${{ github.event_name == 'pull_request' }}
               run: |
+                  echo "restored=false" >> "$GITHUB_OUTPUT"
                   if [ ! -f schema.sql.gz ]; then
-                      echo "::notice::Schema cache miss — falling through to full migrate"
-                      python manage.py migrate
+                      echo "::notice::Schema cache miss; the migrate step will build test_posthog"
                       exit 0
                   fi
                   mkdir -p .postgres-backups
                   mv schema.sql.gz .postgres-backups/schema-latest.sql.gz
-                  if ! ./bin/hogli db:restore-schema-fresh; then
-                      echo "::warning::Schema restore failed (stale/incompatible cached dump?) — falling through to full migrate"
-                      python manage.py migrate
+                  if ./bin/hogli db:restore-test-db; then
+                      echo "restored=true" >> "$GITHUB_OUTPUT"
+                  else
+                      echo "::warning::Schema restore failed (stale/incompatible cached dump?); the migrate step will build test_posthog"
+                  fi
+
+            - name: Migrate test_posthog from scratch
+              # Any run without a restored schema cache (master pushes, PR cache misses)
+              # replays the full migration chain here, in a process that exits before
+              # tests: the executor's memory high-water stays resident in whichever
+              # process runs it, and pytest must not carry it through the test phase.
+              # pytest --reuse-db adopts the DB like the PR prime above; any failure
+              # falls back to the in-pytest migrate.
+              if: ${{ github.event_name != 'pull_request' || steps.prime-schema.outputs.restored != 'true' }}
+              env:
+                  DATABASE_URL: postgres://posthog:posthog@localhost:5432/test_posthog
+              run: |
+                  admin_psql() { docker compose -f docker-compose.dev.yml exec -T db psql -U posthog postgres "$@"; }
+                  if ! admin_psql -c "DROP DATABASE IF EXISTS test_posthog;" -c "CREATE DATABASE test_posthog;"; then
+                      echo "::warning::Could not recreate test_posthog; pytest --reuse-db will run the full migrate itself"
                       exit 0
                   fi
-                  gunzip -c .postgres-backups/schema-latest.sql.gz | \
-                    docker compose -f docker-compose.dev.yml exec -T db psql -q -U posthog posthog
-
-            - name: Run Django migrations (master)
-              # Master pushes don't restore from cache (the artifact-producing run
-              # is in ci-backend, not here). Run a full migrate so migrate_clickhouse
-              # can read posthog_instancesetting from a populated posthog db.
-              if: ${{ github.event_name != 'pull_request' }}
-              run: python manage.py migrate
+                  if ! python manage.py migrate; then
+                      echo "::warning::Out-of-process migrate failed; pytest --reuse-db will run the full migrate itself"
+                      admin_psql -c "DROP DATABASE IF EXISTS test_posthog;" || true
+                  fi
 
             - name: Run persons migrations
               run: |
@@ -451,6 +462,11 @@ jobs:
                     sqlx migrate run --source rust/persons_migrations/
 
             - name: Run clickhouse migrations
+              # Reads posthog_instancesetting through Django, so it needs a migrated
+              # Postgres db. test_posthog is the only one this job maintains, which is
+              # what ci-mcp.yml and ci-e2e-playwright.yml do with their own single db.
+              env:
+                  DATABASE_URL: postgres://posthog:posthog@localhost:5432/test_posthog
               run: python manage.py migrate_clickhouse
 
             - name: Restore test durations from cache

--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -410,9 +410,9 @@ jobs:
               with:
                   path: schema.sql.gz
                   # Prefer the shared content key; fall back to the exact merge-base SHA key.
-                  key: ${{ needs.changes.outputs.schema_migrations_key || needs.changes.outputs.schema_cache_key }}
+                  key: force-cache-miss-${{ github.run_id }}
                   restore-keys: |
-                      ${{ needs.changes.outputs.schema_cache_key }}
+                      force-cache-miss-nothing-is-saved-under-this-
 
             - name: Prime test_posthog from cached schema
               # Treat cache problems as misses; the migrate step below rebuilds the DB


### PR DESCRIPTION
## Problem

- When a Django migration lands on master, merge queue batches start failing the `Dagster Tests Pass` check and Trunk drops them from the queue.
- A new migration changes the shared schema cache key, so batches miss the cache until master's own `check-migrations` job saves a dump for the new migration set.
- On a miss the Dagster job replays the full migration chain twice: once for the `posthog` db, then again inside pytest to build `test_posthog`.
- That takes a shard from about ten minutes to the forty minute job timeout. [This batch](https://github.com/PostHog/posthog/actions/runs/32241294725) lost a shard to it, and the other two finished with under three minutes to spare.

## Changes

- The Dagster job keeps one Postgres database now, so a cache miss replays the migration chain once instead of twice.
- The prime step reports whether it restored the cache, through a `restored` step output.
- A new `Migrate test_posthog from scratch` step builds the test database when the prime step did not. It is a copy of the equivalent step in `ci-backend.yml`, which already solves this.
- `migrate_clickhouse` points at `test_posthog`. It reads `posthog_instancesetting` and writes nothing, so it does not need its own database.
- Master pushes ran the same double replay and go through the same new step.
- Nothing user-visible changes. The whole diff is CI wiring.

Raising `timeout-minutes` was the obvious alternative. It hides the double replay and still pays for it in runner time. `ci-mcp.yml` and `ci-e2e-playwright.yml` already run their whole job against a single database, so this follows them rather than inventing a third pattern.

Before, on a cache miss:

```mermaid
flowchart TD
    A{{Schema cache miss}} --> B[Migrate posthog]
    B --> C[migrate_clickhouse on posthog]
    C --> D[pytest --reuse-db]
    D --> E[Replay migrations to build test_posthog]
    E --> F{{Run tests}}
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A,F phYellow;
    class B,E phRed;
    class C,D phBlue;
```

After:

```mermaid
flowchart TD
    A{{Schema cache miss}} --> B[Migrate test_posthog out of process]
    B --> C[migrate_clickhouse on test_posthog]
    C --> D[pytest --reuse-db adopts test_posthog]
    D --> E{{Run tests}}
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A,E phYellow;
    class B phRed;
    class C,D phBlue;
```

## How did you test this code?

Both paths ran in CI on this branch. `ci-dagster.yml` is in the `dagster_direct` filter, so the job runs against itself.

Cache hit, [run 32246528937](https://github.com/PostHog/posthog/actions/runs/32246528937) — `Migrate test_posthog from scratch` skips, as intended:

| shard | prime | migrate | tests | total |
| --- | --- | --- | --- | --- |
| 1/3 | 0.8m | skipped | 4.8m | 8.1m |
| 2/3 | 0.8m | skipped | 5.1m | 8.5m |
| 3/3 | 0.8m | skipped | 5.1m | 8.4m |

Cache miss, [run 32247474092](https://github.com/PostHog/posthog/actions/runs/32247474092). A temporary commit pointed the restore step at a key nothing is saved under, then was reverted. The last column is the same shard on the miss path before this change, from [the batch that lost a shard to the timeout](https://github.com/PostHog/posthog/actions/runs/32241294725):

| shard | migrate | tests | total | before |
| --- | --- | --- | --- | --- |
| 1/3 | 16.8m | 5.2m | 24.6m | 37.7m |
| 2/3 | 17.2m | 5.1m | 24.9m | 39.4m |
| 3/3 | 16.5m | 4.6m | 23.7m | 40.1m, cancelled at the cap |

The test step drops from about 19m to about 5m. That is the second replay going away.

- Not run locally. The Dagster suite needs the docker compose stack.
- `bin/hogli lint:workflows` and `hogli ci:preflight --strict` pass.
- Checked that `migrate_clickhouse` never writes to Postgres, so pointing it at `test_posthog` adds no rows the tests would see.
- Checked that nothing else in the job needs the `posthog` db. The one real connection in the Dagster tests, `_connect_test_db()` in `posthog/dags/tests/test_events_backfill_to_duckling.py`, reads Django's `settings_dict["NAME"]`.

No tests added. The behavior lives in a workflow file.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Opus 5). Skills invoked: `/writing-pr-descriptions`.
- The session started from a merge queue batch that failed the Dagster check, and traced it to the schema cache key moving when migrations land on master.
- Two earlier proposals were wrong and got dropped. Raising the job timeout treats the symptom. Copying `posthog` into `test_posthog` with `CREATE DATABASE ... TEMPLATE` invents a pattern this repo does not use. Reading how `ci-mcp.yml` and `ci-e2e-playwright.yml` handle the same restore pointed at the single-database shape instead.

