### PR TITLE
fix(desktop): close sidebar hover peek when the window is abandoned

### DIFF
--- a/products/desktop/packages/ui/src/primitives/hooks/useSidebarEdgeHoverPeek.test.ts
+++ b/products/desktop/packages/ui/src/primitives/hooks/useSidebarEdgeHoverPeek.test.ts
@@ -1,10 +1,13 @@
 import {
+  PEEK_ABANDON_CLOSE_DELAY_MS,
   PEEK_CLOSE_MARGIN,
   PEEK_REVEAL_THRESHOLD,
   shouldCloseOnExit,
   shouldRevealOnEdge,
+  useSidebarEdgeHoverPeek,
 } from "@posthog/ui/primitives/hooks/useSidebarEdgeHoverPeek";
-import { describe, expect, it } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("shouldRevealOnEdge", () => {
   const threshold = PEEK_REVEAL_THRESHOLD;
@@ -37,5 +40,112 @@ describe("shouldCloseOnExit", () => {
     ["wide panel closes past its boundary", 400 + margin + 1, 400, true],
   ])("%s", (_name, pointer, width, expected) => {
     expect(shouldCloseOnExit({ pointer, width, margin })).toBe(expected);
+  });
+});
+
+describe("useSidebarEdgeHoverPeek on window abandon", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // jsdom's document.hasFocus() is false by default; reveal requires focus.
+    vi.spyOn(document, "hasFocus").mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  const setup = (initialProps: { enabled: boolean; peeked: boolean }) => {
+    const onReveal = vi.fn();
+    const onClose = vi.fn();
+    const { rerender, unmount } = renderHook(
+      ({ enabled, peeked }: { enabled: boolean; peeked: boolean }) =>
+        useSidebarEdgeHoverPeek({
+          enabled,
+          peeked,
+          side: "left",
+          width: 240,
+          onReveal,
+          onClose,
+        }),
+      { initialProps },
+    );
+    return { onReveal, onClose, rerender, unmount };
+  };
+
+  const blurWindow = () => window.dispatchEvent(new Event("blur"));
+  const leaveDocument = () =>
+    document.documentElement.dispatchEvent(new MouseEvent("mouseleave"));
+  const moveTo = (clientX: number) =>
+    document.dispatchEvent(new MouseEvent("mousemove", { clientX }));
+
+  it.each([
+    ["the window losing focus", blurWindow],
+    ["the pointer leaving the document", leaveDocument],
+  ])("closes an active peek on a timer after %s", (_name, abandon) => {
+    const { onClose, unmount } = setup({ enabled: true, peeked: true });
+    act(() => abandon());
+    expect(onClose).not.toHaveBeenCalled();
+    act(() => vi.advanceTimersByTime(PEEK_ABANDON_CLOSE_DELAY_MS));
+    expect(onClose).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  it.each([
+    ["refocusing", blurWindow, () => window.dispatchEvent(new Event("focus"))],
+    [
+      "the pointer re-entering",
+      leaveDocument,
+      () => moveTo(PEEK_REVEAL_THRESHOLD - 1),
+    ],
+  ])("%s before the timer keeps the peek open", (_name, abandon, comeBack) => {
+    const { onClose, unmount } = setup({ enabled: true, peeked: true });
+    act(() => abandon());
+    act(() => comeBack());
+    act(() => vi.runAllTimers());
+    expect(onClose).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it.each([
+    ["not peeked", { enabled: true, peeked: false }],
+    ["disabled (open or resizing)", { enabled: false, peeked: true }],
+  ])("does not close when %s", (_name, props) => {
+    const { onClose, unmount } = setup(props);
+    act(() => blurWindow());
+    act(() => leaveDocument());
+    act(() => vi.runAllTimers());
+    expect(onClose).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it("does not reveal on edge hover while the window is unfocused", () => {
+    vi.spyOn(document, "hasFocus").mockReturnValue(false);
+    const { onReveal, unmount } = setup({ enabled: true, peeked: false });
+    act(() => moveTo(PEEK_REVEAL_THRESHOLD - 1));
+    act(() => vi.runAllTimers());
+    expect(onReveal).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it("re-reveals on edge re-entry after the pointer left the document", () => {
+    const { onReveal, onClose, rerender, unmount } = setup({
+      enabled: true,
+      peeked: false,
+    });
+    act(() => moveTo(PEEK_REVEAL_THRESHOLD - 1));
+    expect(onReveal).toHaveBeenCalledTimes(1);
+
+    rerender({ enabled: true, peeked: true });
+    act(() => leaveDocument());
+    act(() => vi.advanceTimersByTime(PEEK_ABANDON_CLOSE_DELAY_MS));
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    // Without the wasInside reset the pointer still counts as inside the edge
+    // zone, and coming back through it would not reopen the peek.
+    rerender({ enabled: true, peeked: false });
+    act(() => moveTo(PEEK_REVEAL_THRESHOLD - 1));
+    expect(onReveal).toHaveBeenCalledTimes(2);
+    unmount();
   });
 });

--- a/products/desktop/packages/ui/src/primitives/hooks/useSidebarEdgeHoverPeek.ts
+++ b/products/desktop/packages/ui/src/primitives/hooks/useSidebarEdgeHoverPeek.ts
@@ -2,6 +2,11 @@ import { useEffect, useRef } from "react";
 
 export const PEEK_REVEAL_THRESHOLD = 24;
 export const PEEK_CLOSE_MARGIN = 64;
+// An abandoned window (pointer left, or focus moved to another app) closes the
+// peek on a timer rather than instantly: quick enough that it's gone when the
+// user looks back, slow enough that crossing the window edge or switching apps
+// never reads as the peek glitching shut.
+export const PEEK_ABANDON_CLOSE_DELAY_MS = 5000;
 
 export function shouldRevealOnEdge({
   pointer,
@@ -49,8 +54,18 @@ export function useSidebarEdgeHoverPeek({
 
   useEffect(() => {
     let wasInside = false;
+    let abandonCloseTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const cancelAbandonClose = () => {
+      if (abandonCloseTimer) {
+        clearTimeout(abandonCloseTimer);
+        abandonCloseTimer = null;
+      }
+    };
 
     const handleMouseMove = (e: MouseEvent) => {
+      // The pointer is back inside, so it hasn't abandoned the window.
+      cancelAbandonClose();
       const state = stateRef.current;
       const pointer =
         state.side === "left" ? e.clientX : window.innerWidth - e.clientX;
@@ -71,7 +86,10 @@ export function useSidebarEdgeHoverPeek({
             pointer,
             wasInside,
             threshold: PEEK_REVEAL_THRESHOLD,
-          })
+          }) &&
+          // An unfocused window still gets mousemove but also spurious
+          // pointer-exit events; revealing there makes the peek stutter.
+          document.hasFocus()
         ) {
           state.onReveal();
         }
@@ -80,7 +98,45 @@ export function useSidebarEdgeHoverPeek({
       wasInside = pointer <= PEEK_REVEAL_THRESHOLD;
     };
 
+    // Mousemove can't close the peek once the pointer is outside the window,
+    // so abandoning the window (app switch, pointer exit) closes it too.
+    const closeIfPeeked = () => {
+      const state = stateRef.current;
+      if (state.enabled && state.peeked) state.onClose();
+    };
+
+    const scheduleAbandonClose = () => {
+      if (abandonCloseTimer) return;
+      abandonCloseTimer = setTimeout(() => {
+        abandonCloseTimer = null;
+        closeIfPeeked();
+      }, PEEK_ABANDON_CLOSE_DELAY_MS);
+    };
+
+    const handleWindowFocus = () => {
+      // Came back before the close fired; the peek is still wanted.
+      cancelAbandonClose();
+    };
+
+    const handlePointerExit = () => {
+      // Re-entering the edge from outside the window should reveal again.
+      wasInside = false;
+      scheduleAbandonClose();
+    };
+
     document.addEventListener("mousemove", handleMouseMove);
-    return () => document.removeEventListener("mousemove", handleMouseMove);
+    window.addEventListener("blur", scheduleAbandonClose);
+    window.addEventListener("focus", handleWindowFocus);
+    document.documentElement.addEventListener("mouseleave", handlePointerExit);
+    return () => {
+      cancelAbandonClose();
+      document.removeEventListener("mousemove", handleMouseMove);
+      window.removeEventListener("blur", scheduleAbandonClose);
+      window.removeEventListener("focus", handleWindowFocus);
+      document.documentElement.removeEventListener(
+        "mouseleave",
+        handlePointerExit,
+      );
+    };
   }, []);
 }


### PR DESCRIPTION
## Problem

A collapsed sidebar opened by an accidental edge hover stays open after the user leaves the window: switch apps or move the pointer away, and the peek still overlays the content on return, until the mouse moves past it.

The peek's close path runs only on `mousemove` inside the window, so a pointer that leaves the window, or focus that moves to another app, never triggers it.

## Changes

- A peeked sidebar now closes by itself 5 seconds after the window is abandoned (pointer left the window, or focus moved to another app).
- Returning within those 5 seconds, by pointer re-entry or window refocus, cancels the close, so brief switches and edge crossings never flicker the peek.
- Hovering the edge of an unfocused window no longer reveals the peek. Unfocused windows receive mousemove but also spurious pointer-exit events, which made the peek stutter open and shut.
- Deliberate interactions are unchanged: edge hover reveals instantly, moving past the panel closes instantly, and an open sidebar menu still pins the peek.
- Nothing looks different at rest; the change is only in when the peek closes, so there are no screenshots.

## How did you test this code?

- New Vitest cases in `useSidebarEdgeHoverPeek.test.ts`: each abandon signal closes on the timer (catches removal of the new listeners), each return path cancels it (catches a close firing under an active pointer), no close while the sidebar is open or resizing, no reveal while the window is unfocused, and re-reveal after the pointer re-enters (catches dropping the `wasInside` reset).
- Manual testing on macOS in the dev build by the PR author: app switch, pointer off-window, rapid waving across the window edge, unfocused-window hover, and menu-open pinning.
- Not run: the full desktop suite locally; verification was scoped to the `@posthog/ui` tests plus typecheck and Biome on the touched files.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written in an agent session; the human driver set the design direction and feel-tested each iteration in the dev build.
- Skills invoked: /posthog-desktop, /writing-tests, /writing-pr-descriptions.
- Earlier iterations closed instantly or after short graces (150-500 ms) on blur and pointer exit, and briefly added a hover-intent dwell before reveal; feel-testing rejected them as laggy or glitchy, and the session settled on the single 5 s abandon timer with the reveal path unchanged.
