### PR TITLE
chore(signals): cover the sandbox task id plumbing end to end

### DIFF
--- a/services/llm-gateway/tests/test_dependencies.py
+++ b/services/llm-gateway/tests/test_dependencies.py
@@ -1,12 +1,16 @@
 import json
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID
 
 import pytest
 from fastapi import HTTPException, Request
 from starlette.datastructures import Headers
 
+from llm_gateway.auth.authenticators import OAuthAccessTokenAuthenticator
+from llm_gateway.auth.cache import AuthCache, reset_auth_cache
 from llm_gateway.auth.models import AuthenticatedUser
-from llm_gateway.auth.service import InvalidProjectScopeError, UnauthorizedProjectScopeError
+from llm_gateway.auth.service import AuthService, InvalidProjectScopeError, UnauthorizedProjectScopeError
 from llm_gateway.baseten import BASETEN_DEEPSEEK_PUBLIC_MODEL, BASETEN_GLM53_PUBLIC_MODEL
 from llm_gateway.config import get_settings
 from llm_gateway.dependencies import (
@@ -20,6 +24,7 @@ from llm_gateway.dependencies import (
     resolve_plan_and_quota,
 )
 from llm_gateway.products.config import POSTHOG_CODE_US_APP_ID
+from llm_gateway.rate_limiting.cost_throttles import SandboxTaskCostThrottle
 from llm_gateway.rate_limiting.throttles import ThrottleContext, ThrottleResult
 from llm_gateway.services.plan_resolver import PlanInfo
 from llm_gateway.services.quota_resolver import QuotaResourceStatus
@@ -638,3 +643,87 @@ class TestDesktopAccessGate:
             request.app.state.desktop_access_resolver.has_access.assert_not_awaited()
         finally:
             get_settings.cache_clear()
+
+
+class TestSandboxTaskIdPlumbing:
+    """The whole path the per-run spend ceiling rides on: token row -> AuthenticatedUser ->
+    ThrottleContext -> cache key.
+
+    Every other test of that ceiling builds a ThrottleContext by hand, so either propagation hop
+    could be dropped and `SandboxTaskCostThrottle` would quietly stop keying on the run while the
+    suite stayed green.
+    """
+
+    async def _authenticate_oauth_row(
+        self, token: str, sandbox_task_id: object
+    ) -> tuple[AuthenticatedUser | None, AsyncMock]:
+        conn = AsyncMock()
+        conn.fetchrow = AsyncMock(
+            return_value={
+                "id": 1,
+                "user_id": 123,
+                "scope": "llm_gateway:read internal_run:read",
+                "expires": datetime.now(UTC) + timedelta(hours=1),
+                "current_team_id": 456,
+                "application_id": 789,
+                "distinct_id": "test-distinct-id",
+                "is_staff": False,
+                "sandbox_task_id": sandbox_task_id,
+            }
+        )
+        pool = MagicMock()
+        pool.acquire = AsyncMock(return_value=conn)
+        pool.release = AsyncMock()
+        request = MagicMock(spec=Request)
+        request.headers = {"authorization": f"Bearer {token}"}
+        service = AuthService(authenticators=[OAuthAccessTokenAuthenticator()], cache=AuthCache(max_size=10, ttl=60))
+        return await service.authenticate_request(request, pool), conn
+
+    async def _throttle_context_for(self, user: AuthenticatedUser) -> ThrottleContext:
+        captured: ThrottleContext | None = None
+
+        async def capture_check(context: ThrottleContext) -> ThrottleResult:
+            nonlocal captured
+            captured = context
+            return ThrottleResult.allow()
+
+        runner = MagicMock()
+        runner.check = capture_check
+        with patch("llm_gateway.dependencies.ensure_costs_fresh"):
+            await enforce_throttles(
+                request=_make_request({"model": "gpt-4o", "messages": []}), user=user, runner=runner
+            )
+        assert captured is not None
+        return captured
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("token", "row_value", "expect_ceiling"),
+        [
+            # asyncpg returns a UUID object; the ceiling keys on its string form
+            pytest.param("pha_sandbox", UUID("3f1e2d4c-5b6a-7089-9a0b-1c2d3e4f5061"), True, id="sandbox_run_token"),
+            # an ordinary user token bounds no single run, so the ceiling stays inert
+            pytest.param("pha_interactive", None, False, id="non_sandbox_token"),
+        ],
+    )
+    async def test_token_row_sandbox_task_id_reaches_the_per_run_cost_key(
+        self, token: str, row_value: object, expect_ceiling: bool
+    ) -> None:
+        reset_auth_cache()
+        expected_id = str(row_value) if row_value is not None else None
+
+        user, conn = await self._authenticate_oauth_row(token, row_value)
+        assert user is not None
+        # The row is faked, so the column has to be asserted against the query itself; dropping it
+        # from the SELECT is the one way to break this path that a mocked row cannot show.
+        assert "sandbox_task_id" in conn.fetchrow.await_args.args[0]
+        assert user.sandbox_task_id == expected_id
+
+        context = await self._throttle_context_for(user)
+        assert context.sandbox_task_id == expected_id
+
+        # An empty cache key is how the ceiling turns itself off, so this is the hop that matters.
+        cache_key = SandboxTaskCostThrottle(redis=None)._get_cache_key(context)
+        assert bool(cache_key) is expect_ceiling
+        if expect_ceiling:
+            assert cache_key == f"cost:task:{expected_id}"


