### PR TITLE
chore(ci): skip non-required image pushes on merge queue branches

### DIFF
--- a/.github/workflows/ci-ml-mirror-image-scrub-container.yml
+++ b/.github/workflows/ci-ml-mirror-image-scrub-container.yml
@@ -82,10 +82,13 @@ jobs:
     build:
         needs: changes
         name: Build and push ml-mirror-image-scrub image
+        # Skipped on trunk-merge/** branches: merge-queue PRs are ephemeral, nothing
+        # pulls images pushed for them, and each constituent PR already built its own.
         if: |
-            (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && needs.changes.outputs.scrub_files == 'true') ||
-            (github.event_name == 'workflow_dispatch' && github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true') ||
-            (github.event_name == 'push' && github.ref == 'refs/heads/master' && needs.changes.outputs.scrub_files == 'true' && github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true')
+            !startsWith(github.head_ref, 'trunk-merge/') &&
+            ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && needs.changes.outputs.scrub_files == 'true') ||
+             (github.event_name == 'workflow_dispatch' && github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true') ||
+             (github.event_name == 'push' && github.ref == 'refs/heads/master' && needs.changes.outputs.scrub_files == 'true' && github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true'))
         runs-on: depot-ubuntu-24.04
         timeout-minutes: 30
         permissions:

--- a/.github/workflows/ci-nodejs-container.yml
+++ b/.github/workflows/ci-nodejs-container.yml
@@ -35,7 +35,9 @@ jobs:
             contents: read
             pull-requests: read
         timeout-minutes: 5
-        if: github.repository_owner == 'PostHog'
+        # Skipped on trunk-merge/** branches: merge-queue PRs are ephemeral, nothing
+        # pulls images pushed for them, and each constituent PR already built its own.
+        if: github.repository_owner == 'PostHog' && !startsWith(github.head_ref, 'trunk-merge/')
         name: Determine need to run node Docker build
         outputs:
             node_files: ${{ steps.filter.outputs.node_files }}

--- a/.github/workflows/livestream-docker-image.yml
+++ b/.github/workflows/livestream-docker-image.yml
@@ -23,7 +23,9 @@ jobs:
         runs-on: depot-ubuntu-24.04
         timeout-minutes: 10
 
-        if: github.repository_owner == 'PostHog'
+        # Skipped on trunk-merge/** branches: merge-queue PRs are ephemeral, nothing
+        # pulls images pushed for them, and each constituent PR already built its own.
+        if: github.repository_owner == 'PostHog' && !startsWith(github.head_ref, 'trunk-merge/')
 
         permissions:
             contents: read

--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -39,8 +39,11 @@ jobs:
         runs-on: ubuntu-24.04
         timeout-minutes: 10
         # Skip on workflow_dispatch — always build everything (escape hatch)
+        # Skipped on trunk-merge/** branches: merge-queue PRs are ephemeral, nothing
+        # pulls images pushed for them, and each constituent PR already built its own.
         if: >-
             github.event_name != 'workflow_dispatch' &&
+            !startsWith(github.head_ref, 'trunk-merge/') &&
             (github.event_name != 'pull_request' ||
              github.event.pull_request.head.repo.full_name == github.repository)
         permissions:
@@ -78,8 +81,11 @@ jobs:
         # and a skipped need would otherwise cascade a skip here. !cancelled() covers that
         # while still stopping the build after manual workflow cancellation.
         # Run unless affected explicitly found zero images ('none') or failed.
+        # The trunk-merge guard is repeated here because a skipped 'affected' leaves
+        # image-filter empty, which this condition would otherwise treat as buildable.
         if: |
             !cancelled() &&
+            !startsWith(github.head_ref, 'trunk-merge/') &&
             (github.event_name != 'pull_request' ||
              github.event.pull_request.head.repo.full_name == github.repository) &&
             needs.affected.result != 'failure' &&


### PR DESCRIPTION
## Problem

Every merge queue batch dispatches four container image workflows that push validation images nothing gates on and nobody pulls.

- GHCR started throttling these pushes on 2026-08-18, once queue churn multiplied the attempts: the rust image workflow ran 44 times on Aug 17 and 312 times on Aug 19, mostly on `trunk-merge/**` branches.
- On 2026-08-19, Depot and GHCR flakiness failed 49 rust image builds and 7 node image builds on `trunk-merge/**` branches ([example: no active BuildKit sessions](https://github.com/PostHog/posthog/actions/runs/32282435561), [example: GHCR push retries exhausted](https://github.com/PostHog/posthog/actions/runs/32239443247)).
- None of these workflows emit a required status check, so the failures ejected nothing and only burned Depot builds and reddened batches.
- The extra builds also loaded the shared Depot builders, feeding back into more queue ejections and more attempts.
- The batch's constituent PRs already built and pushed their own validation images on their own branches.

## Changes

Nothing user-visible changes. All edits are CI gating: the four non-required image-push workflows now skip merge queue branches, using the `!startsWith(github.head_ref, 'trunk-merge/')` guard already established in `ci-backend.yml` and `ci-mcp-ui-apps.yml`.

```mermaid
flowchart LR
    Q{{trunk-merge/** batch}} --> R[Rust images ×28 services]
    Q --> N[Node image]
    Q --> M[ml-mirror-scrub image]
    Q --> L[Livestream image]
    R --> P[(GHCR / ECR push)]
    N --> P
    M --> P
    L --> P
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class Q phYellow;
    class R,N,M,L phRed;
    class P phGray;
```

```mermaid
flowchart LR
    Q{{trunk-merge/** batch}} --> S[image workflows skipped]
    O{{regular PR / master push}} --> B[image builds and pushes, unchanged]
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class Q,O phYellow;
    class S phGray;
    class B phBlue;
```

- `rust-docker-build.yml`: the guard sits on both `affected` and `build-images`, because `build-images` runs under `!cancelled()` and treats the empty `image-filter` from a skipped `affected` as buildable.
- `ci-nodejs-container.yml`: the guard sits on `changes`; a skipped filter leaves `node_files` empty, so `build` cannot pass either arm of its condition.
- `ci-ml-mirror-image-scrub-container.yml`: the guard wraps only the `build` condition, so the unit-test job still runs on queue branches.
- `livestream-docker-image.yml`: the guard sits on `build`; `deploy` already requires a master push.
- The only consumer of PR-tagged images is the e2e Playwright suite, which pulls `capture:pr-N` opportunistically and falls back to the `master` image when it is absent, so queue e2e runs keep working.
- Master pushes and `workflow_dispatch` are unaffected, because `github.head_ref` is empty outside pull request events.

## How did you test this code?

- `bin/hogli lint:workflows` passes all 8 checks; `actionlint` reports only pre-existing info-level shellcheck notes in untouched steps.
- Not run: an actual merge queue batch. The guard condition copies the pattern live in `ci-backend.yml:566`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code sessions. Skills invoked: `/authoring-ci-workflows`, `/depot-container-builds`, `/writing-code-comments`, `/writing-pr-descriptions`. The change came out of a merge queue health investigation of 2026-08-19: 137 failed workflow runs on `trunk-merge/**` branches were reconstructed from the Actions API, and these four workflows accounted for 58 of them without gating any merge. A second session investigating the registry throttling independently reached the same fix for the rust and node workflows (#86317, closed as a duplicate subset of this PR), measured the per-day run counts, and verified the e2e capture-image fallback. Guard placement was verified against each workflow's job conditions so skips cascade without leaving an `!cancelled()` job running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
