### PR TITLE
chore(devex): add posthog/libs with tach-driven test selection

### DIFF
--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -352,6 +352,10 @@ jobs:
                         - 'common/migration_utils/**'
                         - 'common/plugin_transpiler/**'
                         - 'posthog/**/*'
+                        # Internal libs are tach nodes whose dependents are declared, so
+                        # turbo-discover selects their own tests and their dependents'
+                        # tests. They must not force the full Django suite.
+                        - '!posthog/libs/**'
                         - bin/build-schema-latest-versions.py
                         - bin/build-taxonomy-json.py
                         - bin/check_uv_python_compatibility.py
@@ -1995,6 +1999,7 @@ jobs:
                     pytest -v --tb=short --reuse-db -o junit_duration_report=call $full_targets -m "not async_migrations" \
                         --ignore=posthog/temporal \
                         --ignore=posthog/dags \
+                        --ignore=posthog/libs \
                         --ignore=common/hogvm/python/test \
                         --ignore=posthog/test/repo_invariants \
                         "${full_ignores[@]}" \

--- a/.github/scripts/trunk-impacted-targets.js
+++ b/.github/scripts/trunk-impacted-targets.js
@@ -19,7 +19,7 @@
 // failed diff in the workflow, which never reaches this script. That is a
 // different statement from "everything": it means "unknown".
 //
-// The bias is relaxed in exactly two places, both bounded by what one PR can
+// The bias is relaxed in exactly three places, all bounded by what one PR can
 // name in another. The conflict that lanes exist to prevent is semantic rather
 // than textual, because a textual one would force a rebase and a retest: PR A
 // renames a facade function and updates every current caller, PR B adds a new
@@ -62,6 +62,15 @@
 //      tach.toml means every member reaches every other, so any seed inside it
 //      expanded to the whole backend and the cascade could not distinguish
 //      products at all.
+//
+//   3. A change to an internal lib under posthog/libs/<name>/ claims the lanes
+//      of the modules that declare it, rather than every Python lane the rest
+//      of posthog/ claims. A lib is a tach module with `depends_on = []`, so
+//      `tach check` forces every importer, posthog and ee included, to list it,
+//      and the declarations bound the importer set the same way they do for a
+//      product. A dependent that is not a product or another lib is core, which
+//      keeps the full widening. A lib tach does not declare at all is
+//      unconstrained and widens to everything.
 //
 // That bias is the opposite of the one in ci-*.yml path filters. Those filters
 // decide which tests to run, where an over-broad match wastes runner minutes
@@ -1465,6 +1474,25 @@ function computeTargets(changedFiles, context) {
             continue
         }
 
