### PR TITLE
fix(skills): move community skills under /skills/community

### DIFF
--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -225,7 +225,7 @@ export const productRoutes: Record<string, [string, string]> = {
     '/skills': ['Skills', 'skills'],
     '/skills/scouts': ['Skills', 'skillsScouts'],
     '/skills/review-hog': ['Skills', 'skillsReviewHog'],
-    '/community-skills': ['CommunitySkills', 'communitySkills'],
+    '/skills/community': ['CommunitySkills', 'communitySkills'],
     '/skills/:name': ['Skill', 'skill'],
     '/stamphog': ['Stamphog', 'stamphog'],
     '/stamphog/runs': ['StamphogRuns', 'stamphogRuns'],
@@ -414,6 +414,8 @@ export const productRedirects: Record<
     '/mcp-analytics': (_params, searchParams, hashParams) =>
         combineUrl(urls.mcpAnalyticsDashboard(), { ...searchParams, landing: 'auto' }, hashParams).url,
     '/replay-vision/templates': '/replay-vision/new/template',
+    '/community-skills': (_params, searchParams, hashParams) =>
+        combineUrl(urls.communitySkills(), searchParams, hashParams).url,
     '/prompt-management/skills': (_params, searchParams, hashParams) =>
         combineUrl(urls.skills(), searchParams, hashParams).url,
     '/prompt-management/skills/:name': (params, searchParams, hashParams) =>
@@ -1438,7 +1440,7 @@ export const productUrls = {
             version?: number
         }
     ): string => combineUrl(`/skills/${name}`, params).url,
-    communitySkills: (): string => '/community-skills',
+    communitySkills: (): string => '/skills/community',
     stamphog: (): string => '/stamphog',
     stamphogRuns: (): string => '/stamphog/runs',
     stamphogDigests: (): string => '/stamphog/digests',

--- a/products/skills/backend/api/skill_serializers.py
+++ b/products/skills/backend/api/skill_serializers.py
@@ -20,9 +20,9 @@ from .skill_services import (
 )
 
 # Skill names that collide with reserved /skills routes and so can't be used: "new" is the create
-# form, and the rest mirror the category-tab slugs registered under /skills/<slug> in
+# form, and the rest mirror the tab slugs registered under /skills/<slug> in
 # products/skills/manifest.tsx — a skill with such a name would be shadowed by its tab route.
-RESERVED_SKILL_NAMES = {"new", "scouts", "review-hog"}
+RESERVED_SKILL_NAMES = {"new", "scouts", "review-hog", "community"}
 # Bundled-file paths that would collide with generated artifacts in the exported skill
 # tree / plugin marketplace (the rendered SKILL.md). Compared case-insensitively.
 RESERVED_SKILL_FILE_PATHS = {"skill.md"}

--- a/products/skills/backend/api/test/test_skills.py
+++ b/products/skills/backend/api/test/test_skills.py
@@ -152,6 +152,7 @@ class TestLLMSkillAPI(APIBaseTest):
             ("reserved_new", "new"),
             ("reserved_scouts", "scouts"),
             ("reserved_review_hog", "review-hog"),
+            ("reserved_community", "community"),
         ]
     )
     def test_create_skill_validates_name_format(self, _label, skill_name):

--- a/products/skills/backend/tools/skills.py
+++ b/products/skills/backend/tools/skills.py
@@ -11,6 +11,7 @@ from posthog.rbac.user_access_control import AccessControlLevel
 from posthog.scopes import APIScopeObject
 from posthog.sync import database_sync_to_async
 
+from products.skills.backend.api.skill_serializers import RESERVED_SKILL_NAMES
 from products.skills.backend.api.skill_services import (
     LLMSkillDuplicateNameConflictError,
     LLMSkillEditError,
@@ -388,6 +389,11 @@ class CreateLLMSkillTool(MaxTool):
         metadata: dict[str, Any] | None = None,
         files: list[dict[str, str]] | None = None,
     ) -> tuple[str, None]:
