### PR TITLE
feat(desktop): show recent command selections

### DIFF
--- a/products/desktop/packages/ui/src/features/command/CommandMenu.feedQuery.test.tsx
+++ b/products/desktop/packages/ui/src/features/command/CommandMenu.feedQuery.test.tsx
@@ -133,6 +133,19 @@ describe("CommandMenu feed queries", () => {
     ).toBeTruthy();
   });
 
+  it("shows a selected command in the recent section", async () => {
+    const user = userEvent.setup();
+    render(
+      <Theme>
+        <CommandMenu open onOpenChange={() => {}} />
+      </Theme>,
+    );
+
+    await user.click(await screen.findByText("Toggle left sidebar"));
+
+    expect(await screen.findByText("Recent")).toBeTruthy();
+  });
+
   it("labels incomplete task search results", async () => {
     taskResultsComplete = false;
     const user = userEvent.setup();

--- a/products/desktop/packages/ui/src/features/command/CommandMenu.tsx
+++ b/products/desktop/packages/ui/src/features/command/CommandMenu.tsx
@@ -46,6 +46,7 @@ import { getDefaultReviewMode } from "@posthog/ui/features/code-review/getDefaul
 import { useReviewNavigationStore } from "@posthog/ui/features/code-review/reviewNavigationStore";
 import { CommandKeyHints } from "@posthog/ui/features/command/CommandKeyHints";
 import {
+  addRecentCommand,
   matchesCommandSearch,
   prioritizeExactCommandMatches,
 } from "@posthog/ui/features/command/commandSearch";
@@ -233,6 +234,7 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
     (state) => state.activeTasks,
   );
   const [query, setQuery] = useState("");
+  const [recentCommands, setRecentCommands] = useState<Command[]>([]);
   const [remoteQuery, setRemoteQuery] = useState("");
   // The legacy title search only ever surfaces while the palette is browsing
   // (see `showRemoteSearch` below). The feed-query `mode` that decides that is
@@ -726,7 +728,7 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
     remoteSearchAllowedRef.current = browsing && !scope;
   }, [mode, scope]);
 
-  const sections = useMemo(() => {
+  const baseSections = useMemo(() => {
     const browsing = mode === "browsing" || mode === "completingKey";
     const showCommands = browsing && (!scope || scope === "command");
     const showChannels = browsing && (!scope || scope === "space");
@@ -753,6 +755,28 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
     searchText,
   ]);
 
+  const sections = useMemo(() => {
+    if (query.trim() || recentCommands.length === 0) return baseSections;
+    const currentCommands = new Map(
+      baseSections.flatMap((section) =>
+        section.items.map((command) => [command.id, command] as const),
+      ),
+    );
+    const recentItems = recentCommands.map(
+      (command) => currentCommands.get(command.id) ?? command,
+    );
+    const recentIds = new Set(recentItems.map((command) => command.id));
+    return [
+      { label: "Recent", items: recentItems },
+      ...baseSections
+        .map((section) => ({
+          ...section,
+          items: section.items.filter((command) => !recentIds.has(command.id)),
+        }))
+        .filter((section) => section.items.length > 0),
+    ];
+  }, [baseSections, query, recentCommands]);
+
   const paletteFilter = useCallback(
     (command: { label: string; keywords?: string }) =>
       matchesCommandSearch(command, searchText),
@@ -775,6 +799,9 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
       action_type: cmd.action,
       channel_id: cmd.channelId,
     });
+    if (!cmd.keepOpen) {
+      setRecentCommands((recent) => addRecentCommand(recent, cmd));
+    }
     cmd.onRun();
     if (cmd.keepOpen) return;
     onOpenChange(false);

--- a/products/desktop/packages/ui/src/features/command/commandSearch.test.ts
+++ b/products/desktop/packages/ui/src/features/command/commandSearch.test.ts
@@ -1,4 +1,5 @@
 import {
+  addRecentCommand,
   matchesCommandSearch,
   prioritizeExactCommandMatches,
 } from "@posthog/ui/features/command/commandSearch";
@@ -38,5 +39,18 @@ describe("prioritizeExactCommandMatches", () => {
     expect(
       matchesCommandSearch(command("release", "Release"), " release "),
     ).toBe(true);
+  });
+
+  it("keeps the five most recently selected commands without duplicates", () => {
+    const selected = ["one", "two", "three", "four", "five", "six"].reduce(
+      (recent, id) => addRecentCommand(recent, command(id, id)),
+      [] as Command[],
+    );
+
+    expect(
+      addRecentCommand(selected, command("four", "four")).map(
+        (item) => item.id,
+      ),
+    ).toEqual(["four", "six", "five", "three", "two"]);
   });
 });

--- a/products/desktop/packages/ui/src/features/command/commandSearch.ts
+++ b/products/desktop/packages/ui/src/features/command/commandSearch.ts
@@ -1,5 +1,19 @@
 import type { CommandSection } from "@posthog/ui/features/command/useSearchSections";
 
+export const RECENT_COMMAND_LIMIT = 5;
+
+export function addRecentCommand<T extends { id: string }>(
+  recentCommands: T[],
+  command: T,
+): T[] {
+  return [
+    command,
+    ...recentCommands.filter(
+      (recentCommand) => recentCommand.id !== command.id,
+    ),
+  ].slice(0, RECENT_COMMAND_LIMIT);
+}
+
 export function matchesCommandSearch(
   command: { label: string; keywords?: string },
   query: string,


### PR DESCRIPTION
## Problem

Desktop users must search again to reopen a command they selected moments earlier.

## Changes

- The desktop command palette now shows the five latest selected commands when it reopens.
- The recent section moves repeated commands to the top and removes duplicate rows.
- The recent list keeps live command callbacks during the desktop session.

![Desktop command palette with a selected command in Recent](https://raw.githubusercontent.com/PostHog/pr-assets/e7aa6f296084ab38f253d79d17ab70473e5a0de5/2026/08/88708c13-8049-4c88-8aac-ff7be3a9450b.png)

## How did you test this code?

- The command menu test verifies that a selected command appears in the Recent section.
- The command history test guards the five-item limit and duplicate promotion.
- `pnpm --filter=@posthog/ui typecheck` completed successfully.
- The desktop UI test suite completed successfully.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- No docs update is needed for this desktop navigation behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Pi created this PR with the `/writing-ui-components`, `/writing-user-facing-copy`, `/writing-tests`, and `/writing-pr-descriptions` skills.
- The command history stays in the mounted desktop command palette so every selected command keeps its existing action callback.
