### PR TITLE
fix(signals): send tab badge counts on every cloud inbox viewed event

### DIFF
--- a/products/desktop/packages/core/src/inbox/engagement.test.ts
+++ b/products/desktop/packages/core/src/inbox/engagement.test.ts
@@ -113,8 +113,8 @@ describe("buildInboxViewedProperties", () => {
     expect(props.report_count).toBe(2);
     expect(props.total_count).toBe(65);
     expect(props.ready_count).toBe(2);
-    expect(props.pulls_count).toBe(38);
-    expect(props.reports_count).toBe(62);
+    expect(props.pulls_tab_count).toBe(38);
+    expect(props.reports_tab_count).toBe(62);
     expect(props.is_empty).toBe(false);
     expect(props.status_filter_count).toBe(0);
   });

--- a/products/desktop/packages/core/src/inbox/engagement.ts
+++ b/products/desktop/packages/core/src/inbox/engagement.ts
@@ -299,7 +299,7 @@ export function buildInboxViewedProperties(
       actionabilityCounts.requires_human_input,
     actionability_not_actionable_count: actionabilityCounts.not_actionable,
     actionability_unknown_count: actionabilityCounts.unknown,
-    pulls_count: tabCounts.pulls,
-    reports_count: tabCounts.reports,
+    pulls_tab_count: tabCounts.pulls,
+    reports_tab_count: tabCounts.reports,
   };
 }

