### PR TITLE
fix(ci): keep fork PRs off Depot runners for jobs running fork code

### DIFF
--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -295,10 +295,11 @@ jobs:
 
     integration-tests:
         name: Integration Tests (depot-ubuntu-24.04-4)
-        # Forks stay on GitHub-hosted: this job checks out and runs fork code, and Depot runners
-        # inject the org-wide sccache credentials ambiently (see ci-frontend.yml
-        # frontend-typescript-checks). Keeping untrusted PRs off Depot stops a fork from reading
-        # the shared cache token.
+        # Fork PRs run on GitHub-hosted runners, not Depot. This job checks out and
+        # runs code from the PR, and Depot exposes the shared sccache token as an
+        # environment variable. A fork could read that token and write to the Rust
+        # build cache that master consumes, so untrusted PRs must not run on Depot.
+        # (ci-frontend.yml frontend-typescript-checks does the same, for the same reason.)
         runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) && 'depot-ubuntu-24.04-4' || 'ubuntu-latest' }}
         needs: changes
         # Sized for a schema-cache miss (full migrate from scratch), not just a hit.

--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -295,7 +295,11 @@ jobs:
 
     integration-tests:
         name: Integration Tests (depot-ubuntu-24.04-4)
-        runs-on: depot-ubuntu-24.04-4
+        # Forks stay on GitHub-hosted: this job checks out and runs fork code, and Depot runners
+        # inject the org-wide sccache credentials ambiently (see ci-frontend.yml
+        # frontend-typescript-checks). Keeping untrusted PRs off Depot stops a fork from reading
+        # the shared cache token.
+        runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) && 'depot-ubuntu-24.04-4' || 'ubuntu-latest' }}
         needs: changes
         # Sized for a schema-cache miss (full migrate from scratch), not just a hit.
         timeout-minutes: 45

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -139,7 +139,11 @@ jobs:
         if: needs.changes.outputs.nodejs == 'true'
         name: Node.js Code quality (depot-ubuntu-24.04)
         needs: changes
-        runs-on: depot-ubuntu-24.04
+        # Forks stay on GitHub-hosted: this job runs fork-controlled install/build steps, and
+        # Depot runners inject the org-wide sccache credentials ambiently (see ci-frontend.yml
+        # frontend-typescript-checks). Keeping untrusted PRs off Depot stops a fork from reading
+        # the shared cache token. Same rationale on the build/tests/rust_ingestion_e2e jobs below.
+        runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
         timeout-minutes: 10
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -204,7 +208,8 @@ jobs:
         if: needs.changes.outputs.nodejs == 'true'
         name: Node.js Build (depot-ubuntu-24.04)
         needs: changes
-        runs-on: depot-ubuntu-24.04
+        # Forks off Depot — see the lint job above.
+        runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
         timeout-minutes: 10
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -266,7 +271,8 @@ jobs:
         if: needs.changes.outputs.nodejs == 'true'
         name: Node.js Tests ${{matrix.shard}}/3 (depot-ubuntu-24.04-4)
         needs: changes
-        runs-on: depot-ubuntu-24.04-4
+        # Forks off Depot — see the lint job above.
+        runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) && 'depot-ubuntu-24.04-4' || 'ubuntu-latest' }}
         # Tests fit comfortably in 30, but a rust change misses the turbo cache and cold-builds the
         # replay-anonymizer addon's whole dependency tree first (no rust caching in this job yet).
         timeout-minutes: 45
@@ -545,7 +551,8 @@ jobs:
         if: needs.changes.outputs.nodejs == 'true'
         name: Rust ingestion consumer Node API e2e (depot-ubuntu-24.04-4)
         needs: changes
-        runs-on: depot-ubuntu-24.04-4
+        # Forks off Depot — see the lint job above.
+        runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) && 'depot-ubuntu-24.04-4' || 'ubuntu-latest' }}
         timeout-minutes: 30
         env:
             DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USER }}

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -139,10 +139,12 @@ jobs:
         if: needs.changes.outputs.nodejs == 'true'
         name: Node.js Code quality (depot-ubuntu-24.04)
         needs: changes
-        # Forks stay on GitHub-hosted: this job runs fork-controlled install/build steps, and
-        # Depot runners inject the org-wide sccache credentials ambiently (see ci-frontend.yml
-        # frontend-typescript-checks). Keeping untrusted PRs off Depot stops a fork from reading
-        # the shared cache token. Same rationale on the build/tests/rust_ingestion_e2e jobs below.
+        # Fork PRs run on GitHub-hosted runners, not Depot. This job runs install and
+        # build steps from the PR, and Depot exposes the shared sccache token as an
+        # environment variable. A fork could read that token and write to the Rust
+        # build cache that master consumes, so untrusted PRs must not run on Depot.
+        # (ci-frontend.yml frontend-typescript-checks does the same, for the same reason.)
+        # The build, tests, and rust_ingestion_e2e jobs below use the same runner rule.
         runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
         timeout-minutes: 10
         steps:
@@ -208,7 +210,7 @@ jobs:
         if: needs.changes.outputs.nodejs == 'true'
         name: Node.js Build (depot-ubuntu-24.04)
         needs: changes
