### PR TITLE
fix(inbox): keep scrolling past the first page of reports

### DIFF
--- a/products/signals/frontend/inbox/components/InboxReportList.test.tsx
+++ b/products/signals/frontend/inbox/components/InboxReportList.test.tsx
@@ -1,0 +1,111 @@
+import '@testing-library/jest-dom'
+
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+
+import { INBOX_FLAT_TAB_LIST_PARAMS } from '../logics/reportListLogic'
+import { SignalReport, SignalReportStatus } from '../types'
+import { InboxReportList, InboxReportCardProps } from './InboxReportList'
+
+// The list chrome is unrelated to paging and pulls in its own scout/filter endpoints.
+jest.mock('./shell/InboxSearchFilterBar', () => ({ InboxSearchFilterBar: () => null }))
+jest.mock('./shell/InboxBulkSelectionBar', () => ({ InboxBulkSelectionBar: () => null }))
+
+/** Fires whatever the component handed to `IntersectionObserver.observe`, as if it scrolled into view. */
+let intersectObservedElement: (() => void) | null = null
+
+function StubCard({ report }: InboxReportCardProps): JSX.Element {
+    return <div>{report.title}</div>
+}
+
+function makeReport(id: string): SignalReport {
+    return {
+        id,
+        title: `Report ${id}`,
+        summary: 'summary',
+        status: SignalReportStatus.READY,
+        total_weight: 0,
+        signal_count: 1,
+        relevant_user_count: null,
+        artefact_count: 0,
+        is_suggested_reviewer: false,
+        priority: 'P2',
+        source_products: ['error_tracking'],
+        created_at: '2026-06-11T10:00:00Z',
+        updated_at: '2026-06-11T10:00:00Z',
+    } as SignalReport
+}
+
+describe('InboxReportList', () => {
+    let requestedOffsets: (string | null)[]
+
+    beforeAll(() => {
+        // jsdom has no IntersectionObserver; the infinite-scroll sentinel needs one.
+        global.IntersectionObserver = class {
+            constructor(private callback: IntersectionObserverCallback) {}
+            observe(): void {
+                intersectObservedElement = () =>
+                    this.callback([{ isIntersecting: true } as IntersectionObserverEntry], this as any)
+            }
+            unobserve(): void {}
+            disconnect(): void {}
+        } as unknown as typeof IntersectionObserver
+    })
+
+    beforeEach(() => {
+        intersectObservedElement = null
+        requestedOffsets = []
+        useMocks({
+            get: {
+                // Reviewer scope loads alongside the list; an empty map keeps it out of the way.
+                '/api/projects/:team_id/signals/reports/available_reviewers': {},
+                '/api/projects/:team_id/signals/reports/': ({ request }) => {
+                    const { searchParams } = new URL(request.url)
+                    const offset = searchParams.get('offset')
+                    const limit = searchParams.get('limit')
+                    // The tab badge fires a separate count-only request; don't count it as a page.
+                    if (limit !== '1') {
+                        requestedOffsets.push(offset)
+                    }
+                    const page = offset === '0' || offset === null ? '1' : '2'
+                    return [
+                        200,
+                        {
+                            count: 277,
+                            // A non-null `next` is what tells the list there are more pages.
+                            next: 'http://localhost/api/projects/997/signals/reports/?offset=50',
+                            previous: null,
+                            results: [makeReport(`page-${page}`)],
+                        },
+                    ]
+                },
+            },
+        })
+        initKeaTests()
+    })
+
+    afterEach(cleanup)
+
+    it('keeps paging once the sentinel scrolls into view', async () => {
+        render(
+            <InboxReportList
+                tabKey="reports"
+                listParams={INBOX_FLAT_TAB_LIST_PARAMS.reports}
+                Card={StubCard}
+                emptyState={{ content: <div>empty</div> }}
+            />
+        )
+
+        await screen.findByText('Report page-1')
+        // The sentinel only enters the DOM after the first page lands, so the observer has to
+        // attach then — not on mount, when there is nothing to observe.
+        await waitFor(() => expect(intersectObservedElement).not.toBeNull())
+
+        act(() => intersectObservedElement!())
+
+        await screen.findByText('Report page-2')
+        expect(requestedOffsets).toEqual(['0', '1'])
+    })
+})

