### PR TITLE
fix(slack-app): ignore mentions glued to a package path

### DIFF
--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -1158,6 +1158,28 @@ def _app_authorship_ignore_reason(event: dict[str, Any]) -> str | None:
     return None
 
 
+_MENTION_WITH_TRAILING_SLASH_RE = re.compile(r"<@[A-Z0-9]+>(/?)")
+
+
+def _every_mention_is_a_path_segment(event: dict[str, Any]) -> bool:
+    """Whether every user mention in the text is glued to a following ``/``.
+
+    Slack linkifies a typed ``@PostHog`` even inside an org-scoped package or repo path, so
+    ``@PostHog/react-native-plugin`` reaches us as ``<@BOT>/react-native-plugin`` and fires a
+    real ``app_mention``. Nobody addressed the app in that message, they named a package, and
+    answering it starts an agent run against a prompt that is only the path's tail.
+
+    Requiring *every* mention to be glued keeps this from firing on a message that also tags
+    the app properly, because the app's own mention can't be told apart from a teammate's
+    without a ``users.info`` round-trip that this gate runs too early to afford.
+    """
+    text = event.get("text")
+    if not isinstance(text, str):
+        return False
+    trailing_slashes = _MENTION_WITH_TRAILING_SLASH_RE.findall(text)
+    return bool(trailing_slashes) and all(trailing_slashes)
+
+
 def _app_mention_ignore_reason(event: dict[str, Any]) -> str | None:
     """Return a short reason if this app_mention shouldn't trigger the coding agent, else None.
 
@@ -1167,10 +1189,16 @@ def _app_mention_ignore_reason(event: dict[str, Any]) -> str | None:
     - "bot_author" / "app_authored": see ``_app_authorship_ignore_reason``. Foreign bots
       that quote `<@PostHog>` in their text (incident bots, alert relays, our own
       notifications integration) would trigger reply loops on every re-post.
+    - "path_mention": see ``_every_mention_is_a_path_segment``.
     """
     if event.get("edited") or event.get("subtype") == "message_changed":
         return "edit"
-    return _app_authorship_ignore_reason(event)
+    authorship = _app_authorship_ignore_reason(event)
+    if authorship:
+        return authorship
+    if _every_mention_is_a_path_segment(event):
+        return "path_mention"
+    return None
 
 
 def _thread_message_event_has_files(event: dict[str, Any]) -> bool:

--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -1180,6 +1180,23 @@ def _every_mention_is_a_path_segment(event: dict[str, Any]) -> bool:
     return bool(trailing_slashes) and all(trailing_slashes)
 
 
