### PR TITLE
fix(desktop): contain task search modal content

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/components/TaskFeedModal.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/TaskFeedModal.tsx
@@ -126,7 +126,7 @@ export function TaskFeedModal({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="overflow-visible sm:max-w-lg">
-        <DialogHeader>
+        <DialogHeader className="min-w-0">
           <DialogTitle>
             {feed ? "Edit saved search" : "Save search"}
           </DialogTitle>
@@ -135,7 +135,7 @@ export function TaskFeedModal({
             the command palette.
           </DialogDescription>
         </DialogHeader>
-        <DialogBody className="flex flex-col gap-4">
+        <DialogBody className="flex min-w-0 flex-col gap-4">
           <div className="flex flex-col gap-2">
             <div className="flex items-center justify-between gap-3">
               <label htmlFor="task-feed-query" className="font-medium text-sm">
@@ -217,7 +217,7 @@ export function TaskFeedModal({
             />
           </div>
         </DialogBody>
-        <DialogFooter>
+        <DialogFooter className="min-w-0">
           <Button variant="outline" onClick={() => onOpenChange(false)}>
             Cancel
           </Button>


### PR DESCRIPTION
## Problem

People who save task searches can see modal fields and actions extend past the dialog boundary in a narrow window.

## Changes

- The saved-search modal now keeps its header, fields, and actions within the dialog.
- Query suggestions can still extend outside the dialog when needed.
- This is a layout-only change.

![Saved-search modal remains contained in a narrow window](https://raw.githubusercontent.com/PostHog/pr-assets/6dabbf4a22b3750090a74ca11cdee5db64cb7032/2026/08/200b7877-0989-4e94-a348-d30f9eaac49a.png)

## How did you test this code?

- Ran `pnpm --dir products/desktop --filter @posthog/ui test -- TaskFeedModal.test.tsx`.
- Ran `pnpm --dir products/desktop --filter @posthog/ui typecheck`.
- Checked the Create Storybook modal at 535px and 1060px viewports. Each content row matched the dialog width.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This fixes an existing layout regression and does not change a documented workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Agent: OpenAI coding agent using pi tools.
- Skills invoked: `/writing-ui-components`, `/writing-user-facing-copy`, `/writing-tests`, and `/writing-pr-descriptions`.
- The fix uses layout constraints on the dialog rows instead of clipping the query suggestions.
