### PR TITLE
docs(surveys): teach debugging-surveys how a response actually gets stored

### DIFF
--- a/products/surveys/skills/debugging-surveys/SKILL.md
+++ b/products/surveys/skills/debugging-surveys/SKILL.md
@@ -151,18 +151,26 @@ inverted.
 `survey dismissed` (explicit close), `survey abandoned` (`handlePageUnload` →
 `sendSurveyAbandonedEvent`). `$survey_partially_completed` appears on `dismissed` and `abandoned`
 only, never on `sent`. All of them carry `sessionRecordingUrl`, so a disputed submission can often
-be **watched** instead of theorised about. A populated URL only proves a session id was captured,
+be **watched** instead of theorized about. A populated URL only proves a session id was captured,
 not that a recording exists: replay is off by default, and the default cloud retention of 30 days is
 well short of these queries' 180-day window. Open the link before offering it as evidence.
 
-### Never guess response property keys
+### Read answers with `getSurveyResponse`, never a guessed key
 
-Response keys come in three formats and the current one is UUID-keyed
-(`$survey_response_<questionId>`). Guessing which UUID belongs to which question is the fastest
-route to a wrong conclusion: it silently reads one question's answers under another's label, and
-the resulting ratio looks like a serious bug. Either take the ids from `questions[].id` and name
-the columns explicitly, or unroll `$survey_questions`. Formats and query templates:
-[references/reading-responses.md](references/reading-responses.md),
+**`getSurveyResponse(<index>, '<questionId>')`** is the HogQL helper the product itself reads
+answers with (`posthog/hogql/functions/survey.py`, used across
+`products/surveys/backend/responses/`). Prefer it over hand-writing a property key: response keys
+come in three formats, and the helper coalesces the current UUID-keyed one
+(`$survey_response_<questionId>`) with the legacy index-keyed one, so it returns what the customer's
+own results table shows. Pass `true` as a third argument for multiple-choice questions. A
+hand-written `properties.$survey_response_<uuid>` misses legacy-keyed answers, and inside a
+`countIf` that silently converts a real answer into "unanswered" and inflates the incomplete ratio.
+
+Whichever you use, **the index and id must come from `questions[]` in the survey JSON.** Guessing
+which UUID belongs to which question is the fastest route to a wrong conclusion: it reads one
+question's answers under another's label, and the resulting ratio looks like a serious bug. If you
+have no survey JSON, unroll `$survey_questions`, which carries the question text alongside the
+answer. Formats and templates: [references/reading-responses.md](references/reading-responses.md),
 [references/diagnostic-queries.md](references/diagnostic-queries.md).
 
 **Sanity check the mapping before trusting the numbers:** if a column you labelled as a
@@ -194,7 +202,7 @@ is expensive and hard to walk back — restructuring destroys the comparability 
 already collected, and reordering questions risks the UUID problem below. Clear all four gates
 before writing "this is a bug":
 
-1. **Read the survey JSON**, per-question `branching`, `optional`, `skipSubmitButton` and `scale` included. Most "impossible" behaviour is configured behaviour.
+1. **Read the survey JSON**, per-question `branching`, `optional`, `skipSubmitButton` and `scale` included. Most "impossible" behavior is configured behavior.
 2. **Reproduce it in Preview.**
 3. **Read the SDK source for the handler you're accusing.** Grep the symbol; don't reason from what a setting is named. `enable_partial_responses` and "all questions answered" both mean something narrower than they sound.
 4. **Re-check your own query before trusting a shocking ratio.** "89% of responses are incomplete" is more often a bad response-key mapping than a real defect.
@@ -230,8 +238,8 @@ Usually not a bug — see [How a response actually gets stored](#how-a-response-
 ### "The respondent says they didn't mean to submit"
 
 - **`skipSubmitButton`, shown in the editor as "Automatically submit on selection".** When true no submit button renders at all (`BottomSection.tsx`) and one click both records the answer and advances — `setRating(response)` then `handleSubmit(response)` → `onNextButtonClick` in the same handler invocation, no debounce, no confirm. Rating and single-choice-without-open-choice only (`canQuestionSkipSubmitButton`); web-only. It is **on by default in every survey template** (`constants.tsx`) and in quick-create, so customers rarely know they enabled it.
-- **It compounds with popup placement.** `appearance.position: middle_center`, a large `maxWidth`, and a non-zero `surveyPopupDelaySeconds` mean the popup materialises seconds after the trigger under a cursor that's still moving, and the next click lands on an answer. Consecutive auto-submitting questions let someone click through most of a survey without reading it.
-- **Diagnose with shown→sent latency,** then confirm from the replay (`sessionRecordingUrl` on `survey sent`). A cluster of sub-10-second completions on a multi-question survey is the signature; genuine respondents take longer and leave text behind. Fix is to uncheck the setting — **not** to move the question, since the behaviour follows the question wherever it sits.
+- **It compounds with popup placement.** `appearance.position: middle_center`, a large `maxWidth`, and a non-zero `surveyPopupDelaySeconds` mean the popup materializes seconds after the trigger under a cursor that's still moving, and the next click lands on an answer. Consecutive auto-submitting questions let someone click through most of a survey without reading it.
+- **Diagnose with shown→sent latency,** then confirm from the replay (`sessionRecordingUrl` on `survey sent`). A cluster of sub-10-second completions on a multi-question survey is the signature; genuine respondents take longer and leave text behind. Fix is to uncheck the setting — **not** to move the question, since the behavior follows the question wherever it sits.
 
 ### "Responses show as zero in the UI but raw events exist"
 

--- a/products/surveys/skills/debugging-surveys/SKILL.md
+++ b/products/surveys/skills/debugging-surveys/SKILL.md
@@ -150,8 +150,10 @@ inverted.
 `surveyPopupDelaySeconds`, so shown→sent latency is real time-on-popup), `survey sent`,
 `survey dismissed` (explicit close), `survey abandoned` (`handlePageUnload` →
 `sendSurveyAbandonedEvent`). `$survey_partially_completed` appears on `dismissed` and `abandoned`
-only, never on `sent`. All of them carry `sessionRecordingUrl`, so a disputed submission can be
-**watched** instead of theorised about.
+only, never on `sent`. All of them carry `sessionRecordingUrl`, so a disputed submission can often
+be **watched** instead of theorised about. A populated URL only proves a session id was captured,
+not that a recording exists: replay is off by default, and the default cloud retention of 30 days is
+well short of these queries' 180-day window. Open the link before offering it as evidence.
 
 ### Never guess response property keys
 

--- a/products/surveys/skills/debugging-surveys/SKILL.md
+++ b/products/surveys/skills/debugging-surveys/SKILL.md
@@ -4,10 +4,13 @@ description: >-
   Debug, support, and build PostHog Surveys across the backend and all five SDKs
   (web/posthog-js, iOS, Android, Flutter, React Native). Use whenever a Surveys
   support ticket is pasted ("survey not showing", "fewer responses than expected",
-  "responses disappeared", "survey shows on wrong platform"), when diagnosing why a
-  survey does or doesn't display, or when doing survey feature work that must ship
-  across SDKs. Covers the eligibility pipeline, cross-SDK feature parity, the known-cause
-  catalog, read-only diagnostic queries, staff access, and the customer-reply style guide.
+  "responses disappeared", "responses are incomplete", "only the first question was
+  answered", "the user says they didn't mean to submit", "survey shows on wrong platform"),
+  when diagnosing why a survey does or doesn't display, or when doing survey feature work
+  that must ship across SDKs. Covers the eligibility pipeline, how a response actually gets
+  stored (partial responses, branching, optional questions, auto-submit), cross-SDK feature
+  parity, the known-cause catalog, read-only diagnostic queries, staff access, and the
+  customer-reply style guide.
 ---
 
 # Debugging surveys