+def _path_mention_drop_properties(event: dict[str, Any]) -> dict[str, Any]:
+    """Analytics context specific to a ``path_mention`` drop.
+
+    The drop count on its own can't separate a harmless package paste from a real request
+    the gate ate, so it can't tell us whether the gate is tuned right. Word count splits
+    them: a message that is only ``@PostHog/posthog-js`` counts one word, and anything
+    higher means prose surrounded the path, which is the shape worth reviewing.
+    """
+    text = event.get("text")
+    if not isinstance(text, str):
+        text = ""
+    return {
+        "slack_mention_count": len(_MENTION_WITH_TRAILING_SLASH_RE.findall(text)),
+        "slack_message_word_count": len(text.split()),
+    }
+
+
 def _app_mention_ignore_reason(event: dict[str, Any]) -> str | None:
     """Return a short reason if this app_mention shouldn't trigger the coding agent, else None.
 
@@ -1988,14 +2005,20 @@ def route_posthog_code_event_to_relevant_region(
         if event_type == "app_mention":
             ignore_reason = _app_mention_ignore_reason(event)
             if ignore_reason:
+                drop_context: dict[str, Any] = (
+                    _path_mention_drop_properties(event) if ignore_reason == "path_mention" else {}
+                )
                 logger.info(
                     "slack_app_event_app_mention_ignored",
                     reason=ignore_reason,
                     slack_team_id=slack_team_id,
                     channel=event.get("channel"),
                     message_ts=event.get("ts"),
+                    **drop_context,
                 )
-                _report_slack_mention_dropped(event, slack_team_id, reason=f"ignored:{ignore_reason}", replied=False)
+                _report_slack_mention_dropped(
+                    event, slack_team_id, reason=f"ignored:{ignore_reason}", replied=False, **drop_context
+                )
                 return ROUTE_HANDLED_LOCALLY
         else:
             ignore_reason = _thread_message_ignore_reason(event)

--- a/products/slack_app/backend/tests/test_posthog_code_event_handler.py
+++ b/products/slack_app/backend/tests/test_posthog_code_event_handler.py
@@ -419,16 +419,29 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
 
     @parameterized.expand(
         [
-            ("edited_field", {"edited": {"user": "U123", "ts": "1234.7777"}}, "ignored:edit"),
-            ("message_changed_subtype", {"subtype": "message_changed"}, "ignored:edit"),
-            ("bot_id", {"bot_id": "B0ALERT"}, "ignored:bot_author"),
-            ("bot_profile", {"bot_profile": {"name": "Mendral", "id": "B0ALERT"}}, "ignored:bot_author"),
+            ("edited_field", {"edited": {"user": "U123", "ts": "1234.7777"}}, "ignored:edit", {}),
+            ("message_changed_subtype", {"subtype": "message_changed"}, "ignored:edit", {}),
+            ("bot_id", {"bot_id": "B0ALERT"}, "ignored:bot_author", {}),
+            ("bot_profile", {"bot_profile": {"name": "Mendral", "id": "B0ALERT"}}, "ignored:bot_author", {}),
             # Still dropped, but under its own reason so the volume of app-posted-as-a-human
             # mentions is measurable rather than hidden inside the bot bucket.
-            ("app_id", {"app_id": "A0ALERT"}, "ignored:app_authored"),
-            ("bot_message_subtype", {"subtype": "bot_message"}, "ignored:bot_author"),
-            ("slackbot_user", {"user": "USLACKBOT"}, "ignored:bot_author"),
-            ("path_mention", {"text": "<@U0BOT>/react-native-plugin"}, "ignored:path_mention"),
+            ("app_id", {"app_id": "A0ALERT"}, "ignored:app_authored", {}),
+            ("bot_message_subtype", {"subtype": "bot_message"}, "ignored:bot_author", {}),
+            ("slackbot_user", {"user": "USLACKBOT"}, "ignored:bot_author", {}),
+            # The word count is what tells a bare package paste from a real request the gate
+            # ate, so it has to survive onto the captured event, not just the log line.
+            (
+                "path_mention",
+                {"text": "<@U0BOT>/react-native-plugin"},
+                "ignored:path_mention",
+                {"slack_mention_count": 1, "slack_message_word_count": 1},
+            ),
+            (
+                "path_mention_with_prose",
+                {"text": "have a look at <@U0BOT>/posthog-js"},
+                "ignored:path_mention",
+                {"slack_mention_count": 1, "slack_message_word_count": 5},
+            ),
         ]
     )
     @patch("products.slack_app.backend.api.posthoganalytics.capture")
@@ -440,6 +453,7 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
         _name,
         ignore_marker: dict,
         expected_drop_reason: str,
+        expected_extra_properties: dict,
         mock_sync_connect,
         mock_asyncio_run,
         mock_capture,
@@ -465,6 +479,8 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
         assert capture_kwargs["event"] == SLACK_MENTION_DROPPED_EVENT
         assert capture_kwargs["properties"]["drop_reason"] == expected_drop_reason
         assert capture_kwargs["properties"]["replied"] is False
+        for key, value in expected_extra_properties.items():
+            assert capture_kwargs["properties"][key] == value
 
     @patch("products.slack_app.backend.api.posthoganalytics.capture")
     @patch("products.slack_app.backend.api._post_slack_user_feedback")

--- a/products/slack_app/backend/tests/test_posthog_code_event_handler.py
+++ b/products/slack_app/backend/tests/test_posthog_code_event_handler.py
@@ -47,6 +47,25 @@ class TestLinkSharedUrlRegion(SimpleTestCase):
         assert _link_shared_url_region(event) == expected
 
 
+class TestAppMentionIgnoreReason(SimpleTestCase):
+    @parameterized.expand(
+        [
+            ("package_path_only", "<@U0BOT>/react-native-plugin", "path_mention"),
+            ("repo_path_mid_sentence", "have a look at <@U0BOT>/posthog-js", "path_mention"),
+            # A glued path alongside a real tag means somebody is addressing the app for real,
+            # and we can't tell which of the two mentions is ours without a users.info call.
+            ("path_plus_tagged_mention", "<@U0BOT>/posthog-js is broken <@U0BOT> fix it", None),
+            ("plain_mention", "<@U0BOT> fix the login redirect", None),
+            ("no_mention", "fix the login redirect", None),
+        ]
+    )
+    def test_mentions_glued_to_a_path_are_ignored(self, _name: str, text: str, expected: str | None) -> None:
+        from products.slack_app.backend.api import _app_mention_ignore_reason
+
+        event = {"type": "app_mention", "channel": "C001", "user": "U123", "ts": "1234.5678", "text": text}
+        assert _app_mention_ignore_reason(event) == expected
+
+
 class TestPostHogCodeEventHandler(SimpleTestCase):
     def setUp(self):
         self.client = APIClient()
@@ -409,6 +428,7 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
             ("app_id", {"app_id": "A0ALERT"}, "ignored:app_authored"),
             ("bot_message_subtype", {"subtype": "bot_message"}, "ignored:bot_author"),
             ("slackbot_user", {"user": "USLACKBOT"}, "ignored:bot_author"),
+            ("path_mention", {"text": "<@U0BOT>/react-native-plugin"}, "ignored:path_mention"),
         ]
     )
     @patch("products.slack_app.backend.api.posthoganalytics.capture")

--- a/products/slack_app/backend/tests/test_posthog_code_event_handler.py
+++ b/products/slack_app/backend/tests/test_posthog_code_event_handler.py
@@ -16,6 +16,7 @@ from posthog.models.organization import Organization, OrganizationMembership
 from posthog.models.team.team import Team
 from posthog.models.user import User
 
+from products.slack_app.backend.api import _app_mention_ignore_reason
 from products.slack_app.backend.models import SlackSettings, SlackUserProfileCache
 from products.slack_app.backend.tests.helpers import sign_slack_request
 
@@ -60,8 +61,6 @@ class TestAppMentionIgnoreReason(SimpleTestCase):
         ]
     )
     def test_mentions_glued_to_a_path_are_ignored(self, _name: str, text: str, expected: str | None) -> None:
-        from products.slack_app.backend.api import _app_mention_ignore_reason
-
         event = {"type": "app_mention", "channel": "C001", "user": "U123", "ts": "1234.5678", "text": text}
         assert _app_mention_ignore_reason(event) == expected
 


### PR DESCRIPTION
## Problem

Writing a package name like `@PostHog/react-native-plugin` in Slack starts an agent run nobody asked for.

- Slack turns the `@PostHog` prefix into a real mention of the app, so an `app_mention` event fires.
- The router only drops edits and app-posted messages, so the run proceeds against a prompt that is just the path's tail.
- The "Thread follow-ups" setting in the Home tab does not help, because it only covers replies that tag nobody.

## Changes

- A mention that sits directly before a `/` no longer draws a reply or an agent run.
- A message that names a package and also tags the app properly still runs, because the gate needs every mention in the text to be glued.
- The gate runs first in the mention path, so a dropped event costs no Slack call and no database query.
- The drop reports as `ignored:path_mention` through the existing mention-dropped analytics event.
- The rejected alternative was matching the app's own user id from the event envelope, where a wrong id turns into a silent drop.
- Backend only, so nothing looks different and there is nothing to screenshot.

## How did you test this code?

- `TestAppMentionIgnoreReason` covers the glue rule without a database. It catches a regression that lets `@PostHog/posthog-js` through, and the opposite one that drops a message which also tags the app properly.
- One case added to `test_app_mention_ignored_does_not_start_workflow`. It guards the wiring, that the router drops the event before starting a workflow and records the drop reason.
- Ran the three slack_app routing suites and repo-wide mypy locally. Not run: the rest of the backend suite, and any live Slack test, because this sandbox has no Slack workspace.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The only Slack doc covers local setup scopes, which this does not change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A teammate reported this in Slack, from a thread the accidental mention itself opened. Their Home tab follow-up setting was already "leave them alone", which ruled out the untagged-followup path and pointed at the `app_mention` gate instead. The PR is unassigned because their GitHub handle was not verified in this session.

Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1787143622387769?thread_ts=1787143622.387769&cid=C09SK2PAGKF)*
