### PR TITLE
fix(mcp): pin antigravity clients to the legacy dialect

### DIFF
--- a/services/mcp/src/hono/dispatcher.ts
+++ b/services/mcp/src/hono/dispatcher.ts
@@ -21,6 +21,7 @@ import GUIDELINES from '@shared/guidelines.md'
 import { randomUUID } from 'node:crypto'
 
 import { mapErrorToAuthResponse } from '@/lib/auth-errors'
+import { isLegacyDialectOnlyClient } from '@/lib/client-detection'
 import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from '@/lib/constants'
 import type { RequestProperties } from '@/lib/request-properties'
 import {
@@ -269,6 +270,10 @@ class McpDispatcher {
         // `handleRequest` before dispatch; here `_meta` only picks the dialect.
         const protocolMeta = parseRequestProtocolMeta(params)
         const stateless = protocolMeta.protocolVersion === STATELESS_PROTOCOL_VERSION
+
+        if (stateless && method === Method.Discover && isLegacyDialectOnlyClient(protocolMeta.clientName)) {
+            return jsonRpcMethodError(id, ErrorCode.MethodNotFound, 'Method not found')
+        }
 
         try {
             const result = await this.dispatchMethod(method, params, props, state, stateless)

--- a/services/mcp/src/hono/dispatcher.ts
+++ b/services/mcp/src/hono/dispatcher.ts
@@ -198,8 +198,20 @@ class McpDispatcher {
             }
         } else {
             const message = messages[0]! as { id?: number | string; method?: unknown; params?: unknown }
-            singleModern = isModernRequest(protocolHeaders, parseRequestProtocolMeta(message.params))
+            const protocolMeta = parseRequestProtocolMeta(message.params)
+            singleModern = isModernRequest(protocolHeaders, protocolMeta)
             if (singleModern) {
+                // Before header validation, so header-dropping bridges fall back to
+                // `initialize` instead of dying on HeaderMismatch.
+                if (message.method === Method.Discover && isLegacyDialectOnlyClient(protocolMeta.clientName)) {
+                    return jsonRpcErrorResponse(
+                        message.id ?? null,
+                        ErrorCode.MethodNotFound,
+                        'Method not found',
+                        undefined,
+                        404
+                    )
+                }
                 const validationError = validateModernRequest(protocolHeaders, message)
                 if (validationError) {
                     return jsonRpcErrorResponse(
@@ -270,10 +282,6 @@ class McpDispatcher {
         // `handleRequest` before dispatch; here `_meta` only picks the dialect.
         const protocolMeta = parseRequestProtocolMeta(params)
         const stateless = protocolMeta.protocolVersion === STATELESS_PROTOCOL_VERSION
-
-        if (stateless && method === Method.Discover && isLegacyDialectOnlyClient(protocolMeta.clientName)) {
-            return jsonRpcMethodError(id, ErrorCode.MethodNotFound, 'Method not found')
-        }
 
         try {
             const result = await this.dispatchMethod(method, params, props, state, stateless)

--- a/services/mcp/src/hono/dispatcher.ts
+++ b/services/mcp/src/hono/dispatcher.ts
@@ -202,15 +202,10 @@ class McpDispatcher {
             singleModern = isModernRequest(protocolHeaders, protocolMeta)
             if (singleModern) {
                 // Before header validation, so header-dropping bridges fall back to
-                // `initialize` instead of dying on HeaderMismatch.
+                // `initialize` instead of dying on HeaderMismatch. HTTP 200, not the
+                // spec's 404: mcp-remote's transport treats any non-2xx as fatal.
                 if (message.method === Method.Discover && isLegacyDialectOnlyClient(protocolMeta.clientName)) {
-                    return jsonRpcErrorResponse(
-                        message.id ?? null,
-                        ErrorCode.MethodNotFound,
-                        'Method not found',
-                        undefined,
-                        404
-                    )
+                    return jsonRpcErrorResponse(message.id ?? null, ErrorCode.MethodNotFound, 'Method not found')
                 }
                 const validationError = validateModernRequest(protocolHeaders, message)
                 if (validationError) {

--- a/services/mcp/src/lib/client-detection.ts
+++ b/services/mcp/src/lib/client-detection.ts
@@ -103,6 +103,12 @@ export const CODING_AGENT_CLIENT_NAME_FRAGMENTS = [
     'ando-mcp-gateway',
 ] as const
 
+// Clients that wedge after a stateless `server/discover` but complete the legacy
+// handshake, so discover answers method-not-found to push them back to `initialize`.
+// Their mcp-remote bridge variants speak the stateless dialect fine and are exempt.
+export const LEGACY_DIALECT_ONLY_CLIENT_NAME_FRAGMENTS = ['antigravity'] as const
+const LEGACY_DIALECT_EXEMPT_CLIENT_NAME_FRAGMENTS = ['mcp-remote'] as const
+
 // Clients that keep the full per-tool roster ("tools" mode) instead of the
 // single-exec CLI default.
 // - Cursor self-reports `clientInfo.name` (`cursor-vscode`, `Cursor`); it sends
@@ -301,6 +307,13 @@ export class MCPClientProfile {
         )
     }
 
+    isLegacyDialectOnly(): boolean {
+        return (
+            matchesAnyFragment(this.clientName, LEGACY_DIALECT_ONLY_CLIENT_NAME_FRAGMENTS) &&
+            !matchesAnyFragment(this.clientName, LEGACY_DIALECT_EXEMPT_CLIENT_NAME_FRAGMENTS)
+        )
+    }
+
     isPostHogCodeConsumer(): boolean {
         return this.consumer === POSTHOG_CODE_CONSUMER
     }
@@ -366,6 +379,10 @@ export class MCPClientProfile {
 
 export function isCliModeEnabledClient(clientName: string | undefined): boolean {
     return new MCPClientProfile({ clientName }).isCliModeEnabled()
+}
+
+export function isLegacyDialectOnlyClient(clientName: string | undefined): boolean {
+    return new MCPClientProfile({ clientName }).isLegacyDialectOnly()
 }
 
 export function isPostHogCodeConsumer(mcpConsumer: string | undefined): boolean {

--- a/services/mcp/src/lib/client-detection.ts
+++ b/services/mcp/src/lib/client-detection.ts
@@ -105,9 +105,8 @@ export const CODING_AGENT_CLIENT_NAME_FRAGMENTS = [
 
 // Clients that wedge after a stateless `server/discover` but complete the legacy
 // handshake, so discover answers method-not-found to push them back to `initialize`.
-// Their mcp-remote bridge variants speak the stateless dialect fine and are exempt.
+// Remove an entry once the client completes the stateless dialect.
 export const LEGACY_DIALECT_ONLY_CLIENT_NAME_FRAGMENTS = ['antigravity'] as const
-const LEGACY_DIALECT_EXEMPT_CLIENT_NAME_FRAGMENTS = ['mcp-remote'] as const
 
 // Clients that keep the full per-tool roster ("tools" mode) instead of the
 // single-exec CLI default.
@@ -308,10 +307,7 @@ export class MCPClientProfile {
     }
 
     isLegacyDialectOnly(): boolean {
-        return (
-            matchesAnyFragment(this.clientName, LEGACY_DIALECT_ONLY_CLIENT_NAME_FRAGMENTS) &&
-            !matchesAnyFragment(this.clientName, LEGACY_DIALECT_EXEMPT_CLIENT_NAME_FRAGMENTS)
-        )
+        return matchesAnyFragment(this.clientName, LEGACY_DIALECT_ONLY_CLIENT_NAME_FRAGMENTS)
     }
 
     isPostHogCodeConsumer(): boolean {

--- a/services/mcp/tests/integration/mcp-protocol-suite.ts
+++ b/services/mcp/tests/integration/mcp-protocol-suite.ts
@@ -1693,12 +1693,15 @@ export function defineStatelessProtocolTests(
         const METHOD_HEADER = 'Mcp-Method'
         const NAME_HEADER = 'Mcp-Name'
 
-        function statelessParams(params: Record<string, unknown> = {}): Record<string, unknown> {
+        function statelessParams(
+            params: Record<string, unknown> = {},
+            clientName = 'stateless-suite'
+        ): Record<string, unknown> {
             return {
                 ...params,
                 _meta: {
                     [META_VERSION_KEY]: STATELESS_VERSION,
-                    [META_CLIENT_INFO_KEY]: { name: 'stateless-suite', version: '0.0.1' },
+                    [META_CLIENT_INFO_KEY]: { name: clientName, version: '0.0.1' },
                     [META_CLIENT_CAPABILITIES_KEY]: {},
                 },
             }
@@ -1985,6 +1988,39 @@ export function defineStatelessProtocolTests(
             expect(json.error?.code).toBe(-32601)
             // Modern initialize must not mint a session either.
             expect(response.headers.get('mcp-session-id')).toBeNull()
+        })
+
+        it('answers server/discover with method-not-found for a legacy-dialect-only client', async () => {
+            const harness = await getHarness()
+            const { response, json } = await postSingle(
+                harness,
+                'server/discover',
+                statelessParams({}, 'antigravity-client'),
+                'legacy-only'
+            )
+
+            expect(response.status).toBe(404)
+            expect(json.error?.code).toBe(-32601)
+            expect(response.headers.get('mcp-session-id')).toBeNull()
+        })
+
+        it('keeps legacy initialize working for a legacy-dialect-only client', async () => {
+            const harness = await getHarness()
+            const { response, json } = await postSingle(
+                harness,
+                'initialize',
+                {
+                    protocolVersion: '2025-06-18',
+                    capabilities: {},
+                    clientInfo: { name: 'antigravity-client', version: 'v1.0.0' },
+                },
+                'legacy-only-init',
+                { [VERSION_HEADER]: '2025-06-18' }
+            )
+
+            expect(response.status).toBe(200)
+            expect(json.error).toBeUndefined()
+            expect(json.result?.protocolVersion).toBe('2025-06-18')
         })
 
         it('leaves legacy initialize untouched when it carries a legacy MCP-Protocol-Version header', async () => {

--- a/services/mcp/tests/integration/mcp-protocol-suite.ts
+++ b/services/mcp/tests/integration/mcp-protocol-suite.ts
@@ -1991,7 +1991,8 @@ export function defineStatelessProtocolTests(
         })
 
         // The headerless variant is how stdio bridges (mcp-remote) forward the
-        // probe; it must get the fallback 404, not a fatal HeaderMismatch 400.
+        // probe. HTTP 200 in both, not the spec's 404: mcp-remote's transport
+        // treats any non-2xx as fatal instead of falling back.
         it.each([
             ['with SEP-2243 headers', {}],
             ['without SEP-2243 headers', { [VERSION_HEADER]: null, [METHOD_HEADER]: null }],
@@ -2007,7 +2008,7 @@ export function defineStatelessProtocolTests(
                     extraHeaders
                 )
 
-                expect(response.status).toBe(404)
+                expect(response.status).toBe(200)
                 expect(json.error?.code).toBe(-32601)
                 expect(response.headers.get('mcp-session-id')).toBeNull()
             }

--- a/services/mcp/tests/integration/mcp-protocol-suite.ts
+++ b/services/mcp/tests/integration/mcp-protocol-suite.ts
@@ -1990,19 +1990,28 @@ export function defineStatelessProtocolTests(
             expect(response.headers.get('mcp-session-id')).toBeNull()
         })
 
-        it('answers server/discover with method-not-found for a legacy-dialect-only client', async () => {
-            const harness = await getHarness()
-            const { response, json } = await postSingle(
-                harness,
-                'server/discover',
-                statelessParams({}, 'antigravity-client'),
-                'legacy-only'
-            )
+        // The headerless variant is how stdio bridges (mcp-remote) forward the
+        // probe; it must get the fallback 404, not a fatal HeaderMismatch 400.
+        it.each([
+            ['with SEP-2243 headers', {}],
+            ['without SEP-2243 headers', { [VERSION_HEADER]: null, [METHOD_HEADER]: null }],
+        ] as Array<[string, Record<string, string | null>]>)(
+            'answers server/discover with method-not-found for a legacy-dialect-only client %s',
+            async (_label, extraHeaders) => {
+                const harness = await getHarness()
+                const { response, json } = await postSingle(
+                    harness,
+                    'server/discover',
+                    statelessParams({}, 'antigravity-client'),
+                    'legacy-only',
+                    extraHeaders
+                )
 
-            expect(response.status).toBe(404)
-            expect(json.error?.code).toBe(-32601)
-            expect(response.headers.get('mcp-session-id')).toBeNull()
-        })
+                expect(response.status).toBe(404)
+                expect(json.error?.code).toBe(-32601)
+                expect(response.headers.get('mcp-session-id')).toBeNull()
+            }
+        )
 
         it('keeps legacy initialize working for a legacy-dialect-only client', async () => {
             const harness = await getHarness()

--- a/services/mcp/tests/unit/client-detection.test.ts
+++ b/services/mcp/tests/unit/client-detection.test.ts
@@ -12,6 +12,7 @@ import {
     TOOLS_MODE_USER_AGENT_FRAGMENTS,
     isClaudeUiHostClient,
     isCliModeEnabledClient,
+    isLegacyDialectOnlyClient,
     isPostHogCodeConsumer,
     isToolsModeClient,
     resolveEffectiveClientName,
@@ -179,6 +180,26 @@ describe('isPostHogCodeConsumer', () => {
 
     it('returns false for undefined', () => {
         expect(isPostHogCodeConsumer(undefined)).toBe(false)
+    })
+})
+
+describe('isLegacyDialectOnlyClient', () => {
+    it.each([['antigravity-client'], ['antigravity'], ['Antigravity'], ['antigravity-client/1.2.3']])(
+        'returns true for %s',
+        (clientName) => {
+            expect(isLegacyDialectOnlyClient(clientName)).toBe(true)
+        }
+    )
+
+    it.each([
+        ['antigravity-client (via mcp-remote 0.1.37)'],
+        ['antigravity (via mcp-remote 0.1.37)'],
+        ['claude-code'],
+        ['cursor'],
+        [''],
+        [undefined],
+    ])('returns false for %s', (clientName) => {
+        expect(isLegacyDialectOnlyClient(clientName)).toBe(false)
     })
 })
 

--- a/services/mcp/tests/unit/client-detection.test.ts
+++ b/services/mcp/tests/unit/client-detection.test.ts
@@ -184,23 +184,24 @@ describe('isPostHogCodeConsumer', () => {
 })
 
 describe('isLegacyDialectOnlyClient', () => {
-    it.each([['antigravity-client'], ['antigravity'], ['Antigravity'], ['antigravity-client/1.2.3']])(
-        'returns true for %s',
+    it.each([
+        ['antigravity-client'],
+        ['antigravity'],
+        ['Antigravity'],
+        ['antigravity-client/1.2.3'],
+        // Bridge variants are gated too: their fallback lands on the legacy
+        // handshake, which works, while their stateless support varies by version.
+        ['antigravity-client (via mcp-remote 0.1.37)'],
+    ])('returns true for %s', (clientName) => {
+        expect(isLegacyDialectOnlyClient(clientName)).toBe(true)
+    })
+
+    it.each([['claude-code'], ['cursor'], ['mcp-remote-fallback-test'], [''], [undefined]])(
+        'returns false for %s',
         (clientName) => {
-            expect(isLegacyDialectOnlyClient(clientName)).toBe(true)
+            expect(isLegacyDialectOnlyClient(clientName)).toBe(false)
         }
     )
-
-    it.each([
-        ['antigravity-client (via mcp-remote 0.1.37)'],
-        ['antigravity (via mcp-remote 0.1.37)'],
-        ['claude-code'],
-        ['cursor'],
-        [''],
-        [undefined],
-    ])('returns false for %s', (clientName) => {
-        expect(isLegacyDialectOnlyClient(clientName)).toBe(false)
-    })
 })
 
 describe('isToolsModeClient', () => {


### PR DESCRIPTION
## Problem

Connecting the PostHog MCP in Google Antigravity hangs and never shows tools, on both of its setup paths.

- A direct `serverUrl` connection completes `server/discover`, commits to the 2026-07-28 stateless dialect, and stalls without ever listing tools.
- The other path bridges stdio through mcp-remote, which forwards the discover probe without the SEP-2243 operation headers.
- The server rejects that probe with HeaderMismatch `-32020` on HTTP 400.
- mcp-remote's transport treats any non-2xx response as fatal and kills the connection.
- Before #72223, both paths received HTTP 200 with method-not-found, fell back to the legacy `initialize` handshake, and worked. #74532 diagnosed an earlier Antigravity hang, but its gate rides on legacy session minting and cannot fire on this traffic.

```mermaid
flowchart LR
    A{{Antigravity direct}} -->|server/discover| B[200 DiscoverResult]
    B --> C[commits to 2026-07-28]
    C --> D[stalls, no tools]
    E{{Antigravity via mcp-remote}} -->|discover, no headers| F[400 HeaderMismatch]
    F --> G[transport fatal, connection killed]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A,E phBlue;
    class B,C phYellow;
    class D,F,G phRed;
```

## Changes

- Antigravity connections complete again: `server/discover` from a client name containing `antigravity` answers method-not-found, and the client falls back to the legacy `initialize` handshake.
- The gate runs before SEP-2243 header validation, so headerless bridge probes get the same fallback signal instead of the fatal 400.
- The answer rides on HTTP 200, not the modern dialect's 404, because mcp-remote's transport dies on any non-2xx. This is the exact wire shape the pre-#72223 server sent, which both connection paths handled correctly.
- This is the spec's own downgrade path: the response matches a legacy-only server, and the [2026-07-28 versioning rules](https://modelcontextprotocol.io/specification/2026-07-28/basic/lifecycle) direct dual-era clients to fall back to `initialize` on any probe error that is not a recognized modern error.
- The client-name list in `client-detection.ts` is the deliberately temporary piece: the entry gets deleted once the client completes the stateless dialect. The gate placement and the wire shape are standard dual-era mechanics and stay either way.
- A name-free alternative exists: answer every headerless discover probe with the legacy shape. That covers any legacy bridge without a list, but relaxes SEP-2243's reject rule for all clients, so it is left as a separate decision.
- No other client changes: headerless modern requests still get `-32020`, and every other client keeps the stateless dialect.

```mermaid
flowchart LR
    A{{Antigravity, either path}} -->|server/discover| B[200 method-not-found]
    B -->|falls back| C[legacy initialize]
    C --> D[tools/list, tool calls]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phBlue;
    class B phYellow;
    class C,D phGray;
```


## How did you test this code?

Manual before/after with real clients against a local gateway, run by the assignee:

- Without the gate: the bridge dies with the exact `-32020` error above, and a direct connection stalls after discover with no tools.
- With the gate (this branch): both transports fell back on the wire (discover answered method-not-found, then legacy `initialize`, then `tools/list`), Antigravity listed the `exec` tool on both connections, and repeated `exec` tool calls returned live data from the assignee's own test project. mcp-remote pinned to 0.1.38.

New tests, and the regression each catches:

- Unit matrix on the fragment matcher: a fragment edit that re-wedges Antigravity or gates an unrelated client.
- Wiring pair, with and without SEP-2243 headers: removing the gate, moving it after header validation, or reverting the 200 to a 404.
- Legacy `initialize` case for the same client name: the gate leaking into the client's only working handshake.

`test:hono`, the unit suite, `typecheck`, and `oxfmt` run locally in `services/mcp`. Not run: anything outside `services/mcp`; nothing else changed.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Antigravity is not a documented client, and documented clients keep their current behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude (Claude Code, Opus) during an investigation of Antigravity connection failures. Root cause confirmed with a live local reproduction using Antigravity and mcp-remote 0.1.38; the human assignee drove the client-side testing.

Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

Decisions across the session: the gate started in dispatch answering 404, moved before header validation when the bridge failure surfaced in local testing, and switched to HTTP 200 after the bridge transport proved fatal on any non-2xx. An mcp-remote name exemption was added and then removed, because a gated bridge still works on the fallback path while an exempted broken bridge stays dead.

Public artifact: nothing in this PR carries material from non-public sources; all test data shown came from the assignee's own empty test project.


