### PR TITLE
chore(desktop): clean up documentation

### DIFF
--- a/products/desktop/README.md
+++ b/products/desktop/README.md
@@ -5,7 +5,7 @@
 
 Found a bug or want to share feedback? [Open an issue](https://github.com/PostHog/posthog/issues/new) on GitHub.
 
-# PostHog
+# PostHog Desktop
 
 This is the source for the PostHog desktop and mobile apps and the agent framework that powers them.
 
@@ -35,7 +35,7 @@ cp .env.example .env
 
 ```
 
-### Running in Development
+### Running in development
 
 By default, `pnpm dev` uses phrocs (our custom process runner) to run the agent and code app in parallel. phrocs auto-installs and keeps itself up to date: on every `pnpm install` the local binary is checked against the latest `phrocs-latest` release checksums and re-downloaded if it differs (skipped when offline or in CI). `pnpm dev` only downloads it if it is missing entirely. It reads the `mprocs.yaml` config file. The binary lives at `bin/phrocs` and is git-ignored.
 
@@ -46,15 +46,13 @@ pnpm dev
 # Or run them separately:
 pnpm dev:agent  # Run agent in watch mode
 pnpm dev:code   # Run code app
-
-
 # Use mprocs instead of phrocs
 pnpm dev:mprocs
 ```
 
 > **Want to connect to a local PostHog instance?** See [docs/LOCAL-DEVELOPMENT.md](./docs/LOCAL-DEVELOPMENT.md) for OAuth setup and connecting to localhost:8010.
 
-### Utility Scripts
+### Utility scripts
 
 Scripts in `scripts/` for development and debugging:
 
@@ -63,9 +61,9 @@ Scripts in `scripts/` for development and debugging:
 | `scripts/clean-posthog-code-macos.sh` | Remove all PostHog app data from macOS (caches, preferences, logs, saved state). Use `--app` flag to also delete PostHog.app from /Applications. |
 | `scripts/test-access-token.js` | Validate a PostHog OAuth access token by testing API endpoints. Usage: `node scripts/test-access-token.js <token> <project_id> [region]` |
 
-## Project Structure
+## Project structure
 
-```
+```text
 products/desktop/
 ├── apps/
 │   ├── code/            # Electron desktop app (React, Vite)
@@ -74,27 +72,22 @@ products/desktop/
 ├── packages/
 │   ├── agent/           # TypeScript agent framework
 │   ├── core/            # Shared business logic
-│   ├── electron-trpc/   # tRPC for Electron IPC
-│   └── shared/          # Shared utilities (Saga pattern, etc.)
+│   ├── ui/              # Shared React UI
+│   ├── workspace-server/ # Local filesystem, git, and process services
+│   └── platform/        # Host capability interfaces
+└── docs/                 # Development and operational guides
 ```
 
 ## Documentation
 
 | File | Description |
 |------|-------------|
-| [apps/code/README.md](./apps/code/README.md) | Desktop app: building, signing, distribution, and workspace configuration |
-| [apps/mobile/README.md](./apps/mobile/README.md) | Mobile app: Expo setup, EAS builds, and TestFlight deployment |
-| [AGENTS.md](./AGENTS.md) | Architecture rules, code style, patterns, and testing guidelines (read by Claude Code, Codex, Cursor, Aider, etc.) |
-| [CONTRIBUTING.md](./CONTRIBUTING.md) | How to contribute to PostHog |
-| [docs/LOCAL-DEVELOPMENT.md](./docs/LOCAL-DEVELOPMENT.md) | Connecting the desktop app to a local PostHog instance |
-| [docs/UPDATES.md](./docs/UPDATES.md) | Release versioning and git tagging |
-| [docs/TROUBLESHOOTING.md](./docs/TROUBLESHOOTING.md) | Common issues and fixes |
-| [docs/DEEP-LINKS.md](./docs/DEEP-LINKS.md) | `posthog-code://` deep link schemes and parameters |
+| [Documentation index](./docs/README.md) | Development, architecture, testing, operations, and feature guides |
+| [Desktop app guide](./apps/code/README.md) | Building, signing, distribution, and workspace configuration |
+| [Mobile app guide](./apps/mobile/README.md) | Expo setup, EAS builds, and TestFlight deployment |
+| [Architecture and code rules](./AGENTS.md) | Source of truth for architecture, code style, and testing rules |
+| [Contributing](./CONTRIBUTING.md) | How to contribute to PostHog Desktop |
 
 ## Contributing
 
 We love contributions big and small. See [CONTRIBUTING.md](./CONTRIBUTING.md) to get started.
-
-## Troubleshooting
-
-See [docs/TROUBLESHOOTING.md](./docs/TROUBLESHOOTING.md) for common issues (black screen, Electron install failures, native module crashes, Secretive commit signing, etc.).

--- a/products/desktop/docs/README.md
+++ b/products/desktop/docs/README.md
@@ -1,0 +1,49 @@
+# Desktop documentation
+
+Start with the guide that matches the work you are doing. [AGENTS.md](../AGENTS.md) remains the source of truth when a guide conflicts with an architecture or code rule.
+
+## Develop and test
+
+| Guide | Use it for |
+| --- | --- |
+| [Local development](./LOCAL-DEVELOPMENT.md) | Connect the desktop app to a local PostHog instance. |
+| [Architecture](./ARCHITECTURE.md) | Understand package layers, dependency injection, host boundaries, and feature placement. |
+| [Code conventions](./CONVENTIONS.md) | Follow component, store, hook, styling, logging, and analytics conventions. |
+| [Testing](./TESTING.md) | Choose and run unit, UI, end-to-end, interactive, and visual tests. |
+| [Troubleshooting](./TROUBLESHOOTING.md) | Resolve common setup, native module, and signing failures. |
+
+## Operate and release
+
+| Guide | Use it for |
+| --- | --- |
+| [Updates](./UPDATES.md) | Understand versioning, release tags, and update publishing. |
+| [Local auto-update testing](./AUTO-UPDATE-TESTING.md) | Exercise the packaged app's update flow without publishing a release. |
+| [Announcements](./ANNOUNCEMENTS.md) | Configure and test remote in-app announcements. |
+| [Cloud task artifacts](./CLOUD-TASK-ARTIFACTS.md) | Understand artifact notifications and dismissal behavior. |
+
+## Feature references
+
+| Guide | Use it for |
+| --- | --- |
+| [Deep links](./DEEP-LINKS.md) | Work with `posthog-code://` routes and OAuth callbacks. |
+| [Pi extensions](./PI-EXTENSIONS.md) | Understand repository trust and desktop RPC behavior for Pi extensions. |
+| [Cloud MCP import](./CLOUD-MCP-IMPORT.md) | Understand importing local MCP configuration into cloud task runs. |
+| [Cloud MCP relay](./CLOUD-MCP-RELAY.md) | Understand the design for relaying local MCP servers to cloud task runs. |
+
+## Design records
+
+These documents capture design intent at a point in time. Check the current code and architecture rules before using them as implementation guidance.
+
+- [Chat thread rebuild](./CHAT-REBUILD-SPEC.md)
+- [Freeform React canvases](./CANVAS-FREEFORM-REACT-PLAN.md)
+- [Browser tabs](./plans/browser-tabs.md)
+- [Skills tab v2](./plans/skills-tab.md)
+- [Quiet backstop narration](./superpowers/specs/2026-07-02-quiet-backstop-narration-design.md)
+
+## App and package guides
+
+- [Electron desktop app](../apps/code/README.md)
+- [Mobile app](../apps/mobile/README.md)
+- [Web app](../apps/web/README.md)
+- [Agent framework](../packages/agent/README.md)
+- [Harness](../packages/harness/README.md)


### PR DESCRIPTION
## Problem

Desktop contributors have to scan an incomplete README and individual files to find the right guide.

**Why:** Clear navigation reduces setup time and separates maintained guides from design records.

## Changes

- Add a categorized documentation index.
- Update the workspace map and simplify setup and contribution guidance.

## How did you test this code?

- `git diff --check` passed.
- A local Node script validated every local link in the changed Markdown files.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

This PR is the docs update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex updated the documentation directly. No repository-provided or public skills were invoked.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*