### PR TITLE
feat(signals): generate report canvases only for teams that use desktop

### DIFF
--- a/products/signals/backend/report_canvas.md
+++ b/products/signals/backend/report_canvas.md
@@ -1,6 +1,6 @@
 # Report canvases
 
-Ready reports and reports awaiting input can run through the canvas generation pipeline. This path is gated by the `signals-report-canvases` organization feature flag.
+Ready reports and reports awaiting input can run through the canvas generation pipeline. This path is gated by the `signals-report-canvases` organization feature flag and by the team already having a general space. PostHog Desktop provisions that space on first run, so a team that does not use Desktop generates nothing and never has a space created for it.
 
 Generation is a shadow workflow by default. Each attempt stores its source, status, duration, model metadata, validation result, and failure details in `SignalReportCanvasGeneration`. Reviewers can inspect and label attempts in Django admin without changing what people see in Inbox.
 
@@ -43,7 +43,7 @@ hogli up -d -y
 hogli wait -y
 ```
 
-Add a working LLM provider key to `.env.local`. Report canvases are enabled automatically when Django runs with `DEBUG=True`.
+Add a working LLM provider key to `.env.local`. Report canvases are enabled automatically when Django runs with `DEBUG=True`, but the team still needs a general space: open Desktop once, or call `POST /api/projects/<team-id>/task_channels/provision_defaults/`.
 
 Create a researched report from the included synthetic fixture:
 

--- a/products/signals/backend/report_canvas.py
+++ b/products/signals/backend/report_canvas.py
@@ -34,7 +34,6 @@ from products.tasks.backend.facade import api as tasks_facade
 
 REPORT_CANVAS_FEATURE_FLAG = "signals-report-canvases"
 REPORT_CANVAS_PUBLISH_FEATURE_FLAG = "signals-report-canvases-publish"
-REPORT_CANVAS_CHANNEL_NAME = "general"
 REPORT_CANVAS_PROMPT_VERSION = "2026-08-17"
 _MAX_CONTEXT_ARTEFACTS = 16
 _MAX_CONTEXT_SIGNALS = 8
@@ -215,6 +214,14 @@ def ensure_and_start_report_canvas_generation(*, team_id: int, report_id: str) -
     report = SignalReport.objects.select_related("team").get(id=report_id, team_id=team_id)
     if report.status not in (SignalReport.Status.READY, SignalReport.Status.PENDING_INPUT):
         return None
+
+    channel_id = tasks_facade.find_general_channel_id(team_id)
+    if channel_id is None:
+        # Canvases are only useful in Desktop, and Desktop is what provisions the general
+        # space. A team without one has nowhere to read them, so generating would spend a
+        # sandbox run and the model budget on something nobody can open.
+        return None
+
     fingerprint = _report_fingerprint(report)
     signals = _fetch_report_signals(report)
     pr_url = fetch_implementation_pr_urls_for_reports([str(report.id)]).get(str(report.id))
@@ -223,12 +230,9 @@ def ensure_and_start_report_canvas_generation(*, team_id: int, report_id: str) -
         report = SignalReport.objects.select_for_update().select_related("team").get(id=report_id, team_id=team_id)
         session = SignalReportCanvas.objects.filter(report=report, team_id=team_id).first()
         if session is None:
-            channel = tasks_facade.resolve_channel(team_id, None, name=REPORT_CANVAS_CHANNEL_NAME, star=False)
-            if channel is None:
-                raise RuntimeError("Could not resolve the report canvas channel")
             discussion_task_id = tasks_facade.create_shared_channel_task_without_run(
                 team_id=team_id,
-                channel_id=channel.id,
+                channel_id=channel_id,
                 title=report.title or "Report",
                 description=report.summary or "",
                 origin_product=tasks_facade.TaskOriginProduct.SIGNAL_REPORT,
@@ -236,7 +240,7 @@ def ensure_and_start_report_canvas_generation(*, team_id: int, report_id: str) -
             )
             canvas_id = canvas_api.create_report_canvas(
                 team_id=team_id,
-                channel_id=channel.id,
+                channel_id=channel_id,
                 name=report.title or "Report",
                 discussion_task_id=discussion_task_id,
             )

--- a/products/signals/backend/test/test_report_canvas.py
+++ b/products/signals/backend/test/test_report_canvas.py
@@ -51,11 +51,15 @@ class TestReportCanvasGeneration(APIBaseTest):
             total_weight=1.0,
         )
 
+    def _provision_spaces(self) -> None:
+        tasks_facade.provision_default_channels(self.team.id, self.user.id)
+
     def _generation_result(self, task_id: uuid.UUID, run_id: uuid.UUID) -> SimpleNamespace:
         return SimpleNamespace(task_id=task_id, latest_run=SimpleNamespace(id=run_id))
 
     def test_creates_one_shared_session_and_reuses_in_flight_generation(self) -> None:
         report = self._report()
+        self._provision_spaces()
         generation_task_id = uuid.uuid4()
         generation_run_id = uuid.uuid4()
 
@@ -103,6 +107,22 @@ class TestReportCanvasGeneration(APIBaseTest):
         assert discussion.state["activity_target"] == {"scope": "desktop_canvas", "id": str(canvas.id)}
         assert attempt.status == SignalReportCanvasGeneration.Status.GENERATING
         assert attempt.generation_task_id == generation_task_id
+
+    def test_skips_a_team_without_a_general_space(self) -> None:
+        report = self._report()
+
+        with (
+            patch("products.signals.backend.report_canvas.report_canvases_enabled", return_value=True),
+            patch("products.signals.backend.report_canvas._fetch_report_signals", return_value=[]),
+            patch("products.signals.backend.report_canvas.tasks_facade.create_and_run_task") as create_generation,
+        ):
+            result = ensure_and_start_report_canvas_generation(team_id=self.team.id, report_id=str(report.id))
+
+        assert result is None
+        create_generation.assert_not_called()
+        with team_scope(self.team.id):
+            assert not self.channel_model.objects.filter(team=self.team).exists()
+            assert not SignalReportCanvas.objects.filter(report=report).exists()
 
     def test_generation_prompt_includes_current_report_decisions_and_rejects_fake_controls(self) -> None:
         report = self._report()

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -6536,6 +6536,21 @@ def _ensure_general_channel(team_id: int, user_id: int | None) -> tuple[Channel,
     )
 
 
+def find_general_channel_id(team_id: int) -> UUID | None:
+    """The team's general space, or ``None`` when nobody has provisioned one. Read-only, so
+    a product filing work into that space can gate on its existence instead of bringing the
+    team's default spaces into being as a side effect."""
+    channels = _team_channels(team_id).filter(deleted=False)
+    channel = channels.filter(system_role=Channel.SystemRole.GENERAL).first()
+    if channel is None:
+        channel = channels.filter(
+            system_role__isnull=True,
+            channel_type=Channel.ChannelType.PUBLIC,
+            name=Channel.GENERAL_CHANNEL_NAME,
+        ).first()
+    return channel.id if channel is not None else None
+
+
 def _is_general_channel(channel: Channel) -> bool:
     """Must match ``isGeneralChannel`` in ``channelName.ts``: a row with no role but the
     general name is still the team's general space."""

--- a/products/tasks/backend/tests/test_channels_api.py
+++ b/products/tasks/backend/tests/test_channels_api.py
@@ -199,6 +199,25 @@ class ChannelsAPITestCase(TestCase):
         response = self.client.post(self._channels_url(), {"name": "###"})
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    def test_finding_the_general_space_never_provisions_one(self):
+        # Products that file work into #general gate on it existing, so a lookup that
+        # created one would put a space in every team that never asked for Desktop.
+        self.assertIsNone(tasks_facade.find_general_channel_id(self.team.id))
+
+        provisioned = self._provision()
+        general = next(c for c in provisioned["channels"] if c["system_role"] == "general")
+        self.assertEqual(str(tasks_facade.find_general_channel_id(self.team.id)), general["id"])
+
+    def test_finding_the_general_space_matches_an_unstamped_row(self):
+        legacy = Channel.objects.for_team(self.team.id).create(
+            team_id=self.team.id,
+            created_by=self.user,
+            name=Channel.GENERAL_CHANNEL_NAME,
+            channel_type=Channel.ChannelType.PUBLIC,
+        )
+
+        self.assertEqual(tasks_facade.find_general_channel_id(self.team.id), legacy.id)
+
     def test_creating_a_space_named_general_resolves_the_system_space(self):
         created = self.client.post(self._channels_url(), {"name": "General"})
         self.assertEqual(created.status_code, status.HTTP_200_OK)


### PR DESCRIPTION
## Problem

- canvases only work in desktop, so we should only generate these canvases from reports for desktop users
- canvas generation pipeline should not auto-create any spaces

## Changes

- report canvases are not generated when a `general` space exists
- report canvas pipeline never creates a space


---- ai generated below -----

## How did you test this code?

Automated, run locally:

- `products/signals/backend/test/test_report_canvas.py` — added a case that a team with no general space generates nothing, starts no task, and ends with no space created. No existing case covered the pipeline declining to run; every other case starts from a team that has one.
- `products/tasks/backend/tests/test_channels_api.py` — added two cases for the new facade read: that looking the space up never provisions one (the property the gate depends on), and that it matches an unstamped legacy row.
- `uv run mypy --cache-fine-grained .` clean.

Not checked: no live report was generated against a real team, and the `signals-report-canvases` flag behavior itself is unchanged and untested here.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`products/signals/backend/report_canvas.md` now states both gates, and the local setup section says a general space is needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code wrote this. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`, `/improving-drf-endpoints`, `/stacking-prs`.

The first proposal was to gate the pipeline on nothing and let Desktop tolerate a pre-existing space. Gating on the space existing is better: it fixes the waste, the premature provisioning, and the first-run signal at once, and it needs no coordination between the two products beyond one read.

The gate sits after the report status check so that the existing "skips reports outside the initial statuses" case still exercises the status path rather than passing for the new reason.

Layer three of a stack. Sits on #83984, which introduces `system_role` and explicit provisioning; #85453 sits on top.