--- a/products/desktop/packages/shared/src/analytics-events.ts
+++ b/products/desktop/packages/shared/src/analytics-events.ts
@@ -671,12 +671,13 @@ export interface InboxViewedProperties {
   actionability_not_actionable_count: number;
   actionability_unknown_count: number;
   /**
-   * Tab badge counts shown in the v2 inbox header on load — the actual numbers
-   * the user sees (Pull requests / Reports / Runs). Optional: only the desktop
-   * v2 shell populates these; the mobile event omits them.
+   * Tab badge counts shown in the inbox header on load — the actual numbers
+   * the user sees (Pull requests / Reports), sent whatever tab is open. Distinct
+   * from `report_count`, which is only the loaded rows of the active tab.
+   * Optional: the mobile event omits them.
    */
-  pulls_count?: number;
-  reports_count?: number;
+  pulls_tab_count?: number;
+  reports_tab_count?: number;
 }
 
 export interface InboxReportOpenedProperties {

--- a/products/signals/frontend/inbox/components/InboxReportList.tsx
+++ b/products/signals/frontend/inbox/components/InboxReportList.tsx
@@ -58,15 +58,15 @@ function InboxReportListInner({ tabKey, Card, emptyState }: InboxReportListProps
     // The Pull requests / Reports badge counts go on every `Inbox viewed`, whatever tab is open: the
     // active tab's `total_count` alone says nothing about a user who lands on Pull requests and has
     // 200 reports waiting. These share the tab bar's keyed instances, so no extra requests.
-    const { count: pullsCount, countLoading: pullsCountLoading } = useValues(
+    const { count: pullsTabCount, countLoading: pullsTabCountLoading } = useValues(
         reportListLogic({ tabKey: 'pulls', listParams: INBOX_FLAT_TAB_LIST_PARAMS.pulls })
     )
-    const { count: reportsCount, countLoading: reportsCountLoading } = useValues(
+    const { count: reportsTabCount, countLoading: reportsTabCountLoading } = useValues(
         reportListLogic({ tabKey: 'reports', listParams: INBOX_FLAT_TAB_LIST_PARAMS.reports })
     )
     // A badge count is settled once loaded, or once its request failed (count stays null, not loading).
     const badgeCountsSettled =
-        (pullsCount !== null || !pullsCountLoading) && (reportsCount !== null || !reportsCountLoading)
+        (pullsTabCount !== null || !pullsTabCountLoading) && (reportsTabCount !== null || !reportsTabCountLoading)
 
     // Fire `Inbox viewed` once per tab mount, the first time its list and the badge counts settle
     // while visible.
@@ -78,8 +78,8 @@ function InboxReportListInner({ tabKey, Card, emptyState }: InboxReportListProps
                 tab: tabKey,
                 reports,
                 totalCount: count,
-                pullsCount,
-                reportsCount,
+                pullsTabCount,
+                reportsTabCount,
                 hasActiveFilters,
                 sourceProductFilter,
                 priorityFilter,
@@ -91,8 +91,8 @@ function InboxReportListInner({ tabKey, Card, emptyState }: InboxReportListProps
         isLoaded,
         count,
         badgeCountsSettled,
-        pullsCount,
-        reportsCount,
+        pullsTabCount,
+        reportsTabCount,
         reports,
         tabKey,
         hasActiveFilters,

--- a/products/signals/frontend/inbox/components/InboxReportList.tsx
+++ b/products/signals/frontend/inbox/components/InboxReportList.tsx
@@ -4,7 +4,7 @@ import { ComponentType, JSX, useEffect, useRef } from 'react'
 import { captureInboxReportsImpressed, captureInboxViewed } from '../inboxAnalytics'
 import { inboxSceneLogic } from '../inboxSceneLogic'
 import { inboxFiltersLogic } from '../logics/inboxFiltersLogic'
-import { reportListLogic, ReportListLogicProps } from '../logics/reportListLogic'
+import { INBOX_FLAT_TAB_LIST_PARAMS, reportListLogic, ReportListLogicProps } from '../logics/reportListLogic'
 import { InboxFlatListTabKey, SignalReport } from '../types'
 import { DismissalReasonValue } from '../utils/dismissalReasons'
 import { CardSkeleton } from './cards/CardSkeleton'
@@ -55,22 +55,51 @@ function InboxReportListInner({ tabKey, Card, emptyState }: InboxReportListProps
     const listVisible = !selectedReportId && !selectedScoutSkillName && !isScratchpadOpen && !isFindingsOpen
     const sentinelRef = useRef<HTMLDivElement>(null)
 
-    // Fire `Inbox viewed` once per tab mount, the first time its list settles while visible.
+    // The Pull requests / Reports badge counts go on every `Inbox viewed`, whatever tab is open: the
+    // active tab's `total_count` alone says nothing about a user who lands on Pull requests and has
+    // 200 reports waiting. These share the tab bar's keyed instances, so no extra requests.
+    const { count: pullsCount, countLoading: pullsCountLoading } = useValues(
+        reportListLogic({ tabKey: 'pulls', listParams: INBOX_FLAT_TAB_LIST_PARAMS.pulls })
+    )
+    const { count: reportsCount, countLoading: reportsCountLoading } = useValues(
+        reportListLogic({ tabKey: 'reports', listParams: INBOX_FLAT_TAB_LIST_PARAMS.reports })
+    )
+    // A badge count is settled once loaded, or once its request failed (count stays null, not loading).
+    const badgeCountsSettled =
+        (pullsCount !== null || !pullsCountLoading) && (reportsCount !== null || !reportsCountLoading)
+
+    // Fire `Inbox viewed` once per tab mount, the first time its list and the badge counts settle
+    // while visible.
     const viewedFiredRef = useRef(false)
     useEffect(() => {
-        if (listVisible && isLoaded && count !== null && !viewedFiredRef.current) {
+        if (listVisible && isLoaded && count !== null && badgeCountsSettled && !viewedFiredRef.current) {
             viewedFiredRef.current = true
             captureInboxViewed({
                 tab: tabKey,
                 reports,
                 totalCount: count,
+                pullsCount,
+                reportsCount,
                 hasActiveFilters,
                 sourceProductFilter,
                 priorityFilter,
                 scope,
             })
         }
-    }, [listVisible, isLoaded, count, reports, tabKey, hasActiveFilters, sourceProductFilter, priorityFilter, scope])
+    }, [
+        listVisible,
+        isLoaded,
+        count,
+        badgeCountsSettled,
+        pullsCount,
+        reportsCount,
+        reports,
+        tabKey,
+        hasActiveFilters,
+        sourceProductFilter,
+        priorityFilter,
+        scope,
+    ])
 
     // Impression log for ranking-model training: record each report the first time it appears in
     // the visible list (initial page, pagination, refresh), with its rank at that moment. Deduped

--- a/products/signals/frontend/inbox/components/InboxReportList.tsx
+++ b/products/signals/frontend/inbox/components/InboxReportList.tsx
@@ -64,9 +64,10 @@ function InboxReportListInner({ tabKey, Card, emptyState }: InboxReportListProps
     const { count: reportsTabCount, countLoading: reportsTabCountLoading } = useValues(
         reportListLogic({ tabKey: 'reports', listParams: INBOX_FLAT_TAB_LIST_PARAMS.reports })
     )
-    // A badge count is settled once loaded, or once its request failed (count stays null, not loading).
-    const badgeCountsSettled =
-        (pullsTabCount !== null || !pullsTabCountLoading) && (reportsTabCount !== null || !reportsTabCountLoading)
+    // A badge count is settled once its request is no longer in flight: loaded, refreshed, or failed
+    // (count stays null). Waiting on the loading flags rather than non-null values means a scope or
+    // filter refresh in progress doesn't fire the event with the previous query's counts.
+    const badgeCountsSettled = !pullsTabCountLoading && !reportsTabCountLoading
 
     // Fire `Inbox viewed` once per tab mount, the first time its list and the badge counts settle
     // while visible.

--- a/products/signals/frontend/inbox/inboxAnalytics.test.ts
+++ b/products/signals/frontend/inbox/inboxAnalytics.test.ts
@@ -50,12 +50,34 @@ describe('inboxAnalytics', () => {
             tab: 'reports',
             reports: [],
             totalCount: 0,
+            pullsCount: 3,
+            reportsCount: 212,
             hasActiveFilters: false,
             sourceProductFilter: [],
             priorityFilter: [],
             scope: 'for-you',
         })
         expect(lastCapture(INBOX_EVENTS.VIEWED)?.inbox_client).toBe('cloud')
+    })
+
+    it('carries the tab badge counts regardless of the active tab', () => {
+        captureInboxViewed({
+            tab: 'pulls',
+            reports: [],
+            totalCount: 0,
+            pullsCount: 0,
+            reportsCount: 212,
+            hasActiveFilters: false,
+            sourceProductFilter: [],
+            priorityFilter: [],
+            scope: 'for-you',
+        })
+        expect(lastCapture(INBOX_EVENTS.VIEWED)).toMatchObject({
+            tab: 'pulls',
+            total_count: 0,
+            pulls_count: 0,
+            reports_count: 212,
+        })
     })
 
     it('breaks the visible reports down by priority and actionability', () => {
@@ -67,6 +89,8 @@ describe('inboxAnalytics', () => {
                 makeReport({ id: 'c', priority: null, actionability: null }),
             ],
             totalCount: 3,
+            pullsCount: 1,
+            reportsCount: 3,
             hasActiveFilters: true,
             sourceProductFilter: ['error_tracking'],
             priorityFilter: ['P0'],

--- a/products/signals/frontend/inbox/inboxAnalytics.test.ts
+++ b/products/signals/frontend/inbox/inboxAnalytics.test.ts
@@ -50,8 +50,8 @@ describe('inboxAnalytics', () => {
             tab: 'reports',
             reports: [],
             totalCount: 0,
-            pullsCount: 3,
-            reportsCount: 212,
+            pullsTabCount: 3,
+            reportsTabCount: 212,
             hasActiveFilters: false,
             sourceProductFilter: [],
             priorityFilter: [],
@@ -65,8 +65,8 @@ describe('inboxAnalytics', () => {
             tab: 'pulls',
             reports: [],
             totalCount: 0,
-            pullsCount: 0,
-            reportsCount: 212,
+            pullsTabCount: 0,
+            reportsTabCount: 212,
             hasActiveFilters: false,
             sourceProductFilter: [],
             priorityFilter: [],
@@ -75,8 +75,8 @@ describe('inboxAnalytics', () => {
         expect(lastCapture(INBOX_EVENTS.VIEWED)).toMatchObject({
             tab: 'pulls',
             total_count: 0,
-            pulls_count: 0,
-            reports_count: 212,
+            pulls_tab_count: 0,
+            reports_tab_count: 212,
         })
     })
 
@@ -89,8 +89,8 @@ describe('inboxAnalytics', () => {
                 makeReport({ id: 'c', priority: null, actionability: null }),
             ],
             totalCount: 3,
-            pullsCount: 1,
-            reportsCount: 3,
+            pullsTabCount: 1,
+            reportsTabCount: 3,
             hasActiveFilters: true,
             sourceProductFilter: ['error_tracking'],
             priorityFilter: ['P0'],

--- a/products/signals/frontend/inbox/inboxAnalytics.ts
+++ b/products/signals/frontend/inbox/inboxAnalytics.ts
@@ -229,7 +229,7 @@ export function captureInboxWelcomeCommandCopied(params: {
 /**
  * The report list settled for the first time in a tab mount. `report_count` / `total_count` describe
  * the active tab's list only (and `report_count` is capped at the loaded page), so the headline
- * "how many reports does this user have" numbers are `pulls_count` / `reports_count`: the tab badge
+ * "how many reports does this user have" numbers are `pulls_tab_count` / `reports_tab_count`: the tab badge
  * counts, sent on every view regardless of which tab is open (same shape as the desktop event).
  * A badge count is null only if its request failed.
  */
@@ -237,8 +237,8 @@ export function captureInboxViewed(params: {
     tab: string
     reports: SignalReport[]
     totalCount: number
-    pullsCount: number | null
-    reportsCount: number | null
+    pullsTabCount: number | null
+    reportsTabCount: number | null
     hasActiveFilters: boolean
     sourceProductFilter: string[]
     priorityFilter: string[]
@@ -248,8 +248,8 @@ export function captureInboxViewed(params: {
         tab: params.tab,
         report_count: params.reports.length,
         total_count: params.totalCount,
-        pulls_count: params.pullsCount,
-        reports_count: params.reportsCount,
+        pulls_tab_count: params.pullsTabCount,
+        reports_tab_count: params.reportsTabCount,
         is_empty: params.totalCount === 0,
         has_active_filters: params.hasActiveFilters,
         source_product_filter: params.sourceProductFilter,

--- a/products/signals/frontend/inbox/inboxAnalytics.ts
+++ b/products/signals/frontend/inbox/inboxAnalytics.ts
@@ -226,10 +226,19 @@ export function captureInboxWelcomeCommandCopied(params: {
     })
 }
 
+/**
+ * The report list settled for the first time in a tab mount. `report_count` / `total_count` describe
+ * the active tab's list only (and `report_count` is capped at the loaded page), so the headline
+ * "how many reports does this user have" numbers are `pulls_count` / `reports_count`: the tab badge
+ * counts, sent on every view regardless of which tab is open (same shape as the desktop event).
+ * A badge count is null only if its request failed.
+ */
 export function captureInboxViewed(params: {
     tab: string
     reports: SignalReport[]
     totalCount: number
+    pullsCount: number | null
+    reportsCount: number | null
     hasActiveFilters: boolean
     sourceProductFilter: string[]
     priorityFilter: string[]
@@ -239,6 +248,8 @@ export function captureInboxViewed(params: {
         tab: params.tab,
         report_count: params.reports.length,
         total_count: params.totalCount,
+        pulls_count: params.pullsCount,
+        reports_count: params.reportsCount,
         is_empty: params.totalCount === 0,
         has_active_filters: params.hasActiveFilters,
         source_product_filter: params.sourceProductFilter,


### PR DESCRIPTION
## Problem

Anyone measuring how many reports users have in the Inbox gets an undercount from the cloud `Inbox viewed` event.

- The cloud event only carries `total_count` for the active tab. A user on the Pull requests tab with 200 reports waiting logs `total_count: 44`.
- `report_count` is the loaded first page, so it pins at the page size (50) on populated inboxes.
- The desktop inbox already sends the tab badge numbers on every view, as `pulls_count` / `reports_count`. Cloud never populated them, and `reports_count` next to `report_count` reads like a typo.

Origin: [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1787152146812449).

## Changes

- The cloud `Inbox viewed` event now carries `pulls_tab_count` and `reports_tab_count`, the numbers shown in the Pull requests and Reports tab badges, whatever tab is open.
- The desktop event renames `pulls_count` / `reports_count` to the same `pulls_tab_count` / `reports_tab_count`, so both clients share one unambiguous name.
- The cloud event waits until both badge counts settle (loaded, or their request failed) before it fires. A failed badge request sends `null`.
- Nothing visible changes. No new requests: the counts come from the tab bar's already-mounted `reportListLogic` instances.

> [!NOTE]
> Queries on desktop's `pulls_count` / `reports_count` need the new names going forward. Those properties covered only desktop views.

## How did you test this code?

- `inboxAnalytics.test.ts`: new case asserts a Pull requests tab view carries `reports_tab_count` from the Reports badge. Existing cases updated for the new required fields.
- Desktop `engagement.test.ts` updated for the rename.
- Not run: the app in a browser.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5), directed by the assignee from the linked Slack thread. Skills invoked: `/writing-pr-descriptions`. First draft reused desktop's `pulls_count` / `reports_count`; renamed to `*_tab_count` on both clients after review flagged the clash with `report_count`. Not actionable and Archived badges are left out: they are staff-only or rarely mounted and would add requests for every user.