+        // An internal lib is a tach module of its own, unlike the rest of
+        // posthog/, so its importers are declared and the lane can follow them
+        // instead of taking every backend lane. Everything in the directory
+        // follows the lib: its package.json and turbo.json define the task that
+        // runs its tests, and its tests read the same symbols an importer does.
+        // Its markdown never reaches here, the prose rule above takes it.
+        if (top === 'posthog' && segments[1] === 'libs' && segments.length > 2) {
+            const lanes = internalLibLanes(segments[2], tachGraph, products)
+            if (lanes === null) {
+                return everything(context)
+            }
+            if (lanes.widen) {
+                allPyProducts()
+            }
+            for (const product of lanes.products) {
+                targets.add(pyProduct(product))
+            }
+            continue
+        }
         if (top === 'posthog' || (top === 'ee' && segments[1] !== 'frontend')) {
             allPyProducts()
             continue
@@ -1647,8 +1675,8 @@ function computeTargets(changedFiles, context) {
     //
     // The seeds are the products whose contract surface changed, plus any
     // product whose own declarations changed, and the dependents are one hop
-    // deep. See the two numbered narrowings at the top of this file for what
-    // that gives up.
+    // deep. See narrowings 1 and 2 at the top of this file for what that gives
+    // up.
     if (cascadeSeeds.size > 0) {
         const dependents = tachDependentProducts([...cascadeSeeds], tachGraph)
         if (dependents === null) {
@@ -1728,11 +1756,83 @@ function tachDependentProducts(changedProducts, tachGraph) {
     }
 }
 
+const TACH_PRODUCT_MODULE_PREFIX = 'products.'
+const TACH_LIB_MODULE_PREFIX = 'posthog.libs.'
+
+// The lanes a change under posthog/libs/<name>/ claims, or null when the lib's
+// importer set cannot be bounded and the caller has to widen to everything.
+// `widen` asks for every Python lane; `products` are the product lanes to add.
+//
+// Walking through a dependent lib is required rather than optional: a lib that
+// imports this one can re-export its symbols, so that lib's own importers can
+// name the changed symbols without ever listing the changed lib themselves.
+// Product dependents are direct importers only, which is narrowing 2 at the top
+// of this file and carries the same accepted risk. A dependent that is neither
+// a product nor a lib is posthog, ee, or a common.* module, none of which has a
+// bounded set of readers, so it takes every Python lane.
+//
+// This is sound against a PR that adds a new importer while another PR changes
+// the lib: `tach check` fails until the new importer is declared in tach.toml,
+// and tach.toml is a tripwire mapped to the python domain, which claims every
+// Python lane. So the PR adding the importer overlaps every lane set this
+// function can return.
+function internalLibLanes(libName, tachGraph, products) {
+    if (!tachGraph || !tachGraph.reverse || !tachGraph.libModules) {
+        return null
+    }
+    const seed = `${TACH_LIB_MODULE_PREFIX}${libName}`
+    if (!tachGraph.libModules.has(seed)) {
+        return null
+    }
+    const dependentProducts = new Set()
+    let widen = false
+    const visited = new Set([seed])
+    const queue = [seed]
+    while (queue.length > 0) {
+        for (const dependent of tachGraph.reverse.get(queue.shift()) || []) {
+            if (visited.has(dependent)) {
+                continue
+            }
+            visited.add(dependent)
+            if (dependent.startsWith(TACH_LIB_MODULE_PREFIX)) {
+                queue.push(dependent)
+                continue
+            }
+            if (!dependent.startsWith(TACH_PRODUCT_MODULE_PREFIX)) {
+                widen = true
+                continue
+            }
+            const product = dependent.slice(TACH_PRODUCT_MODULE_PREFIX.length).replace(/-/g, '_')
+            // A product tach names but products/ does not hold has no lane to
+            // claim, so there is nothing narrower to report than everything.
+            // Same answer the product rule gives an unknown product directory.
+            if (!products.includes(product)) {
+                return null
+            }
+            dependentProducts.add(product)
+        }
+    }
+    // No product dependent leaves nothing to claim, either because core is the
+    // only importer or because nothing declares the lib yet. Both take the lanes
+    // the rest of posthog/ takes rather than leaving the target set empty, which
+    // would read to Trunk as "overlaps nothing". A lib nothing imports should
+    // not exist in the first place.
+    if (dependentProducts.size === 0) {
+        widen = true
+    }
+    return { products: [...dependentProducts], widen }
+}
+
 function loadTachGraph(repoRoot) {
     try {
-        const { parseTachModules, tachDependents } = require('./turbo-discover')
+        const { parseTachModules, parseTachDependents, internalLibModulePaths, tachDependents } = require('./turbo-discover')
         const text = fs.readFileSync(path.join(repoRoot, 'tach.toml'), 'utf8')
-        return { graph: parseTachModules(text), tachDependents }
+        return {
+            graph: parseTachModules(text),
+            reverse: parseTachDependents(text),
+            libModules: new Set(internalLibModulePaths(text)),
+            tachDependents,
+        }
     } catch (error) {
         console.error(`tach.toml graph unavailable (${error.message}); backend changes widen to all products`)
         return null

--- a/.github/scripts/trunk-impacted-targets.test.js
+++ b/.github/scripts/trunk-impacted-targets.test.js
@@ -39,7 +39,7 @@ const {
     RUST,
     UNIVERSAL,
 } = require('./trunk-impacted-targets')
-const { parseTachModules, tachDependents } = require('./turbo-discover')
+const { internalLibModulePaths, parseTachDependents, parseTachModules, tachDependents } = require('./turbo-discover')
 
 const CONTEXT = {
     products: ['alpha', 'beta', 'gamma'],
@@ -537,6 +537,7 @@ test('an unmapped path widens rather than yielding an empty target set', () => {
 test('every target the rules can emit appears in the enumerated universe', () => {
     const everyRule = [
         'posthog/models/team.py',
+        'posthog/libs/dates/parse.py',
         'ee/settings.py',
         'ee/frontend/x.tsx',
         'frontend/src/index.tsx',
@@ -1159,6 +1160,147 @@ test('an unavailable tach graph widens backend changes instead of narrowing', ()
     const targets = computeTargets(['products/alpha/backend/api.py'], noTach)
     assert.equal(targets.includes('py:core'), true)
     assert.equal(targets.includes('py:product:gamma'), true)
+})
+
+// --- Internal libs under posthog/libs/ ---
+
+// Two underscore-named products join the synthetic set here, because a lib's
+// dependents are read straight out of tach module paths and the underscore is
+// where a name conversion can go wrong.
+const LIB_CONTEXT = {
+    ...CONTEXT,
+    products: [...CONTEXT.products, 'legal_documents', 'stamphog'],
+}
+
+const LIB_EVERYTHING = allKnownTargets(LIB_CONTEXT)
+const LIB_ALL_PY = ['py:core', ...LIB_CONTEXT.products.map((product) => `py:product:${product}`)].sort()
+
+function libContext(toml) {
+    return {
+        ...LIB_CONTEXT,
+        tachGraph: {
+            graph: parseTachModules(toml),
+            reverse: parseTachDependents(toml),
+            libModules: new Set(internalLibModulePaths(toml)),
+            tachDependents,
+        },
+    }
+}
+
+// The whole point of the lib layout: a lib is its own tach module, so unlike
+// the rest of posthog/ its importers are declared and the lane can name them.
+test('a lib change claims the lanes of the products that declare it', () => {
+    const context = libContext(`
+[[modules]]
+path = "posthog.libs.dates"
+depends_on = []
+
+[[modules]]
+path = "products.legal_documents"
+depends_on = ["posthog.libs.dates"]
+
+[[modules]]
+path = "products.stamphog"
+depends_on = ["posthog.libs.dates"]
+
+[[modules]]
+path = "products.alpha"
+depends_on = []
+`)
+    // The lib's own declarations and tests read the same symbols an importer
+    // does, so every file in the directory takes the same lanes. Its markdown
+    // is prose, as it is anywhere else in the repo.
+    for (const file of [
+        'posthog/libs/dates/parse.py',
+        'posthog/libs/dates/package.json',
+        'posthog/libs/dates/turbo.json',
+        'posthog/libs/dates/test_parse.py',
+    ]) {
+        assert.deepEqual(computeTargets([file], context), ['py:product:legal_documents', 'py:product:stamphog'], file)
+    }
+    assert.deepEqual(computeTargets(['posthog/libs/dates/README.md'], context), ['prose'])
+})
+
+// A lib that imports another can re-export its symbols, so the importers of the
+// wrapper can name the changed symbols without declaring the changed lib.
+test("a lib change walks through a dependent lib to that lib's products", () => {
+    const context = libContext(`
+[[modules]]
+path = "posthog.libs.dates"
+depends_on = []
+
+[[modules]]
+path = "posthog.libs.calendars"
+depends_on = ["posthog.libs.dates"]
+
+[[modules]]
+path = "products.beta"
+depends_on = ["posthog.libs.calendars"]
+`)
+    assert.deepEqual(computeTargets(['posthog/libs/dates/parse.py'], context), ['py:product:beta'])
+})
+
+// posthog and ee have no bounded set of readers, so a lib either of them
+// declares is back to the radius the rest of posthog/ has.
+test('a lib declared by core claims every backend lane', () => {
+    const context = libContext(`
+[[modules]]
+path = "posthog.libs.dates"
+depends_on = []
+
+[[modules]]
+path = "posthog"
+depends_on = ["posthog.libs.dates"]
+
+[[modules]]
+path = "products.beta"
+depends_on = ["posthog.libs.dates"]
+`)
+    assert.deepEqual(computeTargets(['posthog/libs/dates/parse.py'], context), LIB_ALL_PY)
+})
+
+// Nothing bounds who may import a lib tach does not declare, and the missing
+// declaration also means turbo-discover runs no tests for it, so the change is
+// as unclassified as a brand new tree.
+test('a lib with no tach module widens to every known target', () => {
+    const context = libContext(`
+[[modules]]
+path = "products.beta"
+depends_on = []
+`)
+    assert.deepEqual(computeTargets(['posthog/libs/dates/parse.py'], context), LIB_EVERYTHING)
+})
+
+// Declared but imported by nothing: there is no importer set to narrow to, so
+// the lane stays as wide as core's rather than collapsing to nothing.
+test('a lib nothing declares claims every backend lane', () => {
+    const context = libContext(`
+[[modules]]
+path = "posthog.libs.dates"
+depends_on = []
+
+[[modules]]
+path = "products.beta"
+depends_on = []
+`)
+    assert.deepEqual(computeTargets(['posthog/libs/dates/parse.py'], context), LIB_ALL_PY)
+})
+
+// The lib rule runs before the generic posthog/ rule, so it has to match only
+// the lib subtree. A core file matching it would hand core a product's lane.
+test('the lib rule leaves the rest of posthog on every backend lane', () => {
+    const context = libContext(`
+[[modules]]
+path = "posthog.libs.dates"
+depends_on = ["products.beta"]
+
+[[modules]]
+path = "products.beta"
+depends_on = []
+`)
+    for (const file of ['posthog/foo.py', 'posthog/models/team.py', 'posthog/libs.py']) {
+        assert.deepEqual(computeTargets([file], context), LIB_ALL_PY, file)
+    }
 })
 
 // Core changes have to overlap every leaf in their domain, because set

--- a/.github/scripts/turbo-discover-cascade.test.js
+++ b/.github/scripts/turbo-discover-cascade.test.js
@@ -1,14 +1,23 @@
 // Run with: node --test .github/scripts/turbo-discover-cascade.test.js
 //
 // Unit tests for the dependent-cascade logic in turbo-discover.js:
-// parseTachModules, tachDependents. Uses a synthetic graph throughout —
-// never asserts against the real tach.toml, which would turn into a
-// change-detector test that breaks on every unrelated dependency edit.
+// parseTachModules, tachDependents, and the internal-lib cascade. Uses a
+// synthetic graph throughout — never asserts against the real tach.toml, which
+// would turn into a change-detector test that breaks on every unrelated
+// dependency edit.
 
 const test = require('node:test')
 const assert = require('node:assert/strict')
 
-const { parseTachModules, tachDependents } = require('./turbo-discover')
+const {
+    parseTachModules,
+    parseTachDependents,
+    tachDependents,
+    checkInternalLibConsistency,
+    internalLibDependents,
+    internalLibPackageToModule,
+    buildMatrix,
+} = require('./turbo-discover')
 
 test('normalization round-trip: dashed input resolves against underscored tach names and returns dashed output', () => {
     const toml = `
@@ -263,4 +272,207 @@ layer = "modules"
     const graph = parseTachModules(toml)
     assert.deepEqual(graph.get('a'), ['b'])
     assert.equal(graph.has('no_deps'), false)
+})
+
+// --- Internal libs (posthog/libs/<name>) as cascade sources ---
+//
+// An internal lib is a tach module, so its consumers are declared in tach.toml
+// and enforced by `tach check`. The cascade reads those declarations instead of
+// scanning imports, and it has to see consumers outside products/ too, which
+// the product graph deliberately drops.
+
+test('internal lib package names map to their tach module, with dashes becoming underscores', () => {
+    assert.equal(internalLibPackageToModule('@posthog/lib-probe'), 'posthog.libs.probe')
+    assert.equal(internalLibPackageToModule('@posthog/lib-slack-digest'), 'posthog.libs.slack_digest')
+})
+
+test('fail closed: a package name outside the @posthog/lib-<name> convention throws rather than inventing a module', () => {
+    assert.throws(() => internalLibPackageToModule('@posthog/owners'), /@posthog\/lib-/)
+    assert.throws(() => internalLibPackageToModule('@posthog/lib-'), /@posthog\/lib-/)
+    assert.throws(() => internalLibPackageToModule('@acme/lib-probe'), /@posthog\/lib-/)
+    assert.throws(() => internalLibPackageToModule('@posthog/lib-Probe'), /@posthog\/lib-/)
+})
+
+test('reverse edges cover every module path as written, products and core and libs alike', () => {
+    const toml = `
+[[modules]]
+path = "<root>"
+depends_on = []
+layer = "modules"
+
+[[modules]]
+path = "posthog.libs.probe"
+depends_on = []
+layer = "modules"
+
+[[modules]]
+path = "posthog"
+depends_on = ["posthog.libs.probe"]
+layer = "modules"
+
+[[modules]]
+path = "products.stamphog"
+depends_on = ["posthog", "posthog.libs.probe"]
+layer = "modules"
+
+[[modules]]
+path = "posthog.libs.other"
+depends_on = ["posthog.libs.probe"]
+layer = "modules"
+`
+    const reverse = parseTachDependents(toml)
+    assert.deepEqual(reverse.get('posthog.libs.probe').sort(), ['posthog', 'posthog.libs.other', 'products.stamphog'])
+    assert.deepEqual(reverse.get('posthog'), ['products.stamphog'])
+    assert.equal(reverse.has('posthog.libs.other'), false)
+})
+
+test('reverse edges survive a comment carrying a bracket inside depends_on', () => {
+    const toml = `
+[[modules]]
+path = "products.a"
+depends_on = [
+    "posthog.libs.probe",
+    # Facade-only (enforced by c's [[interfaces]] block): a queues c's work.
+    "products.c",
+]
+layer = "modules"
+`
+    const reverse = parseTachDependents(toml)
+    assert.deepEqual(reverse.get('posthog.libs.probe'), ['products.a'])
+    assert.deepEqual(reverse.get('products.c'), ['products.a'])
+})
+
+test('an internal lib reaches its declared product consumers as dashed product ids', () => {
+    const toml = `
+[[modules]]
+path = "posthog.libs.probe"
+depends_on = []
+layer = "modules"
+
+[[modules]]
+path = "products.data_warehouse"
+depends_on = ["posthog.libs.probe"]
+layer = "modules"
+`
+    const result = internalLibDependents(['posthog.libs.probe'], parseTachDependents(toml))
+    assert.deepEqual(result, { products: ['data-warehouse'], core: [], libs: [] })
+})
+
+test('a lib depending on a lib is walked transitively, and the seed is not reported as its own dependent', () => {
+    const toml = `
+[[modules]]
+path = "posthog.libs.probe"
+depends_on = []
+layer = "modules"
+
+[[modules]]
+path = "posthog.libs.middle"
+depends_on = ["posthog.libs.probe"]
+layer = "modules"
+
+[[modules]]
+path = "posthog.libs.outer"
+depends_on = ["posthog.libs.middle"]
+layer = "modules"
+
+[[modules]]
+path = "products.stamphog"
+depends_on = ["posthog.libs.outer"]
+layer = "modules"
+`
+    const result = internalLibDependents(['posthog.libs.probe'], parseTachDependents(toml))
+    assert.deepEqual(result.libs, ['posthog.libs.middle', 'posthog.libs.outer'])
+    assert.deepEqual(result.products, ['stamphog'])
+    assert.deepEqual(internalLibDependents(['posthog.libs.probe', 'posthog.libs.middle'], parseTachDependents(toml)).libs, ['posthog.libs.outer'])
+})
+
+test('a core dependent is reported by module path, which is what forces Django to run', () => {
+    const toml = `
+[[modules]]
+path = "posthog.libs.probe"
+depends_on = []
+layer = "modules"
+
+[[modules]]
+path = "posthog"
+depends_on = ["posthog.libs.probe"]
+layer = "modules"
+
+[[modules]]
+path = "common.hogvm"
+depends_on = ["posthog.libs.probe"]
+layer = "modules"
+
+[[modules]]
+path = "<root>"
+depends_on = ["posthog.libs.probe"]
+layer = "modules"
+`
+    const result = internalLibDependents(['posthog.libs.probe'], parseTachDependents(toml))
+    assert.deepEqual(result.core, ['<root>', 'common.hogvm', 'posthog'])
+    assert.deepEqual(result.products, [])
+})
+
+// Products and core are terminals: the product graph closes over product
+// dependents separately, and a core dependent already means the full suite. A
+// walk that continued through them would reach the whole repo from any lib.
+test('the walk stops at products and core rather than continuing through them', () => {
+    const toml = `
+[[modules]]
+path = "posthog.libs.probe"
+depends_on = []
+layer = "modules"
+
+[[modules]]
+path = "products.stamphog"
+depends_on = ["posthog.libs.probe"]
+layer = "modules"
+
+[[modules]]
+path = "products.downstream"
+depends_on = ["products.stamphog"]
+layer = "modules"
+
+[[modules]]
+path = "posthog"
+depends_on = ["posthog.libs.probe"]
+layer = "modules"
+
+[[modules]]
+path = "ee"
+depends_on = ["posthog"]
+layer = "modules"
+`
+    const result = internalLibDependents(['posthog.libs.probe'], parseTachDependents(toml))
+    assert.deepEqual(result.products, ['stamphog'])
+    assert.deepEqual(result.core, ['posthog'])
+})
+
+// Half a declaration under-tests silently in both directions, so discovery
+// fails instead of running with it.
+test('a tach lib module with no workspace package throws, naming the package to add', () => {
+    assert.throws(
+        () => checkInternalLibConsistency(['posthog.libs.probe', 'posthog.libs.slack_digest'], ['posthog.libs.probe']),
+        /tach module posthog\.libs\.slack_digest has no @posthog\/lib-slack-digest workspace package/
+    )
+})
+
+test('a lib workspace package with no tach module throws, naming the module to add', () => {
+    assert.throws(
+        () => checkInternalLibConsistency(['posthog.libs.probe'], ['posthog.libs.probe', 'posthog.libs.slack_digest']),
+        /workspace package @posthog\/lib-slack-digest has no posthog\.libs\.slack_digest module in tach\.toml/
+    )
+})
+
+test('matching sets pass, including the case where the repo has no internal libs at all', () => {
+    checkInternalLibConsistency(['posthog.libs.probe', 'posthog.libs.slack_digest'], ['posthog.libs.slack_digest', 'posthog.libs.probe'])
+    checkInternalLibConsistency([], [])
+})
+
+test('internal libs get their own matrix entry, filtered by lib package rather than product package', () => {
+    const matrix = buildMatrix([], null, ['posthog.libs.probe', 'posthog.libs.slack_digest'])
+    assert.deepEqual(matrix, [
+        { group: 'lib: probe', filters: '--filter=@posthog/lib-probe', pytest_args: '' },
+        { group: 'lib: slack-digest', filters: '--filter=@posthog/lib-slack-digest', pytest_args: '' },
+    ])
 })

--- a/.github/scripts/turbo-discover.js
+++ b/.github/scripts/turbo-discover.js
@@ -9,6 +9,15 @@
 // Products without contract-check are non-isolated: any change in them
 // triggers the full test suite (all products + Django).
 //
+// Internal libs are the other kind of workspace package with a backend:test
+// task: plain Python packages under posthog/libs/<name>/, imported as
+// posthog.libs.<name>. Because tach's source root resolves them, each one is a
+// real tach module and every consumer has to list it in depends_on for
+// `tach check` to pass, so their dependents are declared and enforced and
+// tach.toml answers who they are. They do become matrix entries: a lib's own
+// tests only exist as its workspace package's backend:test task, so the product
+// matrix is what runs them, one entry per lib.
+//
 // Products under SMALL_THRESHOLD duration get grouped into one matrix entry
 // to avoid spinning up a full Docker stack for a handful of tests.
 // Durations come from .test_durations (maintained by pytest-split).
@@ -18,7 +27,7 @@
 //         SCHEMA_CHANGED env var ("true"/"false") — when set and LEGACY_CHANGED
 //         is false, schema-impact.js narrows the matrix to products that
 //         depend on the affected posthog.schema types.
-// Output: JSON on stdout: { matrix, run_legacy, django_shards }
+// Output: JSON on stdout: { matrix, run_legacy, django_shards, internal_libs }
 //         Diagnostics on stderr
 
 const { execFileSync } = require('child_process')
@@ -123,20 +132,78 @@ function parseAffectedTasks(raw) {
     return JSON.parse(raw).data.affectedTasks.items
 }
 
+const PRODUCT_PACKAGE_PREFIX = '@posthog/products-'
+const INTERNAL_LIB_PACKAGE_PREFIX = '@posthog/lib-'
+const TACH_INTERNAL_LIB_PREFIX = 'posthog.libs.'
+
+function isProductPackage(name) {
+    return name.startsWith(PRODUCT_PACKAGE_PREFIX)
+}
+
+function isInternalLibPackage(name) {
+    return name.startsWith(INTERNAL_LIB_PACKAGE_PREFIX)
+}
+
 function packageToProduct(pkg) {
-    return pkg.replace('@posthog/products-', '')
+    return pkg.replace(PRODUCT_PACKAGE_PREFIX, '')
+}
+
+// An internal lib package @posthog/lib-<name> is the tach module
+// posthog.libs.<name>. A name this convention can't map throws rather than
+// returning a guess: a module path nothing declares has no dependents in
+// tach.toml, so a bad mapping reads as "no consumer to test" instead of
+// erroring.
+function internalLibPackageToModule(pkg) {
+    const name = pkg.startsWith(INTERNAL_LIB_PACKAGE_PREFIX) ? pkg.slice(INTERNAL_LIB_PACKAGE_PREFIX.length) : ''
+    if (!/^[a-z0-9][a-z0-9-]*$/.test(name)) {
+        throw new Error(
+            `cannot map package '${pkg}' to a tach module — internal lib packages must be named @posthog/lib-<name> with a lowercase, dashed name`
+        )
+    }
+    return `${TACH_INTERNAL_LIB_PREFIX}${name.replace(/-/g, '_')}`
+}
+
+function internalLibModuleToName(module) {
+    return module.slice(TACH_INTERNAL_LIB_PREFIX.length).replace(/_/g, '-')
 }
 
 function getIsolatedProducts(contractTasks) {
-    return new Set(contractTasks.map((t) => packageToProduct(t.package)))
+    return new Set(contractTasks.map((t) => t.package).filter(isProductPackage).map(packageToProduct))
 }
 
 function getAffectedTaskProducts(tasks) {
-    return [...new Set(tasks.map((t) => packageToProduct(t.package.name)))].sort()
+    return [...new Set(tasks.map((t) => t.package.name).filter(isProductPackage).map(packageToProduct))].sort()
+}
+
+// The matrix filters and the cascades below only understand two kinds of
+// workspace package. Anything else carrying a backend:test task would fall out
+// of every filter and quietly run no tests at all, so name it and fail the run.
+function assertKnownBackendTestPackages(names) {
+    for (const name of names) {
+        if (isProductPackage(name) || isInternalLibPackage(name)) {continue}
+        throw new Error(
+            `unsupported workspace package '${name}' with a backend:test task: expected ${PRODUCT_PACKAGE_PREFIX}* or ${INTERNAL_LIB_PACKAGE_PREFIX}*`
+        )
+    }
+}
+
+function getAffectedInternalLibModules(tasks) {
+    return [
+        ...new Set(
+            tasks
+                .map((t) => t.package.name)
+                .filter(isInternalLibPackage)
+                .map(internalLibPackageToModule)
+        ),
+    ].sort()
 }
 
 function getAllProducts(testTasks) {
-    return [...new Set(testTasks.map((t) => packageToProduct(t.package)))].sort()
+    return [...new Set(testTasks.map((t) => t.package).filter(isProductPackage).map(packageToProduct))].sort()
+}
+
+function getAllInternalLibModules(testTasks) {
+    return [...new Set(testTasks.map((t) => t.package).filter(isInternalLibPackage).map(internalLibPackageToModule))].sort()
 }
 
 function affectedArgs(taskName) {
@@ -236,15 +303,6 @@ const TACH_MODULE_PREFIX = 'products.'
 const productToModule = (product) => product.replace(/-/g, '_')
 const moduleToProduct = (module) => module.replace(/_/g, '-')
 
-// Parse tach.toml's [[modules]] blocks into product -> [products it depends
-// on]. Keys/values are tach names with the "products." prefix stripped
-// (underscores preserved) — callers normalize to/from Turbo's dashed names.
-//
-// Only products.* modules become nodes or edges. posthog/ee (and the
-// common.* utility modules) are dropped on both sides deliberately: they
-// aren't products.* so they fall out of the startsWith filter for free. See
-// tachDependents for why routing through them would be wrong, not just
-// inconvenient.
 // TOML comments run to the end of the line, and a `#` inside a double-quoted
 // string does not start one. Comments have to go before the block scan below,
 // because a comment inside a depends_on list can carry a `]`: tach.toml
@@ -271,8 +329,11 @@ function stripTomlComments(tomlText) {
     return out
 }
 
-function parseTachModules(tomlText) {
-    const graph = new Map()
+// Every `[[modules]]` block as { modulePath, deps }, with both sides kept as
+// written in tach.toml. parseTachModules narrows this to the product graph;
+// parseTachDependents keeps all of it.
+function parseTachModuleBlocks(tomlText) {
+    const blocks = []
     // Each `[[modules]]` block holds exactly one `path` and one `depends_on`
     // before the next block starts — split on the marker and take the first
     // match of each within a block. With comments stripped, depends_on entries
@@ -283,10 +344,9 @@ function parseTachModules(tomlText) {
     // Only double-quoted strings are supported. Other valid TOML (single-quoted
     // literals, inline tables) would be dropped by the regexes without error,
     // silently shrinking the cascade — so any entry the regexes can't represent
-    // throws instead, which loadTachModuleGraph turns into "test all products".
+    // throws instead, which loadTachGraphs turns into "test all products".
     // A false trip over-tests; a silent drop under-tests, so err on throwing.
-    const blocks = stripTomlComments(tomlText).split('[[modules]]').slice(1)
-    for (const block of blocks) {
+    for (const block of stripTomlComments(tomlText).split('[[modules]]').slice(1)) {
         const pathMatch = block.match(/path\s*=\s*"([^"]+)"/)
         if (!pathMatch) {
             if (/^\s*path\s*=/m.test(block)) {
@@ -309,16 +369,49 @@ function parseTachModules(tomlText) {
                 `unsupported \`depends_on\` entry for ${pathMatch[1]} in tach.toml (expected double-quoted strings): ${leftover.trim().slice(0, 80)}`
             )
         }
-        const modulePath = pathMatch[1]
+        blocks.push({
+            modulePath: pathMatch[1],
+            deps: [...dependsMatch[1].matchAll(/"([^"]+)"/g)].map((m) => m[1]),
+        })
+    }
+    return blocks
+}
+
+// tach.toml's [[modules]] blocks as product -> [products it depends on].
+// Keys/values are tach names with the "products." prefix stripped (underscores
+// preserved), and callers normalize to/from Turbo's dashed names.
+//
+// Only products.* modules become nodes or edges. posthog/ee (and the
+// common.* utility modules) are dropped on both sides deliberately: they
+// aren't products.* so they fall out of the startsWith filter for free. See
+// tachDependents for why routing through them would be wrong, not just
+// inconvenient.
+function parseTachModules(tomlText) {
+    const graph = new Map()
+    for (const { modulePath, deps } of parseTachModuleBlocks(tomlText)) {
         if (!modulePath.startsWith(TACH_MODULE_PREFIX)) {continue}
-        const product = modulePath.slice(TACH_MODULE_PREFIX.length)
-        const deps = [...dependsMatch[1].matchAll(/"([^"]+)"/g)]
-            .map((m) => m[1])
-            .filter((d) => d.startsWith(TACH_MODULE_PREFIX))
-            .map((d) => d.slice(TACH_MODULE_PREFIX.length))
-        graph.set(product, deps)
+        graph.set(
+            modulePath.slice(TACH_MODULE_PREFIX.length),
+            deps.filter((d) => d.startsWith(TACH_MODULE_PREFIX)).map((d) => d.slice(TACH_MODULE_PREFIX.length))
+        )
     }
     return graph
+}
+
+// Reverse edges over the WHOLE tach graph: module path -> module paths that
+// declare it in depends_on. parseTachModules drops everything outside
+// products.* because routing a product cascade through core reaches every
+// product; an internal lib cascade needs the opposite, since a core dependent
+// is precisely the signal that forces the full Django suite.
+function parseTachDependents(tomlText) {
+    const reverse = new Map()
+    for (const { modulePath, deps } of parseTachModuleBlocks(tomlText)) {
+        for (const dep of deps) {
+            if (!reverse.has(dep)) {reverse.set(dep, [])}
+            reverse.get(dep).push(modulePath)
+        }
+    }
+    return reverse
 }
 
 // Reverse transitive closure over the product graph: who (transitively)
@@ -368,10 +461,77 @@ function tachDependents(changedProducts, moduleGraph, { direct = false } = {}) {
     return [...visited].map(moduleToProduct)
 }
 
+// Who depends on a set of internal libs, split by what the caller can do about
+// it: products get matrix entries, core forces the full Django suite, and libs
+// need their own tests run.
+//
+// The walk continues through posthog.libs.* nodes only. A product dependent
+// stops the walk because the product graph closes it separately
+// (tachDependents), and a core dependent stops it because "core is involved"
+// already means the full suite, which subsumes anything further out.
+//
+// A lib's module path starts with `posthog.`, so the lib check has to run
+// before the core branch. Classed as core, every lib change would force Django.
+function internalLibDependents(libModules, reverse) {
+    const products = new Set()
+    const core = new Set()
+    const libs = new Set()
+
+    const seeds = new Set(libModules)
+    const queue = [...seeds]
+    while (queue.length > 0) {
+        for (const dependent of reverse.get(queue.shift()) || []) {
+            if (dependent.startsWith(TACH_MODULE_PREFIX)) {
+                products.add(moduleToProduct(dependent.slice(TACH_MODULE_PREFIX.length)))
+            } else if (dependent.startsWith(TACH_INTERNAL_LIB_PREFIX)) {
+                if (libs.has(dependent) || seeds.has(dependent)) {continue}
+                libs.add(dependent)
+                queue.push(dependent)
+            } else {
+                core.add(dependent)
+            }
+        }
+    }
+    return { products: [...products].sort(), core: [...core].sort(), libs: [...libs].sort() }
+}
+
+// An internal lib needs both halves of its declaration to work, and neither
+// half fails visibly on its own. A tach module with no workspace package is
+// invisible to Turbo's affectedness query, so changing it cascades nothing and
+// runs no tests. A workspace package with no tach module has no declared
+// dependents, so it gets its own matrix entry while its consumers go untested.
+// Both are silent under-testing, which is what this cascade exists to prevent,
+// so a mismatch fails discovery and names the missing half.
+function checkInternalLibConsistency(tachLibModules, packageLibModules) {
+    const packages = new Set(packageLibModules)
+    for (const module of tachLibModules) {
+        if (!packages.has(module)) {
+            throw new Error(
+                `tach module ${module} has no ${INTERNAL_LIB_PACKAGE_PREFIX}${internalLibModuleToName(module)} workspace package with a backend:test task`
+            )
+        }
+    }
+    const modules = new Set(tachLibModules)
+    for (const module of packageLibModules) {
+        if (!modules.has(module)) {
+            throw new Error(
+                `workspace package ${INTERNAL_LIB_PACKAGE_PREFIX}${internalLibModuleToName(module)} has no ${module} module in tach.toml`
+            )
+        }
+    }
+}
+
+function internalLibModulePaths(tomlText) {
+    return parseTachModuleBlocks(tomlText)
+        .map((block) => block.modulePath)
+        .filter((modulePath) => modulePath.startsWith(TACH_INTERNAL_LIB_PREFIX))
+        .sort()
+}
+
 // Returns null when the graph can't be read or parsed. Callers must treat null as
 // "unknown dependents" and widen the matrix — never as "no dependents", which would
 // silently under-test exactly the contract changes this cascade guards.
-function loadTachModuleGraph() {
+function loadTachGraphs() {
     let text
     try {
         text = fs.readFileSync(TACH_TOML_FILE, 'utf-8')
@@ -380,11 +540,20 @@ function loadTachModuleGraph() {
         return null
     }
     try {
-        return parseTachModules(text)
+        return {
+            moduleGraph: parseTachModules(text),
+            reverse: parseTachDependents(text),
+            libModules: internalLibModulePaths(text),
+        }
     } catch (e) {
         console.error(`::warning::Could not parse ${TACH_TOML_FILE} (${e.message}) — falling back to testing all products`)
         return null
     }
+}
+
+function loadTachModuleGraph() {
+    const graphs = loadTachGraphs()
+    return graphs === null ? null : graphs.moduleGraph
 }
 
 function loadTestDurations() {
@@ -525,13 +694,13 @@ function packProducts(products, durations) {
 }
 
 // Path filters matching the Django workflow pytest invocations.
-// Core: posthog/ + ee/ minus temporal, dags, hogvm
+// Core: posthog/ + ee/ minus temporal, dags, libs, hogvm
 // Core POE: subset of Core (ignores hogql, hogql_queries) — same pool, fewer tests
 // Temporal: posthog/temporal + products/batch_exports/backend/tests/temporal + products/tasks/backend/temporal
 const DJANGO_SEGMENTS = {
     Core: {
         include: ['posthog/', 'ee/'],
-        exclude: ['posthog/temporal/', 'posthog/dags/', 'common/hogvm/'],
+        exclude: ['posthog/temporal/', 'posthog/dags/', 'posthog/libs/', 'common/hogvm/'],
     },
     CorePOE: {
         // Keep in sync with the person-on-events pytest targets in
@@ -543,7 +712,14 @@ const DJANGO_SEGMENTS = {
             'posthog/api/test/dashboards/test_dashboard.py',
             'ee/clickhouse/',
         ],
-        exclude: ['posthog/temporal/', 'posthog/dags/', 'common/hogvm/', 'posthog/hogql_queries/', 'posthog/hogql/'],
+        exclude: [
+            'posthog/temporal/',
+            'posthog/dags/',
+            'posthog/libs/',
+            'common/hogvm/',
+            'posthog/hogql_queries/',
+            'posthog/hogql/',
+        ],
     },
     Temporal: {
         include: ['posthog/temporal/', 'products/batch_exports/backend/tests/temporal/', 'products/tasks/backend/temporal/'],
@@ -592,7 +768,7 @@ function buildDjangoShards(durations) {
     return result
 }
 
-function buildMatrix(products, durations) {
+function buildMatrix(products, durations, internalLibs = []) {
     const matrix = []
     const packable = []
 
@@ -664,19 +840,38 @@ function buildMatrix(products, durations) {
         })
     }
 
+    // One entry per lib, never packed or split: a lib's suite is small enough
+    // that the packing and duration machinery would only add ways to get it
+    // wrong, and .test_durations records nothing under posthog/libs/ to pack it with.
+    for (const libModule of internalLibs) {
+        const name = internalLibModuleToName(libModule)
+        console.error(`  lib: ${name}`)
+        matrix.push({
+            group: `lib: ${name}`,
+            filters: `--filter=${INTERNAL_LIB_PACKAGE_PREFIX}${name}`,
+            pytest_args: '',
+        })
+    }
+
     return matrix
 }
 
 // Exported for unit tests only — not part of the public API.
 module.exports = {
     collectTestFiles,
+    internalLibModulePaths,
     checkProductStaleness,
     productPrefix,
     productEffectiveCost,
     STALENESS_COVERAGE_THRESHOLD,
     STALENESS_FALLBACK_SECONDS_PER_FILE,
     parseTachModules,
+    parseTachDependents,
     tachDependents,
+    checkInternalLibConsistency,
+    internalLibDependents,
+    internalLibPackageToModule,
+    buildMatrix,
 }
 
 // --- Main ---
@@ -702,15 +897,28 @@ try {
     }
     process.exit(1)
 }
+assertKnownBackendTestPackages(allTestTasks.map((t) => t.package))
+
 const allProducts = getAllProducts(allTestTasks)
 const allProductSet = new Set(allProducts)
 
+// Both paths below depend on the two halves agreeing, so the check runs before
+// the branch. A tach.toml that cannot be read or parsed is left to the existing
+// per-cascade fallbacks, which already widen to the full suite.
+const tachGraphsForLibCheck = loadTachGraphs()
+if (tachGraphsForLibCheck !== null) {
+    checkInternalLibConsistency(tachGraphsForLibCheck.libModules, getAllInternalLibModules(allTestTasks))
+}
+
 let products
 let runLegacy
+// Internal libs to run tests for, as tach module paths (posthog.libs.<name>).
+let internalLibs = []
 
 if (legacyChanged) {
     console.error('Legacy code changed — testing all products')
     products = allProducts
+    internalLibs = getAllInternalLibModules(allTestTasks)
     runLegacy = true
 } else {
     const isolatedProducts = getIsolatedProducts(contractTasks)
@@ -762,6 +970,52 @@ if (legacyChanged) {
         console.error('No product changes detected')
         products = []
         runLegacy = false
+    }
+
+    const affectedInternalLibs = getAffectedInternalLibModules(affectedTestTasks)
+    if (affectedInternalLibs.length > 0) {
+        const tachGraphs = loadTachGraphs()
+        if (tachGraphs === null) {
+            // Same fail-toward-over-testing rule as the cascades above. The changed
+            // libs still run their own tests: that part needs no graph.
+            console.error('Internal lib dependent cascade unavailable — testing all products rather than risk skipping a dependent')
+            products = allProducts
+            runLegacy = true
+            internalLibs = affectedInternalLibs
+        } else {
+            const cascaded = new Set()
+            for (const libModule of affectedInternalLibs) {
+                const dependents = internalLibDependents([libModule], tachGraphs.reverse)
+                console.error(
+                    `Internal lib changed: ${libModule} — depended on by products ${JSON.stringify(dependents.products)}, libs ${JSON.stringify(dependents.libs)}`
+                )
+                for (const lib of dependents.libs) {
+                    internalLibs.push(lib)
+                }
+                for (const product of dependents.products.filter((p) => allProductSet.has(p))) {
+                    cascaded.add(product)
+                }
+                if (dependents.core.length > 0) {
+                    console.error(`internal lib ${libModule} is depended on by core (${dependents.core.join(', ')}) — Django will run`)
+                    runLegacy = true
+                }
+            }
+            internalLibs = [...new Set([...affectedInternalLibs, ...internalLibs])].sort()
+
+            const transitive = tachDependents([...cascaded], tachGraphs.moduleGraph).filter((p) => allProductSet.has(p))
+            if (transitive.length > 0) {
+                console.error(`Products depending on those consumers via tach.toml: ${JSON.stringify(transitive)}`)
+            }
+            const cascadedProducts = [...new Set([...cascaded, ...transitive])].sort()
+            products = [...new Set([...products, ...cascadedProducts])].sort()
+            const nonIsolatedCascaded = cascadedProducts.filter((p) => !isolatedProducts.has(p))
+            if (nonIsolatedCascaded.length > 0) {
+                console.error(
+                    `Non-isolated products cascaded in from an internal lib change: ${JSON.stringify(nonIsolatedCascaded)} — Django will run, since core can import their internals`
+                )
+                runLegacy = true
+            }
+        }
     }
 
     if (schemaChanged) {
@@ -822,6 +1076,7 @@ if (process.env.TURBO_SCM_BASE) {
 }
 
 console.error(`Products to test: ${JSON.stringify(products)}`)
+console.error(`Internal libs to test: ${JSON.stringify(internalLibs)}`)
 console.error(`Run legacy (Django): ${runLegacy}`)
 
 const durations = loadTestDurations()
@@ -830,9 +1085,10 @@ console.error('\nDjango shard calculation:')
 const djangoShards = buildDjangoShards(durations)
 
 const result = {
-    matrix: buildMatrix(products, durations),
+    matrix: buildMatrix(products, durations, internalLibs),
     run_legacy: runLegacy,
     django_shards: djangoShards,
+    internal_libs: internalLibs,
 }
 // eslint-disable-next-line no-console
 process.stdout.write(JSON.stringify(result) + '\n')

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -236,6 +236,10 @@ jobs:
                         - 'common/migration_utils/**'
                         - 'common/plugin_transpiler/**'
                         - 'posthog/**/*'
+                        # Internal libs are tach nodes whose dependents are declared, so
+                        # turbo-discover selects their own tests and their dependents'
+                        # tests. They must not force the full Django suite.
+                        - '!posthog/libs/**'
                         - bin/build-schema-latest-versions.py
                         - bin/build-taxonomy-json.py
                         - bin/check_uv_python_compatibility.py
@@ -1065,7 +1069,7 @@ jobs:
               if: ${{ !cancelled() && env.RUNS_ON_INTERNAL_PR == 'true' && github.repository == 'PostHog/posthog' && github.actor != 'dependabot[bot]' && vars.TRUNK_UPLOAD_ENABLED == 'true' }}
               uses: ./.github/actions/trunk-quarantine-gate
               with:
-                  junit-paths: products/*/junit-product.xml
+                  junit-paths: products/*/junit-product.xml,posthog/libs/*/junit-product.xml
                   previous-step-outcome: ${{ steps.run-product-tests.outcome }}
                   token: ${{ secrets.TRUNK_API_TOKEN }}
 
@@ -1088,6 +1092,11 @@ jobs:
                   for f in products/*/junit-product.xml; do
                       [ -f "$f" ] || continue
                       cp "$f" "junit-staging/junit-product-$(basename "$(dirname "$f")").xml"
+                  done
+                  # Internal libs (posthog/libs/<name>) run in the same matrix; keep their files apart from products'.
+                  for f in posthog/libs/*/junit-product.xml; do
+                      [ -f "$f" ] || continue
+                      cp "$f" "junit-staging/junit-product-lib-$(basename "$(dirname "$f")").xml"
                   done
             # Separate artifact prefix from junit-results-backend-* so consumers can select
             # product JUnit by download pattern; the product name rides in each inner filename
@@ -3106,6 +3115,7 @@ jobs:
                     pytest -v --tb=short --reuse-db -o junit_duration_report=call $full_targets -m "not async_migrations" \
                         --ignore=posthog/temporal \
                         --ignore=posthog/dags \
+                        --ignore=posthog/libs \
                         --ignore=common/hogvm/python/test \
                         --ignore=posthog/test/repo_invariants \
                         "${full_ignores[@]}" \

--- a/docs/internal/monorepo-layout.md
+++ b/docs/internal/monorepo-layout.md
@@ -9,6 +9,7 @@ posthog/               # Legacy monolith code
   api/                 # DRF views, serializers
   models/              # Django models
   queries/             # HogQL query runners
+  libs/                # Shared in-venv Python libs: posthog.libs.<name>, tach nodes + turbo packages
   ...
 
 ee/                    # Enterprise features (being migrated to products/ and posthog/)
@@ -87,6 +88,30 @@ For pnpm packages, location doesn't gate who can import them (pnpm resolves by n
 - Promote nested → root only when a second consumer actually depends on it — on real usage, not intent. It's a path rename with a stable package name (no import churn), so don't pay the "shared" cost before it's true.
 
 `pnpm-workspace.yaml` globs are explicit (`products/*`, `packages/quill`, …) and don't yet match nested `products/<product>/packages/*` or a new top-level `packages/<name>/` — so register the package's path there when you add it, or `workspace:*` deps, filters, and scripts won't resolve.
+
+### Shared Python: which home
+
+- One product owns it: `products/<product>/`, exposed through its facade.
+- Several products import it, nothing from Django or the rest of `posthog/`: `posthog/libs/<name>/` (below).
+- It needs Django, Redis, settings, or core imports it: `posthog/<mechanism>/`, egress-style, accepting that a change runs the full suite.
+- A consumer installs it outside the monorepo venv: a uv workspace member under `packages/<name>/`.
+
+### Libs
+
+Shared Python that more than one product imports, living in the monorepo venv with no packaging step.
+`posthog/libs/<name>/` is a plain package imported as `posthog.libs.<name>`.
+
+Unlike `common/`, a lib is mechanically bounded; unlike `packages/<name>/`, it is not a distribution.
+
+- It is a tach node: `[[modules]] path = "posthog.libs.<name>"` with `depends_on = []` and an interfaces block, so it stays a leaf and only its declared surface is importable.
+- Every consumer lists it in its own `depends_on` (`"posthog.libs.<name>"`), and `tach check` fails on an undeclared import. Those declarations are the record `turbo-discover` reads: a lib change runs the lib's own tests plus the tests of the products that declare it, and skips the Django suite.
+- If `posthog` or `ee` declares it, a lib change runs the full Django suite instead, because core has no narrower test selection. Python that needs Django or core belongs in `posthog/<mechanism>/` from the start (see `posthog/egress/`).
+- It carries a `package.json` (`@posthog/lib-<name>`) with a `backend:test` script and a `turbo.json` whose inputs cover its sources; that is how turbo sees the change and how the product test matrix runs the lib's tests. `turbo-discover` fails the run if a `posthog.libs.<name>` tach module and a `@posthog/lib-<name>` package do not come as a pair.
+- Reach for `packages/<name>/` instead when a consumer must install it outside the monorepo venv.
+- The `posthog/libs/*` glob in `pnpm-workspace.yaml` and the Dockerfiles' `posthog/` copy already cover a new lib, so there is no per-lib build wiring. `ci-backend.yml`'s `legacy` filter excludes `posthog/libs/**`, so a lib change does not force the Django suite.
+- Same nest-then-promote rule as the package tiers: code one product owns stays under `products/<product>/` until a second product actually imports it.
+
+Folder names are `under_score` cased, because dashes break Python imports. See [posthog/libs/README.md](/posthog/libs/README.md).
 
 ### Services
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,6 +15,7 @@ packages:
     - playwright
     - nodejs
     - nodejs/src/scripts
+    - posthog/libs/*
     - products/*
     # products/desktop is a nested standalone workspace (own lockfile, catalog,
     # overrides, Node version); the root install must not absorb it.

--- a/posthog/libs/README.md
+++ b/posthog/libs/README.md
@@ -1,0 +1,34 @@
+# Libs
+
+Shared Python that more than one product imports, living in the monorepo venv.
+
+A lib is a plain package at `posthog/libs/<name>/`, imported as `posthog.libs.<name>`.
+There is no packaging step: no `pyproject.toml`, no uv workspace member, nothing to install.
+
+Each lib is three things at once:
+
+- A Python package: `posthog/libs/<name>/__init__.py`, its modules, and its tests.
+- A tach node: `[[modules]] path = "posthog.libs.<name>"` with `depends_on = []` and an interfaces block, so it stays a leaf and only its declared surface is importable.
+  Every consumer adds `"posthog.libs.<name>"` to its own `depends_on`; `tach check` fails on an undeclared import.
+- A turbo workspace package: `posthog/libs/<name>/package.json` named `@posthog/lib-<name>` with a `backend:test` script, plus a `turbo.json` whose inputs cover its sources.
+  Turbo runs the script from the lib's own directory, so it points back at the repo root: `pytest -c ../../../pytest.ini --rootdir ../../.. --durations-path ../../../.test_durations tests -v --tb=short` (the durations path keeps master's timing collection in the root file).
+  CI runs the lib's own tests and the tests of the products that declare it, and skips the Django suite unless `posthog` or `ee` declares it too.
+
+Keep folder names `under_score` cased, because dashes break Python imports.
+
+## When a lib is the right home
+
+Reach for `posthog/libs/<name>/` when shared Python is imported by more than one product and needs neither Django nor anything else from `posthog/`.
+
+Somewhere else if:
+
+- One product owns it.
+  Put it under `products/<product>/`.
+  It is not shared until a second product actually imports it.
+- It needs Django or the rest of core, or core imports it.
+  Put it in `posthog/<mechanism>/` outside `libs/`.
+  Either way a change re-runs the full Django suite, so a lib buys nothing.
+- A consumer must install it outside the monorepo venv, such as a bare-python CI step, a sandbox, or another repo.
+  That is a distribution, so it belongs in `packages/<name>/` with its own `pyproject.toml`.
+
+Full rules, including how this sits next to `common/`, `packages/`, `services/`, and `tools/`, are in [docs/internal/monorepo-layout.md](../../docs/internal/monorepo-layout.md).


### PR DESCRIPTION
## Problem

- Shared Python that several products import has no home that gives both a boundary and narrow CI. Anything under `posthog/` runs the full Django suite on every change, and `packages/` is for distributions that install outside the monorepo venv.
- Two devex libraries are queued behind this (quarantine primitives, Slack digest rendering), and each would otherwise land in core or be duplicated per product.

## Changes

- A new home, `posthog/libs/<name>/`, imported as `posthog.libs.<name>`. Each lib is a tach module with `depends_on = []` and an interfaces block, and every consumer declares it in its own `depends_on`; `tach check` enforces that, and nesting under `posthog` grants no implicit access.
- A change to a lib re-runs the lib's own tests and the products that declare it, and skips the Django suite. `turbo-discover` reads the tach reverse edges, closes over the product graph, and runs Django only if `posthog`/`ee` declare the lib or a dependent is non-isolated.
- Each lib is also a turbo workspace package (`@posthog/lib-<name>`) so turbo sees its changes and the product matrix runs its tests; discover fails the run if a tach module and a package do not come as a pair.
- In the merge queue, a lib change claims its direct importers' product lanes instead of every Python lane.
- Docs: `docs/internal/monorepo-layout.md` gains "Shared Python: which home" and a Libs section; `posthog/libs/README.md` carries the conventions.
- No lib ships in this PR and nothing is user-visible. The `legacy` filter exclusion, the Core shard `--ignore`, the JUnit staging glob, and the `pnpm-workspace.yaml` glob are mechanical.

Before: a change anywhere under `posthog/` runs everything.

```mermaid
flowchart LR
    A[change under posthog/**] --> B[legacy filter]
    B --> C[full Django suite + every product]
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    class A phYellow; class B phGray; class C phRed;
```

After: a lib change is selected from the declared dependents.

```mermaid
flowchart LR
    A[change under posthog/libs/x/] --> B[turbo-discover]
    B --> T[tach.toml reverse edges]
    T --> L[lib: x matrix entry]
    T --> P[products declaring posthog.libs.x]
    T -->|posthog or ee declare it| D[full Django suite]
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    class A phYellow; class B phBlue; class T phGray; class L,P phBlue; class D phRed;
```

> [!NOTE]
> Discover now throws on a non-product workspace package with a `backend:test` task that it cannot classify. Today none exist; the next PR in the stack adds the `packages/` kind.

## How did you test this code?

- Node tests for discover (internal-lib classification, tach reverse edges, lib-to-lib walks, core detection, pair check, matrix entries) and for the lane rule (importer lanes, lib chains, core widening, undeclared lib, rule ordering), all on fixtures.
- End-to-end on a throwaway worktree with a probe lib and `legal_documents` as consumer (not in the PR): a lib-only change selected that product plus the lib and skipped Django; declaring the lib from `posthog` flipped the full suite; removing the consumer's `depends_on` failed `tach check`; the lib's turbo task ran under the root `pytest.ini` with the workflow's `PYTEST_ADDOPTS`.
- Not checked: a real lib through CI, since none exists yet. The first lib PR is the live check; its discover log and lane telemetry are where to look.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`docs/internal/monorepo-layout.md` and `posthog/libs/README.md` in this PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Fable 5) with subagents for implementation and the throwaway proofs; Julian directed the design.
- Skills invoked: `/isolating-product-facade-contracts`, `/authoring-ci-workflows`, `/writing-code-comments`, `/stacking-prs`, `/writing-pr-descriptions`.
- Decisions across the session: a tach carve-out inside `posthog/` alone buys no CI isolation (core consumes it, so the full suite runs anyway), which is why libs get a path-based `legacy` exclusion and discover support. The directory started as top-level `libs/` and moved under `posthog/` for the import name and because `posthog/**` already covers Docker, lint, type-check, and security filters. Discover reads tach declarations here rather than scanning imports, because tach enforces them for first-party modules.
