### PR TITLE
fix(desktop): align space new task repository controls

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/components/WebsiteNewTask.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/WebsiteNewTask.test.tsx
@@ -21,7 +21,10 @@ const { track, useFolderInstructions, taskInputProps } = vi.hoisted(() => ({
 // TaskInput is a huge hook-heavy component; stub it down to just the surface
 // this test cares about — a button that fires onContextChipClick when wired.
 vi.mock("@posthog/ui/features/task-detail/components/TaskInput", () => ({
-  TaskInput: (props: { onContextChipClick?: () => void }) => {
+  TaskInput: (props: {
+    allowNoRepo?: boolean;
+    onContextChipClick?: () => void;
+  }) => {
     taskInputProps(props);
     return (
       <button
@@ -121,6 +124,13 @@ describe("WebsiteNewTask context panel", () => {
         channelContextId: "chan-1",
       }),
     );
+  });
+
+  it("uses the standard repository and branch selectors", () => {
+    useFolderInstructions.mockReturnValue({ data: undefined });
+    renderNewTask();
+
+    expect(taskInputProps.mock.lastCall?.[0]).not.toHaveProperty("allowNoRepo");
   });
 
   it("opens the context panel and tracks view_context when the chip is clicked", async () => {

--- a/products/desktop/packages/ui/src/features/canvas/components/WebsiteNewTask.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/WebsiteNewTask.tsx
@@ -146,9 +146,6 @@ export function WebsiteNewTask({ channelId }: { channelId: string }) {
           channelName={channelName}
           channelId={channelId}
           channelContextId={channelId}
-          allowNoRepo
-          channelRepositories={channel?.repositories}
-          channelGithubIntegration={channel?.github_integration}
           // So a prompt handed to openTaskInput survives routing into a channel.
           initialPrompt={view.initialPrompt}
           initialPromptKey={view.taskInputRequestId}


### PR DESCRIPTION
## Problem

The space New task page hides repository and branch controls that the main new-task page shows.

**Why:** Worktree tasks need an explicit repository and base branch regardless of which full-page entry point opens the composer.

## Changes

- Space New task pages now show the standard repository, branch, environment, and additional-directory controls.
- The embedded space-home composer remains repo-optional for generic and multi-repository tasks.
- Screenshots omitted because the available reproduction contains workspace-specific data.

## How did you test this code?

Added coverage that keeps the full-page space route out of repo-optional mode. The focused component tests, UI typecheck, and desktop boundary checks pass.

Visual behavior was not manually verified in the packaged desktop app.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation change. This aligns two existing new-task entry points.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented this fix using the `posthog-desktop`, `writing-ui-components`, and `writing-pr-descriptions` skills.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*