### PR TITLE
fix(replay): remove redundant per-row ResizeObserver in inspector list

### DIFF
--- a/frontend/src/scenes/session-recordings/player/inspector/components/PlayerInspectorListItem.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/PlayerInspectorListItem.tsx
@@ -1,8 +1,6 @@
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
-import { FunctionComponent, isValidElement, memo, useEffect, useRef } from 'react'
-import { useDebouncedCallback } from 'use-debounce'
-import useResizeObserver from 'use-resize-observer'
+import { FunctionComponent, isValidElement, memo, useRef } from 'react'
 
 import {
     BaseIcon,
@@ -60,8 +58,6 @@ import {
 import { ItemAppState, ItemAppStateDetail, ItemConsoleLog, ItemConsoleLogDetail } from './ItemConsoleLog'
 import { ItemDoctor, ItemDoctorDetail } from './ItemDoctor'
 import { ItemEvent, ItemEventDetail, ItemEventMenu } from './ItemEvent'
-
-const PLAYER_INSPECTOR_LIST_ITEM_MARGIN = 1
 
 interface IconAndDescription {
     Icon: FunctionComponent | undefined
@@ -424,53 +420,22 @@ const ListItemDetail = memo(function ListItemDetail({
 export const PlayerInspectorListItem = memo(function PlayerInspectorListItem({
     item,
     index,
-    onLayout,
     groupCount,
     groupedItems,
 }: {
     item: InspectorListItem
     index: number
-    onLayout?: (layout: { width: number; height: number }) => void
     groupCount?: number
     groupedItems?: InspectorListItem[]
 }): JSX.Element {
     const hoverRef = useRef<HTMLDivElement>(null)
+    const ref = useRef<HTMLDivElement>(null)
 
     const { logicProps } = useValues(sessionRecordingPlayerLogic)
 
     const { expandedItems } = useValues(playerInspectorLogic(logicProps))
 
     const isExpanded = expandedItems.includes(index)
-
-    const onLayoutDebounced = useDebouncedCallback(onLayout ?? (() => {}), 500)
-    const { ref, width, height } = useResizeObserver({})
-
-    const totalHeight = height ? height + PLAYER_INSPECTOR_LIST_ITEM_MARGIN : height
-
-    // Height changes should lay out immediately but width ones (browser resize can be much slower)
-    useEffect(
-        () => {
-            if (!onLayout || !width || !totalHeight) {
-                return
-            }
-            onLayoutDebounced({ width, height: totalHeight })
-        },
-        // purposefully only triggering on width
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-        [width]
-    )
-
-    useEffect(
-        () => {
-            if (!onLayout || !width || !totalHeight) {
-                return
-            }
-            onLayout({ width, height: totalHeight })
-        },
-        // purposefully only triggering on total height
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-        [totalHeight]
-    )
 
     const isHovering = useIsHovering(hoverRef)
 


### PR DESCRIPTION
## Problem

Session Replay's Inspector panel virtualizes its row list with `react-window`, which already manages dynamic row heights via a single shared `ResizeObserver` instance (`useDynamicRowHeight` → `observeRowElements`). Each row (`PlayerInspectorListItem`) *also* independently created its own separate `ResizeObserver` via an `onLayout` callback prop — but nothing in the codebase passes `onLayout` anymore, so this was dead code left over from before the `react-window` migration.

With `overscanCount: 20`, that meant dozens of standalone `ResizeObserver` instances could be alive at once on a busy session, each competing for the browser's per-frame resize-notification budget. Many independent observers (vs. one observer watching many targets) is a known trigger for `ResizeObserver loop completed with undelivered notifications`, and we've seen this error reported on the replay Inspector panel, including on sessions long/heavy enough that it visibly stalls the tab.

## Changes

- Removed the dead `useResizeObserver` call, `onLayout` prop, `onLayoutDebounced`, and both associated effects from `PlayerInspectorListItem.tsx` (confirmed via repo-wide search: no caller passes `onLayout`).
- Replaced the `ref` (previously returned by `useResizeObserver`) with a plain `useRef`, since the outer `<div>` still needs one.
- Removed now-unused imports (`useResizeObserver`, `useDebouncedCallback`) and the now-dead `PLAYER_INSPECTOR_LIST_ITEM_MARGIN` constant.
- Row height measurement is unaffected — it's still handled entirely by `react-window`'s own `useDynamicRowHeight`, which was already the correct, single-shared-instance implementation.

No screenshots, since this is a pure dead-code removal with no visual change.

## How did you test this code?

Re-confirmed on top of current `master`:
- `pnpm --filter=@posthog/frontend typescript:check` — zero errors attributable to the changed file.
- Repo-wide grep confirming `onLayout` has zero remaining callers.
- Diff is byte-identical to the change reviewed on #84826.

## Publish to changelog?
no

## Docs update
Not applicable — internal implementation detail, no user-facing behavior change.

## 🤖 Agent context
Supersedes #84826, whose branch had an unusually old git parent that caused CI to fail on a stale `uv` version pin. Rebasing onto current `master` fixed that, but recreating the branch to complete the rebase caused GitHub to auto-close #84826 (irrecoverable — GitHub refuses to reopen a PR once its branch has been recreated). This PR carries the exact same one-file change, now correctly based on current `master`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