@@ -47,18 +50,24 @@ Confirm the survey's `lib` / the customer's platform before anything else, then 
 this table. Verified against the SDK source — re-verify if it's been months, the gaps
 get filled over time.
 
-| Feature                         | Web (posthog-js)                | iOS                                       | Android                            | Flutter                            | React Native                            |
-| ------------------------------- | ------------------------------- | ----------------------------------------- | ---------------------------------- | ---------------------------------- | --------------------------------------- |
-| Rendering                       | DOM + shadow root               | Native SwiftUI (`SurveysWindow`)          | **No built-in UI** — delegate only | Dart widgets (`SurveyBottomSheet`) | RN components (`SurveyModal`)           |
-| Event-based triggers            | yes (since 1.137.0, 2024-06-05) | yes                                       | yes                                | yes (native side)                  | yes                                     |
-| URL / screen targeting          | yes                             | decoded but **NOT evaluated** (`// TODO`) | decoded but **NOT evaluated**      | **NOT evaluated** (native gap)     | **explicitly excluded** in filter       |
-| Feature-flag / cohort targeting | yes                             | yes                                       | yes                                | yes (native side)                  | yes                                     |
-| `seenSurveyWaitPeriodInDays`    | yes                             | yes                                       | yes                                | yes (native side)                  | stored but **comparison commented out** |
-| `surveyPopupDelaySeconds`       | yes                             | **not implemented**                       | **not implemented**                | **not implemented**                | **not implemented** (TODO)              |
+| Feature                          | Web (posthog-js)                | iOS                                       | Android                            | Flutter                            | React Native                            |
+| -------------------------------- | ------------------------------- | ----------------------------------------- | ---------------------------------- | ---------------------------------- | --------------------------------------- |
+| Rendering                        | DOM + shadow root               | Native SwiftUI (`SurveysWindow`)          | **No built-in UI** — delegate only | Dart widgets (`SurveyBottomSheet`) | RN components (`SurveyModal`)           |
+| Event-based triggers             | yes (since 1.137.0, 2024-06-05) | yes                                       | yes                                | yes (native side)                  | yes                                     |
+| URL / screen targeting           | yes                             | decoded but **NOT evaluated** (`// TODO`) | decoded but **NOT evaluated**      | **NOT evaluated** (native gap)     | **explicitly excluded** in filter       |
+| Feature-flag / cohort targeting  | yes                             | yes                                       | yes                                | yes (native side)                  | yes                                     |
+| `seenSurveyWaitPeriodInDays`     | yes                             | yes                                       | yes                                | yes (native side)                  | stored but **comparison commented out** |
+| `surveyPopupDelaySeconds`        | yes                             | **not implemented**                       | **not implemented**                | **not implemented**                | **not implemented** (TODO)              |
+| `enable_partial_responses`       | yes (≥ 1.240.0)                 | **no**                                    | **no**                             | **no**                             | **no**                                  |
+| `skipSubmitButton` (auto-submit) | yes (≥ 1.244.0)                 | **no**                                    | **no**                             | **no**                             | **no**                                  |
+
+The last two rows are per the editor's own help text ("Doesn't work with the mobile SDKs for
+now" / "Not available for the mobile SDKs at the moment") rather than a per-SDK source audit.
 
 Consequences worth memorizing:
 
 - **`surveyPopupDelaySeconds` is web-only.** If a mobile ticket blames the delay, it's a red herring.
+- **Partial responses and auto-submit are web-only too.** On mobile a survey always stores one response at the end, and a rating tap never self-submits. Don't carry a web diagnosis onto a mobile ticket.
 - **URL targeting is effectively web-only.** Mobile SDKs decode the field but never enforce it; React Native filters those surveys out entirely. A mobile survey with a URL condition behaves as "no URL condition" (mobile/flutter) or "never shows" (RN).
 - **Android ships no survey UI.** The app (or the Flutter plugin) must provide a `PostHogSurveysDelegate`. "Survey never renders on Android" is often a missing delegate, not a PostHog bug.
 - **Flutter is hybrid:** triggering/eligibility runs in the native iOS/Android layer; rendering is Dart (`SurveyService.showSurvey` → `showModalBottomSheet`). It does _not_ "just call native" for UI. So a Flutter rendering bug lives in Dart; a Flutter eligibility bug lives in native.
@@ -85,7 +94,77 @@ Then in `getActiveMatchingSurveys`: URL/device/selector match, event/action trig
 Two non-obvious facts that drive real tickets:
 
 - **The server returns ALL non-archived surveys** (`SurveyViewSet`, `products/surveys/backend/api/survey.py`). It does **not** pre-filter by the internal targeting flag. All eligibility is client-side. So you cannot conclude "the backend excluded them" — the SDK did.
