### PR TITLE
fix(devex): stop product edits from busting the frontend install layer

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -120,12 +120,12 @@ jobs:
               continue-on-error: true
               # A hung build has to end as a step failure, not a job timeout: the retry ladder below
               # is gated on `outcome == 'failure'`, and a cancelled job skips every step it guards.
-              # The bound has to sit above the slowest healthy build, not inside the distribution:
-              # a merge-queue batch starts a dozen of these at once and contention on the shared
-              # Depot builder stretches a normal build several times over. Timing out there cancels
-              # the build server-side and makes the retry re-pay it, turning slowness into a red
-              # master. A genuine hang still ends fast, because the Depot stream drops its keepalive
-              # well before this bound.
+              # The bound has to sit above the slowest healthy build rather than inside the spread:
+              # master pushes land in merge-queue batches that contend for the shared Depot builder,
+              # so a normal build stretches well past its solo time. Timing out cancels the build
+              # server-side and makes the retry re-pay it, so a bound set near the typical build
+              # turns contention into a failed deploy. A real hang still ends well before this,
+              # because the Depot stream drops its keepalive first.
               timeout-minutes: 35
               uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1.17.0
               with:

--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -46,8 +46,9 @@ jobs:
         if: github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true'
         runs-on: depot-ubuntu-24.04
         # Covers two bounded build attempts plus the post-build image-boot verification before
-        # dispatch.
-        timeout-minutes: 60
+        # dispatch. Keep it above the sum of the two step budgets below, so a slow build ends as a
+        # step failure the retry ladder can act on rather than a job cancellation that skips it.
+        timeout-minutes: 80
         permissions:
             id-token: write # allow issuing OIDC tokens for this workflow run
             contents: read # allow at least reading the repo contents, add other permissions if necessary
@@ -119,7 +120,13 @@ jobs:
               continue-on-error: true
               # A hung build has to end as a step failure, not a job timeout: the retry ladder below
               # is gated on `outcome == 'failure'`, and a cancelled job skips every step it guards.
-              timeout-minutes: 25
+              # The bound has to sit above the slowest healthy build, not inside the distribution:
+              # a merge-queue batch starts a dozen of these at once and contention on the shared
+              # Depot builder stretches a normal build several times over. Timing out there cancels
+              # the build server-side and makes the retry re-pay it, turning slowness into a red
+              # master. A genuine hang still ends fast, because the Depot stream drops its keepalive
+              # well before this bound.
+              timeout-minutes: 35
               uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1.17.0
               with:
                   context: . # match the CI build's context so master reuses the shared Depot layer cache
@@ -197,7 +204,7 @@ jobs:
               id: build_retry
               if: steps.build.outcome == 'failure' && steps.preflight_retry.outputs.digest == ''
               continue-on-error: true
-              timeout-minutes: 25
+              timeout-minutes: 35
               uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1.17.0
               with:
                   context: . # match the CI build's context so master reuses the shared Depot layer cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,22 @@ ENV COREPACK_ENABLE_NETWORK=0
 #
 # ---------------------------------------------------------
 #
+# Just the `products/*` workspace manifests, with the sources left behind. pnpm resolves those
+# workspaces from their package.json alone, so putting the whole tree in front of the install makes
+# any product source edit reinstall every dependency. Most master commits touch that tree and
+# almost none touch a manifest, so the install layer is the one that has to see only manifests.
+# This stage re-runs on every product change; only its output feeds the cache key downstream.
+FROM node-base AS product-manifests
+RUN --mount=type=bind,source=products,target=/src \
+    mkdir -p /manifests && cd /src && \
+    find . -mindepth 2 -maxdepth 2 -name package.json -print0 \
+    | tar --null --files-from=- -cf - \
+    | tar -xf - -C /manifests
+
+
+#
+# ---------------------------------------------------------
+#
 FROM node-base AS frontend-build
 
 COPY turbo.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json ./
@@ -54,11 +70,13 @@ COPY common/replay-shared/ common/replay-shared/
 COPY common/tailwind/ common/tailwind/
 COPY packages/quill/ packages/quill/
 COPY packages/llm-normalizer/ packages/llm-normalizer/
