### PR TITLE
fix(charts): stop tooltip scroll animation

### DIFF
--- a/packages/quill/packages/charts/src/overlays/DefaultTooltip.test.tsx
+++ b/packages/quill/packages/charts/src/overlays/DefaultTooltip.test.tsx
@@ -277,5 +277,22 @@ describe('DefaultTooltip', () => {
             expect(closest).toHaveLength(1)
             expect(closest[0].querySelector('[data-attr="hog-chart-tooltip-series"]')?.textContent).toBe('Beta')
         })
+
+        it('keeps smooth scrolling for a small group of equal values', () => {
+            renderTooltip({}, TWO_SERIES, { hoveredSeriesKey: 'b' })
+            const row = document.querySelector<HTMLElement>('[data-attr="hog-chart-tooltip-row"]')
+            expect(row?.parentElement?.style.scrollBehavior).toBe('smooth')
+        })
+
+        it('skips smooth scrolling when more than a viewport of rows share the selected value', () => {
+            const equalSeries: TooltipContext['seriesData'] = Array.from({ length: 11 }, (_, index) => ({
+                series: { key: `${index}`, label: `${index}`, data: [] },
+                value: 0,
+                color: '#000',
+            }))
+            renderTooltip({}, equalSeries, { hoveredSeriesKey: '10' })
+            const row = document.querySelector<HTMLElement>('[data-attr="hog-chart-tooltip-row"]')
+            expect(row?.parentElement?.style.scrollBehavior).toBe('auto')
+        })
     })
 })

--- a/packages/quill/packages/charts/src/overlays/DefaultTooltip.tsx
+++ b/packages/quill/packages/charts/src/overlays/DefaultTooltip.tsx
@@ -76,6 +76,8 @@ export function DefaultTooltip<Meta = unknown>({
     const closestKey =
         hoveredSeriesKey ??
         (hoverPosition != null && rows.length > 1 ? findClosestSeriesKey(rows, hoverPosition.y) : null)
+    const closestValue = rows.find((s) => s.series.key === closestKey)?.value
+    const smoothScroll = closestValue == null || rows.filter((s) => s.value === closestValue).length <= 10
     const renderTotal = showTotal && summable.length > 1
     const total = summable.reduce((acc, s) => acc + s.value, 0)
     const formatTotal = totalFormatter ?? ((value: number): React.ReactNode => format(value, summable[0]))
@@ -151,6 +153,7 @@ export function DefaultTooltip<Meta = unknown>({
                     maxHeight: ROWS_MAX_HEIGHT,
                     overflowY: 'auto',
                     scrollbarWidth: 'none',
+                    scrollBehavior: smoothScroll ? 'smooth' : 'auto',
                     maskImage,
                     WebkitMaskImage: maskImage,
                 }}

--- a/packages/quill/packages/charts/src/overlays/DefaultTooltip.tsx
+++ b/packages/quill/packages/charts/src/overlays/DefaultTooltip.tsx
@@ -151,7 +151,6 @@ export function DefaultTooltip<Meta = unknown>({
                     maxHeight: ROWS_MAX_HEIGHT,
                     overflowY: 'auto',
                     scrollbarWidth: 'none',
-                    scrollBehavior: 'smooth',
                     maskImage,
                     WebkitMaskImage: maskImage,
                 }}


### PR DESCRIPTION
## Problem

Long Quill chart tooltips animate through many rows when hover selects one of many series with the same value. The rapid sweep makes the tooltip look unstable.

**Why:** Tooltip hover should stay calm for large tied groups without losing useful animation during ordinary navigation.

## Changes

The shared tooltip keeps smooth scrolling for normal navigation, but jumps directly when more than a viewport of rows share the selected value.

## How did you test this code?

- Added regression cases for small and large equal-value groups.
- `pnpm --filter @posthog/quill-charts build`
- The focused Jest runner was unavailable without the frontend workspace dependencies.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex traced the shared tooltip and closest-series helper. No skills were invoked. The final behavior retains animation for ordinary navigation and suppresses it only for large tied groups.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*