### PR TITLE
fix(desktop): keep the right panel closed once someone closes it

### DIFF
--- a/products/desktop/packages/ui/src/features/navigation/components/RightPanel.tsx
+++ b/products/desktop/packages/ui/src/features/navigation/components/RightPanel.tsx
@@ -87,11 +87,13 @@ function useRightPanelTask(taskId: string): Task | null {
 /** Which panel this session has open. */
 function useActiveSide(taskId: string): RightPanelSide | null {
   const stored = useRightPanelStore((s) => s.sideByKey[taskId]);
+  const closedByDefault = useRightPanelStore((s) => s.closedByDefault);
   const reviewMode = useReviewNavigationStore(
     (s) => s.reviewModes[taskId] ?? "closed",
   );
   return resolveRightPanelSide({
     stored,
+    closedByDefault,
     isReviewOpen: reviewMode !== "closed",
   });
 }

--- a/products/desktop/packages/ui/src/features/navigation/rightPanelSide.ts
+++ b/products/desktop/packages/ui/src/features/navigation/rightPanelSide.ts
@@ -26,8 +26,10 @@ export function openRightPanelSide(
 export function currentRightPanelSide(taskId: string): RightPanelSide | null {
   const reviewMode =
     useReviewNavigationStore.getState().reviewModes[taskId] ?? "closed";
+  const { sideByKey, closedByDefault } = useRightPanelStore.getState();
   return resolveRightPanelSide({
-    stored: useRightPanelStore.getState().sideByKey[taskId],
+    stored: sideByKey[taskId],
+    closedByDefault,
     isReviewOpen: reviewMode !== "closed",
   });
 }
@@ -52,12 +54,16 @@ export function useRightPanelOpen(taskId: string | undefined): boolean {
   const stored = useRightPanelStore((s) =>
     taskId ? s.sideByKey[taskId] : undefined,
   );
+  const closedByDefault = useRightPanelStore((s) => s.closedByDefault);
   const reviewMode = useReviewNavigationStore((s) =>
     taskId ? (s.reviewModes[taskId] ?? "closed") : "closed",
   );
   if (!taskId) return false;
   return (
-    resolveRightPanelSide({ stored, isReviewOpen: reviewMode !== "closed" }) !=
-    null
+    resolveRightPanelSide({
+      stored,
+      closedByDefault,
+      isReviewOpen: reviewMode !== "closed",
+    }) != null
   );
 }

--- a/products/desktop/packages/ui/src/features/navigation/rightPanelStore.test.ts
+++ b/products/desktop/packages/ui/src/features/navigation/rightPanelStore.test.ts
@@ -1,55 +1,123 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import {
+  DEFAULT_RIGHT_PANEL_SIDE,
   type RightPanelSide,
   resolveArtifactMark,
   resolveRightPanelSide,
+  useRightPanelStore,
 } from "./rightPanelStore";
 
 describe("resolveRightPanelSide", () => {
   it.each<{
     name: string;
     stored: RightPanelSide | null | undefined;
+    closedByDefault: boolean;
     isReviewOpen: boolean;
     expected: RightPanelSide | null;
   }>([
     {
       name: "an untouched session opens on the timeline",
       stored: undefined,
+      closedByDefault: false,
       isReviewOpen: false,
       expected: "timeline",
     },
     {
+      name: "a session opened after someone put the panel away stays closed",
+      stored: undefined,
+      closedByDefault: true,
+      isReviewOpen: false,
+      expected: null,
+    },
+    {
       name: "a session someone closed the panel on stays closed",
       stored: null,
+      closedByDefault: false,
       isReviewOpen: false,
       expected: null,
     },
     {
       name: "a session keeps the panel it was left on",
       stored: "artifacts",
+      closedByDefault: false,
+      isReviewOpen: false,
+      expected: "artifacts",
+    },
+    {
+      name: "a session left on a panel keeps it even after a close elsewhere",
+      stored: "artifacts",
+      closedByDefault: true,
       isReviewOpen: false,
       expected: "artifacts",
     },
     {
       name: "a review opened from elsewhere shows the changes",
       stored: "comments",
+      closedByDefault: false,
       isReviewOpen: true,
       expected: "changes",
     },
     {
       name: "a review opened on a session someone closed the panel on still shows",
       stored: null,
+      closedByDefault: false,
       isReviewOpen: true,
       expected: "changes",
     },
     {
       name: "a review closed from elsewhere closes the panel it was showing in",
       stored: "changes",
+      closedByDefault: false,
       isReviewOpen: false,
       expected: null,
     },
-  ])("$name", ({ stored, isReviewOpen, expected }) => {
-    expect(resolveRightPanelSide({ stored, isReviewOpen })).toBe(expected);
+  ])("$name", ({ stored, closedByDefault, isReviewOpen, expected }) => {
+    expect(
+      resolveRightPanelSide({ stored, closedByDefault, isReviewOpen }),
+    ).toBe(expected);
+  });
+});
+
+describe("setSideForKey", () => {
+  beforeEach(() => {
+    useRightPanelStore.setState({ sideByKey: {}, closedByDefault: false });
+  });
+
+  /** What a session nobody has touched would open on right now. */
+  const freshSessionSide = (): RightPanelSide | null =>
+    resolveRightPanelSide({
+      stored: undefined,
+      closedByDefault: useRightPanelStore.getState().closedByDefault,
+      isReviewOpen: false,
+    });
+
+  it.each<{
+    name: string;
+    sides: (RightPanelSide | null)[];
+    expected: RightPanelSide | null;
+  }>([
+    {
+      name: "closing a panel leaves the next session closed too",
+      sides: [null],
+      expected: null,
+    },
+    {
+      name: "opening one again brings the next session's panel back",
+      sides: [null, "comments"],
+      expected: DEFAULT_RIGHT_PANEL_SIDE,
+    },
+    {
+      // Changes rides the review store, so PR links and diff toggles open it
+      // without anyone reaching for the column.
+      name: "a review opening over a closed panel leaves it closed",
+      sides: [null, "changes"],
+      expected: null,
+    },
+  ])("$name", ({ sides, expected }) => {
+    for (const side of sides) {
+      useRightPanelStore.getState().setSideForKey("task-1", side);
+    }
+    expect(freshSessionSide()).toBe(expected);
   });
 });
 

--- a/products/desktop/packages/ui/src/features/navigation/rightPanelStore.ts
+++ b/products/desktop/packages/ui/src/features/navigation/rightPanelStore.ts
@@ -8,7 +8,7 @@ import { persist } from "zustand/middleware";
  */
 export type RightPanelSide = "timeline" | "artifacts" | "comments" | "changes";
 
-/** What a session opens on before anyone touches its panel. */
+/** The panel the column falls back to when it opens without a side of its own. */
 export const DEFAULT_RIGHT_PANEL_SIDE: RightPanelSide = "timeline";
 
 export const RIGHT_PANEL_MIN_WIDTH = 280;
@@ -20,10 +20,19 @@ interface RightPanelStore {
   /**
    * The panel each session (or the sessionless fallback key) has open, so
    * coming back to a session finds it as it was left. `null` is a panel someone
-   * closed; a missing entry is a session nobody has touched, which opens on the
-   * default. Not persisted, because this is within-run memory.
+   * closed; a missing entry is a session nobody has touched, which falls back to
+   * `closedByDefault`. Not persisted, because this is within-run memory.
    */
   sideByKey: Record<string, RightPanelSide | null | undefined>;
+  /**
+   * Whether a session nobody has touched opens with its panel away, following
+   * whichever someone did last: closing one turns this on, opening one turns it
+   * back off. Persisted, unlike `sideByKey`, because putting the panel away is a
+   * standing preference rather than a fact about one session - someone working
+   * in a narrow window closes it once and expects the sessions they open after
+   * that, this run and the next, to leave the width to the content.
+   */
+  closedByDefault: boolean;
   /**
    * How many artifacts a session had the last time its panel showed them, so
    * the switcher can mark the ones that arrived since. A missing entry is a
@@ -43,13 +52,16 @@ interface RightPanelStore {
  * wins, because every existing "open review" entry point (the command menu, PR
  * links, diff toggles) sets it and expects the changes to appear; then an
  * explicit choice, including the `null` of a panel someone closed; then the
- * default, so opening a session lands on its timeline rather than on nothing.
+ * timeline, unless the last thing anyone did to a panel was put it away, in
+ * which case a session opens leaving the width to its content.
  */
 export function resolveRightPanelSide({
   stored,
+  closedByDefault,
   isReviewOpen,
 }: {
   stored: RightPanelSide | null | undefined;
+  closedByDefault: boolean;
   isReviewOpen: boolean;
 }): RightPanelSide | null {
   if (isReviewOpen) return "changes";
@@ -60,7 +72,7 @@ export function resolveRightPanelSide({
   // has dropped its queries.
   if (stored === "changes") return null;
   if (stored !== undefined) return stored;
-  return DEFAULT_RIGHT_PANEL_SIDE;
+  return closedByDefault ? null : DEFAULT_RIGHT_PANEL_SIDE;
 }
 
 /**
@@ -100,12 +112,20 @@ export const useRightPanelStore = create<RightPanelStore>()(
       width: RIGHT_PANEL_DEFAULT_WIDTH,
       isResizing: false,
       sideByKey: {},
+      closedByDefault: false,
       seenArtifactCountByKey: {},
       setWidth: (width) =>
         set({ width: Math.max(RIGHT_PANEL_MIN_WIDTH, width) }),
       setIsResizing: (isResizing) => set({ isResizing }),
       setSideForKey: (key, side) =>
-        set((state) => ({ sideByKey: { ...state.sideByKey, [key]: side } })),
+        set((state) => ({
+          sideByKey: { ...state.sideByKey, [key]: side },
+          // Opening a review is not a vote on the panel: PR links and diff
+          // toggles open Changes without anyone reaching for the column, and
+          // resolving refuses to carry Changes into a session with no review
+          // open anyway. So a review leaves the preference where it was.
+          closedByDefault: side === "changes" ? state.closedByDefault : !side,
+        })),
       markArtifactsSeen: (key, count) =>
         set((state) =>
           state.seenArtifactCountByKey[key] === count
@@ -124,7 +144,10 @@ export const useRightPanelStore = create<RightPanelStore>()(
       // coalesces the burst behind its debounce instead of writing
       // synchronously on each one, the way every other panel store does.
       storage: electronStorage,
-      partialize: (state) => ({ width: state.width }),
+      partialize: (state) => ({
+        width: state.width,
+        closedByDefault: state.closedByDefault,
+      }),
     },
   ),
 );


### PR DESCRIPTION
## Problem

Someone who closes the right panel meets it open again on their next session, and closes it every time. The panel matters most to people running the app in a narrow window beside a browser, where the timeline takes width they want for the content.

The panel opened on the timeline for every session nobody had touched. A close was recorded per session and never persisted, so it held for that session only.

## Changes

- Closing the right panel keeps it closed on the sessions opened after it, this run and the next.
- Opening it again restores the timeline for later sessions, so the preference recovers without a settings toggle.
- A session someone already set a panel on still opens on that panel, unchanged.
- Opening a code review leaves the preference alone. PR links and diff toggles open Changes without anyone reaching for the column, and treating that as a vote would reopen the panel a person had put away.
- Mechanical: `resolveRightPanelSide` takes the new flag, and its three callers pass it.

Nothing looks different on a session whose panel is open, so there is no screenshot to compare. The change is which state a fresh session starts in.

## How did you test this code?

Automated only. `resolveRightPanelSide` and `setSideForKey` are covered by `rightPanelStore.test.ts`.

- Two resolver cases guard the fix itself: a session opened after a close stays closed, and a session already left on a panel keeps it even after a close elsewhere. Neither path existed before, because the fallback was a constant.
- Three store cases guard the flag's own logic through `setSideForKey`: a close carries to the next session, a reopen brings it back, and a review opening over a closed panel leaves it closed. The last one catches the Changes carve-out, whose absence would draw a Changes title over a session with no review running.

Not checked: the running Electron app. This sandbox has no display, so the persistence round trip across an app restart went unverified beyond `closedByDefault` reaching `partialize`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented workflow describes the panel's default state.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app from a request in a Slack thread. Skills invoked: `/writing-tests` and `/writing-pr-descriptions`.

The first version persisted the whole side (`preferredSide: RightPanelSide | null`), which made clicking an artifact chip on one task change which tab the next task opened on. Narrowing it to a boolean keeps the fix to open-versus-closed and leaves the timeline as the tab a reopened column shows.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1787147823350339?thread_ts=1787147823.350339&cid=C09G8Q32R6F)*