--- a/products/signals/frontend/inbox/components/InboxReportList.test.tsx
+++ b/products/signals/frontend/inbox/components/InboxReportList.test.tsx
@@ -35,7 +35,7 @@ function makeReport(id: string): SignalReport {
         source_products: ['error_tracking'],
         created_at: '2026-06-11T10:00:00Z',
         updated_at: '2026-06-11T10:00:00Z',
-    } as SignalReport
+    } satisfies SignalReport
 }
 
 describe('InboxReportList', () => {

--- a/products/signals/frontend/inbox/components/InboxReportList.tsx
+++ b/products/signals/frontend/inbox/components/InboxReportList.tsx
@@ -1,5 +1,5 @@
 import { BindLogic, useActions, useValues } from 'kea'
-import { ComponentType, JSX, useEffect, useRef } from 'react'
+import { ComponentType, JSX, useCallback, useEffect, useRef } from 'react'
 
 import { captureInboxReportsImpressed, captureInboxViewed } from '../inboxAnalytics'
 import { inboxSceneLogic } from '../inboxSceneLogic'
@@ -53,7 +53,6 @@ function InboxReportListInner({ tabKey, Card, emptyState }: InboxReportListProps
     // `Inbox viewed` and then suppresses the real one when the user navigates back to the list.
     const { selectedReportId, selectedScoutSkillName, isScratchpadOpen, isFindingsOpen } = useValues(inboxSceneLogic)
     const listVisible = !selectedReportId && !selectedScoutSkillName && !isScratchpadOpen && !isFindingsOpen
-    const sentinelRef = useRef<HTMLDivElement>(null)
 
     // Fire `Inbox viewed` once per tab mount, the first time its list settles while visible.
     const viewedFiredRef = useRef(false)
@@ -111,8 +110,8 @@ function InboxReportListInner({ tabKey, Card, emptyState }: InboxReportListProps
         })
     }, [listVisible, isLoaded, totalCount, reports, tabKey, loadedQueryKey, loadedContext])
 
-    // Read fresh state at intersection time via refs so the observer is created once and not
-    // rebuilt twice per page fetch (`hasMore`/`reportsResponseLoading` both flip during a load).
+    // Read fresh state at intersection time via refs so the observer isn't rebuilt twice per page
+    // fetch (`hasMore`/`reportsResponseLoading` both flip during a load).
     const hasMoreRef = useRef(hasMore)
     hasMoreRef.current = hasMore
     const loadingRef = useRef(reportsResponseLoading)
@@ -122,23 +121,32 @@ function InboxReportListInner({ tabKey, Card, emptyState }: InboxReportListProps
         ensureLoaded()
     }, [ensureLoaded])
 
-    useEffect(() => {
-        const el = sentinelRef.current
-        if (!el) {
-            return
-        }
-        const observer = new IntersectionObserver(
-            (entries) => {
-                if (entries[0]?.isIntersecting && hasMoreRef.current && !loadingRef.current) {
-                    loadMore()
-                }
-            },
-            // Generous prefetch margin so the next page lands well before the user reaches the bottom.
-            { rootMargin: '1500px' }
-        )
-        observer.observe(el)
-        return () => observer.disconnect()
-    }, [loadMore])
+    // A callback ref, not an effect over `sentinelRef`: the sentinel only enters the DOM once the
+    // first page has landed and `hasMore` is true, which is after a mount-only effect has already
+    // run and found nothing to observe. Attaching as the node mounts is what keeps paging alive.
+    const observerRef = useRef<IntersectionObserver | null>(null)
+    const sentinelRef = useCallback(
+        (el: HTMLDivElement | null) => {
+            observerRef.current?.disconnect()
+            observerRef.current = null
+            if (!el) {
+                return
+            }
+            const observer = new IntersectionObserver(
+                (entries) => {
+                    if (entries[0]?.isIntersecting && hasMoreRef.current && !loadingRef.current) {
+                        loadMore()
+                    }
+                },
+                // Generous prefetch margin so the next page lands well before the user reaches the bottom.
+                { rootMargin: '1500px' }
+            )
+            observer.observe(el)
+            observerRef.current = observer
+        },
+        [loadMore]
+    )
+    useEffect(() => () => observerRef.current?.disconnect(), [])
 
     // Skeleton while a tab we know is non-empty loads its first page.
     const showSkeleton = !isLoaded && (reportsResponseLoading || (count ?? 0) > 0)


### PR DESCRIPTION
## Problem

Anyone scrolling an inbox tab hits a wall after the first page. The list stops loading and looks like it holds ~50 reports, even when the tab badge says there are hundreds.

Every flat tab is affected — Pull requests, Reports, Not actionable, and Archived all share `InboxReportList`.

The infinite-scroll sentinel only renders once a page has landed and `hasMore` is true. The `IntersectionObserver` was attached from a mount-only effect whose dependency, a kea action, never changes identity. At mount the sentinel is not in the DOM, so the effect found nothing to observe and never ran again.

## Changes

- Scrolling an inbox tab now keeps appending pages until the list is exhausted.
- The observer attaches from a callback ref, so it binds as the sentinel enters the DOM rather than on a mount that predates it. Refs still carry `hasMore` and the loading flag, so the observer is not rebuilt per fetch.

## How did you test this code?

Added `InboxReportList.test.tsx`, which renders the Reports tab against a mocked paginated endpoint, fires the observed sentinel, and asserts a second page is requested and rendered. It catches the regression this PR fixes: reverting the component leaves the sentinel unobserved and the test fails on the first page.

Ran the signals inbox Jest suite and the frontend typecheck locally. No manual browser testing was done.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Reported from a Slack thread where a tab's scroll stopped well short of its badge count. Investigation started from the reports list component and its kea logic, checking page size and the `next`-link plumbing before landing on the observer attachment.

Adding `hasMore` to the effect's dependency array was the smaller fix and matches nearby precedent in `ProjectsGrid`. The callback ref was chosen instead because it makes the observer's lifetime follow the sentinel node, which removes the failure mode rather than working around it.

Written with the PostHog Slack app (Claude Code). No repo skills were invoked.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1787139266177009)*
