### PR TITLE
feat(ingestion): add continuous memory profiling via pyroscope jemalloc backend

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
- "gimli",
+ "gimli 0.32.3",
 ]
 
 [[package]]
@@ -214,7 +214,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
 dependencies = [
- "object",
+ "object 0.37.3",
 ]
 
 [[package]]
@@ -1526,7 +1526,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.37.3",
  "rustc-demangle",
  "windows-link",
 ]
@@ -2748,7 +2748,6 @@ version = "0.1.0"
 dependencies = [
  "envconfig",
  "pyroscope",
- "pyroscope_pprofrs",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -3569,6 +3568,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "dary_heap"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
 
 [[package]]
 name = "dashmap"
@@ -4806,6 +4811,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
+name = "framehop"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f54fe4785e899d4d6f43793b151c63c5647240fc630b005509d2614a939f693"
+dependencies = [
+ "arrayvec",
+ "cfg-if",
+ "fallible-iterator 0.3.0",
+ "gimli 0.33.0",
+ "macho-unwind-info",
+ "pe-unwind-info",
+]
+
+[[package]]
 name = "from_variant"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5035,6 +5054,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 dependencies = [
  "fallible-iterator 0.3.0",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "gimli"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
+dependencies = [
  "stable_deref_trait",
 ]
 
@@ -6037,6 +6065,7 @@ dependencies = [
  "axum 0.7.9",
  "chrono",
  "common-alloc",
+ "common-continuous-profiling",
  "dashmap 6.1.0",
  "envconfig",
  "flate2",
@@ -6864,21 +6893,25 @@ dependencies = [
 
 [[package]]
 name = "libflate"
-version = "1.4.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ff4ae71b685bbad2f2f391fe74f6b7659a34871c08b210fdc039e43bee07d18"
+checksum = "a4da9b700e758e57152a1fd1c52cbdc5727c1aa6d8743dc1acda917398f1d76c"
 dependencies = [
  "adler32",
  "crc32fast",
+ "dary_heap",
  "libflate_lz77",
+ "no_std_io2",
 ]
 
 [[package]]
 name = "libflate_lz77"
-version = "1.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a52d3a8bfc85f250440e4424db7d857e241a3aebbbe301f3eb606ab15c39acbf"
+checksum = "ff7a10e427698aef6eef269482776debfef63384d30f13aad39a1a95e0e098fd"
 dependencies = [
+ "hashbrown 0.16.1",
+ "no_std_io2",
  "rle-decode-fast",
 ]
 
@@ -7126,6 +7159,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "macho-unwind-info"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4bdc8b0ce69932332cf76d24af69c3a155242af95c226b2ab6c2e371ed1149"
+dependencies = [
+ "thiserror 2.0.18",
+ "zerocopy",
+ "zerocopy-derive",
 ]
 
 [[package]]
@@ -7445,15 +7489,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
-name = "names"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bddcd3bf5144b6392de80e04c347cd7fab2508f6df16a85fc496ecd5cec39bc"
-dependencies = [
- "rand 0.8.5",
-]
-
-[[package]]
 name = "native-tls"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7538,17 +7573,6 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
-dependencies = [
- "bitflags 2.11.0",
- "cfg-if",
- "libc",
-]
-
-[[package]]
-name = "nix"
 version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
@@ -7564,6 +7588,15 @@ name = "no-std-compat"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+
+[[package]]
+name = "no_std_io2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "nohash-hasher"
@@ -7920,6 +7953,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
+dependencies = [
+ "flate2",
+ "memchr",
+ "ruzstd",
 ]
 
 [[package]]
@@ -8379,6 +8423,19 @@ dependencies = [
  "pdb",
  "range-collections",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "pe-unwind-info"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97f6fccfd2d9d2df765ca23ff85fe5cc437fb0e6d3e164e4d3cbe09d14780c93"
+dependencies = [
+ "arrayvec",
+ "bitflags 2.11.0",
+ "thiserror 2.0.18",
+ "zerocopy",
+ "zerocopy-derive",
 ]
 
 [[package]]
@@ -9068,27 +9125,7 @@ dependencies = [
  "protobuf-codegen",
  "smallvec",
  "spin 0.10.0",
- "symbolic-demangle",
- "tempfile",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "pprof2"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8961ed0a916b512e565f8070eb0dfa05773dd140160b45ac9a5ad339b557adeb"
-dependencies = [
- "backtrace",
- "cfg-if",
- "findshlibs",
- "libc",
- "log",
- "nix 0.27.1",
- "once_cell",
- "parking_lot",
- "smallvec",
- "symbolic-demangle",
+ "symbolic-demangle 12.17.2",
  "tempfile",
  "thiserror 2.0.18",
 ]
@@ -9302,16 +9339,6 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
-dependencies = [
- "bytes",
- "prost-derive 0.11.9",
-]
-
-[[package]]
-name = "prost"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
@@ -9379,19 +9406,6 @@ dependencies = [
  "regex",
  "syn 2.0.117",
  "tempfile",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
-dependencies = [
- "anyhow",
- "itertools 0.10.5",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -9670,31 +9684,33 @@ dependencies = [
 
 [[package]]
 name = "pyroscope"
-version = "0.5.8"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3a5f63b0d2727095db59045e6a0ef3259b28b90d481ae88f0e3d866d0234ce8"
+checksum = "b6869e0f2cae5cef10281c57d5a260f91372d7f190a7f717eb1a54f643d92151"
 dependencies = [
+ "aligned-vec",
+ "backtrace",
+ "findshlibs",
+ "framehop",
+ "jemalloc_pprof",
+ "lazy_static",
  "libc",
  "libflate",
  "log",
- "names",
- "prost 0.11.9",
- "reqwest 0.12.28",
+ "memmap2",
+ "nix 0.26.4",
+ "object 0.39.1",
+ "once_cell",
+ "prost 0.14.3",
+ "reqwest 0.13.4",
  "serde_json",
- "thiserror 1.0.69",
+ "smallvec",
+ "spin 0.12.3",
+ "symbolic-demangle 13.6.1",
+ "tempfile",
+ "thiserror 2.0.18",
  "url",
- "winapi",
-]
-
-[[package]]
-name = "pyroscope_pprofrs"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50da7a8950c542357de489aa9ee628f46322b1beaac1f4fa3313bcdebe85b4ea"
-dependencies = [
- "log",
- "pprof2",
- "pyroscope",
+ "uuid",
 ]
 
 [[package]]
@@ -10268,7 +10284,6 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
- "futures-channel",
  "futures-core",
  "futures-util",
  "h2 0.4.13",
@@ -10339,6 +10354,7 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -10719,6 +10735,15 @@ dependencies = [
  "quick-error 1.2.3",
  "tempfile",
  "wait-timeout",
+]
+
+[[package]]
+name = "ruzstd"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7c1c839d570d835527c9a5e4db7cb2198683a988cb9d7293fc8674e6bd58fc8"
+dependencies = [
+ "twox-hash",
 ]
 
 [[package]]
@@ -11390,6 +11415,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0134f9043ed38b087ac4f7d4af44c79e2c9e5094421fe3164f435ce585953b10"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11934,9 +11968,9 @@ version = "12.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a7418e0528510cf3b289a1250775e8c8b6a333bcdd01689133f68a818da798f"
 dependencies = [
- "symbolic-common",
+ "symbolic-common 12.17.2",
  "symbolic-debuginfo",
- "symbolic-demangle",
+ "symbolic-demangle 12.17.2",
  "symbolic-sourcemapcache",
  "symbolic-symcache",
 ]
@@ -11946,6 +11980,18 @@ name = "symbolic-common"
 version = "12.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "751a2823d606b5d0a7616499e4130a516ebd01a44f39811be2b9600936509c23"
+dependencies = [
+ "debugid",
+ "memmap2",
+ "stable_deref_trait",
+ "uuid",
+]
+
+[[package]]
+name = "symbolic-common"
+version = "13.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba98c95b1ff25ce40400d286f5dec838097ee42ad1bbd64242cce24c2baace8c"
 dependencies = [
  "debugid",
  "memmap2",
@@ -11964,7 +12010,7 @@ dependencies = [
  "elsa",
  "fallible-iterator 0.3.0",
  "flate2",
- "gimli",
+ "gimli 0.32.3",
  "goblin",
  "nom",
  "nom-supreme",
@@ -11977,7 +12023,7 @@ dependencies = [
  "serde_json",
  "smallvec",
  "srcsrv",
- "symbolic-common",
+ "symbolic-common 12.17.2",
  "symbolic-ppdb",
  "thiserror 2.0.18",
  "wasmparser 0.243.0",
@@ -11995,7 +12041,17 @@ dependencies = [
  "cpp_demangle",
  "msvc-demangler",
  "rustc-demangle",
- "symbolic-common",
+ "symbolic-common 12.17.2",
+]
+
+[[package]]
+name = "symbolic-demangle"
+version = "13.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c547b0231d1794aec8e4795dbb04c1d395ff774954f18e37d46d5a70f0ce4b2"
+dependencies = [
+ "rustc-demangle",
+ "symbolic-common 13.6.1",
 ]
 
 [[package]]
@@ -12008,7 +12064,7 @@ dependencies = [
  "indexmap 2.13.0",
  "serde",
  "serde_json",
- "symbolic-common",
+ "symbolic-common 12.17.2",
  "thiserror 2.0.18",
  "uuid",
  "watto",
@@ -12023,7 +12079,7 @@ dependencies = [
  "itertools 0.14.0",
  "js-source-scopes",
  "sourcemap",
- "symbolic-common",
+ "symbolic-common 12.17.2",
  "thiserror 2.0.18",
  "tracing",
  "watto",
@@ -12036,7 +12092,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b14fe4ebcdce2b318d7b4f04d12e6c73c1504a59ed4423d90607aa7baa9ea37"
 dependencies = [
  "indexmap 2.13.0",
- "symbolic-common",
+ "symbolic-common 12.17.2",
  "symbolic-debuginfo",
  "thiserror 2.0.18",
  "tracing",

--- a/rust/capture/src/v1/quota_limiter_shim.rs
+++ b/rust/capture/src/v1/quota_limiter_shim.rs
@@ -236,12 +236,7 @@ mod tests {
             http1_header_read_timeout_ms: Some(5000),
             body_chunk_read_timeout_ms: None,
             body_read_chunk_size_kb: 256,
-            continuous_profiling: ContinuousProfilingConfig {
-                continuous_profiling_enabled: false,
-                pyroscope_server_address: String::new(),
-                pyroscope_application_name: String::new(),
-                pyroscope_sample_rate: 100,
-            },
+            continuous_profiling: ContinuousProfilingConfig::default(),
             capture_v1_sinks: String::new(),
             capture_v1_max_compressed_body_bytes: 10 * 1024 * 1024,
             capture_v1_max_decompressed_body_bytes: 50 * 1024 * 1024,

--- a/rust/capture/tests/common/utils.rs
+++ b/rust/capture/tests/common/utils.rs
@@ -152,12 +152,7 @@ pub static DEFAULT_CONFIG: Lazy<Config> = Lazy::new(|| Config {
     http1_header_read_timeout_ms: Some(5000), // 5 seconds default
     body_chunk_read_timeout_ms: None,         // disabled by default in tests
     body_read_chunk_size_kb: 256,             // 256KB default
-    continuous_profiling: ContinuousProfilingConfig {
-        continuous_profiling_enabled: false,
-        pyroscope_server_address: String::new(),
-        pyroscope_application_name: String::new(),
-        pyroscope_sample_rate: 100,
-    },
+    continuous_profiling: ContinuousProfilingConfig::default(),
     capture_v1_sinks: String::new(),
     capture_v1_max_compressed_body_bytes: 10 * 1024 * 1024,
     capture_v1_max_decompressed_body_bytes: 50 * 1024 * 1024,

--- a/rust/common/alloc/Cargo.toml
+++ b/rust/common/alloc/Cargo.toml
@@ -7,5 +7,7 @@ edition = "2021"
 workspace = true
 
 [dependencies]
+# "profiling" compiles jemalloc's heap profiler in but leaves it inactive; it only
+# runs when a deploy opts in via _RJEM_MALLOC_CONF (see common/continuous_profiling).
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator = "0.6"
+tikv-jemallocator = { version = "0.6", features = ["profiling"] }

--- a/rust/common/continuous_profiling/Cargo.toml
+++ b/rust/common/continuous_profiling/Cargo.toml
@@ -8,7 +8,6 @@ workspace = true
 
 [dependencies]
 envconfig = { workspace = true }
-pyroscope = "0.5"
-pyroscope_pprofrs = "0.2"
+pyroscope = { version = "2", features = ["backend-pprof-rs", "backend-jemalloc"] }
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/rust/common/continuous_profiling/src/lib.rs
+++ b/rust/common/continuous_profiling/src/lib.rs
@@ -24,7 +24,8 @@ const K8S_TAG_ENV_VARS: &[(&str, &str)] = &[
     ("app", "K8S_APP"),
     ("container", "K8S_CONTAINER_NAME"),
     ("controller_type", "K8S_CONTROLLER_TYPE"),
-    ("service_name", "K8S_SERVICE_NAME"),
+    // No service_name here: pyroscope 2.x already sets it from the application
+    // name, and the server rejects profiles with a duplicate label (HTTP 400).
 ];
 
 #[derive(Envconfig, Clone, Debug)]

--- a/rust/common/continuous_profiling/src/lib.rs
+++ b/rust/common/continuous_profiling/src/lib.rs
@@ -3,11 +3,16 @@ use std::panic;
 use std::sync::Once;
 
 use envconfig::Envconfig;
-use pyroscope::pyroscope::PyroscopeAgentRunning;
+use pyroscope::backend::jemalloc::jemalloc_backend;
+use pyroscope::backend::{
+    pprof_backend, BackendConfig, BackendImpl, BackendUninitialized, PprofConfig,
+};
+use pyroscope::pyroscope::{PyroscopeAgentBuilder, PyroscopeAgentRunning};
 use pyroscope::PyroscopeAgent;
-use pyroscope_pprofrs::{pprof_backend, PprofConfig};
 
 static PANIC_HOOK_INSTALLED: Once = Once::new();
+
+const SPY_NAME: &str = "pyroscope-rs";
 
 /// K8s metadata environment variables for Pyroscope tags
 const K8S_TAG_ENV_VARS: &[(&str, &str)] = &[
@@ -27,6 +32,12 @@ pub struct ContinuousProfilingConfig {
     #[envconfig(default = "false")]
     pub continuous_profiling_enabled: bool,
 
+    /// Also push jemalloc heap profiles (profile type "memory"). Requires jemalloc
+    /// profiling to be active at process start, e.g.
+    /// `_RJEM_MALLOC_CONF=prof:true,prof_active:true,lg_prof_sample:19`.
+    #[envconfig(default = "false")]
+    pub continuous_profiling_memory_enabled: bool,
+
     #[envconfig(default = "")]
     pub pyroscope_server_address: String,
 
@@ -40,10 +51,18 @@ pub struct ContinuousProfilingConfig {
 /// A running Pyroscope agent handle. Keep this alive for the duration of profiling.
 pub type RunningAgent = PyroscopeAgent<PyroscopeAgentRunning>;
 
+/// The running profiling agents. Keep this alive for the duration of profiling;
+/// dropping it stops all profiling.
+pub struct RunningAgents {
+    _cpu: RunningAgent,
+    _memory: Option<RunningAgent>,
+}
+
 impl Default for ContinuousProfilingConfig {
     fn default() -> Self {
         Self {
             continuous_profiling_enabled: false,
+            continuous_profiling_memory_enabled: false,
             pyroscope_server_address: String::new(),
             pyroscope_application_name: String::new(),
             pyroscope_sample_rate: 100,
@@ -107,8 +126,14 @@ fn install_panic_safe_hook() {
 impl ContinuousProfilingConfig {
     /// Initialize continuous profiling if enabled.
     ///
-    /// Returns an `Option<RunningAgent>` that should be kept alive for the
-    /// duration of the application. When dropped, the agent will stop profiling.
+    /// Returns an `Option<RunningAgents>` that should be kept alive for the
+    /// duration of the application. When dropped, the agents will stop profiling.
+    ///
+    /// A CPU profiling agent is always started. When
+    /// `continuous_profiling_memory_enabled` is set, a second agent pushes
+    /// jemalloc heap profiles; if that agent fails to start (typically because
+    /// jemalloc profiling isn't active), the error is logged and CPU profiling
+    /// continues alone.
     ///
     /// This function installs a panic hook to ensure that panics in pyroscope's
     /// internal threads don't crash the main application. The pyroscope library
@@ -119,10 +144,10 @@ impl ContinuousProfilingConfig {
     ///
     /// ```ignore
     /// let config = ContinuousProfilingConfig::init_from_env()?;
-    /// let _agent = config.start_agent()?;
-    /// // Agent runs until _agent is dropped
+    /// let _agents = config.start_agent()?;
+    /// // Agents run until _agents is dropped
     /// ```
-    pub fn start_agent(&self) -> Result<Option<RunningAgent>, ContinuousProfilingError> {
+    pub fn start_agent(&self) -> Result<Option<RunningAgents>, ContinuousProfilingError> {
         if !self.continuous_profiling_enabled {
             tracing::info!("Continuous profiling is disabled");
             return Ok(None);
@@ -145,30 +170,69 @@ impl ContinuousProfilingConfig {
             server_address = %self.pyroscope_server_address,
             app_name = %self.pyroscope_application_name,
             sample_rate = %self.pyroscope_sample_rate,
+            memory_enabled = %self.continuous_profiling_memory_enabled,
             tags = ?tags,
             "Starting continuous profiling"
         );
 
+        let cpu_backend = pprof_backend(
+            PprofConfig {
+                sample_rate: self.pyroscope_sample_rate,
+            },
+            BackendConfig::default(),
+        );
+        let cpu = self.start_backend(cpu_backend, &tags)?;
+
+        let memory = if self.continuous_profiling_memory_enabled {
+            match self.start_backend(jemalloc_backend(), &tags) {
+                Ok(agent) => Some(agent),
+                Err(e) => {
+                    tracing::error!(
+                        error = %e,
+                        "Failed to start memory profiling agent - check that jemalloc \
+                         profiling is active (_RJEM_MALLOC_CONF=prof:true,prof_active:true); \
+                         CPU profiling continues"
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+        tracing::info!(
+            memory_profiling = %memory.is_some(),
+            "Continuous profiling agent started successfully"
+        );
+
+        Ok(Some(RunningAgents {
+            _cpu: cpu,
+            _memory: memory,
+        }))
+    }
+
+    fn start_backend(
+        &self,
+        backend: BackendImpl<BackendUninitialized>,
+        tags: &[(String, String)],
+    ) -> Result<RunningAgent, ContinuousProfilingError> {
         // Convert tags to the format expected by pyroscope: Vec<(&str, &str)>
         let tags_refs: Vec<(&str, &str)> =
             tags.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
 
-        let agent = PyroscopeAgent::builder(
+        let agent = PyroscopeAgentBuilder::new(
             &self.pyroscope_server_address,
             &self.pyroscope_application_name,
+            self.pyroscope_sample_rate,
+            SPY_NAME,
+            env!("CARGO_PKG_VERSION"),
+            backend,
         )
-        .backend(pprof_backend(
-            PprofConfig::new().sample_rate(self.pyroscope_sample_rate),
-        ))
         .tags(tags_refs)
         .build()
         .map_err(ContinuousProfilingError::Build)?;
 
-        let agent = agent.start().map_err(ContinuousProfilingError::Start)?;
-
-        tracing::info!("Continuous profiling agent started successfully");
-
-        Ok(Some(agent))
+        agent.start().map_err(ContinuousProfilingError::Start)
     }
 }
 

--- a/rust/ingestion-consumer/Cargo.toml
+++ b/rust/ingestion-consumer/Cargo.toml
@@ -8,6 +8,7 @@ anyhow = { workspace = true }
 axum = { workspace = true }
 chrono = { workspace = true }
 common-alloc = { path = "../common/alloc" }
+common-continuous-profiling = { path = "../common/continuous_profiling" }
 dashmap = { workspace = true }
 envconfig = { workspace = true }
 flate2 = { workspace = true }

--- a/rust/ingestion-consumer/src/config.rs
+++ b/rust/ingestion-consumer/src/config.rs
@@ -1,3 +1,4 @@
+use common_continuous_profiling::ContinuousProfilingConfig;
 use envconfig::Envconfig;
 use rdkafka::ClientConfig;
 use tracing::info;
@@ -334,6 +335,9 @@ pub struct Config {
     /// default labels. The lag-based KEDA autoscaler selects on this label.
     #[envconfig(from = "INGESTION_LANE")]
     pub ingestion_lane: Option<String>,
+
+    #[envconfig(nested = true)]
+    pub continuous_profiling: ContinuousProfilingConfig,
 }
 
 /// Parse `KAFKA_CONSUMER_*` env vars into rdkafka config key-value pairs.

--- a/rust/ingestion-consumer/src/main.rs
+++ b/rust/ingestion-consumer/src/main.rs
@@ -84,6 +84,16 @@ async fn async_main(config: Config) -> Result<()> {
 
     info!("Starting ingestion consumer");
 
+    // Keep the returned agents alive for the duration of the program.
+    // Fails gracefully - logs error but doesn't prevent service from starting.
+    let _profiling_agents = match config.continuous_profiling.start_agent() {
+        Ok(agents) => agents,
+        Err(e) => {
+            error!("Failed to start continuous profiling agent: {e:#}");
+            None
+        }
+    };
+
     // Lifecycle manager handles signals, health, and shutdown coordination
     let mut manager = Manager::builder("ingestion-consumer")
         .with_global_shutdown_timeout(Duration::from_secs(90))


### PR DESCRIPTION
## Problem

- Engineers investigating memory growth or OOM kills in the Rust services get no heap data in Pyroscope; the SDK only pushed CPU profiles.
- The ingestion consumer had no continuous profiling wiring at all.

## Changes

- `CONTINUOUS_PROFILING_MEMORY_ENABLED` starts a second Pyroscope agent that pushes jemalloc heap profiles (profile type "memory") next to the CPU profiles.
- If jemalloc profiling is not active at startup, the memory agent logs the fix hint and CPU profiling continues alone.
- The pyroscope crate moves from 0.5 to 2.0.6, which ships the jemalloc backend; `pyroscope_pprofrs` is folded into it.
- `common-alloc` now compiles jemalloc with its profiler included. It stays inactive, with zero overhead, until a deploy opts in.
- The ingestion consumer gains the continuous profiling config and startup call, matching capture and the other services.

> [!NOTE]
> Heap profiles only flow when the pod sets `_RJEM_MALLOC_CONF=prof:true,prof_active:true,lg_prof_sample:19` in addition to the two profiling flags. The `_RJEM_` prefix is required because our jemalloc symbols are prefixed.

## How did you test this code?

- Existing ingestion-consumer and capture unit tests pass; no new tests, the change is config plumbing over an external SDK.
- `cargo tree` confirms the jemalloc `profiling` feature reaches `tikv-jemalloc-sys` in the ingestion consumer binary.
- Not checked: an end-to-end push against a live Pyroscope server.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None, internal Rust services only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code. Skills invoked: /writing-pr-descriptions.
- The 2.x SDK allows one backend per agent, so memory profiling runs as a second agent rather than a combined one.
- A failed memory agent degrades to CPU-only profiling instead of failing startup, so a bad malloc_conf cannot cost the existing CPU profiles.
- The jemalloc `profiling` feature landed in `common-alloc` rather than per service, keeping activation a deploy-time env var with no code change per service.
