### PR TITLE
chore(devex): drop the tools/owners transition fallbacks

### DIFF
--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -322,9 +322,6 @@ jobs:
                         # Deliberately not in `legacy` — a leaf-package change should run its
                         # dependents, not the whole Django suite.
                         - 'packages/owners/**'
-                        # Transitional: unrebased branches still have the resolver at
-                        # tools/owners. Drop once open PRs have rebased.
-                        - 'tools/owners/**'
                         # Make sure we run if someone is explicitly changing the workflow
                         - .depot/workflows/ci-backend.yml
                         - .github/clickhouse-versions.json
@@ -438,9 +435,6 @@ jobs:
                         - '**/owners.yaml'
                         # Resolver changes must re-run the owners.yaml lint too.
                         - 'packages/owners/**'
-                        # Transitional: unrebased branches still have the resolver at
-                        # tools/owners. Drop once open PRs have rebased.
-                        - 'tools/owners/**'
                       openapi_types:
                         # Generated OpenAPI types - validate they match schema
                         - 'frontend/src/generated/**/*'

--- a/.github/scripts/trunk-impacted-targets.js
+++ b/.github/scripts/trunk-impacted-targets.js
@@ -298,9 +298,6 @@ const TRIPWIRE_RULES = [
     // nearer file claims it, so it has the same readers as the tooling. A
     // product's own owners.yaml is not here: it keeps its product lane.
     ['packages/owners/**', UNIVERSAL],
-    // Transitional: unrebased branches still have the resolver at tools/owners, where the
-    // tools/ fallback rule would give it the python lanes only. Drop once open PRs have rebased.
-    ['tools/owners/**', UNIVERSAL],
     ['owners.yaml', UNIVERSAL],
     // pytest-split timing data, and nothing else reads it.
     ['.test_durations', PYTHON],

--- a/.github/scripts/trunk-impacted-targets.test.js
+++ b/.github/scripts/trunk-impacted-targets.test.js
@@ -1516,7 +1516,6 @@ test('cross-domain tools are tripwires rather than backend-only', () => {
         computeTargets(['frontend/src/products.json'], CONTEXT)
     )
     assert.deepEqual(computeTargets(['packages/owners/posthog_owners/__init__.py'], CONTEXT), EVERYTHING)
-    assert.deepEqual(computeTargets(['tools/owners/posthog_owners/__init__.py'], CONTEXT), EVERYTHING)
 })
 
 // Prose overlaps only other prose, and has to reach that lane through the

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -206,9 +206,6 @@ jobs:
                         # Deliberately not in `legacy` — a leaf-package change should run its
                         # dependents, not the whole Django suite.
                         - 'packages/owners/**'
-                        # Transitional: unrebased branches still have the resolver at
-                        # tools/owners. Drop once open PRs have rebased.
-                        - 'tools/owners/**'
                         # Make sure we run if someone is explicitly changing the workflow
                         - .github/workflows/ci-backend.yml
                         - .github/clickhouse-versions.json
@@ -328,9 +325,6 @@ jobs:
                         - '**/owners.yaml'
                         # Resolver changes must re-run the owners.yaml lint too.
                         - 'packages/owners/**'
-                        # Transitional: unrebased branches still have the resolver at
-                        # tools/owners. Drop once open PRs have rebased.
-                        - 'tools/owners/**'
                       openapi_types:
                         # Generated OpenAPI types - validate they match schema
                         - 'frontend/src/generated/**/*'
@@ -3910,10 +3904,9 @@ jobs:
               shell: bash
               run: |
                   # The owners resolver is a path dep of the reporter, so a base ref predating it
-                  # can't resolve its deps. The tools/owners fallback covers base refs from before
-                  # the move to packages/owners; drop it once open PRs have rebased.
+                  # can't resolve its deps.
                   available=false
-                  if [[ -f .github/scripts/report_test_timings.py && ( -d packages/owners || -d tools/owners ) ]]; then
+                  if [[ -f .github/scripts/report_test_timings.py && -d packages/owners ]]; then
                     available=true
                   fi
                   # A re-run may emit only through an attempt-aware reporter: an older script would

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -930,9 +930,8 @@ jobs:
               run: |
                   available=false
                   # The owners resolver is a path dep of the reporter, so a base ref predating it