-COPY products/ products/
-COPY docs/onboarding/ docs/onboarding/
+COPY --from=product-manifests /manifests/ products/
+COPY docs/onboarding/package.json docs/onboarding/
 RUN --mount=type=cache,id=pnpm,target=/tmp/pnpm-store-v24 \
     CI=1 pnpm --filter=@posthog/frontend... install --frozen-lockfile --store-dir /tmp/pnpm-store-v24
 
+COPY products/ products/
+COPY docs/onboarding/ docs/onboarding/
 COPY frontend/ frontend/
 RUN bin/turbo --filter=@posthog/frontend build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@
 # The stages are used to:
 #
 # - node-base: shared Node.js base with pnpm already provisioned
+# - product-manifests: the products/* package.json files on their own, for the frontend install
 # - frontend-build: build the frontend (static assets)
 # - sourcemap-upload: upload sourcemaps to PostHog (isolated, no artifacts)
 # - node-scripts-build: build plugin transpiler and other Node.js build artifacts
@@ -41,17 +42,15 @@ ENV COREPACK_ENABLE_NETWORK=0
 #
 # ---------------------------------------------------------
 #
-# Just the `products/*` workspace manifests, with the sources left behind. pnpm resolves those
-# workspaces from their package.json alone, so putting the whole tree in front of the install makes
-# any product source edit reinstall every dependency. Most master commits touch that tree and
-# almost none touch a manifest, so the install layer is the one that has to see only manifests.
-# This stage re-runs on every product change; only its output feeds the cache key downstream.
+# pnpm resolves the products/* workspaces from their package.json alone, so the install layer must
+# see the manifests without the sources. Copying the whole tree in front of it instead ties every
+# product source edit to a full reinstall, and product sources change far more often than product
+# manifests. The depth here tracks the products/* glob in pnpm-workspace.yaml: a workspace nested
+# deeper would be dropped, and the install then fails on the lockfile importer it cannot find.
 FROM node-base AS product-manifests
 RUN --mount=type=bind,source=products,target=/src \
-    mkdir -p /manifests && cd /src && \
-    find . -mindepth 2 -maxdepth 2 -name package.json -print0 \
-    | tar --null --files-from=- -cf - \
-    | tar -xf - -C /manifests
+    cd /src && find . -mindepth 2 -maxdepth 2 -name package.json \
+    -exec install -D {} /manifests/{} \;
 
 
 #


### PR DESCRIPTION
## Problem

Master image builds fail on roughly a fifth of commits, and a failed build ships no deployable image for that commit.

The Depot layer cache breaks at `COPY products/ products/`, which sat directly in front of `pnpm install`. Every master commit carries a different `products/` tree, so that layer almost never hits, and the install plus the frontend build, `collectstatic` and the sourcemap upload all re-run. Builds take 6 to 25 minutes instead of a few, and the 25-minute per-attempt cap then kills builds that are still making progress.

**Where the cache first breaks in `frontend-build`, across 58 platform builds sampled from master on 2026-08-19:**

| First step to miss | Platform builds |
| --- | --- |
| `COPY products/ products/` | 43 |
| `COPY docs/onboarding/` | 4 |
| Never missed (duplicate-SHA reruns) | 11 |
| Any step before those | 0 |

