### PR TITLE
fix(desktop): fix sidebar multi-selection behavior

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
@@ -1,6 +1,11 @@
 import type { ChannelItemModel } from "@posthog/core/canvas/channelItems";
 import { formatRelativeTimeShort } from "@posthog/shared";
 import type { TaskStatusInput } from "@posthog/ui/features/sidebar/components/items/taskStatusVocabulary";
+import {
+  TASK_DRAG_TYPE,
+  TASK_IDS_DRAG_TYPE,
+} from "@posthog/ui/features/sidebar/taskDrag";
+import { useTaskSelectionStore } from "@posthog/ui/features/sidebar/taskSelectionStore";
 import { Theme } from "@radix-ui/themes";
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -80,6 +85,10 @@ function renderRow(model: ChannelItemModel) {
 beforeEach(() => {
   mocks.status = null;
   usePendingCanvasDeleteStore.setState({ pending: {} });
+  useTaskSelectionStore.setState({
+    selectedTaskIds: [],
+    lastClickedId: null,
+  });
 });
 
 describe("ChannelItemRow", () => {
@@ -269,10 +278,28 @@ describe("ChannelItemRow", () => {
 
       fireEvent.dragStart(screen.getByRole("button"), { dataTransfer });
 
-      expect(setData).toHaveBeenCalledWith("text/x-task-id", "task-1");
+      expect(setData).toHaveBeenCalledWith(TASK_DRAG_TYPE, "task-1");
       expect(dataTransfer.effectAllowed).toBe("copyMove");
     },
   );
+
+  it("drags every selected task into the Command Center", () => {
+    useTaskSelectionStore.setState({
+      selectedTaskIds: ["task-2", "task-1"],
+    });
+    renderRow(item());
+    const setData = vi.fn();
+    const dataTransfer = { setData, effectAllowed: "none" };
+
+    fireEvent.dragStart(screen.getByRole("button"), { dataTransfer });
+
+    expect(setData).toHaveBeenCalledWith(TASK_DRAG_TYPE, "task-1");
+    expect(setData).toHaveBeenCalledWith(
+      TASK_IDS_DRAG_TYPE,
+      JSON.stringify(["task-1", "task-2"]),
+    );
+    expect(dataTransfer.effectAllowed).toBe("copyMove");
+  });
 
   it("does not make canvases draggable into the Command Center", () => {
     renderRow(

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.tsx
@@ -37,6 +37,7 @@ import {
   taskDot,
 } from "@posthog/ui/features/sidebar/components/items/taskStatusVocabulary";
 import { SidebarItem } from "@posthog/ui/features/sidebar/components/SidebarItem";
+import { writeTaskDragData } from "@posthog/ui/features/sidebar/taskDrag";
 import { SESSION_ROW_ATTRIBUTE } from "@posthog/ui/features/sidebar/useMarqueeSelection";
 import {
   type DragEvent,
@@ -272,7 +273,7 @@ export function ChannelItemRow({
     (event: DragEvent) => {
       if (item.kind !== "task") return;
 
-      event.dataTransfer.setData("text/x-task-id", item.id);
+      writeTaskDragData(event.dataTransfer, item.id);
       // Both, always. Command Center tiles ask for `copy` and the pinned run
       // asks for `move`; a source that permits only one resolves the other
       // pairing to no drop, and the tile silently stops accepting the row.

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelSidebar.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelSidebar.test.tsx
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   items: [] as ChannelItemModel[],
   isLoading: false,
   channelMissing: false,
+  pathname: "/website/channel-1",
   open: vi.fn(),
 }));
 
@@ -25,7 +26,7 @@ vi.mock("@posthog/ui/features/feature-flags/useFeatureFlag", () => ({
 }));
 vi.mock("@tanstack/react-router", () => ({
   useNavigate: () => vi.fn(),
-  useRouterState: () => "/website/channel-1",
+  useRouterState: () => mocks.pathname,
 }));
 
 // Both mount their own query stacks; this suite is about the list's own
@@ -107,6 +108,7 @@ describe("ChannelSidebar", () => {
     mocks.items = [];
     mocks.isLoading = false;
     mocks.channelMissing = false;
+    mocks.pathname = "/website/channel-1";
   });
 
   it.each([
@@ -370,6 +372,7 @@ describe("ChannelSidebar multi-select", () => {
   beforeEach(() => {
     mocks.isLoading = false;
     mocks.channelMissing = false;
+    mocks.pathname = "/website/channel-1";
     mocks.open.mockClear();
     useTaskSelectionStore.setState({
       selectedTaskIds: [],
@@ -419,6 +422,19 @@ describe("ChannelSidebar multi-select", () => {
       "a",
       "b",
     ]);
+  });
+
+  it("does not style the open session as selected when another session is selected", () => {
+    mocks.pathname = "/website/channel-1/tasks/a";
+    useTaskSelectionStore.setState({ selectedTaskIds: ["b"] });
+
+    renderSidebar();
+
+    const openRow = screen.getByText("First session").closest("button");
+    const selectedRow = screen.getByText("Second session").closest("button");
+    expect(openRow).toHaveAttribute("data-active", "true");
+    expect(openRow).not.toHaveAttribute("data-in-selection");
+    expect(selectedRow).toHaveAttribute("data-in-selection", "true");
   });
 
   // A canvas can't be archived, filed, or tiled like a session, so it stays out

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelSidebar.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelSidebar.tsx
@@ -430,9 +430,9 @@ export function ChannelSidebar({ channelId }: { channelId: string }) {
     pruneSelection(selectableTaskIds);
   }, [selectableTaskIds, pruneSelection]);
 
-  // The open session counts as selected, the same way it does in the code
-  // sidebar — a bulk action is expected to include what you're looking at. Only
-  // a task-kind active row folds in; a canvas can't join a session selection.
+  // Bulk actions include the open session, but selection styling stays tied to
+  // explicit picks so selecting another row does not highlight the open row.
+  // Only a task-kind active row folds in; a canvas can't join a session batch.
   const activeTaskId = activeKey?.startsWith("task:")
     ? activeKey.slice("task:".length)
     : null;
@@ -548,7 +548,7 @@ export function ChannelSidebar({ channelId }: { channelId: string }) {
         item={item}
         channelId={channelId}
         isActive={item.key === activeKey}
-        isSelected={item.kind === "task" && effectiveBulkIds.includes(item.id)}
+        isSelected={item.kind === "task" && selectedTaskIds.includes(item.id)}
         showPinBadge={showPinBadge}
         actions={actions}
         onClick={(e) => handleRowClick(item, e)}

--- a/products/desktop/packages/ui/src/features/command-center/components/CommandCenterGrid.tsx
+++ b/products/desktop/packages/ui/src/features/command-center/components/CommandCenterGrid.tsx
@@ -5,6 +5,11 @@ import {
   getExpansionCellIndex,
 } from "@posthog/core/command-center/grid";
 import { Button } from "@posthog/quill";
+import {
+  readTaskDragData,
+  TASK_DRAG_TYPE,
+  TASK_IDS_DRAG_TYPE,
+} from "@posthog/ui/features/sidebar/taskDrag";
 import { destroyShellTerminal } from "@posthog/ui/features/terminal/destroyShellTerminal";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { FOCUSABLE_SELECTOR } from "../../../utils/overlay";
@@ -14,11 +19,12 @@ import {
   useCommandCenterStore,
 } from "../commandCenterStore";
 import type { CommandCenterCellData } from "../hooks/useCommandCenterData";
-import { expandCommandCenterInto } from "../placeTaskInCommandCenter";
+import {
+  expandTasksInCommandCenterInto,
+  placeTasksInCommandCenterCell,
+} from "../placeTaskInCommandCenter";
 import { getTerminalCellStateKey } from "../terminalCells";
 import { CommandCenterPanel } from "./CommandCenterPanel";
-
-const TASK_DRAG_TYPE = "text/x-task-id";
 
 /**
  * Picking a tile by clicking and by dropping are the same interaction, so they
@@ -35,12 +41,16 @@ interface CommandCenterGridProps {
   cells: CommandCenterCellData[];
 }
 
+function hasTaskDragType(types: readonly string[]): boolean {
+  return types.includes(TASK_IDS_DRAG_TYPE) || types.includes(TASK_DRAG_TYPE);
+}
+
 function useTaskDragActive() {
   const [active, setActive] = useState(false);
 
   useEffect(() => {
     const onDragStart = (e: DragEvent) => {
-      if (e.dataTransfer?.types.includes(TASK_DRAG_TYPE)) {
+      if (e.dataTransfer && hasTaskDragType(e.dataTransfer.types)) {
         setActive(true);
       }
     };
@@ -65,13 +75,13 @@ function useTaskDragActive() {
   return active;
 }
 
-function useTaskDropTarget(onTask: (taskId: string) => void) {
+function useTaskDropTarget(onTasks: (taskIds: string[]) => void) {
   const [isOver, setIsOver] = useState(false);
 
   return {
     isOver,
     onDragOver: (e: React.DragEvent) => {
-      if (!e.dataTransfer.types.includes(TASK_DRAG_TYPE)) return;
+      if (!hasTaskDragType(e.dataTransfer.types)) return;
       e.preventDefault();
       e.dataTransfer.dropEffect = "copy";
       setIsOver(true);
@@ -80,8 +90,8 @@ function useTaskDropTarget(onTask: (taskId: string) => void) {
     onDrop: (e: React.DragEvent) => {
       e.preventDefault();
       setIsOver(false);
-      const taskId = e.dataTransfer.getData(TASK_DRAG_TYPE);
-      if (taskId) onTask(taskId);
+      const taskIds = readTaskDragData(e.dataTransfer);
+      if (taskIds.length > 0) onTasks(taskIds);
     },
   };
 }
@@ -164,11 +174,11 @@ function GridCell({
   );
 
   const placeInCell = useCallback(
-    (taskId: string) => {
+    (taskIds: string[]) => {
       if (cell.terminalId) {
         destroyShellTerminal(getTerminalCellStateKey(cell.terminalId));
       }
-      useCommandCenterStore.getState().assignTask(cell.cellIndex, taskId);
+      placeTasksInCommandCenterCell(taskIds, cell.cellIndex);
     },
     [cell.cellIndex, cell.terminalId],
   );
@@ -214,7 +224,7 @@ function GridCell({
           className={`absolute inset-0 z-10 p-4 ${TARGET_CLASSES} ${targetOutline(dropTarget.isOver)}`}
           onClick={
             placement.mode === "pick"
-              ? () => placeInCell(placement.taskId)
+              ? () => placeInCell([placement.taskId])
               : undefined
           }
           onDragOver={dropTarget.onDragOver}
@@ -245,7 +255,8 @@ function ExpandSlot({
   placement: PlacementState;
 }) {
   const expand = useCallback(
-    (taskId: string) => expandCommandCenterInto(direction, slot, taskId),
+    (taskIds: string[]) =>
+      expandTasksInCommandCenterInto(direction, slot, taskIds),
     [direction, slot],
   );
   const dropTarget = useTaskDropTarget(expand);
@@ -256,7 +267,7 @@ function ExpandSlot({
       type="button"
       className={`flex-1 p-1 text-accent-11 ${TARGET_CLASSES} ${targetOutline(dropTarget.isOver)}`}
       onClick={
-        placement.mode === "pick" ? () => expand(placement.taskId) : undefined
+        placement.mode === "pick" ? () => expand([placement.taskId]) : undefined
       }
       onDragOver={dropTarget.onDragOver}
       onDragLeave={dropTarget.onDragLeave}

--- a/products/desktop/packages/ui/src/features/command-center/placeTaskInCommandCenter.test.ts
+++ b/products/desktop/packages/ui/src/features/command-center/placeTaskInCommandCenter.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  COMMAND_CENTER_INITIAL_STATE,
+  useCommandCenterStore,
+} from "./commandCenterStore";
+import { placeTasksInCommandCenterCell } from "./placeTaskInCommandCenter";
+
+vi.mock("@posthog/ui/router/navigationBridge", () => ({
+  navigateToCommandCenter: vi.fn(),
+}));
+
+describe("placeTasksInCommandCenterCell", () => {
+  beforeEach(() => {
+    useCommandCenterStore.setState({
+      ...COMMAND_CENTER_INITIAL_STATE,
+      cells: ["existing", null, null, null],
+    });
+  });
+
+  it("places the grabbed task in the drop target and the rest in available cells", () => {
+    placeTasksInCommandCenterCell(["dragged", "selected-2", "selected-3"], 0);
+
+    expect(useCommandCenterStore.getState().cells).toEqual([
+      "dragged",
+      "selected-2",
+      "selected-3",
+      null,
+    ]);
+  });
+});

--- a/products/desktop/packages/ui/src/features/command-center/placeTaskInCommandCenter.ts
+++ b/products/desktop/packages/ui/src/features/command-center/placeTaskInCommandCenter.ts
@@ -55,12 +55,27 @@ export function placeTasksInCommandCenter(
   };
 }
 
-/** Grows the grid by one column or row and puts the task in the slot picked. */
-export function expandCommandCenterInto(
+export function placeTasksInCommandCenterCell(
+  taskIds: string[],
+  cellIndex: number,
+): void {
+  const [firstTaskId, ...remainingTaskIds] = taskIds;
+  if (!firstTaskId) return;
+
+  useCommandCenterStore.getState().assignTask(cellIndex, firstTaskId);
+  if (remainingTaskIds.length > 0) {
+    placeTasksInCommandCenter(remainingTaskIds, null);
+  }
+}
+
+export function expandTasksInCommandCenterInto(
   direction: ExpandDirection,
   slot: number,
-  taskId: string,
+  taskIds: string[],
 ): void {
+  const [firstTaskId, ...remainingTaskIds] = taskIds;
+  if (!firstTaskId) return;
+
   const state = useCommandCenterStore.getState();
   const expanded = getExpandedLayout(state.layout, direction);
   if (!expanded) return;
@@ -68,5 +83,8 @@ export function expandCommandCenterInto(
   state.setLayout(expanded);
   useCommandCenterStore
     .getState()
-    .assignTask(getExpansionCellIndex(expanded, direction, slot), taskId);
+    .assignTask(getExpansionCellIndex(expanded, direction, slot), firstTaskId);
+  if (remainingTaskIds.length > 0) {
+    placeTasksInCommandCenter(remainingTaskIds, null);
+  }
 }

--- a/products/desktop/packages/ui/src/features/sidebar/components/SidebarMenu.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/SidebarMenu.tsx
@@ -172,8 +172,8 @@ function SidebarMenuComponent() {
     pruneSelection(allSidebarTaskIds);
   }, [allSidebarTaskIds, pruneSelection]);
 
-  // The active (routed) task is implicitly part of any bulk selection — the
-  // user expects to see and act on it together with cmd/shift-clicked tasks.
+  // Bulk actions include the routed task, but selection styling stays tied to
+  // explicit picks so selecting another row does not highlight the open row.
   const activeTaskId = sidebarData.activeTaskId;
   const effectiveBulkIds = useMemo(
     () => computeEffectiveBulkIds(selectedTaskIds, activeTaskId),
@@ -487,7 +487,7 @@ function SidebarMenuComponent() {
               groupedTasks={sidebarData.groupedTasks}
               activeTaskId={sidebarData.activeTaskId}
               editingTaskId={editingTaskId}
-              selectedTaskIds={effectiveBulkIds}
+              selectedTaskIds={selectedTaskIds}
               onTaskClick={handleTaskClick}
               onTaskDoubleClick={handleTaskDoubleClick}
               onTaskContextMenu={handleTaskContextMenu}

--- a/products/desktop/packages/ui/src/features/sidebar/components/items/TaskItem.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/items/TaskItem.tsx
@@ -4,6 +4,7 @@ import { parseGithubUrl } from "@posthog/git/utils";
 import type { WorkspaceMode } from "@posthog/shared";
 import { formatRelativeTimeShort } from "@posthog/shared";
 import type { TaskRunStatus } from "@posthog/shared/domain-types";
+import { writeTaskDragData } from "@posthog/ui/features/sidebar/taskDrag";
 import { SESSION_ROW_ATTRIBUTE } from "@posthog/ui/features/sidebar/useMarqueeSelection";
 import { navigateToPullRequestView } from "@posthog/ui/router/navigationBridge";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -193,7 +194,7 @@ export function TaskItem({
 
   const handleDragStart = useCallback(
     (e: React.DragEvent) => {
-      e.dataTransfer.setData("text/x-task-id", taskId);
+      writeTaskDragData(e.dataTransfer, taskId);
       // Both, always. Command Center tiles ask for `copy` and the pinned run
       // asks for `move`; a source that permits only one resolves the other
       // pairing to no drop, and the tile silently stops accepting the row.

--- a/products/desktop/packages/ui/src/features/sidebar/schemas.ts
+++ b/products/desktop/packages/ui/src/features/sidebar/schemas.ts
@@ -1,0 +1,3 @@
+import { z } from "zod";
+
+export const taskDragIdsSchema = z.array(z.string().min(1)).min(1);

--- a/products/desktop/packages/ui/src/features/sidebar/taskDrag.test.ts
+++ b/products/desktop/packages/ui/src/features/sidebar/taskDrag.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  readTaskDragData,
+  TASK_DRAG_TYPE,
+  TASK_IDS_DRAG_TYPE,
+  taskIdsForDrag,
+  writeTaskDragData,
+} from "./taskDrag";
+import { useTaskSelectionStore } from "./taskSelectionStore";
+
+describe("task drag data", () => {
+  beforeEach(() => {
+    useTaskSelectionStore.setState({
+      selectedTaskIds: [],
+      lastClickedId: null,
+    });
+  });
+
+  it("drags the full selection when the grabbed task is selected", () => {
+    expect(taskIdsForDrag("b", ["a", "b", "c"])).toEqual(["b", "a", "c"]);
+  });
+
+  it("drags only the grabbed task when it is outside the selection", () => {
+    expect(taskIdsForDrag("d", ["a", "b", "c"])).toEqual(["d"]);
+  });
+
+  it("writes the selection and reads it back in drag order", () => {
+    useTaskSelectionStore.setState({ selectedTaskIds: ["a", "b"] });
+    const payload = new Map<string, string>();
+    const setData = vi.fn((type: string, value: string) => {
+      payload.set(type, value);
+    });
+
+    writeTaskDragData({ setData }, "b");
+
+    expect(setData).toHaveBeenCalledWith(TASK_DRAG_TYPE, "b");
+    expect(setData).toHaveBeenCalledWith(
+      TASK_IDS_DRAG_TYPE,
+      JSON.stringify(["b", "a"]),
+    );
+    expect(
+      readTaskDragData({ getData: (type) => payload.get(type) ?? "" }),
+    ).toEqual(["b", "a"]);
+  });
+});

--- a/products/desktop/packages/ui/src/features/sidebar/taskDrag.ts
+++ b/products/desktop/packages/ui/src/features/sidebar/taskDrag.ts
@@ -1,0 +1,48 @@
+import { dedupeTaskIds } from "@posthog/core/sidebar/selection";
+import { taskDragIdsSchema } from "@posthog/ui/features/sidebar/schemas";
+import { useTaskSelectionStore } from "@posthog/ui/features/sidebar/taskSelectionStore";
+
+export const TASK_DRAG_TYPE = "text/x-task-id";
+export const TASK_IDS_DRAG_TYPE = "application/x-posthog-task-ids";
+
+export function taskIdsForDrag(
+  draggedTaskId: string,
+  selectedTaskIds: readonly string[],
+): string[] {
+  if (!selectedTaskIds.includes(draggedTaskId)) return [draggedTaskId];
+  return dedupeTaskIds([
+    draggedTaskId,
+    ...selectedTaskIds.filter((taskId) => taskId !== draggedTaskId),
+  ]);
+}
+
+export function writeTaskDragData(
+  dataTransfer: Pick<DataTransfer, "setData">,
+  draggedTaskId: string,
+): void {
+  const taskIds = taskIdsForDrag(
+    draggedTaskId,
+    useTaskSelectionStore.getState().selectedTaskIds,
+  );
+  dataTransfer.setData(TASK_DRAG_TYPE, draggedTaskId);
+  dataTransfer.setData(TASK_IDS_DRAG_TYPE, JSON.stringify(taskIds));
+}
+
+export function readTaskDragData(
+  dataTransfer: Pick<DataTransfer, "getData">,
+): string[] {
+  const serializedTaskIds = dataTransfer.getData(TASK_IDS_DRAG_TYPE);
+  if (serializedTaskIds) {
+    let parsed: unknown = null;
+    try {
+      parsed = JSON.parse(serializedTaskIds);
+    } catch {
+      parsed = null;
+    }
+    const result = taskDragIdsSchema.safeParse(parsed);
+    if (result.success) return dedupeTaskIds(result.data);
+  }
+
+  const taskId = dataTransfer.getData(TASK_DRAG_TYPE);
+  return taskId ? [taskId] : [];
+}


### PR DESCRIPTION
## Problem

Sidebar marquee selection highlights the open session when a person selected only another row. Dragging one selected row also drops only that row into Command Center.

## Changes

- Selection highlights now follow only explicit picks. Bulk actions still include the open session.
- Dragging a selected session now carries the full selection.
- The grabbed session uses the chosen drop target. The remaining sessions fill available tiles.
- The drag payload keeps the existing single-session value and adds a validated list for the selection.
- Screenshots are not included because the change was not rendered in an authenticated Desktop session.

## How did you test this code?

- Added drag payload and placement tests that fail when a selected session stays behind after a drop.
- Added a sidebar test that fails when the open session receives selection styling from another selection.
- Ran the four affected Vitest files, the `@posthog/ui` typecheck, Biome, and `hogli ci:preflight --fix`.
- Manual Desktop testing was not run.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation changes. This fixes existing sidebar interaction behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi used GPT-5.6 Sol in session `01a019b0-c184-7e3b-ba07-23d0c54bb5c4`.

Skills invoked: `/stacking-prs`, `/writing-ui-components`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`, and `/writing-simplified-technical-english`.