### PR TITLE
feat(hogli): add test:audit command for suite cost and duplication audits

### DIFF
--- a/hogli.yaml
+++ b/hogli.yaml
@@ -793,6 +793,9 @@ tests:
     test:quarantine:
         click: hogli_commands.quarantine.cli:quarantine
         description: Manage .test_quarantine.json — quarantine flaky tests so they stop blocking CI
+    test:audit:
+        click: hogli_commands.test_audit:test_audit
+        description: Audit the Python test suite — count, growth, where the time goes, duplicate tests to merge
     evals:
         cmd: python -m products.posthog_ai.eval_harness.harness
         description: Run evals — sandboxed agent and one-shot suites (extra args pass through, e.g. `sql` or `cli_mcp --provider modal`)

--- a/tools/hogli-commands/hogli_commands/test_audit.py
+++ b/tools/hogli-commands/hogli_commands/test_audit.py
@@ -29,6 +29,7 @@ import json
 import hashlib
 import subprocess
 from collections import defaultdict
+from dataclasses import dataclass
 from pathlib import Path
 
 import click
@@ -43,6 +44,19 @@ MIN_CLUSTER_SIZE = 3
 
 NODEID_RE = re.compile(r"^[\w./-]+\.py::")
 DEF_TEST_RE = re.compile(rb"^\s*(async )?def test_")
+
+
+@dataclass(frozen=True, kw_only=True)
+class _GrowthRow:
+    month: str
+    defs: int
+    files: int
+
+
+@dataclass(frozen=True, kw_only=True)
+class _DupeCluster:
+    members: list[str]  # nodeids
+    seconds: float
 
 
 def _root() -> Path:
@@ -72,7 +86,7 @@ def _count_defs(root: Path) -> int:
     return total
 
 
-def _growth_rows(root: Path, top: int) -> list[tuple[str, int, int]]:
+def _growth_rows(root: Path, top: int) -> list[_GrowthRow]:
     """(month, def count, file count) sampled at the first commit of each month."""
     months = _sh("git", "log", "--reverse", "--format=%ad", "--date=format:%Y-%m", cwd=root).splitlines()
     months = sorted(set(months))
@@ -93,7 +107,7 @@ def _growth_rows(root: Path, top: int) -> list[tuple[str, int, int]]:
             for f in _sh("git", "ls-tree", "-r", "--name-only", sha, cwd=root).splitlines()
             if f.endswith(".py") and (f.split("/")[-1].startswith("test_") or f.endswith("_test.py"))
         )
-        rows.append((month, defs, files))
+        rows.append(_GrowthRow(month=month, defs=defs, files=files))
     return rows[-top:]
 
 
@@ -139,12 +153,12 @@ def _body_hash(func: ast.FunctionDef | ast.AsyncFunctionDef) -> tuple[str, int]:
     for child in ast.walk(func):
         if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)) and child is not func:
             statements += len(child.body)
-    return hashlib.sha1(ast.dump(func).encode()).hexdigest(), statements
+    return hashlib.sha256(ast.dump(func).encode()).hexdigest(), statements
 
 
-def _dupes(root: Path, durations: dict[str, float]) -> list[tuple[list[tuple[str, str, str]], float]]:
-    """Cluster tests by normalized body hash -> (members, est seconds)."""
-    clusters: dict[str, list[tuple[str, str, str]]] = defaultdict(list)
+def _dupes(root: Path, durations: dict[str, float]) -> list[_DupeCluster]:
+    """Cluster tests by normalized body hash."""
+    clusters: dict[str, list[str]] = defaultdict(list)
 
     def visit(node: ast.AST, path: str, qualname: str) -> None:
         for child in ast.iter_child_nodes(node):
