### PR TITLE
fix(capture): cap lz64 decompression like gzip

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2738,6 +2738,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
  "flate2",
+ "lz-str",
  "thiserror 2.0.18",
  "zstd",
 ]

--- a/rust/capture/src/payload/decompression.rs
+++ b/rust/capture/src/payload/decompression.rs
@@ -6,7 +6,7 @@
 use std::io::prelude::*;
 
 use bytes::Bytes;
-use common_compression::has_gzip_magic_header;
+use common_compression::{decompress_lz64_capped, has_gzip_magic_header, CompressionError};
 use flate2::read::GzDecoder;
 use metrics;
 use tracing::{debug, info, instrument, warn, Span};
@@ -14,9 +14,7 @@ use tracing::{debug, info, instrument, warn, Span};
 use crate::{
     api::CaptureError,
     prometheus::report_dropped_events,
-    utils::{
-        decode_base64, decompress_lz64, is_likely_base64, Base64Option, MAX_PAYLOAD_SNIPPET_SIZE,
-    },
+    utils::{decode_base64, is_likely_base64, Base64Option, MAX_PAYLOAD_SNIPPET_SIZE},
     v0_request::path_is_legacy_endpoint,
 };
 
@@ -25,9 +23,11 @@ use super::types::Compression;
 // Metrics constants
 const METRIC_PAYLOAD_SIZE_EXCEEDED: &str = "capture_payload_size_exceeded";
 const METRIC_GZIP_DECOMPRESSION_RATIO: &str = "capture_gzip_decompression_ratio";
+const METRIC_LZ64_DECOMPRESSION_RATIO: &str = "capture_lz64_decompression_ratio";
 
-/// Decompression ratios above this threshold are flagged as potential GZIP bombs.
+/// Decompression ratios above this threshold are flagged as potential bombs.
 const GZIP_BOMB_RATIO_THRESHOLD: f64 = 20.0;
+const LZ64_BOMB_RATIO_THRESHOLD: f64 = 20.0;
 
 /// Decompress GZIP data with chunked reads and bomb detection.
 /// Returns raw bytes -- callers decide whether to convert to String.
@@ -85,6 +85,77 @@ pub fn decompress_gzip_to_bytes(compressed: &[u8], limit: usize) -> Result<Vec<u
     Ok(buf)
 }
 