### PR DESCRIPTION
## Problem

Follow-up to #84066, now merged, acting on [this review](https://github.com/PostHog/posthog/pull/84066#pullrequestreview-4971804318). Nobody sees this change, but the per-run spend ceiling that PR shipped can stop applying without anyone noticing.

`SandboxTaskCostThrottle` bounds what one sandbox run can spend. It keys on `sandbox_task_id`, which reaches it through three hops on master today:

- The authenticator selects `oat.sandbox_task_id` from the token row.
- The row maps onto `AuthenticatedUser.sandbox_task_id`.
- `enforce_throttles` copies it onto the `ThrottleContext`.

Every existing test of the ceiling builds a `ThrottleContext` by hand. Drop any of the three hops and the id is `None`, the cache key is empty, the ceiling turns itself off, and the suite stays green.

## Changes

Nothing user-visible changes. This PR adds one test and no production code.

- `TestSandboxTaskIdPlumbing` authenticates a faked OAuth token row through the real `AuthService`, feeds the resulting user into the real `enforce_throttles`, and asserts the id arrives on the cache key the ceiling meters against.
- The row is a mock, so the SELECT is asserted against the query text. That is the one hop a faked row cannot exercise.
- A second case covers a token with no `sandbox_task_id`, which must produce an empty key so the ceiling stays inert for ordinary user tokens.

The test spans auth and dependencies, so it lives in `tests/test_dependencies.py` next to the `enforce_throttles` harness rather than in `tests/test_auth.py`.

## How did you test this code?

Each hop was removed in turn to confirm the test fails without it, then restored:

| Hop removed | Result |
| --- | --- |
| `oat.sandbox_task_id` from the SELECT | both cases fail |
| `sandbox_task_id=` from the `AuthenticatedUser` mapping | sandbox case fails |
| `sandbox_task_id=user.sandbox_task_id` from `enforce_throttles` | sandbox case fails |

Not checked: no request ever reached a real Postgres row or a real Redis. The token row is a mock and `SandboxTaskCostThrottle` is constructed with `redis=None`, so this covers propagation, not the ceiling's arithmetic, which `tests/test_cost_throttles.py` already covers.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code (Opus 5) at the request of the PR author, in response to a review comment on #84066 asking for exactly this coverage.

Skills invoked: `/stacking-prs` and `/writing-pr-descriptions`.

The first draft subclassed `TestEnforceThrottles` to reuse its capture harness. That makes pytest re-run every inherited test under the subclass, so the harness is duplicated in about ten lines instead. The three-hop mutation check in the table above is what drove the SQL-text assertion: without it, removing the column from the SELECT left the test green.
