### PR TITLE
fix(desktop): make archiving a task idempotent

### DIFF
--- a/products/desktop/packages/core/src/archive/archiveOrchestration.test.ts
+++ b/products/desktop/packages/core/src/archive/archiveOrchestration.test.ts
@@ -35,7 +35,6 @@ class Harness {
     cache: {
       cancelPathFilter: vi.fn().mockResolvedValue(undefined),
       invalidatePathFilter: vi.fn(),
-      invalidateArchivedState: vi.fn(),
       setArchivedTaskIds: (updater) => {
         this.ids = updater(this.ids);
       },
@@ -113,9 +112,7 @@ describe("archiveTask", () => {
     expect(harness.ids).not.toContain(TASK_ID);
     expect(harness.list).toEqual([]);
     expect(harness.deps.togglePin).toHaveBeenCalledWith(TASK_ID);
-    // Rolling back to "not archived" is a guess about what the host did with a
-    // request that failed, so it has to be re-checked against the host.
-    expect(harness.deps.cache.invalidateArchivedState).toHaveBeenCalled();
+    expect(harness.deps.cache.invalidatePathFilter).toHaveBeenCalled();
   });
 
   it("archives when reading task pins fails", async () => {

--- a/products/desktop/packages/core/src/archive/archiveOrchestration.test.ts
+++ b/products/desktop/packages/core/src/archive/archiveOrchestration.test.ts
@@ -35,6 +35,7 @@ class Harness {
     cache: {
       cancelPathFilter: vi.fn().mockResolvedValue(undefined),
       invalidatePathFilter: vi.fn(),
+      invalidateArchivedState: vi.fn(),
       setArchivedTaskIds: (updater) => {
         this.ids = updater(this.ids);
       },
@@ -112,6 +113,9 @@ describe("archiveTask", () => {
     expect(harness.ids).not.toContain(TASK_ID);
     expect(harness.list).toEqual([]);
     expect(harness.deps.togglePin).toHaveBeenCalledWith(TASK_ID);
+    // Rolling back to "not archived" is a guess about what the host did with a
+    // request that failed, so it has to be re-checked against the host.
+    expect(harness.deps.cache.invalidateArchivedState).toHaveBeenCalled();
   });
 
   it("archives when reading task pins fails", async () => {

--- a/products/desktop/packages/core/src/archive/archiveOrchestration.ts
+++ b/products/desktop/packages/core/src/archive/archiveOrchestration.ts
@@ -15,8 +15,6 @@ export interface ArchiveWorkspaceInfo extends OptimisticWorkspaceInfo {
 export interface ArchiveCacheWriter {
   cancelPathFilter(): Promise<void>;
   invalidatePathFilter(): void;
-  /** Refetch the archived id/list queries so they match what the host stored. */
-  invalidateArchivedState(): void;
   setArchivedTaskIds(updater: (old: string[] | undefined) => string[]): void;
   setArchiveList(
     updater: (old: ArchivedTask[] | undefined) => ArchivedTask[],
@@ -139,7 +137,7 @@ export async function archiveTask(
     // The rollback above assumes the failure left the task unarchived, which is
     // a guess — the host may have stored the archive and failed afterwards. Ask
     // it, so a task that is archived stays out of the sidebar either way.
-    deps.cache.invalidateArchivedState();
+    deps.cache.invalidatePathFilter();
     if (wasPinned) {
       try {
         await deps.togglePin(taskId);

--- a/products/desktop/packages/core/src/archive/archiveOrchestration.ts
+++ b/products/desktop/packages/core/src/archive/archiveOrchestration.ts
@@ -15,6 +15,8 @@ export interface ArchiveWorkspaceInfo extends OptimisticWorkspaceInfo {
 export interface ArchiveCacheWriter {
   cancelPathFilter(): Promise<void>;
   invalidatePathFilter(): void;
+  /** Refetch the archived id/list queries so they match what the host stored. */
+  invalidateArchivedState(): void;
   setArchivedTaskIds(updater: (old: string[] | undefined) => string[]): void;
   setArchiveList(
     updater: (old: ArchivedTask[] | undefined) => ArchivedTask[],
@@ -134,6 +136,10 @@ export async function archiveTask(
 
     deps.cache.setArchivedTaskIds((old) => removeArchivedTaskId(old, taskId));
     deps.cache.setArchiveList((old) => removeArchivedTask(old, taskId));
+    // The rollback above assumes the failure left the task unarchived, which is
+    // a guess — the host may have stored the archive and failed afterwards. Ask
+    // it, so a task that is archived stays out of the sidebar either way.
+    deps.cache.invalidateArchivedState();
     if (wasPinned) {
       try {
         await deps.togglePin(taskId);

--- a/products/desktop/packages/ui/src/features/archive/useArchiveTask.ts
+++ b/products/desktop/packages/ui/src/features/archive/useArchiveTask.ts
@@ -66,6 +66,10 @@ function makeCacheWriter(
     invalidatePathFilter: () => {
       queryClient.invalidateQueries({ queryKey: keys.archivePathFilterKey });
     },
+    invalidateArchivedState: () => {
+      queryClient.invalidateQueries({ queryKey: keys.archivedTaskIdsQueryKey });
+      queryClient.invalidateQueries({ queryKey: keys.archiveListQueryKey });
+    },
     setArchivedTaskIds: (updater) =>
       queryClient.setQueryData(keys.archivedTaskIdsQueryKey, updater),
     setArchiveList: (updater) =>

--- a/products/desktop/packages/ui/src/features/archive/useArchiveTask.ts
+++ b/products/desktop/packages/ui/src/features/archive/useArchiveTask.ts
@@ -66,10 +66,6 @@ function makeCacheWriter(
     invalidatePathFilter: () => {
       queryClient.invalidateQueries({ queryKey: keys.archivePathFilterKey });
     },
-    invalidateArchivedState: () => {
-      queryClient.invalidateQueries({ queryKey: keys.archivedTaskIdsQueryKey });
-      queryClient.invalidateQueries({ queryKey: keys.archiveListQueryKey });
-    },
     setArchivedTaskIds: (updater) =>
       queryClient.setQueryData(keys.archivedTaskIdsQueryKey, updater),
     setArchiveList: (updater) =>

--- a/products/desktop/packages/workspace-server/src/services/archive/archive.integration.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/archive/archive.integration.test.ts
@@ -437,15 +437,16 @@ describe("ArchiveService integration", () => {
         expect(await pathExists(worktreePath)).toBe(false);
       }));
 
-    it("throws when trying to archive already archived task", () =>
+    it("archiving an already archived task returns the existing record", () =>
       withTestContext({}, async (ctx) => {
         await ctx.setupWorktree("detached");
 
         await ctx.service.archiveTask(ctx.archiveInput());
+        const second = await ctx.service.archiveTask(ctx.archiveInput());
 
-        await expect(
-          ctx.service.archiveTask(ctx.archiveInput()),
-        ).rejects.toThrow("already archived");
+        expect(second).toEqual(ctx.service.getArchivedTasks()[0]);
+        expect(ctx.archiveRepo.findAll()).toHaveLength(1);
+        expect(ctx.service.getArchivedTaskIds()).toEqual([TASK_ID]);
       }));
 
     it("archive finds worktree at legacy path format", () =>
@@ -599,12 +600,13 @@ describe("ArchiveService integration", () => {
         );
       }));
 
-    it("rejects archiving a rowless task that is already archived", () =>
+    it("archiving an already archived rowless task returns the existing record", () =>
       withTestContext({ hasWorkspace: false }, async (ctx) => {
         await ctx.service.archiveTask({ taskId: "nonexistent" });
-        await expect(
-          ctx.service.archiveTask({ taskId: "nonexistent" }),
-        ).rejects.toThrow("already archived");
+        const second = await ctx.service.archiveTask({ taskId: "nonexistent" });
+
+        expect(second).toEqual(ctx.service.getArchivedTasks()[0]);
+        expect(ctx.service.getArchivedTaskIds()).toEqual(["nonexistent"]);
       }));
 
     // Unarchive and delete are parallel "remove a rowless task from the archived

--- a/products/desktop/packages/workspace-server/src/services/archive/archive.integration.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/archive/archive.integration.test.ts
@@ -445,7 +445,6 @@ describe("ArchiveService integration", () => {
         const second = await ctx.service.archiveTask(ctx.archiveInput());
 
         expect(second).toEqual(ctx.service.getArchivedTasks()[0]);
-        expect(ctx.archiveRepo.findAll()).toHaveLength(1);
         expect(ctx.service.getArchivedTaskIds()).toEqual([TASK_ID]);
       }));
 

--- a/products/desktop/packages/workspace-server/src/services/archive/archive.integration.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/archive/archive.integration.test.ts
@@ -449,6 +449,27 @@ describe("ArchiveService integration", () => {
         expect(ctx.service.getArchivedTaskIds()).toEqual([TASK_ID]);
       }));
 
+    it("overlapping archive requests share one archive", () =>
+      withTestContext({}, async (ctx) => {
+        const { worktreePath } = await ctx.setupWorktree("detached");
+        await fs.writeFile(path.join(worktreePath, "file.txt"), "content");
+
+        // Both requests start before either finishes, so neither can see the
+        // other's archive row. A second teardown would delete the checkpoint
+        // the surviving archive restores from.
+        const [first, second] = await Promise.all([
+          ctx.service.archiveTask(ctx.archiveInput()),
+          ctx.service.archiveTask(ctx.archiveInput()),
+        ]);
+
+        expect(second).toEqual(first);
+        expect(ctx.archiveRepo.findAll()).toHaveLength(1);
+        expect(first.checkpointId).toBeTruthy();
+        expect(ctx.git("for-each-ref --format='%(refname)'")).toContain(
+          first.checkpointId,
+        );
+      }));
+
     it("archive finds worktree at legacy path format", () =>
       withTestContext({}, async (ctx) => {
         const repoName = path.basename(ctx.repoPath);

--- a/products/desktop/packages/workspace-server/src/services/archive/archive.ts
+++ b/products/desktop/packages/workspace-server/src/services/archive/archive.ts
@@ -95,17 +95,13 @@ export class ArchiveService {
   private readonly inFlightArchives = new Map<string, Promise<ArchivedTask>>();
 
   /**
-   * Idempotent: archiving an already-archived task returns the existing record
-   * instead of failing. The caller wants the task off the list, and it already
-   * is — reporting that as an error made the renderer roll its archived-state
-   * cache back to "not archived", putting the row back in the sidebar and
-   * leaving no way to archive it again.
+   * Idempotent: an already-archived task returns its existing record, so a
+   * caller that asks twice isn't left with a failure it can't act on.
    *
-   * A request that arrives while one is running joins it rather than starting a
-   * second teardown. The existing-record check alone can't cover that: it runs
-   * before the awaited worktree teardown, and the archive row lands after, so
-   * both requests would pass it, and the loser's rollback would delete the
-   * checkpoint the winner's restore point points at.
+   * Overlapping requests join the running one, because the existing-record
+   * check can't see them: it runs before the awaited teardown and the archive
+   * row lands after, so both requests pass it, and the loser's rollback would
+   * delete the checkpoint the winner's restore point points at.
    */
   archiveTask(input: ArchiveTaskInput): Promise<ArchivedTask> {
     const inFlight = this.inFlightArchives.get(input.taskId);
@@ -194,18 +190,13 @@ export class ArchiveService {
       };
     }
 
-    const suspension = this.suspensionRepo.findByWorkspaceId(workspace.id);
-    const worktree = this.worktreeRepo.findByWorkspaceId(workspace.id);
-
     const existingArchive = this.archiveRepo.findByWorkspaceId(workspace.id);
     if (existingArchive) {
-      return this.toArchivedTask(
-        workspace,
-        existingArchive,
-        worktree?.name ?? null,
-        worktree?.path ?? null,
-      );
+      return this.toArchivedTask(workspace, existingArchive);
     }
+
+    const suspension = this.suspensionRepo.findByWorkspaceId(workspace.id);
+    const worktree = this.worktreeRepo.findByWorkspaceId(workspace.id);
 
     if (suspension) {
       const archivedTask: ArchivedTask = {
@@ -545,13 +536,7 @@ export class ArchiveService {
       const workspace = this.workspaceRepo.findById(
         archive.workspaceId,
       ) as Workspace;
-      const worktree = this.worktreeRepo.findByWorkspaceId(workspace.id);
-      return this.toArchivedTask(
-        workspace,
-        archive,
-        worktree?.name ?? null,
-        worktree?.path ?? null,
-      );
+      return this.toArchivedTask(workspace, archive);
     });
     const rowless = this.rowlessArchived().map((meta) =>
       this.toRowlessArchivedTask(meta),
@@ -703,12 +688,9 @@ export class ArchiveService {
     this.log.info(`Deleted archived task ${taskId}`);
   }
 
-  private toArchivedTask(
-    workspace: Workspace,
-    archive: Archive,
-    worktreeName: string | null,
-    worktreePath: string | null,
-  ): ArchivedTask {
+  private toArchivedTask(workspace: Workspace, archive: Archive): ArchivedTask {
+    const worktree = this.worktreeRepo.findByWorkspaceId(workspace.id);
+    const worktreeName = worktree?.name ?? null;
     const repository =
       !archive.repository && workspace.repositoryId
         ? this.repositoryRepo.findById(workspace.repositoryId)
@@ -729,7 +711,8 @@ export class ArchiveService {
           worktreeName,
         ),
       taskCreatedAt: archive.taskCreatedAt ?? workspace.createdAt,
-      repository: archive.repository ?? repository?.path ?? worktreePath,
+      repository:
+        archive.repository ?? repository?.path ?? worktree?.path ?? null,
       recoveryPending: !archive.title,
     };
   }
@@ -744,7 +727,8 @@ export class ArchiveService {
       worktreeName: null,
       branchName: null,
       checkpointId: null,
-      title: meta.archivedTitle ?? `Unknown task (${meta.taskId.slice(0, 8)})`,
+      title:
+        meta.archivedTitle ?? this.unknownTaskTitle(meta.taskId, null, null),
       taskCreatedAt: meta.archivedTaskCreatedAt ?? meta.createdAt,
       repository: meta.archivedRepository,
       recoveryPending: !meta.archivedTitle,

--- a/products/desktop/packages/workspace-server/src/services/archive/archive.ts
+++ b/products/desktop/packages/workspace-server/src/services/archive/archive.ts
@@ -93,6 +93,13 @@ export class ArchiveService {
   private readonly log: ScopedLogger;
   private recoveryStarted = false;
 
+  /**
+   * Idempotent: archiving an already-archived task returns the existing record
+   * instead of failing. The caller wants the task off the list, and it already
+   * is — reporting that as an error made the renderer roll its archived-state
+   * cache back to "not archived", putting the row back in the sidebar and
+   * leaving no way to archive it again.
+   */
   async archiveTask(input: ArchiveTaskInput): Promise<ArchivedTask> {
     this.log.info(`Archiving task ${input.taskId}`);
 
@@ -137,7 +144,7 @@ export class ArchiveService {
       // `getArchivedTaskIds` never reports it and the row reappears on refetch.
       const existing = this.taskMetadataRepo.findByTaskId(taskId);
       if (existing?.archivedAt) {
-        throw new Error(`Task ${taskId} is already archived`);
+        return this.toRowlessArchivedTask(existing);
       }
       const archivedAt = new Date().toISOString();
       await step(
@@ -167,13 +174,18 @@ export class ArchiveService {
       };
     }
 
-    const existingArchive = this.archiveRepo.findByWorkspaceId(workspace.id);
-    if (existingArchive) {
-      throw new Error(`Task ${taskId} is already archived`);
-    }
-
     const suspension = this.suspensionRepo.findByWorkspaceId(workspace.id);
     const worktree = this.worktreeRepo.findByWorkspaceId(workspace.id);
+
+    const existingArchive = this.archiveRepo.findByWorkspaceId(workspace.id);
+    if (existingArchive) {
+      return this.toArchivedTask(
+        workspace,
+        existingArchive,
+        worktree?.name ?? null,
+        worktree?.path ?? null,
+      );
+    }
 
     if (suspension) {
       const archivedTask: ArchivedTask = {
@@ -521,22 +533,8 @@ export class ArchiveService {
         worktree?.path ?? null,
       );
     });
-    const rowless = this.rowlessArchived().map(
-      (meta): ArchivedTask => ({
-        taskId: meta.taskId,
-        // `rowlessArchived` only returns rows with a non-null `archivedAt`.
-        archivedAt: meta.archivedAt as string,
-        folderId: "",
-        mode: "cloud",
-        worktreeName: null,
-        branchName: null,
-        checkpointId: null,
-        title:
-          meta.archivedTitle ?? `Unknown task (${meta.taskId.slice(0, 8)})`,
-        taskCreatedAt: meta.archivedTaskCreatedAt ?? meta.createdAt,
-        repository: meta.archivedRepository,
-        recoveryPending: !meta.archivedTitle,
-      }),
+    const rowless = this.rowlessArchived().map((meta) =>
+      this.toRowlessArchivedTask(meta),
     );
     return [...fromWorkspaces, ...rowless];
   }
@@ -713,6 +711,23 @@ export class ArchiveService {
       taskCreatedAt: archive.taskCreatedAt ?? workspace.createdAt,
       repository: archive.repository ?? repository?.path ?? worktreePath,
       recoveryPending: !archive.title,
+    };
+  }
+
+  private toRowlessArchivedTask(meta: TaskMetadataRow): ArchivedTask {
+    return {
+      taskId: meta.taskId,
+      // Only reached for rows with a non-null `archivedAt`.
+      archivedAt: meta.archivedAt as string,
+      folderId: "",
+      mode: "cloud",
+      worktreeName: null,
+      branchName: null,
+      checkpointId: null,
+      title: meta.archivedTitle ?? `Unknown task (${meta.taskId.slice(0, 8)})`,
+      taskCreatedAt: meta.archivedTaskCreatedAt ?? meta.createdAt,
+      repository: meta.archivedRepository,
+      recoveryPending: !meta.archivedTitle,
     };
   }
 

--- a/products/desktop/packages/workspace-server/src/services/archive/archive.ts
+++ b/products/desktop/packages/workspace-server/src/services/archive/archive.ts
@@ -92,6 +92,7 @@ export class ArchiveService {
 
   private readonly log: ScopedLogger;
   private recoveryStarted = false;
+  private readonly inFlightArchives = new Map<string, Promise<ArchivedTask>>();
 
   /**
    * Idempotent: archiving an already-archived task returns the existing record
@@ -99,8 +100,27 @@ export class ArchiveService {
    * is — reporting that as an error made the renderer roll its archived-state
    * cache back to "not archived", putting the row back in the sidebar and
    * leaving no way to archive it again.
+   *
+   * A request that arrives while one is running joins it rather than starting a
+   * second teardown. The existing-record check alone can't cover that: it runs
+   * before the awaited worktree teardown, and the archive row lands after, so
+   * both requests would pass it, and the loser's rollback would delete the
+   * checkpoint the winner's restore point points at.
    */
-  async archiveTask(input: ArchiveTaskInput): Promise<ArchivedTask> {
+  archiveTask(input: ArchiveTaskInput): Promise<ArchivedTask> {
+    const inFlight = this.inFlightArchives.get(input.taskId);
+    if (inFlight) {
+      this.log.info(`Joining the archive already running for ${input.taskId}`);
+      return inFlight;
+    }
+    const run = this.runArchive(input).finally(() => {
+      this.inFlightArchives.delete(input.taskId);
+    });
+    this.inFlightArchives.set(input.taskId, run);
+    return run;
+  }
+
+  private async runArchive(input: ArchiveTaskInput): Promise<ArchivedTask> {
     this.log.info(`Archiving task ${input.taskId}`);
 
     const rollbacks: RollbackFn[] = [];


### PR DESCRIPTION
## Problem

- Archiving a task does nothing, and the task stays in the sidebar with no way to remove it. Reported for a task whose worktree directory had been deleted, but the trap is not specific to that.
- `ArchiveService.archiveTask` throws `Task <id> is already archived` when an archive record already exists.
- The renderer reads any archive failure as "the task is not archived" and removes the task from its cached archived-id set, so an archived task reappears in the sidebar.
- Every retry then repeats the same loop: the host reports "already archived", the renderer un-hides the row again.
- Two archive calls for one task are enough to enter the loop. The second one fails and discards what the first one did.
- Two archive calls that overlap are worse. The existing-record check runs before the awaited worktree teardown and the archive row lands after it, so both requests pass the check, the second insert violates the unique constraint on `archives.workspaceId`, and its rollback deletes the checkpoint the surviving archive record restores from. The task ends up archived but unrestorable.

## Changes

- Archiving a task that is already archived now succeeds and the row stays out of the sidebar, instead of failing silently and putting the row back.
- Archiving a task twice at once no longer strands its restore point. `archiveTask` returns the running promise to a request that arrives while one is in flight, so only one teardown runs.
- `archiveTask` returns the existing archive record for both storage paths (the `archives` row and the rowless `task_metadata` row) rather than throwing.
- A failed archive now invalidates the archive queries, so the cache re-syncs with the host instead of asserting a state the renderer cannot know. The existing optimistic rollback stays, because the archived-ids query is mounted across the sidebar and the refetch is async, so without it the row flashes back.
- The service is the layer that de-duplicates, not the caller. The two sidebar surfaces already guard per task through `useArchivingTasksStore`, but the spaces sidebar triggers in `useChannelItems` and `useSpaceTaskActions` fire and forget, and a future caller would have to remember the rule again.
- Mechanical: the rowless archived-task mapping moves into a `toRowlessArchivedTask` helper, and `toArchivedTask` now does its own worktree lookup instead of taking the name and path as arguments both callers derived identically.
- Nothing looks different on screen. The archive action, the toast, and the archived list all render as before.

## How did you test this code?

Automated only. Nothing was run against a real app or a real desktop database.

- Reproduced the underlying scenario first with a throwaway integration test: `archiveTask` already handles a worktree whose directory is gone, which ruled out the host archive path and pointed at the already-archived error. That scratch test is not part of the diff.
- Converted the two integration tests that locked in the throw. They now assert the repeat archive returns the record the archived list reports, and that the task is still reported archived — the regression is a reintroduced throw, or an early return that reports an archived state the list does not agree with.
- Added `overlapping archive requests share one archive`, which starts both requests before either finishes and asserts one archive row plus a surviving checkpoint ref. It catches the loser's rollback deleting the winner's restore point. Confirmed it fails with the de-duplication removed.
- Added one assertion to the existing archive-failure rollback test in `archiveOrchestration.test.ts`: a failed archive has to ask the host for the archived state. Without it, the rollback's guess stands and an archived task stays visible.
- Confirmed with a throwaway TanStack Query test that invalidating the `archive` router prefix marks both `archive.list` and `archive.archivedTaskIds` stale and leaves unrelated queries alone. That is what lets the failure path reuse the existing `invalidatePathFilter` rather than adding a second invalidator.
- Ran the archive suites in `@posthog/workspace-server`, the full `@posthog/core` and `@posthog/ui` suites, and `turbo typecheck` across the desktop workspace.
- `@posthog/workspace-server` has one unrelated failure, `session-env/loader.test.ts > ignores files that don't match the SDK hook naming convention`, which also fails on `master` at `3612cfa3` with this branch stashed.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a bug report with an app log and a screenshot. Skills invoked: `/writing-tests` for the test changes, `/writing-pr-descriptions` for this body, and `/simplify` for a cleanup pass over the finished diff.

The first hypothesis was a host-side archive failure on the missing worktree, since that is what the screenshot showed. A scratch integration test disproved it — the host archives a task with a deleted worktree directory without complaint — which moved the diagnosis to the interaction between the "already archived" error and the renderer's failure rollback. Fixing only the renderer was the alternative considered, but the host reporting a satisfied request as an error is the part that reads wrong, so idempotency went in the service and the cache re-sync went in as defense for any other archive failure that leaves state behind.

The second commit answers a ReviewHog finding on the first: the early return covers a repeat archive but not an overlapping one, because the check and the insert sit on either side of the worktree teardown. Guarding the two unguarded renderer call sites was the alternative; per-task de-duplication in the service closes the window for every caller instead.

The third commit is the cleanup pass and changes no behavior. Its main removal is a `invalidateArchivedState` method the earlier commits added to `ArchiveCacheWriter`, which turned out to duplicate the existing `invalidatePathFilter` once the router-prefix semantics of `pathFilter()` were checked.

Two follow-ups the cleanup pass surfaced and deliberately left alone, both pre-existing and outside this PR's intent: `unarchiveTask` and `deleteArchivedTask` still throw when the archive record is absent, so idempotence is one-directional; and the `Map<key, Promise>` single-flight shape is now hand-rolled in six places in `workspace-server`, which a shared primitive in `@posthog/shared` could absorb.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1787144495413949)*
