### PR TITLE
fix(signals): spin only the scout button that started the task

### DIFF
--- a/products/signals/frontend/inbox/components/config/scouts/ScoutCreateButton.test.tsx
+++ b/products/signals/frontend/inbox/components/config/scouts/ScoutCreateButton.test.tsx
@@ -6,6 +6,7 @@ import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 
 import { ScoutCreateButton } from './ScoutCreateButton'
+import { ScoutsRosterActions } from './ScoutsRosterActions'
 import { ScoutSuggestButton } from './ScoutSuggestButton'
 
 jest.mock('lib/utils/accessControlUtils', () => ({
@@ -78,6 +79,17 @@ describe('scout creation buttons', () => {
 
         await waitFor(() => expect(startedChatTypes).toEqual(['author_scout']))
         expect(queryByText('Manual scout form')).toBeNull()
+    })
+
+    it('spins only the button that started the task', async () => {
+        const { getByText } = render(<ScoutsRosterActions />)
+
+        fireEvent.click(getByText('Suggest a scout'))
+
+        // Both assertions read the same render, before the task resolves and clears the state.
+        expect(getByText('Suggest a scout').closest('button')?.querySelector('.Spinner')).toBeTruthy()
+        expect(getByText('Ask').closest('button')?.querySelector('.Spinner')).toBeNull()
+        await waitFor(() => expect(startedChatTypes).toEqual(['author_scout']))
     })
 
     it.each([

--- a/products/signals/frontend/inbox/components/config/scouts/ScoutsRosterActions.tsx
+++ b/products/signals/frontend/inbox/components/config/scouts/ScoutsRosterActions.tsx
@@ -31,16 +31,30 @@ function AskAboutScoutsMenu(): JSX.Element {
         { label: 'How is my scout troop performing?', chatType: 'fleet_overview' },
         { label: 'What signals were emitted recently?', chatType: 'recent_signals' },
     ]
+    // Only spin for this menu's own prompts, so kicking off a task from a sibling button
+    // doesn't make every scout CTA in the header look like it's loading.
+    const isStarting = prompts.some(({ chatType }) => chatType === runningChatType)
+    const anotherTaskIsStarting = runningChatType !== null && !isStarting
 
     return (
         <LemonMenu
             items={prompts.map(({ label, chatType }) => ({
                 label,
                 onClick: () => startScoutChatTask(chatType, label),
-                disabledReason: runningChatType !== null ? 'Starting a task…' : (aiConsentDisabledReason ?? undefined),
+                disabledReason: anotherTaskIsStarting
+                    ? 'Starting another task…'
+                    : isStarting
+                      ? 'Starting a task…'
+                      : (aiConsentDisabledReason ?? undefined),
             }))}
         >
-            <LemonButton type="secondary" size="small" icon={<IconSparkles />} loading={runningChatType !== null}>
+            <LemonButton
+                type="secondary"
+                size="small"
+                icon={<IconSparkles />}
+                loading={isStarting}
+                disabledReason={anotherTaskIsStarting ? 'Starting another task…' : undefined}
+            >
                 Ask
             </LemonButton>
         </LemonMenu>


### PR DESCRIPTION
## Problem

In the scouts roster header, pressing "Suggest a scout" made the neighbouring "Ask" button spin too. Two buttons loading at once for one action reads as unfinished, and it hides which button is actually doing something.

The "Ask" menu was spinning on `runningChatType !== null` — true for any scout chat task, including the one "Suggest a scout" starts.

## Changes

- Pressing "Suggest a scout" now spins only that button. "Ask" stays idle.
- While a sibling task is starting, "Ask" is disabled with "Starting another task…", matching how "Suggest a scout" already behaves in the reverse case.
- The menu items keep their own wording: "Starting a task…" when it's their task, "Starting another task…" when it isn't.

## How did you test this code?

Added a Jest case that renders the header, clicks "Suggest a scout", and asserts a spinner on that button and none on "Ask". It catches the shared-loading regression — the existing tests render each button in isolation, so neither could see one button spinning because of the other. Verified it fails against the old `loading={runningChatType !== null}` and passes with the fix.

Not manually tested in a running app — no browser session was used.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing docs cover this button's loading state.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code (Opus) from a screenshot of the header showing both buttons spinning. Located the shared `scoutFleetLogic.runningChatType` value, which `ScoutSuggestButton` already narrows to its own chat type but `AskAboutScoutsMenu` did not.

The alternative — a per-button local loading flag — was rejected because the mutual-exclusion behaviour (one task at a time across the header) depends on a shared value, and `ScoutSuggestButton` already reads it correctly. Narrowing the read in one place keeps both buttons on the same source of truth.

No skills invoked. Nothing from the session context reached the diff or this description; the change came from repository code.

---

*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
