### PR TITLE
chore(query-perf-ai): total the read volume in print-only mode

### DIFF
--- a/tools/query-performance-ai/query_performance_ai/orchestrator/coordinator.py
+++ b/tools/query-performance-ai/query_performance_ai/orchestrator/coordinator.py
@@ -574,6 +574,8 @@ def _print_only(args: argparse.Namespace) -> int:
         preview = q.clickhouse_query.replace("\n", " ")[:200]
         print(f"        sql_preview: {preview}{'…' if len(q.clickhouse_query) > 200 else ''}")  # noqa: T201
         print()  # noqa: T201
+    total_read = format_bytes(sum(q.read_bytes for q in queries))
+    print(f"{len(queries)} queries would be replayed, {total_read} read between them")  # noqa: T201
     return 0
 
 


### PR DESCRIPTION
## Problem

- `--print-only` shows the read volume of each slow query but no total, so anyone sizing a campaign's ClickHouse load adds the lines up.
- A campaign replays every listed query, so the total is what the test cluster actually pays.

## Changes

- The listing ends with a footer: `5 queries would be replayed, 12.4 GiB read between them`.
- The footer calls `format_bytes`, added in [layer 1](https://github.com/PostHog/posthog/pull/85933).

## How did you test this code?

- No new tests. The sum is one expression over a dataclass field, and [layer 1](https://github.com/PostHog/posthog/pull/85933) covers the formatter.
- Not checked: the command end to end, which needs Metabase credentials and a Docker daemon.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. `--print-only` output is not documented.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written with Claude Code. Skills invoked: `/stacking-prs`, `/writing-pr-descriptions`.
- This layer sits two levels above [layer 1](https://github.com/PostHog/posthog/pull/85933), whose `format_bytes` it calls. Neither the call site nor the definition is on master.