+/// Decompress LZ64 (lz-string) data with an output cap and bomb detection.
+/// The payload arrives as the base64 text lz-string emits.
+pub fn decompress_lz64_to_string(payload: &[u8], limit: usize) -> Result<String, CaptureError> {
+    let b64_payload = std::str::from_utf8(payload).unwrap_or("INVALID_UTF8");
+
+    // The cap counts UTF-16 code units against a byte limit deliberately: UTF-8
+    // is never shorter than the UTF-16 it encodes, so nothing that would have
+    // fit under `limit` bytes gets rejected here.
+    let decomp_utf16 = match decompress_lz64_capped(b64_payload, limit) {
+        Ok(units) => units,
+        Err(CompressionError::Lz64OutputTooLarge { units, .. }) => {
+            metrics::counter!(METRIC_PAYLOAD_SIZE_EXCEEDED, "kind" => "lz64").increment(1);
+            metrics::histogram!("capture_full_payload_size", "oversize" => "true")
+                .record(units as f64);
+            report_dropped_events("event_too_big", 1);
+
+            return Err(CaptureError::EventTooBig(format!(
+                "Decompressed LZ64 payload would exceed {limit} bytes"
+            )));
+        }
+        Err(_) => {
+            let max_chars: usize = std::cmp::min(payload.len(), MAX_PAYLOAD_SNIPPET_SIZE);
+            let payload_snippet = String::from_utf8(payload[..max_chars].to_vec())
+                .unwrap_or(String::from("INVALID_UTF8"));
+            debug!(
+                payload_snippet = payload_snippet,
+                "decompress_lz64: failed decompress to UTF16"
+            );
+            return Err(CaptureError::RequestDecodingError(String::from(
+                "decompress_lz64: failed decompress to UTF16",
+            )));
+        }
+    };
+
+    // the decompressed data is UTF16 so we need to convert it to UTF8 to
+    // obtain the JSON event batch payload we've come to know and love
+    let decompressed = match String::from_utf16(&decomp_utf16) {
+        Ok(result) => result,
+        Err(_) => {
+            return Err(CaptureError::RequestDecodingError(String::from(
+                "decompress_lz64: failed UTF16 to UTF8 conversion",
+            )));
+        }
+    };
+
+    // UTF-8 can be longer than the capped UTF-16, so the byte limit is its own check
+    if decompressed.len() > limit {
+        metrics::counter!(METRIC_PAYLOAD_SIZE_EXCEEDED, "kind" => "lz64").increment(1);
+        report_dropped_events("event_too_big", 1);
+        return Err(CaptureError::EventTooBig(String::from(
+            "lz64 request payload size limit exceeded",
+        )));
+    }
+
+    if !payload.is_empty() {
+        let ratio = decompressed.len() as f64 / payload.len() as f64;
+        metrics::histogram!(METRIC_LZ64_DECOMPRESSION_RATIO).record(ratio);
+
+        if ratio > LZ64_BOMB_RATIO_THRESHOLD {
+            warn!(
+                compressed_size = payload.len(),
+                decompressed_size = decompressed.len(),
+                ratio = ratio,
+                "High LZ64 compression ratio detected - potential LZ64 bomb"
+            );
+        }
+    }
+
+    Ok(decompressed)
+}
+
 /// Decompresses and decodes a payload based on compression hint and content detection.
 /// This is shared logic used by both analytics and recording event processing.
 ///
@@ -133,7 +204,7 @@ pub fn decompress_payload(
             payload_len = bytes.len(),
             "decompress_payload: matched LZ64 compression"
         );
-        decompress_lz64(&bytes, limit)?
+        decompress_lz64_to_string(&bytes, limit)?
     } else {
         debug!(
             path = path,
@@ -272,5 +343,41 @@ mod tests {
         let garbage = b"not gzip data at all";
         let result = decompress_gzip_to_bytes(garbage, 4096);
         assert!(matches!(result, Err(CaptureError::RequestDecodingError(_))));
+    }
+
+    #[test]
+    fn test_decompress_payload_lz64_valid() {
+        let original = r#"[{"event":"$pageview","properties":{"token":"abc"}}]"#;
+        let compressed = lz_str::compress_to_base64(original);
+
+        let result = decompress_payload(
+            Bytes::from(compressed),
+            Compression::LZString,
+            4096,
+            "/i/v0/e",
+        )
+        .unwrap();
+
+        assert_eq!(result, original);
+    }
+
+    #[test]
+    fn test_decompress_payload_lz64_rejects_oversized_output() {
+        // 1 MB of one repeated character, which lz-string packs into ~2KB
+        let compressed = lz_str::compress_to_base64(&"A".repeat(1024 * 1024));
+        assert!(compressed.len() < 16 * 1024);
+
+        let result = decompress_payload(
+            Bytes::from(compressed),
+            Compression::LZString,
+            1024,
+            "/i/v0/e",
+        );
+
+        assert!(
+            matches!(result, Err(CaptureError::EventTooBig(_))),
+            "expected EventTooBig, got {:?}",
+            result
+        );
     }
 }

--- a/rust/capture/src/utils.rs
+++ b/rust/capture/src/utils.rs
@@ -10,7 +10,6 @@ use uuid::Uuid;
 use crate::{
     api::CaptureError,
     payload::{Compression, EventFormData, EventQuery},
-    prometheus::report_dropped_events,
     token::validate_token,
 };
 
@@ -171,46 +170,6 @@ pub fn decode_form(payload: &[u8]) -> Result<EventFormData, CaptureError> {
             )))
         }
     }