@@ -153,8 +167,9 @@ def _dupes(root: Path, durations: dict[str, float]) -> list[tuple[list[tuple[str
                 if name.startswith("test_"):
                     h, size = _body_hash(child)
                     if size >= MIN_BODY_STATEMENTS:
-                        clusters[h].append((path, qualname, name))
-                visit(child, path, f"{qualname}::{child.name}" if qualname else child.name)
+                        nodeid = f"{path}::{qualname}::{name}" if qualname else f"{path}::{name}"
+                        clusters[h].append(nodeid)
+                visit(child, path, f"{qualname}::{name}" if qualname else name)
             elif isinstance(child, ast.ClassDef):
                 visit(child, path, f"{qualname}::{child.name}" if qualname else child.name)
 
@@ -169,12 +184,9 @@ def _dupes(root: Path, durations: dict[str, float]) -> list[tuple[list[tuple[str
     for members in clusters.values():
         if len(members) < MIN_CLUSTER_SIZE:
             continue
-        seconds = sum(
-            durations.get(f"{f}::{cls}::{name}", 0.0) if cls else durations.get(f"{f}::{name}", 0.0)
-            for f, cls, name in members
-        )
-        out.append((members, seconds))
-    out.sort(key=lambda row: (-row[1], -len(row[0])))
+        seconds = sum(durations.get(nodeid, 0.0) for nodeid in members)
+        out.append(_DupeCluster(members=members, seconds=seconds))
+    out.sort(key=lambda cluster: (-cluster.seconds, -len(cluster.members)))
     return out
 
 
@@ -225,9 +237,9 @@ def test_audit(do_collect: bool, top: int, dupes: bool, growth: bool, output: Pa
                 "",
                 "| Month | Test functions | Test files |",
                 "| --- | ---: | ---: |",
-                *[f"| {m} | {d:,} | {f:,} |" for m, d, f in rows],
+                *[f"| {row.month} | {row.defs:,} | {row.files:,} |" for row in rows],
                 "",
-                f"Net change {first[0]} to {last[0]}: **+{last[1] - first[1]:,} functions**.",
+                f"Net change {first.month} to {last.month}: **+{last.defs - first.defs:,} functions**.",
                 "",
             ]
         else:
@@ -317,8 +329,8 @@ def test_audit(do_collect: bool, top: int, dupes: bool, growth: bool, output: Pa
     if dupes:
         lines += ["## Duplicate-shape tests", ""]
         clusters = _dupes(root, durations)
-        in_clusters = sum(len(m) for m, _ in clusters)
-        est = sum(s for _, s in clusters)
+        in_clusters = sum(len(c.members) for c in clusters)
+        est = sum(c.seconds for c in clusters)
         lines += [
             f"Tests in clusters of {MIN_CLUSTER_SIZE}+ with identical bodies (modulo names and literals): "
             f"**{in_clusters:,}** in **{len(clusters):,}** clusters"
@@ -330,10 +342,8 @@ def test_audit(do_collect: bool, top: int, dupes: bool, growth: bool, output: Pa
             "| Cluster size | Est. seconds | Example |",
             "| ---: | ---: | --- |",
         ]
-        for members, seconds in clusters[:top]:
-            f, cls, name = members[0]
-            example = f"{f}::{cls}::{name}" if cls else f"{f}::{name}"
-            lines.append(f"| {len(members)} | {seconds:,.1f} | `{example}` |")
+        for cluster in clusters[:top]:
+            lines.append(f"| {len(cluster.members)} | {cluster.seconds:,.1f} | `{cluster.members[0]}` |")
         lines.append("")
 
     report = "\n".join(lines)

--- a/tools/hogli-commands/hogli_commands/test_audit.py
+++ b/tools/hogli-commands/hogli_commands/test_audit.py
@@ -1,0 +1,344 @@
+"""Audit the Python test suite: count, growth, cost, and consolidation candidates.
+
+Answers three questions with repo-local data:
+
+1. How many tests are there, and how fast is the suite growing?
+   (per-test services bill the *expanded* count, parameterization included)
+2. Where does the time go? (``.test_durations`` per-test timings used by pytest-split)
+3. Which tests look like agent-generated near-duplicates worth merging into
+   one parameterized test? (AST shape hashing across test bodies)
+
+    hogli test:audit                # inventory + durations + duplicates + growth
+    hogli test:audit --collect      # also run `pytest --collect-only` (~3 min) for the
+                                    # exact expanded count and the no-timing-data join
+    hogli test:audit -o audit.md    # write the markdown report to a file
+
+What this does not do: judge value. A slow test can be worth every second and a
+fast one can be dead weight. Pair the cost tables here with failure history
+(Trunk flaky tests / the trunkio_* warehouse tables) before deleting anything,
+and apply the writing-tests gate: what realistic regression does this test
+catch that no existing test catches?
+"""
+
+from __future__ import annotations
+
+import re
+import ast
+import sys
+import json
+import hashlib
+import subprocess
+from collections import defaultdict
+from pathlib import Path
+
+import click
+
+# A test recorded at exactly this many seconds smells like a recording cap,
+# not a true runtime — flag the cluster instead of trusting the number.
+CAP_SECONDS = 60.0
+# Bodies smaller than this hash to the same trivial shapes; ignore them.
+MIN_BODY_STATEMENTS = 4
+# Only clusters at least this large are worth a human's attention.
+MIN_CLUSTER_SIZE = 3
+
+NODEID_RE = re.compile(r"^[\w./-]+\.py::")
+DEF_TEST_RE = re.compile(rb"^\s*(async )?def test_")
+
+
+def _root() -> Path:
+    return Path(_sh("git", "rev-parse", "--show-toplevel"))
+
+
+def _sh(*args: str, cwd: Path | None = None) -> str:
+    result = subprocess.run(args, capture_output=True, text=True, cwd=cwd)
+    if result.returncode != 0:
+        raise click.ClickException(f"{' '.join(args)} failed: {result.stderr.strip()[:300]}")
+    return result.stdout.strip()
+
+
+def _test_files(root: Path) -> list[str]:
+    out = _sh("git", "ls-files", "*.py", cwd=root).splitlines()
+    return [f for f in out if f.split("/")[-1].startswith("test_") or f.endswith("_test.py")]
+
+
+def _count_defs(root: Path) -> int:
+    total = 0
+    for f in _test_files(root):
+        try:
+            data = (root / f).read_bytes()
+        except OSError:
+            continue
+        total += sum(1 for line in data.splitlines() if DEF_TEST_RE.match(line))
+    return total
+
+
+def _growth_rows(root: Path, top: int) -> list[tuple[str, int, int]]:
+    """(month, def count, file count) sampled at the first commit of each month."""
+    months = _sh("git", "log", "--reverse", "--format=%ad", "--date=format:%Y-%m", cwd=root).splitlines()
+    months = sorted(set(months))
+    rows = []
+    for month in months:
+        sha = _sh("git", "rev-list", "-1", "--first-parent", f"--before={month}-01T00:00:00", "HEAD", cwd=root)
+        if not sha:
+            continue
+        grep = subprocess.run(
+            ["git", "grep", "-E", r"^\s*(async )?def test_", sha, "--", "*.py"],
+            capture_output=True,
+            text=True,
+            cwd=root,
+        )
+        defs = grep.stdout.count("\n")
+        files = sum(
+            1
+            for f in _sh("git", "ls-tree", "-r", "--name-only", sha, cwd=root).splitlines()
+            if f.endswith(".py") and (f.split("/")[-1].startswith("test_") or f.endswith("_test.py"))
+        )
+        rows.append((month, defs, files))
+    return rows[-top:]
+
+
+def _load_durations(root: Path) -> dict[str, float]:
+    path = root / ".test_durations"
+    if not path.exists():
+        click.echo("warning: no .test_durations; skipping timing sections", err=True)
+        return {}
+    return json.loads(path.read_text())
+
+
+def _collect_nodeids() -> set[str] | None:
+    proc = subprocess.run(
+        [sys.executable, "-m", "pytest", "--collect-only", "-q", "-p", "no:cacheprovider"],
+        capture_output=True,
+        text=True,
+        timeout=1200,
+    )
+    nodeids = {line.strip() for line in proc.stdout.splitlines() if NODEID_RE.match(line.strip())}
+    if not nodeids:
+        click.echo(f"warning: collection produced no tests:\n{proc.stdout[-500:]}\n{proc.stderr[-500:]}", err=True)
+        return None
+    return nodeids
+
+
+class _Blank(ast.NodeVisitor):
+    """Erase identifiers and literal values so copy-pasted tests hash alike."""
+
+    def visit_Name(self, node: ast.Name) -> None:
+        node.id = "_"
+
+    def visit_arg(self, node: ast.arg) -> None:
+        node.arg = "_"
+
+    def visit_Constant(self, node: ast.Constant) -> None:
+        node.value = None
+
+
+def _body_hash(func: ast.FunctionDef | ast.AsyncFunctionDef) -> tuple[str, int]:
+    _Blank().visit(func)
+    func.name = "_"
+    statements = len(func.body)
+    for child in ast.walk(func):
+        if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)) and child is not func:
+            statements += len(child.body)
+    return hashlib.sha1(ast.dump(func).encode()).hexdigest(), statements
+
+
+def _dupes(root: Path, durations: dict[str, float]) -> list[tuple[list[tuple[str, str, str]], float]]:
+    """Cluster tests by normalized body hash -> (members, est seconds)."""
+    clusters: dict[str, list[tuple[str, str, str]]] = defaultdict(list)
+
+    def visit(node: ast.AST, path: str, qualname: str) -> None:
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                name = child.name  # _body_hash blanks it in place
+                if name.startswith("test_"):
+                    h, size = _body_hash(child)
+                    if size >= MIN_BODY_STATEMENTS:
+                        clusters[h].append((path, qualname, name))
+                visit(child, path, f"{qualname}::{child.name}" if qualname else child.name)
+            elif isinstance(child, ast.ClassDef):
+                visit(child, path, f"{qualname}::{child.name}" if qualname else child.name)
+
+    for f in _test_files(root):
+        try:
+            tree = ast.parse((root / f).read_bytes())
+        except (SyntaxError, ValueError, OSError):
+            continue
+        visit(tree, f, "")
+
+    out = []
+    for members in clusters.values():
+        if len(members) < MIN_CLUSTER_SIZE:
+            continue
+        seconds = sum(
+            durations.get(f"{f}::{cls}::{name}", 0.0) if cls else durations.get(f"{f}::{name}", 0.0)
+            for f, cls, name in members
+        )
+        out.append((members, seconds))
+    out.sort(key=lambda row: (-row[1], -len(row[0])))
+    return out
+
+
+def _pct(part: float, whole: float) -> str:
+    return f"{part / whole:.0%}" if whole else "-"
+
+
+@click.command(name="test:audit", help=__doc__)
+@click.option("--collect", "do_collect", is_flag=True, help="Run pytest --collect-only (~3 min) for exact counts.")
+@click.option("--top", default=15, show_default=True, help="Rows per table.")
+@click.option("--dupes/--no-dupes", default=True, help="Scan for duplicate test bodies.")
+@click.option("--growth/--no-growth", default=True, help="Sample def counts across git history.")
+@click.option(
+    "-o", "--output", type=click.Path(path_type=Path), default=None, help="Write markdown here instead of stdout."
+)
+def test_audit(do_collect: bool, top: int, dupes: bool, growth: bool, output: Path | None) -> None:
+    root = _root()
+    lines: list[str] = ["# Python test suite audit", ""]
+
+    files = _test_files(root)
+    defs = _count_defs(root)
+    lines += [
+        "## Inventory",
+        "",
+        f"- Test files: **{len(files):,}**",
+        f"- Test functions (`def test_`): **{defs:,}**",
+    ]
+
+    nodeids = _collect_nodeids() if do_collect else None
+    if nodeids is not None:
+        param = sum(1 for n in nodeids if "[" in n)
+        lines += [
+            f"- Expanded tests (what a per-test service bills): **{len(nodeids):,}**",
+            f"- Parameterized expansions: **{param:,}** ({_pct(param, len(nodeids))} of expanded)",
+            "",
+            "Run without `--collect` and this section only counts `def test_` lines.",
+        ]
+    else:
+        lines += ["", "Expanded count unknown (run with `--collect`, ~3 min)."]
+    lines.append("")
+
+    if growth:
+        rows = _growth_rows(root, top=12)
+        if len(rows) >= 2:
+            first, last = rows[0], rows[-1]
+            lines += [
+                "## Growth",
+                "",
+                "| Month | Test functions | Test files |",
+                "| --- | ---: | ---: |",
+                *[f"| {m} | {d:,} | {f:,} |" for m, d, f in rows],
+                "",
+                f"Net change {first[0]} to {last[0]}: **+{last[1] - first[1]:,} functions**.",
+                "",
+            ]
+        else:
+            lines += ["## Growth", "", "Not enough git history (shallow clone?). Fetch history to enable.", ""]
+
+    durations = _load_durations(root)
+    if durations:
+        live = {k: v for k, v in durations.items() if (root / k.split("::")[0]).exists()}
+        stale = {k: v for k, v in durations.items() if k not in live}
+        total = sum(live.values())
+        values = sorted(live.values())
+        n = len(values)
+        lines += [
+            "## Where the time goes",
+            "",
+            f"- Timed tests with files still in the tree: **{len(live):,}** holding **{total / 3600:.2f} h serial**.",
+            f"- Stale entries (file moved or deleted): {len(stale):,} holding {sum(stale.values()) / 3600:.2f} h — ignored below.",
+            f"- Median test: **{values[n // 2] * 1000:.0f} ms**. p90: {values[int(n * 0.9)]:.2f} s. p99: {values[int(n * 0.99)]:.2f} s.",
+        ]
+        sorted_vals = sorted(live.values(), reverse=True)
+        for pct in (1, 5, 10):
+            k = max(1, n * pct // 100)
+            lines.append(f"- Top {pct}% of tests ({k:,}) hold **{_pct(sum(sorted_vals[:k]), total)} of all time**.")
+        slow = {k: v for k, v in live.items() if v > 1}
+        very_slow = {k: v for k, v in live.items() if v > 10}
+        lines += [
+            f"- Slower than 1 s: {len(slow):,} tests ({_pct(len(slow), n)}) hold {_pct(sum(slow.values()), total)}.",
+            f"- Slower than 10 s: {len(very_slow):,} tests hold {_pct(sum(very_slow.values()), total)}.",
+            "",
+        ]
+
+        capped = sorted(((k, v) for k, v in live.items() if v == CAP_SECONDS), key=lambda kv: kv[0])
+        if capped:
+            lines += [
+                f"### Recorded at exactly {CAP_SECONDS:.0f} s ({len(capped)} tests)",
+                "",
+                "A round number this precise looks like a recording cap, not a true runtime. "
+                "These probably hung or timed out while timing was recorded — investigate each before trusting anything nearby.",
+                "",
+                "```",
+                *(k for k, _ in capped[:top]),
+                "```",
+                "",
+            ]
+
+        by_file: dict[str, list[float]] = defaultdict(lambda: [0, 0.0])
+        for k, v in live.items():
+            entry = by_file[k.split("::")[0]]
+            entry[0] += 1
+            entry[1] += v
+        lines += [
+            f"### Heaviest files (top {top})",
+            "",
+            "| Seconds | Tests | File |",
+            "| ---: | ---: | --- |",
+            *(f"| {s:,.0f} | {c:,} | `{f}` |" for f, (c, s) in sorted(by_file.items(), key=lambda kv: -kv[1][1])[:top]),
+            "",
+        ]
+
+        param_time = sum(v for k, v in live.items() if "[" in k)
+        param_n = sum(1 for k in live if "[" in k)
+        lines += [
+            "### Parameterized share of timed tests",
+            "",
+            f"{param_n:,} expansions ({_pct(param_n, n)} of timed tests) holding {_pct(param_time, total)} of time.",
+            "",
+        ]
+
+        if nodeids is not None:
+            untimed = nodeids - durations.keys()
+            by_seg: dict[str, int] = defaultdict(int)
+            for k in untimed:
+                by_seg["/".join(k.split("/")[:2])] += 1
+            lines += [
+                "## Tests with no recorded duration",
+                "",
+                f"**{len(untimed):,}** of {len(nodeids):,} collected tests have no timing record. "
+                "pytest-split assigns them a default weight, so shards carrying many of these are balanced on guesses. "
+                "Segments with the most untimed tests:",
+                "",
+                "| Count | Path |",
+                "| ---: | --- |",
+                *(f"| {c:,} | `{seg}` |" for seg, c in sorted(by_seg.items(), key=lambda kv: -kv[1])[:top]),
+                "",
+            ]
+
+    if dupes:
+        lines += ["## Duplicate-shape tests", ""]
+        clusters = _dupes(root, durations)
+        in_clusters = sum(len(m) for m, _ in clusters)
+        est = sum(s for _, s in clusters)
+        lines += [
+            f"Tests in clusters of {MIN_CLUSTER_SIZE}+ with identical bodies (modulo names and literals): "
+            f"**{in_clusters:,}** in **{len(clusters):,}** clusters"
+            + (f", ~{est / 60:.0f} min of recorded time." if est else "."),
+            "",
+            "Each cluster is one parameterized test waiting to happen. Check the surviving test covers every case, "
+            "then delete the copies — deletion still needs a human to name what coverage is lost.",
+            "",
+            "| Cluster size | Est. seconds | Example |",
+            "| ---: | ---: | --- |",
+        ]
+        for members, seconds in clusters[:top]:
+            f, cls, name = members[0]
+            example = f"{f}::{cls}::{name}" if cls else f"{f}::{name}"
+            lines.append(f"| {len(members)} | {seconds:,.1f} | `{example}` |")
+        lines.append("")
+
+    report = "\n".join(lines)
+    if output:
+        output.write_text(report + "\n")
+        click.echo(f"wrote {output}")
+    else:
+        click.echo(report)

--- a/tools/hogli-commands/hogli_commands/tests/test_test_audit.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_test_audit.py
@@ -58,9 +58,8 @@ def test_dupes_clusters_across_files_and_skips_tiny_bodies(tmp_path: Path) -> No
         clusters = test_audit._dupes(tmp_path, {})
 
     assert len(clusters) == 1
-    members, _ = clusters[0]
-    assert len(members) == 3
-    assert all("test_tiny.py" not in path for path, _, _ in members)
+    assert len(clusters[0].members) == 3
+    assert all("test_tiny.py" not in nodeid for nodeid in clusters[0].members)
 
 
 def test_dupes_estimates_seconds_from_durations(tmp_path: Path) -> None:
@@ -75,4 +74,4 @@ def test_dupes_estimates_seconds_from_durations(tmp_path: Path) -> None:
     with patch.object(test_audit, "_test_files", return_value=[f"pkg/test_copy_{i}.py" for i in range(3)]):
         clusters = test_audit._dupes(tmp_path, durations)
 
-    assert clusters[0][1] == 12.0
+    assert clusters[0].seconds == 12.0

--- a/tools/hogli-commands/hogli_commands/tests/test_test_audit.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_test_audit.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+from unittest.mock import patch
+
+from hogli_commands import test_audit
+
+
+def _hash(source: str) -> tuple[str, int]:
+    func = ast.parse(source).body[0]
+    assert isinstance(func, (ast.FunctionDef, ast.AsyncFunctionDef))
+    return test_audit._body_hash(func)
+
+
+@pytest.mark.parametrize(
+    "a, b, same",
+    [
+        (
+            "def test_a():\n    x = call(1, 'one')\n    y = call(2, 'two')\n    z = call(3, 'three')\n    assert x == y == z",
+            "def test_b():\n    x = call(4, 'four')\n    y = call(5, 'five')\n    z = call(6, 'six')\n    assert x == y == z",
+            True,
+        ),
+        (
+            "def test_a():\n    result = fn(alpha=1)\n    assert result\n    assert result.ok\n    assert result.done",
+            "def test_b():\n    result = fn(alpha=1)\n    assert not result\n    assert result.ok\n    assert result.done",
+            False,
+        ),
+    ],
+)
+def test_body_hash_matches_copy_paste_but_not_real_differences(a: str, b: str, same: bool) -> None:
+    assert (_hash(a)[0] == _hash(b)[0]) is same
+
+
+def test_body_hash_size_counts_nested_def_bodies() -> None:
+    _, size = _hash(
+        "def test_a():\n    def helper():\n        return 1\n    x = helper()\n    assert x\n    assert True"
+    )
+    assert size == 5
+
+
+def _write(path: Path, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+
+
+def test_dupes_clusters_across_files_and_skips_tiny_bodies(tmp_path: Path) -> None:
+    big = "    x = call({n})\n    y = call({n})\n    z = call({n})\n    assert x == y == z\n"
+    for i in range(3):
+        _write(tmp_path / f"pkg/test_copy_{i}.py", f"def test_thing_{i}():\n" + big.format(n=i))
+    _write(tmp_path / "pkg/test_tiny.py", "def test_small():\n    assert True\n")
+
+    with patch.object(
+        test_audit, "_test_files", return_value=[str(p.relative_to(tmp_path)) for p in tmp_path.rglob("*.py")]
+    ):
+        clusters = test_audit._dupes(tmp_path, {})
+
+    assert len(clusters) == 1
+    members, _ = clusters[0]
+    assert len(members) == 3
+    assert all("test_tiny.py" not in path for path, _, _ in members)
+
+
+def test_dupes_estimates_seconds_from_durations(tmp_path: Path) -> None:
+    body = "        x = call({n})\n        y = call({n})\n        z = call({n})\n        assert x == y == z\n"
+    for i in range(3):
+        _write(
+            tmp_path / f"pkg/test_copy_{i}.py",
+            f"class TestGroup:\n    def test_thing_{i}(self):\n" + body.format(n=i),
+        )
+
+    durations = {f"pkg/test_copy_{i}.py::TestGroup::test_thing_{i}": 2.0 * (i + 1) for i in range(3)}
+    with patch.object(test_audit, "_test_files", return_value=[f"pkg/test_copy_{i}.py" for i in range(3)]):
+        clusters = test_audit._dupes(tmp_path, durations)
+
+    assert clusters[0][1] == 12.0


### PR DESCRIPTION
## Problem

Anyone asking "how big is the Python test suite, where does its time go, and which tests are duplicates" has to hand-roll git and pytest queries. The suite grew from ~17k test functions in February to ~83k now (~129k expanded with parameterization), and with per-test-priced test tooling under evaluation, count and per-test cost both need to be measurable on demand.

## Changes

- New `hogli test:audit` command prints a markdown audit of the Python suite: test inventory and month-by-month growth from git history, timing distribution and heaviest files from the committed `.test_durations`, tests recorded at exactly 60 s (timing-cap suspects), timing entries for files that no longer exist, collected tests with no timing record, and clusters of tests with identical bodies modulo names and literals (AST shape hashing).
- `--collect` runs `pytest --collect-only` (~3 min) for the exact expanded count and the untimed-test join; skipped by default.
- The duplicate clusters surface consolidation candidates, for example per-vendor warehouse-source config tests repeated across vendor dirs. The report states that merging keeps the expanded count flat and that deletion stays human-gated.
- Mechanical: three lines registering the command in `hogli.yaml`.

## How did you test this code?

- Ran `hogli test:audit` and `hogli test:audit --collect` on this repo and verified the numbers independently (inventory vs `git grep`, distribution slices vs manual computation, cluster output deterministic across runs).
- Added `tools/hogli-commands/hogli_commands/tests/test_test_audit.py` (5 tests): renamed copy-paste tests hash alike while a structurally different body does not (catches over/under-normalization), nested function bodies count toward the size floor (catches tiny-shape false positives), clusters form across files while small bodies are excluded, and per-cluster seconds come from `.test_durations` (catches the nodeid key join).
- Repo-wide `uv run mypy --cache-fine-grained .` and `hogli ci:preflight --fix` both clean.
- Not run: the full hogli-commands suite in CI. Locally 1,476 passed and `test_devbox.py::TestDevboxCommands::test_devbox_setup_runs_explicit_setup_steps` failed identically with and without this change (sandbox lacks the devbox environment).

## Docs update

None: hogli commands are not listed in docs, and the command's help text carries its usage.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Agent/tool: pi coding agent. Session involved analyzing suite growth, timing, and CI flake data at the request of the assignee; this PR is the durable tooling half of that work.
- Skills invoked: `/writing-tests` (value gate applied to the new tests), `/writing-pr-descriptions` (this body). `/fixing-flaky-tests` read for its deletion-gate rules, which the report output cites.
- Decisions: a hogli command was chosen over a standalone script because `hogli.yaml` is where repo test tooling already lives (`test:quarantine` precedent). AST shape hashing was chosen over coverage-based dedupe because it runs in seconds over the whole repo; coverage contexts stay a per-directory follow-up.
- Public artifact check: everything in the diff derives from this repository alone. No session material included.
