### PR TITLE
feat(desktop): identify Signals canvases

### DIFF
--- a/products/desktop/packages/core/src/canvas/channelItems.test.ts
+++ b/products/desktop/packages/core/src/canvas/channelItems.test.ts
@@ -39,6 +39,7 @@ function canvas(over: Partial<DashboardRecord> = {}): DashboardRecord {
     kind: "freeform" as const,
     description: "",
     templateId: "freeform",
+    sourceProduct: "user_created",
     context: "",
     createdAt: 0,
     updatedAt: 1_000,
@@ -193,6 +194,30 @@ describe("buildChannelItems", () => {
       ],
     });
     expect(items.map((i) => i.source)).toEqual(["slack", null]);
+  });
+
+  it("keeps canvas provenance available to source filters", () => {
+    const items = build({
+      dashboards: [
+        canvas({ id: "signals", sourceProduct: "signal_report" }),
+        canvas({ id: "manual", sourceProduct: "user_created" }),
+      ],
+    });
+
+    expect(channelItemSources(items)).toEqual([
+      "signal_report",
+      "user_created",
+    ]);
+    expect(
+      filterChannelItems(items, {
+        query: "",
+        filters: {
+          ...DEFAULT_CHANNEL_ITEM_FILTERS,
+          source: "signal_report",
+        },
+        me: { uuid: ME.uuid },
+      }).map((item) => item.id),
+    ).toEqual(["signals"]);
   });
 
   it("marks the sessions asking for input and the ones you haven't read", () => {

--- a/products/desktop/packages/core/src/canvas/channelItems.ts
+++ b/products/desktop/packages/core/src/canvas/channelItems.ts
@@ -34,6 +34,7 @@ export interface ChannelItemModel {
   environment: ChannelItemEnvironment | null;
   /** The product that filed it (`origin_product`), or null if it started here. */
   source: string | null;
+  sourceResourceId?: string | null;
   /** The agent is blocked on an answer from you. */
   needsInput: boolean;
   /** There is activity here you haven't seen. */
@@ -139,7 +140,8 @@ export function buildChannelItems({
     pinned: d.pinnedAt != null,
     rawStatus: null,
     environment: null,
-    source: null,
+    source: d.sourceProduct,
+    sourceResourceId: d.sourceResourceId ?? null,
     needsInput: false,
     unread: false,
     authorUser: null,
@@ -167,6 +169,7 @@ export function buildChannelItems({
               sessionFacts.workspaceModeByTaskId.get(task.id),
             ),
             source: sourceOf(task),
+            sourceResourceId: task.signal_report ?? null,
             needsInput: sessionFacts.needsInputTaskIds.has(task.id),
             unread: isTaskUnread(
               taskActivityAt(task),

--- a/products/desktop/packages/core/src/canvas/dashboardSchemas.ts
+++ b/products/desktop/packages/core/src/canvas/dashboardSchemas.ts
@@ -26,6 +26,8 @@ export const dashboardRecordSchema = z.object({
   // For components: the head version's placement contract (size, configSchema).
   componentMeta: componentMetaSchema.nullish(),
   templateId: z.string().default("freeform"),
+  sourceProduct: z.string().default("user_created"),
+  sourceResourceId: z.string().nullish(),
   // The live author-written context (markdown) passed to the agent.
   context: z.string().default(""),
   // Id of the task currently generating this canvas (freeform gen runs as a

--- a/products/desktop/packages/core/src/canvas/dashboardsService.test.ts
+++ b/products/desktop/packages/core/src/canvas/dashboardsService.test.ts
@@ -9,6 +9,8 @@ function apiCanvas(overrides: Record<string, unknown> = {}) {
     name: "Revenue board",
     channel: "chan-1",
     template_id: "freeform",
+    source_product: "signal_report",
+    source_resource_id: "report-1",
     context: "",
     generation_task_id: null,
     pinned_at: null,
@@ -69,6 +71,8 @@ describe("DashboardsService.list", () => {
       name: "Revenue board",
       createdBy: "Ada L",
       currentVersionId: "v1",
+      sourceProduct: "signal_report",
+      sourceResourceId: "report-1",
     });
     expect(rows[0].createdAt).toBe(Date.parse("2026-07-01T00:00:00Z"));
   });

--- a/products/desktop/packages/core/src/canvas/dashboardsService.ts
+++ b/products/desktop/packages/core/src/canvas/dashboardsService.ts
@@ -42,6 +42,8 @@ interface ApiCanvas {
   component_meta?: unknown;
   channel: string;
   template_id: string;
+  source_product?: string;
+  source_resource_id?: string | null;
   context: string;
   generation_task_id: string | null;
   pinned_at: string | null;
@@ -102,6 +104,8 @@ function toRecord(api: ApiCanvas): DashboardRecord {
     description: api.description ?? "",
     componentMeta: meta.success ? meta.data : null,
     templateId: api.template_id || FREEFORM_TEMPLATE_ID,
+    sourceProduct: api.source_product ?? "user_created",
+    sourceResourceId: api.source_resource_id,
     context: api.context ?? "",
     generationTaskId: api.generation_task_id,
     createdBy: creatorLabel(api.created_by),

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelFilterMenu.stories.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelFilterMenu.stories.tsx
@@ -31,11 +31,15 @@ function Harness({
     <div className="flex justify-end p-2">
       <ChannelFilterMenu
         filters={filters}
-        onFiltersChange={setFilters}
+        onFilterChange={(key, value) =>
+          setFilters((current) => ({ ...current, [key]: value }))
+        }
+        onClearFilters={() => setFilters(DEFAULT_CHANNEL_ITEM_FILTERS)}
         sort={sort}
         onSortChange={setSort}
         sources={sources}
         showCreatedBy={showCreatedBy}
+        showRunFilters
         active={hasActiveChannelItemFilters(filters)}
       />
     </div>

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelFilterMenu.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelFilterMenu.tsx
@@ -188,7 +188,10 @@ export function ChannelFilterMenu({
       value: source,
       // A source we have no name for still filters — the raw key is a worse
       // label than "Slack", but a missing option would be a worse answer.
-      label: getOriginProductMeta(source)?.label ?? source,
+      label:
+        source === "user_created"
+          ? "Created here"
+          : (getOriginProductMeta(source)?.label ?? source),
     })),
   ];
 
@@ -244,21 +247,19 @@ export function ChannelFilterMenu({
           onChange={(value) => onFilterChange("pinned", value)}
         />
         {showRunFilters && (
-          <>
-            <FilterSubmenu
-              label="Environment"
-              options={ENVIRONMENT_OPTIONS}
-              value={filters.environment}
-              onChange={(value) => onFilterChange("environment", value)}
-            />
-            <FilterSubmenu
-              label="Source"
-              options={sourceOptions}
-              value={filters.source}
-              onChange={(value) => onFilterChange("source", value)}
-            />
-          </>
+          <FilterSubmenu
+            label="Environment"
+            options={ENVIRONMENT_OPTIONS}
+            value={filters.environment}
+            onChange={(value) => onFilterChange("environment", value)}
+          />
         )}
+        <FilterSubmenu
+          label="Source"
+          options={sourceOptions}
+          value={filters.source}
+          onChange={(value) => onFilterChange("source", value)}
+        />
         <DropdownMenuSeparator />
         <FilterSubmenu
           label="Sort by"

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemPreview.stories.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemPreview.stories.tsx
@@ -167,3 +167,33 @@ export const Crowded: Story = {
     ),
   },
 };
+
+/** A report-generated canvas keeps its ordinary canvas identity and names Signals as its source. */
+export const SignalsCanvas: Story = {
+  args: {
+    item: {
+      ...item(run({ status: "completed" })),
+      key: "canvas:activation-drop",
+      kind: "canvas",
+      id: "activation-drop",
+      title: "Activation fell after the onboarding change",
+      source: "signal_report",
+      sourceResourceId: "report-1",
+      rawStatus: null,
+      environment: null,
+      authorUser: null,
+      authorName: "PostHog",
+      authorUuid: null,
+      templateId: "freeform",
+      task: null,
+    },
+    menu: {
+      kind: "canvas",
+      id: "activation-drop",
+      title: "Activation fell after the onboarding change",
+      isPinned: false,
+      onTogglePin: () => {},
+      onDelete: () => {},
+    },
+  },
+};

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemPreview.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemPreview.tsx
@@ -26,6 +26,7 @@ import {
 import { useChannelTaskStatus } from "@posthog/ui/features/canvas/hooks/useChannelTaskStatus";
 import { useLatestTurnMessage } from "@posthog/ui/features/canvas/hooks/useLatestTurnMessage";
 import { userDisplayName } from "@posthog/ui/features/canvas/utils/userDisplay";
+import { getOriginProductMeta } from "@posthog/ui/features/sidebar/components/items/TaskIcon";
 import { TaskDotMark } from "@posthog/ui/features/sidebar/components/items/TaskStatusDot";
 import {
   type TaskBadge,
@@ -239,6 +240,7 @@ export function ChannelItemPreview({
   const status = useChannelTaskStatus(item);
   const message = useLatestTurnMessage(item.task);
   const dot = status ? taskDot(status) : null;
+  const source = getOriginProductMeta(item.source ?? undefined);
 
   return (
     <ItemGroup className="gap-0!">
@@ -253,7 +255,8 @@ export function ChannelItemPreview({
             <span className="min-w-0">{item.title}</span>
           </ItemTitle>
           <ItemDescription>
-            {item.kind === "canvas" ? "Canvas" : "Task"} · updated{" "}
+            {item.kind === "canvas" ? "Canvas" : "Task"}
+            {source ? ` from ${source.label}` : ""} · updated{" "}
             {formatRelativeTimeShort(item.ts)}
           </ItemDescription>
         </ItemContent>

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
@@ -374,6 +374,19 @@ describe("ChannelItemRow", () => {
     expect(screen.queryByRole("img", { name: "All caught up" })).toBeNull();
   });
 
+  it("marks a canvas created from Signals", () => {
+    renderRow(
+      item({
+        key: "canvas:c1",
+        kind: "canvas",
+        id: "c1",
+        source: "signal_report",
+      }),
+    );
+
+    expect(screen.getByLabelText("Signals canvas")).toBeInTheDocument();
+  });
+
   it("gives a canvas the actions it has: pin and delete, not archive or filing", async () => {
     const canvas = item({
       key: "canvas:c1",

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.tsx
@@ -24,6 +24,7 @@ import {
 } from "@posthog/ui/features/canvas/components/TaskRowMenu";
 import { useChannelTaskStatus } from "@posthog/ui/features/canvas/hooks/useChannelTaskStatus";
 import { useIsCanvasPendingDelete } from "@posthog/ui/features/canvas/stores/pendingCanvasDeleteStore";
+import { getOriginProductMeta } from "@posthog/ui/features/sidebar/components/items/TaskIcon";
 import { InlineEditInput } from "@posthog/ui/features/sidebar/components/items/TaskItem";
 import {
   PinnedBadge,
@@ -121,9 +122,15 @@ function CanvasBadgeStack({
   item: ChannelItemModel;
   pinned?: boolean;
 }) {
+  const source = getOriginProductMeta(item.source ?? undefined);
   return (
     <AvatarGroup stacked reverse size="xs" className="shrink-0">
       {pinned ? <PinnedBadge /> : null}
+      {source ? (
+        <RowBadge label={`${source.label} canvas`}>
+          <source.Icon size={9} />
+        </RowBadge>
+      ) : null}
       <RowBadge label="Canvas">
         {/* Violet is the canvas colour everywhere else it appears — the
             artifacts list, the thread panel, the pinned menu — so the badge says

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelSidebar.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelSidebar.test.tsx
@@ -260,13 +260,15 @@ describe("ChannelSidebar", () => {
     ).not.toBeInTheDocument();
 
     // A canvas has no run, so the filters that ask about one are gone rather
-    // than left to empty the tab.
+    // than left to empty the tab. Canvas provenance remains filterable.
     await user.click(screen.getByRole("button", { name: "Filter" }));
     expect(
       await screen.findByRole("menuitem", { name: /Pinned/ }),
     ).toBeInTheDocument();
     expect(screen.queryByRole("menuitem", { name: /Status/ })).toBeNull();
-    expect(screen.queryByRole("menuitem", { name: /Source/ })).toBeNull();
+    expect(
+      screen.getByRole("menuitem", { name: /Source/ }),
+    ).toBeInTheDocument();
   });
 });
 

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelSidebar.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelSidebar.tsx
@@ -322,8 +322,8 @@ export function ChannelSidebar({ channelId }: { channelId: string }) {
   // in the tab rather than from what the current filters left behind — picking
   // one source must not be what removes the others from the menu.
   const sources = useMemo(() => channelItemSources(tabItems), [tabItems]);
-  // A canvas has no run, so the three run filters can only ever empty the
-  // canvases tab. Same treatment as createdBy above: neutralised as well as
+  // A canvas has no run, so the run filters can only ever empty the canvases
+  // tab. Same treatment as createdBy above: neutralised as well as
   // hidden, or a choice made on the sessions tab would empty this one.
   //
   // A source the tab has none of goes the same way, and for the same reason: it
@@ -346,7 +346,6 @@ export function ChannelSidebar({ channelId }: { channelId: string }) {
           ...scoped,
           attention: "any",
           environment: "any",
-          source: ANY_SOURCE,
         }
       : scoped;
   }, [isPersonalChannel, rawFilters, sources, tab]);


### PR DESCRIPTION
## Problem

People browsing canvases in a space cannot distinguish Signals output from canvases created there.

**Why:** Report-generated canvases should remain ordinary canvases while retaining enough identity for discovery.

## Changes

- The Canvases tab can filter by Signals or canvases created in the space.
- Signals canvases show a source badge and identify Signals in their preview.
- Existing search, sorting, and canvas behavior remain unchanged.

![Signals canvas source filter](https://raw.githubusercontent.com/PostHog/pr-assets/8b022c0e7a1a8be30430ace42337db31664cfdb1/2026/08/1b847a65-39f7-49ee-83d7-246a4e870215.png)


### Stack order

This PR is part of the canvas provenance stack:

1. [#85855](https://github.com/PostHog/posthog/pull/85855) stores durable provenance.
2. [#85890](https://github.com/PostHog/posthog/pull/85890) renders and filters that provenance.
3. [#85896](https://github.com/PostHog/posthog/pull/85896) adds summary search and previews.
4. [#85899](https://github.com/PostHog/posthog/pull/85899) adds standalone generation and canvas actions.

Land this stack before the Signals identity adoption layers. Canvas prompt behavior and deduplication belong here.

## How did you test this code?

Added coverage for Signals filtering, API normalization, the source badge, and the preview state. The Desktop core and UI suites, typecheck, and lint passed.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation changes. This layer consumes the provenance documented by the parent PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used the PostHog Desktop, stacked-PR, and PR-description skills. The backend contract moved into the parent PR to preserve independent deployment order.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*