### PR TITLE
fix(desktop/web): bind the speech host capabilities on web

### DIFF
--- a/products/desktop/apps/web/src/web-container.ts
+++ b/products/desktop/apps/web/src/web-container.ts
@@ -148,6 +148,13 @@ import type {
   TeamSkillsService,
 } from "@posthog/core/skills/teamSkillsService";
 import {
+  SPEECH_SETTINGS_PROVIDER,
+  SPEECH_USER_NAME_PROVIDER,
+  type SpeechSettingsProvider,
+  type UserNameProvider,
+} from "@posthog/core/speech/identifiers";
+import { speechCoreModule } from "@posthog/core/speech/speech.module";
+import {
   TASK_CREATION_EFFECTS,
   TASK_CREATION_HOST,
   TASK_SERVICE,
@@ -193,6 +200,7 @@ import {
   type IPowerManager,
   POWER_MANAGER_SERVICE,
 } from "@posthog/platform/power-manager";
+import { type ISpeech, SPEECH_SERVICE } from "@posthog/platform/speech";
 import type { Adapter } from "@posthog/shared";
 import { sandboxProxyHtml } from "@posthog/shared/mcp-sandbox-proxy";
 import { authUiModule } from "@posthog/ui/features/auth/auth.module";
@@ -246,7 +254,9 @@ import {
   ACTIVE_VIEW_PROVIDER,
   type IActiveView,
   type INotificationSettings,
+  type ISpeechNotifySettings,
   NOTIFICATION_SETTINGS_PROVIDER,
+  SPEECH_NOTIFY_SETTINGS,
 } from "@posthog/ui/features/notifications/identifiers";
 import { notificationsUiModule } from "@posthog/ui/features/notifications/notifications.module";
 import { OnboardingGithubConnectClient } from "@posthog/ui/features/onboarding/githubConnectClientImpl";
@@ -322,6 +332,12 @@ import {
 } from "./web-sessions-clients";
 import { webSetupStore } from "./web-setup-store";
 import { webShellClient } from "./web-shell-client";
+import {
+  createWebSpeechUserName,
+  webSpeech,
+  webSpeechNotifySettings,
+  webSpeechSettings,
+} from "./web-speech";
 import {
   webTaskDeletionHost,
   webTaskDeletionWorkspaceClient,
@@ -403,6 +419,10 @@ interface WebBindings {
   [NOTIFICATIONS_SERVICE]: INotifications;
   [NOTIFICATION_SETTINGS_PROVIDER]: INotificationSettings;
   [ACTIVE_VIEW_PROVIDER]: IActiveView;
+  [SPEECH_SERVICE]: ISpeech;
+  [SPEECH_SETTINGS_PROVIDER]: SpeechSettingsProvider;
+  [SPEECH_USER_NAME_PROVIDER]: UserNameProvider;
+  [SPEECH_NOTIFY_SETTINGS]: ISpeechNotifySettings;
   [REPORT_MODEL_RESOLVER]: ReportModelResolver;
 }
 
@@ -808,6 +828,18 @@ container
   .bind(NOTIFICATION_SETTINGS_PROVIDER)
   .toConstantValue(webNotificationSettings);
 container.bind(ACTIVE_VIEW_PROVIDER).toConstantValue(webActiveView);
+
+// ── Spoken notifications ──
+// SpeechNotifier (notificationsUiModule) is what SessionService resolves for
+// agent narration, so the whole chain down to the platform ISpeech has to be
+// bound here too. Web speaks with the browser's system voice.
+container.load(speechCoreModule);
+container.bind(SPEECH_SERVICE).toConstantValue(webSpeech);
+container.bind(SPEECH_SETTINGS_PROVIDER).toConstantValue(webSpeechSettings);
+container
+  .bind(SPEECH_USER_NAME_PROVIDER)
+  .toConstantValue(createWebSpeechUserName(queryClient));
+container.bind(SPEECH_NOTIFY_SETTINGS).toConstantValue(webSpeechNotifySettings);
 
 // ── Inbox: resolve the default cloud-run model from the LLM gateway ──
 // Host capability consumed by UI hooks (canvas/home/inbox) that create cloud

--- a/products/desktop/apps/web/src/web-speech.ts
+++ b/products/desktop/apps/web/src/web-speech.ts
@@ -1,0 +1,57 @@
+import type {
+  SpeechSettingsProvider,
+  UserNameProvider,
+} from "@posthog/core/speech/identifiers";
+import type { ISpeech } from "@posthog/platform/speech";
+import { authKeys } from "@posthog/ui/features/auth/useCurrentUser";
+import type { ISpeechNotifySettings } from "@posthog/ui/features/notifications/identifiers";
+import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
+import type { ImperativeQueryClient } from "@posthog/ui/shell/queryClient";
+import {
+  isSpeechSupported,
+  speakSystemVoice,
+  stopSpeech,
+} from "@posthog/ui/utils/speech";
+
+// System voice only: ElevenLabs synthesis needs the key in a host secure store,
+// which the browser has no equivalent of. voiceId is therefore ignored.
+export const webSpeech: ISpeech = {
+  isSupported: () => isSpeechSupported(),
+  speak: (text) => speakSystemVoice(text),
+  stop: () => stopSpeech(),
+};
+
+export const webSpeechSettings: SpeechSettingsProvider = {
+  get: () => ({ enabled: useSettingsStore.getState().spokenNotifications }),
+};
+
+export const webSpeechNotifySettings: ISpeechNotifySettings = {
+  get: () => {
+    const s = useSettingsStore.getState();
+    return {
+      enabled: s.spokenNotifications,
+      needsInput: s.spokenNotifyNeedsInput,
+      completion: s.spokenNotifyCompletion,
+      progress: s.spokenNotifyProgress,
+      focusMode: s.spokenFocusMode,
+    };
+  },
+};
+
+export function createWebSpeechUserName(
+  queryClient: ImperativeQueryClient,
+): UserNameProvider {
+  return {
+    getFirstName: () => {
+      for (const [, data] of queryClient.getQueriesData({
+        queryKey: authKeys.currentUsers(),
+      })) {
+        const first = (
+          data as { first_name?: string | null } | undefined
+        )?.first_name?.trim();
+        if (first) return first;
+      }
+      return undefined;
+    },
+  };
+}

--- a/products/desktop/packages/ui/src/shell/requiredHostCapabilities.ts
+++ b/products/desktop/packages/ui/src/shell/requiredHostCapabilities.ts
@@ -1,11 +1,17 @@
 import { REPORT_MODEL_RESOLVER } from "@posthog/core/inbox/identifiers";
+import {
+  SPEECH_SETTINGS_PROVIDER,
+  SPEECH_USER_NAME_PROVIDER,
+} from "@posthog/core/speech/identifiers";
 import type { HostCapabilityRequirement } from "@posthog/di/hostCapabilities";
 import { HOST_CAPABILITIES } from "@posthog/platform/host-capabilities";
+import { SPEECH_SERVICE } from "@posthog/platform/speech";
 import { AUTH_SIDE_EFFECTS } from "@posthog/ui/features/auth/identifiers";
 import { REVIEW_HOST } from "@posthog/ui/features/code-review/reviewHost";
 import { CONNECTIVITY_CLIENT } from "@posthog/ui/features/connectivity/connectivityClient";
 import { FEATURE_FLAGS } from "@posthog/ui/features/feature-flags/identifiers";
 import { GIT_CACHE_KEY_PROVIDER } from "@posthog/ui/features/git-interaction/gitCacheProvider";
+import { SPEECH_NOTIFY_SETTINGS } from "@posthog/ui/features/notifications/identifiers";
 import { UPDATES_CLIENT } from "@posthog/ui/features/updates/updatesClient";
 import { DIFF_WORKER_FACTORY } from "@posthog/ui/shell/diffWorkerHost";
 
@@ -68,5 +74,21 @@ export const REQUIRED_HOST_CAPABILITIES: readonly HostCapabilityRequirement[] =
     {
       token: REPORT_MODEL_RESOLVER,
       description: "default cloud-run model resolution (canvas/home/inbox)",
+    },
+    {
+      token: SPEECH_SERVICE,
+      description: "text-to-speech playback for agent narration",
+    },
+    {
+      token: SPEECH_SETTINGS_PROVIDER,
+      description: "spoken-narration enablement and voice",
+    },
+    {
+      token: SPEECH_USER_NAME_PROVIDER,
+      description: "signed-in user's first name for spoken greetings",
+    },
+    {
+      token: SPEECH_NOTIFY_SETTINGS,
+      description: "per-kind gating for spoken notifications",
     },
   ];


### PR DESCRIPTION
## Problem

Signing in to the web app leaves the user on a blank screen with `No bindings found for service: "Symbol(posthog.ui.speech.notifySettings)"`. Nothing in the app is reachable after that.

- `apps/web` loads `notificationsUiModule`, which binds `SpeechNotifier`.
- `SpeechNotifier` injects `SPEECH_NOTIFY_SETTINGS`, and `SpeechQueueService` injects `SPEECH_SERVICE`, `SPEECH_SETTINGS_PROVIDER`, and `SPEECH_USER_NAME_PROVIDER`.
- The web composition root bound none of them. `apps/code`'s renderer binds all four.
- `assertHostCapabilities` did not catch the gap, because `REQUIRED_HOST_CAPABILITIES` does not list the speech tokens.

## Changes

- The web app now signs in and reaches the app again.
- Spoken notifications work on web, using the browser system voice.
- `apps/web/src/web-speech.ts` supplies the four adapters: `ISpeech` over `speechSynthesis`, the two settings providers over the shared settings store, and a first-name provider over the auth query cache.
- `web-container.ts` loads `speechCoreModule` and binds the four tokens.
- Web speaks with the system voice only. ElevenLabs synthesis keeps the API key in a host secure store, and the browser has no equivalent, so `voiceId` is ignored.
- `REQUIRED_HOST_CAPABILITIES` gains the four speech tokens, so a host that misses one throws at container load instead of on the first task event.

Nothing about the desktop app changes. Nothing visual changes on web: the failure was a blank screen, and the fix is the normal app.

## How did you test this code?

- `pnpm --filter @posthog/web test:e2e` passes. The suite boots the app through `assertHostCapabilities`, so with the new entries it now covers this gap.
- Commenting the `SPEECH_NOTIFY_SETTINGS` binding back out failed all three specs. Restoring it passed them. That confirms the boot spec is a real gate and not a coincidence.
- Not checked: whether the browser actually speaks a line. That needs a signed-in session against PostHog cloud and a real agent run, neither of which this sandbox has.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. `products/desktop/AGENTS.md` already documents the rule this fix follows: bind new host capabilities in `web-container.ts`, and let `assertHostCapabilities` catch the gap at boot.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) traced the reported error from the symbol to `SpeechNotifier`, then to the missing bindings, with Grep, Read, Edit, and Bash.

Skills invoked: `/writing-pr-descriptions`.

The first candidate fix was to make the speech dependencies optional so an unbound host stays quiet. That was rejected: it hides the same gap for the next host and the next capability. Binding the adapters and extending `REQUIRED_HOST_CAPABILITIES` fixes the reported crash and converts the whole class into a boot failure the e2e suite catches.