-- **The wait period has TWO independent implementations.** `canActivateRepeatedly` (true when `schedule: 'always'`) short-circuits `_internalFlagCheckSatisfied` (step 5) — so `always` bypasses the internal flag, including its `$last_seen_survey_date` rule. But `hasWaitPeriodPassed` (step 6) reads `localStorage.lastSeenSurveyDate` directly and is **NOT** bypassed by `canActivateRepeatedly`. So a `schedule: 'always'` survey with `seenSurveyWaitPeriodInDays: 30` still enforces the 30-day wait via the localStorage path. `lastSeenSurveyDate` is updated whenever _any_ survey is shown, regardless of completion.
+- **The wait period has TWO independent implementations.** `canActivateRepeatedly` (true when `schedule: 'always'`) short-circuits `_internalFlagCheckSatisfied` (step 5) — so `always` bypasses the internal flag, including its `$last_seen_survey_date` rule. But `hasWaitPeriodPassed` (step 6) reads `localStorage.lastSeenSurveyDate` directly and is **NOT** bypassed by `canActivateRepeatedly`. So a `schedule: 'always'` survey with `seenSurveyWaitPeriodInDays: 30` still enforces the 30-day wait via the localStorage path. `lastSeenSurveyDate` is updated whenever _any_ survey is shown, regardless of completion. The same short-circuit also drops the internal flag's `$survey_responded/<id> is_not_set` rule, so **`schedule: 'always'` lets one person respond repeatedly** — check `uniq(distinct_id)` against `count()` on `survey sent` before reading a response count as a respondent count.
+
+## How a response actually gets stored
+
+Showing a survey and storing a response are separate pipelines. "Wrong data" tickets are about the
+second one, and its UI copy is genuinely misleading — reason from the code, not from the label.
+
+### "Response collection" maps to `enable_partial_responses`
+
+The radio in `frontend/src/scenes/surveys/SurveyResponsesCollection.tsx`. "Any question: when at
+least one question is answered…" is `true`; "Complete survey: the response is stored when all
+questions are answered" is `false`.
+
+- `true` → `sendSurveyEvent` fires on **every** `onNextButtonClick`, so one `survey sent` per
+  question answered, all sharing a `$survey_submission_id` with `$survey_completed` running
+  `false … true`. The responses table collapses them by `argMax(uuid, timestamp)` per submission id
+  (`buildPartialResponsesFilter`, `frontend/src/scenes/surveys/utils.ts`), so **raw SQL shows far
+  more rows than the UI** and the extras look like broken submissions.
+- `false` → one event, at the end of the path. The table instead filters
+  `$survey_completed != 'false'`, keeping events where the property is absent (pre-1.240.0 SDKs).
+
+**The defaults disagree by creation path:** `NEW_SURVEY` sets `true`
+(`frontend/src/scenes/surveys/constants.tsx`) but the Django model default is `False`
+(`products/surveys/backend/models.py`). Read it, don't infer it from the creation date.
+
+### "All questions answered" does not mean what it says
+
+`isSurveyCompleted` is `getNextSurveyStep(...) === End` — **the respondent reached the end of their
+own branching path.** Nothing checks that every question holds a value, and two things then blank
+out cells on a complete response: questions **skipped by branching have no key at all**
+(`onNextButtonClick` prunes to `visitedIndices` before capture, so absent rather than `""` or
+`null`), and **`optional: true` questions clicked past are stored as `null`**
+(`submitDisabled` is `isNull(rating) && !question.optional`).
+
+So on a branching survey with optional tail questions, "only the first question was answered" is
+the **expected shape of a complete response**. Blank ≠ unanswered. Check `branching` and `optional`
+on every question before believing a bug.
+
+### Branching is in the API — read it, don't ask for it
+
+It's `questions[].branching`, returned verbatim by both the management API and the SDK payload, in
+four shapes: `next_question`, `end` (the confirmation message), `specific_question` + `index`, and
+`response_based` + `responseValues`. Two traps: for **rating** questions `responseValues` is keyed
+by _bucket_ (`negative`/`neutral`/`positive`, or NPS `detractors`/`passives`/`promoters`), not by
+value; and a bucket **missing** from `responseValues` silently falls through to
+`currentQuestionIndex + 1`. So `{negative: 3, neutral: 3}` on a 5-scale is a complete, working
+config that reads like an omission. Bucket boundaries per scale are in
+[references/reading-responses.md](references/reading-responses.md) — don't guess them, scale 2 is
+inverted.
+
+### The event vocabulary
+
+`survey shown` (fired inside `showSurvey()` at the moment the popup becomes visible, i.e. **after**
+`surveyPopupDelaySeconds`, so shown→sent latency is real time-on-popup), `survey sent`,
+`survey dismissed` (explicit close), `survey abandoned` (`handlePageUnload` →
+`sendSurveyAbandonedEvent`). `$survey_partially_completed` appears on `dismissed` and `abandoned`
+only, never on `sent`. All of them carry `sessionRecordingUrl`, so a disputed submission can be
+**watched** instead of theorised about.
+
+### Never guess response property keys
+
+Response keys come in three formats and the current one is UUID-keyed
+(`$survey_response_<questionId>`). Guessing which UUID belongs to which question is the fastest
+route to a wrong conclusion: it silently reads one question's answers under another's label, and
+the resulting ratio looks like a serious bug. Either take the ids from `questions[].id` and name
+the columns explicitly, or unroll `$survey_questions`. Formats and query templates:
+[references/reading-responses.md](references/reading-responses.md),
+[references/diagnostic-queries.md](references/diagnostic-queries.md).
+
+**Sanity check the mapping before trusting the numbers:** if a column you labelled as a
+single-choice question contains free text, the mapping is wrong.
 
 ## Debugging workflow
 
@@ -95,13 +174,28 @@ Two non-obvious facts that drive real tickets:
 
 3. **Platform parity check.** Confirm the `lib` and consult the parity table. Eliminate features the platform doesn't support before investigating them.
 
-4. **Pull the survey definition.** `GET /api/projects/<id>/surveys/<sid>/`. Inspect `conditions` (events, url, seenSurveyWaitPeriodInDays), `appearance.surveyPopupDelaySeconds`, `schedule`, `linked_flag`, `targeting_flag`, `internal_targeting_flag.filters`, `responses_limit`, `iteration_*`.
+4. **Pull the survey definition.** `GET /api/projects/<id>/surveys/<sid>/`. Inspect `conditions` (events, url, seenSurveyWaitPeriodInDays, repeatedActivation), `appearance.surveyPopupDelaySeconds`, `appearance.position`, `schedule`, `linked_flag`, `targeting_flag`, `internal_targeting_flag.filters`, `responses_limit`, `iteration_*`, `enable_partial_responses` — and then go **inside each question**: `id`, `type`, `scale`, `optional`, `skipSubmitButton`, `branching`. The per-question fields answer most "wrong data" tickets on their own and are easy to miss, since a shallow look at top-level keys doesn't surface them.
 
 5. **Pull the targeting-flag activity log** for any "stopped showing" ticket. Cohort swaps and rollout changes are invisible in the current config but show up here: `GET /api/projects/<id>/activity_log/?scope=FeatureFlag&item_id=<flag_id>&limit=20`. Also `?scope=Survey&item_id=<sid>` to see whether the survey itself was edited.
 
 6. **Confirm with events.** Use `$feature_flag_called` to see what the gating flag actually returned for affected users, and whether `$groups` is set (see group-aggregation cause below). Use `survey shown` to see real reach vs the stats UI.
 
 7. **Diagnose against the known-cause catalog**, confirm with one targeted query, then write the reply.
+
+## Before you call it an SDK bug
+
+These tickets attract a specific failure mode: the symptom looks impossible, so the SDK gets blamed
+and the customer is told to pause the survey, file a bug, and rebuild their questions. That advice
+is expensive and hard to walk back — restructuring destroys the comparability of every response
+already collected, and reordering questions risks the UUID problem below. Clear all four gates
+before writing "this is a bug":
+
+1. **Read the survey JSON**, per-question `branching`, `optional`, `skipSubmitButton` and `scale` included. Most "impossible" behaviour is configured behaviour.
+2. **Reproduce it in Preview.**
+3. **Read the SDK source for the handler you're accusing.** Grep the symbol; don't reason from what a setting is named. `enable_partial_responses` and "all questions answered" both mean something narrower than they sound.
+4. **Re-check your own query before trusting a shocking ratio.** "89% of responses are incomplete" is more often a bad response-key mapping than a real defect.
+
+If it survives all four it's a bug: name the file and handler, and file it upstream.
 
 ## Known-cause catalog
 
@@ -120,6 +214,21 @@ Ordered roughly by how often they're the answer.
 - **Customer wired the survey to the wrong flag.** They create a flag with email/property targeting but the survey's `linked_flag`/`targeting_flag` points at a _different_ flag. Always confirm the actual `linked_flag.key` / `targeting_flag.key` from the API — don't trust the customer's description.
 - **Behavioral cohort in a realtime flag.** A cohort with `performed_event`/behavioral filters can't be evaluated in realtime flag bytecode (`"Unsupported behavioral filter for realtime bytecode"`, `posthog/api/cohort.py`). The cohort shows a `bytecode_error`. Surveys/flags can't use it directly — the customer must make a _static_ copy of the cohort and target that.
 