+        # The tool calls create_skill directly, which skips the serializer's name validation, so a
+        # reserved name would persist a skill whose /skills/<name> page is taken by a tab route.
+        if name.lower() in RESERVED_SKILL_NAMES:
+            raise MaxToolFatalError(f"'{name}' is a reserved name and cannot be used for a skill.")
+
         try:
             skill = await database_sync_to_async(create_skill)(
                 self._team,

--- a/products/skills/backend/tools/test_skills.py
+++ b/products/skills/backend/tools/test_skills.py
@@ -194,6 +194,14 @@ class TestCreateLLMSkillTool(BaseTest):
         assert first_file is not None
         assert first_file.path == "scripts/mandelbrot.py"
 
+    def test_reserved_name_raises_fatal(self):
+        tool = CreateLLMSkillTool(team=self.team, user=self.user)
+
+        with self.assertRaisesRegex(MaxToolFatalError, "reserved name"):
+            _run(tool, name="community", description="d", body="b")
+
+        assert not LLMSkill.objects.filter(team=self.team, name="community").exists()
+
     def test_duplicate_name_raises_fatal(self):
         LLMSkill.objects.create(team=self.team, name="dup", description="d", body="b")
 

--- a/products/skills/frontend/SkillsSceneShell.tsx
+++ b/products/skills/frontend/SkillsSceneShell.tsx
@@ -11,7 +11,7 @@ import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 
 import { DEFAULT_SKILLS_TAB_KEY, skillTabUrl, skillTabsLogic, visibleCategoryTabs } from './skillTabsLogic'
 
-/** Tab key for the Community scene, which lives at its own URL rather than under /skills. */
+/** Tab key for the Community scene, and its `/skills/<key>` URL segment. */
 export const COMMUNITY_SKILLS_TAB_KEY = 'community'
 
 export const COMMUNITY_SKILLS_TAB_DESCRIPTION = 'Discover and install agent skills shared by the PostHog community.'
@@ -21,11 +21,11 @@ export const COMMUNITY_SKILLS_TAB_DESCRIPTION = 'Discover and install agent skil
  * category tabs (Scouts, Code review), then "Community" — so the category tabs and Community sit
  * in the same row instead of stacking two bars.
  *
- * Community is a separate scene at its own URL, so each scene renders this with only its own tab's
- * content; the other tabs navigate via their `link` and are never mounted here. That keeps the two
- * scenes' logics (and URL contracts) independent while presenting them as one tabbed surface. The
- * Community tab is gated behind the community-skills flag (but stays visible when it's already the
- * active tab, so a direct URL still renders cleanly).
+ * Community is a separate scene (at /skills/community), so each scene renders this with only its own
+ * tab's content; the other tabs navigate via their `link` and are never mounted here. That keeps the
+ * two scenes' logics independent while presenting them as one tabbed surface. The Community tab is
+ * gated behind the community-skills flag (but stays visible when it's already the active tab, so a
+ * direct URL still renders cleanly).
  */
 export function SkillsSceneShell({
     activeTabKey,

--- a/products/skills/frontend/skillConstants.ts
+++ b/products/skills/frontend/skillConstants.ts
@@ -4,10 +4,10 @@ export const SKILL_DESCRIPTION_MAX_LENGTH = 4096
 export const SKILL_FILE_MAX_BYTES = 1_000_000
 export const SKILL_FILE_MAX_COUNT = 200
 
-// Names that collide with reserved /skills routes: 'new' (the create form) and the category-tab
-// slugs registered under /skills/<slug> in manifest.tsx. A skill with one of these names would be
+// Names that collide with reserved /skills routes: 'new' (the create form) and the tab slugs
+// registered under /skills/<slug> in manifest.tsx. A skill with one of these names would be
 // shadowed by its route. Kept in sync with RESERVED_SKILL_NAMES in the backend skill_serializers.
-const RESERVED_SKILL_NAMES = new Set(['new', 'scouts', 'review-hog'])
+const RESERVED_SKILL_NAMES = new Set(['new', 'scouts', 'review-hog', 'community'])
 
 export function validateSkillName(name: string): string | undefined {
     if (!name?.trim()) {

--- a/products/skills/manifest.tsx
+++ b/products/skills/manifest.tsx
@@ -35,8 +35,9 @@ export const manifest: ProductManifest = {
     },
     routes: {
         '/skills': ['Skills', 'skills'],
-        // Category tabs (e.g. /skills/scouts) must precede the `/skills/:name` wildcard so they
-        // aren't captured as a skill named after the tab. Route order = match precedence.
+        // Tab routes (e.g. /skills/scouts) must precede the `/skills/:name` wildcard so they
+        // aren't captured as a skill named after the tab. Route order = match precedence. Every
+        // slug here is also in RESERVED_SKILL_NAMES so no skill can claim a shadowed name.
         '/skills/scouts': ['Skills', 'skillsScouts'],
         '/skills/review-hog': ['Skills', 'skillsReviewHog'],
         '/skills/community': ['CommunitySkills', 'communitySkills'],

--- a/products/skills/manifest.tsx
+++ b/products/skills/manifest.tsx
@@ -39,10 +39,12 @@ export const manifest: ProductManifest = {
         // aren't captured as a skill named after the tab. Route order = match precedence.
         '/skills/scouts': ['Skills', 'skillsScouts'],
         '/skills/review-hog': ['Skills', 'skillsReviewHog'],
-        '/community-skills': ['CommunitySkills', 'communitySkills'],
+        '/skills/community': ['CommunitySkills', 'communitySkills'],
         '/skills/:name': ['Skill', 'skill'],
     },
     redirects: {
+        '/community-skills': (_params, searchParams, hashParams) =>
+            combineUrl(urls.communitySkills(), searchParams, hashParams).url,
         '/prompt-management/skills': (_params, searchParams, hashParams) =>
             combineUrl(urls.skills(), searchParams, hashParams).url,
         '/prompt-management/skills/:name': (params, searchParams, hashParams) =>
@@ -58,7 +60,7 @@ export const manifest: ProductManifest = {
         skillsCategoryTab: (categoryTab: string): string => `/skills/${categoryTab}`,
         skill: (name: string, params?: { file?: string; version?: number }): string =>
             combineUrl(`/skills/${name}`, params).url,
-        communitySkills: (): string => '/community-skills',
+        communitySkills: (): string => '/skills/community',
     },
     fileSystemTypes: {},
     treeItemsNew: [],


### PR DESCRIPTION
## Problem

The Community tab in Skills was the only tab that jumped the user to a different top-level URL: `/community-skills`, while Skills, Scouts and Code review all sit under `/skills`.

## Changes

- The Community tab now opens at `/skills/community`, matching the other tabs in the same tab bar.
- `/community-skills` redirects to the new path, keeping search and hash params, so existing links and bookmarks still land on the page.
- Nothing looks different: the scene, tab bar and copy are unchanged, and the route sits before the `/skills/:name` wildcard so it is not read as a skill named "community".
- A skill can no longer be named `community`, since `/skills/community` would shadow its detail page. The `scouts` and `review-hog` tab slugs are reserved for the same reason.
- Max can no longer create a skill under a reserved name either. Its create tool called the shared service directly, past the serializer that rejects those names.
- The rest is mechanical: `frontend/src/products.tsx` is regenerated from the manifest, and two comments in `SkillsSceneShell.tsx` no longer say the scene lives outside `/skills`.

## How did you test this code?

- Ran `products/skills/frontend/communitySkillsLogic.test.ts` (Jest), which pushes `urls.communitySkills()` and reads filters back off the URL. It passes on the new path.
- Not checked in a browser: this sandbox has no running app, so the redirect and tab navigation were not exercised by hand.
- Added one case to the parameterized reserved-name test in `test_skills.py`, next to the existing `scouts` and `review-hog` cases. It catches a create call that claims `community` and lands a skill the router cannot reach.
- Added one case to `products/skills/backend/tools/test_skills.py` for the create tool. It catches a Max-created skill landing under a name whose page a tab route owns.
- Not run: the Django suites, because this sandbox has no Postgres. CI covers them.
- No frontend test for the URL move. The existing `communitySkillsLogic` test already covers the URL contract, since every caller goes through `urls.communitySkills()`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No doc references the frontend path.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Raised in a [Slack thread](https://posthog.slack.com/archives/C0B89UWRJDP/p1787162688985399) and implemented by the PostHog Slack app.

Skills invoked: `/writing-pr-descriptions`.

Greptile and Codex both flagged that `/skills/community` shadows a skill named `community`. Reserving the name matches how the `scouts` and `review-hog` tabs handle the same collision. Codex then found that the Max create-skill tool skips the serializer, so the reservation had a hole. The tool now checks the same set. Name format still goes unchecked on that path, which predates this change and is left alone.

A team that already holds a skill by that name keeps it, but reaches it through the API rather than the detail page, which is the same trade the earlier tab routes made.

The route could have been folded into `skillsCategoryTab` since the tab key is already `community`, but Community is a separate scene rather than a category filter, so it keeps its own `urls.communitySkills()` helper and route entry.


---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B89UWRJDP/p1787162688985399)*