-        # Forks off Depot — see the lint job above.
+        # Fork PRs stay off Depot for the reason on the lint job above.
         runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
         timeout-minutes: 10
         steps:
@@ -271,7 +273,7 @@ jobs:
         if: needs.changes.outputs.nodejs == 'true'
         name: Node.js Tests ${{matrix.shard}}/3 (depot-ubuntu-24.04-4)
         needs: changes
-        # Forks off Depot — see the lint job above.
+        # Fork PRs stay off Depot for the reason on the lint job above.
         runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) && 'depot-ubuntu-24.04-4' || 'ubuntu-latest' }}
         # Tests fit comfortably in 30, but a rust change misses the turbo cache and cold-builds the
         # replay-anonymizer addon's whole dependency tree first (no rust caching in this job yet).
@@ -551,7 +553,7 @@ jobs:
         if: needs.changes.outputs.nodejs == 'true'
         name: Rust ingestion consumer Node API e2e (depot-ubuntu-24.04-4)
         needs: changes
-        # Forks off Depot — see the lint job above.
+        # Fork PRs stay off Depot for the reason on the lint job above.
         runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) && 'depot-ubuntu-24.04-4' || 'ubuntu-latest' }}
         timeout-minutes: 30
         env:

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -187,7 +187,11 @@ jobs:
 
     build-storybook:
         name: Build Storybook (depot-ubuntu-24.04)
-        runs-on: depot-ubuntu-24.04
+        # Forks stay on GitHub-hosted: this job runs `pnpm install`, so a fork PR controls
+        # lifecycle scripts, and Depot runners inject the org-wide sccache credentials ambiently
+        # (see ci-frontend.yml frontend-typescript-checks). Fork frontend PRs trade the larger
+        # runner for a build that can't exfiltrate the shared cache token.
+        runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
         # The Vite build normally takes ~3.5 minutes, but a degraded runner can stretch
         # the memory-heavy bundling phase past 15 minutes — leave headroom so a slow
         # runner yields a slow-but-green build instead of a cancelled one that hard-fails

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -187,10 +187,11 @@ jobs:
 
     build-storybook:
         name: Build Storybook (depot-ubuntu-24.04)
-        # Forks stay on GitHub-hosted: this job runs `pnpm install`, so a fork PR controls
-        # lifecycle scripts, and Depot runners inject the org-wide sccache credentials ambiently
-        # (see ci-frontend.yml frontend-typescript-checks). Fork frontend PRs trade the larger
-        # runner for a build that can't exfiltrate the shared cache token.
+        # Fork PRs run on GitHub-hosted runners, not Depot. This job runs `pnpm install`,
+        # so the PR controls lifecycle scripts, and Depot exposes the shared sccache token
+        # as an environment variable. A fork could read that token and write to the Rust
+        # build cache that master consumes, so untrusted PRs must not run on Depot.
+        # (ci-frontend.yml frontend-typescript-checks does the same, for the same reason.)
         runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
         # The Vite build normally takes ~3.5 minutes, but a degraded runner can stretch
         # the memory-heavy bundling phase past 15 minutes — leave headroom so a slow


### PR DESCRIPTION
## Changes

- Fork pull requests now run these jobs on `ubuntu-latest` instead of Depot; internal pull requests and master pushes keep their Depot runners.
- Mechanism: each job's `runs-on` becomes the same fork-aware expression `ci-frontend.yml` uses, preserving the Depot runner size for the non-fork path.
- The change is limited to `runs-on`; no job logic, step, or dependency changed.

| Workflow | Job | Non-fork runner | Fork runner |
|---|---|---|---|
| ci-storybook.yml | build-storybook | depot-ubuntu-24.04 | ubuntu-latest |
| ci-nodejs.yml | lint | depot-ubuntu-24.04 | ubuntu-latest |
| ci-nodejs.yml | build | depot-ubuntu-24.04 | ubuntu-latest |
| ci-nodejs.yml | tests | depot-ubuntu-24.04-4 | ubuntu-latest |
| ci-nodejs.yml | rust_ingestion_e2e | depot-ubuntu-24.04-4 | ubuntu-latest |
| ci-mcp.yml | integration-tests | depot-ubuntu-24.04-4 | ubuntu-latest |

> [!NOTE]
> `build-storybook` sets `--max-old-space-size=32768` (32 GB heap); `ubuntu-latest` has 16 GB. If the Storybook build's real peak exceeds 16 GB, fork frontend pull requests may fail there. This matches the degraded-but-safe tradeoff already accepted for `frontend-typescript-checks`. The nodejs and mcp jobs have no comparable heap pressure.

No user-facing change: this touches CI runner selection only, nothing a product user sees.

## How did you test this code?

- `bin/hogli lint:workflows` passes all 8 checks across 126 workflows.
- `hogli ci:preflight --strict` reports 0 failures (workflow-lint triggered, ok).
- `actionlint` accepts the runner expressions and labels; its only output is pre-existing info-level SC2086 notes in unrelated `run:` scripts.
- Not verified: an actual fork pull request run on GitHub, which this sandbox cannot dispatch. The webkit `visual-regression` shard was left unchanged because it only enters the matrix on master pushes, so fork pull requests already run it on `ubuntu-latest`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.