### PR TITLE
fix(cdp): keep configured filters when resetting a function to its template

### DIFF
--- a/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.test.ts
+++ b/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.test.ts
@@ -237,6 +237,45 @@ describe('hogFunctionConfigurationLogic', () => {
         })
     })
 
+    describe('resetting to template', () => {
+        const USER_FILTERS = {
+            events: [{ id: '$pageview', name: '$pageview', type: 'events', order: 0 }],
+            filter_test_accounts: false,
+        }
+        const TEMPLATE_DEFAULT_FILTERS = { events: [], actions: [], filter_test_accounts: true }
+        const TEMPLATE_WITH_DEFAULT_FILTERS: HogFunctionTemplateType = {
+            ...HOG_TEMPLATE,
+            code: `${HOG_TEMPLATE.code}\n// updated`,
+            filters: TEMPLATE_DEFAULT_FILTERS,
+        }
+
+        beforeEach(() => {
+            initKeaTests()
+            mockApi.getTemplate.mockResolvedValue(TEMPLATE_WITH_DEFAULT_FILTERS)
+        })
+
+        it.each([
+            ['keeps the configured filters over the template defaults', USER_FILTERS, USER_FILTERS],
+            ['falls back to the template defaults when none are configured', null, TEMPLATE_DEFAULT_FILTERS],
+        ])('%s', async (_name, functionFilters, expectedFilters) => {
+            mockApi.get.mockResolvedValue({
+                ...HOG_FUNCTION,
+                filters: functionFilters,
+                template: TEMPLATE_WITH_DEFAULT_FILTERS,
+            })
+            logic = hogFunctionConfigurationLogic({ id: HOG_FUNCTION.id })
+            logic.mount()
+            await expectLogic(logic).toDispatchActions(['loadHogFunctionSuccess'])
+
+            await expectLogic(logic, () => {
+                logic.actions.resetToTemplate()
+            }).toDispatchActions(['setConfigurationValues'])
+
+            expect(logic.values.configuration.filters).toEqual(expectedFilters)
+            expect(logic.values.configuration.hog).toEqual(TEMPLATE_WITH_DEFAULT_FILTERS.code)
+        })
+    })
+
     describe('loading a missing function', () => {
         beforeEach(() => {
             initKeaTests()

--- a/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.test.ts
+++ b/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.test.ts
@@ -6,7 +6,7 @@ import api from 'lib/api'
 import { ApiError } from 'lib/api-error'
 
 import { initKeaTests } from '~/test/init'
-import { HogFunctionTemplateType, HogFunctionType } from '~/types'
+import { CyclotronJobFiltersType, HogFunctionTemplateType, HogFunctionType } from '~/types'
 
 import { hogFunctionConfigurationLogic } from './hogFunctionConfigurationLogic'
 
@@ -238,11 +238,15 @@ describe('hogFunctionConfigurationLogic', () => {
     })
 
     describe('resetting to template', () => {
-        const USER_FILTERS = {
+        const USER_FILTERS: CyclotronJobFiltersType = {
             events: [{ id: '$pageview', name: '$pageview', type: 'events', order: 0 }],
             filter_test_accounts: false,
         }
-        const TEMPLATE_DEFAULT_FILTERS = { events: [], actions: [], filter_test_accounts: true }
+        const TEMPLATE_DEFAULT_FILTERS: CyclotronJobFiltersType = {
+            events: [],
+            actions: [],
+            filter_test_accounts: true,
+        }
         const TEMPLATE_WITH_DEFAULT_FILTERS: HogFunctionTemplateType = {
             ...HOG_TEMPLATE,
             code: `${HOG_TEMPLATE.code}\n// updated`,

--- a/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
@@ -2069,7 +2069,7 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
                 actions.setConfigurationValues({
                     ...config,
                     enabled: values.configuration.enabled,
-                    filters: config.filters ?? values.configuration.filters,
+                    filters: values.configuration.filters ?? config.filters,
                     // NOTE: Technically mapping should also be sanitized against the template mappings but this is a bit of a pain
                     mappings: values.configuration.mappings?.length ? values.configuration.mappings : config.mappings,
                     // Keep some existing things when manually resetting the template


### PR DESCRIPTION
## Problem

Clicking "Reset to template" on a destination wipes its configured event filters and replaces them with the template's blank defaults.

Reported in [Slack](https://posthog.slack.com/archives/C0ACRAMJUAG/p1787138653779729).

- The reset already preserves the function's inputs, mappings, name, and description. Only filters get lost.
- Many destination templates ship a non-null default `filters` object, so the precedence `template filters ?? configured filters` always picks the template's.

## Changes

- "Reset to template" now keeps the function's configured filters. It falls back to the template defaults only when the function has no filters.
- No visual change; only the reset behavior differs.

## How did you test this code?

Added two Jest cases to `hogFunctionConfigurationLogic.test.ts`:

- Configured filters survive a reset when the template ships default filters. This case failed before the fix.
- A function without filters still receives the template defaults on reset.

No existing test covered `resetToTemplate`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. Skills invoked: /writing-tests, /writing-pr-descriptions. The test was written first and reproduced the filter loss before the one-line precedence fix.