-}
-
-pub fn decompress_lz64(payload: &[u8], limit: usize) -> Result<String, CaptureError> {
-    // with lz64 the payload is a Base64 string that must be decoded prior to decompression
-    let b64_payload = std::str::from_utf8(payload).unwrap_or("INVALID_UTF8");
-    let decomp_utf16 = match lz_str::decompress_from_base64(b64_payload) {
-        Some(v) => v,
-        None => {
-            let max_chars: usize = std::cmp::min(payload.len(), MAX_PAYLOAD_SNIPPET_SIZE);
-            let payload_snippet = String::from_utf8(payload[..max_chars].to_vec())
-                .unwrap_or(String::from("INVALID_UTF8"));
-            debug!(
-                payload_snippet = payload_snippet,
-                "decompress_lz64: failed decompress to UTF16"
-            );
-            return Err(CaptureError::RequestDecodingError(String::from(
-                "decompress_lz64: failed decompress to UTF16",
-            )));
-        }
-    };
-
-    // the decompressed data is UTF16 so we need to convert it to UTF8 to
-    // obtain the JSON event batch payload we've come to know and love
-    let decompressed = match String::from_utf16(&decomp_utf16) {
-        Ok(result) => result,
-        Err(_) => {
-            return Err(CaptureError::RequestDecodingError(String::from(
-                "decompress_lz64: failed UTF16 to UTF8 conversion",
-            )));
-        }
-    };
-
-    if decompressed.len() > limit {
-        report_dropped_events("event_too_big", 1);
-        return Err(CaptureError::EventTooBig(String::from(
-            "lz64 request payload size limit exceeded",
-        )));
-    }
-
-    Ok(decompressed)
 }
 
 pub fn extract_and_verify_token(

--- a/rust/common/compression/Cargo.toml
+++ b/rust/common/compression/Cargo.toml
@@ -9,3 +9,7 @@ base64 = { workspace = true }
 thiserror = { workspace = true }
 zstd = "0.13"
 
+[dev-dependencies]
+# Reference implementation the capped lz64 decoder is checked against.
+lz-str = { workspace = true }
+

--- a/rust/common/compression/src/lib.rs
+++ b/rust/common/compression/src/lib.rs
@@ -6,12 +6,17 @@
 //! Supports:
 //! - gzip compression/decompression
 //! - Base64 encoding/decoding
+//! - lz-string ("lz64") decompression with a capped output
 
 use base64::{engine::general_purpose, Engine as _};
 use flate2::{read::GzDecoder, write::GzEncoder, Compression};
 use std::io::{Read, Write};
 use thiserror::Error;
 use zstd::{Decoder, Encoder};
+
+mod lz64;
+
+pub use lz64::decompress_lz64_capped;
 
 /// Gzip streams start with the two-byte magic `1f 8b` (ID1, ID2), followed by
 /// compression method `08` (deflate). All three bytes are checked together so
@@ -32,6 +37,12 @@ pub enum CompressionError {
 
     #[error("decompressed output exceeded limit ({decompressed} > {limit} bytes)")]
     OutputTooLarge { decompressed: usize, limit: usize },
+
+    #[error("lz-string data could not be decompressed")]
+    Lz64Invalid,
+
+    #[error("lz-string output exceeded limit ({units} > {limit} UTF-16 code units)")]
+    Lz64OutputTooLarge { units: usize, limit: usize },
 }
 
 /// Gzip decompression with **no output cap**.

--- a/rust/common/compression/src/lz64.rs
+++ b/rust/common/compression/src/lz64.rs
@@ -1,0 +1,365 @@
+//! lz-string ("lz64") decompression with a hard cap on the output.
+//!
+//! Old PostHog SDKs send payloads compressed with lz-string's
+//! `compressToBase64`. The `lz-str` crate decompresses those in one shot with no
+//! way to stop it: LZW rebuilds a back-reference dictionary as it goes, so a few
+//! kilobytes of base64 can expand into gigabytes before the caller ever gets a
+//! length to check. This is that decoder with the cap checked on every emit, so
+//! an oversized payload is refused while it is still small.
+
+use crate::CompressionError;
+
+/// lz-string's base64 alphabet; a character's index is its 6-bit value.
+const BASE64_KEY: &[u8; 65] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
+
+const BITS_PER_CHAR: u8 = 6;
+const START_CODE_BITS: u8 = 2;
+
+/// Stream codes: a literal byte, a literal UTF-16 unit, end of stream.
+const U8_CODE: u32 = 0;
+const U16_CODE: u32 = 1;
+const CLOSE_CODE: u32 = 2;
+
+/// Code width grows with the dictionary, which the output cap bounds, so only
+/// corrupt input gets here. Rejecting it keeps `1 << n` inside a `u32`.
+const MAX_CODE_BITS: u8 = 31;
+
+/// Decompress a string produced by lz-string's `compressToBase64`, refusing any
+/// stream that would emit more than `max_output_units` UTF-16 code units.
+///
+/// Returns the raw UTF-16 units, as `lz_str::decompress_from_base64` does, so
+/// callers convert to a `String` themselves.
+///
+/// The dictionary holds ranges into the output rather than its own copies, so
+/// peak memory stays a small multiple of the cap instead of paying a heap
+/// allocation per entry.
+pub fn decompress_lz64_capped(
+    compressed: &str,
+    max_output_units: usize,
+) -> Result<Vec<u16>, CompressionError> {
+    // Ranges into the output are u32, so a larger cap could not be enforced.
+    let limit = max_output_units.min(u32::MAX as usize);
+
+    // Characters outside the alphabet are skipped, matching lz-string.
+    let input = compressed.encode_utf16().filter_map(|c| {
+        BASE64_KEY
+            .iter()
+            .position(|k| u32::from(c) == u32::from(*k))
+            .map(|n| n as u16)
+    });
+
+    let mut reader = match BitReader::new(input, BITS_PER_CHAR) {
+        Some(reader) => reader,
+        None => return Ok(Vec::new()),
+    };
+
+    let first = match reader
+        .read_bits(START_CODE_BITS)
+        .ok_or(CompressionError::Lz64Invalid)?
+    {
+        code @ (U8_CODE | U16_CODE) => read_literal(&mut reader, code)?,
+        CLOSE_CODE => return Ok(Vec::new()),
+        _ => return Err(CompressionError::Lz64Invalid),
+    };
+
+    let mut out: Vec<u16> = Vec::new();
+    // The three reserved codes above are intercepted before any lookup, so these
+    // placeholder ranges are never read. They only keep dictionary indexes aligned.
+    let mut dictionary: Vec<(u32, u32)> = vec![(0, 0); 3];
+
+    push_unit(&mut out, first, limit)?;
+    dictionary.push((0, 1));
+
+    let mut w: (u32, u32) = (0, 1);
+    let mut num_bits: u8 = 3;
+    let mut enlarge_in: u64 = 4;
+
+    loop {
+        if num_bits > MAX_CODE_BITS {
+            return Err(CompressionError::Lz64Invalid);
+        }
+
+        let mut code = reader
+            .read_bits(num_bits)
+            .ok_or(CompressionError::Lz64Invalid)?;
+        let mut literal = None;
+
+        match code {
+            U8_CODE | U16_CODE => {
+                literal = Some(read_literal(&mut reader, code)?);
+                // The literal's entry is the single unit emitted below.
+                dictionary.push((out_len(&out), 1));
+                code = u32::try_from(dictionary.len() - 1)
+                    .map_err(|_| CompressionError::Lz64Invalid)?;
+                enlarge_in -= 1;
+            }
+            CLOSE_CODE => return Ok(out),
+            _ => {}
+        }
+
+        if enlarge_in == 0 {
+            enlarge_in = 1 << num_bits;
+            num_bits += 1;
+        }
+
+        let entry = if let Some(unit) = literal {
+            push_unit(&mut out, unit, limit)?;
+            (out_len(&out) - 1, 1)
+        } else if let Some(&(start, len)) = dictionary.get(code as usize) {
+            copy_range(&mut out, start, len, limit)?;
+            (out_len(&out) - len, len)
+        } else if code as usize == dictionary.len() {
+            // LZW's "code we are about to define" case: w plus w's first unit.
+            let (start, len) = w;
+            copy_range(&mut out, start, len, limit)?;
+            let first_unit = out[start as usize];
+            push_unit(&mut out, first_unit, limit)?;
+            (out_len(&out) - len - 1, len + 1)
+        } else {
+            return Err(CompressionError::Lz64Invalid);
+        };
+
+        // w plus entry's first unit is contiguous in `out`: entry was emitted
+        // directly after w, so its first unit sits one past the end of w.
+        dictionary.push((w.0, w.1 + 1));
+        enlarge_in -= 1;
+        w = entry;
+
+        if enlarge_in == 0 {
+            enlarge_in = 1 << num_bits;
+            num_bits += 1;
+        }
+    }
+}
+
+/// Reads the bit stream lz-string packs into base64 characters.
+struct BitReader<I> {
+    val: u16,
+    data: I,
+    position: u16,
+    reset_val: u16,
+}
+
+impl<I: Iterator<Item = u16>> BitReader<I> {
+    fn new(mut data: I, bits_per_char: u8) -> Option<Self> {
+        let reset_val = 1 << (bits_per_char - 1);
+        Some(BitReader {
+            val: data.next()?,
+            data,
+            position: reset_val,
+            reset_val,
+        })
+    }
+
+    fn read_bit(&mut self) -> Option<bool> {
+        let res = self.val & self.position;
+        self.position >>= 1;
+
+        if self.position == 0 {
+            self.position = self.reset_val;
+            self.val = self.data.next()?;
+        }
+
+        Some(res != 0)
+    }
+
+    fn read_bits(&mut self, n: u8) -> Option<u32> {
+        let mut res = 0;
+        let max_power: u32 = 1 << n;
+        let mut power: u32 = 1;
+        while power != max_power {
+            res |= u32::from(self.read_bit()?) * power;
+            power <<= 1;
+        }
+
+        Some(res)
+    }
+}
+
+fn read_literal<I: Iterator<Item = u16>>(
+    reader: &mut BitReader<I>,
+    code: u32,
+) -> Result<u16, CompressionError> {
+    let bits_to_read = if code == U8_CODE { 8 } else { 16 };
+    let value = reader
+        .read_bits(bits_to_read)
+        .ok_or(CompressionError::Lz64Invalid)?;
+
+    u16::try_from(value).map_err(|_| CompressionError::Lz64Invalid)
+}
+
+/// The cap keeps the output within `u32::MAX` units, so this never truncates.
+fn out_len(out: &[u16]) -> u32 {
+    out.len() as u32
+}
+
+fn push_unit(out: &mut Vec<u16>, unit: u16, limit: usize) -> Result<(), CompressionError> {
+    check_capacity(out.len(), 1, limit)?;
+    out.push(unit);
+    Ok(())
+}
+
+fn copy_range(
+    out: &mut Vec<u16>,
+    start: u32,
+    len: u32,
+    limit: usize,
+) -> Result<(), CompressionError> {
+    let (start, len) = (start as usize, len as usize);
+    check_capacity(out.len(), len, limit)?;
+    out.extend_from_within(start..start + len);
+    Ok(())
+}
+
+fn check_capacity(current: usize, adding: usize, limit: usize) -> Result<(), CompressionError> {
+    if current + adding > limit {
+        return Err(CompressionError::Lz64OutputTooLarge {
+            units: current + adding,
+            limit,
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const GENEROUS_LIMIT: usize = 1024 * 1024;
+
+    fn decompress_to_string(compressed: &str, limit: usize) -> Result<String, CompressionError> {
+        let units = decompress_lz64_capped(compressed, limit)?;
+        Ok(String::from_utf16(&units).unwrap())
+    }
+
+    /// This decoder is a port, so any divergence from `lz-str` silently drops
+    /// data an SDK sent. Both roundtrip tests exist to catch that.
+    #[test]
+    fn matches_lz_str_on_roundtrips() {
+        let cases = [
+            "",
+            "{}",
+            r#"{"event":"$pageview","properties":{"$lib":"web"}}"#,
+            // Repetition is what LZW's dictionary rewards, so exercise it.
+            &r#"{"event":"$pageview"},"#.repeat(500),
+            // Non-ASCII lands outside the u8 literal code path.
+            r#"{"event":"クリック","emoji":"🦔","accents":"ãéî"}"#,
+            &"a".repeat(100_000),
+        ];
+
+        for case in cases {
+            let compressed = lz_str::compress_to_base64(case);
+            let expected = lz_str::decompress_from_base64(&compressed).unwrap();
+
+            assert_eq!(
+                decompress_lz64_capped(&compressed, GENEROUS_LIMIT).unwrap(),
+                expected,
+                "diverged from lz-str on a {} char payload",
+                case.len()
+            );
+            assert_eq!(
+                decompress_to_string(&compressed, GENEROUS_LIMIT).unwrap(),
+                case
+            );
+        }
+    }
+
+    #[test]
+    fn matches_lz_str_on_generated_payloads() {
+        // A seeded generator, so a divergence reproduces instead of flaking.
+        let mut seed: u64 = 0x5eed;
+        let mut next = move || {
+            seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1);
+            (seed >> 33) as usize
+        };
+
+        for case_index in 0..200 {
+            // A small alphabet with structure keeps the dictionary busy, which is
+            // where the port and lz-str could disagree.
+            let alphabet = [
+                "a",
+                "b",
+                "{",
+                "}",
+                "\"",
+                ":",
+                ",",
+                "0",
+                "$pageview",
+                "properties",
+                "🦔",
+            ];
+            let length = 1 + next() % 400;
+            let payload: String = (0..length)
+                .map(|_| alphabet[next() % alphabet.len()])
+                .collect();
+
+            let compressed = lz_str::compress_to_base64(&payload);
+
+            assert_eq!(
+                decompress_lz64_capped(&compressed, GENEROUS_LIMIT).unwrap(),
+                lz_str::decompress_from_base64(&compressed).unwrap(),
+                "diverged from lz-str on generated case {case_index}: {payload}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_a_decompression_bomb_without_materializing_it() {
+        // ~2KB of base64 expanding to 1MB, well under any request body limit.
+        let bomb = lz_str::compress_to_base64(&"a".repeat(1024 * 1024));
+        assert!(bomb.len() < 16 * 1024);
+
+        let result = decompress_lz64_capped(&bomb, 4096);
+
+        assert!(matches!(
+            result,
+            Err(CompressionError::Lz64OutputTooLarge { limit, .. }) if limit == 4096
+        ));
+    }
+
+    #[test]
+    fn accepts_output_exactly_at_the_limit() {
+        let payload = "b".repeat(4096);
+        let compressed = lz_str::compress_to_base64(&payload);
+
+        assert_eq!(decompress_to_string(&compressed, 4096).unwrap(), payload);
+    }
+
+    #[test]
+    fn rejects_output_one_unit_over_the_limit() {
+        let compressed = lz_str::compress_to_base64(&"b".repeat(4097));
+
+        assert!(matches!(
+            decompress_lz64_capped(&compressed, 4096),
+            Err(CompressionError::Lz64OutputTooLarge { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_truncated_input() {
+        let compressed = lz_str::compress_to_base64(r#"{"event":"$pageview"}"#);
+
+        // Truncated mid-stream, and a stream that ends right after its first code.
+        for case in [&compressed[..compressed.len() / 2], "A"] {
+            assert!(
+                matches!(
+                    decompress_lz64_capped(case, GENEROUS_LIMIT),
+                    Err(CompressionError::Lz64Invalid)
+                ),
+                "expected {case:?} to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn input_with_no_alphabet_characters_decodes_to_nothing() {
+        // lz-string skips characters outside its alphabet, so these are empty streams.
+        for case in ["", "!!!!"] {
+            assert_eq!(
+                decompress_lz64_capped(case, GENEROUS_LIMIT).unwrap(),
+                lz_str::decompress_from_base64(case).unwrap()
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Problem

A single capture request can exhaust a worker's memory before any payload size limit applies.

- The gzip path reads in 8KB chunks and stops as soon as the output would cross `event_payload_size_limit`.
- The lz64 (lz-string) path decompressed the whole payload, then compared the result against that limit.
- lz-string is LZW, so a few kilobytes of base64 can expand by orders of magnitude. The late check cannot help.
- Every endpoint that accepts a `lz64` compression hint is affected, including `/e`, `/batch`, and `/s`.

## Changes

- An oversized lz64 payload now fails with `EventTooBig` while the output is still small, instead of after the worker has already allocated it.
- Payloads that decode today keep decoding. The cap counts UTF-16 code units against a byte limit, and UTF-8 is never shorter than the UTF-16 it encodes.
- Capture increments `capture_payload_size_exceeded{kind="lz64"}` and records `capture_lz64_decompression_ratio`, so lz64 traffic is now visible the way gzip traffic is.
- A high lz64 ratio logs the same potential-bomb warning gzip logs.
- `common-compression` gains `decompress_lz64_capped`, a port of `lz_str::decompress_from_base64` that checks the cap on every emit. lz-str exposes no streaming decoder, so bounding it from outside is not possible.
- The port stores dictionary entries as ranges into the output rather than as their own copies, which keeps peak memory a small multiple of the cap and removes a heap allocation per entry.
- Mechanical: `decompress_lz64` moves from `capture::utils` into `capture::payload::decompression`, beside the gzip equivalent, and gains the metrics above.
- Nothing user-visible changes, and no UI is involved.

> [!NOTE]
> The cap is the enforcement. The ratio is only recorded and warned on, because repetitive event batches compress well enough that a ratio reject would risk dropping real data.

## How did you test this code?

- `cargo test -p common-compression --lib` and `cargo test -p capture --lib payload::decompression`.
- The port is checked against `lz_str::decompress_from_base64` on fixed payload shapes and on 200 seeded generated payloads. That is the regression worth catching: a divergence would silently drop data an SDK sent, and no existing test compares the two decoders.
- New cap tests cover a bomb that expands 1MB from ~2KB, output exactly at the limit, output one unit over, truncated input, and input with no alphabet characters.
- At the capture level, a valid lz64 payload still decodes through `decompress_payload`, and a bomb returns `EventTooBig`.
- Clippy ran for both crates with CI's flags.
- Not run: `hogli ci:preflight` and the capture integration suites, because this sandbox has no `node_modules`, Kafka, or Redis. Five `event_restrictions::repository` unit tests also fail here for the same reason, unrelated to this change.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested in the Slack thread linked below, where a PostHog engineer asked whether capture's gzip bomb protections could be applied to the lz64 path. Built with the PostHog Slack app on the Claude Code harness. Skills invoked: `/writing-code-comments`, `/writing-pr-descriptions`.

Two alternatives were dropped along the way. Bounding lz-str from outside does not work, since its only entry point returns the finished buffer. Rejecting above a fixed expansion ratio was dropped for the reason in the note above.

The lz64 path in `posthog/utils.py` has the same unbounded shape and is left alone here, since it is reached through a different, token-scoped endpoint.

Public artifact: nothing here carries material from the agent session. The test fixtures are repeated characters, a seeded generator, and an invented event payload.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ABCF3JEN6/p1787092735678409?thread_ts=1787092735.678409&cid=C0ABCF3JEN6)*
