### PR TITLE
feat(signals): report roster filter, search, and open-skill clicks on the scouts tab

### DIFF
--- a/products/signals/frontend/inbox/components/config/scouts/ScoutDetailHeader.tsx
+++ b/products/signals/frontend/inbox/components/config/scouts/ScoutDetailHeader.tsx
@@ -119,22 +119,28 @@ export function ScoutDetailHeader({
                     </LemonButton>
                 </Tooltip>
                 <ScoutSettingsButton config={config} surface="scout_detail" showLabel />
-                <Tooltip title="Open the skill that defines what this scout does">
-                    <LemonButton
-                        type="secondary"
-                        size="small"
-                        icon={<IconExternal />}
-                        to={urls.skill(config.skill_name)}
-                        aria-label={`Open the ${config.skill_name} skill`}
-                        onClick={() =>
-                            captureScoutAction({
-                                actionType: 'open_skill_in_posthog',
-                                surface: 'scout_detail',
-                                skillName: config.skill_name,
-                            })
-                        }
-                    />
-                </Tooltip>
+                {/* Captured on the way down: Link swallows Cmd/Ctrl-clicks before its onClick runs, and
+                    those opens count too. */}
+                <span
+                    className="contents"
+                    onClickCapture={() =>
+                        captureScoutAction({
+                            actionType: 'open_skill_in_posthog',
+                            surface: 'scout_detail',
+                            skillName: config.skill_name,
+                        })
+                    }
+                >
+                    <Tooltip title="Open the skill that defines what this scout does">
+                        <LemonButton
+                            type="secondary"
+                            size="small"
+                            icon={<IconExternal />}
+                            to={urls.skill(config.skill_name)}
+                            aria-label={`Open the ${config.skill_name} skill`}
+                        />
+                    </Tooltip>
+                </span>
                 <ScoutEnabledSwitch config={config} onUpdate={updateScoutConfig} updating={updating} />
             </div>
 

--- a/products/signals/frontend/inbox/components/config/scouts/ScoutDetailHeader.tsx
+++ b/products/signals/frontend/inbox/components/config/scouts/ScoutDetailHeader.tsx
@@ -9,6 +9,7 @@ import { urls } from 'scenes/urls'
 
 import type { SignalScoutConfigApi as SignalScoutConfig } from 'products/signals/frontend/generated/api.schemas'
 
+import { captureScoutAction } from '../../../inboxAnalytics'
 import { scoutFleetLogic } from '../../../logics/scoutFleetLogic'
 import { scoutCadenceLabel } from '../../../utils/scoutGroups'
 import { prettifyScoutSkillName, SCOUT_RUNS_PER_SCOUT, ScoutRollup } from '../../../utils/scoutRunsWindow'
@@ -125,6 +126,13 @@ export function ScoutDetailHeader({
                         icon={<IconExternal />}
                         to={urls.skill(config.skill_name)}
                         aria-label={`Open the ${config.skill_name} skill`}
+                        onClick={() =>
+                            captureScoutAction({
+                                actionType: 'open_skill_in_posthog',
+                                surface: 'scout_detail',
+                                skillName: config.skill_name,
+                            })
+                        }
                     />
                 </Tooltip>
                 <ScoutEnabledSwitch config={config} onUpdate={updateScoutConfig} updating={updating} />

--- a/products/signals/frontend/inbox/inboxAnalytics.ts
+++ b/products/signals/frontend/inbox/inboxAnalytics.ts
@@ -97,9 +97,9 @@ export type InboxQueryChange = 'scope' | 'sort' | 'source_product' | 'scout' | '
 export type ScoutSurface = 'fleet_list' | 'scout_detail' | 'empty_state'
 
 /**
- * Scout-management actions. The first block matches desktop's enum; the trailing three are
- * cloud-only, covering affordances desktop doesn't have (creating and deleting scouts, and the
- * scratchpad callout).
+ * Scout-management actions. The first block matches desktop's enum; the trailing block is
+ * cloud-only, covering affordances desktop doesn't have (creating and deleting scouts, the
+ * scratchpad callout, and the roster's on/off filter and search).
  */
 export type ScoutActionType =
     | 'open_settings'
@@ -122,6 +122,8 @@ export type ScoutActionType =
     | 'create_scout'
     | 'delete_scout'
     | 'open_memory'
+    | 'filter_enabled'
+    | 'search_scouts'
 
 /** What a scout chat CTA was asking for. Matches the desktop values. */
 export type ScoutChatType = 'author_scout' | 'fleet_overview' | 'recent_signals'

--- a/products/signals/frontend/inbox/logics/scoutFleetLogic.test.ts
+++ b/products/signals/frontend/inbox/logics/scoutFleetLogic.test.ts
@@ -2,6 +2,7 @@ import { MOCK_DEFAULT_ORGANIZATION, MOCK_TEAM_ID } from 'lib/api.mock'
 
 import { router } from 'kea-router'
 import { expectLogic } from 'kea-test-utils'
+import posthog from 'posthog-js'
 
 import { organizationLogic } from 'scenes/organizationLogic'
 import { teamLogic } from 'scenes/teamLogic'
@@ -18,6 +19,7 @@ import type { SignalScoutConfigApi } from 'products/signals/frontend/generated/a
 import { SignalScoutRunSummary } from '../types'
 import { scoutFleetLogic } from './scoutFleetLogic'
 
+jest.mock('posthog-js')
 jest.mock('products/signals/frontend/generated/api', () => ({
     signalsScoutChatTasksCreate: jest.fn(),
     signalsScoutConfigDestroy: jest.fn(),
@@ -314,6 +316,36 @@ describe('scoutFleetLogic', () => {
         // The endpoint enforces no consent check of its own, so dropping the guard here would
         // start an agent sandbox for an organization that declined AI data processing.
         expect(mockSignalsScoutChatTasksCreate).not.toHaveBeenCalled()
+    })
+
+    it('reports roster filtering without leaking the search term', async () => {
+        jest.useFakeTimers()
+        try {
+            const capture = posthog.capture as jest.Mock
+            capture.mockClear()
+            logic.actions.loadScoutConfigsSuccess([
+                BASE_CONFIG,
+                { ...BASE_CONFIG, id: 'config-2', skill_name: 'signals-scout-revenue', enabled: false },
+            ])
+
+            logic.actions.setScoutEnabledFilter('disabled')
+            logic.actions.setScoutSearch('rev')
+            logic.actions.setScoutSearch('reve')
+            await jest.advanceTimersByTimeAsync(600)
+            logic.actions.setScoutSearch('')
+            await jest.advanceTimersByTimeAsync(600)
+
+            const scoutActions = capture.mock.calls
+                .filter(([event]) => event === 'Scout action')
+                .map(([, properties]) => properties)
+            expect(scoutActions).toEqual([
+                expect.objectContaining({ action_type: 'filter_enabled', filter: 'disabled', filter_match_count: 1 }),
+                expect.objectContaining({ action_type: 'search_scouts', search_length: 4, filter_match_count: 1 }),
+            ])
+            expect(JSON.stringify(scoutActions)).not.toContain('reve')
+        } finally {
+            jest.useRealTimers()
+        }
     })
 
     it('resets the in-flight chat type when the kickoff fails', async () => {

--- a/products/signals/frontend/inbox/logics/scoutFleetLogic.ts
+++ b/products/signals/frontend/inbox/logics/scoutFleetLogic.ts
@@ -91,6 +91,11 @@ const RUNS_REFETCH_INTERVAL_MS = 60_000
 const RUNS_PAGE_LIMIT = 100
 const MAX_RUNS_PAGES = 15
 
+/** Rows the roster is showing after every filter, for the `filter_match_count` analytics property. */
+function rosterMatchCount(buckets: ScoutGroupBucket[]): number {
+    return buckets.reduce((total, bucket) => total + bucket.configs.length, 0)
+}
+
 /** Where each scout's row belongs, given the configs and run rollups currently loaded. */
 function computeRosterPlacement(values: {
     scoutConfigs: SignalScoutConfig[] | null
@@ -792,6 +797,27 @@ export const scoutFleetLogic = kea<scoutFleetLogicType>([
                         ? (values.scoutConfigs ?? []).filter((config) => configMatchesScoutTags(config, tags)).length
                         : undefined,
                 },
+            })
+        },
+        setScoutEnabledFilter: ({ filter }) => {
+            captureScoutAction({
+                actionType: 'filter_enabled',
+                surface: 'fleet_list',
+                extra: { filter, filter_match_count: rosterMatchCount(values.rosterBuckets) },
+            })
+        },
+        // Debounced so a typed query fires once per pause, not per keystroke; clearing fires nothing.
+        // The term itself is not sent — it can name a customer's own scouts — only its length.
+        setScoutSearch: async ({ search }, breakpoint) => {
+            const query = search.trim()
+            if (!query) {
+                return
+            }
+            await breakpoint(600)
+            captureScoutAction({
+                actionType: 'search_scouts',
+                surface: 'fleet_list',
+                extra: { search_length: query.length, filter_match_count: rosterMatchCount(values.rosterBuckets) },
             })
         },
         // Placement is refreshed here, off server data only, and deliberately not from


### PR DESCRIPTION
## Problem

The Scouts inbox tab (#84356) shows how people sort and search their scouts, but three of its controls leave no analytics trace, so nobody can tell from the data whether they get used.

- The roster's All / On / Off filter and its search box fire no event.
- The scout page's "Open skill" link fires nothing, although `open_skill_in_posthog` already exists in the `Scout action` vocabulary and the old fleet section fired it.
- Everything else on the two screens (enable switch, settings, Run now, notes, delete, create, chat kickoffs) already reports through the existing `Scout *` events.

## Changes

- Switching the roster filter fires `Scout action` with `action_type: filter_enabled`, the chosen filter, and how many rows matched.
- Typing in the roster search fires `Scout action` with `action_type: search_scouts` once per pause in typing (600 ms), with the term's length and the match count. The term itself is never sent, since it can name a customer's own scouts. Clearing the box fires nothing.
- Clicking "Open skill" on a scout page fires `Scout action` with `action_type: open_skill_in_posthog` and the scout's skill name.
- Mechanical: `filter_enabled` and `search_scouts` join the cloud-only block of `ScoutActionType`; a `rosterMatchCount` helper sums the visible roster rows.

Nothing looks different on screen.

## How did you test this code?

- New case in `scoutFleetLogic.test.ts`: filtering and searching report `filter_enabled` and `search_scouts` with the match count, the search fires once after the debounce, and the typed term does not appear in any captured property. Guards the privacy contract and the debounce; no existing test covered either.
- Ran locally: that test file, the frontend typecheck, and `pnpm --filter=@posthog/frontend fix`.
- Not run: the full inbox jest suite and a browser check of the events firing.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code while reviewing the scouts tab's telemetry against the Signals Scouts dashboard. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`. The gaps came from grepping the new roster and scout page components for capture calls and comparing against the `Scout action` types seen in production; the search term is deliberately reduced to its length, mirroring `captureInboxQueryChanged`.
