### PR TITLE
chore(canvas): document live task queries

### DIFF
--- a/products/canvas/skills/querying-canvas-data/SKILL.md
+++ b/products/canvas/skills/querying-canvas-data/SKILL.md
@@ -100,6 +100,51 @@ product — rather than every tile resolving the insight's saved default.
 - Values are typed by the variable's definition in PostHog (String / Number / Boolean / Date / List);
   pass the same shape the insight expects, and an array for a multi-select List variable.
 
+## Live Tasks data
+
+For a task inbox, queue, or status board, query `system.tasks` and `system.task_runs` through
+`ph.query`. Do not call `posthog:tasks-list` while authoring and embed its response: that produces a
+snapshot, while the system tables keep the rendered canvas live.
+
+The tables run as the signed-in viewer. They are project-scoped and require access to the Tasks
+resource. `system.tasks` includes only non-internal tasks filed in live public spaces; it excludes
+private, personal, unfiled, and internal tasks. Always exclude soft-deleted tasks explicitly.
+
+Join a task to its latest run when the canvas needs current status:
+
+```tsx
+const data = await ph.query(`
+  SELECT
+    t.id,
+    t.task_number,
+    t.title,
+    t.repository,
+    t.created_by_id,
+    t.created_at,
+    t.updated_at,
+    latest.status AS latest_run_status
+  FROM system.tasks AS t
+  LEFT JOIN (
+    SELECT
+      task_id,
+      argMax(status, tuple(created_at, id)) AS status
+    FROM system.task_runs
+    GROUP BY task_id
+  ) AS latest ON latest.task_id = t.id
+  WHERE t.deleted = 0
+  ORDER BY t.updated_at DESC
+  LIMIT 100
+`)
+```
+
+This is inline HogQL, so declare `capabilities.posthog.inlineQueries: true`. Render links with
+`ph.navigate.toTask(id)` rather than constructing task URLs.
+
+Do not promise filters the tables cannot express. `channel_id` is not queryable, so a canvas cannot
+currently restrict this query to its own space. Filtering to the current viewer also requires a
+known numeric user id; the canvas runtime does not inject one. State these limits when the request
+depends on “this space” or “my tasks” instead of silently showing project-wide public tasks.
+
 ## Runtime memory — ph.state
 
 Durable key-value storage per canvas. Declare every scope you use in `capabilities.posthog.state`


### PR DESCRIPTION
## Problem

Canvas agents can build live task dashboards, but their data skill does not explain the available Tasks system tables or visibility limits.

## Changes

- Canvas agents now receive a live Tasks query pattern with latest-run status.
- The guidance explains customer permissions, public-space visibility, soft deletion, navigation, and unsupported space or viewer filters.
- This change only updates agent guidance. It does not change the canvas runtime.

## How did you test this code?

- `uv run python products/posthog_ai/scripts/build_skills.py --lint`
- `.venv/bin/hogli ci:preflight --fix`
- Full skill build not completed because the local Postgres service is unavailable.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The canvas data skill is the affected documentation.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex authored this change with the `posthog-desktop`, `writing-skills`, and `writing-pr-descriptions` skills.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*