### PR TITLE
feat(desktop): put github repos and cloud defaults first in onboarding

### DIFF
--- a/products/desktop/packages/core/src/git-interaction/gitInteractionLogic.test.ts
+++ b/products/desktop/packages/core/src/git-interaction/gitInteractionLogic.test.ts
@@ -29,6 +29,55 @@ function actionIds(result: ReturnType<typeof computeGitInteractionState>) {
 }
 
 describe("computeGitInteractionState", () => {
+  describe("github cli environment gaps", () => {
+    it.each([
+      {
+        name: "missing",
+        ghStatus: { installed: false, authenticated: false },
+        reason: "Install GitHub CLI: `brew install gh`",
+      },
+      {
+        name: "unauthenticated",
+        ghStatus: { installed: true, authenticated: false },
+        reason: "Authenticate GitHub CLI with `gh auth login`",
+      },
+    ])(
+      "keeps create-pr visible but disabled when gh is $name",
+      ({ ghStatus, reason }) => {
+        const result = computeGitInteractionState(
+          makeState({ hasChanges: true, aheadOfRemote: 1, ghStatus }),
+        );
+        const createPr = result.actions.find((a) => a.id === "create-pr");
+        expect(createPr).toBeDefined();
+        expect(createPr?.enabled).toBe(false);
+        expect(createPr?.disabledReason).toBe(reason);
+        expect(result.primaryAction.id).not.toBe("create-pr");
+      },
+    );
+
+    it("still drops create-pr for routine states like an existing PR", () => {
+      const result = computeGitInteractionState(
+        makeState({
+          hasChanges: true,
+          prStatus: {
+            prExists: true,
+            baseBranch: "main",
+            headBranch: "feature/test",
+            prUrl: "https://github.com/test/test/pull/1",
+          },
+        }),
+      );
+      expect(actionIds(result)).not.toContain("create-pr");
+    });
+
+    it("does not surface create-pr while gh status is still loading", () => {
+      const result = computeGitInteractionState(
+        makeState({ hasChanges: true, aheadOfRemote: 1, ghStatus: null }),
+      );
+      expect(actionIds(result)).not.toContain("create-pr");
+    });
+  });
+
   describe("on default branch with changes", () => {
     it("returns create-pr as primary action", () => {
       const result = computeGitInteractionState(

--- a/products/desktop/packages/core/src/git-interaction/gitInteractionLogic.ts
+++ b/products/desktop/packages/core/src/git-interaction/gitInteractionLogic.ts
@@ -152,6 +152,12 @@ function getCreatePrAction(
   return makeAction("create-pr", "Create PR", createPrDisabledReason);
 }
 
+function hasGhEnvironmentGap(s: GitState): boolean {
+  return (
+    s.ghStatus !== null && (!s.ghStatus.installed || !s.ghStatus.authenticated)
+  );
+}
+
 function getPrimaryAction(
   createPrAction: GitMenuAction,
   commitAction: GitMenuAction,
@@ -231,7 +237,12 @@ export function computeGitInteractionState(input: GitState): GitComputed {
   );
 
   const actions: GitMenuAction[] = [];
-  if (createPrAction.enabled) actions.push(createPrAction);
+  // An environment gap (GitHub CLI missing or logged out) keeps the entry
+  // visible but disabled, so its fix shows in the tooltip. Routine states
+  // (PR exists, nothing to ship) stay dropped.
+  if (createPrAction.enabled || hasGhEnvironmentGap(input)) {
+    actions.push(createPrAction);
+  }
   actions.push(commitAction, pushAction);
   if (viewPrAction) actions.push(viewPrAction);
 

--- a/products/desktop/packages/core/src/git-interaction/gitInteractionLogic.ts
+++ b/products/desktop/packages/core/src/git-interaction/gitInteractionLogic.ts
@@ -98,26 +98,52 @@ function getPushDisabledReason(
   return null;
 }
 
-function getCreatePrDisabledReason(
-  s: GitState,
-  repoReason: string | null,
-): string | null {
-  if (repoReason) return repoReason;
-  if (!s.isOnline) return OFFLINE_REASON;
+interface CreatePrGate {
+  reason: string | null;
+  /** An environment gap the user can fix (missing or logged-out GitHub CLI)
+   * keeps the disabled entry visible with its fix in the tooltip; routine
+   * states (PR exists, nothing to ship) hide the entry instead. */
+  visibleWhenDisabled: boolean;
+}
 
-  if (!s.ghStatus) return "Checking GitHub CLI status...";
-  if (!s.ghStatus.installed) return "Install GitHub CLI: `brew install gh`";
-  if (!s.ghStatus.authenticated)
-    return "Authenticate GitHub CLI with `gh auth login`";
-  if (!s.repoInfo) return "No GitHub remote detected.";
+function getCreatePrGate(s: GitState, repoReason: string | null): CreatePrGate {
+  if (repoReason) return { reason: repoReason, visibleWhenDisabled: false };
+  if (!s.isOnline)
+    return { reason: OFFLINE_REASON, visibleWhenDisabled: false };
 
-  if (s.prStatus?.prExists) return "PR already exists.";
+  if (!s.ghStatus) {
+    return {
+      reason: "Checking GitHub CLI status...",
+      visibleWhenDisabled: false,
+    };
+  }
+  if (!s.ghStatus.installed) {
+    return {
+      reason: "Install GitHub CLI: `brew install gh`",
+      visibleWhenDisabled: true,
+    };
+  }
+  if (!s.ghStatus.authenticated) {
+    return {
+      reason: "Authenticate GitHub CLI with `gh auth login`",
+      visibleWhenDisabled: true,
+    };
+  }
+  if (!s.repoInfo) {
+    return { reason: "No GitHub remote detected.", visibleWhenDisabled: false };
+  }
+
+  if (s.prStatus?.prExists) {
+    return { reason: "PR already exists.", visibleWhenDisabled: false };
+  }
 
   const hasShippableWork =
     s.hasChanges || s.aheadOfRemote > 0 || s.aheadOfDefault > 0 || !s.hasRemote;
-  if (!hasShippableWork) return "No changes to ship.";
+  if (!hasShippableWork) {
+    return { reason: "No changes to ship.", visibleWhenDisabled: false };
+  }
 
-  return null;
+  return { reason: null, visibleWhenDisabled: false };
 }
 
 function getCommitAction(
@@ -150,12 +176,6 @@ function getCreatePrAction(
   createPrDisabledReason: string | null,
 ): GitMenuAction {
   return makeAction("create-pr", "Create PR", createPrDisabledReason);
-}
-
-function hasGhEnvironmentGap(s: GitState): boolean {
-  return (
-    s.ghStatus !== null && (!s.ghStatus.installed || !s.ghStatus.authenticated)
-  );
 }
 
 function getPrimaryAction(
@@ -196,7 +216,8 @@ export function computeGitInteractionState(input: GitState): GitComputed {
   }
 
   const onDefaultBranch = isOnDefaultBranch(input);
-  const createPrDisabledReason = getCreatePrDisabledReason(input, repoReason);
+  const createPrGate = getCreatePrGate(input, repoReason);
+  const createPrDisabledReason = createPrGate.reason;
   const createPrAction = getCreatePrAction(createPrDisabledReason);
 
   if (onDefaultBranch) {
@@ -237,10 +258,7 @@ export function computeGitInteractionState(input: GitState): GitComputed {
   );
 
   const actions: GitMenuAction[] = [];
-  // An environment gap (GitHub CLI missing or logged out) keeps the entry
-  // visible but disabled, so its fix shows in the tooltip. Routine states
-  // (PR exists, nothing to ship) stay dropped.
-  if (createPrAction.enabled || hasGhEnvironmentGap(input)) {
+  if (createPrAction.enabled || createPrGate.visibleWhenDisabled) {
     actions.push(createPrAction);
   }
   actions.push(commitAction, pushAction);

--- a/products/desktop/packages/core/src/git-interaction/gitInteractionLogic.ts
+++ b/products/desktop/packages/core/src/git-interaction/gitInteractionLogic.ts
@@ -1,6 +1,6 @@
 import type { GitMenuAction, GitMenuActionId } from "./types";
 
-interface GitState {
+export interface GitState {
   repoPath?: string;
   isRepo: boolean;
   isRepoLoading: boolean;

--- a/products/desktop/packages/core/src/onboarding/spaceRepoAssignment.test.ts
+++ b/products/desktop/packages/core/src/onboarding/spaceRepoAssignment.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import {
+  type AssignableChannel,
+  planSpaceRepoAssignments,
+  resolveRepoIntegrationId,
+} from "./spaceRepoAssignment";
+
+const ME = "user-uuid-me";
+const TEAMMATE = "user-uuid-teammate";
+
+function channel(overrides: Partial<AssignableChannel>): AssignableChannel {
+  return {
+    id: "id",
+    name: "name",
+    channel_type: "public",
+    system_role: null,
+    created_by: { uuid: ME },
+    ...overrides,
+  };
+}
+
+const personal = channel({
+  id: "personal-id",
+  name: "me",
+  channel_type: "personal",
+  system_role: "personal",
+});
+const general = channel({
+  id: "general-id",
+  name: "general",
+  system_role: "general",
+});
+
+describe("spaceRepoAssignment", () => {
+  describe("planSpaceRepoAssignments", () => {
+    it("targets the personal space and an own-provisioned empty #general", () => {
+      expect(planSpaceRepoAssignments([personal, general], ME)).toEqual([
+        "personal-id",
+        "general-id",
+      ]);
+    });
+
+    it("skips #general when the team already configured repositories", () => {
+      const configured = channel({
+        ...general,
+        repositories: ["example/app"],
+      });
+      expect(planSpaceRepoAssignments([personal, configured], ME)).toEqual([
+        "personal-id",
+      ]);
+    });
+
+    it("skips a teammate-created #general even when its repository list is empty", () => {
+      // A teammate may have emptied it on purpose; empty is not the same
+      // signal as never configured.
+      const inherited = channel({
+        ...general,
+        created_by: { uuid: TEAMMATE },
+      });
+      expect(planSpaceRepoAssignments([personal, inherited], ME)).toEqual([
+        "personal-id",
+      ]);
+    });
+
+    it("skips #general when the creator is unknown", () => {
+      const legacy = channel({ ...general, created_by: null });
+      expect(planSpaceRepoAssignments([personal, legacy], ME)).toEqual([
+        "personal-id",
+      ]);
+    });
+
+    it("returns no targets when neither space exists", () => {
+      expect(
+        planSpaceRepoAssignments(
+          [channel({ id: "other", name: "random" })],
+          ME,
+        ),
+      ).toEqual([]);
+    });
+  });
+
+  describe("resolveRepoIntegrationId", () => {
+    const integrations = [
+      { id: 1, config: { account: { name: "ExampleOrg" } } },
+      { id: 2, config: { account: { name: "other" } } },
+    ];
+
+    it("matches the repo owner to the integration account", () => {
+      expect(resolveRepoIntegrationId("exampleorg/app", integrations)).toBe(1);
+    });
+
+    it("falls back to a sole integration when the owner does not match", () => {
+      expect(resolveRepoIntegrationId("unrelated/app", [integrations[0]])).toBe(
+        1,
+      );
+    });
+
+    it("refuses to guess between several non-matching integrations", () => {
+      expect(resolveRepoIntegrationId("unrelated/app", integrations)).toBe(
+        null,
+      );
+    });
+  });
+});

--- a/products/desktop/packages/core/src/onboarding/spaceRepoAssignment.test.ts
+++ b/products/desktop/packages/core/src/onboarding/spaceRepoAssignment.test.ts
@@ -57,8 +57,6 @@ describe("spaceRepoAssignment", () => {
     });
 
     it("skips an inherited #general even when its repository list is empty", () => {
-      // A teammate may have emptied it on purpose; empty is not the same
-      // signal as just created.
       expect(
         planSpaceRepoAssignments([personal, general], {
           personalCreated: true,

--- a/products/desktop/packages/core/src/onboarding/spaceRepoAssignment.test.ts
+++ b/products/desktop/packages/core/src/onboarding/spaceRepoAssignment.test.ts
@@ -28,20 +28,43 @@ const general = channel({
 });
 
 describe("spaceRepoAssignment", () => {
+  const bothCreated = { personalCreated: true, generalCreated: true };
+  const nothingCreated = { personalCreated: false, generalCreated: false };
+
   describe("planSpaceRepoAssignments", () => {
-    it("targets the personal space and a just-created empty #general", () => {
-      expect(planSpaceRepoAssignments([personal, general], true)).toEqual([
-        "personal-id",
-        "general-id",
-      ]);
+    it("targets both just-created spaces", () => {
+      expect(
+        planSpaceRepoAssignments([personal, general], bothCreated),
+      ).toEqual(["personal-id", "general-id"]);
+    });
+
+    it("still fills an unconfigured pre-existing personal space", () => {
+      expect(
+        planSpaceRepoAssignments([personal, general], nothingCreated),
+      ).toEqual(["personal-id"]);
+    });
+
+    it("keeps a configured personal space on re-onboarding", () => {
+      // Wiped local storage re-runs onboarding; the pick must not clobber the
+      // repos the user already configured on their own space.
+      const configured = channel({
+        ...personal,
+        repositories: ["example/mine"],
+      });
+      expect(
+        planSpaceRepoAssignments([configured, general], nothingCreated),
+      ).toEqual([]);
     });
 
     it("skips an inherited #general even when its repository list is empty", () => {
       // A teammate may have emptied it on purpose; empty is not the same
       // signal as just created.
-      expect(planSpaceRepoAssignments([personal, general], false)).toEqual([
-        "personal-id",
-      ]);
+      expect(
+        planSpaceRepoAssignments([personal, general], {
+          personalCreated: true,
+          generalCreated: false,
+        }),
+      ).toEqual(["personal-id"]);
     });
 
     it("skips a just-created #general that a teammate already configured", () => {
@@ -49,16 +72,16 @@ describe("spaceRepoAssignment", () => {
         ...general,
         repositories: ["example/app"],
       });
-      expect(planSpaceRepoAssignments([personal, configured], true)).toEqual([
-        "personal-id",
-      ]);
+      expect(
+        planSpaceRepoAssignments([personal, configured], bothCreated),
+      ).toEqual(["personal-id"]);
     });
 
     it("returns no targets when neither space exists", () => {
       expect(
         planSpaceRepoAssignments(
           [channel({ id: "other", name: "random" })],
-          true,
+          bothCreated,
         ),
       ).toEqual([]);
     });

--- a/products/desktop/packages/core/src/onboarding/spaceRepoAssignment.test.ts
+++ b/products/desktop/packages/core/src/onboarding/spaceRepoAssignment.test.ts
@@ -5,16 +5,12 @@ import {
   resolveRepoIntegrationId,
 } from "./spaceRepoAssignment";
 
-const ME = "user-uuid-me";
-const TEAMMATE = "user-uuid-teammate";
-
 function channel(overrides: Partial<AssignableChannel>): AssignableChannel {
   return {
     id: "id",
     name: "name",
     channel_type: "public",
     system_role: null,
-    created_by: { uuid: ME },
     ...overrides,
   };
 }
@@ -33,38 +29,27 @@ const general = channel({
 
 describe("spaceRepoAssignment", () => {
   describe("planSpaceRepoAssignments", () => {
-    it("targets the personal space and an own-provisioned empty #general", () => {
-      expect(planSpaceRepoAssignments([personal, general], ME)).toEqual([
+    it("targets the personal space and a just-created empty #general", () => {
+      expect(planSpaceRepoAssignments([personal, general], true)).toEqual([
         "personal-id",
         "general-id",
       ]);
     });
 
-    it("skips #general when the team already configured repositories", () => {
+    it("skips an inherited #general even when its repository list is empty", () => {
+      // A teammate may have emptied it on purpose; empty is not the same
+      // signal as just created.
+      expect(planSpaceRepoAssignments([personal, general], false)).toEqual([
+        "personal-id",
+      ]);
+    });
+
+    it("skips a just-created #general that a teammate already configured", () => {
       const configured = channel({
         ...general,
         repositories: ["example/app"],
       });
-      expect(planSpaceRepoAssignments([personal, configured], ME)).toEqual([
-        "personal-id",
-      ]);
-    });
-
-    it("skips a teammate-created #general even when its repository list is empty", () => {
-      // A teammate may have emptied it on purpose; empty is not the same
-      // signal as never configured.
-      const inherited = channel({
-        ...general,
-        created_by: { uuid: TEAMMATE },
-      });
-      expect(planSpaceRepoAssignments([personal, inherited], ME)).toEqual([
-        "personal-id",
-      ]);
-    });
-
-    it("skips #general when the creator is unknown", () => {
-      const legacy = channel({ ...general, created_by: null });
-      expect(planSpaceRepoAssignments([personal, legacy], ME)).toEqual([
+      expect(planSpaceRepoAssignments([personal, configured], true)).toEqual([
         "personal-id",
       ]);
     });
@@ -73,7 +58,7 @@ describe("spaceRepoAssignment", () => {
       expect(
         planSpaceRepoAssignments(
           [channel({ id: "other", name: "random" })],
-          ME,
+          true,
         ),
       ).toEqual([]);
     });

--- a/products/desktop/packages/core/src/onboarding/spaceRepoAssignment.ts
+++ b/products/desktop/packages/core/src/onboarding/spaceRepoAssignment.ts
@@ -34,25 +34,35 @@ export function resolveRepoIntegrationId(
   return integrations.length === 1 ? integrations[0].id : null;
 }
 
+export interface SpaceRepoAssignmentFlags {
+  personalCreated: boolean;
+  generalCreated: boolean;
+}
+
 /**
- * Which spaces the onboarding repo pick becomes the default for: the personal
- * space always, and the shared #general space only when this onboarding's
- * provisioning call just created it (the server's general_created flag). An
- * inherited #general is team state, even when its repository list is empty:
- * someone may have emptied it on purpose. The empty check guards the race
- * where a teammate configures the just-created space first.
+ * Which spaces the onboarding repo pick becomes the default for. A space that
+ * existed before this onboarding and carries repositories keeps its config: a
+ * re-run of onboarding (wiped local storage) must not clobber what the user or
+ * their team set up. An empty pre-existing personal space is still safe to
+ * fill; an inherited #general is not, because a teammate may have emptied it
+ * on purpose.
  */
 export function planSpaceRepoAssignments(
   channels: AssignableChannel[],
-  generalJustCreated: boolean,
+  flags: SpaceRepoAssignmentFlags,
 ): string[] {
   const targets: string[] = [];
   const personal = channels.find((channel) => isPersonalChannel(channel));
-  if (personal) targets.push(personal.id);
+  if (
+    personal &&
+    (flags.personalCreated || (personal.repositories ?? []).length === 0)
+  ) {
+    targets.push(personal.id);
+  }
   const general = channels.find((channel) => isGeneralChannel(channel));
   if (
     general &&
-    generalJustCreated &&
+    flags.generalCreated &&
     (general.repositories ?? []).length === 0
   ) {
     targets.push(general.id);

--- a/products/desktop/packages/core/src/onboarding/spaceRepoAssignment.ts
+++ b/products/desktop/packages/core/src/onboarding/spaceRepoAssignment.ts
@@ -15,9 +15,8 @@ export interface AssignableGithubIntegration {
 }
 
 /**
- * The team integration that provides an "owner/repo" pick, matched by account
- * name. Falls back to the only integration when there is exactly one, and
- * refuses to guess between several non-matching ones.
+ * Matched by account name, falling back to a sole integration. Returns null
+ * rather than guessing between several that do not match the owner.
  */
 export function resolveRepoIntegrationId(
   repo: string,
@@ -40,12 +39,10 @@ export interface SpaceRepoAssignmentFlags {
 }
 
 /**
- * Which spaces the onboarding repo pick becomes the default for. A space that
- * existed before this onboarding and carries repositories keeps its config: a
- * re-run of onboarding (wiped local storage) must not clobber what the user or
- * their team set up. An empty pre-existing personal space is still safe to
- * fill; an inherited #general is not, because a teammate may have emptied it
- * on purpose.
+ * Which spaces the onboarding repo pick becomes the default for. Re-onboarding
+ * (wiped local storage) must not clobber what a user or their team set up, and
+ * an empty inherited #general is not the same signal as a just-created one:
+ * a teammate may have emptied it on purpose.
  */
 export function planSpaceRepoAssignments(
   channels: AssignableChannel[],

--- a/products/desktop/packages/core/src/onboarding/spaceRepoAssignment.ts
+++ b/products/desktop/packages/core/src/onboarding/spaceRepoAssignment.ts
@@ -7,7 +7,6 @@ import {
 export interface AssignableChannel extends ChannelIdentity {
   id: string;
   repositories?: string[];
-  created_by?: { uuid: string } | null;
 }
 
 export interface AssignableGithubIntegration {
@@ -37,14 +36,15 @@ export function resolveRepoIntegrationId(
 
 /**
  * Which spaces the onboarding repo pick becomes the default for: the personal
- * space always, and the shared #general space only when this user's own
- * onboarding provisioned it (they are its creator) and nobody has configured
- * repositories. A teammate-created #general is team state, even when its
- * repository list is empty: someone may have emptied it on purpose.
+ * space always, and the shared #general space only when this onboarding's
+ * provisioning call just created it (the server's general_created flag). An
+ * inherited #general is team state, even when its repository list is empty:
+ * someone may have emptied it on purpose. The empty check guards the race
+ * where a teammate configures the just-created space first.
  */
 export function planSpaceRepoAssignments(
   channels: AssignableChannel[],
-  currentUserUuid: string | null | undefined,
+  generalJustCreated: boolean,
 ): string[] {
   const targets: string[] = [];
   const personal = channels.find((channel) => isPersonalChannel(channel));
@@ -52,9 +52,8 @@ export function planSpaceRepoAssignments(
   const general = channels.find((channel) => isGeneralChannel(channel));
   if (
     general &&
-    (general.repositories ?? []).length === 0 &&
-    currentUserUuid != null &&
-    general.created_by?.uuid === currentUserUuid
+    generalJustCreated &&
+    (general.repositories ?? []).length === 0
   ) {
     targets.push(general.id);
   }

--- a/products/desktop/packages/core/src/onboarding/spaceRepoAssignment.ts
+++ b/products/desktop/packages/core/src/onboarding/spaceRepoAssignment.ts
@@ -1,0 +1,62 @@
+import {
+  type ChannelIdentity,
+  isGeneralChannel,
+  isPersonalChannel,
+} from "../canvas/channelName";
+
+export interface AssignableChannel extends ChannelIdentity {
+  id: string;
+  repositories?: string[];
+  created_by?: { uuid: string } | null;
+}
+
+export interface AssignableGithubIntegration {
+  id: number;
+  config?: { account?: { name?: string | null } | null };
+}
+
+/**
+ * The team integration that provides an "owner/repo" pick, matched by account
+ * name. Falls back to the only integration when there is exactly one, and
+ * refuses to guess between several non-matching ones.
+ */
+export function resolveRepoIntegrationId(
+  repo: string,
+  integrations: AssignableGithubIntegration[],
+): number | null {
+  const owner = repo.split("/")[0]?.toLowerCase();
+  if (owner) {
+    const match = integrations.find(
+      (integration) =>
+        integration.config?.account?.name?.toLowerCase() === owner,
+    );
+    if (match) return match.id;
+  }
+  return integrations.length === 1 ? integrations[0].id : null;
+}
+
+/**
+ * Which spaces the onboarding repo pick becomes the default for: the personal
+ * space always, and the shared #general space only when this user's own
+ * onboarding provisioned it (they are its creator) and nobody has configured
+ * repositories. A teammate-created #general is team state, even when its
+ * repository list is empty: someone may have emptied it on purpose.
+ */
+export function planSpaceRepoAssignments(
+  channels: AssignableChannel[],
+  currentUserUuid: string | null | undefined,
+): string[] {
+  const targets: string[] = [];
+  const personal = channels.find((channel) => isPersonalChannel(channel));
+  if (personal) targets.push(personal.id);
+  const general = channels.find((channel) => isGeneralChannel(channel));
+  if (
+    general &&
+    (general.repositories ?? []).length === 0 &&
+    currentUserUuid != null &&
+    general.created_by?.uuid === currentUserUuid
+  ) {
+    targets.push(general.id);
+  }
+  return targets;
+}

--- a/products/desktop/packages/core/src/onboarding/steps.test.ts
+++ b/products/desktop/packages/core/src/onboarding/steps.test.ts
@@ -11,24 +11,52 @@ import {
   stepDirection,
 } from "./steps";
 
+const allSteps = {
+  hasCodeAccess: false,
+  hasImportableConfig: true,
+  hasGithubIntegration: undefined,
+};
+
 describe("computeActiveSteps", () => {
   it("drops invite-code when the user already has code access", () => {
-    expect(computeActiveSteps(true, true)).not.toContain("invite-code");
+    expect(
+      computeActiveSteps({ ...allSteps, hasCodeAccess: true }),
+    ).not.toContain("invite-code");
   });
 
   it("keeps invite-code when access is unknown or false", () => {
-    expect(computeActiveSteps(false, true)).toEqual(ONBOARDING_STEPS);
-    expect(computeActiveSteps(null, true)).toEqual(ONBOARDING_STEPS);
-    expect(computeActiveSteps(undefined, true)).toEqual(ONBOARDING_STEPS);
+    expect(computeActiveSteps(allSteps)).toEqual(ONBOARDING_STEPS);
+    expect(computeActiveSteps({ ...allSteps, hasCodeAccess: null })).toEqual(
+      ONBOARDING_STEPS,
+    );
+    expect(
+      computeActiveSteps({ ...allSteps, hasCodeAccess: undefined }),
+    ).toEqual(ONBOARDING_STEPS);
   });
 
   it("drops import-config when there is no importable config", () => {
-    expect(computeActiveSteps(false, false)).not.toContain("import-config");
+    expect(
+      computeActiveSteps({ ...allSteps, hasImportableConfig: false }),
+    ).not.toContain("import-config");
+  });
+
+  it("drops install-cli only on a confirmed github connection", () => {
+    expect(
+      computeActiveSteps({ ...allSteps, hasGithubIntegration: true }),
+    ).not.toContain("install-cli");
+    expect(
+      computeActiveSteps({ ...allSteps, hasGithubIntegration: false }),
+    ).toContain("install-cli");
+    expect(computeActiveSteps(allSteps)).toContain("install-cli");
   });
 });
 
 describe("nearestActiveStep", () => {
-  const withoutConditionals = computeActiveSteps(true, false);
+  const withoutConditionals = computeActiveSteps({
+    hasCodeAccess: true,
+    hasImportableConfig: false,
+    hasGithubIntegration: undefined,
+  });
 
   it("returns the step itself while it is still active", () => {
     expect(nearestActiveStep(ONBOARDING_STEPS, "import-config")).toBe(
@@ -61,7 +89,11 @@ describe("nearestActiveStep", () => {
 });
 
 describe("step navigation", () => {
-  const steps = computeActiveSteps(true, true);
+  const steps = computeActiveSteps({
+    hasCodeAccess: true,
+    hasImportableConfig: true,
+    hasGithubIntegration: undefined,
+  });
 
   it("identifies first and last steps", () => {
     expect(isFirstStep(0)).toBe(true);

--- a/products/desktop/packages/core/src/onboarding/steps.test.ts
+++ b/products/desktop/packages/core/src/onboarding/steps.test.ts
@@ -15,6 +15,7 @@ const allSteps = {
   hasCodeAccess: false,
   hasImportableConfig: true,
   hasGithubIntegration: undefined,
+  projectCount: 2,
 };
 
 describe("computeActiveSteps", () => {
@@ -40,6 +41,22 @@ describe("computeActiveSteps", () => {
     ).not.toContain("import-config");
   });
 
+  it("drops project-select only when there is exactly one project", () => {
+    expect(computeActiveSteps({ ...allSteps, projectCount: 1 })).not.toContain(
+      "project-select",
+    );
+    expect(computeActiveSteps({ ...allSteps, projectCount: 2 })).toContain(
+      "project-select",
+    );
+    // A list that has not loaded says nothing about how many projects exist.
+    expect(
+      computeActiveSteps({ ...allSteps, projectCount: undefined }),
+    ).toContain("project-select");
+    expect(computeActiveSteps({ ...allSteps, projectCount: 0 })).toContain(
+      "project-select",
+    );
+  });
+
   it("drops install-cli only on a confirmed github connection", () => {
     expect(
       computeActiveSteps({ ...allSteps, hasGithubIntegration: true }),
@@ -56,6 +73,7 @@ describe("nearestActiveStep", () => {
     hasCodeAccess: true,
     hasImportableConfig: false,
     hasGithubIntegration: undefined,
+    projectCount: 2,
   });
 
   it("returns the step itself while it is still active", () => {
@@ -93,6 +111,7 @@ describe("step navigation", () => {
     hasCodeAccess: true,
     hasImportableConfig: true,
     hasGithubIntegration: undefined,
+    projectCount: 2,
   });
 
   it("identifies first and last steps", () => {

--- a/products/desktop/packages/core/src/onboarding/steps.test.ts
+++ b/products/desktop/packages/core/src/onboarding/steps.test.ts
@@ -48,7 +48,6 @@ describe("computeActiveSteps", () => {
     expect(computeActiveSteps({ ...allSteps, projectCount: 2 })).toContain(
       "project-select",
     );
-    // A list that has not loaded says nothing about how many projects exist.
     expect(
       computeActiveSteps({ ...allSteps, projectCount: undefined }),
     ).toContain("project-select");

--- a/products/desktop/packages/core/src/onboarding/steps.ts
+++ b/products/desktop/packages/core/src/onboarding/steps.ts
@@ -25,13 +25,18 @@ export interface DetectedRepo {
   branch?: string;
 }
 
-export function computeActiveSteps(
-  hasCodeAccess: boolean | null | undefined,
-  hasImportableConfig: boolean,
-): OnboardingStep[] {
+export function computeActiveSteps(options: {
+  hasCodeAccess: boolean | null | undefined;
+  hasImportableConfig: boolean;
+  /** Undefined while the integrations query is loading; the step only drops on a confirmed connection. */
+  hasGithubIntegration: boolean | undefined;
+}): OnboardingStep[] {
   return ONBOARDING_STEPS.filter((step) => {
-    if (step === "invite-code" && hasCodeAccess === true) return false;
-    if (step === "import-config" && !hasImportableConfig) return false;
+    if (step === "invite-code" && options.hasCodeAccess === true) return false;
+    if (step === "import-config" && !options.hasImportableConfig) return false;
+    if (step === "install-cli" && options.hasGithubIntegration === true) {
+      return false;
+    }
     return true;
   });
 }

--- a/products/desktop/packages/core/src/onboarding/steps.ts
+++ b/products/desktop/packages/core/src/onboarding/steps.ts
@@ -30,8 +30,11 @@ export function computeActiveSteps(options: {
   hasImportableConfig: boolean;
   /** Undefined while the integrations query is loading; the step only drops on a confirmed connection. */
   hasGithubIntegration: boolean | undefined;
+  /** Undefined until the project list has loaded, so a slow list cannot skip a real choice. */
+  projectCount: number | undefined;
 }): OnboardingStep[] {
   return ONBOARDING_STEPS.filter((step) => {
+    if (step === "project-select" && options.projectCount === 1) return false;
     if (step === "invite-code" && options.hasCodeAccess === true) return false;
     if (step === "import-config" && !options.hasImportableConfig) return false;
     if (step === "install-cli" && options.hasGithubIntegration === true) {

--- a/products/desktop/packages/ui/src/features/git-interaction/components/TaskActionsMenu.stories.tsx
+++ b/products/desktop/packages/ui/src/features/git-interaction/components/TaskActionsMenu.stories.tsx
@@ -59,16 +59,12 @@ export default meta;
 
 type Story = StoryObj<typeof ControlFor>;
 
-/** Everything installed: Create PR is the primary action. */
 export const Ready: Story = {
   render: () => <ControlFor state={baseState} />,
 };
 
-/**
- * GitHub CLI missing (e.g. onboarding skipped install-cli because GitHub was
- * connected, then the user runs a local task). Create PR stays in the menu,
- * disabled, with the install command in its tooltip.
- */
+/** How a user gets here: onboarding skipped install-cli because GitHub was
+ * connected, then they run a local task. */
 export const GhCliMissing: Story = {
   render: () => (
     <ControlFor
@@ -80,7 +76,6 @@ export const GhCliMissing: Story = {
   ),
 };
 
-/** GitHub CLI installed but not authenticated: disabled with the login command. */
 export const GhCliUnauthenticated: Story = {
   render: () => (
     <ControlFor

--- a/products/desktop/packages/ui/src/features/git-interaction/components/TaskActionsMenu.stories.tsx
+++ b/products/desktop/packages/ui/src/features/git-interaction/components/TaskActionsMenu.stories.tsx
@@ -44,7 +44,7 @@ function ControlFor({ state }: { state: GitState }) {
       <div className="text-(--gray-10) text-[12px]">
         actions: {computed.actions.map((a) => a.id).join(", ")}
         {computed.createPrDisabledReason
-          ? ` · create-pr reason (not surfaced): ${computed.createPrDisabledReason}`
+          ? ` · create-pr reason: ${computed.createPrDisabledReason}`
           : ""}
       </div>
     </div>
@@ -66,8 +66,8 @@ export const Ready: Story = {
 
 /**
  * GitHub CLI missing (e.g. onboarding skipped install-cli because GitHub was
- * connected, then the user runs a local task). Create PR is dropped from the
- * menu entirely; its disabled reason is computed but rendered nowhere.
+ * connected, then the user runs a local task). Create PR stays in the menu,
+ * disabled, with the install command in its tooltip.
  */
 export const GhCliMissing: Story = {
   render: () => (
@@ -80,7 +80,7 @@ export const GhCliMissing: Story = {
   ),
 };
 
-/** GitHub CLI installed but not authenticated: same silent drop. */
+/** GitHub CLI installed but not authenticated: disabled with the login command. */
 export const GhCliUnauthenticated: Story = {
   render: () => (
     <ControlFor

--- a/products/desktop/packages/ui/src/features/git-interaction/components/TaskActionsMenu.stories.tsx
+++ b/products/desktop/packages/ui/src/features/git-interaction/components/TaskActionsMenu.stories.tsx
@@ -1,0 +1,93 @@
+import {
+  computeGitInteractionState,
+  type GitState,
+} from "@posthog/core/git-interaction/gitInteractionLogic";
+import type { Meta, StoryObj } from "@storybook/react";
+import { GitActionControl } from "./TaskActionsMenu";
+
+// Runs the real computeGitInteractionState over a realistic GitState, so the
+// stories show exactly what the task header offers in each environment,
+// including which actions are dropped rather than disabled.
+const baseState: GitState = {
+  repoPath: "/Users/dev/example-repo",
+  isRepo: true,
+  isRepoLoading: false,
+  hasChanges: true,
+  aheadOfRemote: 2,
+  behind: 0,
+  aheadOfDefault: 2,
+  hasRemote: true,
+  isFeatureBranch: true,
+  currentBranch: "feature/add-export",
+  defaultBranch: "main",
+  ghStatus: { installed: true, authenticated: true },
+  repoInfo: { owner: "example", repo: "example-repo" },
+  prStatus: {
+    prExists: false,
+    baseBranch: null,
+    headBranch: null,
+    prUrl: null,
+  },
+  isOnline: true,
+};
+
+function ControlFor({ state }: { state: GitState }) {
+  const computed = computeGitInteractionState(state);
+  return (
+    <div className="flex flex-col gap-3 p-4">
+      <GitActionControl
+        primaryAction={computed.primaryAction}
+        actions={computed.actions}
+        isBusy={false}
+        onSelect={() => {}}
+      />
+      <div className="text-(--gray-10) text-[12px]">
+        actions: {computed.actions.map((a) => a.id).join(", ")}
+        {computed.createPrDisabledReason
+          ? ` · create-pr reason (not surfaced): ${computed.createPrDisabledReason}`
+          : ""}
+      </div>
+    </div>
+  );
+}
+
+const meta: Meta<typeof ControlFor> = {
+  title: "Features/GitInteraction/TaskActionsMenu",
+  component: ControlFor,
+};
+export default meta;
+
+type Story = StoryObj<typeof ControlFor>;
+
+/** Everything installed: Create PR is the primary action. */
+export const Ready: Story = {
+  render: () => <ControlFor state={baseState} />,
+};
+
+/**
+ * GitHub CLI missing (e.g. onboarding skipped install-cli because GitHub was
+ * connected, then the user runs a local task). Create PR is dropped from the
+ * menu entirely; its disabled reason is computed but rendered nowhere.
+ */
+export const GhCliMissing: Story = {
+  render: () => (
+    <ControlFor
+      state={{
+        ...baseState,
+        ghStatus: { installed: false, authenticated: false },
+      }}
+    />
+  ),
+};
+
+/** GitHub CLI installed but not authenticated: same silent drop. */
+export const GhCliUnauthenticated: Story = {
+  render: () => (
+    <ControlFor
+      state={{
+        ...baseState,
+        ghStatus: { installed: true, authenticated: false },
+      }}
+    />
+  ),
+};

--- a/products/desktop/packages/ui/src/features/git-interaction/components/TaskActionsMenu.tsx
+++ b/products/desktop/packages/ui/src/features/git-interaction/components/TaskActionsMenu.tsx
@@ -431,7 +431,7 @@ interface GitActionControlProps {
   onSelect: (id: GitMenuActionId) => void;
 }
 
-function GitActionControl({
+export function GitActionControl({
   primaryAction,
   actions,
   isBusy,

--- a/products/desktop/packages/ui/src/features/onboarding/components/ImportConfigStep.tsx
+++ b/products/desktop/packages/ui/src/features/onboarding/components/ImportConfigStep.tsx
@@ -236,7 +236,7 @@ export function ImportConfigStep({ onNext, onBack }: ImportConfigStepProps) {
             <ArrowLeft size={16} weight="bold" />
             Back
           </Button>
-          <Button size="3" onClick={onNext}>
+          <Button size="3" onClick={() => onNext()}>
             Continue
             <ArrowRight size={16} weight="bold" />
           </Button>

--- a/products/desktop/packages/ui/src/features/onboarding/components/OnboardingFlow.tsx
+++ b/products/desktop/packages/ui/src/features/onboarding/components/OnboardingFlow.tsx
@@ -16,6 +16,7 @@ import { StepIndicator } from "@posthog/ui/features/onboarding/components/StepIn
 import { WelcomeScreen } from "@posthog/ui/features/onboarding/components/WelcomeScreen";
 import { useOnboardingFlow } from "@posthog/ui/features/onboarding/hooks/useOnboardingFlow";
 import { useOnboardingStore } from "@posthog/ui/features/onboarding/onboardingStore";
+import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
 import { shipIt } from "@posthog/ui/primitives/confetti";
 import { FullScreenLayout } from "@posthog/ui/primitives/FullScreenLayout";
 import { openTaskInput } from "@posthog/ui/router/useOpenTask";
@@ -48,6 +49,9 @@ export function OnboardingFlow() {
     detectedRepo,
     isDetectingRepo,
     handleDirectoryChange,
+    selectedCloudRepo,
+    handleCloudRepoChange,
+    hasGithubIntegration,
   } = useOnboardingFlow();
   const completeOnboarding = useOnboardingStore(
     (state) => state.completeOnboarding,
@@ -58,6 +62,9 @@ export function OnboardingFlow() {
     (state) => state.status === "authenticated",
   );
   const { data: githubUserIntegrations = [] } = useUserGithubIntegrations();
+  const setLastUsedWorkspaceMode = useSettingsStore(
+    (state) => state.setLastUsedWorkspaceMode,
+  );
 
   const flowStartedAtRef = useRef(Date.now());
   const stepEnteredAtRef = useRef(Date.now());
@@ -113,7 +120,11 @@ export function OnboardingFlow() {
   };
 
   const handleNext = (context?: StepCompletedContext) => {
-    trackStepCompleted(context);
+    // `onClick={onNext}` would pass the click event here; a DOM event spread
+    // into capture properties poisons the whole analytics batch.
+    const safeContext =
+      context && "nativeEvent" in context ? undefined : context;
+    trackStepCompleted(safeContext);
     trackStepViewed(currentIndex + 1);
     next();
   };
@@ -147,6 +158,11 @@ export function OnboardingFlow() {
         repoSkipped,
       }),
     );
+    if (githubUserIntegrations.length > 0) {
+      // GitHub is connected, so the first task should start in the cloud even
+      // if an earlier session left a local run-mode preference behind.
+      setLastUsedWorkspaceMode("cloud");
+    }
     shipIt();
     completeOnboarding();
     openTaskInput();
@@ -316,6 +332,9 @@ export function OnboardingFlow() {
                 detectedRepo={detectedRepo}
                 isDetectingRepo={isDetectingRepo}
                 onDirectoryChange={handleDirectoryChange}
+                selectedCloudRepo={selectedCloudRepo}
+                onCloudRepoChange={handleCloudRepoChange}
+                hasGithubIntegration={hasGithubIntegration}
               />
             </motion.div>
           )}

--- a/products/desktop/packages/ui/src/features/onboarding/components/OnboardingFlow.tsx
+++ b/products/desktop/packages/ui/src/features/onboarding/components/OnboardingFlow.tsx
@@ -1,13 +1,25 @@
 import { ArrowRight, SignOut } from "@phosphor-icons/react";
+import { integrationKeys } from "@posthog/core/integrations/repositoryKeys";
+import {
+  classifyIntegrations,
+  type Integration,
+} from "@posthog/core/integrations/selectors";
 import {
   buildAbandonedProps,
   buildCompletedProps,
   buildStepCompletedProps,
   type StepCompletedContext,
 } from "@posthog/core/onboarding/analytics";
+import {
+  planSpaceRepoAssignments,
+  resolveRepoIntegrationId,
+} from "@posthog/core/onboarding/spaceRepoAssignment";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
+import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
 import { useLogoutMutation } from "@posthog/ui/features/auth/useAuthMutations";
+import { useCurrentUser } from "@posthog/ui/features/auth/useCurrentUser";
+import { TASK_CHANNELS_QUERY_KEY } from "@posthog/ui/features/canvas/hooks/useTaskChannels";
 import { useUserGithubIntegrations } from "@posthog/ui/features/integrations/useIntegrations";
 import { ConnectGitHubStep } from "@posthog/ui/features/onboarding/components/ConnectGitHubStep";
 import { ImportConfigStep } from "@posthog/ui/features/onboarding/components/ImportConfigStep";
@@ -21,7 +33,9 @@ import { shipIt } from "@posthog/ui/primitives/confetti";
 import { FullScreenLayout } from "@posthog/ui/primitives/FullScreenLayout";
 import { openTaskInput } from "@posthog/ui/router/useOpenTask";
 import { track } from "@posthog/ui/shell/analytics";
+import { logger } from "@posthog/ui/shell/logger";
 import { Button, Flex } from "@radix-ui/themes";
+import { useQueryClient } from "@tanstack/react-query";
 import { AnimatePresence, LayoutGroup, motion } from "framer-motion";
 import { useEffect, useRef } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
@@ -31,6 +45,8 @@ import { SelectRepoStep } from "./SelectRepoStep";
 
 const IS_DEV = import.meta.env.DEV;
 
+const log = logger.scope("onboarding-flow");
+
 const stepVariants = {
   enter: (dir: number) => ({ opacity: 0, x: dir * 20 }),
   center: { opacity: 1, x: 0 },
@@ -38,6 +54,7 @@ const stepVariants = {
 };
 
 export function OnboardingFlow() {
+  const queryClient = useQueryClient();
   const {
     currentStep,
     currentIndex,
@@ -65,6 +82,44 @@ export function OnboardingFlow() {
   const setLastUsedWorkspaceMode = useSettingsStore(
     (state) => state.setLastUsedWorkspaceMode,
   );
+  const apiClient = useOptionalAuthenticatedClient();
+  const { data: currentUser } = useCurrentUser({ client: apiClient });
+
+  // Best-effort: make the onboarding repo pick the default for the personal
+  // space, and for #general only while the team has not configured one. The
+  // fetch also lazily provisions both spaces and primes the channel cache the
+  // first-run landing reads right after.
+  const assignRepoToSpaces = async (): Promise<void> => {
+    if (!selectedCloudRepo || !apiClient) return;
+    // Fetched directly: the integrations store only fills once the main app's
+    // hooks mount, which has not happened during onboarding.
+    const integrations = await queryClient.fetchQuery({
+      queryKey: integrationKeys.list(),
+      queryFn: () => apiClient.getIntegrations() as Promise<Integration[]>,
+      staleTime: 60_000,
+    });
+    const integrationId = resolveRepoIntegrationId(
+      selectedCloudRepo,
+      classifyIntegrations(integrations).githubIntegrations,
+    );
+    // Channels only accept a team integration alongside repositories, so a
+    // user-level-only GitHub connection cannot set a space default. The task
+    // input still prefills from the last-used cloud repository there.
+    if (integrationId == null) return;
+    const channels = await queryClient.fetchQuery({
+      queryKey: TASK_CHANNELS_QUERY_KEY,
+      queryFn: () => apiClient.getTaskChannels(),
+      staleTime: 60_000,
+    });
+    for (const channelId of planSpaceRepoAssignments(
+      channels,
+      currentUser?.uuid ?? null,
+    )) {
+      await apiClient.updateTaskChannelRepositories(channelId, integrationId, [
+        selectedCloudRepo,
+      ]);
+    }
+  };
 
   const flowStartedAtRef = useRef(Date.now());
   const stepEnteredAtRef = useRef(Date.now());
@@ -163,6 +218,9 @@ export function OnboardingFlow() {
       // if an earlier session left a local run-mode preference behind.
       setLastUsedWorkspaceMode("cloud");
     }
+    assignRepoToSpaces().catch((error) =>
+      log.warn("Failed to save onboarding repo to spaces", { error }),
+    );
     shipIt();
     completeOnboarding();
     openTaskInput();

--- a/products/desktop/packages/ui/src/features/onboarding/components/OnboardingFlow.tsx
+++ b/products/desktop/packages/ui/src/features/onboarding/components/OnboardingFlow.tsx
@@ -84,16 +84,12 @@ export function OnboardingFlow() {
   );
   const apiClient = useOptionalAuthenticatedClient();
 
-  // Best-effort: provision the default spaces and make the onboarding repo
-  // pick their default repo, the personal space always and #general only
-  // when this call just created it. The response also seeds the channel
-  // cache the first-run landing reads right after.
+  // Best-effort. The response also seeds the channel cache that the first-run
+  // landing reads moments later.
   const assignRepoToSpaces = async (): Promise<void> => {
     if (!apiClient) return;
     const provisioned = await apiClient.provisionDefaultTaskChannels();
     queryClient.setQueryData(TASK_CHANNELS_QUERY_KEY, provisioned.channels);
-    // Whoever provisions first consumes the created flags; hand them to the
-    // startup resolver so the first-run landing still sees them.
     primeStartupProvision(provisioned);
     if (!selectedCloudRepo) return;
     // Fetched directly: the integrations store only fills once the main app's
@@ -108,8 +104,7 @@ export function OnboardingFlow() {
       classifyIntegrations(integrations).githubIntegrations,
     );
     // Channels only accept a team integration alongside repositories, so a
-    // user-level-only GitHub connection cannot set a space default. The task
-    // input still prefills from the last-used cloud repository there.
+    // user-level-only GitHub connection cannot set a space default.
     if (integrationId == null) return;
     for (const channelId of planSpaceRepoAssignments(provisioned.channels, {
       personalCreated: provisioned.personal_created,
@@ -214,8 +209,7 @@ export function OnboardingFlow() {
       }),
     );
     if (githubUserIntegrations.length > 0) {
-      // GitHub is connected, so the first task should start in the cloud even
-      // if an earlier session left a local run-mode preference behind.
+      // Overrides a local run mode left behind by an earlier session.
       setLastUsedWorkspaceMode("cloud");
     }
     assignRepoToSpaces().catch((error) =>

--- a/products/desktop/packages/ui/src/features/onboarding/components/OnboardingFlow.tsx
+++ b/products/desktop/packages/ui/src/features/onboarding/components/OnboardingFlow.tsx
@@ -33,6 +33,7 @@ import { FullScreenLayout } from "@posthog/ui/primitives/FullScreenLayout";
 import { openTaskInput } from "@posthog/ui/router/useOpenTask";
 import { track } from "@posthog/ui/shell/analytics";
 import { logger } from "@posthog/ui/shell/logger";
+import { primeStartupProvision } from "@posthog/ui/shell/startupLocation";
 import { Button, Flex } from "@radix-ui/themes";
 import { useQueryClient } from "@tanstack/react-query";
 import { AnimatePresence, LayoutGroup, motion } from "framer-motion";
@@ -91,6 +92,9 @@ export function OnboardingFlow() {
     if (!apiClient) return;
     const provisioned = await apiClient.provisionDefaultTaskChannels();
     queryClient.setQueryData(TASK_CHANNELS_QUERY_KEY, provisioned.channels);
+    // Whoever provisions first consumes the created flags; hand them to the
+    // startup resolver so the first-run landing still sees them.
+    primeStartupProvision(provisioned);
     if (!selectedCloudRepo) return;
     // Fetched directly: the integrations store only fills once the main app's
     // hooks mount, which has not happened during onboarding.
@@ -107,10 +111,10 @@ export function OnboardingFlow() {
     // user-level-only GitHub connection cannot set a space default. The task
     // input still prefills from the last-used cloud repository there.
     if (integrationId == null) return;
-    for (const channelId of planSpaceRepoAssignments(
-      provisioned.channels,
-      provisioned.general_created,
-    )) {
+    for (const channelId of planSpaceRepoAssignments(provisioned.channels, {
+      personalCreated: provisioned.personal_created,
+      generalCreated: provisioned.general_created,
+    })) {
       await apiClient.updateTaskChannelRepositories(channelId, integrationId, [
         selectedCloudRepo,
       ]);

--- a/products/desktop/packages/ui/src/features/onboarding/components/OnboardingFlow.tsx
+++ b/products/desktop/packages/ui/src/features/onboarding/components/OnboardingFlow.tsx
@@ -18,7 +18,6 @@ import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
 import { useLogoutMutation } from "@posthog/ui/features/auth/useAuthMutations";
-import { useCurrentUser } from "@posthog/ui/features/auth/useCurrentUser";
 import { TASK_CHANNELS_QUERY_KEY } from "@posthog/ui/features/canvas/hooks/useTaskChannels";
 import { useUserGithubIntegrations } from "@posthog/ui/features/integrations/useIntegrations";
 import { ConnectGitHubStep } from "@posthog/ui/features/onboarding/components/ConnectGitHubStep";
@@ -83,14 +82,16 @@ export function OnboardingFlow() {
     (state) => state.setLastUsedWorkspaceMode,
   );
   const apiClient = useOptionalAuthenticatedClient();
-  const { data: currentUser } = useCurrentUser({ client: apiClient });
 
-  // Best-effort: make the onboarding repo pick the default for the personal
-  // space, and for #general only while the team has not configured one. The
-  // fetch also lazily provisions both spaces and primes the channel cache the
+  // Best-effort: provision the default spaces and make the onboarding repo
+  // pick their default repo — the personal space always, #general only when
+  // this call just created it. The response also seeds the channel cache the
   // first-run landing reads right after.
   const assignRepoToSpaces = async (): Promise<void> => {
-    if (!selectedCloudRepo || !apiClient) return;
+    if (!apiClient) return;
+    const provisioned = await apiClient.provisionDefaultTaskChannels();
+    queryClient.setQueryData(TASK_CHANNELS_QUERY_KEY, provisioned.channels);
+    if (!selectedCloudRepo) return;
     // Fetched directly: the integrations store only fills once the main app's
     // hooks mount, which has not happened during onboarding.
     const integrations = await queryClient.fetchQuery({
@@ -106,14 +107,9 @@ export function OnboardingFlow() {
     // user-level-only GitHub connection cannot set a space default. The task
     // input still prefills from the last-used cloud repository there.
     if (integrationId == null) return;
-    const channels = await queryClient.fetchQuery({
-      queryKey: TASK_CHANNELS_QUERY_KEY,
-      queryFn: () => apiClient.getTaskChannels(),
-      staleTime: 60_000,
-    });
     for (const channelId of planSpaceRepoAssignments(
-      channels,
-      currentUser?.uuid ?? null,
+      provisioned.channels,
+      provisioned.general_created,
     )) {
       await apiClient.updateTaskChannelRepositories(channelId, integrationId, [
         selectedCloudRepo,

--- a/products/desktop/packages/ui/src/features/onboarding/components/OnboardingFlow.tsx
+++ b/products/desktop/packages/ui/src/features/onboarding/components/OnboardingFlow.tsx
@@ -85,9 +85,9 @@ export function OnboardingFlow() {
   const apiClient = useOptionalAuthenticatedClient();
 
   // Best-effort: provision the default spaces and make the onboarding repo
-  // pick their default repo — the personal space always, #general only when
-  // this call just created it. The response also seeds the channel cache the
-  // first-run landing reads right after.
+  // pick their default repo, the personal space always and #general only
+  // when this call just created it. The response also seeds the channel
+  // cache the first-run landing reads right after.
   const assignRepoToSpaces = async (): Promise<void> => {
     if (!apiClient) return;
     const provisioned = await apiClient.provisionDefaultTaskChannels();

--- a/products/desktop/packages/ui/src/features/onboarding/components/OnboardingFlow.tsx
+++ b/products/desktop/packages/ui/src/features/onboarding/components/OnboardingFlow.tsx
@@ -218,8 +218,14 @@ export function OnboardingFlow() {
       }),
     );
     if (githubUserIntegrations.length > 0) {
-      // Overrides a local run mode left behind by an earlier session.
-      setLastUsedWorkspaceMode("cloud");
+      // GitHub connected defaults the run mode to cloud (overriding a local
+      // mode left behind by an earlier session), but an explicit local folder
+      // pick in this step must win over that default. On cloud-only hosts
+      // selectedDirectory holds an "owner/repo" value, not a local path, so
+      // only treat it as a local pick on local-workspace hosts.
+      const pickedLocalRepo =
+        localWorkspaces && !selectedCloudRepo && !!selectedDirectory;
+      setLastUsedWorkspaceMode(pickedLocalRepo ? "local" : "cloud");
     }
     assignRepoToSpaces().catch((error) =>
       log.warn("Failed to save onboarding repo to spaces", { error }),

--- a/products/desktop/packages/ui/src/features/onboarding/components/OnboardingFlow.tsx
+++ b/products/desktop/packages/ui/src/features/onboarding/components/OnboardingFlow.tsx
@@ -1,4 +1,5 @@
 import { ArrowRight, SignOut } from "@phosphor-icons/react";
+import { getAuthIdentity } from "@posthog/core/auth/authIdentity";
 import { integrationKeys } from "@posthog/core/integrations/repositoryKeys";
 import {
   classifyIntegrations,
@@ -19,6 +20,7 @@ import type { TaskChannel } from "@posthog/shared/domain-types";
 import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
 import { useLogoutMutation } from "@posthog/ui/features/auth/useAuthMutations";
+import { AUTH_SCOPED_QUERY_META } from "@posthog/ui/features/auth/useCurrentUser";
 import { TASK_CHANNELS_QUERY_KEY } from "@posthog/ui/features/canvas/hooks/useTaskChannels";
 import { useUserGithubIntegrations } from "@posthog/ui/features/integrations/useIntegrations";
 import { ConnectGitHubStep } from "@posthog/ui/features/onboarding/components/ConnectGitHubStep";
@@ -86,6 +88,7 @@ export function OnboardingFlow() {
   );
   const apiClient = useOptionalAuthenticatedClient();
   const { localWorkspaces } = useHostCapabilities();
+  const startupIdentity = useAuthStateValue(getAuthIdentity);
 
   // Best-effort. The response also seeds the channel cache that the first-run
   // landing reads moments later.
@@ -96,8 +99,16 @@ export function OnboardingFlow() {
     // flags. This runs synchronously before completeOnboarding mounts the main
     // app, which is what wins the race against startup's own provisioning.
     const provisionPromise = apiClient.provisionDefaultTaskChannels();
-    primeStartupProvision(provisionPromise);
+    if (startupIdentity)
+      primeStartupProvision(startupIdentity, provisionPromise);
     const provisioned = await provisionPromise;
+    // Set before the entry exists: setQueryData builds the query from the defaults in
+    // place at that moment, and an unmarked entry survives clearAuthScopedQueries and
+    // hands the next account these channels. Every mounted read of this key is already
+    // auth-scoped via useAuthenticatedQuery; this covers the one write that precedes them.
+    queryClient.setQueryDefaults(TASK_CHANNELS_QUERY_KEY, {
+      meta: AUTH_SCOPED_QUERY_META,
+    });
     queryClient.setQueryData(TASK_CHANNELS_QUERY_KEY, provisioned.channels);
     // Cloud-only hosts keep the picked GitHub repo in selectedDirectory (they
     // never set selectedCloudRepo). On local-workspace hosts selectedDirectory
@@ -113,6 +124,7 @@ export function OnboardingFlow() {
       queryKey: integrationKeys.list(),
       queryFn: () => apiClient.getIntegrations() as Promise<Integration[]>,
       staleTime: 60_000,
+      meta: AUTH_SCOPED_QUERY_META,
     });
     const integrationId = resolveRepoIntegrationId(
       cloudRepo,

--- a/products/desktop/packages/ui/src/features/onboarding/components/OnboardingFlow.tsx
+++ b/products/desktop/packages/ui/src/features/onboarding/components/OnboardingFlow.tsx
@@ -90,9 +90,14 @@ export function OnboardingFlow() {
   // landing reads moments later.
   const assignRepoToSpaces = async (): Promise<void> => {
     if (!apiClient) return;
-    const provisioned = await apiClient.provisionDefaultTaskChannels();
+    // Prime the in-flight promise before the first await so startup consumes
+    // this result instead of provisioning again and reading false created
+    // flags. This runs synchronously before completeOnboarding mounts the main
+    // app, which is what wins the race against startup's own provisioning.
+    const provisionPromise = apiClient.provisionDefaultTaskChannels();
+    primeStartupProvision(provisionPromise);
+    const provisioned = await provisionPromise;
     queryClient.setQueryData(TASK_CHANNELS_QUERY_KEY, provisioned.channels);
-    primeStartupProvision(provisioned);
     // Cloud-only hosts keep the picked GitHub repo in selectedDirectory (they
     // never set selectedCloudRepo). On local-workspace hosts selectedDirectory
     // can be a filesystem path, so only the explicit cloud pick is a valid

--- a/products/desktop/packages/ui/src/features/onboarding/components/OnboardingFlow.tsx
+++ b/products/desktop/packages/ui/src/features/onboarding/components/OnboardingFlow.tsx
@@ -34,6 +34,7 @@ import { openTaskInput } from "@posthog/ui/router/useOpenTask";
 import { track } from "@posthog/ui/shell/analytics";
 import { logger } from "@posthog/ui/shell/logger";
 import { primeStartupProvision } from "@posthog/ui/shell/startupLocation";
+import { useHostCapabilities } from "@posthog/ui/shell/useHostCapabilities";
 import { Button, Flex } from "@radix-ui/themes";
 import { useQueryClient } from "@tanstack/react-query";
 import { AnimatePresence, LayoutGroup, motion } from "framer-motion";
@@ -83,6 +84,7 @@ export function OnboardingFlow() {
     (state) => state.setLastUsedWorkspaceMode,
   );
   const apiClient = useOptionalAuthenticatedClient();
+  const { localWorkspaces } = useHostCapabilities();
 
   // Best-effort. The response also seeds the channel cache that the first-run
   // landing reads moments later.
@@ -91,7 +93,14 @@ export function OnboardingFlow() {
     const provisioned = await apiClient.provisionDefaultTaskChannels();
     queryClient.setQueryData(TASK_CHANNELS_QUERY_KEY, provisioned.channels);
     primeStartupProvision(provisioned);
-    if (!selectedCloudRepo) return;
+    // Cloud-only hosts keep the picked GitHub repo in selectedDirectory (they
+    // never set selectedCloudRepo). On local-workspace hosts selectedDirectory
+    // can be a filesystem path, so only the explicit cloud pick is a valid
+    // "owner/repo" space default there.
+    const cloudRepo = localWorkspaces
+      ? selectedCloudRepo
+      : selectedDirectory || null;
+    if (!cloudRepo) return;
     // Fetched directly: the integrations store only fills once the main app's
     // hooks mount, which has not happened during onboarding.
     const integrations = await queryClient.fetchQuery({
@@ -100,7 +109,7 @@ export function OnboardingFlow() {
       staleTime: 60_000,
     });
     const integrationId = resolveRepoIntegrationId(
-      selectedCloudRepo,
+      cloudRepo,
       classifyIntegrations(integrations).githubIntegrations,
     );
     // Channels only accept a team integration alongside repositories, so a
@@ -111,7 +120,7 @@ export function OnboardingFlow() {
       generalCreated: provisioned.general_created,
     })) {
       await apiClient.updateTaskChannelRepositories(channelId, integrationId, [
-        selectedCloudRepo,
+        cloudRepo,
       ]);
     }
   };

--- a/products/desktop/packages/ui/src/features/onboarding/components/OnboardingFlow.tsx
+++ b/products/desktop/packages/ui/src/features/onboarding/components/OnboardingFlow.tsx
@@ -15,6 +15,7 @@ import {
   resolveRepoIntegrationId,
 } from "@posthog/core/onboarding/spaceRepoAssignment";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
+import type { TaskChannel } from "@posthog/shared/domain-types";
 import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
 import { useLogoutMutation } from "@posthog/ui/features/auth/useAuthMutations";
@@ -124,9 +125,21 @@ export function OnboardingFlow() {
       personalCreated: provisioned.personal_created,
       generalCreated: provisioned.general_created,
     })) {
-      await apiClient.updateTaskChannelRepositories(channelId, integrationId, [
-        cloudRepo,
-      ]);
+      const updated = await apiClient.updateTaskChannelRepositories(
+        channelId,
+        integrationId,
+        [cloudRepo],
+      );
+      // The direct API call bypasses the standard mutation's cache sync, so
+      // patch the seeded channel cache with the assigned repository. Otherwise
+      // consumers stay on the repository-less provision response until the poll.
+      queryClient.setQueryData<TaskChannel[]>(
+        TASK_CHANNELS_QUERY_KEY,
+        (channels) =>
+          channels?.map((channel) =>
+            channel.id === updated.id ? updated : channel,
+          ),
+      );
     }
   };
 

--- a/products/desktop/packages/ui/src/features/onboarding/components/SelectRepoStep.tsx
+++ b/products/desktop/packages/ui/src/features/onboarding/components/SelectRepoStep.tsx
@@ -55,9 +55,7 @@ export function SelectRepoStep({
     refreshRepositories,
   } = useUserRepositoryIntegration();
 
-  // With GitHub connected the repo list is the primary path; the folder
-  // picker stays reachable through a quiet text link, not an equal-weight
-  // toggle. `null` = follow the default until the user switches explicitly.
+  // `null` follows the default source until the user switches explicitly.
   const [chosenSource, setChosenSource] = useState<RepoSource | null>(null);
   const showSourceSwitch = localWorkspaces && hasGithubIntegration === true;
   const repoSource: RepoSource = !localWorkspaces

--- a/products/desktop/packages/ui/src/features/onboarding/components/SelectRepoStep.tsx
+++ b/products/desktop/packages/ui/src/features/onboarding/components/SelectRepoStep.tsx
@@ -7,7 +7,7 @@ import {
   Lightbulb,
 } from "@phosphor-icons/react";
 import { repoMatchesGitHubRepos } from "@posthog/core/onboarding/repoProvider";
-import { cn, ToggleGroup, ToggleGroupItem } from "@posthog/quill";
+import { cn } from "@posthog/quill";
 import { useHostCapabilities } from "@posthog/ui/shell/useHostCapabilities";
 import { Box, Button, Flex, Text } from "@radix-ui/themes";
 import { AnimatePresence, motion } from "framer-motion";
@@ -55,11 +55,11 @@ export function SelectRepoStep({
     refreshRepositories,
   } = useUserRepositoryIntegration();
 
-  // With GitHub connected the repo list comes first; the folder picker stays
-  // available as the alternative. `null` = follow that default until the user
-  // picks a source explicitly.
+  // With GitHub connected the repo list is the primary path; the folder
+  // picker stays reachable through a quiet text link, not an equal-weight
+  // toggle. `null` = follow the default until the user switches explicitly.
   const [chosenSource, setChosenSource] = useState<RepoSource | null>(null);
-  const showSourceToggle = localWorkspaces && hasGithubIntegration === true;
+  const showSourceSwitch = localWorkspaces && hasGithubIntegration === true;
   const repoSource: RepoSource = !localWorkspaces
     ? "github"
     : (chosenSource ?? (hasGithubIntegration ? "github" : "local"));
@@ -132,24 +132,6 @@ export function SelectRepoStep({
                           : "Select a single repository folder, not a parent folder that contains multiple repos."}
                       </Text>
                     </Flex>
-                    {showSourceToggle && (
-                      <ToggleGroup
-                        value={[repoSource]}
-                        onValueChange={(next: string[]) => {
-                          const selected = next[0] as RepoSource | undefined;
-                          if (selected) setChosenSource(selected);
-                        }}
-                        aria-label="Repository source"
-                        className="gap-1 self-start"
-                      >
-                        <ToggleGroupItem value="github" size="sm">
-                          GitHub repo
-                        </ToggleGroupItem>
-                        <ToggleGroupItem value="local" size="sm">
-                          Local folder
-                        </ToggleGroupItem>
-                      </ToggleGroup>
-                    )}
                     {repoSource === "github" ? (
                       <GitHubRepoPicker
                         value={
@@ -175,6 +157,21 @@ export function SelectRepoStep({
                         onChange={onDirectoryChange}
                         placeholder="Select repository..."
                       />
+                    )}
+                    {showSourceSwitch && (
+                      <button
+                        type="button"
+                        onClick={() =>
+                          setChosenSource(
+                            repoSource === "github" ? "local" : "github",
+                          )
+                        }
+                        className="cursor-pointer self-start border-0 bg-transparent p-0 text-(--gray-10) text-[13px] underline hover:text-(--gray-11)"
+                      >
+                        {repoSource === "github"
+                          ? "Use a local folder instead"
+                          : "Back to GitHub repos"}
+                      </button>
                     )}
                     <AnimatePresence mode="wait">
                       {repoSource === "local" && isDetectingRepo && (

--- a/products/desktop/packages/ui/src/features/onboarding/components/SelectRepoStep.tsx
+++ b/products/desktop/packages/ui/src/features/onboarding/components/SelectRepoStep.tsx
@@ -7,11 +7,11 @@ import {
   Lightbulb,
 } from "@phosphor-icons/react";
 import { repoMatchesGitHubRepos } from "@posthog/core/onboarding/repoProvider";
-import { cn } from "@posthog/quill";
+import { cn, ToggleGroup, ToggleGroupItem } from "@posthog/quill";
 import { useHostCapabilities } from "@posthog/ui/shell/useHostCapabilities";
 import { Box, Button, Flex, Text } from "@radix-ui/themes";
 import { AnimatePresence, motion } from "framer-motion";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { builderHog } from "../../../assets/hedgehogs";
 import { OnboardingHogTip } from "../../../primitives/OnboardingHogTip";
 import { FolderPicker } from "../../folder-picker/FolderPicker";
@@ -29,7 +29,12 @@ interface SelectRepoStepProps {
   detectedRepo: DetectedRepo | null;
   isDetectingRepo: boolean;
   onDirectoryChange: (path: string) => void;
+  selectedCloudRepo: string | null;
+  onCloudRepoChange: (repo: string | null) => void;
+  hasGithubIntegration: boolean | undefined;
 }
+
+type RepoSource = "github" | "local";
 
 export function SelectRepoStep({
   onComplete,
@@ -38,6 +43,9 @@ export function SelectRepoStep({
   detectedRepo,
   isDetectingRepo,
   onDirectoryChange,
+  selectedCloudRepo,
+  onCloudRepoChange,
+  hasGithubIntegration,
 }: SelectRepoStepProps) {
   const { localWorkspaces } = useHostCapabilities();
   const {
@@ -47,10 +55,25 @@ export function SelectRepoStep({
     refreshRepositories,
   } = useUserRepositoryIntegration();
 
+  // With GitHub connected the repo list comes first; the folder picker stays
+  // available as the alternative. `null` = follow that default until the user
+  // picks a source explicitly.
+  const [chosenSource, setChosenSource] = useState<RepoSource | null>(null);
+  const showSourceToggle = localWorkspaces && hasGithubIntegration === true;
+  const repoSource: RepoSource = !localWorkspaces
+    ? "github"
+    : (chosenSource ?? (hasGithubIntegration ? "github" : "local"));
+
   const repoMatchesGitHub = useMemo(
     () => repoMatchesGitHubRepos(detectedRepo, repositories),
     [detectedRepo, repositories],
   );
+
+  // Cloud-only hosts keep the picked repo in selectedDirectory.
+  const hasSelection =
+    localWorkspaces && repoSource === "github"
+      ? !!selectedCloudRepo
+      : !!selectedDirectory;
 
   return (
     <Flex align="center" height="100%" px="8">
@@ -104,31 +127,57 @@ export function SelectRepoStep({
                         </Text>
                       </Flex>
                       <Text className="text-(--gray-11) text-sm">
-                        {localWorkspaces
-                          ? "Select a single repository folder, not a parent folder that contains multiple repos."
-                          : "Pick a repository from your connected GitHub organizations."}
+                        {repoSource === "github"
+                          ? "Pick a repository from your connected GitHub organizations. Tasks on it run in cloud sandboxes."
+                          : "Select a single repository folder, not a parent folder that contains multiple repos."}
                       </Text>
                     </Flex>
-                    {localWorkspaces ? (
-                      <FolderPicker
-                        variant="field"
-                        value={selectedDirectory}
-                        onChange={onDirectoryChange}
-                        placeholder="Select repository..."
-                      />
-                    ) : (
+                    {showSourceToggle && (
+                      <ToggleGroup
+                        value={[repoSource]}
+                        onValueChange={(next: string[]) => {
+                          const selected = next[0] as RepoSource | undefined;
+                          if (selected) setChosenSource(selected);
+                        }}
+                        aria-label="Repository source"
+                        className="gap-1 self-start"
+                      >
+                        <ToggleGroupItem value="github" size="sm">
+                          GitHub repo
+                        </ToggleGroupItem>
+                        <ToggleGroupItem value="local" size="sm">
+                          Local folder
+                        </ToggleGroupItem>
+                      </ToggleGroup>
+                    )}
+                    {repoSource === "github" ? (
                       <GitHubRepoPicker
-                        value={selectedDirectory || null}
-                        onChange={(repo) => onDirectoryChange(repo ?? "")}
+                        value={
+                          localWorkspaces
+                            ? selectedCloudRepo
+                            : selectedDirectory || null
+                        }
+                        onChange={(repo) =>
+                          localWorkspaces
+                            ? onCloudRepoChange(repo)
+                            : onDirectoryChange(repo ?? "")
+                        }
                         repositories={repositories}
                         isLoading={isLoadingRepos}
                         onRefresh={refreshRepositories}
                         isRefreshing={isRefreshingRepos}
                         placeholder="Select repository..."
                       />
+                    ) : (
+                      <FolderPicker
+                        variant="field"
+                        value={selectedDirectory}
+                        onChange={onDirectoryChange}
+                        placeholder="Select repository..."
+                      />
                     )}
                     <AnimatePresence mode="wait">
-                      {localWorkspaces && isDetectingRepo && (
+                      {repoSource === "local" && isDetectingRepo && (
                         <motion.div
                           key="detecting"
                           initial={{ opacity: 0 }}
@@ -147,7 +196,7 @@ export function SelectRepoStep({
                           </Flex>
                         </motion.div>
                       )}
-                      {localWorkspaces &&
+                      {repoSource === "local" &&
                         !isDetectingRepo &&
                         selectedDirectory &&
                         detectedRepo && (
@@ -183,7 +232,7 @@ export function SelectRepoStep({
                             </Flex>
                           </motion.div>
                         )}
-                      {localWorkspaces &&
+                      {repoSource === "local" &&
                         !isDetectingRepo &&
                         selectedDirectory &&
                         !detectedRepo && (
@@ -236,7 +285,7 @@ export function SelectRepoStep({
             <ArrowLeft size={16} weight="bold" />
             Back
           </Button>
-          {selectedDirectory ? (
+          {hasSelection ? (
             <Button size="3" onClick={() => onComplete(false)}>
               Get started
               <ArrowRight size={16} weight="bold" />

--- a/products/desktop/packages/ui/src/features/onboarding/components/SelectRepoStep.tsx
+++ b/products/desktop/packages/ui/src/features/onboarding/components/SelectRepoStep.tsx
@@ -159,11 +159,19 @@ export function SelectRepoStep({
                     {showSourceSwitch && (
                       <button
                         type="button"
-                        onClick={() =>
-                          setChosenSource(
-                            repoSource === "github" ? "local" : "github",
-                          )
-                        }
+                        onClick={() => {
+                          const nextSource =
+                            repoSource === "github" ? "local" : "github";
+                          // Clear the source being left so a later Skip cannot
+                          // silently assign or persist a repo the user
+                          // navigated away from.
+                          if (nextSource === "local") {
+                            onCloudRepoChange(null);
+                          } else {
+                            onDirectoryChange("");
+                          }
+                          setChosenSource(nextSource);
+                        }}
                         className="cursor-pointer self-start border-0 bg-transparent p-0 text-(--gray-10) text-[13px] underline hover:text-(--gray-11)"
                       >
                         {repoSource === "github"

--- a/products/desktop/packages/ui/src/features/onboarding/components/WelcomeScreen.tsx
+++ b/products/desktop/packages/ui/src/features/onboarding/components/WelcomeScreen.tsx
@@ -310,7 +310,7 @@ export function WelcomeScreen({ onNext }: WelcomeScreenProps) {
             message="Let's get you set up! It only takes a minute."
           />
           <StepActions delay={0.25}>
-            <Button size="3" onClick={onNext}>
+            <Button size="3" onClick={() => onNext()}>
               Start shipping
               <ArrowRight size={16} weight="bold" />
             </Button>

--- a/products/desktop/packages/ui/src/features/onboarding/hooks/useOnboardingFlow.ts
+++ b/products/desktop/packages/ui/src/features/onboarding/hooks/useOnboardingFlow.ts
@@ -15,7 +15,10 @@ import {
 } from "@posthog/core/onboarding/steps";
 import { useHostTRPCClient } from "@posthog/host-router/react";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
-import { useAuthStateValue } from "@posthog/ui/features/auth/store";
+import {
+  useAuthStateFetched,
+  useAuthStateValue,
+} from "@posthog/ui/features/auth/store";
 import { useUserGithubIntegrations } from "@posthog/ui/features/integrations/useIntegrations";
 import { useOnboardingStore } from "@posthog/ui/features/onboarding/onboardingStore";
 import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
@@ -133,6 +136,20 @@ export function useOnboardingFlow() {
   const hasGithubIntegration = githubUserIntegrations
     ? githubUserIntegrations.length > 0
     : undefined;
+  // Counted off the store rather than through useProjects, whose auto-select
+  // effect would then run in a second place and re-clear the query cache.
+  const orgProjectsMap = useAuthStateValue((state) => state.orgProjectsMap);
+  const authFetched = useAuthStateFetched();
+  const projectCount = useMemo(
+    () =>
+      authFetched
+        ? Object.values(orgProjectsMap).reduce(
+            (total, org) => total + org.projects.length,
+            0,
+          )
+        : undefined,
+    [authFetched, orgProjectsMap],
+  );
 
   const activeSteps = useMemo(
     () =>
@@ -140,8 +157,9 @@ export function useOnboardingFlow() {
         hasCodeAccess,
         hasImportableConfig,
         hasGithubIntegration,
+        projectCount,
       }),
-    [hasCodeAccess, hasImportableConfig, hasGithubIntegration],
+    [hasCodeAccess, hasImportableConfig, hasGithubIntegration, projectCount],
   );
 
   useEffect(() => {

--- a/products/desktop/packages/ui/src/features/onboarding/hooks/useOnboardingFlow.ts
+++ b/products/desktop/packages/ui/src/features/onboarding/hooks/useOnboardingFlow.ts
@@ -16,6 +16,7 @@ import {
 import { useHostTRPCClient } from "@posthog/host-router/react";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
+import { useUserGithubIntegrations } from "@posthog/ui/features/integrations/useIntegrations";
 import { useOnboardingStore } from "@posthog/ui/features/onboarding/onboardingStore";
 import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
 import { useActiveRepoStore } from "@posthog/ui/shell/activeRepoStore";
@@ -55,6 +56,26 @@ export function useOnboardingFlow() {
       .finally(() => setIsDetectingRepo(false));
   }, [selectedDirectory, hostClient, localWorkspaces]);
 
+  const [selectedCloudRepo, setSelectedCloudRepo] = useState<string | null>(
+    null,
+  );
+  const handleCloudRepoChange = useCallback(
+    (repo: string | null) => {
+      setSelectedCloudRepo(repo);
+      setLastUsedCloudRepository(repo);
+      if (repo) {
+        // A cloud repo replaces any local folder pick, and vice versa.
+        setSelectedDirectory("");
+        setDetectedRepo(null);
+        track(ANALYTICS_EVENTS.ONBOARDING_FOLDER_SELECTED, {
+          has_git_remote: true,
+          repository_provider: "github",
+        });
+      }
+    },
+    [setLastUsedCloudRepository, setSelectedDirectory],
+  );
+
   const handleDirectoryChange = useCallback(
     async (path: string) => {
       setSelectedDirectory(path);
@@ -70,6 +91,9 @@ export function useOnboardingFlow() {
         });
         return;
       }
+
+      setSelectedCloudRepo(null);
+      setLastUsedCloudRepository(null);
 
       if (!path) return;
 
@@ -105,10 +129,19 @@ export function useOnboardingFlow() {
 
   const hasCodeAccess = useAuthStateValue((state) => state.hasCodeAccess);
   const hasImportableConfig = useHasImportableConfig();
+  const { data: githubUserIntegrations } = useUserGithubIntegrations();
+  const hasGithubIntegration = githubUserIntegrations
+    ? githubUserIntegrations.length > 0
+    : undefined;
 
   const activeSteps = useMemo(
-    () => computeActiveSteps(hasCodeAccess, hasImportableConfig),
-    [hasCodeAccess, hasImportableConfig],
+    () =>
+      computeActiveSteps({
+        hasCodeAccess,
+        hasImportableConfig,
+        hasGithubIntegration,
+      }),
+    [hasCodeAccess, hasImportableConfig, hasGithubIntegration],
   );
 
   useEffect(() => {
@@ -157,5 +190,8 @@ export function useOnboardingFlow() {
     detectedRepo,
     isDetectingRepo,
     handleDirectoryChange,
+    selectedCloudRepo,
+    handleCloudRepoChange,
+    hasGithubIntegration,
   };
 }

--- a/products/desktop/packages/ui/src/features/onboarding/hooks/useOnboardingFlow.ts
+++ b/products/desktop/packages/ui/src/features/onboarding/hooks/useOnboardingFlow.ts
@@ -67,7 +67,6 @@ export function useOnboardingFlow() {
       setSelectedCloudRepo(repo);
       setLastUsedCloudRepository(repo);
       if (repo) {
-        // A cloud repo replaces any local folder pick, and vice versa.
         setSelectedDirectory("");
         setDetectedRepo(null);
         track(ANALYTICS_EVENTS.ONBOARDING_FOLDER_SELECTED, {

--- a/products/desktop/packages/ui/src/shell/App.tsx
+++ b/products/desktop/packages/ui/src/shell/App.tsx
@@ -14,7 +14,6 @@ import { ScopeReauthPrompt } from "@posthog/ui/features/auth/components/ScopeRea
 import { useAuthSession } from "@posthog/ui/features/auth/useAuthSession";
 import { useIsOrgAdmin } from "@posthog/ui/features/auth/useOrgRole";
 import { CanvasGenerationToaster } from "@posthog/ui/features/canvas/freeform/useCanvasGenerationToasts";
-import { TASK_CHANNELS_QUERY_KEY } from "@posthog/ui/features/canvas/hooks/useTaskChannels";
 import {
   keepListForRoute,
   showChannelList,
@@ -38,7 +37,6 @@ import {
   resolveStartupLocation,
 } from "@posthog/ui/shell/startupLocation";
 import { useAppVisibilityWatchdog } from "@posthog/ui/shell/useAppVisibilityWatchdog";
-import { useQueryClient } from "@tanstack/react-query";
 import { RouterProvider } from "@tanstack/react-router";
 import { AnimatePresence, motion } from "framer-motion";
 import { type ReactNode, useEffect, useRef, useState } from "react";
@@ -51,7 +49,6 @@ interface AppProps {
 const log = logger.scope("app");
 
 function App({ devToolbar }: AppProps) {
-  const queryClient = useQueryClient();
   const { isBootstrapped } = useAuthSession();
   const authState = useAuthStateValue((state) => state);
   const hasCompletedOnboarding = useOnboardingStore(
@@ -125,16 +122,7 @@ function App({ devToolbar }: AppProps) {
         // request instead of firing back-to-back.
         const { href, firstRun } = await resolveStartupLocation(
           startupIdentity,
-          {
-            getTaskChannels: () =>
-              queryClient.fetchQuery({
-                queryKey: TASK_CHANNELS_QUERY_KEY,
-                queryFn: () => authenticatedClient.getTaskChannels(),
-                staleTime: 60_000,
-              }),
-            provisionDefaultTaskChannels: () =>
-              authenticatedClient.provisionDefaultTaskChannels(),
-          },
+          authenticatedClient,
         );
         if (firstRun) {
           showChannelList();
@@ -160,7 +148,6 @@ function App({ devToolbar }: AppProps) {
     initialRouteLoaded,
     startupIdentity,
     authenticatedClient,
-    queryClient.fetchQuery,
   ]);
 
   useEffect(() => {

--- a/products/desktop/packages/ui/src/shell/App.tsx
+++ b/products/desktop/packages/ui/src/shell/App.tsx
@@ -117,9 +117,6 @@ function App({ devToolbar }: AppProps) {
     let cancelled = false;
     const loadInitialRoute = async (): Promise<void> => {
       try {
-        // Route the channel fetch through the query cache so onboarding
-        // completion (which primes the same key) and this landing share one
-        // request instead of firing back-to-back.
         const { href, firstRun } = await resolveStartupLocation(
           startupIdentity,
           authenticatedClient,

--- a/products/desktop/packages/ui/src/shell/App.tsx
+++ b/products/desktop/packages/ui/src/shell/App.tsx
@@ -132,6 +132,8 @@ function App({ devToolbar }: AppProps) {
                 queryFn: () => authenticatedClient.getTaskChannels(),
                 staleTime: 60_000,
               }),
+            provisionDefaultTaskChannels: () =>
+              authenticatedClient.provisionDefaultTaskChannels(),
           },
         );
         if (firstRun) {

--- a/products/desktop/packages/ui/src/shell/App.tsx
+++ b/products/desktop/packages/ui/src/shell/App.tsx
@@ -14,6 +14,7 @@ import { ScopeReauthPrompt } from "@posthog/ui/features/auth/components/ScopeRea
 import { useAuthSession } from "@posthog/ui/features/auth/useAuthSession";
 import { useIsOrgAdmin } from "@posthog/ui/features/auth/useOrgRole";
 import { CanvasGenerationToaster } from "@posthog/ui/features/canvas/freeform/useCanvasGenerationToasts";
+import { TASK_CHANNELS_QUERY_KEY } from "@posthog/ui/features/canvas/hooks/useTaskChannels";
 import {
   keepListForRoute,
   showChannelList,
@@ -37,6 +38,7 @@ import {
   resolveStartupLocation,
 } from "@posthog/ui/shell/startupLocation";
 import { useAppVisibilityWatchdog } from "@posthog/ui/shell/useAppVisibilityWatchdog";
+import { useQueryClient } from "@tanstack/react-query";
 import { RouterProvider } from "@tanstack/react-router";
 import { AnimatePresence, motion } from "framer-motion";
 import { type ReactNode, useEffect, useRef, useState } from "react";
@@ -49,6 +51,7 @@ interface AppProps {
 const log = logger.scope("app");
 
 function App({ devToolbar }: AppProps) {
+  const queryClient = useQueryClient();
   const { isBootstrapped } = useAuthSession();
   const authState = useAuthStateValue((state) => state);
   const hasCompletedOnboarding = useOnboardingStore(
@@ -117,9 +120,19 @@ function App({ devToolbar }: AppProps) {
     let cancelled = false;
     const loadInitialRoute = async (): Promise<void> => {
       try {
+        // Route the channel fetch through the query cache so onboarding
+        // completion (which primes the same key) and this landing share one
+        // request instead of firing back-to-back.
         const { href, firstRun } = await resolveStartupLocation(
           startupIdentity,
-          authenticatedClient,
+          {
+            getTaskChannels: () =>
+              queryClient.fetchQuery({
+                queryKey: TASK_CHANNELS_QUERY_KEY,
+                queryFn: () => authenticatedClient.getTaskChannels(),
+                staleTime: 60_000,
+              }),
+          },
         );
         if (firstRun) {
           showChannelList();
@@ -145,6 +158,7 @@ function App({ devToolbar }: AppProps) {
     initialRouteLoaded,
     startupIdentity,
     authenticatedClient,
+    queryClient.fetchQuery,
   ]);
 
   useEffect(() => {

--- a/products/desktop/packages/ui/src/shell/startupLocation.test.ts
+++ b/products/desktop/packages/ui/src/shell/startupLocation.test.ts
@@ -113,10 +113,39 @@ describe("startup location", () => {
     expect(removeItem).not.toHaveBeenCalled();
   });
 
+  it("ignores a hand-off primed by a different account", async () => {
+    // A logout or account switch between priming and consuming would otherwise hand the
+    // next account the previous project's channels.
+    vi.spyOn(stateStorage, "getItem").mockResolvedValue(null);
+    const client = {
+      provisionDefaultTaskChannels: vi.fn().mockResolvedValue({
+        channels: [personal, general],
+        personal_created: false,
+        general_created: false,
+      }),
+      startOnboardingSession: vi.fn().mockResolvedValue(true),
+    };
+    primeStartupProvision(
+      "someone-else",
+      Promise.resolve({
+        channels: [personal, general],
+        personal_created: true,
+        general_created: true,
+      }),
+    );
+
+    await expect(resolveStartupLocation("project", client)).resolves.toEqual({
+      href: "/website/general-id",
+      firstRun: null,
+    });
+    expect(client.provisionDefaultTaskChannels).toHaveBeenCalledOnce();
+  });
+
   it("consumes a primed provisioning result exactly once", async () => {
     vi.spyOn(stateStorage, "getItem").mockResolvedValue(null);
     const client = { provisionDefaultTaskChannels: vi.fn() };
     primeStartupProvision(
+      "project",
       Promise.resolve({
         channels: [personal, general],
         personal_created: true,

--- a/products/desktop/packages/ui/src/shell/startupLocation.test.ts
+++ b/products/desktop/packages/ui/src/shell/startupLocation.test.ts
@@ -116,11 +116,13 @@ describe("startup location", () => {
   it("consumes a primed provisioning result exactly once", async () => {
     vi.spyOn(stateStorage, "getItem").mockResolvedValue(null);
     const client = { provisionDefaultTaskChannels: vi.fn() };
-    primeStartupProvision({
-      channels: [personal, general],
-      personal_created: true,
-      general_created: false,
-    });
+    primeStartupProvision(
+      Promise.resolve({
+        channels: [personal, general],
+        personal_created: true,
+        general_created: false,
+      }),
+    );
 
     await expect(resolveStartupLocation("project", client)).resolves.toEqual({
       href: "/website/general-id",

--- a/products/desktop/packages/ui/src/shell/startupLocation.ts
+++ b/products/desktop/packages/ui/src/shell/startupLocation.ts
@@ -19,7 +19,10 @@ interface StartupLocation {
   firstRun: { generalChannelId: string } | null;
 }
 
-let primedProvision: Promise<ProvisionedTaskChannels> | null = null;
+let primedProvision: {
+  identity: string;
+  result: Promise<ProvisionedTaskChannels>;
+} | null = null;
 
 /**
  * Whoever provisions first consumes the created flags, so a flow that provisions
@@ -29,19 +32,24 @@ let primedProvision: Promise<ProvisionedTaskChannels> | null = null;
  * the caller mounts the app, even while the network call is still pending.
  */
 export function primeStartupProvision(
+  identity: string,
   result: Promise<ProvisionedTaskChannels>,
 ): void {
-  primedProvision = result;
+  primedProvision = { identity, result };
 }
 
 async function consumePrimedProvision(
+  identity: string,
   client: StartupLocationClient,
 ): Promise<ProvisionedTaskChannels> {
   const primed = primedProvision;
   primedProvision = null;
-  if (primed) {
+  // Keyed by identity because a logout or account switch between priming and
+  // consuming would otherwise hand the next account the previous project's
+  // channels. Everything else in this module is already keyed the same way.
+  if (primed && primed.identity === identity) {
     try {
-      return await primed;
+      return await primed.result;
     } catch {
       // A failed hand-off must not cost the user their provisioning, so fall
       // back to provisioning here as if nothing had been primed.
@@ -68,7 +76,7 @@ export async function resolveStartupLocation(
     return { href: legacy, firstRun: null };
   }
 
-  const provisioned = await consumePrimedProvision(client);
+  const provisioned = await consumePrimedProvision(identity, client);
   const general = provisioned.channels.find((channel) =>
     isGeneralChannel(channel),
   );

--- a/products/desktop/packages/ui/src/shell/startupLocation.ts
+++ b/products/desktop/packages/ui/src/shell/startupLocation.ts
@@ -19,15 +19,35 @@ interface StartupLocation {
   firstRun: { generalChannelId: string } | null;
 }
 
-let primedProvision: ProvisionedTaskChannels | null = null;
+let primedProvision: Promise<ProvisionedTaskChannels> | null = null;
 
 /**
  * Whoever provisions first consumes the created flags, so a flow that provisions
  * before the app mounts has to hand its result over rather than let startup
- * provision again and read false flags.
+ * provision again and read false flags. The in-flight promise is handed over
+ * (not the resolved value) so the hand-off wins the race synchronously, before
+ * the caller mounts the app, even while the network call is still pending.
  */
-export function primeStartupProvision(result: ProvisionedTaskChannels): void {
+export function primeStartupProvision(
+  result: Promise<ProvisionedTaskChannels>,
+): void {
   primedProvision = result;
+}
+
+async function consumePrimedProvision(
+  client: StartupLocationClient,
+): Promise<ProvisionedTaskChannels> {
+  const primed = primedProvision;
+  primedProvision = null;
+  if (primed) {
+    try {
+      return await primed;
+    } catch {
+      // A failed hand-off must not cost the user their provisioning, so fall
+      // back to provisioning here as if nothing had been primed.
+    }
+  }
+  return client.provisionDefaultTaskChannels();
 }
 
 export async function resolveStartupLocation(
@@ -48,9 +68,7 @@ export async function resolveStartupLocation(
     return { href: legacy, firstRun: null };
   }
 
-  const provisioned =
-    primedProvision ?? (await client.provisionDefaultTaskChannels());
-  primedProvision = null;
+  const provisioned = await consumePrimedProvision(client);
   const general = provisioned.channels.find((channel) =>
     isGeneralChannel(channel),
   );


### PR DESCRIPTION
## Problem

we want to prioritize cloud if we have a github connection

some analytics are broken

we don't handle missing `gh` very nicely

## Changes

- github is connected &rarr; cloud-first onboarding
	- cli installation step is gone
	- remote repo selector instead of local folder
	- chosen repo is used to prefill:
		- the user's first task
		- `#personal` space default repo, always
		- `#general` space default repo, if the space was just created (e.g. first user to onboard in this org)
	- set default task mode to cloud
- better handling on missing `gh` (tooltips on disabled features)
- analytics bug fix

<img width="2016" height="1732" alt="wizard-select-repo-local" src="https://github.com/user-attachments/assets/277a04a3-7ec4-4e27-8516-c29bb2381a94" />
<img width="2016" height="1732" alt="wizard-select-repo-github" src="https://github.com/user-attachments/assets/772cb5b5-ee8f-4394-8ba6-351ad3572c32" />

--- ai generated below ---

## How did you test this code?

- Live pass against a local Django stack, driving the dev app over CDP:
  - The repo step rendered the GitHub picker first with the source toggle; picking a repo enabled "Get started"; toggling showed the folder picker.
  - Landing on install-cli with GitHub connected bounced forward to import-config, not back to welcome.
  - Clicking "Start shipping" on welcome sent "Onboarding step completed", and the event arrived in the analytics project with `step_id=welcome`, `step_index=0`, and a sane duration.
- `computeActiveSteps` tests now cover the install-cli gate: dropped only on a confirmed connection, kept while the query loads (a loading-state regression no existing test caught).
- Event-volume evidence for the analytics fix comes from the shared analytics project: welcome viewed 285 / completed 1, import-config viewed 50 / completed 1, over 30 days.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Fable 5) directed by the assignee.
- Skills invoked: /writing-user-facing-copy, /writing-pr-descriptions, /stacking-prs, test-electron-app (live CDP verification).
- The welcome-event root cause was found by querying production event volumes, then tracing the two `onClick={onNext}` call sites; the fix landed as its own commit ahead of the wizard changes.
- The cloud repo selection deliberately does not reuse `activeRepoStore.path`, which must stay a local filesystem path on desktop; it persists via the settings store instead.

