### PR TITLE
fix(tasks): forward saved feed filters

### DIFF
--- a/products/desktop/packages/api-client/src/posthog-client.test.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.test.ts
@@ -63,6 +63,31 @@ describe("PostHogAPIClient", () => {
   });
 
   it.each([
+    ["pinned", { pinned: true }, "pinned", "true"],
+    ["commented-by", { commentedBy: 17 }, "commented_by", "17"],
+    ["mentions", { mentions: 19 }, "mentions", "19"],
+  ])("sends the %s task-list filter", async (_name, options, param, value) => {
+    const fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ results: [], count: 0 }), {
+        status: 200,
+      }),
+    );
+    const client = new PostHogAPIClient(
+      "https://app.posthog.test",
+      async () => "token",
+      async () => "token",
+      42,
+      { fetch },
+    );
+
+    await client.getTasksPage(options);
+
+    const url = fetch.mock.calls[0][0] as URL;
+    expect(url.pathname).toBe("/api/projects/42/tasks/");
+    expect(url.searchParams.get(param)).toBe(value);
+  });
+
+  it.each([
     "user_message",
     "permission_response",
     "set_config_option",

--- a/products/desktop/packages/api-client/src/posthog-client.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.ts
@@ -242,6 +242,12 @@ export interface TaskListOptions {
   prState?: string;
   /** Filter by the CI rollup on the latest run's pull request (passing/failing/pending/none). */
   ciStatus?: string;
+  /** List only tasks the requesting user has pinned. */
+  pinned?: boolean;
+  /** Filter to tasks with a thread comment from this user ID. */
+  commentedBy?: number;
+  /** Filter to tasks whose thread mentions this user ID. */
+  mentions?: number;
   /** List only archived tasks; the server excludes them by default. */
   archived?: boolean;
   /** Caller-side cap for surfaces that only show the newest few. */
@@ -2372,6 +2378,18 @@ export class PostHogAPIClient {
 
     if (options?.ciStatus) {
       params.ci_status = options.ciStatus;
+    }
+
+    if (options?.pinned) {
+      params.pinned = true;
+    }
+
+    if (options?.commentedBy) {
+      params.commented_by = options.commentedBy;
+    }
+
+    if (options?.mentions) {
+      params.mentions = options.mentions;
     }
 
     if (options?.archived) {

--- a/products/desktop/packages/core/src/tasks/feedQuery.test.ts
+++ b/products/desktop/packages/core/src/tasks/feedQuery.test.ts
@@ -401,6 +401,15 @@ describe("feedQuery", () => {
       expect(plan.requests).toEqual([{ pinned: true }]);
     });
 
+    it("matches no tasks when archived is both required and excluded", () => {
+      const plan = planFeedQuery(
+        parseFeedQuery("is:archived -is:archived"),
+        context,
+      );
+      expect(plan.requests).toEqual([{}]);
+      expect(plan.matches(task())).toBe(false);
+    });
+
     it("flags -is:pinned as unsupported instead of silently ignoring it", () => {
       const plan = planFeedQuery(parseFeedQuery("-is:pinned"), context);
       expect(plan.requests).toEqual([{}]);

--- a/products/desktop/packages/core/src/tasks/feedQuery.ts
+++ b/products/desktop/packages/core/src/tasks/feedQuery.ts
@@ -841,9 +841,13 @@ export function planFeedQuery(
   }
 
   const archived = groups.get("archived");
-  if (archived && archived.positives.length > 0) {
+  if (archived) {
     // Task lists exclude archived tasks unless the query includes them.
-    server.archived = true;
+    if (archived.positives.length > 0 && archived.negatives.length > 0) {
+      predicates.push(MATCH_NONE);
+    } else if (archived.positives.length > 0) {
+      server.archived = true;
+    }
   }
 
   const pr = groups.get("pr");


### PR DESCRIPTION
## Problem

Saved-search users could see unpinned tasks because the app did not send the pin filter to the task-list API.

## Changes

- Saved searches now send pin, commenter, and mention filters to the task-list API.
- Contradictory archive filters now return no tasks.
- No screenshot: the existing saved-search UI has no visual change.

## How did you test this code?

- Added client request tests that catch saved-search filters being omitted from task-list requests.
- Added a query-planner test that catches contradictory archive filters returning results.
- Ran the desktop client and query-planner tests, type checks, formatting checks, and the backend task-filter matrix.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation update needed. No documented workflow changed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with PostHog Code tools.
- Invoked `/writing-tests` and `/writing-pr-descriptions`.
- The change forwards existing saved-search filters through the existing task-list API.