+### "Responses are incomplete — only the first question has a value"
+
+Usually not a bug — see [How a response actually gets stored](#how-a-response-actually-gets-stored). Work these four first; only then is the completion condition genuinely not being honoured.
+
+- **Branching skipped the blank questions.** Map it from `questions[].branching` yourself. Customers describe their intent, which may not be what's saved, and a rating bucket absent from `responseValues` falls through to the next index.
+- **The blank questions are `optional: true`** and the respondent clicked past them. A rating plus two skipped optional open-text questions is a _complete_ submission with one value in it.
+- **Partial responses is on** and you're reading intermediate events in raw SQL that the UI collapses by `$survey_submission_id`.
+- **The response keys were guessed.** Re-run keyed off `questions[].id`.
+
+### "The respondent says they didn't mean to submit"
+
+- **`skipSubmitButton`, shown in the editor as "Automatically submit on selection".** When true no submit button renders at all (`BottomSection.tsx`) and one click both records the answer and advances — `setRating(response)` then `handleSubmit(response)` → `onNextButtonClick` in the same handler invocation, no debounce, no confirm. Rating and single-choice-without-open-choice only (`canQuestionSkipSubmitButton`); web-only. It is **on by default in every survey template** (`constants.tsx`) and in quick-create, so customers rarely know they enabled it.
+- **It compounds with popup placement.** `appearance.position: middle_center`, a large `maxWidth`, and a non-zero `surveyPopupDelaySeconds` mean the popup materialises seconds after the trigger under a cursor that's still moving, and the next click lands on an answer. Consecutive auto-submitting questions let someone click through most of a survey without reading it.
+- **Diagnose with shown→sent latency,** then confirm from the replay (`sessionRecordingUrl` on `survey sent`). A cluster of sub-10-second completions on a multi-question survey is the signature; genuine respondents take longer and leave text behind. Fix is to uncheck the setting — **not** to move the question, since the behaviour follows the question wherever it sits.
+
 ### "Responses show as zero in the UI but raw events exist"
 
 - **Max AI corrupted the survey definition.** Max's `edit_survey` tool (`products/surveys/backend/max_tools.py`) has two failure modes: (a) on reorder/edit it rebuilds each question from `QUESTION_TYPE_MAP` (`nps`→scale 10, `csat`→scale 5, etc.), so picking the wrong semantic type silently changes a question's scale; (b) the `id` field expects 1-indexed labels (`"1"`,`"2"`) — passing a real UUID falls through and a _fresh_ UUID is generated, so responses keyed by `$survey_response_<old_uuid>` no longer join to the question. Raw events are intact; only the definition is wrong. Fix: PATCH the `questions` array back to the original UUIDs (recoverable from the response events) and restore the question type. Tell the customer to edit question _text_ via the UI, and avoid asking Max to reorder questions on a survey with historical responses until the tool guards UUIDs.
@@ -132,6 +241,7 @@ Ordered roughly by how often they're the answer.
 
 - **Aged tickets are dirty.** Config may have been edited by the customer or a prior agent during troubleshooting. Pull activity logs; frame secondary findings as "while you're in there, double-check X" rather than "we found X is broken."
 - **The stats UI can undercount vs raw `survey shown` events.** If the numbers don't reconcile, trust the raw events and flag the discrepancy as a separate follow-up.
+- **Check both `$email` and `email` on the person.** `person.properties.$email` is what the SDKs set; plenty of customers also set a bare `email`. Querying one and concluding "this user was never identified" is a common miss — use `coalesce(person.properties.$email, person.properties.email)`.
 
 ## Diagnostic queries
 
@@ -161,7 +271,8 @@ fixes, clear with no jargon). Rules:
 
 - **Lead with the cause, then the fix.** One line on what's happening, then what to do.
 - **Bold the issue and bold each action.** Make the problem and the next step scannable.
-- **Use the labels the customer sees in the UI,** never internal field names. Grep `frontend/src/scenes/surveys/` for the real string. E.g. `surveyPopupDelaySeconds` → "Delay survey popup by at least N seconds once the display conditions are met"; the wait period is "Survey wait period" / "Don't show this survey if another one was shown to the user in the last N days". The customer's own event names stay verbatim.
+- **Use the labels the customer sees in the UI,** never internal field names. Grep `frontend/src/scenes/surveys/` for the real string. E.g. `surveyPopupDelaySeconds` → "Delay survey popup by at least N seconds once the display conditions are met"; the wait period is "Survey wait period" / "Don't show this survey if another one was shown to the user in the last N days"; `skipSubmitButton` → "Automatically submit on selection"; `enable_partial_responses` → the "Response collection" radio ("Any question…" / "Complete survey…"); `optional` → the question's "Optional" toggle. The customer's own event names stay verbatim.
+- **When correcting an earlier wrong answer, say so plainly and early,** then give the real cause. Don't bury it or let the customer keep acting on advice we've retracted. If they've already been told to pause or rebuild something, tell them explicitly that they can stop.
 - **Link every PostHog entity** by ID. Cohorts: `https://<us|eu>.posthog.com/project/<id>/cohorts/<cohort_id>`. Flags: `.../feature_flags/<flag_id>`. Surveys: `.../surveys/<survey_id>`. Match the customer's instance (US vs EU).
 - **Predict the expected outcome** so the customer can verify the fix worked ("you should see ~X going forward").
 - **Gauge the customer's technical level.** If they can run SQL and hit the API, offer the patch path. If not, offer to apply the fix ourselves (and confirm any destructive detail first).

--- a/products/surveys/skills/debugging-surveys/SKILL.md
+++ b/products/surveys/skills/debugging-surveys/SKILL.md
@@ -173,7 +173,7 @@ have no survey JSON, unroll `$survey_questions`, which carries the question text
 answer. Formats and templates: [references/reading-responses.md](references/reading-responses.md),
 [references/diagnostic-queries.md](references/diagnostic-queries.md).
 
-**Sanity check the mapping before trusting the numbers:** if a column you labelled as a
+**Sanity check the mapping before trusting the numbers:** if a column you labeled as a
 single-choice question contains free text, the mapping is wrong.
 
 ## Debugging workflow
@@ -228,7 +228,7 @@ Ordered roughly by how often they're the answer.
 
 ### "Responses are incomplete — only the first question has a value"
 
