### PR TITLE
chore(rbac): show what project access falls back to without an override

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/AccessControlDetail.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/AccessControlDetail.tsx
@@ -230,8 +230,9 @@ function ProjectAccessSection({
                 levels={availableProjectLevels}
                 onChange={onChange}
                 disabledReason={subjectDisabledReason(entry, canEdit, user?.uuid)}
-                // Plain "No override": project access is object-resolved at runtime (an explicit role rule
-                // can undercut the default), so annotating what applies without a rule can be wrong here.
+                inherited={inheritedFor(entry.project, 'this project')}
+                // Falls back to a plain "No override" for a subject with nothing above them, which
+                // is the project's own default rather than a member or a role
                 allowNoOverride
             />
         </div>


### PR DESCRIPTION
## Problem

- A member's project access shows a plain "No override", so it's hard tell what the member actually gets. Every tool below it says what applies, for example "No override · Editor".
- The project row was left plain because the level it would have shown came from a flat max-wins re-implementation (refactored in #83510)
- A project is an object, so its rules resolve most specific first. An explicit role rule beats the project default even when the role rule is lower. 

## Changes

<img width="1640" height="1320" alt="2026-08-19 17 08 21" src="https://github.com/user-attachments/assets/3329722b-5879-4806-8505-310ef64ecdea" />

- The project row now reads "No override · Member", with the reason under it, exactly like each tool.
- The level comes from the object walk that enforces access, through `inherited_access` on the project entry
- The menu entry and the tooltip name the source: the project default, a role rule, or the organization admin bypass.
- Deleted the comment that said this annotation could not be trusted. It described the old calculation.

## How did you test this code?

- No new tests. This change passes an already-resolved value into a component prop; `inheritedFor` and the provenance mapping carry their own Jest cases in #83510.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.