-                  # can't resolve its deps. The tools/owners fallback covers base refs from before
-                  # the move to packages/owners; drop it once open PRs have rebased.
-                  if [[ -f .github/scripts/report_test_timings.py && ( -d packages/owners || -d tools/owners ) ]] && grep -q -- '"jest"' .github/scripts/report_test_timings.py; then
+                  # can't resolve its deps.
+                  if [[ -f .github/scripts/report_test_timings.py && -d packages/owners ]] && grep -q -- '"jest"' .github/scripts/report_test_timings.py; then
                     available=true
                   fi
                   if [[ "$GITHUB_RUN_ATTEMPT" != "1" ]] && ! grep -q "def partition_run_attempt" .github/scripts/report_test_timings.py 2>/dev/null; then

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -66,9 +66,6 @@ jobs:
                         - 'tools/hogli/**'
                         - 'tools/hogli-commands/hogli_commands/**'
                         - 'packages/owners/**'
-                        # Transitional: unrebased branches still have the resolver at
-                        # tools/owners. Drop once open PRs have rebased.
-                        - 'tools/owners/**'
                         - 'hogli.yaml'
                         - 'bin/**'
                         # Dev tools with dedicated pytest steps below
@@ -204,14 +201,7 @@ jobs:
 
                   - name: Run owners resolver tests
                     shell: bash
-                    # The tools/owners fallback covers unrebased branches; drop it once open PRs
-                    # have rebased past the move to packages/owners.
-                    run: |
-                        if [ -d packages/owners ]; then
-                            pytest packages/owners/tests -v --junitxml=junit-owners.xml
-                        else
-                            pytest tools/owners/tests -v --junitxml=junit-owners.xml
-                        fi
+                    run: pytest packages/owners/tests -v --junitxml=junit-owners.xml
 
                   - name: Run query-performance-ai tests
                     shell: bash

--- a/.github/workflows/ci-scripts.yml
+++ b/.github/workflows/ci-scripts.yml
@@ -36,15 +36,8 @@ jobs:
                   python-version-file: pyproject.toml
 
             # defusedxml + opentelemetry + the owners resolver are report_test_timings.py's script deps.
-            # The tools/owners fallback covers unrebased branches; drop it once open PRs have
-            # rebased past the move to packages/owners.
             - name: Install pytest
-              run: |
-                  owners_dir=packages/owners
-                  if [ ! -d "$owners_dir" ]; then
-                      owners_dir=tools/owners
-                  fi
-                  python -m pip install --quiet pytest defusedxml==0.7.1 opentelemetry-sdk==1.33.1 opentelemetry-exporter-otlp-proto-http==1.33.1 "./$owners_dir"
+              run: python -m pip install --quiet pytest defusedxml==0.7.1 opentelemetry-sdk==1.33.1 opentelemetry-exporter-otlp-proto-http==1.33.1 ./packages/owners
 
             # `-c /dev/null` skips the repo pytest.ini (its --reuse-db addopt needs
             # pytest-django, which we don't install here). `--noconftest` skips the

--- a/.stamphog/policy.yml
+++ b/.stamphog/policy.yml
@@ -125,7 +125,6 @@ deny:
                 - 'tools/pr-approval-agent/'
                 - 'products/stamphog/backend/logic/policy_defaults/'
                 - 'packages/owners/'
-                - 'tools/owners/'
                 - 'CODEOWNERS'
                 - 'owners\.yaml'
                 - 'product\.yaml'


### PR DESCRIPTION
## Problem

- #85392 moved the owners resolver to `packages/owners` but kept `tools/owners` alongside in the workflows, the merge-queue lane table, and the stamphog policy, so branches that had not rebased past the move kept working.
- Once open PRs carry the new path, those fallbacks only read as load-bearing to the next editor.

Layer 3 of stack #85393, on top of #85392. Hold this layer until the open PRs that touch CI have rebased; merging it early breaks `ci-scripts` and the owners test step on any branch still at the old path.

## Changes

- Workflows reference `packages/owners` only: ci-backend and the `.depot` shadow filters, ci-python filter and test step, ci-scripts install, the report-test-timings guards in ci-backend and ci-frontend.
- The lane table and the stamphog policy drop the `tools/owners` entries.
- The review engine keeps its legacy sibling lookup on purpose: downstream repos vendor it by directory name and re-sync on their own schedule.
- All mechanical; nothing user-visible.

## How did you test this code?

- Workflow lint and the lane selector tests (the `tools/owners` expectation removed with its rule).
- Not checked: nothing else; the diff is deletions of fallbacks whose live path the two layers below exercise.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Fable 5); Julian asked for the fallbacks to land as their own layer rather than linger.
- Skills invoked: `/stacking-prs`, `/writing-pr-descriptions`.
