### PR TITLE
fix(desktop): space folder picker label

### DIFF
--- a/products/desktop/packages/ui/src/features/folder-picker/FolderPicker.tsx
+++ b/products/desktop/packages/ui/src/features/folder-picker/FolderPicker.tsx
@@ -30,7 +30,7 @@ import type { RegisteredFolder } from "@posthog/ui/features/folders/types";
 import { useFolders } from "@posthog/ui/features/folders/useFolders";
 import { toast } from "@posthog/ui/primitives/toast";
 import { FIELD_TRIGGER_CLASS } from "@posthog/ui/styles/fieldTrigger";
-import { Flex, Text } from "@radix-ui/themes";
+import { Text } from "@radix-ui/themes";
 import { useQueries } from "@tanstack/react-query";
 import { type RefObject, useMemo, useState } from "react";
 
@@ -168,7 +168,7 @@ export function FolderPicker({
 
   const fieldContent = (
     <>
-      <Flex align="center" gap="2" className="min-w-0 flex-1">
+      <div className="flex min-w-0 flex-1 items-center gap-2">
         <FolderIcon size={16} className="shrink-0 text-(--gray-12)" />
         <Text
           className="min-w-0 max-w-full truncate text-left font-medium text-(--gray-12)"
@@ -176,7 +176,7 @@ export function FolderPicker({
         >
           {isOpening ? "Opening..." : displayValue || placeholder}
         </Text>
-      </Flex>
+      </div>
       {isOpening ? (
         <CircleNotch
           size={14}


### PR DESCRIPTION
## Problem

The local task editor places the folder label directly against its icon, which makes the folder picker look cramped.

## Changes

- The folder picker now keeps a consistent gap between the folder icon and label.
- The layout uses desktop Tailwind styling instead of theme-dependent spacing.
- Updated screenshot not captured in this environment.

## How did you test this code?

The desktop UI typecheck, folder-picker tests, and formatter checks passed.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation changes are needed for this visual fix.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex made this targeted fix using the /posthog-desktop and /writing-pr-descriptions skills. The change contains no session-derived customer data.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*