### PR TITLE
fix(customer-analytics): expose shared saved views

### DIFF
--- a/products/customer_analytics/frontend/components/Accounts/AGENTS.md
+++ b/products/customer_analytics/frontend/components/Accounts/AGENTS.md
@@ -206,6 +206,7 @@ Views are persisted as `ColumnConfiguration` rows under `context_key = 'customer
 
 **Auto-restore:** the last-used view `id` is persisted in a team-scoped localStorage key (`currentViewId`).
 A shared link's `#view=` URL hash always wins over the saved `currentViewId`.
+When saved views exist but the viewer has no last-used view, the selector remains available without applying a view automatically.
 `isDirty` is true when the live state diverges from the selected view's saved state.
 
 **One-time tiles migration:** on first load, if the signed-in user is the creator of the existing default `ColumnConfiguration` row and its `properties.tiles` is empty while their localStorage tiles differ from `DEFAULT_TILES`, `accountsViewsLogic` patches the localStorage tiles into that row.

--- a/products/customer_analytics/frontend/components/Accounts/AccountsTabFilters.test.tsx
+++ b/products/customer_analytics/frontend/components/Accounts/AccountsTabFilters.test.tsx
@@ -10,19 +10,26 @@ import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
 import { initKeaTests } from '~/test/init'
 import type { UserType } from '~/types'
 
+import type { ColumnConfigurationApi } from 'products/product_analytics/frontend/generated/api.schemas'
+
 import { ACCOUNTS_TABLE_DATA_NODE_KEY } from '../../constants'
 import { accountsLogic } from './accountsLogic'
 import { AccountsTabFilters } from './AccountsTabFilters'
 
 describe('AccountsTabFilters', () => {
     let logic: ReturnType<typeof accountsLogic.build>
+    let savedViews: ColumnConfigurationApi[]
 
     beforeEach(() => {
+        savedViews = []
         useMocks({
             get: {
                 '/api/organizations/:organization_id/members/': () => [200, { results: [] }],
                 '/api/projects/:team_id/tags': () => [200, []],
-                '/api/environments/:team_id/column_configurations': () => [200, { results: [] }],
+                '/api/environments/:team_id/column_configurations': () => [
+                    200,
+                    { count: savedViews.length, results: savedViews },
+                ],
             },
         })
         initKeaTests()
@@ -55,6 +62,29 @@ describe('AccountsTabFilters', () => {
     function myAccountsCheckbox(): HTMLInputElement {
         return screen.getByText('My accounts').closest('.LemonCheckbox')!.querySelector('input')!
     }
+
+    it('offers shared saved views when none is selected', async () => {
+        savedViews = [
+            {
+                id: 'shared-view',
+                context_key: 'customer_analytics_accounts_columns',
+                columns: ['name'],
+                name: 'Shared accounts',
+                filters: {},
+                order_by: [],
+                properties: {},
+                visibility: 'shared',
+                created_by: 999,
+                created_at: '2026-01-01T00:00:00Z',
+                updated_at: '2026-01-01T00:00:00Z',
+            },
+        ]
+        renderFilters()
+
+        fireEvent.click(await screen.findByText('Select view'))
+
+        expect(await screen.findByText('Shared accounts')).toBeInTheDocument()
+    })
 
     it('renders the "My accounts" checkbox', () => {
         renderFilters()

--- a/products/customer_analytics/frontend/components/Accounts/AccountsViewSelector.tsx
+++ b/products/customer_analytics/frontend/components/Accounts/AccountsViewSelector.tsx
@@ -65,11 +65,17 @@ export function AccountsViewSelector(): JSX.Element {
 
     return (
         <div className="flex items-center gap-2">
-            {currentView ? (
+            {views.length > 0 ? (
                 <LemonMenu items={menuItems} closeOnClickInside>
                     <LemonButton type="secondary" size="small" sideIcon={<IconChevronDown />}>
-                        <ViewVisibilityIcon view={currentView} />
-                        <span className="ml-2">{currentView.name}</span>
+                        {currentView ? (
+                            <>
+                                <ViewVisibilityIcon view={currentView} />
+                                <span className="ml-2">{currentView.name}</span>
+                            </>
+                        ) : (
+                            'Select view'
+                        )}
                     </LemonButton>
                 </LemonMenu>
             ) : (


### PR DESCRIPTION
## Problem

Customer Analytics team members cannot open shared saved views unless they already selected a view in that browser.

The API returns shared views, but the selector hides its menu when no current view exists.

## Changes

- Team members now see a “Select view” menu whenever saved views exist.
- The selector leaves account filters unchanged until the team member chooses a view.
- The Accounts guide documents the unselected state.
- Screenshot pending. The local browser journey was not run.

## How did you test this code?

- `hogli test products/customer_analytics/frontend/components/Accounts/AccountsTabFilters.test.tsx`
- The new component case catches shared views becoming unreachable without a prior selection.
- `pnpm --filter=@posthog/frontend typescript:check`
- `hogli ci:preflight --strict`
- Not run: browser testing.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated the internal Accounts guide. No published docs change is needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- GPT-5.6 used the Pi coding agent in a local session.
- Skills: `/implement-issue`, `/writing-tests`, `/improving-drf-endpoints`, `/writing-user-facing-copy`, `/writing-pr-descriptions`, `/pr-description`, `/ship-it`.
- The test fixture is invented and contains no private source material.
