### PR TITLE
feat(desktop): search canvas report summaries

### DIFF
--- a/products/desktop/packages/core/src/canvas/channelItems.test.ts
+++ b/products/desktop/packages/core/src/canvas/channelItems.test.ts
@@ -220,6 +220,26 @@ describe("buildChannelItems", () => {
     ).toEqual(["signals"]);
   });
 
+  it("finds a canvas by its description", () => {
+    const items = build({
+      dashboards: [
+        canvas({
+          id: "activation",
+          name: "Onboarding performance",
+          description: "Activation fell after the onboarding change.",
+        }),
+      ],
+    });
+
+    expect(
+      filterChannelItems(items, {
+        query: "activation fell",
+        filters: DEFAULT_CHANNEL_ITEM_FILTERS,
+        me: { uuid: ME.uuid },
+      }).map((item) => item.id),
+    ).toEqual(["activation"]);
+  });
+
   it("marks the sessions asking for input and the ones you haven't read", () => {
     const items = build({
       feedTasks: [

--- a/products/desktop/packages/core/src/canvas/channelItems.ts
+++ b/products/desktop/packages/core/src/canvas/channelItems.ts
@@ -20,6 +20,8 @@ export interface ChannelItemModel {
   kind: "task" | "canvas";
   id: string;
   title: string;
+  /** Searchable supporting text. Report canvases carry the report summary here. */
+  description?: string;
   /** Activity time for the activity-first sort: a session's `last_activity_at`, or a canvas's `updatedAt`. */
   ts: number;
   /** When it was first made, for the created-first sort. */
@@ -135,6 +137,7 @@ export function buildChannelItems({
     kind: "canvas",
     id: d.id,
     title: d.name,
+    description: d.description,
     ts: d.updatedAt,
     createdAt: d.createdAt,
     pinned: d.pinnedAt != null,
@@ -160,6 +163,7 @@ export function buildChannelItems({
             kind: "task" as const,
             id: task.id,
             title: task.title || "Untitled task",
+            description: task.description ?? "",
             ts: taskActivityTimestamp(task, "updated") || 0,
             createdAt: Date.parse(task.created_at) || 0,
             pinned: pinnedTaskIds.has(task.id),
@@ -266,7 +270,8 @@ export function filterChannelItems(
   return items.filter((item) => {
     if (
       normalizedQuery &&
-      !item.title.toLowerCase().includes(normalizedQuery)
+      !item.title.toLowerCase().includes(normalizedQuery) &&
+      !item.description?.toLowerCase().includes(normalizedQuery)
     ) {
       return false;
     }

--- a/products/desktop/packages/ui/src/features/canvas/AGENTS.md
+++ b/products/desktop/packages/ui/src/features/canvas/AGENTS.md
@@ -133,6 +133,10 @@ changing breadcrumbs, canvas naming, or the canvas generation harness. The root
   this window has the session, otherwise the closing prose a cloud run persists
   to `latest_run.output.final_message`.
   Neither costs a request.
+- **Canvas search includes descriptions.** Report generation stores its summary
+  on the ordinary canvas description, so Signals canvases are discoverable by
+  their subject without a separate report lookup. The hover card shows the
+  summary's first sentence; the canvas remains the place for the full report.
 - **The open session's header wears the same marks under bluebird.** `TaskHeaderMark` / `TaskHeaderActions` (task-detail) draw `taskDot` and `taskBadges` around the title, from `useTaskStatusInput` — the row hook's task-shaped half, which `useChannelTaskStatus` now delegates to.
   Off the flag the header keeps its workspace-mode glyph, and the PR lookup is skipped with it.
   So the cloud glyph goes: it said where the run lives and nothing about whether the run wants anything, and in this vocabulary cloud is silent — running there is the default, so only the local exception earns a badge.

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemHoverCard.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemHoverCard.test.tsx
@@ -54,7 +54,7 @@ function item(title: string, overrides: Partial<ChannelItemModel> = {}) {
 
 function menuFor(model: ChannelItemModel): TaskRowMenuProps {
   return {
-    kind: "task",
+    kind: model.kind,
     id: model.id,
     title: model.title,
     isPinned: false,
@@ -128,6 +128,27 @@ describe("ChannelItemHoverCard", () => {
 
     expect(screen.getByText("Needs your input")).not.toBeNull();
     expect(screen.queryByText("Ready")).toBeNull();
+  });
+
+  it("shows a canvas description as a compact summary", async () => {
+    renderRows([
+      item("Activation report", {
+        kind: "canvas",
+        key: "canvas:activation",
+        description:
+          "Activation fell after the onboarding change. The remaining detail belongs inside the canvas.",
+        source: "signal_report",
+      }),
+    ]);
+
+    await openCardOn("Activation report");
+
+    expect(
+      screen.getByText("Activation fell after the onboarding change."),
+    ).not.toBeNull();
+    expect(
+      screen.queryByText("The remaining detail belongs inside the canvas."),
+    ).toBeNull();
   });
 
   it("names what the row's badges mean", async () => {

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemPreview.stories.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemPreview.stories.tsx
@@ -177,6 +177,8 @@ export const SignalsCanvas: Story = {
       kind: "canvas",
       id: "activation-drop",
       title: "Activation fell after the onboarding change",
+      description:
+        "Activation fell after the onboarding change. The largest decline appears in the final setup step.",
       source: "signal_report",
       sourceResourceId: "report-1",
       rawStatus: null,

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemPreview.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemPreview.tsx
@@ -1,5 +1,6 @@
 import { ChatCircleIcon } from "@phosphor-icons/react";
 import type { ChannelItemModel } from "@posthog/core/canvas/channelItems";
+import { deriveHeadline } from "@posthog/core/inbox/reportPresentation";
 import {
   Avatar,
   AvatarFallback,
@@ -241,6 +242,8 @@ export function ChannelItemPreview({
   const message = useLatestTurnMessage(item.task);
   const dot = status ? taskDot(status) : null;
   const source = getOriginProductMeta(item.source ?? undefined);
+  const canvasSummary =
+    item.kind === "canvas" ? deriveHeadline(item.description) : null;
 
   return (
     <ItemGroup className="gap-0!">
@@ -259,6 +262,11 @@ export function ChannelItemPreview({
             {source ? ` from ${source.label}` : ""} · updated{" "}
             {formatRelativeTimeShort(item.ts)}
           </ItemDescription>
+          {canvasSummary ? (
+            <p className="line-clamp-3 break-words text-muted-foreground text-xs leading-snug">
+              {canvasSummary}
+            </p>
+          ) : null}
         </ItemContent>
         {/* Who made it rides on the identity row rather than taking a row of
             its own — the card is a glance, and a line of chrome for a name is


### PR DESCRIPTION
## Problem

People can identify a Signals canvas, but they can only find it by title and cannot preview what the report found.

**Why:** The canvas sidebar should support finding relevant report output without recreating Inbox or fetching report records per row.

## Changes

- Canvas search now matches the existing canvas description as well as its title.
- Canvas hover previews show the description's first sentence.
- Report canvases use the summary already copied into their ordinary canvas description.

![Signals canvas preview](https://raw.githubusercontent.com/PostHog/pr-assets/f0ce2293454623e3f1b9cd7185ba1fc02be948e2/2026/08/b34fadbf-36ae-4af9-b2ee-9b42fc6f27f7.png)


### Stack order

This PR is part of the canvas provenance stack:

1. [#85855](https://github.com/PostHog/posthog/pull/85855) stores durable provenance.
2. [#85890](https://github.com/PostHog/posthog/pull/85890) renders and filters that provenance.
3. [#85896](https://github.com/PostHog/posthog/pull/85896) adds summary search and previews.
4. [#85899](https://github.com/PostHog/posthog/pull/85899) adds standalone generation and canvas actions.

Land this stack before the Signals identity adoption layers. Canvas prompt behavior and deduplication belong here.

## How did you test this code?

Added coverage for searching report summary text and rendering a compact canvas summary. The focused core and UI tests, Desktop typecheck, and lint passed.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Documented how canvas search and previews use the existing description field.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used the PostHog Desktop, stacked-PR, and PR-description skills. This layer reuses canvas descriptions instead of coupling Spaces to Inbox report queries.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*