### PR TITLE
feat(desktop): add posthog-code://usage deep link to the plan & usage page

### DIFF
--- a/products/desktop/apps/web/src/web-host-router.ts
+++ b/products/desktop/apps/web/src/web-host-router.ts
@@ -77,6 +77,17 @@ const deepLinkStubRouter = router({
   onOpenLoop: neverEmit,
 });
 
+// UI events are main-process signals (menu items, deep links). Web has no
+// main process, so the streams never fire and there is no pending link.
+const uiStubRouter = router({
+  onOpenSettings: neverEmit,
+  onNewTask: neverEmit,
+  onResetLayout: neverEmit,
+  onClearStorage: neverEmit,
+  onInvalidateToken: neverEmit,
+  getPendingSettingsLink: publicProcedure.query(() => null),
+});
+
 // Slack/GitHub connect. Desktop opens the PostHog integration authorize URL in
 // the system browser and relays the result back through a posthog-code:// deep
 // link (captured by the main process). The browser has no URL scheme, but it
@@ -506,6 +517,7 @@ export const webHostRouter = router({
   os: osStubRouter,
   skills: skillsStubRouter,
   slackIntegration: slackIntegrationRouter,
+  ui: uiStubRouter,
   workspace: workspaceStubRouter,
 });
 

--- a/products/desktop/docs/DEEP-LINKS.md
+++ b/products/desktop/docs/DEEP-LINKS.md
@@ -10,7 +10,7 @@ PostHog registers custom URL schemes so the desktop app can be opened with conte
 | Development | `posthog-code-dev://` |
 | Legacy (production only) | `twig://`, `array://` |
 
-All schemes route through the same dispatcher. The host portion of the URL selects the handler (`task`, `inbox`, `scout`, `loop`, `approval`, `canvas`, `channel`, `new`, `plan`, `issue`, `callback`, `integration`, `slack-integration`, `mcp-oauth-complete`).
+All schemes route through the same dispatcher. The host portion of the URL selects the handler (`task`, `inbox`, `scout`, `loop`, `approval`, `canvas`, `channel`, `new`, `plan`, `issue`, `usage`, `callback`, `integration`, `slack-integration`, `mcp-oauth-complete`).
 
 If the app is not running, the OS launches it and the link is queued until the renderer is ready. If the app is minimised, it is restored and focused before the link is handled.
 
@@ -194,6 +194,20 @@ posthog-code://channel/019ebc38-d862-77f2-9e56-c5ec42965758/tasks/task_abc123
 
 These are issued by external services and consumed by the app. You should not need to construct them yourself, but they are documented for completeness.
 
+### `posthog-code://usage[/<category>]`
+
+Open the Plan & usage settings page, or another settings page. With no path
+segment it opens Plan & usage; a category segment opens that settings page.
+
+| Segment | Required | Description |
+|---|---|---|
+| `<category>` | No | Settings category slug (e.g. `plan-usage`, `agents`, `github`). Defaults to `plan-usage` when omitted. Unknown categories are ignored. |
+
+```
+posthog-code://usage
+posthog-code://usage/agents
+```
+
 ### `posthog-code://callback`
 
 PKCE OAuth callback for user sign-in. PostHog Cloud redirects to this URL after the user authorises in their browser.
