### PR TITLE
feat(flags): warn when a fractional rollout breaks local evaluation

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
@@ -585,11 +585,7 @@ export function FeatureFlagReleaseConditions({
                     it.
                 </LemonBanner>
             )}
-            <FractionalRolloutWarning
-                filterGroups={filterGroups}
-                evaluationRuntime={evaluationRuntime}
-                className="mb-3"
-            />
+            <FractionalRolloutWarning filterGroups={filterGroups} className="mb-3" />
             {!readOnly &&
                 !filterGroups.every(
                     (group) => filterGroups.filter((g) => g.variant === group.variant && g.variant !== null).length < 2

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
@@ -43,6 +43,8 @@ import {
     PropertyOperator,
 } from '~/types'
 
+import { FractionalRolloutWarning } from 'products/feature_flags/frontend/FractionalRolloutWarning'
+
 import { resolveAggregationGroupTypeIndex } from './aggregation'
 import { EARLY_ACCESS_GROUP_TARGETING_DISABLED_REASON, MATCHING_ESTIMATE_TOOLTIP } from './constants'
 import { featureFlagLogic } from './featureFlagLogic'
@@ -583,6 +585,11 @@ export function FeatureFlagReleaseConditions({
                     it.
                 </LemonBanner>
             )}
+            <FractionalRolloutWarning
+                filterGroups={filterGroups}
+                evaluationRuntime={evaluationRuntime}
+                className="mb-3"
+            />
             {!readOnly &&
                 !filterGroups.every(
                     (group) => filterGroups.filter((g) => g.variant === group.variant && g.variant !== null).length < 2

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
@@ -1121,7 +1121,7 @@ export function FeatureFlagReleaseConditionsCollapsible({
 
             <FeatureFlagConditionWarning properties={properties} evaluationRuntime={evaluationRuntime} />
 
-            <FractionalRolloutWarning filterGroups={filterGroups} evaluationRuntime={evaluationRuntime} />
+            <FractionalRolloutWarning filterGroups={filterGroups} />
 
             {flagId && <IntentWarningsBanner flagId={flagId} />}
 

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
@@ -71,6 +71,7 @@ import {
 } from '~/types'
 
 import { INTENT_METADATA } from 'products/feature_flags/frontend/featureFlagTemplateConstants'
+import { FractionalRolloutWarning } from 'products/feature_flags/frontend/FractionalRolloutWarning'
 
 import { resolveAggregationGroupTypeIndex } from './aggregation'
 import { EARLY_ACCESS_GROUP_TARGETING_DISABLED_REASON, MATCHING_ESTIMATE_TOOLTIP } from './constants'
@@ -1119,6 +1120,8 @@ export function FeatureFlagReleaseConditionsCollapsible({
             )}
 
             <FeatureFlagConditionWarning properties={properties} evaluationRuntime={evaluationRuntime} />
+
+            <FractionalRolloutWarning filterGroups={filterGroups} evaluationRuntime={evaluationRuntime} />
 
             {flagId && <IntentWarningsBanner flagId={flagId} />}
 

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsReadonly.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsReadonly.tsx
@@ -152,7 +152,7 @@ export function FeatureFlagReleaseConditionsReadonly({
 
             <FeatureFlagConditionWarning properties={properties} evaluationRuntime={evaluationRuntime} />
 
-            <FractionalRolloutWarning filterGroups={filterGroups} evaluationRuntime={evaluationRuntime} />
+            <FractionalRolloutWarning filterGroups={filterGroups} />
 
             <div className={isDisabled ? 'opacity-60' : ''}>
                 {filterGroups.map((group, index) => (

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsReadonly.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsReadonly.tsx
@@ -18,6 +18,8 @@ import {
     PropertyFilterType,
 } from '~/types'
 
+import { FractionalRolloutWarning } from 'products/feature_flags/frontend/FractionalRolloutWarning'
+
 import { EarlyExitIndicator } from './EarlyExitIndicator'
 import { FeatureFlagConditionWarning } from './FeatureFlagConditionWarning'
 import {
@@ -149,6 +151,8 @@ export function FeatureFlagReleaseConditionsReadonly({
             {filters.early_exit && <EarlyExitIndicator />}
 
             <FeatureFlagConditionWarning properties={properties} evaluationRuntime={evaluationRuntime} />
+
+            <FractionalRolloutWarning filterGroups={filterGroups} evaluationRuntime={evaluationRuntime} />
 
             <div className={isDisabled ? 'opacity-60' : ''}>
                 {filterGroups.map((group, index) => (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3272,6 +3272,9 @@ importers:
       '@posthog/icons':
         specifier: 'catalog:'
         version: 0.38.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@testing-library/jest-dom':
+        specifier: '*'
+        version: 5.17.0
       '@types/react':
         specifier: 18.3.27
         version: 18.3.27
@@ -3300,6 +3303,9 @@ importers:
       '@storybook/react':
         specifier: 'catalog:'
         version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
+      '@testing-library/react':
+        specifier: ^14.3.1
+        version: 14.3.1(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       kea-test-utils:
         specifier: 'catalog:'
         version: 0.2.4(kea@4.0.0-pre.6(patch_hash=139b8d1f1304f9d9da452a9a1244c94ea679dbcb85687d8999563146879fb6f5)(react@18.3.1))

--- a/products/feature_flags/frontend/FractionalRolloutWarning.test.tsx
+++ b/products/feature_flags/frontend/FractionalRolloutWarning.test.tsx
@@ -1,0 +1,77 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render } from '@testing-library/react'
+import { Provider } from 'kea'
+
+import { initKeaTests } from '~/test/init'
+import { FeatureFlagEvaluationRuntime, FeatureFlagGroupType } from '~/types'
+
+import { FractionalRolloutWarning, fractionalRolloutPercentages } from './FractionalRolloutWarning'
+
+function group(rollout_percentage: number | null): FeatureFlagGroupType {
+    return { properties: [], rollout_percentage, variant: null, sort_key: `group-${rollout_percentage}` }
+}
+
+function renderWarning(
+    filterGroups: FeatureFlagGroupType[],
+    evaluationRuntime?: FeatureFlagEvaluationRuntime
+): HTMLElement {
+    const { container } = render(
+        <Provider>
+            <FractionalRolloutWarning filterGroups={filterGroups} evaluationRuntime={evaluationRuntime} />
+        </Provider>
+    )
+    return container
+}
+
+describe('fractionalRolloutPercentages', () => {
+    it('picks out only percentages that are not whole numbers', () => {
+        expect(fractionalRolloutPercentages([group(100), group(0.5), group(0), group(33.33)])).toEqual([0.5, 33.33])
+    })
+
+    it('ignores null and missing rollout percentages', () => {
+        expect(fractionalRolloutPercentages([group(null), {}])).toEqual([])
+        expect(fractionalRolloutPercentages(undefined)).toEqual([])
+    })
+})
+
+describe('FractionalRolloutWarning', () => {
+    beforeEach(() => {
+        initKeaTests()
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    it('warns and names the offending percentage', () => {
+        renderWarning([group(100), group(0.5)])
+
+        expect(document.body).toHaveTextContent('fractional rollout percentage (0.5%)')
+        expect(document.body).toHaveTextContent('every flag in the project')
+    })
+
+    it('lists every offending percentage when several condition sets are fractional', () => {
+        renderWarning([group(0.5), group(33.33)])
+
+        expect(document.body).toHaveTextContent('(0.5%, 33.33%)')
+    })
+
+    it('stays silent when every rollout percentage is a whole number', () => {
+        expect(renderWarning([group(100), group(0), group(50)])).toBeEmptyDOMElement()
+    })
+
+    // Local evaluation is server-side only, so a client-only flag never parses the definitions payload.
+    it('stays silent for client-only flags', () => {
+        expect(renderWarning([group(0.5)], FeatureFlagEvaluationRuntime.CLIENT)).toBeEmptyDOMElement()
+    })
+
+    it.each([FeatureFlagEvaluationRuntime.SERVER, FeatureFlagEvaluationRuntime.ALL])(
+        'warns for the %s evaluation runtime',
+        (evaluationRuntime) => {
+            renderWarning([group(0.5)], evaluationRuntime)
+
+            expect(document.body).toHaveTextContent('fractional rollout percentage')
+        }
+    )
+})

--- a/products/feature_flags/frontend/FractionalRolloutWarning.test.tsx
+++ b/products/feature_flags/frontend/FractionalRolloutWarning.test.tsx
@@ -8,9 +8,22 @@ import { FeatureFlagGroupType } from '~/types'
 
 import { FractionalRolloutWarning, fractionalRolloutPercentages } from './FractionalRolloutWarning'
 
-function group(rollout_percentage: number | null): FeatureFlagGroupType {
-    return { properties: [], rollout_percentage, variant: null, sort_key: `group-${rollout_percentage}` }
+function group(rollout_percentage: number | null, variant: string | null = null): FeatureFlagGroupType {
+    return { properties: [], rollout_percentage, variant, sort_key: `group-${rollout_percentage}-${variant}` }
 }
+
+// A condition group can carry a variant override. The group's own rollout is what breaks the parse,
+// so the override must not change whether the warning fires.
+const variantOverrideCases: [number, boolean][] = [
+    [0.5, true],
+    [50, false],
+]
+
+// Flags saved through the API carry more precision than the editor's two decimal places allows.
+const precisionCases: [number, string][] = [
+    [33.333333333333336, '(33.33%)'],
+    [0.00015, '(0.00015%)'],
+]
 
 function renderWarning(filterGroups: FeatureFlagGroupType[]): HTMLElement {
     const { container } = render(
@@ -45,18 +58,32 @@ describe('FractionalRolloutWarning', () => {
         it('warns and names the offending percentage', () => {
             renderWarning([group(100), group(0.5)])
 
-            expect(document.body).toHaveTextContent('fractional rollout percentage (0.5%)')
+            expect(document.body).toHaveTextContent('This flag has a fractional rollout percentage (0.5%)')
             expect(document.body).toHaveTextContent('every flag in the project')
         })
 
-        it('lists every offending percentage when several condition sets are fractional', () => {
+        it('pluralizes and lists every percentage when several condition sets are fractional', () => {
             renderWarning([group(0.5), group(33.33)])
 
-            expect(document.body).toHaveTextContent('(0.5%, 33.33%)')
+            expect(document.body).toHaveTextContent('This flag has fractional rollout percentages (0.5%, 33.33%)')
         })
 
         it('stays silent when every rollout percentage is a whole number', () => {
             expect(renderWarning([group(100), group(0), group(50)])).toBeEmptyDOMElement()
+        })
+
+        it.each(variantOverrideCases)('with rollout %s on a group targeting a variant, warns: %s', (rollout, warns) => {
+            const container = renderWarning([group(rollout, 'test')])
+
+            if (warns) {
+                expect(container).toHaveTextContent('fractional rollout percentage')
+            } else {
+                expect(container).toBeEmptyDOMElement()
+            }
+        })
+
+        it.each(precisionCases)('trims %s for display without rounding it to zero', (rollout, expected) => {
+            expect(renderWarning([group(rollout)])).toHaveTextContent(expected)
         })
     })
 })

--- a/products/feature_flags/frontend/FractionalRolloutWarning.test.tsx
+++ b/products/feature_flags/frontend/FractionalRolloutWarning.test.tsx
@@ -4,7 +4,7 @@ import { cleanup, render } from '@testing-library/react'
 import { Provider } from 'kea'
 
 import { initKeaTests } from '~/test/init'
-import { FeatureFlagEvaluationRuntime, FeatureFlagGroupType } from '~/types'
+import { FeatureFlagGroupType } from '~/types'
 
 import { FractionalRolloutWarning, fractionalRolloutPercentages } from './FractionalRolloutWarning'
 
@@ -12,13 +12,10 @@ function group(rollout_percentage: number | null): FeatureFlagGroupType {
     return { properties: [], rollout_percentage, variant: null, sort_key: `group-${rollout_percentage}` }
 }
 
-function renderWarning(
-    filterGroups: FeatureFlagGroupType[],
-    evaluationRuntime?: FeatureFlagEvaluationRuntime
-): HTMLElement {
+function renderWarning(filterGroups: FeatureFlagGroupType[]): HTMLElement {
     const { container } = render(
         <Provider>
-            <FractionalRolloutWarning filterGroups={filterGroups} evaluationRuntime={evaluationRuntime} />
+            <FractionalRolloutWarning filterGroups={filterGroups} />
         </Provider>
     )
     return container
@@ -60,18 +57,4 @@ describe('FractionalRolloutWarning', () => {
     it('stays silent when every rollout percentage is a whole number', () => {
         expect(renderWarning([group(100), group(0), group(50)])).toBeEmptyDOMElement()
     })
-
-    // Local evaluation is server-side only, so a client-only flag never parses the definitions payload.
-    it('stays silent for client-only flags', () => {
-        expect(renderWarning([group(0.5)], FeatureFlagEvaluationRuntime.CLIENT)).toBeEmptyDOMElement()
-    })
-
-    it.each([FeatureFlagEvaluationRuntime.SERVER, FeatureFlagEvaluationRuntime.ALL])(
-        'warns for the %s evaluation runtime',
-        (evaluationRuntime) => {
-            renderWarning([group(0.5)], evaluationRuntime)
-
-            expect(document.body).toHaveTextContent('fractional rollout percentage')
-        }
-    )
 })

--- a/products/feature_flags/frontend/FractionalRolloutWarning.test.tsx
+++ b/products/feature_flags/frontend/FractionalRolloutWarning.test.tsx
@@ -21,17 +21,6 @@ function renderWarning(filterGroups: FeatureFlagGroupType[]): HTMLElement {
     return container
 }
 
-describe('fractionalRolloutPercentages', () => {
-    it('picks out only percentages that are not whole numbers', () => {
-        expect(fractionalRolloutPercentages([group(100), group(0.5), group(0), group(33.33)])).toEqual([0.5, 33.33])
-    })
-
-    it('ignores null and missing rollout percentages', () => {
-        expect(fractionalRolloutPercentages([group(null), {}])).toEqual([])
-        expect(fractionalRolloutPercentages(undefined)).toEqual([])
-    })
-})
-
 describe('FractionalRolloutWarning', () => {
     beforeEach(() => {
         initKeaTests()
@@ -41,20 +30,33 @@ describe('FractionalRolloutWarning', () => {
         cleanup()
     })
 
-    it('warns and names the offending percentage', () => {
-        renderWarning([group(100), group(0.5)])
+    describe('fractionalRolloutPercentages', () => {
+        it('picks out only percentages that are not whole numbers', () => {
+            expect(fractionalRolloutPercentages([group(100), group(0.5), group(0), group(33.33)])).toEqual([0.5, 33.33])
+        })
 
-        expect(document.body).toHaveTextContent('fractional rollout percentage (0.5%)')
-        expect(document.body).toHaveTextContent('every flag in the project')
+        it('ignores null and missing rollout percentages', () => {
+            expect(fractionalRolloutPercentages([group(null), {}])).toEqual([])
+            expect(fractionalRolloutPercentages(undefined)).toEqual([])
+        })
     })
 
-    it('lists every offending percentage when several condition sets are fractional', () => {
-        renderWarning([group(0.5), group(33.33)])
+    describe('rendering', () => {
+        it('warns and names the offending percentage', () => {
+            renderWarning([group(100), group(0.5)])
 
-        expect(document.body).toHaveTextContent('(0.5%, 33.33%)')
-    })
+            expect(document.body).toHaveTextContent('fractional rollout percentage (0.5%)')
+            expect(document.body).toHaveTextContent('every flag in the project')
+        })
 
-    it('stays silent when every rollout percentage is a whole number', () => {
-        expect(renderWarning([group(100), group(0), group(50)])).toBeEmptyDOMElement()
+        it('lists every offending percentage when several condition sets are fractional', () => {
+            renderWarning([group(0.5), group(33.33)])
+
+            expect(document.body).toHaveTextContent('(0.5%, 33.33%)')
+        })
+
+        it('stays silent when every rollout percentage is a whole number', () => {
+            expect(renderWarning([group(100), group(0), group(50)])).toBeEmptyDOMElement()
+        })
     })
 })

--- a/products/feature_flags/frontend/FractionalRolloutWarning.tsx
+++ b/products/feature_flags/frontend/FractionalRolloutWarning.tsx
@@ -1,7 +1,7 @@
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { Link } from 'lib/lemon-ui/Link'
 
-import { FeatureFlagEvaluationRuntime, FeatureFlagGroupType } from '~/types'
+import { FeatureFlagGroupType } from '~/types'
 
 /** First SDK releases that deserialize a fractional rollout percentage. */
 const MIN_DOTNET_VERSION = '2.13.3'
@@ -18,21 +18,17 @@ export function fractionalRolloutPercentages(filterGroups: FeatureFlagGroupType[
         .filter((percentage): percentage is number => typeof percentage === 'number' && !Number.isInteger(percentage))
 }
 
-/** Warns that a fractional release-condition rollout breaks local evaluation on older SDKs. */
+/** Warns that a fractional release-condition rollout breaks local evaluation on older SDKs.
+ *
+ *  Not gated on the flag's evaluation runtime: the local evaluation payload carries client-only flags
+ *  too (SDKs filter by runtime only after parsing), so even a client-only flag breaks the parse. */
 export function FractionalRolloutWarning({
     filterGroups,
-    evaluationRuntime = FeatureFlagEvaluationRuntime.ALL,
     className,
 }: {
     filterGroups: FeatureFlagGroupType[] | undefined
-    evaluationRuntime?: FeatureFlagEvaluationRuntime
     className?: string
 }): JSX.Element | null {
-    // Local evaluation only runs in server-side SDKs, so a client-only flag can't hit this.
-    if (evaluationRuntime === FeatureFlagEvaluationRuntime.CLIENT) {
-        return null
-    }
-
     const percentages = fractionalRolloutPercentages(filterGroups)
     if (percentages.length === 0) {
         return null

--- a/products/feature_flags/frontend/FractionalRolloutWarning.tsx
+++ b/products/feature_flags/frontend/FractionalRolloutWarning.tsx
@@ -1,0 +1,53 @@
+import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
+import { Link } from 'lib/lemon-ui/Link'
+
+import { FeatureFlagEvaluationRuntime, FeatureFlagGroupType } from '~/types'
+
+/** First SDK releases that deserialize a fractional rollout percentage. */
+const MIN_DOTNET_VERSION = '2.13.3'
+const MIN_JAVA_VERSION = '2.12.1'
+
+/** Release-condition rollout percentages that aren't whole numbers.
+ *
+ *  Ignores multivariate variant rollouts on purpose: the SDKs that typed rollout percentages as
+ *  integers only did so for the condition group field, so fractional variant splits, which an even
+ *  three-way split can't avoid, parse everywhere. */
+export function fractionalRolloutPercentages(filterGroups: FeatureFlagGroupType[] | undefined): number[] {
+    return (filterGroups ?? [])
+        .map((group) => group.rollout_percentage)
+        .filter((percentage): percentage is number => typeof percentage === 'number' && !Number.isInteger(percentage))
+}
+
+/** Warns that a fractional release-condition rollout breaks local evaluation on older SDKs. */
+export function FractionalRolloutWarning({
+    filterGroups,
+    evaluationRuntime = FeatureFlagEvaluationRuntime.ALL,
+    className,
+}: {
+    filterGroups: FeatureFlagGroupType[] | undefined
+    evaluationRuntime?: FeatureFlagEvaluationRuntime
+    className?: string
+}): JSX.Element | null {
+    // Local evaluation only runs in server-side SDKs, so a client-only flag can't hit this.
+    if (evaluationRuntime === FeatureFlagEvaluationRuntime.CLIENT) {
+        return null
+    }
+
+    const percentages = fractionalRolloutPercentages(filterGroups)
+    if (percentages.length === 0) {
+        return null
+    }
+
+    return (
+        <LemonBanner type="warning" className={className}>
+            This flag has a fractional rollout percentage ({percentages.join('%, ')}%). The .NET and Java server-side
+            SDKs read rollout percentages as whole numbers before .NET {MIN_DOTNET_VERSION} and Java {MIN_JAVA_VERSION}.
+            On an older version the flag definitions payload fails to parse, so local evaluation stops working for{' '}
+            <strong>every flag in the project</strong> and each evaluation goes to the <code>/flags</code> endpoint
+            instead. Upgrade those SDKs, or use a whole number here.{' '}
+            <Link to="https://posthog.com/docs/feature-flags/local-evaluation" target="_blank">
+                Learn more about local evaluation
+            </Link>
+        </LemonBanner>
+    )
+}

--- a/products/feature_flags/frontend/FractionalRolloutWarning.tsx
+++ b/products/feature_flags/frontend/FractionalRolloutWarning.tsx
@@ -18,6 +18,14 @@ export function fractionalRolloutPercentages(filterGroups: FeatureFlagGroupType[
         .filter((percentage): percentage is number => typeof percentage === 'number' && !Number.isInteger(percentage))
 }
 
+/** Trims a stored rollout to something readable. A flag saved through the API can carry far more
+ *  precision than the editor's two decimal places, and 33.333333333333336 reads as a bug rather
+ *  than a warning. Significant digits rather than fixed decimals, so a sub-0.01 rollout such as
+ *  0.00015 doesn't render as 0. */
+function formatPercentage(percentage: number): string {
+    return `${Number(percentage.toPrecision(4))}%`
+}
+
 /** Warns that a fractional release-condition rollout breaks local evaluation on older SDKs.
  *
  *  Not gated on the flag's evaluation runtime: the local evaluation payload carries client-only flags
@@ -34,13 +42,18 @@ export function FractionalRolloutWarning({
         return null
     }
 
+    const formatted = percentages.map(formatPercentage).join(', ')
+
     return (
         <LemonBanner type="warning" className={className}>
-            This flag has a fractional rollout percentage ({percentages.join('%, ')}%). The .NET and Java server-side
-            SDKs read rollout percentages as whole numbers before .NET {MIN_DOTNET_VERSION} and Java {MIN_JAVA_VERSION}.
-            On an older version the flag definitions payload fails to parse, so local evaluation stops working for{' '}
-            <strong>every flag in the project</strong> and each evaluation goes to the <code>/flags</code> endpoint
-            instead. Upgrade those SDKs, or use a whole number here.{' '}
+            {percentages.length === 1
+                ? `This flag has a fractional rollout percentage (${formatted}).`
+                : `This flag has fractional rollout percentages (${formatted}).`}{' '}
+            The .NET and Java server-side SDKs read rollout percentages as whole numbers before .NET{' '}
+            {MIN_DOTNET_VERSION} and Java {MIN_JAVA_VERSION}. On an older version the flag definitions payload fails to
+            parse, so local evaluation stops working for <strong>every flag in the project</strong> and each evaluation
+            goes to the <code>/flags</code> endpoint instead. Upgrade those SDKs, or change the rollout to a whole
+            number.{' '}
             <Link to="https://posthog.com/docs/feature-flags/local-evaluation" target="_blank">
                 Learn more about local evaluation
             </Link>

--- a/products/feature_flags/package.json
+++ b/products/feature_flags/package.json
@@ -11,11 +11,14 @@
     },
     "devDependencies": {
         "@storybook/react": "catalog:",
+        "@testing-library/react": "^14.3.1",
         "kea-test-utils": "catalog:"
     },
     "peerDependencies": {
         "@posthog/brand": "catalog:",
         "@posthog/icons": "catalog:",
+        "@testing-library/jest-dom": "*",
+        "@testing-library/react": "*",
         "@types/react": "*",
         "clsx": "*",
         "fuse.js": "*",


### PR DESCRIPTION
## Problem

Someone editing a feature flag can set a release condition rollout to a fractional percentage such as 0.5%, and nothing in the UI says older server-side SDKs cannot read it. On .NET before 2.13.3 and Java before 2.12.1 the flag definitions payload fails to parse, so local evaluation stops working for every flag in the project and each evaluation goes to `/flags` instead. The edited flag looks fine, so the breakage surfaces as unexplained request volume from a service nobody was touching.

Variant splits are not affected. Those SDKs typed only the condition group field as an integer, so a fractional variant split, which an even three-way split cannot avoid, has always parsed. A warning that fired on variants would be noise.

Follows the write-path fix in #84957 and the backfill in #85042. Those stop whole numbers being widened to `100.0`; they cannot help a flag whose rollout is genuinely fractional, which is what this warns about.

## Changes

- Editing a flag whose release condition rollout is not a whole number now shows a warning above the release conditions. It names each offending percentage, both minimum SDK versions, and says local evaluation stops for every flag in the project.
- The warning shows regardless of the flag's evaluation runtime. The local evaluation payload carries client-only flags too, and the SDKs filter by runtime only after parsing the whole document, so a client-only flag with a fractional rollout still breaks the parse.
- The warning ignores multivariate variant rollouts, so an even three-way split does not trigger it.
- Mechanical: new component and test under `products/feature_flags/frontend/`, rendered from the three existing release-condition surfaces (editor, collapsible, and readonly). `@testing-library/react` joins the product's devDependencies so a component test can run there, matching how `products/ai_observability` is set up.

No screenshot captured: this environment had no browser available, so the rendering was not checked visually. The warning is a standard `LemonBanner type="warning"`, placed where the existing local-evaluation condition warning already sits.

## How did you test this code?

Automated only. No manual browser check was run.

- New `FractionalRolloutWarning.test.tsx` covers the regressions no existing suite caught: a fractional group rollout warns and names every offending value, several fractional condition sets are all listed, and a whole-number rollout stays silent.
- Ran the feature flag product and scene suites and the repo-wide TypeScript check locally, both clean for these files. CI reports the counts with more authority.
- Not checked: how the banner renders in a browser, and the copy with a designer.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs page currently states which SDK versions read a fractional rollout percentage, so the warning links to the general local evaluation page. Worth a short note on that page as a follow-up.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude Opus 5) from the Slack thread linked below, where a flag owner asked for this warning after the wire-format change was traced. Assignee is deliberately unset: the person who directed the work was identified only by their Slack display name, and guessing a GitHub handle from that risks tagging an unrelated account. The requester should self-assign as DRI.

Repo skills consulted while producing this: `/writing-user-facing-copy` (which caught em-dashes in the first draft of the banner copy, and a "not just this one" antithesis), `/placing-product-frontend-code` (its `scene_product_split.py` script reported feature flags as mid-migration and sent the new files to `products/feature_flags/frontend/` rather than `frontend/src/scenes/feature-flags/`), `/writing-pr-descriptions`, and the frontend guide's reuse rule, which is why this is a `LemonBanner` rather than a hand-rolled callout.

Two decisions worth a reviewer's attention. The warning was first written as an extra entry in the existing `featureFlagConditionWarningLogic` issue list; that was wrong, because that component's copy promises the flag still works normally through the API, whereas this failure disables local evaluation project-wide. It became a sibling component instead. Scoping it to condition groups rather than all rollout percentages came from reading the two SDK fixes: `posthog-dotnet` [#292](https://github.com/PostHog/posthog-dotnet/pull/292) and `posthog-android` [#699](https://github.com/PostHog/posthog-android/pull/699) each widened exactly one field, and the variant field was already a float in both.

Nothing in this PR carries material from the originating session that is not already public: no customer names, ticket contents, quoted thread text, or usage figures. The example percentages in the copy and tests are invented.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACMS2BNTU/p1787085798435629?thread_ts=1787085798.435629&cid=C0ACMS2BNTU)*

