### PR TITLE
feat(desktop): let the question card be resized and hidden

### DIFF
--- a/products/desktop/packages/ui/src/features/sessions/components/ComposerWidth.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ComposerWidth.tsx
@@ -1,0 +1,58 @@
+import {
+  CHAT_CONTENT_MAX_WIDTH,
+  CHAT_CONTENT_PADDING_INLINE,
+} from "@posthog/ui/features/sessions/constants";
+
+/** Widest ring the composer paints outside its border box (quill's 3px focus outline). */
+const OUTLINE_BLEED = 4;
+
+/**
+ * Centers composer-slot content at the chat width (or compact padding).
+ *
+ * The composer reserves the same horizontal room as the thread's scroll
+ * content and caps at the same width, so the two columns are identical at
+ * every panel width rather than only once the panel is wide enough for the
+ * full column. Padding on the capped box instead of around it would eat into
+ * `CHAT_CONTENT_MAX_WIDTH` and leave the composer narrower than the messages.
+ *
+ * The gutter is a percentage of this box, and the thread's equivalent box sits
+ * inside a scroller whose `scrollbar-gutter: stable` has already taken the
+ * scrollbar's width off it. Without the same reservation here, the composer
+ * centers on a wider box and its column lands half a scrollbar right of the
+ * messages. Reserving it rather than subtracting a constant keeps the browser's
+ * own measurement authoritative, since scrollbar width varies by platform.
+ */
+export function ComposerWidth({
+  compact,
+  children,
+}: {
+  compact: boolean;
+  children: React.ReactNode;
+}) {
+  if (compact) {
+    return <div className="p-1">{children}</div>;
+  }
+
+  return (
+    <div
+      style={{
+        paddingInline: CHAT_CONTENT_PADDING_INLINE,
+        overflow: "hidden",
+        scrollbarGutter: "stable",
+        // `overflow: hidden` clips at this box's padding edge, which sits flush
+        // with the composer's top, so the focus ring painted outside its border
+        // box would lose its top. Buy the ring room and take it back out of the
+        // layout. The sides have the gutter and `pb-2` covers below.
+        paddingBlockStart: OUTLINE_BLEED,
+        marginBlockStart: -OUTLINE_BLEED,
+      }}
+    >
+      <div
+        className="mx-auto pb-2"
+        style={{ maxWidth: CHAT_CONTENT_MAX_WIDTH }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/products/desktop/packages/ui/src/features/sessions/components/PermissionDock.stories.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/PermissionDock.stories.tsx
@@ -1,0 +1,87 @@
+import {
+  buildQuestionOptions,
+  buildQuestionToolCallData,
+  type QuestionItem,
+} from "@posthog/agent/adapters/claude/questions/utils";
+import { PermissionSelector } from "@posthog/ui/features/permissions/PermissionSelector";
+import { PermissionDock } from "@posthog/ui/features/sessions/components/PermissionDock";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const wordyQuestions: QuestionItem[] = [
+  {
+    question:
+      "The migration can move the queue off Postgres in three different orders. Which one do you want?",
+    header: "Approach",
+    options: [
+      {
+        label: "Dual-write, then cut reads over",
+        description:
+          "Write every job to both stores, leave reads on Postgres until the new store has a full day of traffic, then flip reads in one deploy. Slowest, but every step is reversible on its own.",
+      },
+      {
+        label: "Shadow the consumer first",
+        description:
+          "Stand up a second consumer that reads the new store and discards its results, compare its output against the live one for a week, then promote it. Catches ordering bugs before any user sees them.",
+      },
+      {
+        label: "Cut over per queue",
+        description:
+          "Move one low-volume queue end to end, watch it for a day, then work up to the busiest one. Keeps the blast radius small but stretches the migration across several weeks.",
+      },
+      {
+        label: "Freeze writes and copy",
+        description:
+          "Pause producers, drain the backlog, copy what is left, and restart against the new store. Fastest to finish and easiest to reason about, at the cost of a short window where jobs queue up in the producers.",
+      },
+      {
+        label: "Leave it on Postgres",
+        description:
+          "Keep the queue where it is and spend the time on the indexes and the vacuum schedule instead. Worth considering if the current pain is throughput rather than storage.",
+      },
+    ],
+  },
+];
+
+/** Stands in for the thread the dock must not swallow. */
+function ChatColumn({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex h-[520px] flex-col overflow-hidden rounded-(--radius-3) border border-(--gray-6) bg-(--gray-2)">
+      <div className="min-h-0 flex-1 overflow-y-auto px-3 py-2 text-[13px]">
+        {Array.from({ length: 12 }, (_, i) => `step-${i + 1}`).map(
+          (step, i) => (
+            <p key={step} className="mb-2 text-(--gray-11)">
+              Investigation step {i + 1}: read the consumer, traced the retry
+              path, and confirmed the backlog builds only while the nightly job
+              holds its advisory lock.
+            </p>
+          ),
+        )}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+const meta: Meta<typeof PermissionDock> = {
+  title: "Components/Sessions/PermissionDock",
+  component: PermissionDock,
+  parameters: { layout: "padded" },
+};
+
+export default meta;
+type Story = StoryObj<typeof PermissionDock>;
+
+export const WordyQuestion: Story = {
+  render: () => (
+    <ChatColumn>
+      <PermissionDock compact={false}>
+        <PermissionSelector
+          toolCall={buildQuestionToolCallData(wordyQuestions)}
+          options={buildQuestionOptions(wordyQuestions[0])}
+          onSelect={() => {}}
+          onCancel={() => {}}
+        />
+      </PermissionDock>
+    </ChatColumn>
+  ),
+};

--- a/products/desktop/packages/ui/src/features/sessions/components/PermissionDock.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/PermissionDock.test.tsx
@@ -65,6 +65,29 @@ describe("PermissionDock", () => {
     expect(dockEl.style.maxHeight).toBe(`min(${expected}, calc(100% - 120px))`);
   });
 
+  it("releasing the button outside the window ends the drag", () => {
+    render(
+      <div>
+        <PermissionDock compact={false}>
+          <div>Question card</div>
+        </PermissionDock>
+      </div>,
+    );
+
+    const separator = screen.getByRole("separator");
+    const dockEl = stubHeights(separator, 300, 600);
+    fireEvent.mouseDown(separator, { clientY: 400 });
+    fireEvent.mouseMove(document, { clientY: 360, buttons: 1 });
+    const draggedTo = dockEl.style.maxHeight;
+
+    // No mouseup ever arrives; the pointer just comes back with nothing held.
+    fireEvent.mouseMove(document, { clientY: 200, buttons: 0 });
+    fireEvent.mouseMove(document, { clientY: 100, buttons: 1 });
+
+    expect(document.body.style.cursor).toBe("");
+    expect(dockEl.style.maxHeight).toBe(draggedTo);
+  });
+
   it("answering mid-drag leaves the app without a stuck cursor", () => {
     const { unmount } = render(
       <div>

--- a/products/desktop/packages/ui/src/features/sessions/components/PermissionDock.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/PermissionDock.test.tsx
@@ -65,6 +65,26 @@ describe("PermissionDock", () => {
     expect(dockEl.style.maxHeight).toBe(`min(${expected}, calc(100% - 120px))`);
   });
 
+  it("answering mid-drag leaves the app without a stuck cursor", () => {
+    const { unmount } = render(
+      <div>
+        <PermissionDock compact={false}>
+          <div>Question card</div>
+        </PermissionDock>
+      </div>,
+    );
+
+    const separator = screen.getByRole("separator");
+    stubHeights(separator, 300, 600);
+    fireEvent.mouseDown(separator, { clientY: 400 });
+    expect(document.body.style.cursor).toBe("row-resize");
+
+    unmount();
+
+    expect(document.body.style.cursor).toBe("");
+    expect(document.body.style.userSelect).toBe("");
+  });
+
   it("hiding and showing again keeps the card's own state", () => {
     let mounts = 0;
     function Card() {

--- a/products/desktop/packages/ui/src/features/sessions/components/PermissionDock.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/PermissionDock.test.tsx
@@ -1,0 +1,90 @@
+import {
+  act,
+  fireEvent,
+  render,
+  renderHook,
+  screen,
+} from "@testing-library/react";
+import { useEffect } from "react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useSessionViewActions } from "../sessionViewStore";
+import { PermissionDock } from "./PermissionDock";
+
+/** jsdom measures everything as 0, so the sizes under test are stubbed on. */
+function stubHeights(separator: HTMLElement, dock: number, container: number) {
+  const dockEl = separator.parentElement?.parentElement;
+  const containerEl = dockEl?.parentElement;
+  if (!dockEl || !containerEl) throw new Error("dock not found");
+  dockEl.getBoundingClientRect = () => ({ height: dock }) as DOMRect;
+  containerEl.getBoundingClientRect = () => ({ height: container }) as DOMRect;
+  return dockEl;
+}
+
+describe("PermissionDock", () => {
+  beforeEach(() => {
+    const { result } = renderHook(() => useSessionViewActions());
+    act(() => result.current.setPermissionDockHeight(null));
+  });
+
+  it.each([
+    { name: "grows by one step", key: "ArrowUp", dock: 300, expected: "340px" },
+    {
+      name: "shrinks by one step",
+      key: "ArrowDown",
+      dock: 300,
+      expected: "260px",
+    },
+    {
+      name: "stops short of the thread's reserved room",
+      key: "ArrowUp",
+      dock: 470,
+      expected: "480px",
+    },
+    {
+      name: "stops at the shortest useful dock",
+      key: "ArrowDown",
+      dock: 100,
+      expected: "96px",
+    },
+  ])("resizing with the keyboard $name", ({ key, dock, expected }) => {
+    render(
+      <div>
+        <PermissionDock compact={false}>
+          <div>Question card</div>
+        </PermissionDock>
+      </div>,
+    );
+
+    const separator = screen.getByRole("separator");
+    const dockEl = stubHeights(separator, dock, 600);
+
+    fireEvent.keyDown(separator, { key });
+
+    // The reserve rides along in CSS, so the height the drag settled on is the
+    // first term of the applied `min()`.
+    expect(dockEl.style.maxHeight).toBe(`min(${expected}, calc(100% - 120px))`);
+  });
+
+  it("hiding and showing again keeps the card's own state", () => {
+    let mounts = 0;
+    function Card() {
+      useEffect(() => {
+        mounts += 1;
+      }, []);
+      return <div>Question card</div>;
+    }
+
+    render(
+      <PermissionDock compact={false}>
+        <Card />
+      </PermissionDock>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Hide" }));
+    expect(screen.getByText("Waiting for your response")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Show" }));
+    expect(screen.getByText("Question card")).toBeTruthy();
+    expect(mounts).toBe(1);
+  });
+});

--- a/products/desktop/packages/ui/src/features/sessions/components/PermissionDock.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/PermissionDock.test.tsx
@@ -65,6 +65,29 @@ describe("PermissionDock", () => {
     expect(dockEl.style.maxHeight).toBe(`min(${expected}, calc(100% - 120px))`);
   });
 
+  it("reaching the handle after a window resize reports the current range", () => {
+    render(
+      <div>
+        <PermissionDock compact={false}>
+          <div>Question card</div>
+        </PermissionDock>
+      </div>,
+    );
+
+    const separator = screen.getByRole("separator");
+    stubHeights(separator, 300, 600);
+    fireEvent.focus(separator);
+    expect(separator.getAttribute("aria-valuenow")).toBe("300");
+    expect(separator.getAttribute("aria-valuemax")).toBe("480");
+
+    // The window shrinks: CSS re-caps the dock with no React render behind it.
+    stubHeights(separator, 200, 400);
+    fireEvent.focus(separator);
+
+    expect(separator.getAttribute("aria-valuenow")).toBe("200");
+    expect(separator.getAttribute("aria-valuemax")).toBe("280");
+  });
+
   it("releasing the button outside the window ends the drag", () => {
     render(
       <div>

--- a/products/desktop/packages/ui/src/features/sessions/components/PermissionDock.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/PermissionDock.tsx
@@ -61,14 +61,21 @@ export function PermissionDock({
     [],
   );
 
+  // Both caps are CSS, so the dock re-sizes with the window without React
+  // hearing about it. Re-measuring whenever the handle is reached keeps what a
+  // screen reader announces true at the moment it is read.
+  const refreshReportedRange = useCallback(() => {
+    measureMax();
+    setReportedHeight(measureDock());
+  }, [measureMax, measureDock]);
+
   const attachDock = useCallback(
     (node: HTMLDivElement | null) => {
       dockRef.current = node;
       if (!node) return;
-      measureMax();
-      setReportedHeight(measureDock());
+      refreshReportedRange();
     },
-    [measureMax, measureDock],
+    [refreshReportedRange],
   );
 
   const resizeTo = useCallback(
@@ -168,6 +175,7 @@ export function PermissionDock({
             aria-valuemin={MIN_DOCK_HEIGHT}
             aria-valuemax={maxHeightAllowed}
             tabIndex={0}
+            onFocus={refreshReportedRange}
             onMouseDown={handleResizeStart}
             onKeyDown={handleResizeKey}
             className="group flex flex-1 cursor-row-resize justify-center py-1 outline-none"

--- a/products/desktop/packages/ui/src/features/sessions/components/PermissionDock.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/PermissionDock.tsx
@@ -1,5 +1,11 @@
 import { CaretDown, CaretUp } from "@phosphor-icons/react";
-import { Button, Text } from "@posthog/quill";
+import {
+  Button,
+  Text,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@posthog/quill";
 import { ComposerWidth } from "@posthog/ui/features/sessions/components/ComposerWidth";
 import {
   usePermissionDockHeight,
@@ -153,15 +159,24 @@ export function PermissionDock({
             <div className="h-1 w-8 rounded-full bg-(--gray-6) group-hover:bg-(--gray-8) group-focus-visible:bg-(--gray-8)" />
           </div>
         )}
-        <Button
-          type="button"
-          variant="default"
-          size="xs"
-          onClick={() => setIsHidden(!isHidden)}
-        >
-          {isHidden ? <CaretUp size={12} /> : <CaretDown size={12} />}
-          {isHidden ? "Show" : "Hide"}
-        </Button>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                type="button"
+                variant="default"
+                size="icon-sm"
+                aria-label={isHidden ? "Show" : "Hide"}
+                onClick={() => setIsHidden(!isHidden)}
+              >
+                {isHidden ? <CaretUp size={12} /> : <CaretDown size={12} />}
+              </Button>
+            }
+          />
+          <TooltipContent>
+            {isHidden ? "Show the options again" : "Hide to read the thread"}
+          </TooltipContent>
+        </Tooltip>
       </div>
       <div className={isHidden ? "hidden" : "min-h-0 flex-1 overflow-y-auto"}>
         <ComposerWidth compact={compact}>{children}</ComposerWidth>

--- a/products/desktop/packages/ui/src/features/sessions/components/PermissionDock.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/PermissionDock.tsx
@@ -11,7 +11,7 @@ import {
   usePermissionDockHeight,
   useSessionViewActions,
 } from "@posthog/ui/features/sessions/sessionViewStore";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 /** Shortest the dock goes, and the room the thread above always keeps. */
 const MIN_DOCK_HEIGHT = 96;
@@ -40,6 +40,8 @@ export function PermissionDock({
   const { setPermissionDockHeight } = useSessionViewActions();
   const [isHidden, setIsHidden] = useState(false);
   const dockRef = useRef<HTMLDivElement>(null);
+  /** Set while a drag is in flight, so an unmount can end it. */
+  const endDragRef = useRef<(() => void) | null>(null);
   // What the handle reports to assistive tech. Measured rather than read off
   // the store, because until the first drag the dock sits at its default share
   // of the column and has no stored height to report.
@@ -89,20 +91,27 @@ export function PermissionDock({
       const onMouseMove = (moveEvent: MouseEvent) => {
         resizeTo(startHeight + (startY - moveEvent.clientY));
       };
-      const onMouseUp = () => {
+      const endDrag = () => {
         document.removeEventListener("mousemove", onMouseMove);
-        document.removeEventListener("mouseup", onMouseUp);
+        document.removeEventListener("mouseup", endDrag);
         document.body.style.cursor = "";
         document.body.style.userSelect = "";
+        endDragRef.current = null;
       };
 
       document.body.style.cursor = "row-resize";
       document.body.style.userSelect = "none";
       document.addEventListener("mousemove", onMouseMove);
-      document.addEventListener("mouseup", onMouseUp);
+      document.addEventListener("mouseup", endDrag);
+      endDragRef.current = endDrag;
     },
     [resizeTo],
   );
+
+  // Answering the prompt unmounts the dock, and that can land mid-drag: without
+  // this the listeners outlive it, and the whole app keeps the resize cursor
+  // with text selection off.
+  useEffect(() => () => endDragRef.current?.(), []);
 
   const handleResizeKey = useCallback(
     (e: React.KeyboardEvent) => {

--- a/products/desktop/packages/ui/src/features/sessions/components/PermissionDock.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/PermissionDock.tsx
@@ -1,0 +1,171 @@
+import { CaretDown, CaretUp } from "@phosphor-icons/react";
+import { Button, Text } from "@posthog/quill";
+import { ComposerWidth } from "@posthog/ui/features/sessions/components/ComposerWidth";
+import {
+  usePermissionDockHeight,
+  useSessionViewActions,
+} from "@posthog/ui/features/sessions/sessionViewStore";
+import { useCallback, useRef, useState } from "react";
+
+/** Shortest the dock goes, and the room the thread above always keeps. */
+const MIN_DOCK_HEIGHT = 96;
+const MIN_THREAD_HEIGHT = 120;
+/** How far one arrow-key press on the handle moves the dock's ceiling. */
+const RESIZE_STEP = 40;
+
+/**
+ * Holds a permission or question card below the thread, capped so the card
+ * never swallows the conversation that led to it: a long option list scrolls
+ * inside the dock, the handle re-sizes it, and hiding it drops it to a single
+ * bar so the thread can be read in full before answering.
+ *
+ * Hidden content stays mounted — a half-filled multi-question answer survives
+ * the round trip, and a `display: none` card cannot hold focus, so the card's
+ * digit and arrow shortcuts stand down while it is out of sight.
+ */
+export function PermissionDock({
+  compact,
+  children,
+}: {
+  compact: boolean;
+  children: React.ReactNode;
+}) {
+  const height = usePermissionDockHeight();
+  const { setPermissionDockHeight } = useSessionViewActions();
+  const [isHidden, setIsHidden] = useState(false);
+  const dockRef = useRef<HTMLDivElement>(null);
+  // What the handle reports to assistive tech. Measured rather than read off
+  // the store, because until the first drag the dock sits at its default share
+  // of the column and has no stored height to report.
+  const [reportedHeight, setReportedHeight] = useState(MIN_DOCK_HEIGHT);
+  const [maxHeightAllowed, setMaxHeightAllowed] = useState(MIN_DOCK_HEIGHT);
+
+  const measureMax = useCallback(() => {
+    const available =
+      dockRef.current?.parentElement?.getBoundingClientRect().height ?? 0;
+    const max = Math.max(MIN_DOCK_HEIGHT, available - MIN_THREAD_HEIGHT);
+    setMaxHeightAllowed(max);
+    return max;
+  }, []);
+
+  const measureDock = useCallback(
+    () => Math.round(dockRef.current?.getBoundingClientRect().height ?? 0),
+    [],
+  );
+
+  const attachDock = useCallback(
+    (node: HTMLDivElement | null) => {
+      dockRef.current = node;
+      if (!node) return;
+      measureMax();
+      setReportedHeight(measureDock());
+    },
+    [measureMax, measureDock],
+  );
+
+  const resizeTo = useCallback(
+    (next: number) => {
+      const clamped = Math.round(
+        Math.min(measureMax(), Math.max(MIN_DOCK_HEIGHT, next)),
+      );
+      setPermissionDockHeight(clamped);
+      setReportedHeight(clamped);
+    },
+    [measureMax, setPermissionDockHeight],
+  );
+
+  const handleResizeStart = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      const startY = e.clientY;
+      const startHeight = dockRef.current?.getBoundingClientRect().height ?? 0;
+
+      const onMouseMove = (moveEvent: MouseEvent) => {
+        resizeTo(startHeight + (startY - moveEvent.clientY));
+      };
+      const onMouseUp = () => {
+        document.removeEventListener("mousemove", onMouseMove);
+        document.removeEventListener("mouseup", onMouseUp);
+        document.body.style.cursor = "";
+        document.body.style.userSelect = "";
+      };
+
+      document.body.style.cursor = "row-resize";
+      document.body.style.userSelect = "none";
+      document.addEventListener("mousemove", onMouseMove);
+      document.addEventListener("mouseup", onMouseUp);
+    },
+    [resizeTo],
+  );
+
+  const handleResizeKey = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key !== "ArrowUp" && e.key !== "ArrowDown") return;
+      e.preventDefault();
+      resizeTo(
+        measureDock() + (e.key === "ArrowUp" ? RESIZE_STEP : -RESIZE_STEP),
+      );
+    },
+    [measureDock, resizeTo],
+  );
+
+  // A height dragged in a tall window outlives that window: the store keeps it
+  // app-wide, so the reserve is re-applied in CSS rather than trusted from the
+  // drag that set it.
+  const maxHeight =
+    height !== null
+      ? `min(${height}px, calc(100% - ${MIN_THREAD_HEIGHT}px))`
+      : undefined;
+
+  return (
+    <div
+      ref={attachDock}
+      className={`flex min-h-0 shrink-0 flex-col ${
+        isHidden ? "" : compact ? "max-h-[50%]" : "max-h-[60%]"
+      }`}
+      style={{ maxHeight: isHidden ? undefined : maxHeight }}
+    >
+      <div
+        className={`flex shrink-0 items-center gap-2 px-2 ${
+          // Hidden, the bar is the only thing between the thread and the window
+          // edge, so it needs an edge of its own to not read as another message.
+          isHidden ? "border-(--gray-4) border-t py-1" : ""
+        }`}
+      >
+        {isHidden ? (
+          <Text className="flex-1 truncate text-(--gray-11) text-[13px]">
+            Waiting for your response
+          </Text>
+        ) : (
+          // biome-ignore lint/a11y/useSemanticElements: <hr> is void, so it cannot hold the grip it would have to draw
+          <div
+            role="separator"
+            aria-orientation="horizontal"
+            aria-label="Resize"
+            aria-valuenow={reportedHeight}
+            aria-valuemin={MIN_DOCK_HEIGHT}
+            aria-valuemax={maxHeightAllowed}
+            tabIndex={0}
+            onMouseDown={handleResizeStart}
+            onKeyDown={handleResizeKey}
+            className="group flex flex-1 cursor-row-resize justify-center py-1 outline-none"
+          >
+            <div className="h-1 w-8 rounded-full bg-(--gray-6) group-hover:bg-(--gray-8) group-focus-visible:bg-(--gray-8)" />
+          </div>
+        )}
+        <Button
+          type="button"
+          variant="default"
+          size="xs"
+          onClick={() => setIsHidden(!isHidden)}
+        >
+          {isHidden ? <CaretUp size={12} /> : <CaretDown size={12} />}
+          {isHidden ? "Show" : "Hide"}
+        </Button>
+      </div>
+      <div className={isHidden ? "hidden" : "min-h-0 flex-1 overflow-y-auto"}>
+        <ComposerWidth compact={compact}>{children}</ComposerWidth>
+      </div>
+    </div>
+  );
+}

--- a/products/desktop/packages/ui/src/features/sessions/components/PermissionDock.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/PermissionDock.tsx
@@ -89,6 +89,13 @@ export function PermissionDock({
       const startHeight = dockRef.current?.getBoundingClientRect().height ?? 0;
 
       const onMouseMove = (moveEvent: MouseEvent) => {
+        // A button released outside the window delivers no mouseup, so the
+        // first move back inside — the one reporting no button held — is what
+        // ends that drag.
+        if (moveEvent.buttons === 0) {
+          endDrag();
+          return;
+        }
         resizeTo(startHeight + (startY - moveEvent.clientY));
       };
       const endDrag = () => {

--- a/products/desktop/packages/ui/src/features/sessions/components/SessionView.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/SessionView.tsx
@@ -27,6 +27,7 @@ import {
   CloudStreamDisconnectedBanner,
   ConnectingToAgent,
 } from "@posthog/ui/features/sessions/components/CloudSessionLifecycle";
+import { ComposerWidth } from "@posthog/ui/features/sessions/components/ComposerWidth";
 import { ContextUsageIndicator } from "@posthog/ui/features/sessions/components/ContextUsageIndicator";
 import type { PromptRecallHandler } from "@posthog/ui/features/sessions/components/chat-thread/composerPromptRecall";
 import {
@@ -35,6 +36,7 @@ import {
 } from "@posthog/ui/features/sessions/components/copyContextTarget";
 import { DropZoneOverlay } from "@posthog/ui/features/sessions/components/DropZoneOverlay";
 import { PendingChatView } from "@posthog/ui/features/sessions/components/PendingChatView";
+import { PermissionDock } from "@posthog/ui/features/sessions/components/PermissionDock";
 import { PlanStatusBar } from "@posthog/ui/features/sessions/components/PlanStatusBar";
 import { QueuedMessagesDock } from "@posthog/ui/features/sessions/components/QueuedMessagesDock";
 import { ReasoningLevelSelector } from "@posthog/ui/features/sessions/components/ReasoningLevelSelector";
@@ -47,10 +49,7 @@ import {
   submitComposerPrompt,
 } from "@posthog/ui/features/sessions/components/submitComposerPrompt";
 import { ThreadView } from "@posthog/ui/features/sessions/components/ThreadView";
-import {
-  CHAT_CONTENT_MAX_WIDTH,
-  CHAT_CONTENT_PADDING_INLINE,
-} from "@posthog/ui/features/sessions/constants";
+import { CHAT_CONTENT_MAX_WIDTH } from "@posthog/ui/features/sessions/constants";
 import { useContextUsage } from "@posthog/ui/features/sessions/hooks/useContextUsage";
 import { useCancelQueuedMessageEdit } from "@posthog/ui/features/sessions/hooks/useEditQueuedMessage";
 import { useSessionEventsResidency } from "@posthog/ui/features/sessions/hooks/useSessionEventsResidency";
@@ -122,85 +121,6 @@ interface SessionViewProps {
 
 const DEFAULT_ERROR_MESSAGE =
   "Failed to resume this session. The working directory may have been deleted. Please start a new session.";
-
-/**
- * Centers composer-slot content at the chat width (or compact padding).
- *
- * The composer reserves the same horizontal room as the thread's scroll
- * content and caps at the same width, so the two columns are identical at
- * every panel width rather than only once the panel is wide enough for the
- * full column. Padding on the capped box instead of around it would eat into
- * `CHAT_CONTENT_MAX_WIDTH` and leave the composer narrower than the messages.
- *
- * The gutter is a percentage of this box, and the thread's equivalent box sits
- * inside a scroller whose `scrollbar-gutter: stable` has already taken the
- * scrollbar's width off it. Without the same reservation here, the composer
- * centers on a wider box and its column lands half a scrollbar right of the
- * messages. Reserving it rather than subtracting a constant keeps the browser's
- * own measurement authoritative, since scrollbar width varies by platform.
- */
-/** Widest ring the composer paints outside its border box (quill's 3px focus outline). */
-const OUTLINE_BLEED = 4;
-
-function ComposerWidth({
-  compact,
-  children,
-}: {
-  compact: boolean;
-  children: React.ReactNode;
-}) {
-  if (compact) {
-    return <Box className="p-1">{children}</Box>;
-  }
-
-  return (
-    <Box
-      style={{
-        paddingInline: CHAT_CONTENT_PADDING_INLINE,
-        overflow: "hidden",
-        scrollbarGutter: "stable",
-        // `overflow: hidden` clips at this box's padding edge, which sits flush
-        // with the composer's top, so the focus ring painted outside its border
-        // box would lose its top. Buy the ring room and take it back out of the
-        // layout. The sides have the gutter and `pb-2` covers below.
-        paddingBlockStart: OUTLINE_BLEED,
-        marginBlockStart: -OUTLINE_BLEED,
-      }}
-    >
-      <Box
-        className="mx-auto pb-2"
-        style={{ maxWidth: CHAT_CONTENT_MAX_WIDTH }}
-      >
-        {children}
-      </Box>
-    </Box>
-  );
-}
-
-/**
- * Input region replacing the composer: `shrink-0` keeps it from being
- * compressed by the scroller above, and `min-h-0 overflow-y-auto` lets tall
- * content scroll inside itself.
- */
-function ComposerSlot({
-  compact,
-  children,
-}: {
-  compact: boolean;
-  children: React.ReactNode;
-}) {
-  return (
-    <Box
-      className={
-        compact
-          ? "max-h-[50%] min-h-0 overflow-y-auto"
-          : "min-h-0 shrink-0 overflow-y-auto"
-      }
-    >
-      <ComposerWidth compact={compact}>{children}</ComposerWidth>
-    </Box>
-  );
-}
 
 export function SessionView({
   events,
@@ -786,14 +706,19 @@ export function SessionView({
                     </Flex>
                   </Flex>
                 ) : hideInput ? null : firstPendingPermission ? (
-                  <ComposerSlot compact={compact}>
+                  // Keyed on the prompt, so each new one arrives shown even if
+                  // the last one was hidden.
+                  <PermissionDock
+                    key={firstPendingPermission.toolCall.toolCallId}
+                    compact={compact}
+                  >
                     <PermissionSelector
                       toolCall={firstPendingPermission.toolCall}
                       options={firstPendingPermission.options}
                       onSelect={handlePermissionSelect}
                       onCancel={handlePermissionCancel}
                     />
-                  </ComposerSlot>
+                  </PermissionDock>
                 ) : (
                   <Box className="relative shrink-0">
                     <Box

--- a/products/desktop/packages/ui/src/features/sessions/components/SessionView.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/SessionView.tsx
@@ -706,10 +706,12 @@ export function SessionView({
                     </Flex>
                   </Flex>
                 ) : hideInput ? null : firstPendingPermission ? (
-                  // Keyed on the prompt, so each new one arrives shown even if
-                  // the last one was hidden.
+                  // Keyed on when the prompt arrived, not just which tool call
+                  // it belongs to, so a re-asked permission for the same call
+                  // arrives shown rather than inheriting the last one's hidden
+                  // state.
                   <PermissionDock
-                    key={firstPendingPermission.toolCall.toolCallId}
+                    key={`${firstPendingPermission.toolCall.toolCallId}-${firstPendingPermission.receivedAt}`}
                     compact={compact}
                   >
                     <PermissionSelector

--- a/products/desktop/packages/ui/src/features/sessions/sessionViewStore.ts
+++ b/products/desktop/packages/ui/src/features/sessions/sessionViewStore.ts
@@ -24,6 +24,13 @@ interface SessionViewState {
    * thread scrolled its row out of the window. Not persisted.
    */
   turnFeedbackByTurnId: Record<string, AgentTurnFeedbackSentiment>;
+  /**
+   * Height in px the permission dock was last dragged to; `null` follows the
+   * default share of the chat column. Kept app-wide rather than per task, since
+   * someone who sizes the dock once means it for the next prompt too. Not
+   * persisted.
+   */
+  permissionDockHeight: number | null;
 }
 
 interface SessionViewActions {
@@ -37,6 +44,7 @@ interface SessionViewActions {
     turnId: string,
     sentiment: AgentTurnFeedbackSentiment,
   ) => void;
+  setPermissionDockHeight: (height: number | null) => void;
 }
 
 type SessionViewStore = SessionViewState & { actions: SessionViewActions };
@@ -48,6 +56,7 @@ const useStore = create<SessionViewStore>((set) => ({
   groupOverrides: {},
   queueCollapsedByTaskId: {},
   turnFeedbackByTurnId: {},
+  permissionDockHeight: null,
   actions: {
     setShowRawLogs: (show) => set({ showRawLogs: show }),
     setSearchQuery: (query) => set({ searchQuery: query }),
@@ -80,6 +89,7 @@ const useStore = create<SessionViewStore>((set) => ({
           [turnId]: sentiment,
         },
       })),
+    setPermissionDockHeight: (height) => set({ permissionDockHeight: height }),
   },
 }));
 
@@ -89,6 +99,8 @@ export const useShowSearch = () => useStore((s) => s.showSearch);
 export const useGroupOverrides = () => useStore((s) => s.groupOverrides);
 export const useQueueCollapsed = (taskId: string) =>
   useStore((s) => s.queueCollapsedByTaskId[taskId] ?? false);
+export const usePermissionDockHeight = () =>
+  useStore((s) => s.permissionDockHeight);
 export const useTurnFeedback = (turnId: string) =>
   useStore((s) => s.turnFeedbackByTurnId[turnId] ?? null);
 export const useSessionViewActions = () => useStore((s) => s.actions);


### PR DESCRIPTION
## Problem

A wordy "pick an option" prompt in the desktop app could take almost the whole chat pane, leaving the investigation that led to the question in a three-line window. Answering then meant scrolling up through a sliver of text, or dismissing the prompt to read the thread and asking for the options again.

Raised in [#team-posthog-code](https://posthog.slack.com/archives/C09G8Q32R6F/p1787156359966619?thread_ts=1787156359.966619&cid=C09G8Q32R6F).

## Changes

- A question or permission card now takes at most 60% of the chat column (50% in the embedded chat) and scrolls inside that, so the thread always keeps its share.
- A drag handle above the card re-sizes it; the thread keeps 120px whatever happens, including after the window shrinks.
- A caret button drops the card to a one-line "Waiting for your response" bar, so the whole thread can be read before answering. The caret brings it back with a part-filled multi-question answer intact, and each new prompt arrives shown.
- The handle is a focusable separator: arrow keys re-size it 40px at a time.
- Mechanical: `ComposerWidth` moved out of `SessionView.tsx` into its own file so the dock can reuse it, and its Radix `Box`es became `div`s on the way.

Default cap, dragged taller, and hidden:

![dock-default](https://raw.githubusercontent.com/PostHog/pr-assets/750b7ba0cad18896f5f1e001adf411f14aa58107/2026/08/1e9c23d4-5221-4106-9ffc-8f92a8e1b074.png)

![dock-dragged](https://raw.githubusercontent.com/PostHog/pr-assets/aa996ae770ce91e03162e0f7d69c69e8cce98213/2026/08/30e33004-381b-4491-990c-f612da665137.png)

![dock-hidden](https://raw.githubusercontent.com/PostHog/pr-assets/f215ea95a5f40e53b0d54fde338962e85a3018ee/2026/08/cb069d03-7a63-4761-a1aa-753e81e48b4a.png)

## How did you test this code?

The screenshots above are the new `PermissionDock` story driven in Storybook over CDP: default cap, a drag on the handle, then hide and show. The app itself was not launched, so behavior against a live agent session is unverified.

`PermissionDock.test.tsx` covers two regressions no existing test did: the resize clamp (a nudge past either end settles on the floor or on the thread's reserve rather than running away), and hiding keeping the card mounted, which is what saves a part-filled multi-question answer.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no documented workflow changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Written by the PostHog Slack app (Claude Code) from a feature request in Slack. No repo skills were invoked; the conventions in `products/desktop/AGENTS.md` and the repo `CLAUDE.md` were followed directly.

Two decisions worth a reviewer's attention. The dock wraps the whole composer slot rather than `ActionSelector`, so every permission prompt gets the cap and the handle, not only multiple-choice questions. And hiding uses `display: none` rather than unmounting: card state survives, and a hidden card cannot hold focus, so its digit and arrow shortcuts stand down while it is out of sight. An earlier pass stored the dragged height as a bare pixel cap, which let a height set in a tall window squeeze the thread flat after a resize; the cap is now a CSS `min()` against the column.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1787156359966619?thread_ts=1787156359.966619&cid=C09G8Q32R6F)*


