### PR TITLE
fix: refresh dashboards after insight additions

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -89,7 +89,11 @@ export function DashboardHeader({ loading = false }: { loading?: boolean }): JSX
                                   text: dashboard.name,
                                   icon: iconForType('dashboard'),
                               },
-                              callback: () => loadDashboard({ action: DashboardLoadAction.Update }),
+                              callback: (toolOutput: { dashboard_id?: string | number }) => {
+                                  if (Number(toolOutput?.dashboard_id) === dashboard.id) {
+                                      loadDashboard({ action: DashboardLoadAction.Update })
+                                  }
+                              },
                           }
                         : undefined
                 }

--- a/frontend/src/scenes/saved-insights/addSavedInsightsModalLogic.test.ts
+++ b/frontend/src/scenes/saved-insights/addSavedInsightsModalLogic.test.ts
@@ -4,6 +4,8 @@ import { expectLogic, partial } from 'kea-test-utils'
 
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { DashboardLoadAction, dashboardLogic } from 'scenes/dashboard/dashboardLogic'
+import { insightsApi } from 'scenes/insights/utils/api'
 
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
@@ -262,5 +264,23 @@ describe('addSavedInsightsModalLogic', () => {
 
             expect(apiCallCount).toBe(1)
         })
+    })
+
+    it('refreshes the mounted dashboard after adding an insight', async () => {
+        initKeaTests()
+        const dashboard = dashboardLogic({ id: 1, dashboard: { id: 1, tiles: [] } as any })
+        dashboard.mount()
+        const loadDashboard = jest.spyOn(dashboard.actions, 'loadDashboard').mockImplementation()
+        jest.spyOn(insightsApi, 'update').mockResolvedValue(createInsight(1))
+
+        const logic = addSavedInsightsModalLogic()
+        logic.mount()
+
+        await expectLogic(logic, () => logic.actions.addInsightToDashboard(createInsight(1), 1)).toFinishAllListeners()
+
+        expect(loadDashboard).toHaveBeenCalledWith({ action: DashboardLoadAction.Update })
+
+        logic.unmount()
+        dashboard.unmount()
     })
 })

--- a/frontend/src/scenes/saved-insights/addSavedInsightsModalLogic.test.ts
+++ b/frontend/src/scenes/saved-insights/addSavedInsightsModalLogic.test.ts
@@ -5,6 +5,7 @@ import { expectLogic, partial } from 'kea-test-utils'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { DashboardLoadAction, dashboardLogic } from 'scenes/dashboard/dashboardLogic'
+import { dashboardResult } from 'scenes/dashboard/dashboardLogic.testHelpers'
 import { insightsApi } from 'scenes/insights/utils/api'
 
 import { useMocks } from '~/mocks/jest'
@@ -268,7 +269,7 @@ describe('addSavedInsightsModalLogic', () => {
 
     it('refreshes the mounted dashboard after adding an insight', async () => {
         initKeaTests()
-        const dashboard = dashboardLogic({ id: 1, dashboard: { id: 1, tiles: [] } as any })
+        const dashboard = dashboardLogic({ id: 1, dashboard: dashboardResult(1, []) })
         dashboard.mount()
         const loadDashboard = jest.spyOn(dashboard.actions, 'loadDashboard').mockImplementation()
         jest.spyOn(insightsApi, 'update').mockResolvedValue(createInsight(1))

--- a/frontend/src/scenes/saved-insights/addSavedInsightsModalLogic.ts
+++ b/frontend/src/scenes/saved-insights/addSavedInsightsModalLogic.ts
@@ -371,10 +371,9 @@ export const addSavedInsightsModalLogic = kea<addSavedInsightsModalLogicType>([
                 })
                 if (response) {
                     actions.updateInsight(response)
-                    const logic = dashboardLogic({ id: dashboardId })
-                    logic.mount()
-                    logic.actions.loadDashboard({ action: DashboardLoadAction.Update })
-                    logic.unmount()
+                    dashboardLogic.findMounted({ id: dashboardId })?.actions.loadDashboard({
+                        action: DashboardLoadAction.Update,
+                    })
                     lemonToast.success('Insight added to dashboard')
                 }
             } catch (e) {
@@ -402,10 +401,9 @@ export const addSavedInsightsModalLogic = kea<addSavedInsightsModalLogicType>([
                 })
                 if (response) {
                     actions.updateInsight(response)
-                    const logic = dashboardLogic({ id: dashboardId })
-                    logic.mount()
-                    logic.actions.loadDashboard({ action: DashboardLoadAction.Update })
-                    logic.unmount()
+                    dashboardLogic.findMounted({ id: dashboardId })?.actions.loadDashboard({
+                        action: DashboardLoadAction.Update,
+                    })
                     lemonToast.success('Insight removed from dashboard')
                 }
             } catch (e) {


### PR DESCRIPTION
## Problem

Dashboard tiles added through AI or the saved-insights modal can remain stale until a page refresh.

## Changes

- Refresh only the dashboard reported by the AI dashboard-update completion payload.
- Refresh the already-mounted dashboard after saved-insight changes, avoiding a transient mount/unmount cycle.

## Why

Keep the dashboard in sync after insight additions without resetting the AI conversation.

## How did you test this code?

- Checked the staged diff for whitespace errors.
- Full frontend test tooling is not installed in this checkout.

## Publish to changelog?

No

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B9A53J8RF/p1787153897948719)*