### PR TITLE
feat(bigquery): Combine all final merges into one

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
@@ -808,9 +808,9 @@ class BigQueryClient:
     async def merge_tables(
         self,
         final: BigQueryTable,
-        stage: BigQueryTable,
+        stage: BigQueryTable | collections.abc.Iterable[BigQueryTable],
     ):
-        """Merge `stage` into `final`.
+        """Merge one or more `stage` tables into `final`.
 
         This method can execute one of two queries, depending on the type of `final`:
         When it is a `MutableTable`, then it executes a more complex `MERGE` query as it
@@ -820,31 +820,34 @@ class BigQueryClient:
 
         Arguments:
             final: The BigQuery table we are merging into.
-            stage: The BigQuery table we are merging from.
+            stage: One or more BigQuery tables we are merging from.
         """
+        tables = [stage] if isinstance(stage, BigQueryTable) else list(stage)
+        assert len(tables) > 0
+
         if final.is_mutable():
             return await self.merge_into_final_from_stage(
                 final,
-                stage,
+                tables,
             )
         else:
             return await self.insert_into_final_from_stage(
                 final,
-                stage,
+                tables,
             )
 
     async def insert_into_final_from_stage(
         self,
         final: BigQueryTable,
-        stage: BigQueryTable,
+        stage: list[BigQueryTable],
     ):
-        """Insert data from `stage` into `final`."""
+        """Insert data from one or more `stage` tables into `final`."""
         into_table_fields = ",".join(f"`{field.name}`" for field in final.fields)
 
         fields_to_cast = {
             field.name
             for field in final
-            if field.bigquery_type.name == "JSON" and stage[field.name].bigquery_type.name != "JSON"
+            if field.bigquery_type.name == "JSON" and stage[0][field.name].bigquery_type.name != "JSON"
         }
 
         # The following `REGEXP_REPLACE` functions are used to clean-up un-paired
@@ -878,13 +881,17 @@ class BigQueryClient:
 
         query = f"""
         INSERT INTO `{final.fully_qualified_name}`
-          ({into_table_fields})
-        SELECT
-          {stage_table_fields}
-        FROM `{stage.fully_qualified_name}`
+            ({into_table_fields})
         """
+        query += "\nUNION ALL\n".join(
+            f"SELECT {stage_table_fields} FROM `{table.fully_qualified_name}`" for table in stage
+        )
 
-        self.logger.info("Inserting into final table", format=format, table_id=final.name, stage_table_id=stage.name)
+        self.logger.info(
+            "Inserting into final table",
+            table_id=final.name,
+            stage_table_id=", ".join(table.name for table in stage),
+        )
         query_job = make_retryable_with_exponential_backoff(
             self.execute_query,
             retryable_exceptions=(BadRequest,),
@@ -899,14 +906,14 @@ class BigQueryClient:
     async def merge_into_final_from_stage(
         self,
         final: BigQueryTable,
-        stage: BigQueryTable,
+        stage: list[BigQueryTable],
     ):
-        """Merge two identical person model tables in BigQuery."""
+        """Merge data from one or more person model `stage` tables to `final`."""
 
         fields_to_cast = {
             field.name
             for field in final
-            if field.bigquery_type.name == "JSON" and stage[field.name].bigquery_type.name != "JSON"
+            if field.bigquery_type.name == "JSON" and stage[0][field.name].bigquery_type.name != "JSON"
         }
 
         merge_condition = "ON "
@@ -969,16 +976,26 @@ class BigQueryClient:
         if not update_clause:
             raise ValueError("Empty update clause")
 
+        inner_union_query = "\nUNION ALL\n".join(f"SELECT * FROM `{table.fully_qualified_name}`" for table in stage)
+
+        union_query = f"""
+        SELECT
+            *,
+            ROW_NUMBER() OVER (
+              PARTITION BY {",".join(field_name for field_name in final.primary_key)}
+              ORDER BY {",".join(f"{field_name} DESC" for field_name in final.version_key)}
+              ) row_num
+        FROM (
+            {inner_union_query}
+        )
+        """
+
         merge_query = f"""
         MERGE `{final.fully_qualified_name}` final
         USING (
             SELECT * FROM
             (
-              SELECT
-              *,
-              ROW_NUMBER() OVER (PARTITION BY {",".join(field_name for field_name in final.primary_key)}) row_num
-            FROM
-              `{stage.fully_qualified_name}`
+                {union_query}
             )
             WHERE row_num = 1
         ) stage