@@ -259,6 +273,7 @@ In development the same payload is delivered to `http://localhost:8238/mcp-oauth
 | `canvas` | [packages/core/src/links/canvas-link.ts](../packages/core/src/links/canvas-link.ts) |
 | `channel` | [packages/core/src/links/channel-link.ts](../packages/core/src/links/channel-link.ts) |
 | `new`, `plan`, `issue` | [packages/core/src/links/new-task-link.ts](../packages/core/src/links/new-task-link.ts) |
+| `usage` | [packages/core/src/ui/ui.ts](../packages/core/src/ui/ui.ts) |
 | `callback` | [packages/core/src/oauth/oauth.ts](../packages/core/src/oauth/oauth.ts) |
 | `integration` | [packages/core/src/integrations/github.ts](../packages/core/src/integrations/github.ts) |
 | `slack-integration` | [packages/core/src/integrations/slack.ts](../packages/core/src/integrations/slack.ts) |

--- a/products/desktop/packages/core/src/ui/schemas.ts
+++ b/products/desktop/packages/core/src/ui/schemas.ts
@@ -7,9 +7,15 @@ export const UIServiceEvent = {
   InvalidateToken: "invalidate-token",
 } as const;
 
-// UI events are simple signals - payload is just a marker that the event fired
+export interface OpenSettingsPayload {
+  /** Settings category slug to open. Defaults to `plan-usage` when empty. */
+  category: string;
+}
+
+// UI events are simple signals - payload is just a marker that the event fired.
+// OpenSettings is the exception: it carries the settings category to open.
 export interface UIServiceEvents {
-  [UIServiceEvent.OpenSettings]: true;
+  [UIServiceEvent.OpenSettings]: OpenSettingsPayload;
   [UIServiceEvent.NewTask]: true;
   [UIServiceEvent.ResetLayout]: true;
   [UIServiceEvent.ClearStorage]: true;

--- a/products/desktop/packages/core/src/ui/ui.test.ts
+++ b/products/desktop/packages/core/src/ui/ui.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it, vi } from "vitest";
+import type { IDeepLinkRegistry } from "@posthog/platform/deep-link";
+import type { IMainWindow } from "@posthog/platform/main-window";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { UiAuth } from "./ports";
 import { UIServiceEvent } from "./schemas";
 import { UIService } from "./ui";
@@ -7,14 +9,32 @@ function makeAuth(): UiAuth {
   return { invalidateAccessTokenForTest: vi.fn().mockResolvedValue(undefined) };
 }
 
+function makeDeepLink(): IDeepLinkRegistry {
+  return {
+    registerHandler: vi.fn(),
+    unregisterHandler: vi.fn(),
+  } as unknown as IDeepLinkRegistry;
+}
+
+function makeMainWindow(): IMainWindow {
+  return {
+    isMinimized: vi.fn().mockReturnValue(false),
+    focus: vi.fn(),
+    restore: vi.fn(),
+  } as unknown as IMainWindow;
+}
+
+function makeService(): UIService {
+  return new UIService(makeAuth(), makeDeepLink(), makeMainWindow());
+}
+
 describe("UIService signal events", () => {
   it.each([
-    ["openSettings", UIServiceEvent.OpenSettings],
     ["newTask", UIServiceEvent.NewTask],
     ["resetLayout", UIServiceEvent.ResetLayout],
     ["clearStorage", UIServiceEvent.ClearStorage],
   ] as const)("%s emits %s", (method, event) => {
-    const service = new UIService(makeAuth());
+    const service = makeService();
     const listener = vi.fn();
     service.on(event, listener);
 
@@ -22,12 +42,121 @@ describe("UIService signal events", () => {
 
     expect(listener).toHaveBeenCalledWith(true);
   });
+
+  it("openSettings emits the category, defaulting to plan-usage", () => {
+    const service = makeService();
+    const listener = vi.fn();
+    service.on(UIServiceEvent.OpenSettings, listener);
+
+    service.openSettings();
+
+    expect(listener).toHaveBeenCalledWith({ category: "plan-usage" });
+  });
+
+  it("openSettings forwards a custom category", () => {
+    const service = makeService();
+    const listener = vi.fn();
+    service.on(UIServiceEvent.OpenSettings, listener);
+
+    service.openSettings("agents");
+
+    expect(listener).toHaveBeenCalledWith({ category: "agents" });
+  });
+});
+
+describe("UIService usage deep link", () => {
+  let deepLink: IDeepLinkRegistry;
+  let mainWindow: IMainWindow;
+  let service: UIService;
+
+  beforeEach(() => {
+    deepLink = makeDeepLink();
+    mainWindow = makeMainWindow();
+    service = new UIService(makeAuth(), deepLink, mainWindow);
+  });
+
+  function handler(): (path: string) => boolean {
+    return (deepLink.registerHandler as ReturnType<typeof vi.fn>).mock
+      .calls[0][1] as (path: string) => boolean;
+  }
+
+  it("registers a usage handler", () => {
+    expect(deepLink.registerHandler).toHaveBeenCalledWith(
+      "usage",
+      expect.any(Function),
+    );
+  });
+
+  it("defaults an empty path to plan-usage", () => {
+    const listener = vi.fn();
+    service.on(UIServiceEvent.OpenSettings, listener);
+
+    expect(handler()("")).toBe(true);
+    expect(listener).toHaveBeenCalledWith({ category: "plan-usage" });
+  });
+
+  it("takes the first segment as the category", () => {
+    const listener = vi.fn();
+    service.on(UIServiceEvent.OpenSettings, listener);
+
+    expect(handler()("agents")).toBe(true);
+    expect(listener).toHaveBeenCalledWith({ category: "agents" });
+  });
+
+  it("ignores extra path segments", () => {
+    const listener = vi.fn();
+    service.on(UIServiceEvent.OpenSettings, listener);
+
+    handler()("agents/foo");
+    expect(listener).toHaveBeenCalledWith({ category: "agents" });
+  });
+
+  it("percent-decodes the category", () => {
+    const listener = vi.fn();
+    service.on(UIServiceEvent.OpenSettings, listener);
+
+    handler()("plan%20usage");
+    expect(listener).toHaveBeenCalledWith({ category: "plan usage" });
+  });
+
+  it("queues the link when no renderer is listening", () => {
+    expect(handler()("agents")).toBe(true);
+
+    expect(service.consumePendingSettingsLink()).toEqual({
+      category: "agents",
+    });
+  });
+
+  it("emits instead of queueing when a listener is attached", () => {
+    const listener = vi.fn();
+    service.on(UIServiceEvent.OpenSettings, listener);
+
+    handler()("agents");
+    expect(service.consumePendingSettingsLink()).toBeNull();
+  });
+
+  it("drains the pending link once", () => {
+    handler()("agents");
+    expect(service.consumePendingSettingsLink()).toEqual({
+      category: "agents",
+    });
+    expect(service.consumePendingSettingsLink()).toBeNull();
+  });
+
+  it("focuses and restores the window", () => {
+    (mainWindow.isMinimized as ReturnType<typeof vi.fn>).mockReturnValue(true);
+    service.on(UIServiceEvent.OpenSettings, vi.fn());
+
+    handler()("");
+    expect(mainWindow.restore).toHaveBeenCalledTimes(1);
+    expect(mainWindow.focus).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("UIService.invalidateToken", () => {
   it("invalidates the access token before emitting the signal", async () => {
     const auth = makeAuth();
-    const service = new UIService(auth);
+    const service = new UIService(auth, makeDeepLink(), makeMainWindow());
     const listener = vi.fn();
     service.on(UIServiceEvent.InvalidateToken, listener);
 

--- a/products/desktop/packages/core/src/ui/ui.ts
+++ b/products/desktop/packages/core/src/ui/ui.ts
@@ -1,20 +1,42 @@
+import {
+  DEEP_LINK_SERVICE,
+  type IDeepLinkRegistry,
+} from "@posthog/platform/deep-link";
+import {
+  type IMainWindow,
+  MAIN_WINDOW_SERVICE,
+} from "@posthog/platform/main-window";
 import { TypedEventEmitter } from "@posthog/shared";
 import { inject, injectable } from "inversify";
 import { UI_AUTH } from "./identifiers";
 import type { UiAuth } from "./ports";
-import { UIServiceEvent, type UIServiceEvents } from "./schemas";
+import {
+  type OpenSettingsPayload,
+  UIServiceEvent,
+  type UIServiceEvents,
+} from "./schemas";
 
 @injectable()
 export class UIService extends TypedEventEmitter<UIServiceEvents> {
+  private pendingSettingsLink: OpenSettingsPayload | null = null;
+
   constructor(
     @inject(UI_AUTH)
     private readonly auth: UiAuth,
+    @inject(DEEP_LINK_SERVICE)
+    private readonly deepLinkService: IDeepLinkRegistry,
+    @inject(MAIN_WINDOW_SERVICE)
+    private readonly mainWindow: IMainWindow,
   ) {
     super();
+
+    this.deepLinkService.registerHandler("usage", (path) =>
+      this.handleUsageLink(path),
+    );
   }
 
-  openSettings(): void {
-    this.emit(UIServiceEvent.OpenSettings, true);
+  openSettings(category: string = "plan-usage"): void {
+    this.emit(UIServiceEvent.OpenSettings, { category });
   }
 
   newTask(): void {
@@ -32,5 +54,37 @@ export class UIService extends TypedEventEmitter<UIServiceEvents> {
   async invalidateToken(): Promise<void> {
     await this.auth.invalidateAccessTokenForTest();
     this.emit(UIServiceEvent.InvalidateToken, true);
+  }
+
+  /** Drain a usage deep link that arrived before the renderer subscribed. */
+  consumePendingSettingsLink(): OpenSettingsPayload | null {
+    const pending = this.pendingSettingsLink;
+    this.pendingSettingsLink = null;
+    return pending;
+  }
+
+  private handleUsageLink(path: string): boolean {
+    const segment = path.split("/")[0];
+    const decoded = segment === "" ? "" : safeDecode(segment);
+    const category = decoded === "" ? "plan-usage" : decoded;
+    const payload: OpenSettingsPayload = { category };
+
+    if (this.listenerCount(UIServiceEvent.OpenSettings) > 0) {
+      this.emit(UIServiceEvent.OpenSettings, payload);
+    } else {
+      this.pendingSettingsLink = payload;
+    }
+
+    if (this.mainWindow.isMinimized()) this.mainWindow.restore();
+    this.mainWindow.focus();
+    return true;
+  }
+}
+
+function safeDecode(segment: string): string {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
   }
 }

--- a/products/desktop/packages/host-router/src/routers/ui.router.ts
+++ b/products/desktop/packages/host-router/src/routers/ui.router.ts
@@ -1,4 +1,5 @@
 import { UI_SERVICE } from "@posthog/core/ui/identifiers";
+import type { OpenSettingsPayload } from "@posthog/core/ui/schemas";
 import { UIServiceEvent, type UIServiceEvents } from "@posthog/core/ui/schemas";
 import type { UIService } from "@posthog/core/ui/ui";
 import { publicProcedure, router } from "@posthog/host-trpc/trpc";
@@ -15,6 +16,10 @@ function subscribeToUIEvent<K extends keyof UIServiceEvents>(event: K) {
 
 export const uiRouter = router({
   onOpenSettings: subscribeToUIEvent(UIServiceEvent.OpenSettings),
+  getPendingSettingsLink: publicProcedure.query(
+    ({ ctx }): OpenSettingsPayload | null =>
+      ctx.container.get<UIService>(UI_SERVICE).consumePendingSettingsLink(),
+  ),
   onNewTask: subscribeToUIEvent(UIServiceEvent.NewTask),
   onResetLayout: subscribeToUIEvent(UIServiceEvent.ResetLayout),
   onClearStorage: subscribeToUIEvent(UIServiceEvent.ClearStorage),

--- a/products/desktop/packages/ui/src/shell/GlobalEventHandlers.tsx
+++ b/products/desktop/packages/ui/src/shell/GlobalEventHandlers.tsx
@@ -18,6 +18,7 @@ import { useFolders } from "@posthog/ui/features/folders/useFolders";
 import { toggleRightPanel } from "@posthog/ui/features/navigation/rightPanelSide";
 import { usePanelLayoutStore } from "@posthog/ui/features/panels/panelLayoutStore";
 import { openSettings } from "@posthog/ui/features/settings/hooks/useOpenSettings";
+import { resolveSettingsCategory } from "@posthog/ui/features/settings/types";
 import { useSidebarStore } from "@posthog/ui/features/sidebar/sidebarStore";
 import type { TaskData } from "@posthog/ui/features/sidebar/useSidebarData";
 import { useFocusWorkspace } from "@posthog/ui/features/workspace/useFocusWorkspace";
@@ -36,6 +37,7 @@ import { logger } from "@posthog/ui/shell/logger";
 import { useRendererWindowFocusStore } from "@posthog/ui/shell/rendererWindowFocusStore";
 import { installUncaughtErrorLogging } from "@posthog/ui/shell/uncaughtErrorLog";
 import { clearApplicationStorage } from "@posthog/ui/utils/clearStorage";
+import { useQuery } from "@tanstack/react-query";
 import { useSubscription } from "@trpc/tanstack-react-query";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
@@ -144,6 +146,14 @@ export function GlobalEventHandlers({
   const handleOpenSettings = useCallback(() => {
     openSettingsDialog();
   }, [openSettingsDialog]);
+
+  const handleSettingsDeepLink = useCallback(
+    (data?: { category: string }) => {
+      const category = data ? resolveSettingsCategory(data.category) : null;
+      openSettingsDialog(category ?? "plan-usage");
+    },
+    [openSettingsDialog],
+  );
 
   const handleFocusTaskMode = useCallback((data?: unknown) => {
     if (!data) return;
@@ -342,9 +352,23 @@ export function GlobalEventHandlers({
 
   useSubscription(
     trpcReact.ui.onOpenSettings.subscriptionOptions(undefined, {
-      onData: handleOpenSettings,
+      onData: handleSettingsDeepLink,
     }),
   );
+
+  // Drain a usage deep link that arrived before the subscription was live.
+  const pendingSettingsLink = useQuery(
+    trpcReact.ui.getPendingSettingsLink.queryOptions(undefined, {
+      staleTime: Number.POSITIVE_INFINITY,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+    }),
+  );
+  useEffect(() => {
+    if (pendingSettingsLink.data) {
+      handleSettingsDeepLink(pendingSettingsLink.data);
+    }
+  }, [pendingSettingsLink.data, handleSettingsDeepLink]);
 
   useSubscription(
     trpcReact.ui.onNewTask.subscriptionOptions(undefined, {


### PR DESCRIPTION
## Problem

The PostHog desktop app had no deep link to its Plan & usage settings page. Remote announcement CTAs and external tools that wanted to drop someone on that page had no `posthog-code://` URL to use — the only path was in-app navigation, and the closest helper (`getBillingUrl`) opens an external PostHog Cloud URL in the browser, not an in-app route.