**Failure rate, `Container Images CD` on master** ([workflow runs](https://github.com/PostHog/posthog/actions/workflows/container-images-cd.yml?query=branch%3Amaster)):

| Day | Runs | Failed | Rate |
| --- | --- | --- | --- |
| 2026-08-13 | 255 | 25 | 10% |
| 2026-08-14 | 169 | 0 | 0% |
| 2026-08-17 | 145 | 14 | 10% |
| 2026-08-18 | 203 | 13 | 6% |
| 2026-08-19 | 240 | 54 | 22% |

The rate swings day to day while the cache break is constant, so the break is not what fails a build on its own. It is what makes a build slow enough to sit against whatever cap is above it, and the failures land when that meets a busy day.

Two runs show the mechanism directly:

- [Run 32284216531](https://github.com/PostHog/posthog/actions/runs/32284216531) ran with no other image build overlapping it. Steps 1-11 of `frontend-build` are `CACHED`; step 12 `COPY products/` runs, and the install runs behind it.
- [Run 32286565019](https://github.com/PostHog/posthog/actions/runs/32286565019) built a commit that changed only `.github/` and `.depot/` files, none of which enter the build context. It still re-ran 106 of 226 steps.

Only 3 of the last 300 master commits changed a `products/*/package.json`, which is all the install reads from that tree.

## Changes

Nothing user-visible changes. Both files are build and CI configuration.

- A [`product-manifests` stage](https://github.com/PostHog/posthog/blob/52386527cf21de12d8d16e2979f3d612179126b8/Dockerfile#L49-L54) feeds only `products/*/package.json` into the install, and the `products/` sources [copy in after it](https://github.com/PostHog/posthog/blob/52386527cf21de12d8d16e2979f3d612179126b8/Dockerfile#L71-L79).
- `docs/onboarding` gets the same treatment, for the other 4 misses in the table.
- The per-attempt build timeout goes 25 to 35 minutes on both attempts, and the job timeout 60 to 80.

A bind mount feeds the prune stage instead of a `COPY`, so the stage adds no image layer. It re-runs on every product change, and only its output joins the cache key downstream.

The timeout change rests on its own evidence rather than on the cache fix: Depot's build records put p95 build time at 1468s against a 1500s cap, and 28 attempts hit that cap on 2026-08-19 against 5 the day before. It is a floor under the failure mode, not the fix for it. Job budget stays consistent: 35 + 35 + about 3 minutes of setup and boot verification sits under 80, the same headroom 25 + 25 had under 60.

> [!NOTE]
> The `find` depth tracks the `products/*` glob in `pnpm-workspace.yaml`. A workspace nested deeper would be dropped from the manifests, and `pnpm install --frozen-lockfile` then fails naming the missing importer. It fails loudly rather than installing something wrong.

## How did you test this code?

Controlled local builds of the `frontend-build` target on `linux/arm64`, this Dockerfile against master's, editing one product source file in both:

<details>
<summary>Before: master's Dockerfile, after editing <code>products/early_access_features/frontend/EarlyAccessFeatures.tsx</code></summary>

```
#20 [frontend-build 12/16] COPY products/ products/
#20 DONE 3.1s
#21 [frontend-build 13/16] COPY docs/onboarding/ docs/onboarding/
#21 DONE 0.1s
#22 [frontend-build 14/16] RUN ... pnpm --filter=@posthog/frontend... install --frozen-lockfile ...
#22 DONE 17.4s
```

</details>

<details>
<summary>After: this branch, same edit plus an edit to <code>docs/onboarding/steps.ts</code></summary>

```
#19 [frontend-build 12/18] COPY --from=product-manifests /manifests/ products/
#19 CACHED
#15 [frontend-build 13/18] COPY docs/onboarding/package.json docs/onboarding/
#15 CACHED
#23 [frontend-build 14/18] RUN ... pnpm --filter=@posthog/frontend... install --frozen-lockfile ...
#23 CACHED
#24 [frontend-build 15/18] COPY products/ products/
#24 DONE 4.4s
```

</details>

To reproduce, run this twice on each branch, editing any file under `products/` between the two runs:

```bash
docker buildx build --target frontend-build --platform linux/arm64 --progress plain .
```

Also checked:

- A cold build against the pruned manifests passes `--frozen-lockfile` and reports `Scope: 79 of 97 workspace projects`, so the manifest set is complete. The prune emits 81 manifests, matching the 81 `products/` importers in `pnpm-lock.yaml`.
- The `SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]` from `node-base` is inherited by the new stage, confirmed with a probe build, so a failing `find` fails the build rather than emitting empty manifests.
- The simplified `install -D` prune produces a byte-identical manifest tree to the `tar` pipeline it replaced, confirmed by `diff -r` between two stages in one build.

Not checked: no Depot-backed or multi-platform build ran, and no full image build past the `frontend-build` target. The first master build after merge is the real measurement.

No new tests. This changes layer ordering, not behavior.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) investigated a report that master image builds were failing. Skills invoked: `/writing-pr-descriptions`, `/code-review`.

The session first blamed Depot connection drops and the timeout alone, then wrongly cleared the Dockerfile after testing whether each commit's own diff touched `products/`. That was the wrong question, and one apparent counterexample turned out to be a duplicate-SHA rerun reusing an earlier build's cache. Reading BuildKit's per-step cache frontier settled it.

A review pass replaced a `find | tar | tar` pipeline with `find -exec install -D`, added the new stage to the stage list at the top of the Dockerfile, and cut unsourced rate claims out of both new comments.

Depot builder concurrency, and whether every master SHA needs its own image, both still look worth examining. Neither is addressed here.

