### PR TITLE
fix(bigquery): stop retrying when a service account lacks connection-use permission

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
@@ -107,6 +107,17 @@ class BigQuerySource(SQLSource[BigQuerySourceConfig]):
             # Deterministic IAM config problem; retrying can't grant the permission. Matched on the
             # stable permission name, not the volatile project id.
             "bigquery.jobs.create": "BigQuery denied your service account permission to run query jobs — it's missing the bigquery.jobs.create permission on the project it queries. Read access alone isn't enough, because PostHog runs query jobs to sync your data. Please grant your service account permission to run jobs (for example the BigQuery Job User role) on that project, then reconnect the source.",
+            # Raised as a 403 Forbidden when a table or view being synced reads through a BigQuery
+            # connection (used for federated queries or BigLake external tables) that the service
+            # account isn't authorized to use, e.g. "Access Denied: Connection projects/<p>/
+            # locations/<l>/connections/<c>: User does not have bigquery.connections.use permission
+            # for connection projects/<p>/locations/<l>/connections/<c>.". This is a separate IAM
+            # grant from table/dataset access — it lives on the connection resource itself, not the
+            # dataset — so the generic "Access Denied:" key below would match first and misdirect the
+            # customer to grant table read access (Data Viewer), which can't authorize connection use.
+            # Deterministic IAM config problem; retrying can't grant the permission. Matched on the
+            # stable permission name, not the volatile project/location/connection id.
+            "bigquery.connections.use": "BigQuery denied access to a BigQuery connection that a table or view being synced depends on (used for federated queries or external/BigLake tables). Please grant your service account the bigquery.connections.use permission (for example the BigQuery Connection User role) on that connection, then reconnect the source.",
             # BigQuery prefixes every IAM/permission failure with "Access Denied:" — e.g.
             # "Access Denied: Table <id>: Permission bigquery.tables.getData denied on table <id>
             # (or it may not exist).". The matched string above only covers the REST client's

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -1291,13 +1291,27 @@ def test_non_retryable_errors_match_permission_denied(observed_error):
             "bigquery.tables.create",
             "create",
         ),
+        # Querying a table/view that reads through a BigQuery connection (federated query or
+        # BigLake) the service account isn't authorized to use — denied with
+        # bigquery.connections.use on the connection resource, not the table/dataset.
+        (
+            str(
+                Forbidden(
+                    "Access Denied: Connection projects/proj/locations/us/connections/conn: User does not "
+                    "have bigquery.connections.use permission for connection "
+                    "projects/proj/locations/us/connections/conn."
+                )
+            ),
+            "bigquery.connections.use",
+            "connection",
+        ),
     ],
 )
-def test_temp_table_write_denial_surfaces_write_permission_guidance(observed_error, expected_key, expected_word):
-    # A temp-table write/create denial also contains "Access Denied:", so both that generic key and the
-    # write-specific key match. external_data_job surfaces the first matching key's message, so the
-    # write-specific key must sit above "Access Denied:" — otherwise the customer is told to grant read
-    # access to fix a write/create failure.
+def test_specific_permission_denial_outranks_generic_access_denied(observed_error, expected_key, expected_word):
+    # Each of these denials also contains "Access Denied:", so both the generic key and the
+    # more specific key match. external_data_job surfaces the first matching key's message, so the
+    # specific key must sit above "Access Denied:" — otherwise the customer is told to grant table
+    # read access to fix a failure that read access can't resolve.
     non_retryable_errors = BigQuerySource().get_non_retryable_errors()
     first_key, friendly = next((key, msg) for key, msg in non_retryable_errors.items() if key in observed_error)
     assert first_key == expected_key


### PR DESCRIPTION
## Problem

A BigQuery source stops syncing when its service account can't use a BigQuery connection (used for federated queries or BigLake external tables) that a synced table or view reads through. Google rejects the query with a `bigquery.connections.use` permission error ([error tracking issue](https://us.posthog.com/project/2/error_tracking/01a01b40-1dd1-7b23-803e-299f65cf6d21)).

The generic `"Access Denied:"` match already stops retrying this error, since the message contains that prefix, but the guidance it shows tells the customer to grant table read access (BigQuery Data Viewer). That can't fix a missing connection grant, which lives on the connection resource rather than the table or dataset.

## Changes

- Adds a `bigquery.connections.use` entry to `BigQuerySource.get_non_retryable_errors`, positioned above the generic `"Access Denied:"` key so its message wins.
- The new message points the customer at the BigQuery Connection User role instead of Data Viewer.
- Mechanical: renames the test covering key-priority ordering, since it now covers more than temp-table writes, and adds a parameterized case for the new key.

## How did you test this code?

Extended `test_specific_permission_denial_outranks_generic_access_denied` (previously `test_temp_table_write_denial_surfaces_write_permission_guidance`) with a case asserting the `bigquery.connections.use` key wins over the generic `"Access Denied:"` key. That's the regression this PR fixes: without the new key sitting above the generic one, the customer would see read-access guidance that can't resolve a connection-permission error.

Ran the full `bigquery` test module locally (177 passed) and `mypy` on the changed file (clean). Not run: CI's full matrix, which the PR's own checks will cover.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None needed — this only changes an internal error classification and its user-facing toast text.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via the error tracking issue linked above, then read `products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/{bigquery,source}.py` and the Stripe source's equivalent classifier for the established pattern. No skills invoked beyond `/writing-tests` and `/writing-pr-descriptions`, both used as instructed by this repo's CLAUDE.md.