## Changes

- A person opening `posthog-code://usage` now lands on the Plan & usage settings page inside the desktop app, with the window focused (and restored if minimized).
- `posthog-code://usage/<category>` opens a different settings page by slug, e.g. `posthog-code://usage/agents`. Unknown category slugs are ignored rather than navigating to a broken route.
- The link works whether the app is already running (delivered live) or launched cold (queued until the renderer subscribes), matching the existing task/inbox/scout/loop links.
- Mechanical: the `usage` deep-link handler is registered on the existing `UIService` (which already emits `OpenSettings` for the Settings menu item). The `OpenSettings` event now carries the category, `GlobalEventHandlers` passes it to `openSettingsDialog`, and a `getPendingSettingsLink` query on the existing `ui` router drains links that arrive before the renderer subscribes. The web host gets a `ui` stub router (it previously had no `ui` router at all, so the existing `onOpenSettings` subscription would have NOT_FOUND'd on web).

## How did you test this code?

Automated tests the agent ran:

- Updated `UIService` tests (`packages/core/src/ui/ui.test.ts`, 15 tests) — cover the existing signal events plus the new usage handler: registration, default-to-`plan-usage` on empty path, first-segment category extraction, extra-segment ignoring, percent-decoding, pending-link queueing + draining, emit-vs-queue behavior, and window focus/restore on minimized. The pending-queue and handler-parsing regressions are not covered by any existing test.
- Existing deep-link dispatcher tests (`apps/code/src/main/services/deep-link/service.test.ts`, 24 tests) still pass — confirms the new `usage` handler integrates with the dispatcher without breaking other handlers.
- Typecheck passes for `@posthog/core`, `@posthog/host-router`, `code` (node + web), `@posthog/ui`, and `@posthog/web`. Host-boundary check reports no new violations.

The agent did not manually open the Electron app to click a `posthog-code://usage` link (no display in this environment); the dispatcher test plus the UIService handler test cover the handler path, and the renderer wiring reuses the already-shipped `onOpenSettings` subscription in `GlobalEventHandlers`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- DEEP-LINKS.md updated in this PR (new `usage` scheme in the handler list, a user-facing section, and the implementation table pointing to `ui.ts`).

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tools: pi coding agent (Claude) operating in the `products/desktop` workspace. No external session link.
- Skills invoked: none of the repo-provided skills applied directly (this is a desktop-app deep-link feature, not a Django/DRF/ClickHouse/migration change); `products/desktop/AGENTS.md` and `docs/DEEP-LINKS.md` were followed.
- Decisions: two earlier attempts over-built this. The first modeled it on the heaviest link pattern (`LoopLinkService` + a dedicated DI token + host `MAIN_*` alias + a shared `buildUsageDeeplink` builder) — 16 files. The second followed the `integration`-link pattern (core DI module, no `MAIN_*`) — 12 files. This third version reuses the pipe that already exists for the Settings menu item: `UIService` already emits `OpenSettings`, the `ui` router already exposes `onOpenSettings`, and `GlobalEventHandlers` already subscribes. The `usage` handler just registers on `UIService` and the event payload gains a `category` field — 7 files, no new service/token/module. The one forced addition is a `ui` stub router on web, which previously had no `ui` router (the existing `onOpenSettings` subscription would NOT_FOUND on web; this PR makes that explicit rather than relying on swallowed errors).
- Public artifact: nothing in this PR carries session material — the change is a conventional deep-link feature built from the repo's own patterns.