### PR TITLE
chore(query-perf-ai): add metric formatting helpers

### DIFF
--- a/tools/query-performance-ai/query_performance_ai/orchestrator/formatting.py
+++ b/tools/query-performance-ai/query_performance_ai/orchestrator/formatting.py
@@ -1,0 +1,31 @@
+"""Human-readable renderings of ClickHouse query metrics.
+
+Kept local to this bundle on purpose: it is a standalone CLI that runs without
+Django, so it cannot reach the formatters that live in the web app.
+"""
+
+from __future__ import annotations
+
+_MS_PER_SECOND = 1000
+_MS_PER_MINUTE = 60 * _MS_PER_SECOND
+_BYTE_UNITS = ("B", "KiB", "MiB", "GiB", "TiB")
+
+
+def format_duration_ms(milliseconds: float) -> str:
+    """Render a duration as `840ms`, `31.4s`, or `2m 11s`."""
+    if milliseconds < _MS_PER_SECOND:
+        return f"{milliseconds:.0f}ms"
+    if milliseconds < _MS_PER_MINUTE:
+        return f"{milliseconds / _MS_PER_SECOND:.1f}s"
+    minutes, remainder = divmod(round(milliseconds), _MS_PER_MINUTE)
+    return f"{minutes}m {remainder // _MS_PER_SECOND}s"
+
+
+def format_bytes(count: float) -> str:
+    """Render a byte count in the largest binary unit that keeps it below 1024."""
+    size = float(count)
+    for unit in _BYTE_UNITS[:-1]:
+        if size < 1024:
+            return f"{size:.0f} {unit}" if unit == "B" else f"{size:.1f} {unit}"
+        size /= 1024
+    return f"{size:.1f} {_BYTE_UNITS[-1]}"

--- a/tools/query-performance-ai/query_performance_ai/orchestrator/tests/test_formatting.py
+++ b/tools/query-performance-ai/query_performance_ai/orchestrator/tests/test_formatting.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import pytest
+
+from query_performance_ai.orchestrator.formatting import format_bytes, format_duration_ms
+
+
+@pytest.mark.parametrize(
+    ("milliseconds", "expected"),
+    [
+        (840, "840ms"),
+        (999, "999ms"),
+        (1000, "1.0s"),
+        (31_400, "31.4s"),
+        (131_000, "2m 11s"),
+    ],
+)
+def test_format_duration_ms(milliseconds: int, expected: str) -> None:
+    assert format_duration_ms(milliseconds) == expected
+
+
+@pytest.mark.parametrize(
+    ("count", "expected"),
+    [
+        (0, "0 B"),
+        (999, "999 B"),
+        (1024, "1.0 KiB"),
+        (1_572_864, "1.5 MiB"),
+        (5 * 1024**3, "5.0 GiB"),
+        (2 * 1024**4, "2.0 TiB"),
+    ],
+)
+def test_format_bytes(count: int, expected: str) -> None:
+    assert format_bytes(count) == expected


### PR DESCRIPTION
## Problem

- A query-performance-ai dry run prints raw counters, so an engineer picking the worst slow query converts milliseconds and bytes by hand.
- This layer only adds the formatters. [Layer 2](https://github.com/PostHog/posthog/pull/85934) and [layer 3](https://github.com/PostHog/posthog/pull/85935) change what the command prints.

## Changes

- `format_duration_ms` renders `840ms`, `31.4s`, or `2m 11s`.
- `format_bytes` renders binary units from `B` up to `TiB`.
- Nothing calls either helper yet, so no command output changes.
- The helpers live in the bundle rather than reusing `posthog.views.format_bytes`, because this is a standalone CLI that runs without Django.

## How did you test this code?

- New parameterized tests cover the boundaries where each format switches: sub-second to seconds, seconds to minutes, and every binary unit step.
- Not checked: the coordinator itself, which needs Metabase credentials and a Docker daemon.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The helpers are internal to the bundle.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written with Claude Code. Skills invoked: `/stacking-prs`, `/writing-pr-descriptions`.
- The stack also exercises stamphog's stacked-PR support from [feat(stamphog): support stacked PRs](https://github.com/PostHog/posthog/pull/54933). Layers 2 and 3 call symbols that exist only in this layer, so the reviewer has to resolve them from the PR head tree.