@@ -992,7 +1009,9 @@ class BigQueryClient:
             VALUES ({values});
         """
 
-        self.logger.info("Merging into final table", table_id=final.name, stage_table_id=stage.name)
+        self.logger.info(
+            "Merging into final table", table_id=final.name, stage_table_id=", ".join(table.name for table in stage)
+        )
         query_job = make_retryable_with_exponential_backoff(
             self.execute_query,
             retryable_exceptions=(BadRequest,),
@@ -1241,20 +1260,20 @@ def _make_jsonl_pipeline_transformer(table: BigQueryTable, max_file_size_bytes: 
 async def run_consumer(
     client: BigQueryClient,
     consumer_table: BigQueryTable,
-    target_table: BigQueryTable,
     model: str,
     file_format: FileFormat,
     queue: RecordBatchQueue,
     transformer: PipelineTransformer,
-    all_consumers_done: asyncio.Barrier,
     producer_task: asyncio.Task[None],
+    all_consumers_done: asyncio.Barrier,
     merge: bool,
-    merge_semaphore: asyncio.Semaphore,
+    merge_done: asyncio.Event,
     records_total: int | None = None,
 ) -> BatchExportResult:
     """Run a BigQueryConsumer until completion.
 
-    If necessary, also merge the consumer's table into the provided table.
+    Each consumer manages the lifecycle of its own stage table, so the
+    consumer waits in case a merge needs to be executed.
     """
     async with client.managed_table(
         table=consumer_table,
@@ -1278,19 +1297,33 @@ async def run_consumer(
 
         await all_consumers_done.wait()
 
-        # Only merge to final table if the upstream producer has not failed and
-        # has not been cancelled. Upstream producer must be done by now as it
-        # is part of the termination condition for consumers.
-        producer_failed = producer_task.cancelled() or producer_task.exception() is not None
-
-        if merge and not producer_failed:
-            async with merge_semaphore:
-                _ = await client.merge_tables(
-                    final=target_table,
-                    stage=managed_consumer_table,
-                )
+        if merge:
+            # Block table cleanup until merge is done.
+            await merge_done.wait()
 
     return result
+
+
+async def merge_all_consumer_tables(
+    client: BigQueryClient,
+    target_table: BigQueryTable,
+    consumer_tables: collections.abc.Iterable[BigQueryTable],
+    all_consumers_done: asyncio.Barrier,
+    producer_task: asyncio.Task[None],
+) -> None:
+
+    await all_consumers_done.wait()
+
+    # Only merge to final table if the upstream producer has not failed and
+    # has not been cancelled. Upstream producer must be done by now as it
+    # is part of the termination condition for consumers.
+    producer_failed = producer_task.cancelled() or producer_task.exception() is not None
+
+    if not producer_failed:
+        _ = await client.merge_tables(
+            final=target_table,
+            stage=consumer_tables,
+        )
 
 
 class MergeSettings(typing.NamedTuple):
@@ -1541,8 +1574,9 @@ async def insert_into_bigquery_activity_from_stage(inputs: BigQueryInsertInputs)
             file_format: typing.Literal["Parquet", "JSONLines"] = "Parquet" if can_perform_merge else "JSONLines"
 
             max_file_size_bytes_per_consumer = settings.BATCH_EXPORT_BIGQUERY_UPLOAD_CHUNK_SIZE_BYTES // max_consumers
-            all_consumers_done = asyncio.Barrier(max_consumers)
-            merge_semaphore = asyncio.Semaphore(1)
+            barrier_size = max_consumers + 1 if can_perform_merge else max_consumers
+            all_consumers_done = asyncio.Barrier(barrier_size)
+            merge_done = asyncio.Event()
 
             tasks = []
             try:
@@ -1562,7 +1596,6 @@ async def insert_into_bigquery_activity_from_stage(inputs: BigQueryInsertInputs)
                                 run_consumer(
                                     client=bq_client,
                                     consumer_table=consumer_table,
-                                    target_table=bigquery_target_table,
                                     model=model.name if isinstance(model, BatchExportModel) else "events",
                                     file_format=file_format,
                                     queue=queue,
@@ -1570,12 +1603,25 @@ async def insert_into_bigquery_activity_from_stage(inputs: BigQueryInsertInputs)
                                     all_consumers_done=all_consumers_done,
                                     producer_task=producer_task,
                                     merge=can_perform_merge,
-                                    merge_semaphore=merge_semaphore,
+                                    merge_done=merge_done,
                                     records_total=inputs.records_total if max_consumers == 1 else None,
                                 ),
                                 name=f"consumer-{index}",
                             )
                         )
+
+                    if can_perform_merge:
+                        merge_task = tg.create_task(
+                            merge_all_consumer_tables(
+                                client=bq_client,
+                                target_table=bigquery_target_table,
+                                consumer_tables=consumer_tables,
+                                all_consumers_done=all_consumers_done,
+                                producer_task=producer_task,
+                            )
+                        )
+                        merge_task.add_done_callback(lambda _: merge_done.set())
+
             except ExceptionGroup as eg:
                 has_only_one_type = len({type(exc) for exc in eg.exceptions}) == 1
                 if has_only_one_type:

--- a/products/batch_exports/backend/tests/temporal/destinations/bigquery/test_client.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/bigquery/test_client.py
@@ -108,6 +108,63 @@ async def test_create_table(fields, time_partitioning, bigquery_client, bigquery
 
 @SKIP_IF_MISSING_GOOGLE_APPLICATION_CREDENTIALS
 @pytest.mark.asyncio
+async def test_merge_tables_with_multiple_stage_tables(bigquery_client, bigquery_dataset):
+    fields = (
+        BigQueryField("id", BigQueryType("INT64", False), False),
+        BigQueryField("version", BigQueryType("INT64", False), False),
+        BigQueryField("value", BigQueryType("STRING", False), True),
+    )
+    suffix = "".join(random.choices(string.ascii_letters, k=10))
+    parents = (bigquery_client.project, bigquery_dataset.dataset_id)
+    final_table = BigQueryTable(
+        f"test_merge_final_{suffix}", fields, parents, primary_key=("id",), version_key=("version",)
+    )
+    stage_tables = [
+        BigQueryTable(
+            f"test_merge_stage_{index}_{suffix}", fields, parents, primary_key=("id",), version_key=("version",)
+        )
+        for index in range(2)
+    ]
+
+    client = BigQueryClient(bigquery_client)
+    for table in (final_table, *stage_tables):
+        await client.create_table(table)
+
+    try:
+        # Key 1 exists in final and in both stage tables: the highest version across all
+        # stage tables must win. Key 4 is newer in final than in stage: it must not be
+        # overwritten.
+        await client.execute_query(
+            f"INSERT INTO `{final_table.fully_qualified_name}` (id, version, value)"
+            " VALUES (1, 1, 'final-v1'), (4, 5, 'final-v5')"
+        )
+        await client.execute_query(
+            f"INSERT INTO `{stage_tables[0].fully_qualified_name}` (id, version, value)"
+            " VALUES (1, 2, 'stage0-v2'), (2, 1, 'stage0-only'), (4, 1, 'stage0-v1')"
+        )
+        await client.execute_query(
+            f"INSERT INTO `{stage_tables[1].fully_qualified_name}` (id, version, value)"
+            " VALUES (1, 3, 'stage1-v3'), (3, 1, 'stage1-only')"
+        )
+
+        await client.merge_tables(final=final_table, stage=stage_tables)
+
+        result = await client.execute_query(f"SELECT id, version, value FROM `{final_table.fully_qualified_name}`")
+        rows = {row["id"]: (row["version"], row["value"]) for row in result}
+
+        assert rows == {
+            1: (3, "stage1-v3"),
+            2: (1, "stage0-only"),
+            3: (1, "stage1-only"),
+            4: (5, "final-v5"),
+        }
+    finally:
+        for table in (final_table, *stage_tables):
+            await client.delete_table(table)
+
+
+@SKIP_IF_MISSING_GOOGLE_APPLICATION_CREDENTIALS
+@pytest.mark.asyncio
 @pytest.mark.parametrize("integration", ["impersonated", "key_file"], indirect=True)
 async def test_from_service_account_integration(
     integration,


### PR DESCRIPTION


<!-- This has to stand on its own: a reader who opens no files should still know why the PR is necessary and what it does. Length tracks the change, so a small diff gets a few bullets rather than a full-length body, and a section you have nothing for gets one line or "None". -->

## Problem

For multiple consumers, doing one merge per table could lead to increased resource usage in bigquery, as each merge does a full table scan. It's more efficient to just merge all the tables in one go.

<!-- Who are we building for, what are their needs, why is this important? -->
<!-- First line: what is different for a person, and who they are. A fix says what breaks; a feature says what someone can now do; a chore says who is blocked. The code path goes underneath. -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

This adds a new task that waits for all consumers and merges/inserts all tables. The impact is higher and significant on merges only, but it doesn't hurt to just do the same thing for inserts just to simplify the code. 

Coordination with the new task does get a tad more complicated: A new `asyncio.Event` is used to sync things up: Since each consumer manages its own stage table, we have to keep the consumers waiting until after the merge is done. Happy to answer questions here if there is something not clear.

There are some other random fixes here and there, I will call them out in comments below.

For single consumer batch exports, this is effectively a no-op (just that things now happen in a separate task).

<!-- For each change a person can notice, say what they will now see or do differently, not only the code path that does it. Mark the rest as mechanical so a reviewer knows nothing user-visible is hiding in it. -->

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

I had the robot review the changes, came back okay (called out the random fixes like logging format=format). It did flag that we do not have a test for the specific case of asserting the order when unioning multiple person tables, so I had it write a new test.

I ran all existing tests + the new one, and they are all passing.

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->
<!-- Don't recite pass counts for suites CI runs; the checks report those with more authority. Link the evidence instead (run, permalink, error tracking issue), and say what you did not check. Long transcripts go in a <details> block. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [x] Publish to changelog?
Yes, I think it's worth calling out for bigquery users with multiple consumers (i.e. those with large volumes of data).

## Docs update

Yeah, I think we should include this in some part of the bigquery docs just to clarify.
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

What I said above, review + the new test.
<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
     - Public artifact: nothing in this PR — code, fixtures and sample data, comments, commit messages, or this description — carries material from the agent session that isn't already public. If the work drew on a customer conversation, ticket, or log, say so here and state that the committed data is invented. Renaming people, hosts, and identifiers does not clear real material; see AGENTS.md "Public open source repo guidance".
-->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way: what changed across the session. The reason the shipped design beats the obvious alternative goes in Changes instead, where a reviewer will actually see it.
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session — that applies to every part of this PR, not just this section.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Voice: the subject of every sentence is the change, never its author. No "I", "me" or "my" anywhere in the body. "I (actually Claude)" is worse than either half: it hands the assignee an account of work they did not do. Authorship is one stated fact in the Agent context section below.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Flow and topology changes: include separate before-and-after Mermaid `flowchart` blocks with PostHog colors. This includes CI wiring, pipelines, state machines, and request paths. Use `/writing-pr-descriptions` for the palette and role mapping.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Stack instead of stuffing: if the diff holds two or more separable steps (migration then behavior, rename then rewrite), open a stack rather than one big PR. See AGENTS.md, "Stacked PRs" and /stacking-prs.
- Simplify before opening: if your agent has a behavior-preserving cleanup pass (Claude Code: `/simplify`), run it on a non-trivial diff before final tests and preflight, since it edits the tree. Skip it for small mechanical changes.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- Shape and style: invoke the `/writing-pr-descriptions` skill before writing this body. In short: lead with the effect a person sees rather than the code path behind it, make the body stand alone for a reader who opens no files, size it to the change, link evidence rather than asserting what CI already reports, then hold what's left to one fact per bullet in under 25 words. A body that got longer as bullets was not cut.
-->
