### PR TITLE
feat(desktop): add posthog-code://usage deep link to the plan & usage page

### DIFF
--- a/products/desktop/apps/code/src/main/di/bindings.ts
+++ b/products/desktop/apps/code/src/main/di/bindings.ts
@@ -59,6 +59,7 @@ import type {
   OPEN_TARGET_LINK_SERVICE,
   SCOUT_LINK_SERVICE,
   TASK_LINK_SERVICE,
+  USAGE_LINK_SERVICE,
 } from "@posthog/core/links/identifiers";
 import type { InboxLinkService } from "@posthog/core/links/inbox-link";
 import type { LoopLinkService } from "@posthog/core/links/loop-link";
@@ -66,6 +67,7 @@ import type { NewTaskLinkService } from "@posthog/core/links/new-task-link";
 import type { OpenTargetLinkService } from "@posthog/core/links/open-target-link";
 import type { ScoutLinkService } from "@posthog/core/links/scout-link";
 import type { TaskLinkService } from "@posthog/core/links/task-link";
+import type { UsageLinkService } from "@posthog/core/links/usage-link";
 import type {
   LLM_GATEWAY_HOST,
   LlmGatewayHost,
@@ -318,6 +320,7 @@ import type {
   SUSPENSION_SERVICE as MAIN_SUSPENSION_SERVICE,
   TASK_LINK_SERVICE as MAIN_TASK_LINK_SERVICE,
   UPDATES_SERVICE as MAIN_UPDATES_SERVICE,
+  USAGE_LINK_SERVICE as MAIN_USAGE_LINK_SERVICE,
   WATCHER_REGISTRY_SERVICE as MAIN_WATCHER_REGISTRY_SERVICE,
   WORKSPACE_CLIENT as MAIN_WORKSPACE_CLIENT,
   WORKSPACE_REPOSITORY as MAIN_WORKSPACE_REPOSITORY,
@@ -469,6 +472,7 @@ export interface MainBindings {
   [MAIN_CANVAS_LINK_SERVICE]: CanvasLinkService;
   [MAIN_CHANNEL_LINK_SERVICE]: ChannelLinkService;
   [MAIN_LOOP_LINK_SERVICE]: LoopLinkService;
+  [MAIN_USAGE_LINK_SERVICE]: UsageLinkService;
   [TASK_LINK_SERVICE]: TaskLinkService;
   [INBOX_LINK_SERVICE]: InboxLinkService;
   [SCOUT_LINK_SERVICE]: ScoutLinkService;
@@ -478,6 +482,7 @@ export interface MainBindings {
   [CANVAS_LINK_SERVICE]: CanvasLinkService;
   [CHANNEL_LINK_SERVICE]: ChannelLinkService;
   [LOOP_LINK_SERVICE]: LoopLinkService;
+  [USAGE_LINK_SERVICE]: UsageLinkService;
 
   // Watcher registry
   [MAIN_WATCHER_REGISTRY_SERVICE]: WatcherRegistryService;

--- a/products/desktop/apps/code/src/main/di/container.ts
+++ b/products/desktop/apps/code/src/main/di/container.ts
@@ -59,6 +59,7 @@ import {
   OPEN_TARGET_LINK_SERVICE,
   SCOUT_LINK_SERVICE,
   TASK_LINK_SERVICE,
+  USAGE_LINK_SERVICE,
 } from "@posthog/core/links/identifiers";
 import { InboxLinkService } from "@posthog/core/links/inbox-link";
 import { LoopLinkService } from "@posthog/core/links/loop-link";
@@ -66,6 +67,7 @@ import { NewTaskLinkService } from "@posthog/core/links/new-task-link";
 import { OpenTargetLinkService } from "@posthog/core/links/open-target-link";
 import { ScoutLinkService } from "@posthog/core/links/scout-link";
 import { TaskLinkService } from "@posthog/core/links/task-link";
+import { UsageLinkService } from "@posthog/core/links/usage-link";
 import {
   LLM_GATEWAY_HOST,
   LLM_GATEWAY_SERVICE,
@@ -330,6 +332,7 @@ import {
   SUSPENSION_SERVICE as MAIN_SUSPENSION_SERVICE,
   TASK_LINK_SERVICE as MAIN_TASK_LINK_SERVICE,
   UPDATES_SERVICE as MAIN_UPDATES_SERVICE,
+  USAGE_LINK_SERVICE as MAIN_USAGE_LINK_SERVICE,
   WATCHER_REGISTRY_SERVICE as MAIN_WATCHER_REGISTRY_SERVICE,
   WORKSPACE_CLIENT as MAIN_WORKSPACE_CLIENT,
   WORKSPACE_REPOSITORY as MAIN_WORKSPACE_REPOSITORY,
@@ -724,6 +727,8 @@ container.bind(MAIN_CHANNEL_LINK_SERVICE).to(ChannelLinkService);
 container.bind(CHANNEL_LINK_SERVICE).toService(MAIN_CHANNEL_LINK_SERVICE);
 container.bind(MAIN_LOOP_LINK_SERVICE).to(LoopLinkService);
 container.bind(LOOP_LINK_SERVICE).toService(MAIN_LOOP_LINK_SERVICE);
+container.bind(MAIN_USAGE_LINK_SERVICE).to(UsageLinkService);
+container.bind(USAGE_LINK_SERVICE).toService(MAIN_USAGE_LINK_SERVICE);
 container.load(watcherRegistryModule);
 container
   .bind(MAIN_WATCHER_REGISTRY_SERVICE)

--- a/products/desktop/apps/code/src/main/di/tokens.ts
+++ b/products/desktop/apps/code/src/main/di/tokens.ts
@@ -118,6 +118,9 @@ export const CHANNEL_LINK_SERVICE = Symbol.for(
 export const LOOP_LINK_SERVICE = Symbol.for(
   "posthog.host.main.loop-link.service",
 );
+export const USAGE_LINK_SERVICE = Symbol.for(
+  "posthog.host.main.usage-link.service",
+);
 export const WATCHER_REGISTRY_SERVICE = Symbol.for(
   "posthog.host.main.watcher-registry.service",
 );

--- a/products/desktop/apps/code/src/main/index.ts
+++ b/products/desktop/apps/code/src/main/index.ts
@@ -30,6 +30,7 @@ import type { LoopLinkService } from "@posthog/core/links/loop-link";
 import type { NewTaskLinkService } from "@posthog/core/links/new-task-link";
 import type { ScoutLinkService } from "@posthog/core/links/scout-link";
 import type { TaskLinkService } from "@posthog/core/links/task-link";
+import type { UsageLinkService } from "@posthog/core/links/usage-link";
 import { NOTIFICATION_SERVICE } from "@posthog/core/notification/identifiers";
 import type { NotificationService } from "@posthog/core/notification/notification";
 import { OAUTH_SERVICE } from "@posthog/core/oauth/identifiers";
@@ -70,6 +71,7 @@ import {
   SCOUT_LINK_SERVICE,
   TASK_LINK_SERVICE,
   UPDATES_SERVICE,
+  USAGE_LINK_SERVICE,
   WORKSPACE_CLIENT,
   WORKSPACE_SERVER_SERVICE,
   WORKSPACE_SERVICE,
@@ -285,6 +287,7 @@ async function initializeServices(): Promise<void> {
   container.get<CanvasLinkService>(CANVAS_LINK_SERVICE);
   container.get<ChannelLinkService>(CHANNEL_LINK_SERVICE);
   container.get<LoopLinkService>(LOOP_LINK_SERVICE);
+  container.get<UsageLinkService>(USAGE_LINK_SERVICE);
   container.get<GitHubIntegrationService>(GITHUB_INTEGRATION_SERVICE);
   container.get<SlackIntegrationService>(SLACK_INTEGRATION_SERVICE);
   container.get<ExternalAppsService>(EXTERNAL_APPS_SERVICE);

--- a/products/desktop/apps/web/src/web-host-router.ts
+++ b/products/desktop/apps/web/src/web-host-router.ts
@@ -66,6 +66,7 @@ const deepLinkStubRouter = router({
   getPendingCanvasLink: publicProcedure.query(() => null),
   getPendingChannelLink: publicProcedure.query(() => null),
   getPendingLoopLink: publicProcedure.query(() => null),
+  getPendingUsageLink: publicProcedure.query(() => null),
   onOpenTask: neverEmit,
   onOpenReport: neverEmit,
   onOpenScout: neverEmit,
@@ -75,6 +76,7 @@ const deepLinkStubRouter = router({
   onOpenCanvas: neverEmit,
   onOpenChannel: neverEmit,
   onOpenLoop: neverEmit,
+  onOpenUsage: neverEmit,
 });
 
 // Slack/GitHub connect. Desktop opens the PostHog integration authorize URL in

--- a/products/desktop/docs/DEEP-LINKS.md
+++ b/products/desktop/docs/DEEP-LINKS.md
@@ -10,7 +10,7 @@ PostHog registers custom URL schemes so the desktop app can be opened with conte
 | Development | `posthog-code-dev://` |
 | Legacy (production only) | `twig://`, `array://` |
 
-All schemes route through the same dispatcher. The host portion of the URL selects the handler (`task`, `inbox`, `scout`, `loop`, `approval`, `canvas`, `channel`, `new`, `plan`, `issue`, `callback`, `integration`, `slack-integration`, `mcp-oauth-complete`).
+All schemes route through the same dispatcher. The host portion of the URL selects the handler (`task`, `inbox`, `scout`, `loop`, `approval`, `canvas`, `channel`, `new`, `plan`, `issue`, `usage`, `callback`, `integration`, `slack-integration`, `mcp-oauth-complete`).
 
 If the app is not running, the OS launches it and the link is queued until the renderer is ready. If the app is minimised, it is restored and focused before the link is handled.
 
@@ -75,6 +75,20 @@ posthog-code://issue?url=https%3A%2F%2Fgithub.com%2Fposthog%2Fposthog%2Fissues%2
 ```
 
 The link is rejected if `url` is missing, is not a `github.com` URL, or does not match `/<owner>/<repo>/issues/<number>`. If the issue cannot be fetched, a toast is shown and no navigation happens.
+
+### `posthog-code://usage[/<category>]`
+
+Open the Plan & usage settings page, or another settings page. With no path
+segment it opens Plan & usage; a category segment opens that settings page.
+
+| Segment | Required | Description |
+|---|---|---|
+| `<category>` | No | Settings category slug (e.g. `plan-usage`, `agents`, `github`). Defaults to `plan-usage` when omitted. Unknown categories are ignored. |
+
+```
+posthog-code://usage
+posthog-code://usage/agents
+```
 
 ### `posthog-code://task/<taskId>[/run/<taskRunId>]`
 
@@ -259,6 +273,7 @@ In development the same payload is delivered to `http://localhost:8238/mcp-oauth
 | `canvas` | [packages/core/src/links/canvas-link.ts](../packages/core/src/links/canvas-link.ts) |
 | `channel` | [packages/core/src/links/channel-link.ts](../packages/core/src/links/channel-link.ts) |
 | `new`, `plan`, `issue` | [packages/core/src/links/new-task-link.ts](../packages/core/src/links/new-task-link.ts) |
+| `usage` | [packages/core/src/links/usage-link.ts](../packages/core/src/links/usage-link.ts) |
 | `callback` | [packages/core/src/oauth/oauth.ts](../packages/core/src/oauth/oauth.ts) |
 | `integration` | [packages/core/src/integrations/github.ts](../packages/core/src/integrations/github.ts) |
 | `slack-integration` | [packages/core/src/integrations/slack.ts](../packages/core/src/integrations/slack.ts) |

--- a/products/desktop/packages/core/src/links/identifiers.ts
+++ b/products/desktop/packages/core/src/links/identifiers.ts
@@ -25,3 +25,4 @@ export const CHANNEL_LINK_SERVICE = Symbol.for(
   "posthog.core.channelLinkService",
 );
 export const LOOP_LINK_SERVICE = Symbol.for("posthog.core.loopLinkService");
+export const USAGE_LINK_SERVICE = Symbol.for("posthog.core.usageLinkService");

--- a/products/desktop/packages/core/src/links/usage-link.test.ts
+++ b/products/desktop/packages/core/src/links/usage-link.test.ts
@@ -1,0 +1,135 @@
+import type {
+  DeepLinkHandler,
+  IDeepLinkRegistry,
+} from "@posthog/platform/deep-link";
+import type { IMainWindow } from "@posthog/platform/main-window";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  UsageLinkEvent,
+  type UsageLinkPayload,
+  UsageLinkService,
+} from "./usage-link";
+
+function makeLogger() {
+  const logger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    scope: vi.fn(() => logger),
+  };
+  return logger;
+}
+
+function makeDeepLinkService() {
+  const handlers = new Map<string, DeepLinkHandler>();
+  const service = {
+    registerHandler: vi.fn((key: string, handler: DeepLinkHandler) => {
+      handlers.set(key, handler);
+    }),
+    trigger: (key: string, path: string, search = "") => {
+      const handler = handlers.get(key);
+      if (!handler) throw new Error(`No handler for ${key}`);
+      return handler(path, new URLSearchParams(search));
+    },
+  };
+  return service as unknown as IDeepLinkRegistry & {
+    trigger: (key: string, path: string, search?: string) => boolean;
+  };
+}
+
+function makeMainWindow() {
+  return {
+    focus: vi.fn(),
+    restore: vi.fn(),
+    isMinimized: vi.fn().mockReturnValue(false),
+  } as unknown as IMainWindow & {
+    focus: ReturnType<typeof vi.fn>;
+    restore: ReturnType<typeof vi.fn>;
+    isMinimized: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe("UsageLinkService", () => {
+  let deepLinkService: ReturnType<typeof makeDeepLinkService>;
+  let mainWindow: ReturnType<typeof makeMainWindow>;
+  let service: UsageLinkService;
+
+  beforeEach(() => {
+    deepLinkService = makeDeepLinkService();
+    mainWindow = makeMainWindow();
+    service = new UsageLinkService(deepLinkService, mainWindow, makeLogger());
+  });
+
+  it("registers a 'usage' handler on the DeepLinkService", () => {
+    expect(deepLinkService.registerHandler).toHaveBeenCalledWith(
+      "usage",
+      expect.any(Function),
+    );
+  });
+
+  it.each<{ name: string; path: string; expected: UsageLinkPayload }>([
+    {
+      name: "defaults to plan-usage when the path is empty",
+      path: "",
+      expected: { category: "plan-usage" },
+    },
+    {
+      name: "takes the first path segment as the settings category",
+      path: "agents",
+      expected: { category: "agents" },
+    },
+    {
+      name: "ignores extra path segments",
+      path: "agents/extra/segments",
+      expected: { category: "agents" },
+    },
+    {
+      name: "decodes a percent-encoded category",
+      path: "plan%2Dusage",
+      expected: { category: "plan-usage" },
+    },
+  ])("$name", ({ path, expected }) => {
+    const listener = vi.fn();
+    service.on(UsageLinkEvent.OpenUsage, listener);
+
+    const result = deepLinkService.trigger("usage", path);
+
+    expect(result).toBe(true);
+    expect(listener).toHaveBeenCalledWith(expected);
+  });
+
+  it("queues a pending deep link when no listener is attached", () => {
+    deepLinkService.trigger("usage", "");
+
+    const pending = service.consumePendingDeepLink();
+    expect(pending).toEqual({ category: "plan-usage" });
+
+    // Draining clears it
+    expect(service.consumePendingDeepLink()).toBeNull();
+  });
+
+  it.each<{ name: string; minimized: boolean; expectRestore: boolean }>([
+    {
+      name: "focuses the main window on link arrival",
+      minimized: false,
+      expectRestore: false,
+    },
+    {
+      name: "restores then focuses the main window when it is minimized",
+      minimized: true,
+      expectRestore: true,
+    },
+  ])("$name", ({ minimized, expectRestore }) => {
+    mainWindow.isMinimized.mockReturnValue(minimized);
+
+    deepLinkService.trigger("usage", "");
+
+    expect(mainWindow.focus).toHaveBeenCalledTimes(1);
+    if (expectRestore) {
+      expect(mainWindow.restore).toHaveBeenCalledTimes(1);
+    } else {
+      expect(mainWindow.restore).not.toHaveBeenCalled();
+    }
+  });
+});

--- a/products/desktop/packages/core/src/links/usage-link.ts
+++ b/products/desktop/packages/core/src/links/usage-link.ts
@@ -1,0 +1,99 @@
+import { ROOT_LOGGER, type RootLogger } from "@posthog/di/logger";
+import {
+  DEEP_LINK_SERVICE,
+  type IDeepLinkRegistry,
+} from "@posthog/platform/deep-link";
+import {
+  type IMainWindow,
+  MAIN_WINDOW_SERVICE,
+} from "@posthog/platform/main-window";
+import { TypedEventEmitter } from "@posthog/shared";
+import { inject, injectable } from "inversify";
+import type { LinkLogger } from "./identifiers";
+
+export const UsageLinkEvent = {
+  OpenUsage: "openUsage",
+} as const;
+
+export interface UsageLinkPayload {
+  /**
+   * Settings category to open. Defaults to `plan-usage` (the Plan & usage
+   * page) when the link carries no category, e.g. `posthog-code://usage`.
+   * A link like `posthog-code://usage/agents` overrides it.
+   */
+  category: string;
+}
+
+export interface UsageLinkEvents {
+  [UsageLinkEvent.OpenUsage]: UsageLinkPayload;
+}
+
+const DEFAULT_CATEGORY = "plan-usage";
+
+@injectable()
+export class UsageLinkService extends TypedEventEmitter<UsageLinkEvents> {
+  private pendingDeepLink: UsageLinkPayload | null = null;
+  private readonly log: LinkLogger;
+
+  constructor(
+    @inject(DEEP_LINK_SERVICE)
+    private readonly deepLinkService: IDeepLinkRegistry,
+    @inject(MAIN_WINDOW_SERVICE)
+    private readonly mainWindow: IMainWindow,
+    @inject(ROOT_LOGGER)
+    rootLogger: RootLogger,
+  ) {
+    super();
+    this.log = rootLogger.scope("usage-link-service");
+
+    this.deepLinkService.registerHandler("usage", (path) =>
+      this.handleUsageLink(path),
+    );
+  }
+
+  private handleUsageLink(path: string): boolean {
+    const category = decodeSegment(path.split("/")[0]) || DEFAULT_CATEGORY;
+
+    const payload: UsageLinkPayload = { category };
+
+    const hasListeners = this.listenerCount(UsageLinkEvent.OpenUsage) > 0;
+
+    if (hasListeners) {
+      this.log.info(`Emitting usage link event: category=${category}`);
+      this.emit(UsageLinkEvent.OpenUsage, payload);
+    } else {
+      this.log.info(
+        `Queueing usage link (renderer not ready): category=${category}`,
+      );
+      this.pendingDeepLink = payload;
+    }
+
+    this.log.info("Deep link focusing window", { category });
+    if (this.mainWindow.isMinimized()) {
+      this.mainWindow.restore();
+    }
+    this.mainWindow.focus();
+
+    return true;
+  }
+
+  public consumePendingDeepLink(): UsageLinkPayload | null {
+    const pending = this.pendingDeepLink;
+    this.pendingDeepLink = null;
+    if (pending) {
+      this.log.info(
+        `Consumed pending usage link: category=${pending.category}`,
+      );
+    }
+    return pending;
+  }
+}
+
+function decodeSegment(segment: string | undefined): string {
+  if (!segment) return "";
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+}

--- a/products/desktop/packages/host-router/src/routers/deep-link.router.ts
+++ b/products/desktop/packages/host-router/src/routers/deep-link.router.ts
@@ -23,6 +23,7 @@ import {
   OPEN_TARGET_LINK_SERVICE,
   SCOUT_LINK_SERVICE,
   TASK_LINK_SERVICE,
+  USAGE_LINK_SERVICE,
 } from "@posthog/core/links/identifiers";
 import {
   InboxLinkEvent,
@@ -53,6 +54,11 @@ import {
   TaskLinkEvent,
   type TaskLinkService,
 } from "@posthog/core/links/task-link";
+import {
+  UsageLinkEvent,
+  type UsageLinkPayload,
+  type UsageLinkService,
+} from "@posthog/core/links/usage-link";
 import { publicProcedure, router } from "@posthog/host-trpc/trpc";
 import {
   DEEP_LINK_SERVICE,
@@ -243,6 +249,25 @@ export const deepLinkRouter = router({
     ({ ctx }): LoopLinkPayload | null => {
       return ctx.container
         .get<LoopLinkService>(LOOP_LINK_SERVICE)
+        .consumePendingDeepLink();
+    },
+  ),
+
+  onOpenUsage: publicProcedure.subscription(async function* (opts) {
+    const service =
+      opts.ctx.container.get<UsageLinkService>(USAGE_LINK_SERVICE);
+    const iterable = service.toIterable(UsageLinkEvent.OpenUsage, {
+      signal: opts.signal,
+    });
+    for await (const data of iterable) {
+      yield data;
+    }
+  }),
+
+  getPendingUsageLink: publicProcedure.query(
+    ({ ctx }): UsageLinkPayload | null => {
+      return ctx.container
+        .get<UsageLinkService>(USAGE_LINK_SERVICE)
         .consumePendingDeepLink();
     },
   ),

--- a/products/desktop/packages/shared/src/deep-links.test.ts
+++ b/products/desktop/packages/shared/src/deep-links.test.ts
@@ -3,6 +3,7 @@ import {
   buildInboxDeeplink,
   buildLoopDeeplink,
   buildScoutDeeplink,
+  buildUsageDeeplink,
   decodePlanBase64,
   getDeeplinkProtocol,
   isPostHogCodeDeeplink,
@@ -125,6 +126,48 @@ describe("buildLoopDeeplink", () => {
     },
   ])("$name", ({ loopId, isDevBuild, expected }) => {
     expect(buildLoopDeeplink(loopId, { isDevBuild })).toBe(expected);
+  });
+});
+
+describe("buildUsageDeeplink", () => {
+  it.each<{
+    name: string;
+    category: string | null | undefined;
+    isDevBuild: boolean;
+    expected: string;
+  }>([
+    {
+      name: "builds a bare usage link when category is null",
+      category: null,
+      isDevBuild: false,
+      expected: "posthog-code://usage",
+    },
+    {
+      name: "builds a bare usage link when category is undefined",
+      category: undefined,
+      isDevBuild: false,
+      expected: "posthog-code://usage",
+    },
+    {
+      name: "appends the category as a path segment",
+      category: "plan-usage",
+      isDevBuild: false,
+      expected: "posthog-code://usage/plan-usage",
+    },
+    {
+      name: "uses the dev scheme for dev builds",
+      category: null,
+      isDevBuild: true,
+      expected: "posthog-code-dev://usage",
+    },
+    {
+      name: "encodes special characters in the category",
+      category: "a b/c",
+      isDevBuild: false,
+      expected: "posthog-code://usage/a%20b%2Fc",
+    },
+  ])("$name", ({ category, isDevBuild, expected }) => {
+    expect(buildUsageDeeplink(category, { isDevBuild })).toBe(expected);
   });
 });
 

--- a/products/desktop/packages/shared/src/deep-links.ts
+++ b/products/desktop/packages/shared/src/deep-links.ts
@@ -43,6 +43,20 @@ export function buildInboxDeeplink(
 }
 
 /**
+ * Build a canonical deep link to the Plan & usage settings page, or another
+ * settings category (`<scheme>://usage[/<category>]`). The inbound side lives
+ * in the `usage` handler (`UsageLinkService`), which routes to
+ * `/settings/<category>`. Omit `category` for the default Plan & usage page.
+ */
+export function buildUsageDeeplink(
+  category: string | null | undefined,
+  { isDevBuild }: { isDevBuild: boolean },
+): string {
+  const base = `${getDeeplinkProtocol(isDevBuild)}://usage`;
+  return category ? `${base}/${encodeURIComponent(category)}` : base;
+}
+
+/**
  * Build a canonical deep link to a loop's detail page
  * (`<scheme>://loop/<loopId>`). The inbound side lives in the `loop` handler
  * (`LoopLinkService`), which routes to `/code/loops/<loopId>`.

--- a/products/desktop/packages/shared/src/deeplink.ts
+++ b/products/desktop/packages/shared/src/deeplink.ts
@@ -1,6 +1,7 @@
 export {
   buildInboxDeeplink,
   buildScoutDeeplink,
+  buildUsageDeeplink,
   DEEPLINK_PROTOCOL_DEVELOPMENT,
   DEEPLINK_PROTOCOL_PRODUCTION,
   getDeeplinkProtocol,

--- a/products/desktop/packages/shared/src/index.ts
+++ b/products/desktop/packages/shared/src/index.ts
@@ -107,6 +107,7 @@ export {
   buildInboxDeeplink,
   buildLoopDeeplink,
   buildScoutDeeplink,
+  buildUsageDeeplink,
   DEEPLINK_PROTOCOL_DEVELOPMENT,
   DEEPLINK_PROTOCOL_PRODUCTION,
   decodePlanBase64,

--- a/products/desktop/packages/ui/src/features/settings/hooks/useUsageDeepLink.ts
+++ b/products/desktop/packages/ui/src/features/settings/hooks/useUsageDeepLink.ts
@@ -1,0 +1,60 @@
+import { useHostTRPC } from "@posthog/host-router/react";
+import { useAuthStateValue } from "@posthog/ui/features/auth/store";
+import { isSettingsCategory } from "@posthog/ui/features/settings/types";
+import { navigateToSettings } from "@posthog/ui/router/navigationBridge";
+import { logger } from "@posthog/ui/shell/logger";
+import { useQuery } from "@tanstack/react-query";
+import { useSubscription } from "@trpc/tanstack-react-query";
+import { useCallback, useEffect } from "react";
+
+const log = logger.scope("usage-deep-link");
+
+/**
+ * Handles Plan & usage deep links (`<scheme>://usage[/<category>]`, e.g.
+ * `posthog-code://usage` for the Plan & usage page, or
+ * `posthog-code://usage/agents` for another settings category) and opens the
+ * matching settings page. Mirrors `useLoopDeepLink`: drains any link that
+ * arrived before the renderer was ready and subscribes for links delivered
+ * while the app is already running.
+ */
+export function useUsageDeepLink() {
+  const trpcReact = useHostTRPC();
+  const isAuthenticated = useAuthStateValue(
+    (s) => s.status === "authenticated",
+  );
+
+  const pendingDeepLink = useQuery(
+    trpcReact.deepLink.getPendingUsageLink.queryOptions(undefined, {
+      enabled: isAuthenticated,
+      // Drain once per session – the main process clears its pending entry on read.
+      staleTime: Number.POSITIVE_INFINITY,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+    }),
+  );
+
+  const openUsage = useCallback((category: string) => {
+    if (!isSettingsCategory(category)) {
+      log.warn(
+        `Usage deep link carried an unknown settings category: ${category}`,
+      );
+      return;
+    }
+    log.info(`Opening settings from deep link: category=${category}`);
+    navigateToSettings(category);
+  }, []);
+
+  useEffect(() => {
+    if (pendingDeepLink.data?.category) {
+      openUsage(pendingDeepLink.data.category);
+    }
+  }, [pendingDeepLink.data, openUsage]);
+
+  useSubscription(
+    trpcReact.deepLink.onOpenUsage.subscriptionOptions(undefined, {
+      onData: (data) => {
+        if (data?.category) openUsage(data.category);
+      },
+    }),
+  );
+}

--- a/products/desktop/packages/ui/src/router/routes/__root.tsx
+++ b/products/desktop/packages/ui/src/router/routes/__root.tsx
@@ -45,6 +45,7 @@ import { useInboxDeepLink } from "@posthog/ui/features/inbox/hooks/useInboxDeepL
 import { useIntegrations } from "@posthog/ui/features/integrations/useIntegrations";
 import { useLoopDeepLink } from "@posthog/ui/features/loops/hooks/useLoopDeepLink";
 import { useScoutDeepLink } from "@posthog/ui/features/scouts/hooks/useScoutDeepLink";
+import { useUsageDeepLink } from "@posthog/ui/features/settings/hooks/useUsageDeepLink";
 import { useSetupDiscovery } from "@posthog/ui/features/setup/useSetupDiscovery";
 import {
   beginSidebarPeek,
@@ -231,6 +232,7 @@ function RootLayout() {
   useCanvasDeepLink();
   useChannelDeepLink();
   useLoopDeepLink();
+  useUsageDeepLink();
   useShareLinkInterceptor();
   const approvalDeepLink = useApprovalDeepLink();
   useSetupDiscovery();


### PR DESCRIPTION
## Problem

The PostHog desktop app had no deep link to its Plan & usage settings page. Remote announcement CTAs and external tools that wanted to drop someone on that page had no `posthog-code://` URL to use — the only path was in-app navigation, and the closest helper (`getBillingUrl`) opens an external PostHog Cloud URL in the browser, not an in-app route.

## Changes

- A person opening `posthog-code://usage` now lands on the Plan & usage settings page inside the desktop app, with the window focused (and restored if minimized).
- `posthog-code://usage/<category>` opens a different settings page by slug, e.g. `posthog-code://usage/agents`. Unknown category slugs are ignored rather than navigating to a broken route.
- The link works whether the app is already running (delivered live) or launched cold (queued until the renderer is ready), matching the existing task/inbox/scout/loop links.
- Mechanical: new `UsageLinkService` in `packages/core/src/links` registers a `usage` handler on the shared deep-link dispatcher; `onOpenUsage` / `getPendingUsageLink` tRPC procedures bridge it to the renderer; `useUsageDeepLink` in `__root.tsx` navigates to `/settings/<category>`; the web host stubs the new procedures (no URL scheme in the browser); `buildUsageDeeplink` helper added to `@posthog/shared`.

## How did you test this code?

Automated tests the agent ran:

- New `UsageLinkService` unit tests (`packages/core/src/links/usage-link.test.ts`, 8 tests) — cover: handler registration, default-to-`plan-usage` on empty path, first-segment category extraction, extra-segment ignoring, percent-decoding, pending-link queueing + draining, and window focus/restore on minimized. These regressions (default category, segment parsing, pending-queue lifecycle) are not covered by any existing test.
- New `buildUsageDeeplink` tests in `packages/shared/src/deep-links.test.ts` — cover null/undefined category, category segment, dev scheme, and special-character encoding.
- Existing deep-link dispatcher tests (`apps/code/src/main/services/deep-link/service.test.ts`, 24 tests) still pass — confirms the new `usage` handler integrates with the dispatcher without breaking other handlers.
- Typecheck passes for `@posthog/core`, `@posthog/host-router`, `code` (node + web), `@posthog/ui`, and `@posthog/web`. Host-boundary check reports no new violations.

The agent did not manually open the Electron app to click a `posthog-code://usage` link (no display in this environment); the dispatcher test plus the link-service test cover the handler path, and the renderer hook mirrors the already-shipped `useLoopDeepLink`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- DEEP-LINKS.md updated in this PR (new `usage` scheme documented in the handler list, a user-facing section, and the implementation table).

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tools: pi coding agent (Claude) operating in the `products/desktop` workspace. No external session link.
- Skills invoked: none of the repo-provided skills applied directly (this is a desktop-app deep-link feature, not a Django/DRF/ClickHouse/migration change); the `products/desktop/AGENTS.md` architecture and `docs/DEEP-LINKS.md` conventions were followed, modeling the new link on the existing `LoopLinkService` / `useLoopDeepLink` pair.
- Decisions: chose `usage` as the scheme host (matches the existing `/usage` redirect route and `useUsage`/`UsageButton` naming) over `plan-usage` or `billing`, since the handler can open any settings category and `usage` is the broad name. Defaulted an empty path to `plan-usage` so the bare `posthog-code://usage` link reaches the Plan & usage page specifically, while `posthog-code://usage/<category>` stays general. Rejected an unknown category silently in the renderer hook (warn + no-op) rather than navigating to a 404.
- Public artifact: nothing in this PR carries session material — the change is a conventional deep-link feature built from the repo's own patterns.