### PR TITLE
feat(cdp): add google data manager destination

### DIFF
--- a/nodejs/src/cdp/templates/_destinations/google_data_manager/google-data-manager.template.test.ts
+++ b/nodejs/src/cdp/templates/_destinations/google_data_manager/google-data-manager.template.test.ts
@@ -30,7 +30,7 @@ describe('Google Data Manager template', () => {
         expect(response.finished).toEqual(false)
         expect(response.invocation.queueParameters).toMatchInlineSnapshot(`
             {
-              "body": "{\"destinations\":[{\"operatingAccount\":{\"accountType\":\"GOOGLE_ADS\",\"accountId\":\"1231231234\"},\"productDestinationId\":\"123456789\",\"loginAccount\":{\"accountType\":\"GOOGLE_ADS\",\"accountId\":\"5675675678\"}}],\"events\":[{\"eventTimestamp\":\"2025-01-01T00:00:00Z\",\"eventSource\":\"WEB\",\"adIdentifiers\":{\"gclid\":\"google-id\",\"gbraid\":\"gbraid-id\"},\"userData\":{\"userIdentifiers\":[{\"email_address\":\"3d4eee8538a4bbbe2ef7912f90ee494c1280f74dd7fd81232e58deb9cb9997e3\"}]},\"conversionValue\":100,\"currency\":\"USD\",\"transactionId\":\"order-123\",\"consent\":{\"adUserData\":\"CONSENT_GRANTED\"}}],\"encoding\":\"HEX\"}",
+              "body": "{\"destinations\":[{\"operatingAccount\":{\"accountType\":\"GOOGLE_ADS\",\"accountId\":\"1231231234\"},\"productDestinationId\":\"123456789\",\"loginAccount\":{\"accountType\":\"GOOGLE_ADS\",\"accountId\":\"5675675678\"}}],\"events\":[{\"eventTimestamp\":\"2025-01-01T00:00:00Z\",\"eventSource\":\"WEB\",\"adIdentifiers\":{\"gclid\":\"google-id\",\"gbraid\":\"gbraid-id\"},\"userData\":{\"userIdentifiers\":[{\"emailAddress\":\"3d4eee8538a4bbbe2ef7912f90ee494c1280f74dd7fd81232e58deb9cb9997e3\"}]},\"conversionValue\":100,\"currency\":\"USD\",\"transactionId\":\"order-123\",\"consent\":{\"adUserData\":\"CONSENT_GRANTED\"}}],\"encoding\":\"HEX\"}",
               "headers": {
                 "Authorization": "Bearer access-token",
                 "Content-Type": "application/json",

--- a/nodejs/src/cdp/templates/_destinations/google_data_manager/google-data-manager.template.test.ts
+++ b/nodejs/src/cdp/templates/_destinations/google_data_manager/google-data-manager.template.test.ts
@@ -1,0 +1,61 @@
+import { TemplateTester, createAdDestinationPayload } from '../../test/test-helpers'
+import { template } from './google-data-manager.template'
+
+describe('Google Data Manager template', () => {
+    const tester = new TemplateTester(template)
+
+    beforeEach(async () => {
+        await tester.beforeEach()
+    })
+
+    it('sends a Google Ads conversion event', async () => {
+        const response = await tester.invokeMapping(
+            'Conversion',
+            {
+                oauth: { access_token: 'access-token' },
+                customerId: '1231231234/5675675678',
+                conversionActionId: '123456789',
+            },
+            createAdDestinationPayload(),
+            {
+                gbraid: 'gbraid-id',
+                conversionValue: '100',
+                currency: 'USD',
+                transactionId: 'order-123',
+                adUserDataConsent: 'CONSENT_GRANTED',
+            }
+        )
+
+        expect(response.error).toBeUndefined()
+        expect(response.finished).toEqual(false)
+        expect(response.invocation.queueParameters).toMatchInlineSnapshot(`
+            {
+              "body": "{\"destinations\":[{\"operatingAccount\":{\"accountType\":\"GOOGLE_ADS\",\"accountId\":\"1231231234\"},\"productDestinationId\":\"123456789\",\"loginAccount\":{\"accountType\":\"GOOGLE_ADS\",\"accountId\":\"5675675678\"}}],\"events\":[{\"eventTimestamp\":\"2025-01-01T00:00:00Z\",\"eventSource\":\"WEB\",\"adIdentifiers\":{\"gclid\":\"google-id\",\"gbraid\":\"gbraid-id\"},\"userData\":{\"userIdentifiers\":[{\"email_address\":\"3d4eee8538a4bbbe2ef7912f90ee494c1280f74dd7fd81232e58deb9cb9997e3\"}]},\"conversionValue\":100,\"currency\":\"USD\",\"transactionId\":\"order-123\",\"consent\":{\"adUserData\":\"CONSENT_GRANTED\"}}],\"encoding\":\"HEX\"}",
+              "headers": {
+                "Authorization": "Bearer access-token",
+                "Content-Type": "application/json",
+              },
+              "method": "POST",
+              "type": "fetch",
+              "url": "https://datamanager.googleapis.com/v1/events:ingest",
+            }
+        `)
+    })
+
+    it('skips events without a click ID or user identifier', async () => {
+        const response = await tester.invokeMapping(
+            'Conversion',
+            {
+                oauth: { access_token: 'access-token' },
+                customerId: '1231231234/5675675678',
+                conversionActionId: '123456789',
+            },
+            createAdDestinationPayload({ person: { properties: { email: null, gclid: null } } })
+        )
+
+        expect(response.finished).toEqual(true)
+        expect(response.logs.filter((log) => log.level === 'info').map((log) => log.message)).toEqual([
+            'No click ID or user identifiers. Skipping...',
+        ])
+    })
+})

--- a/nodejs/src/cdp/templates/_destinations/google_data_manager/google-data-manager.template.ts
+++ b/nodejs/src/cdp/templates/_destinations/google_data_manager/google-data-manager.template.ts
@@ -1,0 +1,264 @@
+import { HogFunctionInputSchemaType, HogFunctionTemplate } from '~/cdp/types'
+
+const buildInputs = (): HogFunctionInputSchemaType[] => [
+    {
+        key: 'conversionActionId',
+        type: 'integration_field',
+        integration_key: 'oauth',
+        integration_field: 'google_ads_conversion_action',
+        requires_field: 'customerId',
+        label: 'Conversion action',
+        description: 'The Google Ads conversion action that receives this event.',
+        secret: false,
+        required: true,
+    },
+    {
+        key: 'gclid',
+        type: 'string',
+        label: 'Google Click ID (gclid)',
+        description: 'The Google click ID associated with this conversion.',
+        default: '{person.properties.gclid ?? person.properties.$initial_gclid}',
+        secret: false,
+        required: false,
+    },
+    {
+        key: 'gbraid',
+        type: 'string',
+        label: 'Google braid ID (gbraid)',
+        description: 'The Google app-click identifier associated with this conversion.',
+        default: '{person.properties.gbraid ?? person.properties.$initial_gbraid}',
+        secret: false,
+        required: false,
+    },
+    {
+        key: 'wbraid',
+        type: 'string',
+        label: 'Google braid ID (wbraid)',
+        description: 'The Google web-click identifier associated with this conversion.',
+        default: '{person.properties.wbraid ?? person.properties.$initial_wbraid}',
+        secret: false,
+        required: false,
+    },
+    {
+        key: 'eventTimestamp',
+        type: 'string',
+        label: 'Event timestamp',
+        description: 'The time the conversion occurred in RFC 3339 format.',
+        default: '{event.timestamp}',
+        secret: false,
+        required: true,
+    },
+    {
+        key: 'eventSource',
+        type: 'choice',
+        label: 'Event source',
+        choices: [
+            { label: 'Web', value: 'WEB' },
+            { label: 'App', value: 'APP' },
+            { label: 'In store', value: 'IN_STORE' },
+            { label: 'Phone', value: 'PHONE' },
+            { label: 'Message', value: 'MESSAGE' },
+            { label: 'Other', value: 'OTHER' },
+        ],
+        default: 'WEB',
+        secret: false,
+        required: true,
+    },
+    {
+        key: 'conversionValue',
+        type: 'string',
+        label: 'Conversion value',
+        description: 'The value of this conversion.',
+        default: '',
+        secret: false,
+        required: false,
+    },
+    {
+        key: 'currency',
+        type: 'string',
+        label: 'Currency',
+        description: 'The ISO 4217 currency code for the conversion value.',
+        default: '',
+        secret: false,
+        required: false,
+    },
+    {
+        key: 'transactionId',
+        type: 'string',
+        label: 'Transaction ID',
+        description: 'A unique conversion identifier used to deduplicate events.',
+        default: '',
+        secret: false,
+        required: false,
+    },
+    {
+        key: 'email',
+        type: 'string',
+        label: 'Email address',
+        description: 'Sent SHA-256 hashed. Normalize by lowercasing and trimming before sending.',
+        default: '{person.properties.email}',
+        secret: false,
+        required: false,
+    },
+    {
+        key: 'phone',
+        type: 'string',
+        label: 'Phone number',
+        description: 'Sent SHA-256 hashed. Provide an E.164 phone number, for example +14255551234.',
+        default: '',
+        secret: false,
+        required: false,
+    },
+    {
+        key: 'adUserDataConsent',
+        type: 'choice',
+        label: 'Ad user data consent',
+        choices: [
+            { label: 'Unspecified', value: '' },
+            { label: 'Granted', value: 'CONSENT_GRANTED' },
+            { label: 'Denied', value: 'CONSENT_DENIED' },
+        ],
+        default: '',
+        secret: false,
+        required: false,
+    },
+    {
+        key: 'adPersonalizationConsent',
+        type: 'choice',
+        label: 'Ad personalization consent',
+        choices: [
+            { label: 'Unspecified', value: '' },
+            { label: 'Granted', value: 'CONSENT_GRANTED' },
+            { label: 'Denied', value: 'CONSENT_DENIED' },
+        ],
+        default: '',
+        secret: false,
+        required: false,
+    },
+]
+
+export const template: HogFunctionTemplate = {
+    free: false,
+    status: 'alpha',
+    type: 'destination',
+    id: 'template-google-data-manager',
+    name: 'Google Ads Data Manager',
+    description: 'Send server-side conversion events to Google Ads using the Data Manager API',
+    icon_url: '/static/services/google-ads.png',
+    category: ['Advertisement'],
+    code_language: 'hog',
+    code: `
+let userIdentifiers := []
+if (not empty(inputs.email)) {
+    userIdentifiers := arrayPushBack(userIdentifiers, {'email_address': sha256Hex(lower(trim(inputs.email)))})
+}
+if (not empty(inputs.phone)) {
+    userIdentifiers := arrayPushBack(userIdentifiers, {'phone_number': sha256Hex(trim(inputs.phone))})
+}
+
+if (empty(inputs.gclid) and empty(inputs.gbraid) and empty(inputs.wbraid) and empty(userIdentifiers)) {
+    print('No click ID or user identifiers. Skipping...')
+    return
+}
+
+let event := {
+    'eventTimestamp': inputs.eventTimestamp,
+    'eventSource': inputs.eventSource
+}
+let adIdentifiers := {}
+if (not empty(inputs.gclid)) {
+    adIdentifiers.gclid := inputs.gclid
+}
+if (not empty(inputs.gbraid)) {
+    adIdentifiers.gbraid := inputs.gbraid
+}
+if (not empty(inputs.wbraid)) {
+    adIdentifiers.wbraid := inputs.wbraid
+}
+if (not empty(adIdentifiers)) {
+    event.adIdentifiers := adIdentifiers
+}
+if (not empty(userIdentifiers)) {
+    event.userData := {'userIdentifiers': userIdentifiers}
+}
+if (not empty(inputs.conversionValue)) {
+    event.conversionValue := toFloat(inputs.conversionValue)
+}
+if (not empty(inputs.currency)) {
+    event.currency := inputs.currency
+}
+if (not empty(inputs.transactionId)) {
+    event.transactionId := inputs.transactionId
+}
+
+let consent := {}
+if (not empty(inputs.adUserDataConsent)) {
+    consent.adUserData := inputs.adUserDataConsent
+}
+if (not empty(inputs.adPersonalizationConsent)) {
+    consent.adPersonalization := inputs.adPersonalizationConsent
+}
+if (not empty(consent)) {
+    event.consent := consent
+}
+
+let accountIds := splitByString('/', inputs.customerId)
+let destination := {
+    'operatingAccount': {'accountType': 'GOOGLE_ADS', 'accountId': accountIds[1]},
+    'productDestinationId': inputs.conversionActionId
+}
+if (not empty(accountIds[2])) {
+    destination.loginAccount := {'accountType': 'GOOGLE_ADS', 'accountId': accountIds[2]}
+}
+
+let res := fetch('https://datamanager.googleapis.com/v1/events:ingest', {
+    'method': 'POST',
+    'headers': {
+        'Authorization': f'Bearer {inputs.oauth.access_token}',
+        'Content-Type': 'application/json'
+    },
+    'body': {
+        'destinations': [destination],
+        'events': [event],
+        'encoding': 'HEX'
+    }
+})
+
+if (res.status >= 400) {
+    throw Error(f'Error from datamanager.googleapis.com (status {res.status}): {res.body}')
+}
+if (not empty(res.body.requestId)) {
+    print(f'Data Manager request accepted: {res.body.requestId}')
+}
+`,
+    inputs_schema: [
+        {
+            key: 'oauth',
+            type: 'integration',
+            integration: 'google-ads',
+            label: 'Google Ads account',
+            requiredScopes:
+                'https://www.googleapis.com/auth/adwords https://www.googleapis.com/auth/datamanager https://www.googleapis.com/auth/userinfo.email',
+            secret: false,
+            required: true,
+        },
+        {
+            key: 'customerId',
+            type: 'integration_field',
+            integration_key: 'oauth',
+            integration_field: 'google_ads_customer_id',
+            label: 'Customer ID',
+            description: 'The Google Ads account and optional manager account that receive this conversion.',
+            secret: false,
+            required: true,
+        },
+    ],
+    mapping_templates: [
+        {
+            name: 'Conversion',
+            include_by_default: true,
+            filters: { events: [] },
+            inputs_schema: buildInputs(),
+        },
+    ],
+}

--- a/nodejs/src/cdp/templates/_destinations/google_data_manager/google-data-manager.template.ts
+++ b/nodejs/src/cdp/templates/_destinations/google_data_manager/google-data-manager.template.ts
@@ -150,10 +150,10 @@ export const template: HogFunctionTemplate = {
     code: `
 let userIdentifiers := []
 if (not empty(inputs.email)) {
-    userIdentifiers := arrayPushBack(userIdentifiers, {'email_address': sha256Hex(lower(trim(inputs.email)))})
+    userIdentifiers := arrayPushBack(userIdentifiers, {'emailAddress': sha256Hex(lower(trim(inputs.email)))})
 }
 if (not empty(inputs.phone)) {
-    userIdentifiers := arrayPushBack(userIdentifiers, {'phone_number': sha256Hex(trim(inputs.phone))})
+    userIdentifiers := arrayPushBack(userIdentifiers, {'phoneNumber': sha256Hex(trim(inputs.phone))})
 }
 
 if (empty(inputs.gclid) and empty(inputs.gbraid) and empty(inputs.wbraid) and empty(userIdentifiers)) {

--- a/nodejs/src/cdp/templates/index.ts
+++ b/nodejs/src/cdp/templates/index.ts
@@ -11,6 +11,7 @@ import { template as githubTemplate } from './_destinations/github/github.templa
 import { template as gitlabTemplate } from './_destinations/gitlab/gitlab.template'
 import { template as googleTagManagerTemplate } from './_destinations/google-tag-manager/google-tag-manager.template'
 import { template as googleAdsTemplate } from './_destinations/google_ads/google.template'
+import { template as googleDataManagerTemplate } from './_destinations/google_data_manager/google-data-manager.template'
 import { template as googleSheetsTemplate } from './_destinations/google_sheets/google_sheets.template'
 import { template as hubspotCompanyTemplate } from './_destinations/hubspot/hubspot.template'
 import { template as klimeTemplate } from './_destinations/klime/klime.template'
@@ -71,6 +72,7 @@ export const HOG_FUNCTION_TEMPLATES_DESTINATIONS: HogFunctionTemplate[] = [
     githubTemplate,
     gitlabTemplate,
     googleAdsTemplate,
+    googleDataManagerTemplate,
     metaAdsTemplate,
     linkedinAdsTemplate,
     microsoftAdsTemplate,

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -1047,7 +1047,10 @@ class OauthIntegration:
                 token_url="https://oauth2.googleapis.com/token",
                 client_id=settings.GOOGLE_ADS_APP_CLIENT_ID,
                 client_secret=settings.GOOGLE_ADS_APP_CLIENT_SECRET,
-                scope="https://www.googleapis.com/auth/adwords https://www.googleapis.com/auth/userinfo.email",
+                scope=(
+                    "https://www.googleapis.com/auth/adwords https://www.googleapis.com/auth/datamanager "
+                    "https://www.googleapis.com/auth/userinfo.email"
+                ),
                 id_path="sub",
                 name_path="email",
             )

--- a/posthog/models/test/test_integration_model.py
+++ b/posthog/models/test/test_integration_model.py
@@ -389,7 +389,7 @@ class TestOauthIntegrationModel(BaseTest):
             url = OauthIntegration.authorize_url("google-ads", token="state_token", next="/projects/test")
             assert (
                 url
-                == "https://accounts.google.com/o/oauth2/v2/auth?client_id=google-client-id&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fadwords+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.email&redirect_uri=https%3A%2F%2Flocalhost%3A8010%2Fintegrations%2Fgoogle-ads%2Fcallback&response_type=code&state=next%3D%252Fprojects%252Ftest%26token%3Dstate_token&access_type=offline&prompt=consent"
+                == "https://accounts.google.com/o/oauth2/v2/auth?client_id=google-client-id&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fadwords+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fdatamanager+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.email&redirect_uri=https%3A%2F%2Flocalhost%3A8010%2Fintegrations%2Fgoogle-ads%2Fcallback&response_type=code&state=next%3D%252Fprojects%252Ftest%26token%3Dstate_token&access_type=offline&prompt=consent"
             )
 
     def test_authorize_url_google_calendar(self):


### PR DESCRIPTION
## Problem

People cannot send server-side Google Ads conversions through the Data Manager API.

## Changes

- Adds an alpha destination for Google Ads conversions through the Data Manager API.
- Adds click identifiers, hashed identifiers, consent, value, currency, and transaction ID inputs.
- Requests the Data Manager OAuth scope and prompts existing connections to reconnect.
- Logs the accepted request ID. Google processes the request asynchronously.
- Google OAuth verification for the new sensitive scope remains required before release.

Before:

```mermaid
flowchart LR
    Event[PostHog event] --> Ads[Google Ads API]
    Ads --> Conversion[Google Ads conversion]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class Event phYellow;
    class Ads phRed;
    class Conversion phBlue;
```

After:

```mermaid
flowchart LR
    Event[PostHog event] --> Destination[Data Manager destination]
    Destination --> Api[Data Manager API]
    Api --> Conversion[Google Ads conversion]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class Event phYellow;
    class Destination phBlue;
    class Api phRed;
    class Conversion phBlue;
```

## How did you test this code?

- Added destination tests for conversion payloads and missing identifiers.
- Ran the targeted Jest test.
- Not run: the integration-model test requires the local PostgreSQL stack.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- No existing destination documentation covers this alpha integration.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Created by the PostHog Slack app with the `/writing-pr-descriptions` skill.
- The implementation follows Google's published Data Manager event schema.
- No customer data or private operational details appear in this PR.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C011L071P8U/p1787158699406589?thread_ts=1787158699.406589&cid=C011L071P8U)*