### PR TITLE
feat(customer-analytics): add feature request MCP tools

### DIFF
--- a/posthog/hogql/database/schema/system.py
+++ b/posthog/hogql/database/schema/system.py
@@ -41,6 +41,12 @@ from products.customer_analytics.backend.facade.hogql import (
     account_tagged_items,
     accounts,
     custom_property_definitions,
+    feature_request_account_links,
+    feature_request_evidence,
+    feature_request_history,
+    feature_request_product_area_links,
+    feature_request_product_areas,
+    feature_requests,
 )
 from products.warehouse_sources.backend.facade.types import DIRECT_ENGINE_BY_SOURCE_TYPE
 
@@ -2859,6 +2865,18 @@ class SystemTables(TableNode):
         "experiments": TableNode(name="experiments", table=experiments),
         "exports": TableNode(name="exports", table=exports),
         "feature_flags": TableNode(name="feature_flags", table=feature_flags),
+        "feature_request_account_links": TableNode(
+            name="feature_request_account_links", table=feature_request_account_links
+        ),
+        "feature_request_evidence": TableNode(name="feature_request_evidence", table=feature_request_evidence),
+        "feature_request_history": TableNode(name="feature_request_history", table=feature_request_history),
+        "feature_request_product_area_links": TableNode(
+            name="feature_request_product_area_links", table=feature_request_product_area_links
+        ),
+        "feature_request_product_areas": TableNode(
+            name="feature_request_product_areas", table=feature_request_product_areas
+        ),
+        "feature_requests": TableNode(name="feature_requests", table=feature_requests),
         "file_system": TableNode(name="file_system", table=file_system),
         "groups": TableNode(name="groups", table=groups),
         "group_type_mappings": TableNode(name="group_type_mappings", table=group_type_mappings),

--- a/posthog/hogql/database/schema/test/test_system_tables.py
+++ b/posthog/hogql/database/schema/test/test_system_tables.py
@@ -65,6 +65,14 @@ if TYPE_CHECKING:
     from products.customer_analytics.backend.models.account import Account
     from products.customer_analytics.backend.models.custom_property_definition import CustomPropertyDefinition
     from products.customer_analytics.backend.models.custom_property_value import CustomPropertyValue
+    from products.customer_analytics.backend.models.feature_request import (
+        FeatureRequest,
+        FeatureRequestAccountLink,
+        FeatureRequestEvidence,
+        FeatureRequestHistory,
+        FeatureRequestProductArea,
+        FeatureRequestProductAreaLink,
+    )
     from products.customer_analytics.backend.models.relationship import (
         AccountRelationship,
         AccountRelationshipDefinition,
@@ -83,6 +91,12 @@ else:
     Account = apps.get_model("customer_analytics", "Account")
     CustomPropertyDefinition = apps.get_model("customer_analytics", "CustomPropertyDefinition")
     CustomPropertyValue = apps.get_model("customer_analytics", "CustomPropertyValue")
+    FeatureRequest = apps.get_model("customer_analytics", "FeatureRequest")
+    FeatureRequestAccountLink = apps.get_model("customer_analytics", "FeatureRequestAccountLink")
+    FeatureRequestEvidence = apps.get_model("customer_analytics", "FeatureRequestEvidence")
+    FeatureRequestHistory = apps.get_model("customer_analytics", "FeatureRequestHistory")
+    FeatureRequestProductArea = apps.get_model("customer_analytics", "FeatureRequestProductArea")
+    FeatureRequestProductAreaLink = apps.get_model("customer_analytics", "FeatureRequestProductAreaLink")
     AccountRelationship = apps.get_model("customer_analytics", "AccountRelationship")
     AccountRelationshipDefinition = apps.get_model("customer_analytics", "AccountRelationshipDefinition")
     ErrorTrackingIssue = apps.get_model("error_tracking", "ErrorTrackingIssue")
@@ -250,6 +264,50 @@ def _create_account_relationship(team: Team, label: str) -> "AccountRelationship
 
 def _create_account_relationship_definition(team: Team, label: str) -> "AccountRelationshipDefinition":
     return AccountRelationshipDefinition.objects.unscoped().create(team=team, name=f"rel_def_{label}")
+
+
+def _create_feature_request(team: Team, label: str) -> "FeatureRequest":
+    account = Account.objects.unscoped().create(team=team, name=f"feature_request_account_{label}")
+    feature_request = FeatureRequest.objects.unscoped().create(team=team, title=f"feature_request_{label}")
+    FeatureRequestAccountLink.objects.unscoped().create(team=team, feature_request=feature_request, account=account)
+    return feature_request
+
+
+def _create_feature_request_product_area(team: Team, label: str) -> "FeatureRequestProductArea":
+    return FeatureRequestProductArea.objects.unscoped().create(team=team, name=f"product_area_{label}")
+
+
+def _create_feature_request_account_link(team: Team, label: str) -> "FeatureRequestAccountLink":
+    account = Account.objects.unscoped().create(team=team, name=f"linked_account_{label}")
+    feature_request = FeatureRequest.objects.unscoped().create(team=team, title=f"linked_request_{label}")
+    return FeatureRequestAccountLink.objects.unscoped().create(
+        team=team, feature_request=feature_request, account=account
+    )
+
+
+def _create_feature_request_evidence(team: Team, label: str) -> "FeatureRequestEvidence":
+    account_link = _create_feature_request_account_link(team, label)
+    return FeatureRequestEvidence.objects.unscoped().create(
+        team=team, account_link=account_link, source="conversation", summary=f"evidence_{label}"
+    )
+
+
+def _create_feature_request_product_area_link(team: Team, label: str) -> "FeatureRequestProductAreaLink":
+    feature_request = _create_feature_request(team, label)
+    product_area = _create_feature_request_product_area(team, label)
+    return FeatureRequestProductAreaLink.objects.unscoped().create(
+        team=team, feature_request=feature_request, product_area=product_area
+    )
+
+
+def _create_feature_request_history(team: Team, label: str) -> "FeatureRequestHistory":
+    feature_request = _create_feature_request(team, label)
+    return FeatureRequestHistory.objects.unscoped().create(
+        team=team,
+        feature_request=feature_request,
+        changes=[],
+        changed_at=timezone.now(),
+    )
 
 
 def _create_action(team: Team, label: str) -> Action:
@@ -845,6 +903,12 @@ SYSTEM_TABLE_FACTORIES = [
     ("experiments", _create_experiment),
     ("exports", _create_export),
     ("feature_flags", _create_feature_flag),
+    ("feature_request_account_links", _create_feature_request_account_link),
+    ("feature_request_evidence", _create_feature_request_evidence),
+    ("feature_request_history", _create_feature_request_history),
+    ("feature_request_product_area_links", _create_feature_request_product_area_link),
+    ("feature_request_product_areas", _create_feature_request_product_area),
+    ("feature_requests", _create_feature_request),
     ("file_system", _create_file_system),
     ("groups", _create_group),
     ("group_type_mappings", _create_group_type_mapping),

--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -7116,6 +7116,530 @@
           "row_count": null,
           "type": "system"
       },
+      "system.feature_request_account_links": {
+          "certification": null,
+          "fields": {
+              "id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "id",
+                  "id": null,
+                  "name": "id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "feature_request_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "feature_request_id",
+                  "id": null,
+                  "name": "feature_request_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "account_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "account_id",
+                  "id": null,
+                  "name": "account_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "created_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "created_at",
+                  "id": null,
+                  "name": "created_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "updated_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "updated_at",
+                  "id": null,
+                  "name": "updated_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              }
+          },
+          "id": "system.feature_request_account_links",
+          "name": "system.feature_request_account_links",
+          "row_count": null,
+          "type": "system"
+      },
+      "system.feature_request_evidence": {
+          "certification": null,
+          "fields": {
+              "id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "id",
+                  "id": null,
+                  "name": "id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "account_link_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "account_link_id",
+                  "id": null,
+                  "name": "account_link_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "summary": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "summary",
+                  "id": null,
+                  "name": "summary",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "customer_quote": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "customer_quote",
+                  "id": null,
+                  "name": "customer_quote",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "source": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "source",
+                  "id": null,
+                  "name": "source",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "source_url": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "source_url",
+                  "id": null,
+                  "name": "source_url",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "requested_on": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "requested_on",
+                  "id": null,
+                  "name": "requested_on",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "date"
+              },
+              "created_by_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "created_by_id",
+                  "id": null,
+                  "name": "created_by_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "updated_by_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "updated_by_id",
+                  "id": null,
+                  "name": "updated_by_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "created_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "created_at",
+                  "id": null,
+                  "name": "created_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "updated_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "updated_at",
+                  "id": null,
+                  "name": "updated_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              }
+          },
+          "id": "system.feature_request_evidence",
+          "name": "system.feature_request_evidence",
+          "row_count": null,
+          "type": "system"
+      },
+      "system.feature_request_history": {
+          "certification": null,
+          "fields": {
+              "id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "id",
+                  "id": null,
+                  "name": "id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "feature_request_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "feature_request_id",
+                  "id": null,
+                  "name": "feature_request_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "changes": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "changes",
+                  "id": null,
+                  "name": "changes",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "json"
+              },
+              "is_initial": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "is_initial",
+                  "id": null,
+                  "name": "is_initial",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "source": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "source",
+                  "id": null,
+                  "name": "source",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "actor_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "actor_id",
+                  "id": null,
+                  "name": "actor_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "changed_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "changed_at",
+                  "id": null,
+                  "name": "changed_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              }
+          },
+          "id": "system.feature_request_history",
+          "name": "system.feature_request_history",
+          "row_count": null,
+          "type": "system"
+      },
+      "system.feature_request_product_area_links": {
+          "certification": null,
+          "fields": {
+              "id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "id",
+                  "id": null,
+                  "name": "id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "feature_request_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "feature_request_id",
+                  "id": null,
+                  "name": "feature_request_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "product_area_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "product_area_id",
+                  "id": null,
+                  "name": "product_area_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "created_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "created_at",
+                  "id": null,
+                  "name": "created_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              }
+          },
+          "id": "system.feature_request_product_area_links",
+          "name": "system.feature_request_product_area_links",
+          "row_count": null,
+          "type": "system"
+      },
+      "system.feature_request_product_areas": {
+          "certification": null,
+          "fields": {
+              "id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "id",
+                  "id": null,
+                  "name": "id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "name": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "name",
+                  "id": null,
+                  "name": "name",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "display_order": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "display_order",
+                  "id": null,
+                  "name": "display_order",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "is_active": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "is_active",
+                  "id": null,
+                  "name": "is_active",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "created_by_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "created_by_id",
+                  "id": null,
+                  "name": "created_by_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "updated_by_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "updated_by_id",
+                  "id": null,
+                  "name": "updated_by_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "created_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "created_at",
+                  "id": null,
+                  "name": "created_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "updated_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "updated_at",
+                  "id": null,
+                  "name": "updated_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              }
+          },
+          "id": "system.feature_request_product_areas",
+          "name": "system.feature_request_product_areas",
+          "row_count": null,
+          "type": "system"
+      },
+      "system.feature_requests": {
+          "certification": null,
+          "fields": {
+              "id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "id",
+                  "id": null,
+                  "name": "id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "title": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "title",
+                  "id": null,
+                  "name": "title",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "description": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "description",
+                  "id": null,
+                  "name": "description",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "status": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "status",
+                  "id": null,
+                  "name": "status",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "priority": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "priority",
+                  "id": null,
+                  "name": "priority",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "archived_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "archived_at",
+                  "id": null,
+                  "name": "archived_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "archived_by_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "archived_by_id",
+                  "id": null,
+                  "name": "archived_by_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "version": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "version",
+                  "id": null,
+                  "name": "version",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "created_by_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "created_by_id",
+                  "id": null,
+                  "name": "created_by_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "updated_by_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "updated_by_id",
+                  "id": null,
+                  "name": "updated_by_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "created_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "created_at",
+                  "id": null,
+                  "name": "created_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "updated_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "updated_at",
+                  "id": null,
+                  "name": "updated_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              }
+          },
+          "id": "system.feature_requests",
+          "name": "system.feature_requests",
+          "row_count": null,
+          "type": "system"
+      },
       "system.file_system": {
           "certification": null,
           "fields": {
@@ -17402,6 +17926,530 @@
           },
           "id": "system.feature_flags",
           "name": "system.feature_flags",
+          "row_count": null,
+          "type": "system"
+      },
+      "system.feature_request_account_links": {
+          "certification": null,
+          "fields": {
+              "id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "id",
+                  "id": null,
+                  "name": "id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "feature_request_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "feature_request_id",
+                  "id": null,
+                  "name": "feature_request_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "account_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "account_id",
+                  "id": null,
+                  "name": "account_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "created_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "created_at",
+                  "id": null,
+                  "name": "created_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "updated_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "updated_at",
+                  "id": null,
+                  "name": "updated_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              }
+          },
+          "id": "system.feature_request_account_links",
+          "name": "system.feature_request_account_links",
+          "row_count": null,
+          "type": "system"
+      },
+      "system.feature_request_evidence": {
+          "certification": null,
+          "fields": {
+              "id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "id",
+                  "id": null,
+                  "name": "id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "account_link_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "account_link_id",
+                  "id": null,
+                  "name": "account_link_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "summary": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "summary",
+                  "id": null,
+                  "name": "summary",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "customer_quote": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "customer_quote",
+                  "id": null,
+                  "name": "customer_quote",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "source": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "source",
+                  "id": null,
+                  "name": "source",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "source_url": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "source_url",
+                  "id": null,
+                  "name": "source_url",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "requested_on": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "requested_on",
+                  "id": null,
+                  "name": "requested_on",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "date"
+              },
+              "created_by_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "created_by_id",
+                  "id": null,
+                  "name": "created_by_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "updated_by_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "updated_by_id",
+                  "id": null,
+                  "name": "updated_by_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "created_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "created_at",
+                  "id": null,
+                  "name": "created_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "updated_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "updated_at",
+                  "id": null,
+                  "name": "updated_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              }
+          },
+          "id": "system.feature_request_evidence",
+          "name": "system.feature_request_evidence",
+          "row_count": null,
+          "type": "system"
+      },
+      "system.feature_request_history": {
+          "certification": null,
+          "fields": {
+              "id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "id",
+                  "id": null,
+                  "name": "id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "feature_request_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "feature_request_id",
+                  "id": null,
+                  "name": "feature_request_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "changes": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "changes",
+                  "id": null,
+                  "name": "changes",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "json"
+              },
+              "is_initial": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "is_initial",
+                  "id": null,
+                  "name": "is_initial",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "source": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "source",
+                  "id": null,
+                  "name": "source",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "actor_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "actor_id",
+                  "id": null,
+                  "name": "actor_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "changed_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "changed_at",
+                  "id": null,
+                  "name": "changed_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              }
+          },
+          "id": "system.feature_request_history",
+          "name": "system.feature_request_history",
+          "row_count": null,
+          "type": "system"
+      },
+      "system.feature_request_product_area_links": {
+          "certification": null,
+          "fields": {
+              "id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "id",
+                  "id": null,
+                  "name": "id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "feature_request_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "feature_request_id",
+                  "id": null,
+                  "name": "feature_request_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "product_area_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "product_area_id",
+                  "id": null,
+                  "name": "product_area_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "created_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "created_at",
+                  "id": null,
+                  "name": "created_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              }
+          },
+          "id": "system.feature_request_product_area_links",
+          "name": "system.feature_request_product_area_links",
+          "row_count": null,
+          "type": "system"
+      },
+      "system.feature_request_product_areas": {
+          "certification": null,
+          "fields": {
+              "id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "id",
+                  "id": null,
+                  "name": "id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "name": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "name",
+                  "id": null,
+                  "name": "name",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "display_order": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "display_order",
+                  "id": null,
+                  "name": "display_order",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "is_active": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "is_active",
+                  "id": null,
+                  "name": "is_active",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "created_by_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "created_by_id",
+                  "id": null,
+                  "name": "created_by_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "updated_by_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "updated_by_id",
+                  "id": null,
+                  "name": "updated_by_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "created_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "created_at",
+                  "id": null,
+                  "name": "created_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "updated_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "updated_at",
+                  "id": null,
+                  "name": "updated_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              }
+          },
+          "id": "system.feature_request_product_areas",
+          "name": "system.feature_request_product_areas",
+          "row_count": null,
+          "type": "system"
+      },
+      "system.feature_requests": {
+          "certification": null,
+          "fields": {
+              "id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "id",
+                  "id": null,
+                  "name": "id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "title": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "title",
+                  "id": null,
+                  "name": "title",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "description": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "description",
+                  "id": null,
+                  "name": "description",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "status": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "status",
+                  "id": null,
+                  "name": "status",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "priority": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "priority",
+                  "id": null,
+                  "name": "priority",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "archived_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "archived_at",
+                  "id": null,
+                  "name": "archived_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "archived_by_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "archived_by_id",
+                  "id": null,
+                  "name": "archived_by_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "version": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "version",
+                  "id": null,
+                  "name": "version",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "created_by_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "created_by_id",
+                  "id": null,
+                  "name": "created_by_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "updated_by_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "updated_by_id",
+                  "id": null,
+                  "name": "updated_by_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "created_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "created_at",
+                  "id": null,
+                  "name": "created_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "updated_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "updated_at",
+                  "id": null,
+                  "name": "updated_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              }
+          },
+          "id": "system.feature_requests",
+          "name": "system.feature_requests",
           "row_count": null,
           "type": "system"
       },

