### PR TITLE
fix(tasks): mint run credentials as the recorded run actor

### DIFF
--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -2021,6 +2021,12 @@ def delete_sandbox_custom_image(image_id: str | UUID, team_id: int, user_id: int
 # These keys are reserved for server-owned run state, never PATCH input.
 _PROTECTED_RUN_STATE_KEYS = frozenset(
     {
+        # The recorded run actor decides whose OAuth token and API credentials the
+        # sandbox mints (run_actor.get_task_run_credential_user). Server-side writers
+        # go through TaskRun.update_state_atomic; a PATCHable value would let a task
+        # controller mint credentials as any user id they name.
+        "actor_user_id",
+        "slack_actor_user_id",
         "github_credential_source",
         "pr_authorship_mode",
         "repositories",
@@ -3936,6 +3942,14 @@ def bootstrap_task_run(
             },
         )
 
+    if user_id is not None:
+        from products.tasks.backend.logic.services.run_actor import (  # noqa: PLC0415 — keep tasks internals off the api import path
+            actor_state_updates,
+        )
+
+        extra_state = extra_state or {}
+        extra_state.update(actor_state_updates(user_id=user_id))
+
     logger.info(
         "Creating task run for task %s with mode=%s, branch=%s, environment=%s", task.id, mode, branch, environment
     )
@@ -4838,6 +4852,7 @@ def create_task(
                 artifact_ids=pending_user_artifact_ids,
                 auto_publish=warm_auto_publish,
                 reasoning_effort=warm_reasoning_effort,
+                actor_user_id=user_id,
             )
             return _task_detail_to_dto(_task_detail_queryset().get(pk=warm_task.pk))
 
@@ -5296,6 +5311,7 @@ def _activate_warm_run(
     description: str | None = None,
     auto_publish: bool | None = None,
     reasoning_effort: str | None = None,
+    actor_user_id: int | None = None,
 ) -> None:
     """Activate an idling warm Run: set the draft Task's visible description from raw task text,
     forward the first message to the already-running agent, and drop the ``await_user_message`` marker
@@ -5319,6 +5335,14 @@ def _activate_warm_run(
         activation_state_updates["auto_publish"] = auto_publish
     if reasoning_effort is not None:
         activation_state_updates["reasoning_effort"] = reasoning_effort
+    if actor_user_id is not None:
+        from products.tasks.backend.logic.services.run_actor import (  # noqa: PLC0415 — keep tasks internals off the api import path
+            actor_state_updates,
+        )
+
+        # Before the signal, like auto_publish: credential minting for the forwarded
+        # first message must already see who is driving this run.
+        activation_state_updates.update(actor_state_updates(user_id=actor_user_id))
     TaskRun.update_state_atomic(
         run.id,
         updates=activation_state_updates,
@@ -5565,6 +5589,7 @@ def run_task(
                         artifact_ids=pending_user_artifact_ids,
                         auto_publish=validated_data.get("auto_publish"),
                         reasoning_effort=validated_data.get("reasoning_effort"),
+                        actor_user_id=user_id,
                     )
                     return contracts.TaskRunResult(task=get_task_detail(task.id, team_id, user_id))
     sandbox_environment_id = validated_data.get("sandbox_environment_id")
@@ -5798,6 +5823,14 @@ def run_task(
                     missing_artifact_ids=missing_artifact_ids,
                 )
             )
+
+    if user_id is not None:
+        from products.tasks.backend.logic.services.run_actor import (  # noqa: PLC0415 — keep tasks internals off the api import path
+            actor_state_updates,
+        )
+
+        extra_state = extra_state or {}
+        extra_state.update(actor_state_updates(user_id=user_id))
 
     logger.info("Creating task run for task %s with mode=%s, branch=%s", task.id, mode, branch)
     task_run = task.create_run(mode=mode, branch=branch, extra_state=extra_state)

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -3798,6 +3798,18 @@ def _resolve_cloud_pr_authorship_mode(
     )
 
 
+def _with_recorded_actor(extra_state: dict | None, user_id: int | None) -> dict | None:
+    """Record the acting user on a new run's state so credential minting resolves them
+    (run_actor.get_task_run_credential_user) instead of the task creator."""
+    if user_id is None:
+        return extra_state
+    from products.tasks.backend.logic.services.run_actor import (  # noqa: PLC0415 — keep tasks internals off the api import path
+        actor_state_updates,
+    )
+
+    return {**(extra_state or {}), **actor_state_updates(user_id=user_id)}
+
+
 def _github_credential_source_extra_state(pr_authorship_mode, github_user_token: str | None) -> dict[str, str]:
     from products.tasks.backend.temporal.process_task.utils import (  # noqa: PLC0415 — keep temporalio off the api import path
         GitHubCredentialSource,
@@ -3942,13 +3954,7 @@ def bootstrap_task_run(
             },
         )
 
-    if user_id is not None:
-        from products.tasks.backend.logic.services.run_actor import (  # noqa: PLC0415 — keep tasks internals off the api import path
-            actor_state_updates,
-        )
-
-        extra_state = extra_state or {}
-        extra_state.update(actor_state_updates(user_id=user_id))
+    extra_state = _with_recorded_actor(extra_state, user_id)
 
     logger.info(
         "Creating task run for task %s with mode=%s, branch=%s, environment=%s", task.id, mode, branch, environment
@@ -5824,13 +5830,7 @@ def run_task(
                 )
             )
 
-    if user_id is not None:
-        from products.tasks.backend.logic.services.run_actor import (  # noqa: PLC0415 — keep tasks internals off the api import path
-            actor_state_updates,
-        )
-
-        extra_state = extra_state or {}
-        extra_state.update(actor_state_updates(user_id=user_id))
+    extra_state = _with_recorded_actor(extra_state, user_id)
 
     logger.info("Creating task run for task %s with mode=%s, branch=%s", task.id, mode, branch)
     task_run = task.create_run(mode=mode, branch=branch, extra_state=extra_state)

--- a/products/tasks/backend/logic/services/run_actor.py
+++ b/products/tasks/backend/logic/services/run_actor.py
@@ -53,15 +53,15 @@ def is_slack_interaction_state(state: dict[str, Any] | None) -> bool:
     return (state or {}).get("interaction_origin") == "slack"
 
 
-def _recorded_actor_key(state: dict[str, Any]) -> str:
+def recorded_actor_key(state: dict[str, Any] | None) -> str:
+    """The run-state key carrying this run's recorded actor for its interaction origin."""
     return SLACK_ACTOR_USER_STATE_KEY if is_slack_interaction_state(state) else ACTOR_USER_STATE_KEY
 
 
 def has_recorded_actor(state: dict[str, Any] | None) -> bool:
     """Whether this run recorded the user driving it (Slack steering, or a web run
-    started or commanded on a task the driver did not create)."""
-    state = state or {}
-    return _recorded_actor_key(state) in state
+    start or follow-up)."""
+    return recorded_actor_key(state) in (state or {})
 
 
 def actor_resolution_fails_closed(state: dict[str, Any] | None) -> bool:
@@ -70,7 +70,7 @@ def actor_resolution_fails_closed(state: dict[str, Any] | None) -> bool:
     True for every Slack run and for any run that recorded a driving actor: once an
     actor is on record, an invalid one must stop the run, not silently escalate to
     the creator's credentials."""
-    return is_slack_interaction_state(state) or ACTOR_USER_STATE_KEY in (state or {})
+    return is_slack_interaction_state(state) or has_recorded_actor(state)
 
 
 def get_task_run_actor_user(
@@ -82,9 +82,10 @@ def get_task_run_actor_user(
     """Return the PostHog user acting on this task run.
 
     Slack runs carry their current steering user in run state; web runs carry the
-    user who started or last messaged them when that user is not the task creator.
-    Credential-bearing paths should pass ``allow_task_creator_fallback=False`` so a
-    missing or unauthorized actor fails closed instead of silently using the creator.
+    user who started or last messaged them (the creator included — the stamp is
+    unconditional). Credential-bearing paths should pass
+    ``allow_task_creator_fallback=False`` so a missing or unauthorized actor fails
+    closed instead of silently using the creator.
     """
     state = state or {}
     task_created_by = task.created_by if getattr(task, "created_by_id", None) is not None else None
@@ -94,7 +95,7 @@ def get_task_run_actor_user(
     def fallback_actor() -> User | None:
         return task_created_by if allow_task_creator_fallback else None
 
-    actor_user_id = state.get(_recorded_actor_key(state))
+    actor_user_id = state.get(recorded_actor_key(state))
     if not isinstance(actor_user_id, int) or isinstance(actor_user_id, bool):
         return fallback_actor()
     if task_created_by is not None and actor_user_id == task_created_by.id:

--- a/products/tasks/backend/logic/services/run_actor.py
+++ b/products/tasks/backend/logic/services/run_actor.py
@@ -45,8 +45,32 @@ def loop_owner_eligible_for_credentials(user_id: int | None, team: Team) -> bool
     return UserPermissions(user=owner, team=team).current_team.effective_membership_level is not None
 
 
+ACTOR_USER_STATE_KEY = "actor_user_id"
+SLACK_ACTOR_USER_STATE_KEY = "slack_actor_user_id"
+
+
 def is_slack_interaction_state(state: dict[str, Any] | None) -> bool:
     return (state or {}).get("interaction_origin") == "slack"
+
+
+def _recorded_actor_key(state: dict[str, Any]) -> str:
+    return SLACK_ACTOR_USER_STATE_KEY if is_slack_interaction_state(state) else ACTOR_USER_STATE_KEY
+
+
+def has_recorded_actor(state: dict[str, Any] | None) -> bool:
+    """Whether this run recorded the user driving it (Slack steering, or a web run
+    started or commanded on a task the driver did not create)."""
+    state = state or {}
+    return _recorded_actor_key(state) in state
+
+
+def actor_resolution_fails_closed(state: dict[str, Any] | None) -> bool:
+    """Whether credential minting must fail closed instead of falling back to the task creator.
+
+    True for every Slack run and for any run that recorded a driving actor: once an
+    actor is on record, an invalid one must stop the run, not silently escalate to
+    the creator's credentials."""
+    return is_slack_interaction_state(state) or ACTOR_USER_STATE_KEY in (state or {})
 
 
 def get_task_run_actor_user(
@@ -57,19 +81,20 @@ def get_task_run_actor_user(
 ) -> User | None:
     """Return the PostHog user acting on this task run.
 
-    Slack runs carry their current steering user in run state. Credential-bearing
-    paths should pass ``allow_task_creator_fallback=False`` so a missing or
-    unauthorized Slack actor fails closed instead of silently using the creator.
+    Slack runs carry their current steering user in run state; web runs carry the
+    user who started or last messaged them when that user is not the task creator.
+    Credential-bearing paths should pass ``allow_task_creator_fallback=False`` so a
+    missing or unauthorized actor fails closed instead of silently using the creator.
     """
     state = state or {}
     task_created_by = task.created_by if getattr(task, "created_by_id", None) is not None else None
-    if not is_slack_interaction_state(state):
+    if not is_slack_interaction_state(state) and ACTOR_USER_STATE_KEY not in state:
         return task_created_by
 
     def fallback_actor() -> User | None:
         return task_created_by if allow_task_creator_fallback else None
 
-    actor_user_id = state.get("slack_actor_user_id")
+    actor_user_id = state.get(_recorded_actor_key(state))
     if not isinstance(actor_user_id, int) or isinstance(actor_user_id, bool):
         return fallback_actor()
     if task_created_by is not None and actor_user_id == task_created_by.id:
@@ -107,17 +132,22 @@ def get_task_run_actor_user(
 def get_task_run_credential_user(task: Task, state: dict[str, Any] | None = None) -> User | None:
     """Return the user whose credentials may be minted for this run.
 
-    Slack runs fail closed when their recorded actor can't be validated, but runs
-    started before actor tracking existed carry no ``slack_actor_user_id`` at all —
-    those grandfather to the task creator so in-flight runs survive the rollout.
+    A run with a recorded actor fails closed when that actor can't be validated, but
+    runs started before actor tracking existed carry no actor key at all — those
+    grandfather to the task creator so in-flight runs survive the rollout.
     """
     state = state or {}
-    allow_fallback = not is_slack_interaction_state(state) or "slack_actor_user_id" not in state
-    return get_task_run_actor_user(task, state, allow_task_creator_fallback=allow_fallback)
+    return get_task_run_actor_user(task, state, allow_task_creator_fallback=not has_recorded_actor(state))
 
 
 def get_actor_distinct_id(actor: User) -> str:
     return actor.distinct_id or f"user_{actor.id}"
+
+
+def actor_state_updates(*, user_id: int) -> dict[str, Any]:
+    """Run-state update recording the user driving a non-Slack run (run start or follow-up).
+    Credential resolution reads ``actor_user_id`` — every non-Slack writer must build it here."""
+    return {ACTOR_USER_STATE_KEY: user_id}
 
 
 def slack_actor_state_updates(*, user_id: int, slack_user_id: str | None = None) -> dict[str, Any]:

--- a/products/tasks/backend/temporal/oauth.py
+++ b/products/tasks/backend/temporal/oauth.py
@@ -19,8 +19,8 @@ from posthog.temporal.oauth import (
 from products.mcp_store.backend.facade.api import is_builtin_agent_enforcement_enabled
 from products.tasks.backend.exceptions import OAuthTokenError, TaskInvalidStateError
 from products.tasks.backend.logic.services.run_actor import (
+    actor_resolution_fails_closed,
     get_task_run_credential_user,
-    is_slack_interaction_state,
     loop_owner_eligible_for_credentials,
 )
 from products.tasks.backend.models import Task
@@ -105,9 +105,9 @@ def create_oauth_access_token_for_run(
 ) -> str:
     """Mint the sandbox OAuth token for a run, resolving the acting user from run state.
 
-    Single entry point for the run credential policy: Slack runs fail closed when their
-    recorded actor can't be validated (never falling back to the task creator), while
-    other runs keep the creator fallback. Callers must not re-derive this pairing by
+    Single entry point for the run credential policy: a run with a recorded actor
+    fails closed when that actor can't be validated (never falling back to the task
+    creator), while runs that never recorded one keep the creator fallback. Callers must not re-derive this pairing by
     hand — passing ``user``/``allow_task_creator_fallback`` separately makes it possible
     to mint creator credentials for a Slack run by omitting one kwarg. Loop-fired runs
     (``loop_id`` in run state) get ``loop:write`` stripped from the granted scopes here.
@@ -119,7 +119,7 @@ def create_oauth_access_token_for_run(
             task,
             scopes=scopes,
             user=actor_user,
-            allow_task_creator_fallback=not is_slack_interaction_state(state),
+            allow_task_creator_fallback=not actor_resolution_fails_closed(state),
             loop_id=None,
         )
 
@@ -140,7 +140,7 @@ def create_oauth_access_token_for_run(
             task,
             scopes=scopes,
             user=actor_user,
-            allow_task_creator_fallback=not is_slack_interaction_state(state),
+            allow_task_creator_fallback=not actor_resolution_fails_closed(state),
             loop_id=loop_id if isinstance(loop_id, str) else None,
         )
 

--- a/products/tasks/backend/temporal/process_task/activities/forward_pending_message.py
+++ b/products/tasks/backend/temporal/process_task/activities/forward_pending_message.py
@@ -12,9 +12,9 @@ from posthog.temporal.common.utils import close_db_connections
 from products.tasks.backend.temporal.observability import log_activity_execution
 from products.tasks.backend.temporal.process_task.activities.feature_flags import AGENT_DESIGN_STATE_KEY
 from products.tasks.backend.temporal.process_task.utils import (
+    actor_resolution_fails_closed,
     get_actor_distinct_id,
     get_task_run_credential_user,
-    is_slack_interaction_state,
 )
 
 logger = get_logger(__name__)
@@ -130,8 +130,8 @@ def forward_pending_user_message(run_id: str) -> None:
 
         auth_token = None
         actor_user = get_task_run_credential_user(task_run.task, state)
-        if is_slack_interaction_state(state) and actor_user is None:
-            raise RuntimeError("Slack task run is missing an acting user")
+        if actor_resolution_fails_closed(state) and actor_user is None:
+            raise RuntimeError("Task run is missing an acting user")
         if actor_user and actor_user.id:
             auth_token = create_sandbox_connection_token(
                 task_run, user_id=actor_user.id, distinct_id=get_actor_distinct_id(actor_user)

--- a/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
@@ -48,6 +48,7 @@ from products.tasks.backend.models import SandboxCustomImage, SandboxEnvironment
 from products.tasks.backend.temporal.constants import resolve_inactivity_timeout, resolve_max_run_duration
 from products.tasks.backend.temporal.observability import emit_agent_log, log_with_activity_context
 from products.tasks.backend.temporal.process_task.utils import (
+    actor_resolution_fails_closed,
     format_allowed_domains_for_log,
     get_actor_distinct_id,
     get_pr_authorship_mode,
@@ -780,11 +781,11 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
 
     state = task_run.state or {}
     actor_user = get_task_run_credential_user(task, state)
-    if is_slack_interaction_state(state) and actor_user is None:
+    if actor_resolution_fails_closed(state) and actor_user is None:
         raise TaskInvalidStateError(
-            f"Task {task.id} has no valid Slack actor",
+            f"Task {task.id} has no valid run actor",
             {"task_id": str(task.id), "run_id": run_id},
-            cause=RuntimeError(f"Task {task.id} missing Slack actor for task run {run_id}"),
+            cause=RuntimeError(f"Task {task.id} missing run actor for task run {run_id}"),
         )
     distinct_id = (
         get_actor_distinct_id(actor_user) if actor_user else task.created_by.distinct_id or "process_task_workflow"

--- a/products/tasks/backend/temporal/process_task/activities/relay_sandbox_events.py
+++ b/products/tasks/backend/temporal/process_task/activities/relay_sandbox_events.py
@@ -33,9 +33,9 @@ from products.tasks.backend.models import (
 from products.tasks.backend.redis import run_uses_dedicated_stream
 from products.tasks.backend.temporal.constants import INACTIVITY_TIMEOUT_DEFAULT_SECONDS, resolve_inactivity_timeout
 from products.tasks.backend.temporal.process_task.utils import (
+    actor_resolution_fails_closed,
     get_actor_distinct_id,
     get_task_run_credential_user,
-    is_slack_interaction_state,
 )
 
 from ee.hogai.sandbox import is_turn_complete
@@ -134,11 +134,11 @@ async def _relay_sandbox_events(input: RelaySandboxEventsInput, *, finalize_stre
     await redis_stream.initialize()
 
     actor_user = await sync_to_async(get_task_run_credential_user)(task_run.task, task_run.state)
-    if is_slack_interaction_state(task_run.state) and actor_user is None:
-        # Deterministic: the recorded Slack actor no longer resolves, so every retry
+    if actor_resolution_fails_closed(task_run.state) and actor_user is None:
+        # Deterministic: the recorded actor no longer resolves, so every retry
         # would fail identically. Write the error sentinel and fail for good instead
         # of retrying until the run dies on the inactivity timeout with no reason.
-        error_message = "Slack task run is missing an acting user"
+        error_message = "Task run is missing an acting user"
         logger.error("relay_sandbox_events_missing_actor", run_id=input.run_id)
         await redis_stream.mark_error(error_message)
         raise ApplicationError(error_message, non_retryable=True)

--- a/products/tasks/backend/temporal/process_task/activities/send_followup_to_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/send_followup_to_sandbox.py
@@ -24,7 +24,13 @@ from products.tasks.backend.logic.services.agent_command import (
     user_facing_agent_error,
 )
 from products.tasks.backend.logic.services.connection_token import create_sandbox_connection_token
-from products.tasks.backend.logic.services.run_actor import slack_actor_state_updates
+from products.tasks.backend.logic.services.run_actor import (
+    ACTOR_USER_STATE_KEY,
+    SLACK_ACTOR_USER_STATE_KEY,
+    actor_resolution_fails_closed,
+    actor_state_updates,
+    slack_actor_state_updates,
+)
 from products.tasks.backend.logic.services.staged_artifacts import get_task_run_artifacts_by_id
 from products.tasks.backend.logic.stream.redis_stream import get_task_run_stream_key
 from products.tasks.backend.models import TaskRun
@@ -164,11 +170,12 @@ def _deliver_followup(input: SendFollowupToSandboxInput) -> str | None:
 
     state = task_run.state
     if input.actor_user_id is not None:
-        state = {**(state or {}), "slack_actor_user_id": input.actor_user_id}
+        actor_key = SLACK_ACTOR_USER_STATE_KEY if is_slack_interaction_state(state) else ACTOR_USER_STATE_KEY
+        state = {**(state or {}), actor_key: input.actor_user_id}
 
     actor_user = get_task_run_credential_user(task_run.task, state)
-    if is_slack_interaction_state(state) and actor_user is None:
-        error_msg = "Slack actor unavailable for this run"
+    if actor_resolution_fails_closed(state) and actor_user is None:
+        error_msg = "Acting user unavailable for this run"
         _write_error_and_complete(input.run_id, error_msg, run_uses_dedicated_stream(task_run.state))
         raise RuntimeError(f"send_followup failed: {error_msg}")
 
@@ -189,10 +196,14 @@ def _deliver_followup(input: SendFollowupToSandboxInput) -> str | None:
             )
             return STEER_DECLINED_OUTCOME
 
-    if input.actor_user_id is not None and is_slack_interaction_state(state):
+    if input.actor_user_id is not None:
         # Deliveries are serialized by the workflow, so stamping here moves
         # the durable actor only after an active steer passes its identity gate.
-        updates = slack_actor_state_updates(user_id=input.actor_user_id, slack_user_id=actor_slack_user_id)
+        updates = (
+            slack_actor_state_updates(user_id=input.actor_user_id, slack_user_id=actor_slack_user_id)
+            if is_slack_interaction_state(state)
+            else actor_state_updates(user_id=input.actor_user_id)
+        )
         current = task_run.state or {}
         if any(current.get(key) != value for key, value in updates.items()):
             try:

--- a/products/tasks/backend/temporal/process_task/activities/send_followup_to_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/send_followup_to_sandbox.py
@@ -25,10 +25,9 @@ from products.tasks.backend.logic.services.agent_command import (
 )
 from products.tasks.backend.logic.services.connection_token import create_sandbox_connection_token
 from products.tasks.backend.logic.services.run_actor import (
-    ACTOR_USER_STATE_KEY,
-    SLACK_ACTOR_USER_STATE_KEY,
     actor_resolution_fails_closed,
     actor_state_updates,
+    recorded_actor_key,
     slack_actor_state_updates,
 )
 from products.tasks.backend.logic.services.staged_artifacts import get_task_run_artifacts_by_id
@@ -170,8 +169,7 @@ def _deliver_followup(input: SendFollowupToSandboxInput) -> str | None:
 
     state = task_run.state
     if input.actor_user_id is not None:
-        actor_key = SLACK_ACTOR_USER_STATE_KEY if is_slack_interaction_state(state) else ACTOR_USER_STATE_KEY
-        state = {**(state or {}), actor_key: input.actor_user_id}
+        state = {**(state or {}), recorded_actor_key(state): input.actor_user_id}
 
     actor_user = get_task_run_credential_user(task_run.task, state)
     if actor_resolution_fails_closed(state) and actor_user is None:

--- a/products/tasks/backend/temporal/process_task/sandbox_credentials.py
+++ b/products/tasks/backend/temporal/process_task/sandbox_credentials.py
@@ -21,6 +21,7 @@ from products.tasks.backend.logic.services.run_actor import loop_owner_eligible_
 from products.tasks.backend.models import Task, TaskRun
 from products.tasks.backend.temporal.process_task.utils import (
     PrAuthorshipMode,
+    actor_resolution_fails_closed,
     get_github_token,
     get_pr_authorship_mode,
     get_readonly_github_token,
@@ -28,7 +29,6 @@ from products.tasks.backend.temporal.process_task.utils import (
     get_sandbox_github_token,
     get_task_run_credential_user,
     is_caller_token_run,
-    is_slack_interaction_state,
     resolve_user_github_integration_for_task,
     sandbox_identity_scope,
 )
@@ -402,8 +402,8 @@ class GitHubSandboxCredential:
             )
 
         actor_user = get_task_run_credential_user(task, ctx.state)
-        if is_slack_interaction_state(ctx.state) and actor_user is None:
-            raise ReauthorizationRequired("Slack run requires an acting user before refreshing GitHub credentials.")
+        if actor_resolution_fails_closed(ctx.state) and actor_user is None:
+            raise ReauthorizationRequired("Run requires an acting user before refreshing GitHub credentials.")
 
         integration = None
         if get_pr_authorship_mode(task, ctx.state) == PrAuthorshipMode.USER and not is_caller_token_run(

--- a/products/tasks/backend/temporal/process_task/tests/test_send_followup_to_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_send_followup_to_sandbox.py
@@ -739,12 +739,21 @@ class TestSendFollowupActivityRefreshOrdering:
             updates={"slack_actor_user_id": 99, "slack_actor_slack_user_id": "U_BOB"},
         )
 
-    def test_non_slack_delivery_does_not_stamp(self, _patches):
+    def test_non_slack_delivery_stamps_run_actor(self, _patches):
+        # A teammate messaging a picked-up run must move the durable actor too, so
+        # later credential minting resolves the sender rather than the task creator.
         _patches["user_msg"].return_value = CommandResult(success=True, status_code=200)
 
-        send_followup_to_sandbox(SendFollowupToSandboxInput(run_id="run-1", message="hi", actor_user_id=99))
+        with patch(
+            "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_task_run_credential_user"
+        ) as mock_resolve:
+            mock_resolve.return_value = MagicMock(id=99)
+            send_followup_to_sandbox(SendFollowupToSandboxInput(run_id="run-1", message="hi", actor_user_id=99))
 
-        _patches["task_run_cls"].update_state_atomic.assert_not_called()
+        _patches["task_run_cls"].update_state_atomic.assert_any_call(
+            _patches["task_run"].id,
+            updates={"actor_user_id": 99},
+        )
 
     def test_default_scope_is_read_only(self, _patches):
         _patches["user_msg"].return_value = CommandResult(success=True, status_code=200)
@@ -758,9 +767,13 @@ class TestSendFollowupActivityRefreshOrdering:
         _patches["task_run"].state = {"sandbox_id": "sandbox-1"}
         _patches["task_run"].task.created_by_id = 42
 
-        outcome = send_followup_to_sandbox(
-            SendFollowupToSandboxInput(run_id="run-1", message="hi", actor_user_id=99, steer=True)
-        )
+        with patch(
+            "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_task_run_credential_user"
+        ) as mock_resolve:
+            mock_resolve.return_value = MagicMock(id=99)
+            outcome = send_followup_to_sandbox(
+                SendFollowupToSandboxInput(run_id="run-1", message="hi", actor_user_id=99, steer=True)
+            )
 
         assert outcome == STEER_DECLINED_OUTCOME
         _patches["conn_token"].assert_not_called()

--- a/products/tasks/backend/temporal/process_task/tests/test_utils.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_utils.py
@@ -722,6 +722,47 @@ class TestSlackTaskRunActorUser(TestCase):
         assert get_task_run_credential_user(task, state) == creator
 
 
+class TestWebRunActorUser(TestCase):
+    def _task_with_creator(self, slug: str):
+        from posthog.models import Organization, Team
+        from posthog.models.user import User
+
+        organization = Organization.objects.create(name=f"{slug}-org")
+        team = Team.objects.create(organization=organization, name=f"{slug}-team")
+        creator = User.objects.create(email=f"creator-{slug}@example.com")
+        task = Task.objects.create(
+            team=team,
+            title="Signals report task",
+            created_by=creator,
+            origin_product=Task.OriginProduct.SIGNAL_REPORT,
+        )
+        return organization, team, creator, task
+
+    def test_credential_user_uses_recorded_actor_over_creator(self) -> None:
+        from posthog.models.organization import OrganizationMembership
+        from posthog.models.user import User
+
+        organization, _team, creator, task = self._task_with_creator("web-actor")
+        teammate = User.objects.create(email="teammate-web-actor@example.com")
+        OrganizationMembership.objects.create(user=teammate, organization=organization)
+        state = {"actor_user_id": teammate.id}
+
+        assert get_task_run_actor_user(task, state) == teammate
+        assert get_task_run_credential_user(task, state) == teammate
+
+    def test_credential_user_fails_closed_when_recorded_actor_invalid(self) -> None:
+        _organization, _team, creator, task = self._task_with_creator("web-actor-invalid")
+        state = {"actor_user_id": creator.id + 999_999}
+
+        assert get_task_run_credential_user(task, state) is None
+
+    def test_credential_user_falls_back_to_creator_without_recorded_actor(self) -> None:
+        _organization, _team, creator, task = self._task_with_creator("web-actor-none")
+
+        assert get_task_run_credential_user(task, {}) == creator
+        assert get_task_run_credential_user(task, None) == creator
+
+
 class TestGetSandboxGitHubToken(TestCase):
     @parameterized.expand(
         [

--- a/products/tasks/backend/temporal/process_task/utils.py
+++ b/products/tasks/backend/temporal/process_task/utils.py
@@ -1105,11 +1105,16 @@ def _resolve_sandbox_github_token(
     """
     pr_authorship_mode: PrAuthorshipMode | None
     slack_interaction = is_slack_interaction_state(state)
+    # A run with an authoritative actor (Slack, or a recorded web driver) must never
+    # resolve the creator's identity in that actor's place. The team-token fallbacks
+    # below stay Slack-only: a valid web actor without a linked GitHub account keeps
+    # the team integration fallback, which swaps a token, not a user identity.
+    actor_is_authoritative = actor_resolution_fails_closed(state)
     created_by = actor_user or created_by
     if task is not None:
-        if actor_user is None and slack_interaction:
+        if actor_user is None and actor_is_authoritative:
             actor_user = get_task_run_credential_user(task, state)
-        created_by = actor_user or (task.created_by if not slack_interaction else None)
+        created_by = actor_user or (task.created_by if not actor_is_authoritative else None)
         repository = repository or task.repository
         github_user_integration_id = github_user_integration_id or (
             str(task.github_user_integration_id) if task.github_user_integration_id else None
@@ -1132,8 +1137,8 @@ def _resolve_sandbox_github_token(
                 return None
 
     if pr_authorship_mode == PrAuthorshipMode.USER:
-        if task is not None and slack_interaction and created_by is None:
-            raise ReauthorizationRequired(f"Slack run {run_id} requires an acting user with GitHub repo access.")
+        if task is not None and actor_is_authoritative and created_by is None:
+            raise ReauthorizationRequired(f"Run {run_id} requires an acting user with GitHub repo access.")
         cached = get_cached_github_user_token(run_id)
         if cached:
             return cached

--- a/products/tasks/backend/temporal/process_task/utils.py
+++ b/products/tasks/backend/temporal/process_task/utils.py
@@ -33,6 +33,7 @@ from products.tasks.backend.logic.services.mcp_url import resolve_mcp_url as _re
 # Re-exported so existing activity/workflow imports keep working after the move to
 # logic/services (non-temporal callers import run_actor directly).
 from products.tasks.backend.logic.services.run_actor import (
+    actor_resolution_fails_closed as actor_resolution_fails_closed,
     get_actor_distinct_id as get_actor_distinct_id,
     get_task_run_actor_user as get_task_run_actor_user,
     get_task_run_credential_user as get_task_run_credential_user,

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -2216,6 +2216,23 @@ class TestTaskAPI(BaseTaskAPITest):
         self.assertEqual(latest_run["environment"], "cloud")
 
     @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
+    def test_run_endpoint_records_the_acting_user_on_run_state(self, mock_workflow):
+        # A teammate driving a team-visible signals task must run it as themselves:
+        # the run records them as the actor, so credential minting
+        # (run_actor.get_task_run_credential_user) resolves them, not the creator.
+        task = self.create_task()
+        task.origin_product = Task.OriginProduct.SIGNAL_REPORT
+        task.save(update_fields=["origin_product"])
+        teammate = self.create_organization_user()
+        self.client.force_login(teammate)
+
+        response = self.client.post(f"/api/projects/@current/tasks/{task.id}/run/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        run = task.runs.get()
+        self.assertEqual(run.state["actor_user_id"], teammate.id)
+
+    @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
     def test_run_endpoint_starts_pi_task(self, mock_workflow):
         task = self.create_task(runtime=Task.Runtime.PI)
 


### PR DESCRIPTION
## Problem

A team member who picks up a teammate's team-visible task (a signals task from the inbox, onboarding, hogdesk) drives it under the teammate's identity. The sandbox mints its OAuth token from `task.created_by`, so the run acts with the creator's resource access and sandbox, not the driver's.

Team-wide pickup of these tasks is by design (`task_control_q`, #68254). The credential side is not: the `command` endpoint already sends `actor_user_id=request.user.id` down to credential resolution, but the resolver only honors it for Slack-steered runs. Everything else falls back to the creator.

Internal ref: VERIA-310.

## Changes

- Runs started or messaged through the web API now execute as the user driving them, not the task creator.
- `run_task`, `bootstrap_task_run`, and warm-run activation stamp `actor_user_id` into run state at creation, via one shared helper (`products/tasks/backend/facade/api.py`).
- Follow-up delivery stamps the sender durably on non-Slack runs, the way Slack steering already does (`send_followup_to_sandbox.py`).
- `get_task_run_credential_user` honors the recorded actor on any run and fails closed when the actor no longer validates (`logic/services/run_actor.py`).
- Sandbox GitHub identity resolution treats a recorded web actor as authoritative too, so an invalid actor no longer resolves the creator's GitHub identity (`_resolve_sandbox_github_token`). The team-token fallback for a valid actor without a linked GitHub account stays Slack-only, preserving today's behavior for creator-started runs.
- Runs with no recorded actor keep the creator fallback. Signals autostarts create runs through `Task.create_and_run`, which this PR does not touch, so the pipeline is unchanged.
- `actor_user_id` and `slack_actor_user_id` join `_PROTECTED_RUN_STATE_KEYS`, so a run-state PATCH cannot name whose credentials get minted.
- Mechanical: Slack-only fail-closed gates in five activities now use the origin-neutral `actor_resolution_fails_closed`.

> Semantics choice, open to discuss: the actor moves per message (Slack's model), so a teammate's follow-up re-binds the rest of the run to them. The alternative is pinning the actor at run start; that's a small change in `send_followup_to_sandbox.py` if preferred.

**Not in this PR (follow-ups):**
- Warm sandbox and custom image selection still resolve against `task.created_by_id` (`_warm_sandbox_selection_is_accessible`).
- A plain `user_message` still lacks the steer path's bound-session identity check.

## How did you test this code?

Tests:
- `products/tasks/backend/tests/test_api.py::test_run_endpoint_records_the_acting_user_on_run_state` - a teammate's run on a signals task records them as the actor (the previously missing stamp).
- `products/tasks/backend/temporal/process_task/tests/test_utils.py::TestWebRunActorUser` - recorded actor wins over creator; invalid actor fails closed; no recorded actor falls back to creator.
- Updated non-Slack stamping test in `test_send_followup_to_sandbox.py`.

Not run locally (authored in a review worktree without the stack); relying on CI, including repo-wide mypy. `ruff` and `ty check` pass locally.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code from an investigation of an internal security finding. Skills invoked: `/writing-pr-descriptions`, a personal PR-voice skill. The design reuses the existing Slack run-actor machinery (`run_actor.py`) rather than adding a parallel mechanism; the main decision was generalizing the recorded-actor key instead of dropping team origins from `task_control_q`, which would have removed inbox pickup. In review follow-up, GitHub identity resolution was scoped deliberately: identity substitution fails closed for any recorded actor, while the team-token fallback stays Slack-only to avoid breaking creator runs without a linked GitHub account. Description keeps the finding's details behind the internal reference.
