### PR TITLE
fix(oauth): delete refresh tokens orphaned by an access token revoke

### DIFF
--- a/products/growth/dags/oauth.py
+++ b/products/growth/dags/oauth.py
@@ -76,6 +76,14 @@ def clear_expired_oauth_tokens(context: dagster.OpExecutionContext) -> None:
             {
                 "revoked": Q(revoked__lt=retention_cutoff),
                 "expired_via_access_token": Q(access_token__expires__lt=refresh_token_expiry_cutoff),
+                # Revoking an access token deletes the row, and this side of the OneToOne is
+                # SET_NULL, so a refresh token can lose the join the query above reaches it by
+                # while staying valid: validate_refresh_token never compares against created.
+                "expired_orphaned": Q(
+                    access_token__isnull=True,
+                    revoked__isnull=True,
+                    created__lt=refresh_token_expiry_cutoff,
+                ),
             },
         ),
         (

--- a/products/growth/dags/tests/test_oauth.py
+++ b/products/growth/dags/tests/test_oauth.py
@@ -208,6 +208,46 @@ class TestBatchDeleteFunctionality(TestCase):
         self.assertTrue(OAuthAccessToken.objects.filter(id=recent_expired_token.id).exists())
         self.assertFalse(OAuthGrant.objects.filter(id=old_grant.id).exists())
 
+    def test_clear_expired_oauth_tokens_deletes_orphaned_refresh_tokens(self):
+        """A refresh token whose access token was revoked keeps working, so age has to reach it."""
+        now = timezone.now()
+        beyond_expiry = now - timedelta(days=95)
+
+        access_token = OAuthAccessToken.objects.create(
+            user=self.user,
+            application=self.oauth_application,
+            token="orphaning_access_token",
+            expires=now + timedelta(hours=1),
+            scope="read",
+        )
+        orphaned = OAuthRefreshToken.objects.create(
+            user=self.user, application=self.oauth_application, token="orphaned_refresh", access_token=access_token
+        )
+        recent_orphan = OAuthRefreshToken.objects.create(
+            user=self.user, application=self.oauth_application, token="recent_orphaned_refresh"
+        )
+        revoked_within_retention = OAuthRefreshToken.objects.create(
+            user=self.user,
+            application=self.oauth_application,
+            token="revoked_recently",
+            revoked=now - timedelta(minutes=5),
+        )
+
+        # revoke() nulls the FK without setting `revoked`, which is the state under test.
+        access_token.revoke()
+        OAuthRefreshToken.objects.filter(id=orphaned.id).update(created=beyond_expiry)
+        OAuthRefreshToken.objects.filter(id=revoked_within_retention.id).update(created=beyond_expiry)
+
+        orphaned.refresh_from_db()
+        self.assertIsNone(orphaned.access_token)
+        self.assertIsNone(orphaned.revoked)
+
+        clear_expired_oauth_tokens(dagster.build_op_context())
+
+        self.assertFalse(OAuthRefreshToken.objects.filter(id=orphaned.id).exists())
+        self.assertTrue(OAuthRefreshToken.objects.filter(id=recent_orphan.id).exists())
+        self.assertTrue(OAuthRefreshToken.objects.filter(id=revoked_within_retention.id).exists())
+
     @unittest.mock.patch("products.growth.dags.oauth.batch_delete_model")
     def test_clear_expired_oauth_tokens_metadata_output(self, mock_batch_delete):
         mock_batch_delete.return_value = 5


### PR DESCRIPTION
## Problem

An OAuth application keeps access to a user account after a revoke, because its refresh token survives and nothing expires that token.

- `AccessToken.revoke()` deletes the access token row. The refresh token holds the other side of the OneToOne, and that side is `SET_NULL`. A revoke therefore leaves a refresh token with no access token and no `revoked` timestamp.
- That refresh token still works. `validate_refresh_token` checks the token value, the `revoked` timestamp, and the client. It never compares `created` against `REFRESH_TOKEN_EXPIRE_SECONDS`.
- The nightly cleanup job cannot reach the row either. The job selects expired refresh tokens with `Q(access_token__expires__lt=cutoff)`. A null foreign key never satisfies that join. The job's other query selects on `revoked`.
- Only this job enforces the 30-day refresh token lifetime. That lifetime therefore never applied to these rows.

Production US held 45 of these credentials on 2026-08-25. 25 of them were created before the 60-day cutoff. An earlier count on 2026-08-19 found 39 in US and 6 in EU, across 18 applications, and the oldest was five months old.

## Changes

- The cleanup job now also deletes a refresh token that has no access token, has no `revoked` timestamp, and was created before the cutoff. The cutoff is the refresh token lifetime plus the retention period, which is the same cutoff the neighboring query uses. These connections then lose access, which is the result the 30-day lifetime always specified.
- An orphaned refresh token with no `revoked` timestamp is a valid state, and the code produces it repeatedly. The job therefore selects these rows by age. It does not try to prevent their creation.
- The job does not delete a revoked orphan. The existing `revoked` query already keeps a revoked row for the retention period, and the new query excludes any row with a `revoked` timestamp, so the job cannot delete a recently revoked token early.

This PR leaves two problems open on purpose:

- `validate_refresh_token` still does not check expiry. That check changes token validation for every OAuth client, and it can remove access from live connections. It needs a separate decision.
- Nothing prevents an access token revoke from orphaning a refresh token. Whether the revoke paths must also revoke the refresh token is a larger question than this cleanup job.

## How did you test this code?

- I added one test in `products/growth/dags/tests/test_oauth.py`. The test calls a real `access_token.revoke()`, ages the orphaned refresh token past the cutoff, and asserts that the job deletes it. The test also asserts that the job keeps a recent orphan and a recently revoked token. No test covered the orphaned state before this PR.
- The test fails on master and passes with this change, so it detects a return to the join-only query.
- I ran the 8 tests in that file locally. All 8 passed.
- I did not run the Dagster job against any database. The production counts above come from read-only queries, not from an observed cleanup run.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented behavior changes. The docs already describe the 30-day refresh token lifetime.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude Opus 5, in Claude Code) wrote this at Matt's direction. It came from a review of [fix(oauth): count refresh tokens as live application access](https://github.com/PostHog/posthog/pull/84974), which shows refresh-token-only connections in Settings and lets a user revoke them. A check of whether the cleanup job retires those connections showed that the job cannot reach them, which produced this PR.

The scope narrowed during the session. My first read of the data reported a backlog of 42,000 rows and a failing cleanup job. My own query used the wrong cutoff: 30 days, where the retention period makes the correct threshold 60 days. At the correct threshold the job is current on every path it can reach, which left the orphaned rows as the only finding.

Skills invoked: `/pr-ready`, `/writing-pr-descriptions`, `/unambiguous-agent-text`.

Public artifact: the counts here are aggregates from production Postgres. They contain no customer data, no application names, and no identifiers. The test fixtures are invented.