--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -7317,15 +7317,15 @@
                   "table": null,
                   "type": "string"
               },
-              "changes": {
+              "changed_fields": {
                   "chain": null,
                   "fields": null,
-                  "hogql_value": "changes",
+                  "hogql_value": "changed_fields",
                   "id": null,
-                  "name": "changes",
+                  "name": "changed_fields",
                   "schema_valid": true,
                   "table": null,
-                  "type": "json"
+                  "type": "array"
               },
               "is_initial": {
                   "chain": null,
@@ -18130,15 +18130,15 @@
                   "table": null,
                   "type": "string"
               },
-              "changes": {
+              "changed_fields": {
                   "chain": null,
                   "fields": null,
-                  "hogql_value": "changes",
+                  "hogql_value": "changed_fields",
                   "id": null,
-                  "name": "changes",
+                  "name": "changed_fields",
                   "schema_valid": true,
                   "table": null,
-                  "type": "json"
+                  "type": "array"
               },
               "is_initial": {
                   "chain": null,

--- a/products/customer_analytics/backend/facade/hogql.py
+++ b/products/customer_analytics/backend/facade/hogql.py
@@ -1,7 +1,7 @@
-"""Customer analytics' federated HogQL system tables (`system.accounts`,
-`system.custom_property_definitions`) and the aggregating tables plus lazy joins that
-power `system.accounts.tags`, `system.accounts.notebooks`, and
-`system.accounts.custom_properties`.
+"""Customer analytics' federated HogQL system tables for accounts, custom
+properties, relationships, and feature requests. This module also owns the aggregating
+tables and lazy joins that power `system.accounts.tags`, `system.accounts.notebooks`,
+and `system.accounts.custom_properties`.
 
 Owned here rather than in core so the coupling between core's HogQL schema and this
 product's Postgres tables is import-visible (tach) and facade-gated (CI): core
@@ -27,6 +27,7 @@ from posthog.hogql.database.lazy_join_tags import (
 from posthog.hogql.database.models import (
     BooleanDatabaseField,
     DANGEROUS_NoTeamIdCheckTable,
+    DateDatabaseField,
     DateTimeDatabaseField,
     ExpressionField,
     FieldOrTable,
@@ -682,6 +683,187 @@ accounts: PostgresTable = PostgresTable(
         "custom_properties": account_custom_properties_lazy_join,
         "custom_properties_history": account_custom_properties_history_lazy_join,
         "relationships": account_relationships_lazy_join,
+    },
+)
+
+
+feature_request_product_areas: PostgresTable = PostgresTable(
+    name="feature_request_product_areas",
+    postgres_table_name="customer_analytics_featurerequestproductarea",
+    access_scope="customer_analytics",
+    description="Product areas used to categorize Customer analytics feature requests, one row per team-defined area.",
+    fields={
+        "id": UUIDDatabaseField(name="id", description="Product area UUID."),
+        "team_id": IntegerDatabaseField(name="team_id"),
+        "name": StringDatabaseField(name="name", description="Team-maintained product area name."),
+        "display_order": IntegerDatabaseField(
+            name="display_order", description="Position in product area selectors. Lower values appear first."
+        ),
+        "_is_active": BooleanDatabaseField(name="is_active", hidden=True),
+        "is_active": ExpressionField(
+            name="is_active",
+            expr=ast.Call(name="toInt", args=[ast.Field(chain=["_is_active"])]),
+            description="1 if editors can select this area for new requests, 0 otherwise.",
+        ),
+        "created_by_id": IntegerDatabaseField(
+            name="created_by_id", nullable=True, description="PostHog user who created the product area."
+        ),
+        "updated_by_id": IntegerDatabaseField(
+            name="updated_by_id", nullable=True, description="PostHog user who last updated the product area."
+        ),
+        "created_at": DateTimeDatabaseField(name="created_at", description="When the product area was created."),
+        "updated_at": DateTimeDatabaseField(name="updated_at", description="When the product area was last updated."),
+    },
+)
+
+
+feature_request_account_links: PostgresTable = PostgresTable(
+    name="feature_request_account_links",
+    postgres_table_name="customer_analytics_featurerequestaccountlink",
+    access_scope="account",
+    access_control_id_field="account_id",
+    predicates=[parse_expr("unlinked_at IS NULL")],
+    description="Active links between Customer analytics feature requests and affected accounts, one row per request and account pair.",
+    fields={
+        "id": UUIDDatabaseField(name="id", description="Feature request account link UUID."),
+        "team_id": IntegerDatabaseField(name="team_id"),
+        "feature_request_id": UUIDDatabaseField(
+            name="feature_request_id",
+            description="Feature request this link belongs to. Join to `system.feature_requests.id`.",
+        ),
+        "account_id": UUIDDatabaseField(
+            name="account_id", description="Affected account. Join to `system.accounts.id`."
+        ),
+        "unlinked_at": DateTimeDatabaseField(name="unlinked_at", nullable=True, hidden=True),
+        "created_at": DateTimeDatabaseField(name="created_at", description="When the account was first linked."),
+        "updated_at": DateTimeDatabaseField(
+            name="updated_at", nullable=True, description="When the account link was last changed."
+        ),
+    },
+)
+
+
+feature_requests: PostgresTable = PostgresTable(
+    name="feature_requests",
+    postgres_table_name="customer_analytics_featurerequest",
+    access_scope="customer_analytics",
+    predicates=[parse_expr("id IN (SELECT feature_request_id FROM system.feature_request_account_links)")],
+    description="Customer analytics feature requests linked to at least one account the caller can access, one row per request.",
+    fields={
+        "id": UUIDDatabaseField(name="id", description="Feature request UUID."),
+        "team_id": IntegerDatabaseField(name="team_id"),
+        "title": StringDatabaseField(name="title", description="Customer-facing request title."),
+        "description": StringDatabaseField(name="description", description="Customer-facing description in Markdown."),
+        "status": StringDatabaseField(
+            name="status",
+            description="Current lifecycle status: 'requested', 'planned', 'completed', 'wont_fix', or 'duplicate'.",
+        ),
+        "priority": StringDatabaseField(
+            name="priority", nullable=True, description="Manual priority: 'high', 'medium', 'low', or NULL."
+        ),
+        "archived_at": DateTimeDatabaseField(
+            name="archived_at", nullable=True, description="When the request was archived. NULL while active."
+        ),
+        "archived_by_id": IntegerDatabaseField(
+            name="archived_by_id", nullable=True, description="PostHog user who archived the request."
+        ),
+        "version": IntegerDatabaseField(
+            name="version", description="Version required for optimistic concurrency on mutations."
+        ),
+        "created_by_id": IntegerDatabaseField(
+            name="created_by_id", nullable=True, description="PostHog user who created the request."
+        ),
+        "updated_by_id": IntegerDatabaseField(
+            name="updated_by_id", nullable=True, description="PostHog user who last updated the request."
+        ),
+        "created_at": DateTimeDatabaseField(name="created_at", description="When the request was created."),
+        "updated_at": DateTimeDatabaseField(name="updated_at", description="When the request was last updated."),
+    },
+)
+
+
+feature_request_evidence: PostgresTable = PostgresTable(
+    name="feature_request_evidence",
+    postgres_table_name="customer_analytics_featurerequestevidence",
+    access_scope="customer_analytics",
+    predicates=[parse_expr("account_link_id IN (SELECT id FROM system.feature_request_account_links)")],
+    description="Evidence recorded for active feature request account links, one row per evidence item.",
+    fields={
+        "id": UUIDDatabaseField(name="id", description="Evidence UUID."),
+        "team_id": IntegerDatabaseField(name="team_id"),
+        "account_link_id": UUIDDatabaseField(
+            name="account_link_id",
+            description="Request and account pair this evidence supports. Join to `system.feature_request_account_links.id`.",
+        ),
+        "summary": StringDatabaseField(name="summary", description="Internal summary of the request evidence."),
+        "customer_quote": StringDatabaseField(
+            name="customer_quote", description="Customer quote kept with this evidence item."
+        ),
+        "source": StringDatabaseField(name="source", description="Free-form name of the evidence source."),
+        "source_url": StringDatabaseField(
+            name="source_url", description="HTTP or HTTPS link to the source, or an empty string."
+        ),
+        "requested_on": DateDatabaseField(
+            name="requested_on", nullable=True, description="Date the account made the request, or NULL when unknown."
+        ),
+        "created_by_id": IntegerDatabaseField(
+            name="created_by_id", nullable=True, description="PostHog user who added the evidence."
+        ),
+        "updated_by_id": IntegerDatabaseField(
+            name="updated_by_id", nullable=True, description="PostHog user who last updated the evidence."
+        ),
+        "created_at": DateTimeDatabaseField(name="created_at", description="When the evidence was added."),
+        "updated_at": DateTimeDatabaseField(name="updated_at", description="When the evidence was last updated."),
+    },
+)
+
+
+feature_request_product_area_links: PostgresTable = PostgresTable(
+    name="feature_request_product_area_links",
+    postgres_table_name="customer_analytics_featurerequestproductarealink",
+    access_scope="customer_analytics",
+    predicates=[parse_expr("feature_request_id IN (SELECT id FROM system.feature_requests)")],
+    description="Links between visible feature requests and product areas, one row per request and area pair.",
+    fields={
+        "id": UUIDDatabaseField(name="id", description="Feature request product area link UUID."),
+        "team_id": IntegerDatabaseField(name="team_id"),
+        "feature_request_id": UUIDDatabaseField(
+            name="feature_request_id", description="Feature request. Join to `system.feature_requests.id`."
+        ),
+        "product_area_id": UUIDDatabaseField(
+            name="product_area_id", description="Product area. Join to `system.feature_request_product_areas.id`."
+        ),
+        "created_at": DateTimeDatabaseField(name="created_at", description="When the product area was linked."),
+    },
+)
+
+
+feature_request_history: PostgresTable = PostgresTable(
+    name="feature_request_history",
+    postgres_table_name="customer_analytics_featurerequesthistory",
+    access_scope="customer_analytics",
+    predicates=[parse_expr("feature_request_id IN (SELECT id FROM system.feature_requests)")],
+    description="Change history for visible Customer analytics feature requests, one row per successful save.",
+    fields={
+        "id": UUIDDatabaseField(name="id", description="Feature request history entry UUID."),
+        "team_id": IntegerDatabaseField(name="team_id"),
+        "feature_request_id": UUIDDatabaseField(
+            name="feature_request_id", description="Feature request that changed. Join to `system.feature_requests.id`."
+        ),
+        "changes": StringJSONDatabaseField(
+            name="changes", description="JSON array of tracked field changes with before and after values."
+        ),
+        "_is_initial": BooleanDatabaseField(name="is_initial", hidden=True),
+        "is_initial": ExpressionField(
+            name="is_initial",
+            expr=ast.Call(name="toInt", args=[ast.Field(chain=["_is_initial"])]),
+            description="1 if this entry records the request's initial values, 0 otherwise.",
+        ),
+        "source": StringDatabaseField(name="source", description="System that recorded the change."),
+        "actor_id": IntegerDatabaseField(
+            name="actor_id", nullable=True, description="PostHog user who changed the request."
+        ),
+        "changed_at": DateTimeDatabaseField(name="changed_at", description="When the request changed."),
     },
 )
 

--- a/products/customer_analytics/backend/facade/hogql.py
+++ b/products/customer_analytics/backend/facade/hogql.py
@@ -850,8 +850,11 @@ feature_request_history: PostgresTable = PostgresTable(
         "feature_request_id": UUIDDatabaseField(
             name="feature_request_id", description="Feature request that changed. Join to `system.feature_requests.id`."
         ),
-        "changes": StringJSONDatabaseField(
-            name="changes", description="JSON array of tracked field changes with before and after values."
+        "_changes": StringJSONDatabaseField(name="changes", hidden=True),
+        "changed_fields": ExpressionField(
+            name="changed_fields",
+            expr=parse_expr("arrayMap(change -> JSONExtractString(change, 'field'), JSONExtractArrayRaw(_changes))"),
+            description="Names of the fields changed in this save. Before and after values are not exposed.",
         ),
         "_is_initial": BooleanDatabaseField(name="is_initial", hidden=True),
         "is_initial": ExpressionField(

--- a/products/customer_analytics/backend/test/test_facade_hogql.py
+++ b/products/customer_analytics/backend/test/test_facade_hogql.py
@@ -1,17 +1,20 @@
-# The facade owns the PostgresTable defs that core exposes as `system.accounts`,
-# `system.custom_property_definitions`, `system.accounts.custom_properties`, and the hidden
-# junction tables behind `system.accounts.tags`/`.notebooks`. Core's own system-table suite
+# The facade owns the PostgresTable defs that core exposes for Customer analytics accounts,
+# custom properties, relationships, and feature requests. Core's own system-table suite
 # is skipped on this product's CI shard by the isolation contract-check, so this guard lives
 # in-product: it fails here if a backing table is renamed or a model column is renamed/dropped
 # without updating facade/hogql.py, catching the drift on the shard that actually runs for
 # model changes.
+from posthog.test.base import NonAtomicBaseTest
+
 from django.test import SimpleTestCase
 
 from parameterized import parameterized
 
 from posthog.hogql.database.models import ExpressionField, LazyJoin, Table
+from posthog.hogql.query import execute_hogql_query
 
-from posthog.models import TaggedItem
+from posthog.models import OrganizationMembership, TaggedItem, User
+from posthog.models.organization import AvailableFeature
 
 from products.customer_analytics.backend.facade.hogql import (
     account_custom_property_values,
@@ -20,9 +23,27 @@ from products.customer_analytics.backend.facade.hogql import (
     account_tagged_items,
     accounts,
     custom_property_definitions,
+    feature_request_account_links,
+    feature_request_evidence,
+    feature_request_history,
+    feature_request_product_area_links,
+    feature_request_product_areas,
+    feature_requests,
 )
-from products.customer_analytics.backend.models import Account, CustomPropertyDefinition, CustomPropertyValue
+from products.customer_analytics.backend.models import (
+    Account,
+    CustomPropertyDefinition,
+    CustomPropertyValue,
+    FeatureRequest,
+    FeatureRequestAccountLink,
+    FeatureRequestEvidence,
+    FeatureRequestHistory,
+    FeatureRequestProductArea,
+    FeatureRequestProductAreaLink,
+)
 from products.notebooks.backend.models import ResourceNotebook
+
+from ee.models.rbac.access_control import AccessControl
 
 
 class TestFacadeHogqlSystemTables(SimpleTestCase):
@@ -34,6 +55,12 @@ class TestFacadeHogqlSystemTables(SimpleTestCase):
             ("account_custom_property_values_history", account_custom_property_values_history, CustomPropertyValue),
             ("account_tagged_items", account_tagged_items, TaggedItem),
             ("account_resource_notebooks", account_resource_notebooks, ResourceNotebook),
+            ("feature_requests", feature_requests, FeatureRequest),
+            ("feature_request_product_areas", feature_request_product_areas, FeatureRequestProductArea),
+            ("feature_request_account_links", feature_request_account_links, FeatureRequestAccountLink),
+            ("feature_request_evidence", feature_request_evidence, FeatureRequestEvidence),
+            ("feature_request_product_area_links", feature_request_product_area_links, FeatureRequestProductAreaLink),
+            ("feature_request_history", feature_request_history, FeatureRequestHistory),
         ]
     )
     def test_federated_table_matches_model(self, _name, table, model):
@@ -51,3 +78,54 @@ class TestFacadeHogqlSystemTables(SimpleTestCase):
             f"system.{table.name} exposes {sorted(missing)}, which no longer exist as columns on "
             f"{model.__name__}. Update the PostgresTable def in facade/hogql.py to match the model."
         )
+
+
+class TestFeatureRequestHogqlAccess(NonAtomicBaseTest):
+    CLASS_DATA_LEVEL_SETUP = False
+
+    def test_account_access_filters_requests_links_and_evidence(self) -> None:
+        self.organization.available_product_features = [
+            {"key": AvailableFeature.ACCESS_CONTROL, "name": AvailableFeature.ACCESS_CONTROL},
+            {"key": AvailableFeature.ROLE_BASED_ACCESS, "name": AvailableFeature.ROLE_BASED_ACCESS},
+        ]
+        self.organization.save()
+        viewer = User.objects.create_and_join(self.organization, "feature-request-hogql-viewer@example.com", "testtest")
+        membership = OrganizationMembership.objects.get(user=viewer, organization=self.organization)
+        visible_account = Account.objects.unscoped().create(team=self.team, name="Visible account")
+        denied_account = Account.objects.unscoped().create(team=self.team, name="Denied account")
+        visible_request = FeatureRequest.objects.unscoped().create(team=self.team, title="Partly visible request")
+        visible_link = FeatureRequestAccountLink.objects.unscoped().create(
+            team=self.team, feature_request=visible_request, account=visible_account
+        )
+        denied_link = FeatureRequestAccountLink.objects.unscoped().create(
+            team=self.team, feature_request=visible_request, account=denied_account
+        )
+        FeatureRequestEvidence.objects.unscoped().create(
+            team=self.team, account_link=visible_link, source="conversation", summary="Visible evidence"
+        )
+        FeatureRequestEvidence.objects.unscoped().create(
+            team=self.team, account_link=denied_link, source="conversation", summary="Denied evidence"
+        )
+        denied_request = FeatureRequest.objects.unscoped().create(team=self.team, title="Denied request")
+        FeatureRequestAccountLink.objects.unscoped().create(
+            team=self.team, feature_request=denied_request, account=denied_account
+        )
+        AccessControl.objects.create(
+            team=self.team,
+            resource="account",
+            resource_id=str(denied_account.id),
+            access_level="none",
+            organization_member=membership,
+        )
+
+        requests = execute_hogql_query("SELECT id FROM system.feature_requests", team=self.team, user=viewer).results
+        links = execute_hogql_query(
+            "SELECT id FROM system.feature_request_account_links", team=self.team, user=viewer
+        ).results
+        evidence = execute_hogql_query(
+            "SELECT summary FROM system.feature_request_evidence", team=self.team, user=viewer
+        ).results
+
+        assert {str(row[0]) for row in requests} == {str(visible_request.id)}
+        assert {str(row[0]) for row in links} == {str(visible_link.id)}
+        assert evidence == [("Visible evidence",)]

--- a/products/customer_analytics/backend/test/test_facade_hogql.py
+++ b/products/customer_analytics/backend/test/test_facade_hogql.py
@@ -7,10 +7,12 @@
 from posthog.test.base import NonAtomicBaseTest
 
 from django.test import SimpleTestCase
+from django.utils import timezone
 
 from parameterized import parameterized
 
 from posthog.hogql.database.models import ExpressionField, LazyJoin, Table
+from posthog.hogql.errors import QueryError
 from posthog.hogql.query import execute_hogql_query
 
 from posthog.models import OrganizationMembership, TaggedItem, User
@@ -106,6 +108,21 @@ class TestFeatureRequestHogqlAccess(NonAtomicBaseTest):
         FeatureRequestEvidence.objects.unscoped().create(
             team=self.team, account_link=denied_link, source="conversation", summary="Denied evidence"
         )
+        FeatureRequestHistory.objects.unscoped().create(
+            team=self.team,
+            feature_request=visible_request,
+            changes=[
+                {
+                    "field": "evidence",
+                    "before": None,
+                    "after": {
+                        "account": {"id": str(denied_account.id), "name": denied_account.name},
+                        "summary": "Denied evidence",
+                    },
+                }
+            ],
+            changed_at=timezone.now(),
+        )
         denied_request = FeatureRequest.objects.unscoped().create(team=self.team, title="Denied request")
         FeatureRequestAccountLink.objects.unscoped().create(
             team=self.team, feature_request=denied_request, account=denied_account
@@ -125,7 +142,13 @@ class TestFeatureRequestHogqlAccess(NonAtomicBaseTest):
         evidence = execute_hogql_query(
             "SELECT summary FROM system.feature_request_evidence", team=self.team, user=viewer
         ).results
+        history = execute_hogql_query(
+            "SELECT changed_fields FROM system.feature_request_history", team=self.team, user=viewer
+        ).results
 
         assert {str(row[0]) for row in requests} == {str(visible_request.id)}
         assert {str(row[0]) for row in links} == {str(visible_link.id)}
         assert evidence == [("Visible evidence",)]
+        assert history == [(["evidence"],)]
+        with self.assertRaises(QueryError):
+            execute_hogql_query("SELECT changes FROM system.feature_request_history", team=self.team, user=viewer)

--- a/products/customer_analytics/mcp/tools.yaml
+++ b/products/customer_analytics/mcp/tools.yaml
@@ -894,55 +894,256 @@ tools:
         enabled: false
     feature-request-product-areas-create:
         operation: feature_request_product_areas_create
-        enabled: false
+        enabled: true
+        scopes:
+            - customer_analytics:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        title: Create feature request product area
+        description: >
+            Create a product area for categorizing Customer analytics feature requests. Manager access to Customer
+            analytics is required. Provide a unique `name` and optional `display_order`. Lower display orders appear
+            first. New areas are active by default.
+        feature_flag: customer-analytics-feature-requests
     feature-request-product-areas-list:
         operation: feature_request_product_areas_list
-        enabled: false
+        enabled: true
+        scopes:
+            - customer_analytics:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        list: true
+        title: List feature request product areas
+        description: >
+            List active product areas used to categorize Customer analytics feature requests. Each area includes its
+            `id`, `name`, `display_order`, and active state. Set `include_inactive` to true when editing an existing
+            request or managing areas. The same data is queryable through `system.feature_request_product_areas`.
+        feature_flag: customer-analytics-feature-requests
     feature-request-product-areas-partial-update:
         operation: feature_request_product_areas_partial_update
-        enabled: false
+        enabled: true
+        scopes:
+            - customer_analytics:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        title: Update feature request product area
+        description: >
+            Update a feature request product area by id. Manager access to Customer analytics is required. Accepts any
+            subset of `name`, `display_order`, and `is_active`. Inactive areas remain on requests that already use them,
+            but editors cannot add them to new requests.
+        feature_flag: customer-analytics-feature-requests
     feature-request-product-areas-update:
         operation: feature_request_product_areas_update
         enabled: false
     feature-requests-add-account-create:
         operation: feature_requests_add_account_create
-        enabled: false
+        enabled: true
+        scopes:
+            - customer_analytics:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        enrich_url: 'feature-requests/{id}'
+        title: Link account to feature request
+        description: >
+            Link another accessible account to a Customer analytics feature request. Pass the request `id`, its current
+            `expected_version`, and the account id. You can also provide the account's first evidence item in the same
+            atomic change. Relinking an account restores its preserved evidence. The response contains the updated
+            request and its next version.
+        feature_flag: customer-analytics-feature-requests
     feature-requests-add-evidence-create:
         operation: feature_requests_add_evidence_create
-        enabled: false
+        enabled: true
+        scopes:
+            - customer_analytics:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        enrich_url: 'feature-requests/{id}'
+        title: Add feature request evidence
+        description: >
+            Add evidence to an active account link on a Customer analytics feature request. Pass the request `id`, its
+            current `expected_version`, the `account_link_id`, a free-form `evidence_source`, and at least one of
+            `summary`, `customer_quote`, or `source_url`. The response contains the updated request and its next version.
+        feature_flag: customer-analytics-feature-requests
     feature-requests-archive-create:
         operation: feature_requests_archive_create
-        enabled: false
+        enabled: true
+        scopes:
+            - customer_analytics:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        enrich_url: 'feature-requests/{id}'
+        title: Archive feature request
+        description: >
+            Archive a Customer analytics feature request without deleting its account links, evidence, product areas,
+            or history. Pass the request `id` and its current `expected_version`. Archived requests cannot be edited
+            until restored.
+        feature_flag: customer-analytics-feature-requests
     feature-requests-create:
         operation: feature_requests_create
-        enabled: false
+        enabled: true
+        scopes:
+            - customer_analytics:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        enrich_url: 'feature-requests/{id}'
+        title: Create feature request
+        description: >
+            Create a Customer analytics feature request linked to one accessible account and one or more active product
+            areas. Provide a client-generated UUID as `idempotency_key`. Retrying with the same key returns the original
+            request. Use `accounts-list` and `feature-request-product-areas-list` to resolve the required IDs.
+        feature_flag: customer-analytics-feature-requests
     feature-requests-history-list:
         operation: feature_requests_history_list
-        enabled: false
+        enabled: true
+        scopes:
+            - customer_analytics:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        list: true
+        title: List feature request history
+        description: >
+            List the complete change history for a Customer analytics feature request, newest first. Entries group the
+            status, priority, account, evidence, and product area changes from one successful save. Account snapshots
+            the caller cannot access are removed or redacted. The same data is queryable through
+            `system.feature_request_history`.
+        feature_flag: customer-analytics-feature-requests
     feature-requests-list:
         operation: feature_requests_list
-        enabled: false
+        enabled: true
+        scopes:
+            - customer_analytics:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        list: true
+        enrich_url: 'feature-requests/{id}'
+        title: List feature requests
+        description: >
+            List Customer analytics feature requests linked to accounts the caller can access. Filter by search text,
+            lifecycle status, priority, product area, account, or archive state. Active requests are returned by default.
+            Each request includes its active visible account links, account-specific evidence, product areas, and version.
+            For bulk reads and aggregations, query `system.feature_requests` and its related system tables.
+        feature_flag: customer-analytics-feature-requests
     feature-requests-partial-update:
         operation: feature_requests_partial_update
-        enabled: false
+        enabled: true
+        scopes:
+            - customer_analytics:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        enrich_url: 'feature-requests/{id}'
+        title: Update feature request
+        description: >
+            Update a Customer analytics feature request by id. Pass its current `expected_version` and any subset of
+            `title`, `description`, `account_ids`, `product_area_ids`, `request_status`, and `request_priority`. Pass null
+            as `request_priority` to remove the priority. Removing an account unlinks it but preserves its evidence for a
+            later relink. The response contains the next version.
+        param_overrides:
+            expected_version:
+                required: true
+        feature_flag: customer-analytics-feature-requests
     feature-requests-remove-evidence-create:
         operation: feature_requests_remove_evidence_create
-        enabled: false
+        enabled: true
+        scopes:
+            - customer_analytics:write
+        annotations:
+            readOnly: false
+            destructive: true
+            idempotent: true
+        enrich_url: 'feature-requests/{id}'
+        title: Delete feature request evidence
+        description: >
+            Permanently delete one evidence item from a Customer analytics feature request. Pass the request `id`, its
+            current `expected_version`, and the `evidence_id`. The request, account link, and other evidence remain. The
+            response contains the updated request and its next version.
+        feature_flag: customer-analytics-feature-requests
     feature-requests-restore-create:
         operation: feature_requests_restore_create
-        enabled: false
+        enabled: true
+        scopes:
+            - customer_analytics:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        enrich_url: 'feature-requests/{id}'
+        title: Restore feature request
+        description: >
+            Restore an archived Customer analytics feature request so editors can change it again. Pass the request `id`
+            and its current `expected_version`. Account links, evidence, product areas, and history remain attached.
+        feature_flag: customer-analytics-feature-requests
     feature-requests-retrieve:
         operation: feature_requests_retrieve
-        enabled: false
+        enabled: true
+        scopes:
+            - customer_analytics:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        enrich_url: 'feature-requests/{id}'
+        title: Get feature request
+        description: >
+            Fetch one Customer analytics feature request by id. The response includes its lifecycle status, priority,
+            archive state, version, active account links visible to the caller, account-specific evidence, and product
+            areas. Use the returned `version` as `expected_version` for the next mutation.
+        feature_flag: customer-analytics-feature-requests
     feature-requests-status-history-list:
         operation: feature_requests_status_history_list
-        enabled: false
+        enabled: true
+        scopes:
+            - customer_analytics:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        list: true
+        title: List feature request status history
+        description: >
+            List status changes for one Customer analytics feature request, newest first. Each entry includes the previous
+            status, resulting status, actor, source, and change time. Query `system.feature_request_history` when status
+            changes need to be combined with other request changes.
+        feature_flag: customer-analytics-feature-requests
     feature-requests-update:
         operation: feature_requests_update
         enabled: false
     feature-requests-update-evidence-create:
         operation: feature_requests_update_evidence_create
-        enabled: false
+        enabled: true
+        scopes:
+            - customer_analytics:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        enrich_url: 'feature-requests/{id}'
+        title: Update feature request evidence
+        description: >
+            Replace the editable fields of one feature request evidence item. Pass the request `id`, its current
+            `expected_version`, the `evidence_id`, a free-form `evidence_source`, and the complete values for `summary`,
+            `customer_quote`, `source_url`, and `requested_on`. The response contains the updated request and its next
+            version.
+        feature_flag: customer-analytics-feature-requests
     usage-metrics-create:
         operation: groups_types_metrics_create
         enabled: true

--- a/products/customer_analytics/mcp/tools.yaml
+++ b/products/customer_analytics/mcp/tools.yaml
@@ -1021,8 +1021,8 @@ tools:
         description: >
             List the complete change history for a Customer analytics feature request, newest first. Entries group the
             status, priority, account, evidence, and product area changes from one successful save. Account snapshots
-            the caller cannot access are removed or redacted. The same data is queryable through
-            `system.feature_request_history`.
+            the caller cannot access are removed or redacted. HogQL `system.feature_request_history` exposes entry
+            metadata and changed field names, but not before and after values.
         feature_flag: customer-analytics-feature-requests
     feature-requests-list:
         operation: feature_requests_list
@@ -1122,8 +1122,8 @@ tools:
         title: List feature request status history
         description: >
             List status changes for one Customer analytics feature request, newest first. Each entry includes the
-            previous status, resulting status, actor, source, and change time. Query `system.feature_request_history`
-            when status changes need to be combined with other request changes.
+            previous status, resulting status, actor, source, and change time. HogQL `system.feature_request_history`
+            exposes when changes occurred and which fields changed, but not status values.
         feature_flag: customer-analytics-feature-requests
     feature-requests-update:
         operation: feature_requests_update

--- a/products/customer_analytics/mcp/tools.yaml
+++ b/products/customer_analytics/mcp/tools.yaml
@@ -950,7 +950,7 @@ tools:
             readOnly: false
             destructive: false
             idempotent: false
-        enrich_url: 'feature-requests/{id}'
+        enrich_url: feature-requests/{id}
         title: Link account to feature request
         description: >
             Link another accessible account to a Customer analytics feature request. Pass the request `id`, its current
@@ -967,12 +967,13 @@ tools:
             readOnly: false
             destructive: false
             idempotent: false
-        enrich_url: 'feature-requests/{id}'
+        enrich_url: feature-requests/{id}
         title: Add feature request evidence
         description: >
             Add evidence to an active account link on a Customer analytics feature request. Pass the request `id`, its
             current `expected_version`, the `account_link_id`, a free-form `evidence_source`, and at least one of
-            `summary`, `customer_quote`, or `source_url`. The response contains the updated request and its next version.
+            `summary`, `customer_quote`, or `source_url`. The response contains the updated request and its next
+            version.
         feature_flag: customer-analytics-feature-requests
     feature-requests-archive-create:
         operation: feature_requests_archive_create
@@ -983,12 +984,12 @@ tools:
             readOnly: false
             destructive: false
             idempotent: true
-        enrich_url: 'feature-requests/{id}'
+        enrich_url: feature-requests/{id}
         title: Archive feature request
         description: >
-            Archive a Customer analytics feature request without deleting its account links, evidence, product areas,
-            or history. Pass the request `id` and its current `expected_version`. Archived requests cannot be edited
-            until restored.
+            Archive a Customer analytics feature request without deleting its account links, evidence, product areas, or
+            history. Pass the request `id` and its current `expected_version`. Archived requests cannot be edited until
+            restored.
         feature_flag: customer-analytics-feature-requests
     feature-requests-create:
         operation: feature_requests_create
@@ -999,7 +1000,7 @@ tools:
             readOnly: false
             destructive: false
             idempotent: true
-        enrich_url: 'feature-requests/{id}'
+        enrich_url: feature-requests/{id}
         title: Create feature request
         description: >
             Create a Customer analytics feature request linked to one accessible account and one or more active product
@@ -1032,14 +1033,14 @@ tools:
             readOnly: true
             destructive: false
             idempotent: true
+        enrich_url: feature-requests/{id}
         list: true
-        enrich_url: 'feature-requests/{id}'
         title: List feature requests
         description: >
             List Customer analytics feature requests linked to accounts the caller can access. Filter by search text,
-            lifecycle status, priority, product area, account, or archive state. Active requests are returned by default.
-            Each request includes its active visible account links, account-specific evidence, product areas, and version.
-            For bulk reads and aggregations, query `system.feature_requests` and its related system tables.
+            lifecycle status, priority, product area, account, or archive state. Active requests are returned by
+            default. Each request includes its active visible account links, account-specific evidence, product areas,
+            and version. For bulk reads and aggregations, query `system.feature_requests` and its related system tables.
         feature_flag: customer-analytics-feature-requests
     feature-requests-partial-update:
         operation: feature_requests_partial_update
@@ -1050,13 +1051,13 @@ tools:
             readOnly: false
             destructive: false
             idempotent: true
-        enrich_url: 'feature-requests/{id}'
+        enrich_url: feature-requests/{id}
         title: Update feature request
         description: >
             Update a Customer analytics feature request by id. Pass its current `expected_version` and any subset of
-            `title`, `description`, `account_ids`, `product_area_ids`, `request_status`, and `request_priority`. Pass null
-            as `request_priority` to remove the priority. Removing an account unlinks it but preserves its evidence for a
-            later relink. The response contains the next version.
+            `title`, `description`, `account_ids`, `product_area_ids`, `request_status`, and `request_priority`. Pass
+            null as `request_priority` to remove the priority. Removing an account unlinks it but preserves its evidence
+            for a later relink. The response contains the next version.
         param_overrides:
             expected_version:
                 required: true
@@ -1070,7 +1071,7 @@ tools:
             readOnly: false
             destructive: true
             idempotent: true
-        enrich_url: 'feature-requests/{id}'
+        enrich_url: feature-requests/{id}
         title: Delete feature request evidence
         description: >
             Permanently delete one evidence item from a Customer analytics feature request. Pass the request `id`, its
@@ -1086,7 +1087,7 @@ tools:
             readOnly: false
             destructive: false
             idempotent: true
-        enrich_url: 'feature-requests/{id}'
+        enrich_url: feature-requests/{id}
         title: Restore feature request
         description: >
             Restore an archived Customer analytics feature request so editors can change it again. Pass the request `id`
@@ -1101,7 +1102,7 @@ tools:
             readOnly: true
             destructive: false
             idempotent: true
-        enrich_url: 'feature-requests/{id}'
+        enrich_url: feature-requests/{id}
         title: Get feature request
         description: >
             Fetch one Customer analytics feature request by id. The response includes its lifecycle status, priority,
@@ -1120,9 +1121,9 @@ tools:
         list: true
         title: List feature request status history
         description: >
-            List status changes for one Customer analytics feature request, newest first. Each entry includes the previous
-            status, resulting status, actor, source, and change time. Query `system.feature_request_history` when status
-            changes need to be combined with other request changes.
+            List status changes for one Customer analytics feature request, newest first. Each entry includes the
+            previous status, resulting status, actor, source, and change time. Query `system.feature_request_history`
+            when status changes need to be combined with other request changes.
         feature_flag: customer-analytics-feature-requests
     feature-requests-update:
         operation: feature_requests_update
@@ -1136,7 +1137,7 @@ tools:
             readOnly: false
             destructive: false
             idempotent: true
-        enrich_url: 'feature-requests/{id}'
+        enrich_url: feature-requests/{id}
         title: Update feature request evidence
         description: >
             Replace the editable fields of one feature request evidence item. Pass the request `id`, its current

--- a/products/posthog_ai/frontend/policy/toolPolicy.test.ts
+++ b/products/posthog_ai/frontend/policy/toolPolicy.test.ts
@@ -66,6 +66,7 @@ describe('toolPolicy', () => {
             // Destructive-annotated names with no verb segment come from the exact-name set.
             'workflows-publish',
             'experiment-ship-variant',
+            'feature-requests-remove-evidence-create',
             'skill-archive',
             'error-tracking-issues-merge-create',
         ])('%s is destructive', (sub) => expect(isPostHogDestructiveSubTool(sub)).toBe(true))

--- a/products/posthog_ai/frontend/policy/toolPolicy.ts
+++ b/products/posthog_ai/frontend/policy/toolPolicy.ts
@@ -47,6 +47,7 @@ const POSTHOG_DESTRUCTIVE_SUB_TOOLS = new Set([
     'experiment-ship-variant',
     'external-data-schemas-resync',
     'external-data-sources-repair-cdc-create',
+    'feature-requests-remove-evidence-create',
     'heatmaps-saved-regenerate',
     'inbox-reports-bulk-set-state',
     'inbox-reports-set-state',

--- a/products/posthog_ai/skills/querying-posthog-data/SKILL.md
+++ b/products/posthog_ai/skills/querying-posthog-data/SKILL.md
@@ -56,7 +56,7 @@ Schema reference for PostHog's core system models, organized by domain:
 - [Batch exports](./references/models-batch-exports.md)
 - [Early Access Features](./references/models-early-access-features.md)
 - [Cohorts & Persons](./references/models-cohorts.md)
-- [Customer analytics accounts, relationships (CSM, account owner) & custom properties (`system.accounts`, `system.account_relationships`)](./references/models-customer-analytics.md)
+- [Customer analytics accounts, relationships, custom properties & feature requests (`system.accounts`, `system.feature_requests`)](./references/models-customer-analytics.md)
 - [Dashboards, Tiles & Insights](./references/models-dashboards-insights.md)
 - [Data Warehouse](./references/models-data-warehouse.md)
 - [Data Modeling Endpoints](./references/models-endpoints.md)

--- a/products/posthog_ai/skills/querying-posthog-data/references/models-customer-analytics.md
+++ b/products/posthog_ai/skills/querying-posthog-data/references/models-customer-analytics.md
@@ -1,10 +1,10 @@
-# Customer analytics accounts
+# Customer analytics accounts and feature requests
 
-Customer analytics tracks **accounts** — the companies/organizations a team does business with — plus who owns them (relationships such as CSM or Account executive) and typed custom attributes.
+Customer analytics tracks **accounts**, their owners and custom properties, and the feature requests linked to those accounts.
 
 **Source of truth for account ownership questions** ("who is the CSM of X?", "which accounts does Y own?"): answer them from these tables, not from warehouse CRM columns (`salesforce.*`, `hubspot.*`, ...). Warehouse copies of ownership fields can lag behind reassignments made in PostHog.
 
-Prefer the typed `posthog:accounts-*`, `posthog:account-relationship-definitions-*`, and `posthog:custom-property-definitions-*` MCP tools for writes; use HogQL for reads and aggregations.
+Prefer the typed `posthog:accounts-*`, `posthog:account-relationship-definitions-*`, `posthog:custom-property-definitions-*`, and `posthog:feature-request*` MCP tools for writes. Use HogQL for reads and aggregations.
 
 ## Account (`system.accounts`)
 
@@ -62,6 +62,127 @@ Column | Type | Nullable | Description
 
 - Active assignments are `ended_at IS NULL`; ended rows are kept as history.
 - The role keys in `system.accounts.properties` (`csm`, `account_executive`, `account_owner`) mirror the active assignments and include the user's email; the relationships table has only `user_id`.
+
+## Feature requests
+
+A feature request records a customer need across one or more accounts. Evidence belongs to a specific request and account pair. Product areas categorize requests, and history records each successful save.
+
+The tables apply account access rules. `system.feature_requests` includes a request when the caller can access at least one active linked account. The account links and evidence tables exclude inaccessible and unlinked accounts.
+
+### `system.feature_requests` columns
+
+Column | Type | Nullable | Description
+`id` | uuid | NOT NULL | Primary key
+`team_id` | integer | NOT NULL | Team this request belongs to
+`title` | varchar(400) | NOT NULL | Customer-facing request title
+`description` | text | NOT NULL | Customer-facing description in Markdown
+`status` | varchar(32) | NOT NULL | `requested`, `planned`, `completed`, `wont_fix`, or `duplicate`
+`priority` | varchar(16) | NULL | `high`, `medium`, `low`, or NULL
+`archived_at` | timestamptz | NULL | When the request was archived. NULL means active
+`archived_by_id` | integer | NULL | User who archived the request
+`version` | integer | NOT NULL | Version used for optimistic concurrency
+`created_by_id` | integer | NULL | User who created the request
+`updated_by_id` | integer | NULL | User who last updated the request
+`created_at` | timestamptz | NOT NULL | When the request was created
+`updated_at` | timestamptz | NOT NULL | When the request was last updated
+
+### `system.feature_request_account_links` columns
+
+One row per active request and account pair visible to the caller.
+
+Column | Type | Nullable | Description
+`id` | uuid | NOT NULL | Primary key and parent key for evidence
+`team_id` | integer | NOT NULL | Team this link belongs to
+`feature_request_id` | uuid | NOT NULL | Join to `system.feature_requests.id`
+`account_id` | uuid | NOT NULL | Join to `system.accounts.id`
+`created_at` | timestamptz | NOT NULL | When the account was first linked
+`updated_at` | timestamptz | NULL | When the link last changed
+
+### `system.feature_request_evidence` columns
+
+Column | Type | Nullable | Description
+`id` | uuid | NOT NULL | Primary key
+`team_id` | integer | NOT NULL | Team this evidence belongs to
+`account_link_id` | uuid | NOT NULL | Join to `system.feature_request_account_links.id`
+`summary` | text | NOT NULL | Internal evidence summary
+`customer_quote` | text | NOT NULL | Customer quote
+`source` | varchar(200) | NOT NULL | Free-form source name
+`source_url` | varchar(2000) | NOT NULL | Source URL or an empty string
+`requested_on` | date | NULL | Date the account made the request
+`created_by_id` | integer | NULL | User who added the evidence
+`updated_by_id` | integer | NULL | User who last updated the evidence
+`created_at` | timestamptz | NOT NULL | When the evidence was added
+`updated_at` | timestamptz | NOT NULL | When the evidence was last updated
+
+### Product area tables
+
+`system.feature_request_product_areas` defines the available areas. `system.feature_request_product_area_links` joins visible requests to those areas.
+
+`system.feature_request_product_areas` column | Type | Nullable | Description
+`id` | uuid | NOT NULL | Primary key
+`team_id` | integer | NOT NULL | Team this area belongs to
+`name` | varchar(200) | NOT NULL | Product area name
+`display_order` | integer | NOT NULL | Selector position. Lower values appear first
+`is_active` | integer | NOT NULL | `1` if editors can select the area, `0` otherwise
+`created_by_id` | integer | NULL | User who created the area
+`updated_by_id` | integer | NULL | User who last updated the area
+`created_at` | timestamptz | NOT NULL | When the area was created
+`updated_at` | timestamptz | NOT NULL | When the area was last updated
+
+`system.feature_request_product_area_links` column | Type | Nullable | Description
+`id` | uuid | NOT NULL | Primary key
+`team_id` | integer | NOT NULL | Team this link belongs to
+`feature_request_id` | uuid | NOT NULL | Join to `system.feature_requests.id`
+`product_area_id` | uuid | NOT NULL | Join to `system.feature_request_product_areas.id`
+`created_at` | timestamptz | NOT NULL | When the area was linked
+
+### `system.feature_request_history` columns
+
+Column | Type | Nullable | Description
+`id` | uuid | NOT NULL | Primary key
+`team_id` | integer | NOT NULL | Team this history entry belongs to
+`feature_request_id` | uuid | NOT NULL | Join to `system.feature_requests.id`
+`changes` | json | NOT NULL | Changed fields with before and after values
+`is_initial` | integer | NOT NULL | `1` for the initial snapshot, `0` otherwise
+`source` | varchar(32) | NOT NULL | System that recorded the change
+`actor_id` | integer | NULL | User who changed the request
+`changed_at` | timestamptz | NOT NULL | When the request changed
+
+### Feature request query patterns
+
+**List active requests and their affected accounts:**
+
+```sql
+SELECT r.id, r.title, r.status, r.priority, a.id AS account_id, a.name AS account_name
+FROM system.feature_requests r
+JOIN system.feature_request_account_links l ON l.feature_request_id = r.id
+JOIN system.accounts a ON a.id = l.account_id
+WHERE r.archived_at IS NULL
+ORDER BY r.updated_at DESC
+```
+
+**Count evidence items by request and account:**
+
+```sql
+SELECT r.title, a.name AS account_name, count(e.id) AS evidence_count
+FROM system.feature_requests r
+JOIN system.feature_request_account_links l ON l.feature_request_id = r.id
+JOIN system.accounts a ON a.id = l.account_id
+LEFT JOIN system.feature_request_evidence e ON e.account_link_id = l.id
+GROUP BY r.id, r.title, a.id, a.name
+ORDER BY evidence_count DESC
+```
+
+**List requests for one product area:**
+
+```sql
+SELECT r.id, r.title, r.status, p.name AS product_area
+FROM system.feature_requests r
+JOIN system.feature_request_product_area_links l ON l.feature_request_id = r.id
+JOIN system.feature_request_product_areas p ON p.id = l.product_area_id
+WHERE p.name ILIKE '%analytics%'
+ORDER BY r.updated_at DESC
+```
 
 ## Custom properties (`system.custom_property_definitions`)
 

--- a/products/posthog_ai/skills/querying-posthog-data/references/models-customer-analytics.md
+++ b/products/posthog_ai/skills/querying-posthog-data/references/models-customer-analytics.md
@@ -142,7 +142,7 @@ Column | Type | Nullable | Description
 `id` | uuid | NOT NULL | Primary key
 `team_id` | integer | NOT NULL | Team this history entry belongs to
 `feature_request_id` | uuid | NOT NULL | Join to `system.feature_requests.id`
-`changes` | json | NOT NULL | Changed fields with before and after values
+`changed_fields` | array(varchar) | NOT NULL | Names of the fields changed in this save. Before and after values are not exposed
 `is_initial` | integer | NOT NULL | `1` for the initial snapshot, `0` otherwise
 `source` | varchar(32) | NOT NULL | System that recorded the change
 `actor_id` | integer | NULL | User who changed the request

--- a/products/tasks/backend/constants.py
+++ b/products/tasks/backend/constants.py
@@ -217,6 +217,7 @@ POSTHOG_EXEC_DESTRUCTIVE_SUB_TOOLS: tuple[str, ...] = (
     "experiment-ship-variant",
     "external-data-schemas-resync",
     "external-data-sources-repair-cdc-create",
+    "feature-requests-remove-evidence-create",
     "heatmaps-saved-regenerate",
     "inbox-reports-bulk-set-state",
     "inbox-reports-set-state",

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -4754,6 +4754,231 @@
             "readOnlyHint": true
         }
     },
+    "feature-request-product-areas-create": {
+        "description": "Create a product area for categorizing Customer analytics feature requests. Manager access to Customer analytics is required. Provide a unique `name` and optional `display_order`. Lower display orders appear first. New areas are active by default.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Create feature request product area",
+        "title": "Create feature request product area",
+        "required_scopes": ["customer_analytics:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "customer-analytics-feature-requests"
+    },
+    "feature-request-product-areas-list": {
+        "description": "List active product areas used to categorize Customer analytics feature requests. Each area includes its `id`, `name`, `display_order`, and active state. Set `include_inactive` to true when editing an existing request or managing areas. The same data is queryable through `system.feature_request_product_areas`.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "List feature request product areas",
+        "title": "List feature request product areas",
+        "required_scopes": ["customer_analytics:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "customer-analytics-feature-requests"
+    },
+    "feature-request-product-areas-partial-update": {
+        "description": "Update a feature request product area by id. Manager access to Customer analytics is required. Accepts any subset of `name`, `display_order`, and `is_active`. Inactive areas remain on requests that already use them, but editors cannot add them to new requests.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Update feature request product area",
+        "title": "Update feature request product area",
+        "required_scopes": ["customer_analytics:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "customer-analytics-feature-requests"
+    },
+    "feature-requests-add-account-create": {
+        "description": "Link another accessible account to a Customer analytics feature request. Pass the request `id`, its current `expected_version`, and the account id. You can also provide the account's first evidence item in the same atomic change. Relinking an account restores its preserved evidence. The response contains the updated request and its next version.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Link account to feature request",
+        "title": "Link account to feature request",
+        "required_scopes": ["customer_analytics:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "customer-analytics-feature-requests"
+    },
+    "feature-requests-add-evidence-create": {
+        "description": "Add evidence to an active account link on a Customer analytics feature request. Pass the request `id`, its current `expected_version`, the `account_link_id`, a free-form `evidence_source`, and at least one of `summary`, `customer_quote`, or `source_url`. The response contains the updated request and its next version.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Add feature request evidence",
+        "title": "Add feature request evidence",
+        "required_scopes": ["customer_analytics:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "customer-analytics-feature-requests"
+    },
+    "feature-requests-archive-create": {
+        "description": "Archive a Customer analytics feature request without deleting its account links, evidence, product areas, or history. Pass the request `id` and its current `expected_version`. Archived requests cannot be edited until restored.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Archive feature request",
+        "title": "Archive feature request",
+        "required_scopes": ["customer_analytics:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "customer-analytics-feature-requests"
+    },
+    "feature-requests-create": {
+        "description": "Create a Customer analytics feature request linked to one accessible account and one or more active product areas. Provide a client-generated UUID as `idempotency_key`. Retrying with the same key returns the original request. Use `accounts-list` and `feature-request-product-areas-list` to resolve the required IDs.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Create feature request",
+        "title": "Create feature request",
+        "required_scopes": ["customer_analytics:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "customer-analytics-feature-requests"
+    },
+    "feature-requests-history-list": {
+        "description": "List the complete change history for a Customer analytics feature request, newest first. Entries group the status, priority, account, evidence, and product area changes from one successful save. Account snapshots the caller cannot access are removed or redacted. The same data is queryable through `system.feature_request_history`.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "List feature request history",
+        "title": "List feature request history",
+        "required_scopes": ["customer_analytics:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "customer-analytics-feature-requests"
+    },
+    "feature-requests-list": {
+        "description": "List Customer analytics feature requests linked to accounts the caller can access. Filter by search text, lifecycle status, priority, product area, account, or archive state. Active requests are returned by default. Each request includes its active visible account links, account-specific evidence, product areas, and version. For bulk reads and aggregations, query `system.feature_requests` and its related system tables.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "List feature requests",
+        "title": "List feature requests",
+        "required_scopes": ["customer_analytics:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "customer-analytics-feature-requests"
+    },
+    "feature-requests-partial-update": {
+        "description": "Update a Customer analytics feature request by id. Pass its current `expected_version` and any subset of `title`, `description`, `account_ids`, `product_area_ids`, `request_status`, and `request_priority`. Pass null as `request_priority` to remove the priority. Removing an account unlinks it but preserves its evidence for a later relink. The response contains the next version.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Update feature request",
+        "title": "Update feature request",
+        "required_scopes": ["customer_analytics:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "customer-analytics-feature-requests"
+    },
+    "feature-requests-remove-evidence-create": {
+        "description": "Permanently delete one evidence item from a Customer analytics feature request. Pass the request `id`, its current `expected_version`, and the `evidence_id`. The request, account link, and other evidence remain. The response contains the updated request and its next version.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Delete feature request evidence",
+        "title": "Delete feature request evidence",
+        "required_scopes": ["customer_analytics:write"],
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "customer-analytics-feature-requests"
+    },
+    "feature-requests-restore-create": {
+        "description": "Restore an archived Customer analytics feature request so editors can change it again. Pass the request `id` and its current `expected_version`. Account links, evidence, product areas, and history remain attached.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Restore feature request",
+        "title": "Restore feature request",
+        "required_scopes": ["customer_analytics:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "customer-analytics-feature-requests"
+    },
+    "feature-requests-retrieve": {
+        "description": "Fetch one Customer analytics feature request by id. The response includes its lifecycle status, priority, archive state, version, active account links visible to the caller, account-specific evidence, and product areas. Use the returned `version` as `expected_version` for the next mutation.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Get feature request",
+        "title": "Get feature request",
+        "required_scopes": ["customer_analytics:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "customer-analytics-feature-requests"
+    },
+    "feature-requests-status-history-list": {
+        "description": "List status changes for one Customer analytics feature request, newest first. Each entry includes the previous status, resulting status, actor, source, and change time. Query `system.feature_request_history` when status changes need to be combined with other request changes.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "List feature request status history",
+        "title": "List feature request status history",
+        "required_scopes": ["customer_analytics:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "customer-analytics-feature-requests"
+    },
+    "feature-requests-update-evidence-create": {
+        "description": "Replace the editable fields of one feature request evidence item. Pass the request `id`, its current `expected_version`, the `evidence_id`, a free-form `evidence_source`, and the complete values for `summary`, `customer_quote`, `source_url`, and `requested_on`. The response contains the updated request and its next version.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Update feature request evidence",
+        "title": "Update feature request evidence",
+        "required_scopes": ["customer_analytics:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "customer-analytics-feature-requests"
+    },
     "field-notes-get": {
         "description": "Get a single field note by id, including the full element context (selector, element chain, inferred selectors, attributes) needed to locate the element in code.",
         "category": "Field notes",

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -4860,7 +4860,7 @@
         "feature_flag": "customer-analytics-feature-requests"
     },
     "feature-requests-history-list": {
-        "description": "List the complete change history for a Customer analytics feature request, newest first. Entries group the status, priority, account, evidence, and product area changes from one successful save. Account snapshots the caller cannot access are removed or redacted. The same data is queryable through `system.feature_request_history`.",
+        "description": "List the complete change history for a Customer analytics feature request, newest first. Entries group the status, priority, account, evidence, and product area changes from one successful save. Account snapshots the caller cannot access are removed or redacted. HogQL `system.feature_request_history` exposes entry metadata and changed field names, but not before and after values.",
         "category": "Customer analytics",
         "feature": "customer_analytics",
         "summary": "List feature request history",
@@ -4950,7 +4950,7 @@
         "feature_flag": "customer-analytics-feature-requests"
     },
     "feature-requests-status-history-list": {
-        "description": "List status changes for one Customer analytics feature request, newest first. Each entry includes the previous status, resulting status, actor, source, and change time. Query `system.feature_request_history` when status changes need to be combined with other request changes.",
+        "description": "List status changes for one Customer analytics feature request, newest first. Each entry includes the previous status, resulting status, actor, source, and change time. HogQL `system.feature_request_history` exposes when changes occurred and which fields changed, but not status values.",
         "category": "Customer analytics",
         "feature": "customer_analytics",
         "summary": "List feature request status history",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -4909,6 +4909,231 @@
             "readOnlyHint": true
         }
     },
+    "feature-request-product-areas-create": {
+        "description": "Create a product area for categorizing Customer analytics feature requests. Manager access to Customer analytics is required. Provide a unique `name` and optional `display_order`. Lower display orders appear first. New areas are active by default.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Create feature request product area",
+        "title": "Create feature request product area",
+        "required_scopes": ["customer_analytics:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "customer-analytics-feature-requests"
+    },
+    "feature-request-product-areas-list": {
+        "description": "List active product areas used to categorize Customer analytics feature requests. Each area includes its `id`, `name`, `display_order`, and active state. Set `include_inactive` to true when editing an existing request or managing areas. The same data is queryable through `system.feature_request_product_areas`.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "List feature request product areas",
+        "title": "List feature request product areas",
+        "required_scopes": ["customer_analytics:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "customer-analytics-feature-requests"
+    },
+    "feature-request-product-areas-partial-update": {
+        "description": "Update a feature request product area by id. Manager access to Customer analytics is required. Accepts any subset of `name`, `display_order`, and `is_active`. Inactive areas remain on requests that already use them, but editors cannot add them to new requests.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Update feature request product area",
+        "title": "Update feature request product area",
+        "required_scopes": ["customer_analytics:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "customer-analytics-feature-requests"
+    },
+    "feature-requests-add-account-create": {
+        "description": "Link another accessible account to a Customer analytics feature request. Pass the request `id`, its current `expected_version`, and the account id. You can also provide the account's first evidence item in the same atomic change. Relinking an account restores its preserved evidence. The response contains the updated request and its next version.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Link account to feature request",
+        "title": "Link account to feature request",
+        "required_scopes": ["customer_analytics:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "customer-analytics-feature-requests"
+    },
+    "feature-requests-add-evidence-create": {
+        "description": "Add evidence to an active account link on a Customer analytics feature request. Pass the request `id`, its current `expected_version`, the `account_link_id`, a free-form `evidence_source`, and at least one of `summary`, `customer_quote`, or `source_url`. The response contains the updated request and its next version.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Add feature request evidence",
+        "title": "Add feature request evidence",
+        "required_scopes": ["customer_analytics:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "customer-analytics-feature-requests"
+    },
+    "feature-requests-archive-create": {
+        "description": "Archive a Customer analytics feature request without deleting its account links, evidence, product areas, or history. Pass the request `id` and its current `expected_version`. Archived requests cannot be edited until restored.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Archive feature request",
+        "title": "Archive feature request",
+        "required_scopes": ["customer_analytics:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "customer-analytics-feature-requests"
+    },
+    "feature-requests-create": {
+        "description": "Create a Customer analytics feature request linked to one accessible account and one or more active product areas. Provide a client-generated UUID as `idempotency_key`. Retrying with the same key returns the original request. Use `accounts-list` and `feature-request-product-areas-list` to resolve the required IDs.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Create feature request",
+        "title": "Create feature request",
+        "required_scopes": ["customer_analytics:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "customer-analytics-feature-requests"
+    },
+    "feature-requests-history-list": {
+        "description": "List the complete change history for a Customer analytics feature request, newest first. Entries group the status, priority, account, evidence, and product area changes from one successful save. Account snapshots the caller cannot access are removed or redacted. The same data is queryable through `system.feature_request_history`.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "List feature request history",
+        "title": "List feature request history",
+        "required_scopes": ["customer_analytics:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "customer-analytics-feature-requests"
+    },
+    "feature-requests-list": {
+        "description": "List Customer analytics feature requests linked to accounts the caller can access. Filter by search text, lifecycle status, priority, product area, account, or archive state. Active requests are returned by default. Each request includes its active visible account links, account-specific evidence, product areas, and version. For bulk reads and aggregations, query `system.feature_requests` and its related system tables.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "List feature requests",
+        "title": "List feature requests",
+        "required_scopes": ["customer_analytics:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "customer-analytics-feature-requests"
+    },
+    "feature-requests-partial-update": {
+        "description": "Update a Customer analytics feature request by id. Pass its current `expected_version` and any subset of `title`, `description`, `account_ids`, `product_area_ids`, `request_status`, and `request_priority`. Pass null as `request_priority` to remove the priority. Removing an account unlinks it but preserves its evidence for a later relink. The response contains the next version.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Update feature request",
+        "title": "Update feature request",
+        "required_scopes": ["customer_analytics:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "customer-analytics-feature-requests"
+    },
+    "feature-requests-remove-evidence-create": {
+        "description": "Permanently delete one evidence item from a Customer analytics feature request. Pass the request `id`, its current `expected_version`, and the `evidence_id`. The request, account link, and other evidence remain. The response contains the updated request and its next version.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Delete feature request evidence",
+        "title": "Delete feature request evidence",
+        "required_scopes": ["customer_analytics:write"],
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "customer-analytics-feature-requests"
+    },
+    "feature-requests-restore-create": {
+        "description": "Restore an archived Customer analytics feature request so editors can change it again. Pass the request `id` and its current `expected_version`. Account links, evidence, product areas, and history remain attached.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Restore feature request",
+        "title": "Restore feature request",
+        "required_scopes": ["customer_analytics:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "customer-analytics-feature-requests"
+    },
+    "feature-requests-retrieve": {
+        "description": "Fetch one Customer analytics feature request by id. The response includes its lifecycle status, priority, archive state, version, active account links visible to the caller, account-specific evidence, and product areas. Use the returned `version` as `expected_version` for the next mutation.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Get feature request",
+        "title": "Get feature request",
+        "required_scopes": ["customer_analytics:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "customer-analytics-feature-requests"
+    },
+    "feature-requests-status-history-list": {
+        "description": "List status changes for one Customer analytics feature request, newest first. Each entry includes the previous status, resulting status, actor, source, and change time. Query `system.feature_request_history` when status changes need to be combined with other request changes.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "List feature request status history",
+        "title": "List feature request status history",
+        "required_scopes": ["customer_analytics:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "customer-analytics-feature-requests"
+    },
+    "feature-requests-update-evidence-create": {
+        "description": "Replace the editable fields of one feature request evidence item. Pass the request `id`, its current `expected_version`, the `evidence_id`, a free-form `evidence_source`, and the complete values for `summary`, `customer_quote`, `source_url`, and `requested_on`. The response contains the updated request and its next version.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Update feature request evidence",
+        "title": "Update feature request evidence",
+        "required_scopes": ["customer_analytics:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "customer-analytics-feature-requests"
+    },
     "field-notes-get": {
         "description": "Get a single field note by id, including the full element context (selector, element chain, inferred selectors, attributes) needed to locate the element in code.",
         "category": "Field notes",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -5015,7 +5015,7 @@
         "feature_flag": "customer-analytics-feature-requests"
     },
     "feature-requests-history-list": {
-        "description": "List the complete change history for a Customer analytics feature request, newest first. Entries group the status, priority, account, evidence, and product area changes from one successful save. Account snapshots the caller cannot access are removed or redacted. The same data is queryable through `system.feature_request_history`.",
+        "description": "List the complete change history for a Customer analytics feature request, newest first. Entries group the status, priority, account, evidence, and product area changes from one successful save. Account snapshots the caller cannot access are removed or redacted. HogQL `system.feature_request_history` exposes entry metadata and changed field names, but not before and after values.",
         "category": "Customer analytics",
         "feature": "customer_analytics",
         "summary": "List feature request history",
@@ -5105,7 +5105,7 @@
         "feature_flag": "customer-analytics-feature-requests"
     },
     "feature-requests-status-history-list": {
-        "description": "List status changes for one Customer analytics feature request, newest first. Each entry includes the previous status, resulting status, actor, source, and change time. Query `system.feature_request_history` when status changes need to be combined with other request changes.",
+        "description": "List status changes for one Customer analytics feature request, newest first. Each entry includes the previous status, resulting status, actor, source, and change time. HogQL `system.feature_request_history` exposes when changes occurred and which fields changed, but not status values.",
         "category": "Customer analytics",
         "feature": "customer_analytics",
         "summary": "List feature request status history",

--- a/services/mcp/src/generated/customer_analytics/api.ts
+++ b/services/mcp/src/generated/customer_analytics/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 49 enabled ops
+ * PostHog API - MCP 64 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -1090,6 +1090,428 @@ export const EventStreamsSendTestMessageCreateParams = /* @__PURE__ */ zod.objec
         .describe(
             "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
         ),
+})
+
+export const FeatureRequestProductAreasListParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const featureRequestProductAreasListQueryIncludeInactiveDefault = false
+
+export const FeatureRequestProductAreasListQueryParams = /* @__PURE__ */ zod.object({
+    include_inactive: zod
+        .boolean()
+        .default(featureRequestProductAreasListQueryIncludeInactiveDefault)
+        .describe('Include inactive product areas. Defaults to false.'),
+})
+
+export const FeatureRequestProductAreasCreateParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const featureRequestProductAreasCreateBodyNameMax = 200
+
+export const featureRequestProductAreasCreateBodyDisplayOrderDefault = 0
+export const featureRequestProductAreasCreateBodyDisplayOrderMin = 0
+
+export const featureRequestProductAreasCreateBodyIsActiveDefault = true
+
+export const FeatureRequestProductAreasCreateBody = /* @__PURE__ */ zod.object({
+    name: zod.string().max(featureRequestProductAreasCreateBodyNameMax).describe('Team-maintained product area name.'),
+    display_order: zod
+        .number()
+        .min(featureRequestProductAreasCreateBodyDisplayOrderMin)
+        .default(featureRequestProductAreasCreateBodyDisplayOrderDefault)
+        .describe('Position in product area selectors. Lower values appear first.'),
+    is_active: zod
+        .boolean()
+        .default(featureRequestProductAreasCreateBodyIsActiveDefault)
+        .describe('Whether editors can select this product area for new requests.'),
+})
+
+export const FeatureRequestProductAreasPartialUpdateParams = /* @__PURE__ */ zod.object({
+    id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const featureRequestProductAreasPartialUpdateBodyNameMax = 200
+
+export const featureRequestProductAreasPartialUpdateBodyDisplayOrderMin = 0
+
+export const FeatureRequestProductAreasPartialUpdateBody = /* @__PURE__ */ zod.object({
+    name: zod
+        .string()
+        .max(featureRequestProductAreasPartialUpdateBodyNameMax)
+        .optional()
+        .describe('Team-maintained product area name.'),
+    display_order: zod
+        .number()
+        .min(featureRequestProductAreasPartialUpdateBodyDisplayOrderMin)
+        .optional()
+        .describe('Position in product area selectors. Lower values appear first.'),
+    is_active: zod.boolean().optional().describe('Whether editors can select this product area for new requests.'),
+})
+
+export const FeatureRequestsListParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const featureRequestsListQueryArchiveStateDefault = `active`
+export const featureRequestsListQueryRequestOrderingDefault = `-updated_at`
+
+export const FeatureRequestsListQueryParams = /* @__PURE__ */ zod.object({
+    account_ids: zod
+        .array(zod.string())
+        .optional()
+        .describe('Accessible account IDs to include. Multiple values use OR semantics.'),
+    archive_state: zod
+        .enum(['active', 'archived', 'all'])
+        .default(featureRequestsListQueryArchiveStateDefault)
+        .describe(
+            'Whether to return active requests, archived requests, or all requests.\n\n\* `active` - Active\n\* `archived` - Archived\n\* `all` - All'
+        ),
+    limit: zod.number().optional().describe('Number of results to return per page.'),
+    offset: zod.number().optional().describe('The initial index from which to return the results.'),
+    priorities: zod
+        .array(
+            zod
+                .enum(['high', 'medium', 'low', 'none'])
+                .describe('\* `high` - High\n\* `medium` - Medium\n\* `low` - Low\n\* `none` - No priority')
+        )
+        .optional()
+        .describe('Priorities to include. Use none for requests without a priority.'),
+    product_area_ids: zod
+        .array(zod.string())
+        .optional()
+        .describe('Product area IDs to include. Multiple values use OR semantics.'),
+    request_ordering: zod
+        .string()
+        .min(1)
+        .default(featureRequestsListQueryRequestOrderingDefault)
+        .describe(
+            'Stable ordering for the result list.\n\n\* `-updated_at` - Last updated: newest\n\* `updated_at` - Last updated: oldest\n\* `-created_at` - Date created: newest\n\* `created_at` - Date created: oldest\n\* `-priority` - Priority: high to low\n\* `priority` - Priority: low to high\n\* `title` - Title: A to Z\n\* `-title` - Title: Z to A'
+        ),
+    search: zod.string().optional().describe('Case-insensitive text to find in request titles and descriptions.'),
+    statuses: zod
+        .array(
+            zod
+                .enum(['requested', 'planned', 'completed', 'wont_fix', 'duplicate'])
+                .describe(
+                    "\* `requested` - Requested\n\* `planned` - Planned\n\* `completed` - Completed\n\* `wont_fix` - Won't fix\n\* `duplicate` - Duplicate"
+                )
+        )
+        .optional()
+        .describe('Lifecycle statuses to include. Multiple values use OR semantics.'),
+})
+
+export const FeatureRequestsCreateParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const featureRequestsCreateBodyTitleMax = 400
+
+export const featureRequestsCreateBodyDescriptionDefault = ``
+
+export const FeatureRequestsCreateBody = /* @__PURE__ */ zod.object({
+    title: zod.string().max(featureRequestsCreateBodyTitleMax).describe('Required customer-facing request title.'),
+    description: zod
+        .string()
+        .default(featureRequestsCreateBodyDescriptionDefault)
+        .describe('Optional customer-facing request description in Markdown.'),
+    account_id: zod.string().describe('ID of the affected Customer Analytics account.'),
+    product_area_ids: zod
+        .array(zod.string())
+        .describe('One or more active product area IDs. Duplicate IDs are ignored.'),
+    idempotency_key: zod
+        .string()
+        .describe(
+            'Client-generated key that makes retries return the original request instead of creating a duplicate.'
+        ),
+})
+
+export const FeatureRequestsRetrieveParams = /* @__PURE__ */ zod.object({
+    id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const FeatureRequestsPartialUpdateParams = /* @__PURE__ */ zod.object({
+    id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const featureRequestsPartialUpdateBodyTitleMax = 400
+
+export const FeatureRequestsPartialUpdateBody = /* @__PURE__ */ zod.object({
+    expected_version: zod
+        .number()
+        .min(1)
+        .optional()
+        .describe('Request version loaded by the editor. Stale versions return 409 Conflict.'),
+    title: zod
+        .string()
+        .max(featureRequestsPartialUpdateBodyTitleMax)
+        .optional()
+        .describe('Updated customer-facing request title.'),
+    description: zod.string().optional().describe('Updated optional customer-facing request description in Markdown.'),
+    account_id: zod.string().optional().describe('Deprecated single affected account ID. Use account_ids.'),
+    account_ids: zod
+        .array(zod.string())
+        .optional()
+        .describe('One or more affected account IDs. Removed accounts are unlinked without deleting their evidence.'),
+    product_area_ids: zod
+        .array(zod.string())
+        .optional()
+        .describe('One or more product area IDs. Existing inactive areas can remain linked.'),
+    request_status: zod
+        .enum(['requested', 'planned', 'completed', 'wont_fix', 'duplicate'])
+        .describe(
+            "\* `requested` - Requested\n\* `planned` - Planned\n\* `completed` - Completed\n\* `wont_fix` - Won't fix\n\* `duplicate` - Duplicate"
+        )
+        .optional()
+        .describe(
+            "Updated customer-facing lifecycle status.\n\n\* `requested` - Requested\n\* `planned` - Planned\n\* `completed` - Completed\n\* `wont_fix` - Won't fix\n\* `duplicate` - Duplicate"
+        ),
+    request_priority: zod
+        .union([
+            zod.enum(['high', 'medium', 'low']).describe('\* `high` - High\n\* `medium` - Medium\n\* `low` - Low'),
+            zod.null(),
+        ])
+        .optional()
+        .describe(
+            'Updated manual priority. Pass null to remove the priority.\n\n\* `high` - High\n\* `medium` - Medium\n\* `low` - Low'
+        ),
+})
+
+export const FeatureRequestsAddAccountCreateParams = /* @__PURE__ */ zod.object({
+    id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const featureRequestsAddAccountCreateBodyEvidenceOneSummaryDefault = ``
+export const featureRequestsAddAccountCreateBodyEvidenceOneCustomerQuoteDefault = ``
+export const featureRequestsAddAccountCreateBodyEvidenceOneEvidenceSourceMax = 200
+
+export const featureRequestsAddAccountCreateBodyEvidenceOneSourceUrlDefault = ``
+export const featureRequestsAddAccountCreateBodyEvidenceOneSourceUrlMax = 2000
+
+export const FeatureRequestsAddAccountCreateBody = /* @__PURE__ */ zod.object({
+    expected_version: zod
+        .number()
+        .min(1)
+        .describe('Request version loaded by the editor. Stale versions return 409 Conflict.'),
+    account_id: zod.string().describe('Accessible account to link to this feature request.'),
+    evidence: zod
+        .union([
+            zod.object({
+                summary: zod
+                    .string()
+                    .default(featureRequestsAddAccountCreateBodyEvidenceOneSummaryDefault)
+                    .describe("Internal summary of this account's request evidence."),
+                customer_quote: zod
+                    .string()
+                    .default(featureRequestsAddAccountCreateBodyEvidenceOneCustomerQuoteDefault)
+                    .describe('Customer quote kept with this evidence item.'),
+                evidence_source: zod
+                    .string()
+                    .max(featureRequestsAddAccountCreateBodyEvidenceOneEvidenceSourceMax)
+                    .describe('Free-form name of the source where this evidence was recorded.'),
+                source_url: zod
+                    .url()
+                    .max(featureRequestsAddAccountCreateBodyEvidenceOneSourceUrlMax)
+                    .default(featureRequestsAddAccountCreateBodyEvidenceOneSourceUrlDefault)
+                    .describe('Optional HTTP or HTTPS link to the source.'),
+                requested_on: zod.iso
+                    .date()
+                    .nullish()
+                    .describe('Date the account made the request, or null when unknown.'),
+            }),
+            zod.null(),
+        ])
+        .optional()
+        .describe('Optional first evidence item to create for the account in the same change.'),
+})
+
+export const FeatureRequestsAddEvidenceCreateParams = /* @__PURE__ */ zod.object({
+    id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const featureRequestsAddEvidenceCreateBodySummaryDefault = ``
+export const featureRequestsAddEvidenceCreateBodyCustomerQuoteDefault = ``
+export const featureRequestsAddEvidenceCreateBodyEvidenceSourceMax = 200
+
+export const featureRequestsAddEvidenceCreateBodySourceUrlDefault = ``
+export const featureRequestsAddEvidenceCreateBodySourceUrlMax = 2000
+
+export const FeatureRequestsAddEvidenceCreateBody = /* @__PURE__ */ zod.object({
+    summary: zod
+        .string()
+        .default(featureRequestsAddEvidenceCreateBodySummaryDefault)
+        .describe("Internal summary of this account's request evidence."),
+    customer_quote: zod
+        .string()
+        .default(featureRequestsAddEvidenceCreateBodyCustomerQuoteDefault)
+        .describe('Customer quote kept with this evidence item.'),
+    evidence_source: zod
+        .string()
+        .max(featureRequestsAddEvidenceCreateBodyEvidenceSourceMax)
+        .describe('Free-form name of the source where this evidence was recorded.'),
+    source_url: zod
+        .url()
+        .max(featureRequestsAddEvidenceCreateBodySourceUrlMax)
+        .default(featureRequestsAddEvidenceCreateBodySourceUrlDefault)
+        .describe('Optional HTTP or HTTPS link to the source.'),
+    requested_on: zod.iso.date().nullish().describe('Date the account made the request, or null when unknown.'),
+    expected_version: zod
+        .number()
+        .min(1)
+        .describe('Request version loaded by the editor. Stale versions return 409 Conflict.'),
+    account_link_id: zod.string().describe('Active account link that owns this evidence.'),
+})
+
+export const FeatureRequestsArchiveCreateParams = /* @__PURE__ */ zod.object({
+    id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const FeatureRequestsArchiveCreateBody = /* @__PURE__ */ zod.object({
+    expected_version: zod
+        .number()
+        .min(1)
+        .describe('Request version loaded by the editor. Stale versions return 409 Conflict.'),
+})
+
+export const FeatureRequestsHistoryListParams = /* @__PURE__ */ zod.object({
+    id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const FeatureRequestsRemoveEvidenceCreateParams = /* @__PURE__ */ zod.object({
+    id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const FeatureRequestsRemoveEvidenceCreateBody = /* @__PURE__ */ zod.object({
+    expected_version: zod
+        .number()
+        .min(1)
+        .describe('Request version loaded by the editor. Stale versions return 409 Conflict.'),
+    evidence_id: zod.string().describe('Evidence item to delete.'),
+})
+
+export const FeatureRequestsRestoreCreateParams = /* @__PURE__ */ zod.object({
+    id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const FeatureRequestsRestoreCreateBody = /* @__PURE__ */ zod.object({
+    expected_version: zod
+        .number()
+        .min(1)
+        .describe('Request version loaded by the editor. Stale versions return 409 Conflict.'),
+})
+
+export const FeatureRequestsStatusHistoryListParams = /* @__PURE__ */ zod.object({
+    id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const FeatureRequestsUpdateEvidenceCreateParams = /* @__PURE__ */ zod.object({
+    id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const featureRequestsUpdateEvidenceCreateBodySummaryDefault = ``
+export const featureRequestsUpdateEvidenceCreateBodyCustomerQuoteDefault = ``
+export const featureRequestsUpdateEvidenceCreateBodyEvidenceSourceMax = 200
+
+export const featureRequestsUpdateEvidenceCreateBodySourceUrlDefault = ``
+export const featureRequestsUpdateEvidenceCreateBodySourceUrlMax = 2000
+
+export const FeatureRequestsUpdateEvidenceCreateBody = /* @__PURE__ */ zod.object({
+    summary: zod
+        .string()
+        .default(featureRequestsUpdateEvidenceCreateBodySummaryDefault)
+        .describe("Internal summary of this account's request evidence."),
+    customer_quote: zod
+        .string()
+        .default(featureRequestsUpdateEvidenceCreateBodyCustomerQuoteDefault)
+        .describe('Customer quote kept with this evidence item.'),
+    evidence_source: zod
+        .string()
+        .max(featureRequestsUpdateEvidenceCreateBodyEvidenceSourceMax)
+        .describe('Free-form name of the source where this evidence was recorded.'),
+    source_url: zod
+        .url()
+        .max(featureRequestsUpdateEvidenceCreateBodySourceUrlMax)
+        .default(featureRequestsUpdateEvidenceCreateBodySourceUrlDefault)
+        .describe('Optional HTTP or HTTPS link to the source.'),
+    requested_on: zod.iso.date().nullish().describe('Date the account made the request, or null when unknown.'),
+    expected_version: zod
+        .number()
+        .min(1)
+        .describe('Request version loaded by the editor. Stale versions return 409 Conflict.'),
+    evidence_id: zod.string().describe('Evidence item to replace.'),
 })
 
 export const groupsTypesMetricsListPathGroupTypeIndexMin = -2147483648

--- a/services/mcp/src/tools/generated/customer_analytics.ts
+++ b/services/mcp/src/tools/generated/customer_analytics.ts
@@ -59,6 +59,29 @@ import {
     EventStreamsRemoveAccountCreateBody,
     EventStreamsRemoveAccountCreateParams,
     EventStreamsSendTestMessageCreateParams,
+    FeatureRequestProductAreasCreateBody,
+    FeatureRequestProductAreasListQueryParams,
+    FeatureRequestProductAreasPartialUpdateBody,
+    FeatureRequestProductAreasPartialUpdateParams,
+    FeatureRequestsAddAccountCreateBody,
+    FeatureRequestsAddAccountCreateParams,
+    FeatureRequestsAddEvidenceCreateBody,
+    FeatureRequestsAddEvidenceCreateParams,
+    FeatureRequestsArchiveCreateBody,
+    FeatureRequestsArchiveCreateParams,
+    FeatureRequestsCreateBody,
+    FeatureRequestsHistoryListParams,
+    FeatureRequestsListQueryParams,
+    FeatureRequestsPartialUpdateBody,
+    FeatureRequestsPartialUpdateParams,
+    FeatureRequestsRemoveEvidenceCreateBody,
+    FeatureRequestsRemoveEvidenceCreateParams,
+    FeatureRequestsRestoreCreateBody,
+    FeatureRequestsRestoreCreateParams,
+    FeatureRequestsRetrieveParams,
+    FeatureRequestsStatusHistoryListParams,
+    FeatureRequestsUpdateEvidenceCreateBody,
+    FeatureRequestsUpdateEvidenceCreateParams,
     GroupsTypesMetricsCreateBody,
     GroupsTypesMetricsCreateParams,
     GroupsTypesMetricsDestroyParams,
@@ -1179,6 +1202,457 @@ const eventStreamsSendTestMessage = (): ToolBase<
     },
 })
 
+const FeatureRequestProductAreasCreateSchema = FeatureRequestProductAreasCreateBody
+
+const featureRequestProductAreasCreate = (): ToolBase<
+    typeof FeatureRequestProductAreasCreateSchema,
+    Schemas.FeatureRequestProductArea
+> => ({
+    name: 'feature-request-product-areas-create',
+    schema: FeatureRequestProductAreasCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof FeatureRequestProductAreasCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.name !== undefined) {
+            body['name'] = params.name
+        }
+        if (params.display_order !== undefined) {
+            body['display_order'] = params.display_order
+        }
+        if (params.is_active !== undefined) {
+            body['is_active'] = params.is_active
+        }
+        const result = await context.api.request<Schemas.FeatureRequestProductArea>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/feature_request_product_areas/`,
+            body,
+        })
+        return result
+    },
+})
+
+const FeatureRequestProductAreasListSchema = FeatureRequestProductAreasListQueryParams
+
+const featureRequestProductAreasList = (): ToolBase<
+    typeof FeatureRequestProductAreasListSchema,
+    WithPostHogUrl<Schemas.FeatureRequestProductArea[]>
+> => ({
+    name: 'feature-request-product-areas-list',
+    schema: FeatureRequestProductAreasListSchema,
+    handler: async (context: Context, params: z.infer<typeof FeatureRequestProductAreasListSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.FeatureRequestProductArea[]>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/feature_request_product_areas/`,
+            query: {
+                include_inactive: params.include_inactive,
+            },
+        })
+        return await withPostHogUrl(context, result, '/customer_analytics')
+    },
+})
+
+const FeatureRequestProductAreasPartialUpdateSchema = FeatureRequestProductAreasPartialUpdateParams.omit({
+    project_id: true,
+}).extend(FeatureRequestProductAreasPartialUpdateBody.shape)
+
+const featureRequestProductAreasPartialUpdate = (): ToolBase<
+    typeof FeatureRequestProductAreasPartialUpdateSchema,
+    Schemas.FeatureRequestProductArea
+> => ({
+    name: 'feature-request-product-areas-partial-update',
+    schema: FeatureRequestProductAreasPartialUpdateSchema,
+    handler: async (context: Context, params: z.infer<typeof FeatureRequestProductAreasPartialUpdateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.name !== undefined) {
+            body['name'] = params.name
+        }
+        if (params.display_order !== undefined) {
+            body['display_order'] = params.display_order
+        }
+        if (params.is_active !== undefined) {
+            body['is_active'] = params.is_active
+        }
+        const result = await context.api.request<Schemas.FeatureRequestProductArea>({
+            method: 'PATCH',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/feature_request_product_areas/${encodeURIComponent(String(params.id))}/`,
+            body,
+        })
+        return result
+    },
+})
+
+const FeatureRequestsAddAccountCreateSchema = FeatureRequestsAddAccountCreateParams.omit({ project_id: true }).extend(
+    FeatureRequestsAddAccountCreateBody.shape
+)
+
+const featureRequestsAddAccountCreate = (): ToolBase<
+    typeof FeatureRequestsAddAccountCreateSchema,
+    WithPostHogUrl<Schemas.FeatureRequest>
+> => ({
+    name: 'feature-requests-add-account-create',
+    schema: FeatureRequestsAddAccountCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof FeatureRequestsAddAccountCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.expected_version !== undefined) {
+            body['expected_version'] = params.expected_version
+        }
+        if (params.account_id !== undefined) {
+            body['account_id'] = params.account_id
+        }
+        if (params.evidence !== undefined) {
+            body['evidence'] = params.evidence
+        }
+        const result = await context.api.request<Schemas.FeatureRequest>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/feature_requests/${encodeURIComponent(String(params.id))}/add_account/`,
+            body,
+        })
+        return await withPostHogUrl(context, result, `/customer_analytics/feature-requests/${result.id}`)
+    },
+})
+
+const FeatureRequestsAddEvidenceCreateSchema = FeatureRequestsAddEvidenceCreateParams.omit({ project_id: true }).extend(
+    FeatureRequestsAddEvidenceCreateBody.shape
+)
+
+const featureRequestsAddEvidenceCreate = (): ToolBase<
+    typeof FeatureRequestsAddEvidenceCreateSchema,
+    WithPostHogUrl<Schemas.FeatureRequest>
+> => ({
+    name: 'feature-requests-add-evidence-create',
+    schema: FeatureRequestsAddEvidenceCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof FeatureRequestsAddEvidenceCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.summary !== undefined) {
+            body['summary'] = params.summary
+        }
+        if (params.customer_quote !== undefined) {
+            body['customer_quote'] = params.customer_quote
+        }
+        if (params.evidence_source !== undefined) {
+            body['evidence_source'] = params.evidence_source
+        }
+        if (params.source_url !== undefined) {
+            body['source_url'] = params.source_url
+        }
+        if (params.requested_on !== undefined) {
+            body['requested_on'] = params.requested_on
+        }
+        if (params.expected_version !== undefined) {
+            body['expected_version'] = params.expected_version
+        }
+        if (params.account_link_id !== undefined) {
+            body['account_link_id'] = params.account_link_id
+        }
+        const result = await context.api.request<Schemas.FeatureRequest>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/feature_requests/${encodeURIComponent(String(params.id))}/add_evidence/`,
+            body,
+        })
+        return await withPostHogUrl(context, result, `/customer_analytics/feature-requests/${result.id}`)
+    },
+})
+
+const FeatureRequestsArchiveCreateSchema = FeatureRequestsArchiveCreateParams.omit({ project_id: true }).extend(
+    FeatureRequestsArchiveCreateBody.shape
+)
+
+const featureRequestsArchiveCreate = (): ToolBase<
+    typeof FeatureRequestsArchiveCreateSchema,
+    WithPostHogUrl<Schemas.FeatureRequest>
+> => ({
+    name: 'feature-requests-archive-create',
+    schema: FeatureRequestsArchiveCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof FeatureRequestsArchiveCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.expected_version !== undefined) {
+            body['expected_version'] = params.expected_version
+        }
+        const result = await context.api.request<Schemas.FeatureRequest>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/feature_requests/${encodeURIComponent(String(params.id))}/archive/`,
+            body,
+        })
+        return await withPostHogUrl(context, result, `/customer_analytics/feature-requests/${result.id}`)
+    },
+})
+
+const FeatureRequestsCreateSchema = FeatureRequestsCreateBody
+
+const featureRequestsCreate = (): ToolBase<
+    typeof FeatureRequestsCreateSchema,
+    WithPostHogUrl<Schemas.FeatureRequest>
+> => ({
+    name: 'feature-requests-create',
+    schema: FeatureRequestsCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof FeatureRequestsCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.title !== undefined) {
+            body['title'] = params.title
+        }
+        if (params.description !== undefined) {
+            body['description'] = params.description
+        }
+        if (params.account_id !== undefined) {
+            body['account_id'] = params.account_id
+        }
+        if (params.product_area_ids !== undefined) {
+            body['product_area_ids'] = params.product_area_ids
+        }
+        if (params.idempotency_key !== undefined) {
+            body['idempotency_key'] = params.idempotency_key
+        }
+        const result = await context.api.request<Schemas.FeatureRequest>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/feature_requests/`,
+            body,
+        })
+        return await withPostHogUrl(context, result, `/customer_analytics/feature-requests/${result.id}`)
+    },
+})
+
+const FeatureRequestsHistoryListSchema = FeatureRequestsHistoryListParams.omit({ project_id: true })
+
+const featureRequestsHistoryList = (): ToolBase<
+    typeof FeatureRequestsHistoryListSchema,
+    WithPostHogUrl<Schemas.FeatureRequestHistory[]>
+> => ({
+    name: 'feature-requests-history-list',
+    schema: FeatureRequestsHistoryListSchema,
+    handler: async (context: Context, params: z.infer<typeof FeatureRequestsHistoryListSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.FeatureRequestHistory[]>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/feature_requests/${encodeURIComponent(String(params.id))}/history/`,
+        })
+        return await withPostHogUrl(context, result, '/customer_analytics')
+    },
+})
+
+const FeatureRequestsListSchema = FeatureRequestsListQueryParams
+
+const featureRequestsList = (): ToolBase<
+    typeof FeatureRequestsListSchema,
+    WithPostHogUrl<Schemas.PaginatedFeatureRequestList>
+> => ({
+    name: 'feature-requests-list',
+    schema: FeatureRequestsListSchema,
+    handler: async (context: Context, params: z.infer<typeof FeatureRequestsListSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.PaginatedFeatureRequestList>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/feature_requests/`,
+            query: {
+                account_ids: params.account_ids,
+                archive_state: params.archive_state,
+                limit: params.limit,
+                offset: params.offset,
+                priorities: params.priorities,
+                product_area_ids: params.product_area_ids,
+                request_ordering: params.request_ordering,
+                search: params.search,
+                statuses: params.statuses,
+            },
+        })
+        return await withPostHogUrl(
+            context,
+            {
+                ...result,
+                results: await Promise.all(
+                    (result.results ?? []).map((item) =>
+                        withPostHogUrl(context, item, `/customer_analytics/feature-requests/${item.id}`)
+                    )
+                ),
+            },
+            '/customer_analytics'
+        )
+    },
+})
+
+const FeatureRequestsPartialUpdateSchema = FeatureRequestsPartialUpdateParams.omit({ project_id: true })
+    .extend(FeatureRequestsPartialUpdateBody.shape)
+    .extend({ expected_version: FeatureRequestsPartialUpdateBody.shape['expected_version'].unwrap() })
+
+const featureRequestsPartialUpdate = (): ToolBase<
+    typeof FeatureRequestsPartialUpdateSchema,
+    WithPostHogUrl<Schemas.FeatureRequest>
+> => ({
+    name: 'feature-requests-partial-update',
+    schema: FeatureRequestsPartialUpdateSchema,
+    handler: async (context: Context, params: z.infer<typeof FeatureRequestsPartialUpdateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.expected_version !== undefined) {
+            body['expected_version'] = params.expected_version
+        }
+        if (params.title !== undefined) {
+            body['title'] = params.title
+        }
+        if (params.description !== undefined) {
+            body['description'] = params.description
+        }
+        if (params.account_id !== undefined) {
+            body['account_id'] = params.account_id
+        }
+        if (params.account_ids !== undefined) {
+            body['account_ids'] = params.account_ids
+        }
+        if (params.product_area_ids !== undefined) {
+            body['product_area_ids'] = params.product_area_ids
+        }
+        if (params.request_status !== undefined) {
+            body['request_status'] = params.request_status
+        }
+        if (params.request_priority !== undefined) {
+            body['request_priority'] = params.request_priority
+        }
+        const result = await context.api.request<Schemas.FeatureRequest>({
+            method: 'PATCH',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/feature_requests/${encodeURIComponent(String(params.id))}/`,
+            body,
+        })
+        return await withPostHogUrl(context, result, `/customer_analytics/feature-requests/${result.id}`)
+    },
+})
+
+const FeatureRequestsRemoveEvidenceCreateSchema = FeatureRequestsRemoveEvidenceCreateParams.omit({
+    project_id: true,
+}).extend(FeatureRequestsRemoveEvidenceCreateBody.shape)
+
+const featureRequestsRemoveEvidenceCreate = (): ToolBase<
+    typeof FeatureRequestsRemoveEvidenceCreateSchema,
+    WithPostHogUrl<Schemas.FeatureRequest>
+> => ({
+    name: 'feature-requests-remove-evidence-create',
+    schema: FeatureRequestsRemoveEvidenceCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof FeatureRequestsRemoveEvidenceCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.expected_version !== undefined) {
+            body['expected_version'] = params.expected_version
+        }
+        if (params.evidence_id !== undefined) {
+            body['evidence_id'] = params.evidence_id
+        }
+        const result = await context.api.request<Schemas.FeatureRequest>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/feature_requests/${encodeURIComponent(String(params.id))}/remove_evidence/`,
+            body,
+        })
+        return await withPostHogUrl(context, result, `/customer_analytics/feature-requests/${result.id}`)
+    },
+})
+
+const FeatureRequestsRestoreCreateSchema = FeatureRequestsRestoreCreateParams.omit({ project_id: true }).extend(
+    FeatureRequestsRestoreCreateBody.shape
+)
+
+const featureRequestsRestoreCreate = (): ToolBase<
+    typeof FeatureRequestsRestoreCreateSchema,
+    WithPostHogUrl<Schemas.FeatureRequest>
+> => ({
+    name: 'feature-requests-restore-create',
+    schema: FeatureRequestsRestoreCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof FeatureRequestsRestoreCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.expected_version !== undefined) {
+            body['expected_version'] = params.expected_version
+        }
+        const result = await context.api.request<Schemas.FeatureRequest>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/feature_requests/${encodeURIComponent(String(params.id))}/restore/`,
+            body,
+        })
+        return await withPostHogUrl(context, result, `/customer_analytics/feature-requests/${result.id}`)
+    },
+})
+
+const FeatureRequestsRetrieveSchema = FeatureRequestsRetrieveParams.omit({ project_id: true })
+
+const featureRequestsRetrieve = (): ToolBase<
+    typeof FeatureRequestsRetrieveSchema,
+    WithPostHogUrl<Schemas.FeatureRequest>
+> => ({
+    name: 'feature-requests-retrieve',
+    schema: FeatureRequestsRetrieveSchema,
+    handler: async (context: Context, params: z.infer<typeof FeatureRequestsRetrieveSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.FeatureRequest>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/feature_requests/${encodeURIComponent(String(params.id))}/`,
+        })
+        return await withPostHogUrl(context, result, `/customer_analytics/feature-requests/${result.id}`)
+    },
+})
+
+const FeatureRequestsStatusHistoryListSchema = FeatureRequestsStatusHistoryListParams.omit({ project_id: true })
+
+const featureRequestsStatusHistoryList = (): ToolBase<
+    typeof FeatureRequestsStatusHistoryListSchema,
+    WithPostHogUrl<Schemas.FeatureRequestStatusHistory[]>
+> => ({
+    name: 'feature-requests-status-history-list',
+    schema: FeatureRequestsStatusHistoryListSchema,
+    handler: async (context: Context, params: z.infer<typeof FeatureRequestsStatusHistoryListSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.FeatureRequestStatusHistory[]>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/feature_requests/${encodeURIComponent(String(params.id))}/status_history/`,
+        })
+        return await withPostHogUrl(context, result, '/customer_analytics')
+    },
+})
+
+const FeatureRequestsUpdateEvidenceCreateSchema = FeatureRequestsUpdateEvidenceCreateParams.omit({
+    project_id: true,
+}).extend(FeatureRequestsUpdateEvidenceCreateBody.shape)
+
+const featureRequestsUpdateEvidenceCreate = (): ToolBase<
+    typeof FeatureRequestsUpdateEvidenceCreateSchema,
+    WithPostHogUrl<Schemas.FeatureRequest>
+> => ({
+    name: 'feature-requests-update-evidence-create',
+    schema: FeatureRequestsUpdateEvidenceCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof FeatureRequestsUpdateEvidenceCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.summary !== undefined) {
+            body['summary'] = params.summary
+        }
+        if (params.customer_quote !== undefined) {
+            body['customer_quote'] = params.customer_quote
+        }
+        if (params.evidence_source !== undefined) {
+            body['evidence_source'] = params.evidence_source
+        }
+        if (params.source_url !== undefined) {
+            body['source_url'] = params.source_url
+        }
+        if (params.requested_on !== undefined) {
+            body['requested_on'] = params.requested_on
+        }
+        if (params.expected_version !== undefined) {
+            body['expected_version'] = params.expected_version
+        }
+        if (params.evidence_id !== undefined) {
+            body['evidence_id'] = params.evidence_id
+        }
+        const result = await context.api.request<Schemas.FeatureRequest>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/feature_requests/${encodeURIComponent(String(params.id))}/update_evidence/`,
+            body,
+        })
+        return await withPostHogUrl(context, result, `/customer_analytics/feature-requests/${result.id}`)
+    },
+})
+
 const UsageMetricsCreateSchema = GroupsTypesMetricsCreateParams.omit({ project_id: true })
     .extend(GroupsTypesMetricsCreateBody.shape)
     .extend({
@@ -1387,6 +1861,21 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'event-streams-partial-update': eventStreamsPartialUpdate,
     'event-streams-remove-account': eventStreamsRemoveAccount,
     'event-streams-send-test-message': eventStreamsSendTestMessage,
+    'feature-request-product-areas-create': featureRequestProductAreasCreate,
+    'feature-request-product-areas-list': featureRequestProductAreasList,
+    'feature-request-product-areas-partial-update': featureRequestProductAreasPartialUpdate,
+    'feature-requests-add-account-create': featureRequestsAddAccountCreate,
+    'feature-requests-add-evidence-create': featureRequestsAddEvidenceCreate,
+    'feature-requests-archive-create': featureRequestsArchiveCreate,
+    'feature-requests-create': featureRequestsCreate,
+    'feature-requests-history-list': featureRequestsHistoryList,
+    'feature-requests-list': featureRequestsList,
+    'feature-requests-partial-update': featureRequestsPartialUpdate,
+    'feature-requests-remove-evidence-create': featureRequestsRemoveEvidenceCreate,
+    'feature-requests-restore-create': featureRequestsRestoreCreate,
+    'feature-requests-retrieve': featureRequestsRetrieve,
+    'feature-requests-status-history-list': featureRequestsStatusHistoryList,
+    'feature-requests-update-evidence-create': featureRequestsUpdateEvidenceCreate,
     'usage-metrics-create': usageMetricsCreate,
     'usage-metrics-destroy': usageMetricsDestroy,
     'usage-metrics-list': usageMetricsList,

--- a/services/mcp/tests/unit/tool-filtering.test.ts
+++ b/services/mcp/tests/unit/tool-filtering.test.ts
@@ -855,6 +855,7 @@ describe('Tool Filtering - Feature Flags', () => {
                 'visual-review',
                 'user-interviews',
                 'customer-analytics-csp',
+                'customer-analytics-feature-requests',
                 'notebooks-collaboration',
                 'revamped-py-notebooks',
                 'tasks',
@@ -882,7 +883,7 @@ describe('Tool Filtering - Feature Flags', () => {
                 'data-quality-checks',
             ])
         )
-        expect(flags).toHaveLength(31)
+        expect(flags).toHaveLength(32)
     })
 
     it('every loops tool is gated on the loops flag', () => {


### PR DESCRIPTION
## Problem

Agents cannot manage or query Customer analytics feature requests, including the multi-account evidence from #83975.

## Changes

- Fifteen MCP tools cover product areas, request CRUD, lifecycle history, account links, and account-specific evidence.
- Six HogQL tables support bulk reads and joins across requests, accounts, product areas, evidence, and history.
- HogQL reads apply team isolation and account access rules. Inaccessible links and evidence stay hidden.
- The current MCP uses one tool catalog, so this PR adds no retired v1/v2 split.
- OpenAPI generation supplies the Zod schemas, handlers, metadata, and feature request links.
- This PR changes agent interfaces only, so there are no screenshots.

## How did you test this code?

- Focused HogQL tests guard tenant isolation, denied-account redaction, model drift, and system table registration.
- MCP tests guard generated handlers, schemas, feature flag discovery, and tool names.
- Local checks ran OpenAPI generation, MCP typecheck, repository-wide mypy, skill linting, and strict preflight.
- Not checked: live MCP calls against a deployed PostHog instance.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated the querying skill reference with schemas and query patterns for six feature request tables.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi implemented the human-directed change with `gh`, `hogli`, pytest, and Vitest.

Skills invoked: `/implementing-mcp-tools`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-code-comments`, `/writing-skills`, `/writing-pr-descriptions`, `/stacking-prs`, `/ship-it`, `/orwell-writing`, `/tracking-tasks-in-obsidian`, and `/implement-issue`.

The current MCP no longer supports a v1/v2 split, so one feature-gated catalog exposes both read and write tools. All test data is invented.
