### PR TITLE
fix(desktop): enable quick ask in production

### DIFF
--- a/products/desktop/apps/code/README.md
+++ b/products/desktop/apps/code/README.md
@@ -41,6 +41,7 @@ pnpm run check:write       # Linting & typecheck
 - `⌘R` - Refresh task list
 - `⌘⇧[/]` - Switch between tabs
 - `⌘W` - Close current tab
+- `⌘⌥P` / `Ctrl+Alt+P` - Open Quick ask
 
 ### Screen recording permission in development
 

--- a/products/desktop/apps/code/src/main/quick-ask.ts
+++ b/products/desktop/apps/code/src/main/quick-ask.ts
@@ -48,7 +48,6 @@ import {
   setupQuickAskCapture,
   teardownQuickAskCapture,
 } from "./quick-ask-capture";
-import { isDevBuild } from "./utils/env";
 import { logger } from "./utils/logger";
 import { quickAskStore } from "./utils/store";
 import { attachWindowToTrpc, focusMainWindow } from "./window";
@@ -507,10 +506,6 @@ function fromPanel(event: Electron.IpcMainEvent): boolean {
 }
 
 export function setupQuickAsk(): void {
-  // Prototype: dev builds only, or explicit opt-in.
-  if (!isDevBuild() && process.env.POSTHOG_QUICK_ASK !== "1") {
-    return;
-  }
   quickAskEnabled = true;
 
   ipcMain.on(QUICK_ASK_HIDE_CHANNEL, (event) => {


### PR DESCRIPTION
## Problem

- Packaged Desktop users cannot open Quick ask because startup exits before it creates the panel and registers its shortcut.

## Changes

- Packaged Desktop builds now initialize Quick ask and its configured global shortcut.
- The Desktop keyboard shortcut list now documents the Quick ask default.
- This reuses the existing Quick ask UI, so no visual design changed.

## How did you test this code?

- Ran `pnpm --filter @posthog/code typecheck`.
- Ran `pnpm exec biome check apps/code/src/main/quick-ask.ts`.
- Not run: a packaged Desktop smoke test. This cloud environment has no macOS Desktop session.
- No test was added. The change removes an environment guard from Electron host setup.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- Documented the default Quick ask shortcut in the Desktop README.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- An agent removed the production-only Quick ask gate and documented the default shortcut.
- Skills invoked: /writing-code-comments, /writing-tests, /writing-user-facing-copy, /writing-pr-descriptions.
