### PR TITLE
fix(llm-gateway): give GLM 5.3 its own model access flag

### DIFF
--- a/products/desktop/packages/harness/src/extensions/posthog-provider/model-catalog.ts
+++ b/products/desktop/packages/harness/src/extensions/posthog-provider/model-catalog.ts
@@ -21,6 +21,7 @@ const PI_MODEL_LABELS: Record<string, string> = {
   "gpt-5.6-terra": "GPT-5.6 Terra",
   "gpt-5.6-luna": "GPT-5.6 Luna",
   "@cf/zai-org/glm-5.2": "GLM-5.2",
+  "zai-org/glm-5.3": "GLM-5.3",
   "moonshotai/kimi-k3": "Kimi K3",
 };
 

--- a/products/desktop/packages/shared/src/cloud-task-models.test.ts
+++ b/products/desktop/packages/shared/src/cloud-task-models.test.ts
@@ -36,6 +36,7 @@ describe("formatGatewayModelName", () => {
     [model("openai/gpt-5.6-sol", "openai"), "GPT-5.6 Sol"],
     [model("moonshotai/kimi-k3", "modal"), "Kimi K3"],
     [model("@cf/zai-org/glm-5.2", "cloudflare"), "GLM-5.2"],
+    [model("zai-org/glm-5.3", "baseten"), "GLM-5.3"],
     [
       model("deepseek-ai/deepseek-v4-flash-0731", "baseten"),
       "DeepSeek V4 Flash",

--- a/products/desktop/packages/shared/src/cloud-task-models.ts
+++ b/products/desktop/packages/shared/src/cloud-task-models.ts
@@ -278,7 +278,7 @@ export function formatGatewayModelName(model: GatewayModel): string {
   if (displayName) {
     return displayName;
   }
-  if (isCloudflareModel(model)) {
+  if (isCloudflareModel(model) || isBasetenModel(model)) {
     return formatProviderModelName(model.id.split("/").pop() ?? model.id);
   }
   if (isModalModel(model)) {

--- a/products/desktop/packages/shared/src/flags.ts
+++ b/products/desktop/packages/shared/src/flags.ts
@@ -20,7 +20,6 @@ export const CHANNELS_LAYOUT_FLAG = "code-spaces-layout";
 export const LOOPS_FLAG = "loops";
 export const TASKS_PREWARM_SANDBOX_FLAG = "tasks-prewarm-sandbox";
 export const GLM_MODEL_FLAG = "posthog-code-glm-model";
-/** Its own flag, not the GLM Baseten routing one: 5.3 has no open weights to serve yet. */
 export const GLM53_MODEL_FLAG = "posthog-code-glm-53-model";
 /** PostHog Desktop: show DeepSeek V4 Flash in the model picker. Off = hidden. */
 export const DEEPSEEK_MODEL_FLAG = "posthog-code-deepseek-model";

--- a/products/desktop/packages/shared/src/flags.ts
+++ b/products/desktop/packages/shared/src/flags.ts
@@ -20,7 +20,8 @@ export const CHANNELS_LAYOUT_FLAG = "code-spaces-layout";
 export const LOOPS_FLAG = "loops";
 export const TASKS_PREWARM_SANDBOX_FLAG = "tasks-prewarm-sandbox";
 export const GLM_MODEL_FLAG = "posthog-code-glm-model";
-export const GLM53_MODEL_FLAG = "tasks-glm-baseten-inference";
+/** Its own flag, not the GLM Baseten routing one: 5.3 has no open weights to serve yet. */
+export const GLM53_MODEL_FLAG = "posthog-code-glm-53-model";
 /** PostHog Desktop: show DeepSeek V4 Flash in the model picker. Off = hidden. */
 export const DEEPSEEK_MODEL_FLAG = "posthog-code-deepseek-model";
 export const KIMI_MODEL_FLAG = "tasks-kimi-k3";

--- a/products/desktop/packages/ui/src/features/loops/loopModels.ts
+++ b/products/desktop/packages/ui/src/features/loops/loopModels.ts
@@ -47,6 +47,7 @@ const FALLBACK_MODEL_OPTIONS: Record<
     { value: "claude-sonnet-5", label: "Claude Sonnet 5" },
     { value: "claude-fable-5", label: "Claude Fable 5" },
     { value: "@cf/zai-org/glm-5.2", label: "GLM-5.2" },
+    { value: "zai-org/glm-5.3", label: "GLM-5.3" },
     { value: "moonshotai/kimi-k3", label: "Kimi K3" },
   ],
   codex: [

--- a/services/llm-gateway/README.md
+++ b/services/llm-gateway/README.md
@@ -215,7 +215,10 @@ Use your runtime's standard AWS authentication mechanism (e.g. IAM role, IRSA, E
 The gateway exposes models consistently across Anthropic Messages, chat/completions, and Responses while choosing their inference provider internally in `src/llm_gateway/inference_routing.py`.
 
 - **GLM 5.2** (`@cf/zai-org/glm-5.2`) can run on Cloudflare Workers AI, Modal, or Baseten.
-- **GLM 5.3** (`zai-org/glm-5.3`) runs only on Baseten and is available to ReviewHog and PostHog Desktop behind the `tasks-glm-baseten-inference` flag. Do not enable the flag until Baseten lists the model and the deployment slug, context window, and contract rate in `model_cost_overrides.py` / `model_registry.py` are confirmed against `inference.baseten.co/v1/models`: the rate is pinned, so a wrong placeholder bills at the wrong price with no automatic correction.
+- **GLM 5.3** (`zai-org/glm-5.3`) runs only on Baseten and is available to ReviewHog and PostHog Desktop behind its own `posthog-code-glm-53-model` flag.
+  Deliberately not `tasks-glm-baseten-inference`: that one only moves GLM 5.2 traffic onto Baseten, so sharing it would grant 5.3 by proxy the moment 5.2 routing changed.
+  GLM 5.3 has no open weights released yet, so the flag is not created: the access gate fails closed, keeping the model blocked server-side and hidden in every picker.
+  Do not create the flag until Baseten lists the model and the deployment slug, context window, and contract rate in `model_cost_overrides.py` / `model_registry.py` are confirmed against `inference.baseten.co/v1/models`: the rate is pinned, so a wrong placeholder bills at the wrong price with no automatic correction.
 - **DeepSeek V4 Flash** (`deepseek-ai/deepseek-v4-flash-0731`) runs only on Baseten and is available to ReviewHog and PostHog Desktop (client-gated by the `posthog-code-deepseek-model` flag).
 
 Provider configuration:
@@ -224,7 +227,7 @@ Provider configuration:
 - **Modal** (an OpenAI-compatible vLLM endpoint) — configure `LLM_GATEWAY_MODAL_API_BASE`, `LLM_GATEWAY_MODAL_KEY`, and `LLM_GATEWAY_MODAL_SECRET` (a [Modal proxy-token](https://modal.com/docs/guide/endpoints) pair, sent as `Modal-Key`/`Modal-Secret` headers).
 - **Baseten** (an OpenAI-compatible endpoint) - configure `LLM_GATEWAY_BASETEN_API_BASE` and `LLM_GATEWAY_BASETEN_API_KEY`.
 
-The `tasks-glm-baseten-inference` feature flag routes matching users to Baseten when its API key is configured. The flag is evaluated server-side, and caller-forwarded flag headers cannot select Baseten. Cloudflare or Modal must remain configured as the fallback for users who do not match the flag or when evaluation is unavailable.
+The `tasks-glm-baseten-inference` feature flag routes matching users' GLM 5.2 traffic to Baseten when its API key is configured. The flag is evaluated server-side, and caller-forwarded flag headers cannot select Baseten. Cloudflare or Modal must remain configured as the fallback for users who do not match the flag or when evaluation is unavailable.
 
 Two knobs opt traffic into Modal (OR semantics, both default off):
 

--- a/services/llm-gateway/src/llm_gateway/products/config.py
+++ b/services/llm-gateway/src/llm_gateway/products/config.py
@@ -475,7 +475,7 @@ def check_free_tier_model_access(
 MODEL_ACCESS_FLAGS: Final[dict[str, str]] = {
     "moonshotai/kimi-k3": "tasks-kimi-k3",
     "deepseek-ai/deepseek-v4-flash-0731": "posthog-code-deepseek-model",
-    "zai-org/glm-5.3": "tasks-glm-baseten-inference",
+    "zai-org/glm-5.3": "posthog-code-glm-53-model",
 }
 
 

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/model_cost_overrides.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/model_cost_overrides.py
@@ -35,7 +35,7 @@ BASETEN_GLM_COST: Final[ModelCost] = {
 
 # Placeholder: the GLM 5.2 contract rate, pending Baseten listing GLM 5.3. The pin below
 # blocks any automatic correction, so confirm the real contract rate here BEFORE creating
-# the tasks-glm-baseten-inference flag (see the README's GLM 5.3 go-live note).
+# the posthog-code-glm-53-model flag (see the README's GLM 5.3 go-live note).
 BASETEN_GLM53_COST: Final[ModelCost] = {
     "litellm_provider": "baseten",
     "mode": "chat",

--- a/services/llm-gateway/tests/test_dependencies.py
+++ b/services/llm-gateway/tests/test_dependencies.py
@@ -470,7 +470,7 @@ class TestBasetenExclusiveModelGateWiring:
         ("model", "access_flag", "path"),
         [
             (BASETEN_DEEPSEEK_PUBLIC_MODEL, "posthog-code-deepseek-model", "/posthog_code/v1/messages"),
-            (BASETEN_GLM53_PUBLIC_MODEL, "tasks-glm-baseten-inference", "/posthog_code/v1/messages"),
+            (BASETEN_GLM53_PUBLIC_MODEL, "posthog-code-glm-53-model", "/posthog_code/v1/messages"),
         ],
     )
     @pytest.mark.parametrize("flag_result", [False, None])

--- a/services/llm-gateway/tests/test_product_config.py
+++ b/services/llm-gateway/tests/test_product_config.py
@@ -714,8 +714,6 @@ class TestModelAccessFlag:
     def test_every_gated_model_has_its_own_flag(self):
         flags = list(MODEL_ACCESS_FLAGS.values())
         assert len(flags) == len(set(flags))
-        # an entitlement flag must not double as a backend routing flag, or flipping a
-        # routing flag would widen model access as a side effect
         assert not set(flags) & {GLM_BASETEN_FLAG, GLM_MODAL_FLAG}
 
     @pytest.mark.parametrize("model", [None, "", "gpt-5.2", "claude-opus-5", "@cf/zai-org/glm-5.2"])

--- a/services/llm-gateway/tests/test_product_config.py
+++ b/services/llm-gateway/tests/test_product_config.py
@@ -5,6 +5,7 @@ from fastapi import HTTPException
 
 from llm_gateway.baseten import BASETEN_MODELS
 from llm_gateway.cloudflare import CLOUDFLARE_ALLOWED_MODELS
+from llm_gateway.flags import GLM_BASETEN_FLAG, GLM_MODAL_FLAG
 from llm_gateway.inference_routing import is_inference_routed_model
 from llm_gateway.modal import is_modal_served_model
 from llm_gateway.products.config import (
@@ -713,6 +714,9 @@ class TestModelAccessFlag:
     def test_every_gated_model_has_its_own_flag(self):
         flags = list(MODEL_ACCESS_FLAGS.values())
         assert len(flags) == len(set(flags))
+        # an entitlement flag must not double as a backend routing flag, or flipping a
+        # routing flag would widen model access as a side effect
+        assert not set(flags) & {GLM_BASETEN_FLAG, GLM_MODAL_FLAG}
 
     @pytest.mark.parametrize("model", [None, "", "gpt-5.2", "claude-opus-5", "@cf/zai-org/glm-5.2"])
     def test_ungated_models_need_no_flag(self, model: str | None):


### PR DESCRIPTION
## Problem

PostHog Desktop users never see GLM 5.3 in a model picker, even when their flag gate should show it.

- The model was gated on `tasks-glm-baseten-inference`, the flag that routes GLM 5.2 traffic onto Baseten.
- That flag evaluates server-side only, so posthog-js never receives it and `useFeatureFlag` reads false.
- Sharing it also couples the two: widening GLM 5.2 routing would grant GLM 5.3 access as a side effect.

GLM 5.3 has no open weights released yet, so it cannot serve a request either way.

## Changes

- GLM 5.3 now sits behind its own `posthog-code-glm-53-model` flag, in the gateway entitlement map and the Desktop pickers.
- That flag does not exist yet. Both gates fail closed, so the model stays blocked server-side and hidden in every picker until someone creates it.
- `tasks-glm-baseten-inference` keeps only its routing job.
- Mechanical: the llm-gateway README and a cost-override comment name the new flag.