-Usually not a bug — see [How a response actually gets stored](#how-a-response-actually-gets-stored). Work these four first; only then is the completion condition genuinely not being honoured.
+Usually not a bug — see [How a response actually gets stored](#how-a-response-actually-gets-stored). Work these four first; only then is the completion condition genuinely not being honored.
 
 - **Branching skipped the blank questions.** Map it from `questions[].branching` yourself. Customers describe their intent, which may not be what's saved, and a rating bucket absent from `responseValues` falls through to the next index.
 - **The blank questions are `optional: true`** and the respondent clicked past them. A rating plus two skipped optional open-text questions is a _complete_ submission with one value in it.

--- a/products/surveys/skills/debugging-surveys/SKILL.md
+++ b/products/surveys/skills/debugging-surveys/SKILL.md
@@ -172,6 +172,8 @@ single-choice question contains free text, the mapping is wrong.
 
 2. **Disambiguate "none" vs "fewer."** Customers say "no responses" when they mean "fewer." Pull the `survey shown` vs `survey sent` counts before/after the suspected change (see [references/diagnostic-queries.md](references/diagnostic-queries.md)). If the _response rate_ (sent/shown) is stable, the problem is upstream eligibility (fewer people shown), not rendering or submission. This single check redirects most investigations correctly.
 
+2b. **For a data-quality ticket, disambiguate "incomplete" vs "complete but sparse."** Before anything else, check whether the blank cells are questions the respondent was never asked. Branching plus optional questions makes a complete response look abandoned, and this is the single most common reason a survey gets reported as broken when it isn't. See [How a response actually gets stored](#how-a-response-actually-gets-stored).
+
 3. **Platform parity check.** Confirm the `lib` and consult the parity table. Eliminate features the platform doesn't support before investigating them.
 
 4. **Pull the survey definition.** `GET /api/projects/<id>/surveys/<sid>/`. Inspect `conditions` (events, url, seenSurveyWaitPeriodInDays, repeatedActivation), `appearance.surveyPopupDelaySeconds`, `appearance.position`, `schedule`, `linked_flag`, `targeting_flag`, `internal_targeting_flag.filters`, `responses_limit`, `iteration_*`, `enable_partial_responses` — and then go **inside each question**: `id`, `type`, `scale`, `optional`, `skipSubmitButton`, `branching`. The per-question fields answer most "wrong data" tickets on their own and are easy to miss, since a shallow look at top-level keys doesn't surface them.

--- a/products/surveys/skills/debugging-surveys/references/diagnostic-queries.md
+++ b/products/surveys/skills/debugging-surveys/references/diagnostic-queries.md
@@ -57,3 +57,129 @@ WHERE event = 'survey shown' AND timestamp >= toDateTime('<WINDOW_START>')
 GROUP BY survey_id HAVING shown_before > 0 OR shown_after > 0
 ORDER BY shown_before DESC
 ```
+
+## Was partial-response collection ever on?
+
+```sql
+SELECT
+  coalesce(toString(properties.$survey_completed), '(not set)') AS completed,
+  count() AS events,
+  uniq(properties.$survey_submission_id) AS submissions,
+  min(timestamp) AS first_seen, max(timestamp) AS last_seen
+FROM events
+WHERE event = 'survey sent' AND properties.$survey_id = '<SURVEY_ID>'
+  AND timestamp >= now() - INTERVAL 180 DAY
+GROUP BY completed ORDER BY events DESC
+```
+
+Any `completed = false` rows ⇒ `enable_partial_responses` was `true` in that window, so raw
+`survey sent` rows include intermediate saves the UI collapses. `(not set)` ⇒ pre-1.240.0 SDK.
+Compare `events` vs `submissions` to see how much of the gap is partial saves.
+
+## Full event funnel including abandonment
+
+```sql
+SELECT event, count() AS events,
+  uniq(distinct_id) AS people,
+  uniq(properties.$survey_submission_id) AS submissions
+FROM events
+WHERE properties.$survey_id = '<SURVEY_ID>'
+  AND event IN ('survey shown', 'survey sent', 'survey dismissed', 'survey abandoned')
+  AND timestamp >= now() - INTERVAL 180 DAY
+GROUP BY event ORDER BY events DESC
+```
+
+`events` well above `people` on `survey sent` ⇒ repeat responders, usually `schedule: 'always'`
+bypassing the internal targeting flag.
+
+## Every question and its answer, keyed off the survey JSON (preferred)
+
+Take the ids from `questions[].id` and name the columns. Never guess which UUID is which
+question — backtick the property because of the dashes.
+
+```sql
+SELECT timestamp,
+  coalesce(person.properties.$email, person.properties.email) AS email,
+  properties.`$survey_response_<Q1_UUID>` AS q1,
+  properties.`$survey_response_<Q2_UUID>` AS q2,
+  properties.$survey_completed AS completed,
+  properties.$survey_submission_id AS submission_id
+FROM events
+WHERE event = 'survey sent' AND properties.$survey_id = '<SURVEY_ID>'
+  AND timestamp >= now() - INTERVAL 180 DAY
+ORDER BY timestamp DESC LIMIT 60
+```
+
+## Same thing without the survey JSON: unroll `$survey_questions`
+
+`$survey_questions` is an array of `{id, question, response}` over the full question list, so the
+arrays line up positionally with the survey's questions. Note the `ifNull` — without it ClickHouse
+rejects the query with `Nested type Array(String) cannot be inside Nullable type`, because
+`properties.$survey_questions` is `Nullable(String)`.
+
+```sql
+SELECT timestamp,
+  properties.$survey_submission_id AS submission_id,
+  properties.$survey_completed AS completed,
+  arrayMap(x -> JSONExtractString(x, 'question'),
+    JSONExtractArrayRaw(ifNull(toString(properties.$survey_questions), '[]'))) AS questions,
+  arrayMap(x -> JSONExtractRaw(x, 'response'),
+    JSONExtractArrayRaw(ifNull(toString(properties.$survey_questions), '[]'))) AS responses
+FROM events
+WHERE event = 'survey sent' AND properties.$survey_id = '<SURVEY_ID>'
+  AND timestamp >= now() - INTERVAL 180 DAY
+ORDER BY timestamp DESC LIMIT 60
+```
+
+## Answer rate per question (is "incomplete" just branching?)
+
+Cross-tab the branching question's answer against whether the downstream questions got values. If
+the split lines up exactly with the branching rules, the data is fine and the complaint is
+explained.
+
+```sql
+SELECT properties.`$survey_response_<BRANCHING_Q_UUID>` AS branch_answer,
+  count() AS submissions,
+  countIf(coalesce(toString(properties.`$survey_response_<DOWNSTREAM_Q_UUID>`), '') != '') AS answered_downstream
+FROM events
+WHERE event = 'survey sent' AND properties.$survey_id = '<SURVEY_ID>'
+  AND coalesce(toString(properties.$survey_completed), 'true') != 'false'
+  AND timestamp >= now() - INTERVAL 180 DAY
+GROUP BY branch_answer ORDER BY branch_answer
+```
+
+## Shown → sent latency (accidental / stray-click submissions)
+
+`survey shown` fires when the popup becomes visible, _after_ `surveyPopupDelaySeconds`, so this is
+real time-on-popup. A cluster of sub-10-second completions on a multi-question survey points at
+`skipSubmitButton` plus a centred popup rather than considered feedback.
+
+```sql
+SELECT $session_id AS session,
+  minIf(timestamp, event = 'survey shown') AS shown_at,
+  minIf(timestamp, event = 'survey sent') AS sent_at,
+  dateDiff('second', minIf(timestamp, event = 'survey shown'),
+    minIf(timestamp, event = 'survey sent')) AS seconds_to_submit
+FROM events
+WHERE properties.$survey_id = '<SURVEY_ID>'
+  AND event IN ('survey shown', 'survey sent')
+  AND timestamp >= now() - INTERVAL 180 DAY
+GROUP BY session HAVING sent_at > shown_at
+ORDER BY seconds_to_submit ASC LIMIT 60
+```
+
+## Replay link per response (watch a disputed submission)
+
+```sql
+SELECT timestamp, distinct_id,
+  coalesce(person.properties.$email, person.properties.email) AS email,
+  properties.sessionRecordingUrl AS replay_url,
+  properties.$survey_submission_id AS submission_id, $session_id
+FROM events
+WHERE event = 'survey sent' AND properties.$survey_id = '<SURVEY_ID>'
+  AND timestamp >= now() - INTERVAL 180 DAY
+ORDER BY timestamp DESC LIMIT 60
+```
+
+Beats arguing about whether a submission was intentional. Every `survey sent` / `dismissed` /
+`abandoned` event carries `sessionRecordingUrl`.

--- a/products/surveys/skills/debugging-surveys/references/diagnostic-queries.md
+++ b/products/surveys/skills/debugging-surveys/references/diagnostic-queries.md
@@ -182,8 +182,14 @@ SELECT timestamp, distinct_id,
 FROM events
 WHERE event = 'survey sent' AND properties.$survey_id = '<SURVEY_ID>'
   AND timestamp >= now() - INTERVAL 180 DAY
-ORDER BY timestamp DESC LIMIT 60
+ORDER BY timestamp DESC
+LIMIT 1 BY coalesce(nullIf(properties.$survey_submission_id, ''), toString(uuid))
+LIMIT 60
 ```
 
 Beats arguing about whether a submission was intentional. Every `survey sent` / `dismissed` /
-`abandoned` event carries `sessionRecordingUrl`.
+`abandoned` event carries `sessionRecordingUrl`. The `LIMIT 1 BY` collapses partial mode's
+per-question `survey sent` rows to the latest one per submission — matching how the results table
+dedupes — so you get one link per response, not one per intermediate save. The `coalesce` falls
+back to the event UUID for pre-1.240.0 events, which have no `$survey_submission_id`, so those are
+kept as distinct rows rather than folded together.

--- a/products/surveys/skills/debugging-surveys/references/diagnostic-queries.md
+++ b/products/surveys/skills/debugging-surveys/references/diagnostic-queries.md
@@ -89,8 +89,12 @@ WHERE properties.$survey_id = '<SURVEY_ID>'
 GROUP BY event ORDER BY events DESC
 ```
 
-`events` well above `people` on `survey sent` ⇒ repeat responders, usually `schedule: 'always'`
-bypassing the internal targeting flag.
+`events` above `submissions` on `survey sent` is the normal partial-response shape — partial mode
+fires one `survey sent` per question (see above), so the raw event count inflates on its own.
+Compare `submissions` against `people` instead: `submissions` well above `people` ⇒ repeat
+responders, one likely cause being `schedule: 'always'` bypassing the internal targeting flag.
+(`people` is `uniq(distinct_id)`, which one person spread across several IDs inflates, so this
+comparison undercounts repeats rather than inventing them.)
 
 ## Every question and its answer, keyed off the survey JSON (preferred)
 

--- a/products/surveys/skills/debugging-surveys/references/diagnostic-queries.md
+++ b/products/surveys/skills/debugging-surveys/references/diagnostic-queries.md
@@ -99,13 +99,16 @@ comparison undercounts repeats rather than inventing them.)
 ## Every question and its answer, keyed off the survey JSON (preferred)
 
 Take the ids from `questions[].id` and name the columns. Never guess which UUID is which
-question — backtick the property because of the dashes.
+question — backtick the property because of the dashes. Coalesce each UUID key with its legacy
+index key — bare `$survey_response` for the first question, `$survey_response_<N>` for the N-th
+(0-based) — because older responses store the answer under the index key alone and otherwise read
+blank, the same fallback the results table applies.
 
 ```sql
 SELECT timestamp,
   coalesce(person.properties.$email, person.properties.email) AS email,
-  properties.`$survey_response_<Q1_UUID>` AS q1,
-  properties.`$survey_response_<Q2_UUID>` AS q2,
+  coalesce(nullIf(properties.`$survey_response_<Q1_UUID>`, ''), nullIf(properties.$survey_response, '')) AS q1,
+  coalesce(nullIf(properties.`$survey_response_<Q2_UUID>`, ''), nullIf(properties.$survey_response_1, '')) AS q2,
   properties.$survey_completed AS completed,
   properties.$survey_submission_id AS submission_id
 FROM events
@@ -139,12 +142,14 @@ ORDER BY timestamp DESC LIMIT 60
 
 Cross-tab the branching question's answer against whether the downstream questions got values. If
 the split lines up exactly with the branching rules, the data is fine and the complaint is
-explained.
+explained. Coalesce each UUID key with its legacy index key here too — `<..._LEGACY_KEY>` is bare
+`$survey_response` for the first question, `$survey_response_<N>` for the N-th (0-based) — otherwise
+a legacy-keyed answer counts as unanswered and inflates the incomplete ratio.
 
 ```sql
-SELECT properties.`$survey_response_<BRANCHING_Q_UUID>` AS branch_answer,
+SELECT coalesce(nullIf(properties.`$survey_response_<BRANCHING_Q_UUID>`, ''), nullIf(properties.<BRANCHING_Q_LEGACY_KEY>, '')) AS branch_answer,
   count() AS submissions,
-  countIf(coalesce(toString(properties.`$survey_response_<DOWNSTREAM_Q_UUID>`), '') != '') AS answered_downstream
+  countIf(coalesce(nullIf(toString(properties.`$survey_response_<DOWNSTREAM_Q_UUID>`), ''), nullIf(toString(properties.<DOWNSTREAM_Q_LEGACY_KEY>), '')) != '') AS answered_downstream
 FROM events
 WHERE event = 'survey sent' AND properties.$survey_id = '<SURVEY_ID>'
   AND coalesce(toString(properties.$survey_completed), 'true') != 'false'

--- a/products/surveys/skills/debugging-surveys/references/diagnostic-queries.md
+++ b/products/surveys/skills/debugging-surveys/references/diagnostic-queries.md
@@ -187,8 +187,11 @@ LIMIT 1 BY coalesce(nullIf(properties.$survey_submission_id, ''), toString(uuid)
 LIMIT 60
 ```
 
-Beats arguing about whether a submission was intentional. Every `survey sent` / `dismissed` /
-`abandoned` event carries `sessionRecordingUrl`. The `LIMIT 1 BY` collapses partial mode's
+Beats arguing about whether a submission was intentional — when a recording exists. Every
+`survey sent` / `dismissed` / `abandoned` event carries `sessionRecordingUrl`, but that only points
+at a session id: replay is off by default, and the default cloud retention of 30 days is shorter
+than this 180-day window, so the recording may never have been captured or may have aged out. Open
+the link before citing it. The `LIMIT 1 BY` collapses partial mode's
 per-question `survey sent` rows to the latest one per submission — matching how the results table
 dedupes — so you get one link per response, not one per intermediate save. The `coalesce` falls
 back to the event UUID for pre-1.240.0 events, which have no `$survey_submission_id`, so those are

--- a/products/surveys/skills/debugging-surveys/references/diagnostic-queries.md
+++ b/products/surveys/skills/debugging-surveys/references/diagnostic-queries.md
@@ -73,8 +73,15 @@ GROUP BY completed ORDER BY events DESC
 ```
 
 Any `completed = false` rows ⇒ `enable_partial_responses` was `true` in that window, so raw
-`survey sent` rows include intermediate saves the UI collapses. `(not set)` ⇒ pre-1.240.0 SDK.
-Compare `events` vs `submissions` to see how much of the gap is partial saves.
+`survey sent` rows include intermediate saves the UI collapses. Compare `events` vs `submissions`
+to see how much of the gap is partial saves.
+
+`(not set)` does **not** mean an old SDK on its own. Only the web SDK sets `$survey_completed` (and
+`$survey_submission_id`) at all — React Native's `sendSurveyEvent` sets neither, the other mobile
+SDKs don't support partial responses, and an `api`-type survey is captured by the customer's own
+code with whatever properties they choose. So `(not set)` means web SDK below 1.240.0 **or** a
+non-web SDK **or** a hand-rolled `survey sent`. Check the `lib` property before reading it as a
+version signal.
 
 ## Full event funnel including abandonment
 
@@ -98,17 +105,21 @@ comparison undercounts repeats rather than inventing them.)
 
 ## Every question and its answer, keyed off the survey JSON (preferred)
 
-Take the ids from `questions[].id` and name the columns. Never guess which UUID is which
-question — backtick the property because of the dashes. Coalesce each UUID key with its legacy
-index key — bare `$survey_response` for the first question, `$survey_response_<N>` for the N-th
-(0-based) — because older responses store the answer under the index key alone and otherwise read
-blank, the same fallback the results table applies.
+**Use `getSurveyResponse(<index>, '<questionId>')`** — the HogQL helper the product itself uses
+(`posthog/hogql/functions/survey.py`; callers in `products/surveys/backend/responses/`). It
+coalesces the UUID key with the legacy index key for you, so it can't miss an older response the way
+a hand-written `properties.$survey_response_<uuid>` does, and it returns what the results table
+shows the same customer. Pass a third argument `true` for multiple-choice questions so the array is
+unpacked. Both the index and the id must be literal constants.
+
+Take the index and id from `questions[]` in the survey JSON, in order:
 
 ```sql
 SELECT timestamp,
   coalesce(person.properties.$email, person.properties.email) AS email,
-  coalesce(nullIf(properties.`$survey_response_<Q1_UUID>`, ''), nullIf(properties.$survey_response, '')) AS q1,
-  coalesce(nullIf(properties.`$survey_response_<Q2_UUID>`, ''), nullIf(properties.$survey_response_1, '')) AS q2,
+  getSurveyResponse(0, '<Q1_UUID>') AS q1_rating,
+  getSurveyResponse(1, '<Q2_UUID>') AS q2_single_choice,
+  getSurveyResponse(2, '<Q3_UUID>', true) AS q3_multiple_choice,
   properties.$survey_completed AS completed,
   properties.$survey_submission_id AS submission_id
 FROM events
@@ -116,6 +127,10 @@ WHERE event = 'survey sent' AND properties.$survey_id = '<SURVEY_ID>'
   AND timestamp >= now() - INTERVAL 180 DAY
 ORDER BY timestamp DESC LIMIT 60
 ```
+
+Reading the raw property directly is still fine for a one-off sanity check, but backtick it because
+of the dashes — `properties.` `` `$survey_response_<uuid>` `` — and remember it sees only the
+UUID-keyed format.
 
 ## Same thing without the survey JSON: unroll `$survey_questions`
 
@@ -142,14 +157,12 @@ ORDER BY timestamp DESC LIMIT 60
 
 Cross-tab the branching question's answer against whether the downstream questions got values. If
 the split lines up exactly with the branching rules, the data is fine and the complaint is
-explained. Coalesce each UUID key with its legacy index key here too — `<..._LEGACY_KEY>` is bare
-`$survey_response` for the first question, `$survey_response_<N>` for the N-th (0-based) — otherwise
-a legacy-keyed answer counts as unanswered and inflates the incomplete ratio.
+explained.
 
 ```sql
-SELECT coalesce(nullIf(properties.`$survey_response_<BRANCHING_Q_UUID>`, ''), nullIf(properties.<BRANCHING_Q_LEGACY_KEY>, '')) AS branch_answer,
+SELECT getSurveyResponse(<BRANCH_IDX>, '<BRANCHING_Q_UUID>') AS branch_answer,
   count() AS submissions,
-  countIf(coalesce(nullIf(toString(properties.`$survey_response_<DOWNSTREAM_Q_UUID>`), ''), nullIf(toString(properties.<DOWNSTREAM_Q_LEGACY_KEY>), '')) != '') AS answered_downstream
+  countIf(coalesce(getSurveyResponse(<DOWN_IDX>, '<DOWNSTREAM_Q_UUID>'), '') != '') AS answered_downstream
 FROM events
 WHERE event = 'survey sent' AND properties.$survey_id = '<SURVEY_ID>'
   AND coalesce(toString(properties.$survey_completed), 'true') != 'false'
@@ -157,25 +170,50 @@ WHERE event = 'survey sent' AND properties.$survey_id = '<SURVEY_ID>'
 GROUP BY branch_answer ORDER BY branch_answer
 ```
 
+`getSurveyResponse` matters more here than in a browsing query: a legacy-keyed answer read through
+the raw UUID property counts as unanswered inside `countIf`, which inflates the very "incomplete"
+ratio you're trying to disprove.
+
 ## Shown → sent latency (accidental / stray-click submissions)
 
 `survey shown` fires when the popup becomes visible, _after_ `surveyPopupDelaySeconds`, so this is
 real time-on-popup. A cluster of sub-10-second completions on a multi-question survey points at
-`skipSubmitButton` plus a centred popup rather than considered feedback.
+`skipSubmitButton` plus a centered popup rather than considered feedback.
+
+Pair each response with the `survey shown` **immediately before it**, not with the first one in the
+session. Grouping by `$session_id` alone silently drops repeat submissions: a `schedule: 'always'`
+survey can be shown and answered twice in one session, and `minIf` then pairs the first display with
+the first response and discards the rest. `survey shown` carries no `$survey_submission_id`, so
+there's no shared key to join on — carry the last-seen display forward with a window function
+instead. The filter on that result needs the subquery, since a window function can't be referenced
+from the same `WHERE`.
 
 ```sql
-SELECT $session_id AS session,
-  minIf(timestamp, event = 'survey shown') AS shown_at,
-  minIf(timestamp, event = 'survey sent') AS sent_at,
-  dateDiff('second', minIf(timestamp, event = 'survey shown'),
-    minIf(timestamp, event = 'survey sent')) AS seconds_to_submit
-FROM events
-WHERE properties.$survey_id = '<SURVEY_ID>'
-  AND event IN ('survey shown', 'survey sent')
-  AND timestamp >= now() - INTERVAL 180 DAY
-GROUP BY session HAVING sent_at > shown_at
-ORDER BY seconds_to_submit ASC LIMIT 60
+SELECT session, submission_id, shown_at, sent_at,
+  dateDiff('second', shown_at, sent_at) AS seconds_to_submit
+FROM (
+  SELECT $session_id AS session, event, timestamp AS sent_at,
+    coalesce(nullIf(properties.$survey_submission_id, ''), toString(uuid)) AS submission_id,
+    max(if(event = 'survey shown', timestamp, NULL)) OVER (
+      PARTITION BY $session_id ORDER BY timestamp
+      ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+    ) AS shown_at
+  FROM events
+  WHERE properties.$survey_id = '<SURVEY_ID>'
+    AND event IN ('survey shown', 'survey sent')
+    AND timestamp >= now() - INTERVAL 180 DAY
+)
+WHERE event = 'survey sent' AND shown_at IS NOT NULL
+ORDER BY seconds_to_submit ASC
+LIMIT 1 BY submission_id
+LIMIT 60
 ```
+
+In partial-response mode this measures **time to first answer**, because `LIMIT 1 BY submission_id`
+after an ascending sort keeps each submission's earliest row. That's the right signal for a stray
+click — how fast something got clicked — but it is not time to completion, so don't relabel it.
+Events with no submission id (non-web SDKs, pre-1.240.0 web) fall back to the event UUID and stay as
+separate rows.
 
 ## Replay link per response (watch a disputed submission)
 

--- a/products/surveys/skills/debugging-surveys/references/reading-responses.md
+++ b/products/surveys/skills/debugging-surveys/references/reading-responses.md
@@ -1,0 +1,62 @@
+# Reading survey config and response data
+
+Lookup tables for interpreting a survey's branching and its stored responses. The rules that
+matter during triage are in SKILL.md; this file is the detail you check rather than remember.
+
+## Rating branching buckets
+
+`response_based` branching on a rating question is keyed by _bucket_, not by the value the
+respondent picked (`getRatingBucketForResponseValue`,
+`packages/browser/src/utils/survey-branching.ts`):
+
+| Scale | Buckets                                        |
+| ----- | ---------------------------------------------- |
+| 2     | `1 → positive`, `2 → negative`                 |
+| 3     | `1 negative`, `2 neutral`, `3 positive`        |
+| 5     | `≤2 negative`, `=3 neutral`, `≥4 positive`     |
+| 7     | `≤3 negative`, `=4 neutral`, `≥5 positive`     |
+| 10    | `≤6 detractors`, `≤8 passives`, `≥9 promoters` |
+
+**Scale 2 is inverted** relative to the others: it's a thumbs up/down where 1 is the thumbs-up, so
+`1 → positive`. Easy to get backwards when tracing a path by hand.
+
+A bucket **absent** from `responseValues` falls through to `currentQuestionIndex + 1`, so a config
+that only lists some buckets is usually deliberate rather than broken. An out-of-range response
+throws (`'The response must be in range 1-5'`), as does an unsupported scale.
+
+## Single-choice branching
+
+`responseValues` is keyed by choice index as a string: `{"0": 2, "1": 4}`. With `hasOpenChoice`, a
+response not found in `choices` is treated as the **last** choice index. Values are either an
+integer question index or the string `end`.
+
+## Response property key formats
+
+All produced by `buildSurveyResponseProperties` (`packages/core/src/surveys/events.ts`), and a
+single event can carry both the current and the legacy format:
+
+| Key                             | When                                                   |
+| ------------------------------- | ------------------------------------------------------ |
+| `$survey_response_<questionId>` | current; UUID-keyed, stable across question reorders   |
+| `$survey_response`              | legacy, for `originalQuestionIndex === 0`              |
+| `$survey_response_<N>`          | legacy index, only when `originalQuestionIndex` is set |
+
+Question ids are UUIDs assigned by the backend, so **the key does not tell you which question it
+belongs to.** Read `questions[].id` from the survey JSON and name your columns from it.
+
+## `$survey_questions`
+
+Present on every `survey sent` / `dismissed` / `abandoned` event: an array of
+`{id, question, response}` over the **full** question list, in survey order. Useful when you don't
+have the survey JSON, since it carries the question text alongside the answer. Questions never
+reached have `response` absent.
+
+Values to expect in `response`:
+
+| Situation                              | Stored as                                    |
+| -------------------------------------- | -------------------------------------------- |
+| Answered                               | string, number, or array (multiple choice)   |
+| Reached but skipped (`optional: true`) | `null`                                       |
+| Skipped by branching                   | key absent entirely (pruned to visited path) |
+
+That last row is the one that makes a complete response look incomplete.

--- a/products/surveys/skills/debugging-surveys/references/reading-responses.md
+++ b/products/surveys/skills/debugging-surveys/references/reading-responses.md
@@ -44,6 +44,16 @@ single event can carry both the current and the legacy format:
 Question ids are UUIDs assigned by the backend, so **the key does not tell you which question it
 belongs to.** Read `questions[].id` from the survey JSON and name your columns from it.
 
+Rather than picking a format yourself, read answers with the HogQL helper
+`getSurveyResponse(<index>, '<questionId>')` (`posthog/hogql/functions/survey.py`). It builds the
+UUID key and coalesces it with the legacy index key, which is what every first-party read in
+`products/surveys/backend/` does, so your numbers match the customer's results table. A third
+argument `true` unpacks multiple-choice arrays. Both the index and the id must be literal constants.
+
+Only the **web** SDK sets `$survey_completed` and `$survey_submission_id`. React Native's
+`sendSurveyEvent` sets neither, and an `api`-type survey carries whatever the customer's own code
+captures — so a missing `$survey_completed` is not by itself evidence of an old SDK.
+
 ## `$survey_questions`
 
 Present on every `survey sent` / `dismissed` / `abandoned` event: an array of


### PR DESCRIPTION
## Why

A Surveys support ticket was diagnosed as a posthog-js bug: *"clicking a rating fires `survey sent` immediately, so the completion condition is not enforced for rating questions."* On that basis the customer was told to pause their survey, file a bug report, and restructure all five questions plus their branching.

None of that was right. The survey was working exactly as configured, and the advice cost the customer real work. Two separate things produced the illusion:

1. **"Complete survey: the response is stored when all questions are answered" does not mean that.** `isSurveyCompleted` is `getNextSurveyStep(...) === End`, i.e. the respondent reached the end of *their* branching path. Questions skipped by branching are pruned from the payload entirely (`responsesOnPath` over `visitedIndices`), and `optional: true` questions clicked past are stored as `null`. On a branching survey with optional tail questions, "only the first question was answered" is the **expected shape of a complete response**.

2. **A guessed response-key mapping produced a fake statistic.** The investigation guessed two `$survey_response_<uuid>` keys and reported "89% of responses are incomplete." The column it labelled as the single-choice question actually held free text, which was the tell. Re-run keyed off `questions[].id`, the survey was fine: every 4–5 rater answered the required follow-up, every "Ja" answered the next question, and no low rater answered anything they were never shown.

The genuine issue turned out to be `skipSubmitButton` ("Automatically submit on selection"), which is **on by default in every survey template** and hides the submit button so a single click both answers and advances. Combined with a centred popup and a non-zero display delay, a stray click is a submitted rating.

The skill had zero coverage of `enable_partial_responses`, `skipSubmitButton`, or how to read a response payload. So it gets that, plus a gate for the failure mode that actually caused the wrong call.

## What changed

`SKILL.md`, +112 lines on 204:

- **New `## How a response actually gets stored`.** The completion semantics above; `enable_partial_responses` and its two conflicting defaults (`NEW_SURVEY` is `true`, the Django model is `False`, so UI-created and API-created surveys differ); that partial mode fires one `survey sent` per question and the results table collapses them by `argMax(uuid, timestamp)` per `$survey_submission_id`, so raw SQL shows far more rows than the UI; the `shown` / `sent` / `dismissed` / `abandoned` vocabulary and which of them carry `$survey_partially_completed`; and a hard rule against guessing response keys.
- **Branching is in the API.** The prior investigation asserted it wasn't and asked the customer to re-explain their logic by hand. It's `questions[].branching`, returned verbatim. Documents the two traps: rating `responseValues` is keyed by *bucket* not value, and a bucket absent from `responseValues` silently falls through to the next index, so a partial-looking config is often complete.
- **New `## Before you call it an SDK bug`,** four gates. Read the survey JSON including per-question fields, reproduce in Preview, read the source for the handler you're accusing, and re-check your own query before trusting a shocking ratio.
- **Two new known causes** plus a workflow step so a sparse-response ticket routes correctly from the top of the file rather than only from the reference section.
- Parity rows for `enable_partial_responses` and `skipSubmitButton`, both web-only. Flagged inline that those two rows come from the editor's help text rather than a per-SDK source audit, unlike the rest of that table.
- The `$email` vs `email` gotcha, which is why the investigation wrongly concluded the affected respondent had never been identified.

New `references/reading-responses.md`, and `references/diagnostic-queries.md` gains seven templates. The lookup detail lives in references rather than the always-loaded skill: rating bucket boundaries per scale (scale 2 is inverted), the three response-key formats, and the `$survey_questions` shape including what a branch-skipped versus optional-blank answer looks like.

Query highlights: the `$survey_questions` unroll, which needs an `ifNull` to avoid `Nested type Array(String) cannot be inside Nullable type` since `properties.$survey_questions` is `Nullable(String)`; shown-to-sent latency, which cleanly separated stray clicks from real feedback on the ticket that prompted this; and the replay-link query, since every response carries `sessionRecordingUrl` and a disputed submission can be watched rather than argued about.

## Notes for review

- Every behavioural claim was read from source in `posthog-js` (`main`) and this repo, and re-verified by symbol rather than line number. The two version floors (1.240.0, 1.244.0) and the mobile gaps come from the survey editor's own help strings.
- Deliberately kept out: a `shuffleQuestions` note, an `isNpsQuestion` template-leftover note, and a `JSONExtractKeys` key-discovery query I couldn't verify. All true or plausible, none load-bearing, and this file is loaded on every Surveys ticket.
- No customer data in any of it.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*