### PR TITLE
fix(batch-exports): relax events model HogQL values type

### DIFF
--- a/products/batch_exports/backend/api/batch_export.py
+++ b/products/batch_exports/backend/api/batch_export.py
@@ -863,7 +863,7 @@ class BatchExportsField(TypedDict):
 
 class BatchExportsSchema(TypedDict):
     fields: list[BatchExportsField]
-    values: dict[str, str]
+    values: dict[str, Any]
     hogql_query: str
 
 

--- a/products/batch_exports/backend/service.py
+++ b/products/batch_exports/backend/service.py
@@ -137,7 +137,8 @@ class BatchExportField(typing.TypedDict):
 
 class BatchExportSchema(typing.TypedDict):
     fields: list[BatchExportField]
-    values: dict[str, str]
+    # HogQL binds these at any type; narrowing breaks Temporal input decoding.
+    values: dict[str, typing.Any]
 
 
 @dataclass


### PR DESCRIPTION
## Problem

Currently the `BatchExportSchema.values` type is `dict[str, str]` but this is too narrow in certain cases. This can cause Temporal input decoding errors.

## Changes

Relax the type to `dict[str, typing.Any]`. `Any` was chosen rather than a narrower type, because Temporal resolves a union by trying each member in order and casting to the first that accepts the value, so a union can sometimes unexpectedly cast a value to the wrong type.

## How did you test this code?

Claude did some adhoc testing, flagging the issue above with using unions in the type.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

Diagnosed issue in production using Claude. Also asked Claude to check for any issues and to check if we could narrow the type at all.