### PR TITLE
feat(desktop): describe a canvas widget in the task composer

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/grid/GridCanvasView.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/grid/GridCanvasView.tsx
@@ -179,6 +179,8 @@ export function GridCanvasView({
 
   const {
     drag,
+    hover,
+    onPointerLeave,
     onSurfacePointerDown,
     onPointerMove,
     onPointerUp,
@@ -289,6 +291,11 @@ export function GridCanvasView({
   // layout; horizontal comes from the measured surface width (1fr columns).
   const pitchX = (surfaceWidth + grid.gap) / grid.columns;
   const pitchY = grid.rowHeight + grid.gap;
+  // A cell already under a tile is not free to draw on, so it stays unlit.
+  const hoveredCell =
+    hover && !collides({ x: hover.col, y: hover.row, w: 1, h: 1 }, placements)
+      ? { x: hover.col, y: hover.row, w: 1, h: 1 }
+      : null;
 
   return (
     <div className="flex h-full">
@@ -333,6 +340,7 @@ export function GridCanvasView({
             onPointerMove={onPointerMove}
             onPointerUp={onPointerUp}
             onPointerCancel={onPointerCancel}
+            onPointerLeave={onPointerLeave}
             onLostPointerCapture={onPointerCancel}
           >
             {interactive && surfaceWidth > 0 ? (
@@ -351,6 +359,15 @@ export function GridCanvasView({
                   backgroundSize: `${pitchX}px ${pitchY}px`,
                   backgroundPosition: `${pitchX / 2 - grid.gap / 2}px ${DOT_FADE_RADIUS - pitchY / 2}px`,
                 }}
+              />
+            ) : null}
+            {hoveredCell ? (
+              // The cell a click would fill, so the empty surface says it is
+              // drawable before the pointer goes down.
+              <div
+                aria-hidden
+                className="pointer-events-none rounded-(--radius-3) bg-fill-hover"
+                style={gridItemStyle(hoveredCell)}
               />
             ) : null}
             {placements.length === 0 && !drag ? (

--- a/products/desktop/packages/ui/src/features/canvas/grid/GridCanvasView.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/grid/GridCanvasView.tsx
@@ -32,7 +32,12 @@ import {
   GridPlacementTile,
   type PlacementTileActions,
 } from "./GridPlacementTile";
-import { collides, type GridRect, surfaceRows } from "./gridGeometry";
+import {
+  collides,
+  type GridRect,
+  rectFromCells,
+  surfaceRows,
+} from "./gridGeometry";
 import { type GridDragOutcome, useGridDrag } from "./useGridDrag";
 import { useGridLayout, usePatchLayout } from "./useGridLayout";
 
@@ -292,10 +297,9 @@ export function GridCanvasView({
   const pitchX = (surfaceWidth + grid.gap) / grid.columns;
   const pitchY = grid.rowHeight + grid.gap;
   // A cell already under a tile is not free to draw on, so it stays unlit.
+  const hoveredRect = hover && rectFromCells(hover, hover);
   const hoveredCell =
-    hover && !collides({ x: hover.col, y: hover.row, w: 1, h: 1 }, placements)
-      ? { x: hover.col, y: hover.row, w: 1, h: 1 }
-      : null;
+    hoveredRect && !collides(hoveredRect, placements) ? hoveredRect : null;
 
   return (
     <div className="flex h-full">

--- a/products/desktop/packages/ui/src/features/canvas/grid/GridPlacementTile.stories.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/grid/GridPlacementTile.stories.tsx
@@ -22,7 +22,9 @@ const actions: PlacementTileActions = {
 };
 
 // A drawn box sits on the grid at the size it was drawn, so the stories frame
-// the tile the way the canvas does rather than letting it fill the page.
+// the tile the way the canvas does rather than letting it fill the page. The
+// chrome mirrors the wrapper in GridCanvasView; keep the two in step, since
+// these stories are what say the smallest box still fits its contents.
 function Tile({
   height,
   placement,

--- a/products/desktop/packages/ui/src/features/canvas/grid/GridPlacementTile.stories.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/grid/GridPlacementTile.stories.tsx
@@ -1,0 +1,76 @@
+import type { GridPlacement } from "@posthog/core/canvas/gridLayoutSchemas";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  GridPlacementTile,
+  type PlacementTileActions,
+} from "./GridPlacementTile";
+
+const PLACEMENT: GridPlacement = {
+  id: "p1",
+  status: "pending",
+  x: 0,
+  y: 0,
+  w: 2,
+  h: 2,
+};
+
+const actions: PlacementTileActions = {
+  describe: async () => {},
+  reset: () => {},
+  remove: () => {},
+  discuss: () => {},
+};
+
+// A drawn box sits on the grid at the size it was drawn, so the stories frame
+// the tile the way the canvas does rather than letting it fill the page.
+function Tile({
+  height,
+  placement,
+}: {
+  height: number;
+  placement: GridPlacement;
+}) {
+  return (
+    <div
+      className="overflow-hidden rounded-(--radius-3) border border-(--gray-5) bg-(--color-panel-solid)"
+      style={{ width: 320, height }}
+    >
+      <GridPlacementTile
+        placement={placement}
+        interactive
+        patching={false}
+        actions={actions}
+      />
+    </div>
+  );
+}
+
+const meta = {
+  title: "Canvas/GridPlacementTile",
+  component: Tile,
+} satisfies Meta<typeof Tile>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** A box waiting for its description, drawn two rows tall. */
+export const Pending: Story = {
+  args: { height: 200, placement: PLACEMENT },
+};
+
+/** The smallest box the grid draws: one column, one row. */
+export const PendingSingleCell: Story = {
+  args: { height: 96, placement: { ...PLACEMENT, w: 1, h: 1 } },
+};
+
+/** A fill that failed keeps the prompt and offers a retry. */
+export const Failed: Story = {
+  args: {
+    height: 200,
+    placement: {
+      ...PLACEMENT,
+      status: "failed",
+      prompt: "Weekly signups by source",
+    },
+  },
+};

--- a/products/desktop/packages/ui/src/features/canvas/grid/GridPlacementTile.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/grid/GridPlacementTile.tsx
@@ -2,11 +2,10 @@ import type { GridPlacement } from "@posthog/core/canvas/gridLayoutSchemas";
 import { Button, Spinner, Text } from "@posthog/quill";
 import { isTerminalStatus } from "@posthog/shared/domain-types";
 import { PromptInput } from "@posthog/ui/features/message-editor/components/PromptInput";
-import type { EditorHandle } from "@posthog/ui/features/message-editor/types";
 import { useSessionStore } from "@posthog/ui/features/sessions/sessionStore";
 import { taskDetailQuery } from "@posthog/ui/features/tasks/queries";
 import { useQuery } from "@tanstack/react-query";
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import { ComponentFrame } from "./ComponentFrame";
 
 // Poll cadence for the fill task's run status while a tile is generating —
@@ -199,18 +198,6 @@ function DescribeTile({
   actions: PlacementTileActions;
 }) {
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const editorRef = useRef<EditorHandle>(null);
-  // A failed fill keeps what was asked for, so the retry starts from it rather
-  // than from an empty box. Only on mount: the draft the user is typing owns
-  // the editor from then on.
-  const prefilled = useRef(false);
-  useEffect(() => {
-    if (prefilled.current || !placement.prompt) return;
-    prefilled.current = true;
-    if (editorRef.current?.isEmpty()) {
-      editorRef.current.setContent(placement.prompt);
-    }
-  }, [placement.prompt]);
 
   if (!interactive) {
     return (
@@ -241,9 +228,11 @@ function DescribeTile({
           skills. Its own toolbar stays hidden — the only control this box
           needs beside send is the one that takes the box away. */}
       <PromptInput
-        ref={editorRef}
         sessionId={`grid-placement-${placement.id}`}
         placeholder="What should go here?"
+        // A failed fill keeps what was asked for, so the retry starts from it
+        // unless a draft is already waiting in the box.
+        initialContent={placement.prompt ?? undefined}
         autoFocus
         disabled={isSubmitting}
         isLoading={isSubmitting}

--- a/products/desktop/packages/ui/src/features/canvas/grid/GridPlacementTile.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/grid/GridPlacementTile.tsx
@@ -1,10 +1,12 @@
 import type { GridPlacement } from "@posthog/core/canvas/gridLayoutSchemas";
-import { Button, Input, Spinner, Text } from "@posthog/quill";
+import { Button, Spinner, Text } from "@posthog/quill";
 import { isTerminalStatus } from "@posthog/shared/domain-types";
+import { PromptInput } from "@posthog/ui/features/message-editor/components/PromptInput";
+import type { EditorHandle } from "@posthog/ui/features/message-editor/types";
 import { useSessionStore } from "@posthog/ui/features/sessions/sessionStore";
 import { taskDetailQuery } from "@posthog/ui/features/tasks/queries";
 import { useQuery } from "@tanstack/react-query";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { ComponentFrame } from "./ComponentFrame";
 
 // Poll cadence for the fill task's run status while a tile is generating —
@@ -170,7 +172,7 @@ function GeneratingTile({
         {viewTask}
         {interactive ? (
           <Button
-            variant="default"
+            variant="destructive"
             size="sm"
             disabled={patching}
             onClick={() => actions.remove(placement)}
@@ -196,8 +198,19 @@ function DescribeTile({
   patching: boolean;
   actions: PlacementTileActions;
 }) {
-  const [prompt, setPrompt] = useState(placement.prompt ?? "");
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const editorRef = useRef<EditorHandle>(null);
+  // A failed fill keeps what was asked for, so the retry starts from it rather
+  // than from an empty box. Only on mount: the draft the user is typing owns
+  // the editor from then on.
+  const prefilled = useRef(false);
+  useEffect(() => {
+    if (prefilled.current || !placement.prompt) return;
+    prefilled.current = true;
+    if (editorRef.current?.isEmpty()) {
+      editorRef.current.setContent(placement.prompt);
+    }
+  }, [placement.prompt]);
 
   if (!interactive) {
     return (
@@ -208,51 +221,47 @@ function DescribeTile({
       </div>
     );
   }
-  const submit = async () => {
-    if (!prompt.trim() || isSubmitting) return;
+  const submit = async (text: string) => {
+    const instruction = text.trim();
+    if (!instruction || isSubmitting) return;
     setIsSubmitting(true);
     try {
-      await actions.describe(placement, prompt.trim());
+      await actions.describe(placement, instruction);
     } finally {
       setIsSubmitting(false);
     }
   };
   return (
-    <div className="flex h-full w-full flex-col items-center justify-center gap-2 p-3 text-center">
+    <div className="flex h-full w-full flex-col justify-center gap-2 p-3">
       {failed ? (
         <Text size="sm">This widget failed to build. Describe it again:</Text>
       ) : null}
-      <form
-        className="flex w-full items-center gap-1"
-        onSubmit={(event) => {
-          event.preventDefault();
-          void submit();
-        }}
-      >
-        <Input
-          autoFocus
-          value={prompt}
-          onChange={(event) => setPrompt(event.target.value)}
-          placeholder="What should go here?"
-          disabled={isSubmitting}
-        />
-        <Button
-          type="submit"
-          size="sm"
-          loading={isSubmitting}
-          disabled={!prompt.trim() || isSubmitting}
-        >
-          {failed ? "Retry" : "Create"}
-        </Button>
-      </form>
-      <Button
-        variant="default"
-        size="sm"
-        disabled={patching}
-        onClick={() => actions.remove(placement)}
-      >
-        Remove
-      </Button>
+      {/* The task composer's editor, as the freeform canvas uses it: markdown
+          as you type, shift+enter for a new line, @ for files and / for
+          skills. Its own toolbar stays hidden — the only control this box
+          needs beside send is the one that takes the box away. */}
+      <PromptInput
+        ref={editorRef}
+        sessionId={`grid-placement-${placement.id}`}
+        placeholder="What should go here?"
+        autoFocus
+        disabled={isSubmitting}
+        isLoading={isSubmitting}
+        enableCommands
+        enableBashMode={false}
+        hideDefaultToolbar
+        onSubmit={(text) => void submit(text)}
+        toolbarEndSlot={
+          <Button
+            variant="destructive"
+            size="sm"
+            disabled={patching}
+            onClick={() => actions.remove(placement)}
+          >
+            Remove
+          </Button>
+        }
+      />
     </div>
   );
 }

--- a/products/desktop/packages/ui/src/features/canvas/grid/gridGeometry.ts
+++ b/products/desktop/packages/ui/src/features/canvas/grid/gridGeometry.ts
@@ -3,6 +3,17 @@ import type {
   GridPlacement,
 } from "@posthog/core/canvas/gridLayoutSchemas";
 
+/** A single cell of the grid, by column and row. */
+export interface GridCell {
+  col: number;
+  row: number;
+}
+
+export function sameCell(a: GridCell | null, b: GridCell | null): boolean {
+  if (!a || !b) return a === b;
+  return a.col === b.col && a.row === b.row;
+}
+
 export interface GridRect {
   x: number;
   y: number;
@@ -46,7 +57,7 @@ export function cellFromPoint(
   pointerY: number,
   surface: { left: number; top: number; width: number },
   grid: GridDefinition,
-): { col: number; row: number } {
+): GridCell {
   const cellWidth = (surface.width + grid.gap) / grid.columns;
   const col = Math.floor((pointerX - surface.left) / cellWidth);
   const row = Math.floor(
@@ -59,10 +70,7 @@ export function cellFromPoint(
 }
 
 // The normalized rect spanned by two cells (a drag's anchor and current cell).
-export function rectFromCells(
-  anchor: { col: number; row: number },
-  current: { col: number; row: number },
-): GridRect {
+export function rectFromCells(anchor: GridCell, current: GridCell): GridRect {
   const x = Math.min(anchor.col, current.col);
   const y = Math.min(anchor.row, current.row);
   return {

--- a/products/desktop/packages/ui/src/features/canvas/grid/useGridDrag.ts
+++ b/products/desktop/packages/ui/src/features/canvas/grid/useGridDrag.ts
@@ -6,16 +6,18 @@ import { type RefObject, useState } from "react";
 import {
   cellFromPoint,
   clampRect,
+  type GridCell,
   type GridRect,
   rectFromCells,
+  sameCell,
 } from "./gridGeometry";
 
 export type GridDragState =
-  | { kind: "draw"; anchor: { col: number; row: number }; rect: GridRect }
+  | { kind: "draw"; anchor: GridCell; rect: GridRect }
   | {
       kind: "move";
       placementId: string;
-      grabbed: { col: number; row: number };
+      grabbed: GridCell;
       origin: GridRect;
       rect: GridRect;
     }
@@ -34,13 +36,6 @@ export interface GridDragOutcome {
  * snapped as the pointer moves (move/resize rects stay clamped to the grid);
  * the caller decides what a completed drag means.
  */
-type GridCell = { col: number; row: number };
-
-function sameCell(a: GridCell | null, b: GridCell | null): boolean {
-  if (!a || !b) return a === b;
-  return a.col === b.col && a.row === b.row;
-}
-
 export function useGridDrag({
   surfaceRef,
   grid,
@@ -183,7 +178,10 @@ export function useGridDrag({
 
   return {
     drag,
-    hover,
+    // Derived rather than reset: a hover left behind by the pointer resting on
+    // the surface when edit mode ends would otherwise paint a cell the canvas
+    // no longer lets you fill.
+    hover: interactive ? hover : null,
     onPointerLeave,
     onSurfacePointerDown,
     onPointerMove,

--- a/products/desktop/packages/ui/src/features/canvas/grid/useGridDrag.ts
+++ b/products/desktop/packages/ui/src/features/canvas/grid/useGridDrag.ts
@@ -34,6 +34,13 @@ export interface GridDragOutcome {
  * snapped as the pointer moves (move/resize rects stay clamped to the grid);
  * the caller decides what a completed drag means.
  */
+type GridCell = { col: number; row: number };
+
+function sameCell(a: GridCell | null, b: GridCell | null): boolean {
+  if (!a || !b) return a === b;
+  return a.col === b.col && a.row === b.row;
+}
+
 export function useGridDrag({
   surfaceRef,
   grid,
@@ -46,6 +53,10 @@ export function useGridDrag({
   onComplete: (outcome: GridDragOutcome) => void;
 }) {
   const [drag, setDrag] = useState<GridDragState | null>(null);
+  // The empty cell under a resting pointer, so the surface can show where a
+  // click would put a box. Only the surface itself reports one: a tile handles
+  // its own presses, and hovering it is not an offer to draw.
+  const [hover, setHover] = useState<GridCell | null>(null);
 
   const cellAt = (event: React.PointerEvent) => {
     const surface = surfaceRef.current?.getBoundingClientRect();
@@ -62,6 +73,7 @@ export function useGridDrag({
     if (event.target !== surfaceRef.current) return;
     const anchor = cellAt(event);
     capture(event);
+    setHover(null);
     setDrag({ kind: "draw", anchor, rect: rectFromCells(anchor, anchor) });
   };
 
@@ -70,6 +82,7 @@ export function useGridDrag({
       if (!interactive || event.button !== 0) return;
       event.stopPropagation();
       capture(event);
+      setHover(null);
       setDrag({
         kind: "move",
         placementId: placement.id,
@@ -89,6 +102,7 @@ export function useGridDrag({
       if (!interactive || event.button !== 0) return;
       event.stopPropagation();
       capture(event);
+      setHover(null);
       setDrag({
         kind: "resize",
         placementId: placement.id,
@@ -103,7 +117,17 @@ export function useGridDrag({
     };
 
   const onPointerMove = (event: React.PointerEvent) => {
-    if (!drag) return;
+    if (!drag) {
+      const cell =
+        interactive && event.target === surfaceRef.current
+          ? cellAt(event)
+          : null;
+      // Every pointer move crosses this, and the surface renders a widget per
+      // tile — so hold the same cell rather than re-rendering the canvas at
+      // pointer rate.
+      setHover((current) => (sameCell(current, cell) ? current : cell));
+      return;
+    }
     const cell = cellAt(event);
     if (drag.kind === "draw") {
       setDrag({ ...drag, rect: rectFromCells(drag.anchor, cell) });
@@ -153,8 +177,14 @@ export function useGridDrag({
     setDrag(null);
   };
 
+  const onPointerLeave = () => {
+    setHover(null);
+  };
+
   return {
     drag,
+    hover,
+    onPointerLeave,
     onSurfacePointerDown,
     onPointerMove,
     onPointerUp,

--- a/products/desktop/packages/ui/src/features/message-editor/components/PromptInput.tsx
+++ b/products/desktop/packages/ui/src/features/message-editor/components/PromptInput.tsx
@@ -51,6 +51,8 @@ export interface PromptInputProps {
   isActiveSession?: boolean;
   submitDisabledExternal?: boolean;
   clearOnSubmit?: boolean;
+  /** What the composer starts from when this session has no draft yet. */
+  initialContent?: string;
   // session context
   taskId?: string;
   repoPath?: string | null;
@@ -142,6 +144,7 @@ export const PromptInput = forwardRef<EditorHandle, PromptInputProps>(
       isActiveSession = true,
       submitDisabledExternal = false,
       clearOnSubmit,
+      initialContent,
       taskId,
       repoPath,
       modeOption,
@@ -233,6 +236,7 @@ export const PromptInput = forwardRef<EditorHandle, PromptInputProps>(
       isLoading,
       autoFocus,
       clearOnSubmit,
+      initialContent,
       context: { taskId, repoPath: repoPath ?? undefined },
       capabilities: {
         bashMode: enableBashMode,

--- a/products/desktop/packages/ui/src/features/message-editor/tiptap/useDraftSync.test.tsx
+++ b/products/desktop/packages/ui/src/features/message-editor/tiptap/useDraftSync.test.tsx
@@ -10,7 +10,39 @@ vi.mock("@posthog/ui/shell/rendererStorage", () => ({
 }));
 
 import { useDraftStore } from "@posthog/ui/features/message-editor/draftStore";
+import type { Editor } from "@tiptap/core";
 import { useDraftSync } from "./useDraftSync";
+
+// The hook only reaches the editor through commands, so a stub of those is the
+// whole surface a restore test needs.
+function fakeEditor(): {
+  editor: Editor;
+  setContent: ReturnType<typeof vi.fn>;
+} {
+  const setContent = vi.fn();
+  const editor = {
+    commands: {
+      setContent,
+      focus: vi.fn(),
+      insertContent: vi.fn(),
+    },
+    getJSON: () => ({ type: "doc", content: [] }),
+  } as unknown as Editor;
+  return { editor, setContent };
+}
+
+function RestoreProbe({
+  editor,
+  sessionId,
+  initialContent,
+}: {
+  editor: Editor;
+  sessionId: string;
+  initialContent?: string;
+}) {
+  useDraftSync(editor, sessionId, undefined, initialContent);
+  return null;
+}
 
 function DraftAttachmentsProbe({ sessionId }: { sessionId: string }) {
   const { restoredAttachments } = useDraftSync(null, sessionId);
@@ -33,6 +65,60 @@ describe("useDraftSync", () => {
       pendingContent: {},
       _hasHydrated: true,
     }));
+  });
+
+  // The composer is what a user sees on open, and two things want to fill it.
+  it.each([
+    [
+      "starts from initialContent when the session has no draft",
+      null,
+      "Sales by week",
+    ],
+    [
+      "leaves a saved draft alone",
+      { segments: [{ type: "text" as const, text: "half a thought" }] },
+      undefined,
+    ],
+  ])("%s", (_name, draft, expected) => {
+    const { editor, setContent } = fakeEditor();
+    if (draft) {
+      useDraftStore.getState().actions.setDraft("session-restore", draft);
+    }
+
+    render(
+      <RestoreProbe
+        editor={editor}
+        sessionId="session-restore"
+        initialContent="Sales by week"
+      />,
+    );
+
+    if (expected) {
+      expect(setContent).toHaveBeenCalledWith(expected);
+    } else {
+      expect(setContent).not.toHaveBeenCalledWith("Sales by week");
+    }
+  });
+
+  // Drafts land only once the store hydrates, so filling the box before that
+  // would show the caller's text and then swap it for what the user had typed.
+  it("holds initialContent until the draft store hydrates", () => {
+    useDraftStore.setState((state) => ({ ...state, _hasHydrated: false }));
+    const { editor, setContent } = fakeEditor();
+
+    render(
+      <RestoreProbe
+        editor={editor}
+        sessionId="session-hydration"
+        initialContent="Sales by week"
+      />,
+    );
+    expect(setContent).not.toHaveBeenCalled();
+
+    act(() => {
+      useDraftStore.getState().actions.setHasHydrated(true);
+    });
+    expect(setContent).toHaveBeenCalledWith("Sales by week");
   });
 
   it("clears restored attachments when a draft no longer has attachments", () => {

--- a/products/desktop/packages/ui/src/features/message-editor/tiptap/useDraftSync.test.tsx
+++ b/products/desktop/packages/ui/src/features/message-editor/tiptap/useDraftSync.test.tsx
@@ -10,25 +10,28 @@ vi.mock("@posthog/ui/shell/rendererStorage", () => ({
 }));
 
 import { useDraftStore } from "@posthog/ui/features/message-editor/draftStore";
-import type { Editor } from "@tiptap/core";
+import { Editor } from "@tiptap/core";
+import { getEditorExtensions } from "./extensions";
 import { useDraftSync } from "./useDraftSync";
 
-// The hook only reaches the editor through commands, so a stub of those is the
-// whole surface a restore test needs.
-function fakeEditor(): {
-  editor: Editor;
-  setContent: ReturnType<typeof vi.fn>;
-} {
-  const setContent = vi.fn();
-  const editor = {
-    commands: {
-      setContent,
-      focus: vi.fn(),
-      insertContent: vi.fn(),
-    },
-    getJSON: () => ({ type: "doc", content: [] }),
-  } as unknown as Editor;
-  return { editor, setContent };
+// A real editor rather than a stub of the commands the hook calls: what the
+// restore path is worth testing for is the text a user would see in the box.
+function makeEditor(): Editor {
+  const element = document.createElement("div");
+  document.body.appendChild(element);
+  return new Editor({
+    element,
+    extensions: getEditorExtensions({ sessionId: "session-1" }),
+  });
+}
+
+function DraftAttachmentsProbe({ sessionId }: { sessionId: string }) {
+  const { restoredAttachments } = useDraftSync(null, sessionId);
+  return (
+    <div>
+      {restoredAttachments.map((att) => att.label).join(",") || "empty"}
+    </div>
+  );
 }
 
 function RestoreProbe({
@@ -42,15 +45,6 @@ function RestoreProbe({
 }) {
   useDraftSync(editor, sessionId, undefined, initialContent);
   return null;
-}
-
-function DraftAttachmentsProbe({ sessionId }: { sessionId: string }) {
-  const { restoredAttachments } = useDraftSync(null, sessionId);
-  return (
-    <div>
-      {restoredAttachments.map((att) => att.label).join(",") || "empty"}
-    </div>
-  );
 }
 
 describe("useDraftSync", () => {
@@ -77,10 +71,10 @@ describe("useDraftSync", () => {
     [
       "leaves a saved draft alone",
       { segments: [{ type: "text" as const, text: "half a thought" }] },
-      undefined,
+      "half a thought",
     ],
   ])("%s", (_name, draft, expected) => {
-    const { editor, setContent } = fakeEditor();
+    const editor = makeEditor();
     if (draft) {
       useDraftStore.getState().actions.setDraft("session-restore", draft);
     }
@@ -93,18 +87,14 @@ describe("useDraftSync", () => {
       />,
     );
 
-    if (expected) {
-      expect(setContent).toHaveBeenCalledWith(expected);
-    } else {
-      expect(setContent).not.toHaveBeenCalledWith("Sales by week");
-    }
+    expect(editor.getText()).toBe(expected);
   });
 
   // Drafts land only once the store hydrates, so filling the box before that
   // would show the caller's text and then swap it for what the user had typed.
   it("holds initialContent until the draft store hydrates", () => {
     useDraftStore.setState((state) => ({ ...state, _hasHydrated: false }));
-    const { editor, setContent } = fakeEditor();
+    const editor = makeEditor();
 
     render(
       <RestoreProbe
@@ -113,12 +103,12 @@ describe("useDraftSync", () => {
         initialContent="Sales by week"
       />,
     );
-    expect(setContent).not.toHaveBeenCalled();
+    expect(editor.getText()).toBe("");
 
     act(() => {
       useDraftStore.getState().actions.setHasHydrated(true);
     });
-    expect(setContent).toHaveBeenCalledWith("Sales by week");
+    expect(editor.getText()).toBe("Sales by week");
   });
 
   it("clears restored attachments when a draft no longer has attachments", () => {

--- a/products/desktop/packages/ui/src/features/message-editor/tiptap/useDraftSync.ts
+++ b/products/desktop/packages/ui/src/features/message-editor/tiptap/useDraftSync.ts
@@ -20,6 +20,8 @@ export function useDraftSync(
   editor: Editor | null,
   sessionId: string,
   context?: DraftContext,
+  /** What the composer starts from when this session has no draft yet. */
+  initialContent?: string,
 ) {
   const hasRestoredRef = useRef(false);
   const lastSessionIdRef = useRef(sessionId);
@@ -63,7 +65,16 @@ export function useDraftSync(
   // Restore draft on mount or when sessionId/editor changes
   useLayoutEffect(() => {
     if (!hasHydrated || !editor || hasRestoredRef.current) return;
-    if (!draft || isContentEmpty(draft)) return;
+    if (!draft || isContentEmpty(draft)) {
+      // A caller's starting point fills the box only when nothing was left in
+      // it. It waits for hydration like the draft does, so the two can't race
+      // and flash one over the other.
+      if (initialContent) {
+        hasRestoredRef.current = true;
+        editor.commands.setContent(initialContent);
+      }
+      return;
+    }
 
     hasRestoredRef.current = true;
 
@@ -72,7 +83,7 @@ export function useDraftSync(
     } else {
       editor.commands.setContent(editorContentToTiptapJson(draft));
     }
-  }, [hasHydrated, draft, editor]);
+  }, [hasHydrated, draft, editor, initialContent]);
 
   // Handle pending content (e.g., restoring queued messages after cancel)
   useLayoutEffect(() => {

--- a/products/desktop/packages/ui/src/features/message-editor/tiptap/useTiptapEditor.ts
+++ b/products/desktop/packages/ui/src/features/message-editor/tiptap/useTiptapEditor.ts
@@ -68,6 +68,8 @@ export interface UseTiptapEditorOptions {
     bashMode?: boolean;
   };
   clearOnSubmit?: boolean;
+  /** What the composer starts from when this session has no draft yet. */
+  initialContent?: string;
   getPromptHistory?: () => string[];
   onPromptRecall?: PromptRecallHandler;
   onBeforeSubmit?: (text: string, clearEditor: () => void) => boolean;
@@ -246,6 +248,7 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
     context,
     capabilities = {},
     clearOnSubmit = true,
+    initialContent,
     getPromptHistory,
     onPromptRecall,
     onBeforeSubmit,
@@ -737,7 +740,7 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
     [sessionId, disabled, fileMentions, commands, placeholder],
   );
 
-  const draft = useDraftSync(editor, sessionId, context);
+  const draft = useDraftSync(editor, sessionId, context, initialContent);
   draftRef.current = draft;
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: `editor` is the trigger: a recreated editor brings a new schema, and restoring a snapshot taken against the old one would throw on replaceWith.


### PR DESCRIPTION
Replaces #85411, which was stacked on #85375. Same diff, rebased onto master, so it can land on its own.

## Problem

Drawing a box on a grid canvas dropped you into a one-line text field, while every other place you talk to an agent in this app is the task composer. You could not write a second line, and markdown you typed stayed literal.

Edit mode also never said where a box would land. The dotted lattice and the crosshair cursor were the only hints, so the first press was a guess.

## Changes

<img width="2556" height="1012" alt="2026-08-19 13 25 48" src="https://github.com/user-attachments/assets/162f6606-e916-4a96-9442-775963b23746"/>

| | Before | After |
| --- | --- | --- |
| A drawn box | ![before](https://raw.githubusercontent.com/PostHog/pr-assets/38819ee9a1947f9e7ec7669511dce97bdc2262a8/2026/08/9cb91f83-0c76-45db-8540-6ca48fd817b2.png) | ![after](https://raw.githubusercontent.com/PostHog/pr-assets/06f90241e53ec85110d94097a4693c626da299ae/2026/08/64528d9d-860d-41b1-a588-93c2b7a3ee00.png) |

- The empty cell under the pointer lights up in edit mode, so the surface shows where a click would put a box.
- A drawn box carries `PromptInput`, the editor the task composer and the freeform canvas already use: shift+enter for a new line, markdown as you type, `@` for files, `/` for skills, up and down for prompt history.
- A half-written description survives a remount, keyed per placement.
- A failed box prefills what was asked for the first time, so a retry starts from it. It only prefills on mount, and only into an empty editor.
- Remove is `destructive` on both boxes that offer it, and moves under the editor.

![failed](https://raw.githubusercontent.com/PostHog/pr-assets/af860759a0af7f6212a2dde7e0799f723505f056/2026/08/e481c277-beb2-4bb2-97d4-67987081d8b6.png)

The hover state is one `hover` cell in `useGridDrag`. It only reports the surface's own cells, so a tile never lights, and it holds the same cell across pointer moves rather than re-rendering the canvas and its widget frames at pointer rate.

## How did you test this code?

- Added `GridPlacementTile.stories.tsx` (pending, single cell, failed) and rendered it in Storybook. The screenshots above come from those stories, before and after, in Storybook's dark theme.
- The single-cell story is the one that matters: the editor plus its Remove row has to fit a 96px tile.
- Ran `pnpm --filter=@posthog/ui exec vitest run src/features/canvas/grid src/features/message-editor` and `pnpm --filter=@posthog/ui exec tsc --noEmit` on this branch, against master.
- No test for the hover cell. It needs a pointer simulation over a mounted canvas, and the grid has no harness for that.
- Not checked in the running app: hover, markdown input, and shift+enter were not exercised by hand in this session.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code wrote the change. Skills invoked: `/writing-pr-descriptions`, `/stacking-prs`, `/writing-user-facing-copy`.

The describe box went through a middle state that is not in this diff: a quill `InputGroup` with Create and Remove buttons in a `block-end` addon. Reusing `PromptInput` replaced it, on the grounds that the freeform canvas already does exactly that (`FreeformGenerateBar`), so the grid canvas gets the same editor rather than a second one to maintain. Send is that editor's own arrow button, which is why the Create label is gone.

`enableCommands` is on, so `/` opens the skills menu inside a widget box. That matches the freeform canvas; flag it if a widget prompt should be plain prose.

On the detach: the four commits cherry-picked onto master with no conflicts, and the resulting diff is byte-identical to what #85411 added on top of #85375. The two PRs touched disjoint files, so nothing from the layer below was needed.


---
_Generated by [Claude Code](https://claude.ai/code/session_018m2sHczLahuW1mh3ywYrzx)_