### PR TITLE
fix(cymbal): include the column in node frame ids

### DIFF
--- a/rust/cymbal/src/core/types/langs/node.rs
+++ b/rust/cymbal/src/core/types/langs/node.rs
@@ -123,6 +123,10 @@ impl RawNodeFrame {
         hasher.update(self.filename.as_bytes());
         hasher.update(self.function.as_bytes());
         hasher.update(self.lineno.unwrap_or_default().to_be_bytes());
+        // In a minified bundle every frame shares the file, the line (1), an anonymized
+        // function name, and the context line — the column is the only discriminator, so
+        // leaving it out of the id collapses distinct frames into one cached resolution.
+        hasher.update(self.colno.unwrap_or_default().to_be_bytes());
         self.module
             .as_ref()
             .inspect(|m| hasher.update(m.as_bytes()));
@@ -322,6 +326,28 @@ fn is_dependency_source(source: &str) -> bool {
 #[cfg(test)]
 mod test {
     use super::RawNodeFrame;
+
+    #[test]
+    fn frame_id_distinguishes_columns_on_the_same_line() {
+        // Minified bundles put every frame on line 1 of the same file with an anonymized
+        // function name and an identical context line, so the column is the only field
+        // separating distinct frames. An id that ignores it collapses them into one
+        // cached resolution.
+        let frame = |colno: u32| -> RawNodeFrame {
+            serde_json::from_value(serde_json::json!({
+                "filename": "dist/index.js",
+                "function": "?",
+                "lineno": 1,
+                "colno": colno,
+                "module": "index",
+                "context_line": "!function(){try{var e=global}catch(e){}}();(()=>{\"use strict\"})();",
+            }))
+            .unwrap()
+        };
+
+        assert_ne!(frame(1345).frame_id(), frame(1453).frame_id());
+        assert_eq!(frame(1345).frame_id(), frame(1345).frame_id());
+    }
 
     #[test]
     fn test_in_app_normalization() {


### PR DESCRIPTION
## Problem

A node exception from a minified bundle renders as one frame repeated several times: every in-app frame shows the same resolved position and `<anonymous>`, and the repeated position can even come from a build that no longer exists.

`RawNodeFrame::frame_id` hashes the filename, function, line, module, and context lines, but not the column. A minified bundle puts every frame on line 1 of the same file, with an anonymized function name and one shared context line, so the column is the only field separating distinct frames. Frames that differ only by column collide into one id.

The resolution cache is keyed by that id, so the first colliding frame's resolution - position, name, and stored raw frame - is served for every later one. The collisions persist across events and rebuilds, because the shared context line stays stable between builds.

The web frame id already hashes line and column (`js.rs`), which is why browser bundles never showed this. Node was the only JS path missing it.

## Changes

- `RawNodeFrame::frame_id` now hashes `colno`, mirroring the web frame id.
- Cached node-frame resolutions keyed by the old ids become unreachable and re-derive on the next event. Frame ids do not participate in issue fingerprinting, so no issues regroup.

## How did you test this code?

- New unit test: two node frames identical except for the column get distinct ids, and equal frames still get equal ids. This is the collision every webpack or vite production bundle produces.
- Reproduced end to end against a local PostHog with a webpack production bundle whose stack has three same-line anonymous frames: before the fix all three resolved to one repeated position served from the cache, after restarting the resolution service with the fix they resolved to three distinct original files.
- Not run: the full CI matrix.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. Skills invoked: /writing-pr-descriptions. Found while testing webpack event release mode (PostHog/posthog-js#4563) with a local example app: the layer-by-layer comparison of the raw V8 stack, the SDK wire payload, and the stored frames isolated the collapse to the server-side frame id. The reproduction data in this description is from local example apps; no customer data was involved.
