### PR TITLE
chore(query-perf-ai): format the print-only query listing

### DIFF
--- a/tools/query-performance-ai/query_performance_ai/orchestrator/coordinator.py
+++ b/tools/query-performance-ai/query_performance_ai/orchestrator/coordinator.py
@@ -40,6 +40,7 @@ from typing import TYPE_CHECKING
 from .backends.base import ExecutionBackend
 from .backends.local import LocalClickhouseBackend
 from .backends.metabase import MetabaseBackend
+from .formatting import format_bytes, format_duration_ms
 from .server import ServerInfo, generate_token, make_server, serve_forever_in_thread
 from .slow_queries import SlowQuery, fetch_available_columns, fetch_available_dictionaries, fetch_slow_queries
 
@@ -567,7 +568,8 @@ def _print_only(args: argparse.Namespace) -> int:
     print()  # noqa: T201 — print-only mode emits structured output to stdout
     for i, q in enumerate(queries, start=1):
         print(f"[{i}/{len(queries)}] query_id={q.query_id}")  # noqa: T201
-        print(f"        team_id={q.team_id} duration={q.query_duration_ms}ms read_bytes={q.read_bytes}")  # noqa: T201
+        duration = format_duration_ms(q.query_duration_ms)
+        print(f"        team_id={q.team_id} duration={duration} read={format_bytes(q.read_bytes)}")  # noqa: T201
         print(f"        event_time={q.event_time}")  # noqa: T201
         preview = q.clickhouse_query.replace("\n", " ")[:200]
         print(f"        sql_preview: {preview}{'…' if len(q.clickhouse_query) > 200 else ''}")  # noqa: T201


### PR DESCRIPTION
## Problem

- `--print-only` lists the slow queries a campaign would replay, but prints the two numbers that decide which one to look at as raw counters.
- An engineer triaging that list divides by 1024 in their head to compare read volumes.
- [Layer 1](https://github.com/PostHog/posthog/pull/85933) added the formatters and left them unused. This layer wires them into the listing.

## Changes

- Each query line now reads `duration=2m 11s read=1.5 GiB` instead of `duration=131000ms read_bytes=1572864000`.

Before:

```text
[1/3] query_id=8f2c1a04-...
        team_id=2 duration=131000ms read_bytes=1572864000
```

After:

```text
[1/3] query_id=8f2c1a04-...
        team_id=2 duration=2m 11s read=1.5 GiB
```

- Mechanical: one import and one print line in `_print_only`. No other command output changes.

## How did you test this code?

- No new tests. The formatters carry the logic and [layer 1](https://github.com/PostHog/posthog/pull/85933) covers them; what is left here is one f-string.
- Not checked: the command end to end, which needs Metabase credentials and a Docker daemon.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. `--print-only` output is not documented.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written with Claude Code. Skills invoked: `/stacking-prs`, `/writing-pr-descriptions`.
- This layer is stacked on [layer 1](https://github.com/PostHog/posthog/pull/85933): `format_bytes` and `format_duration_ms` do not exist on master yet.
