### PR TITLE
feat(error-tracking): show platform in the release popover

### DIFF
--- a/frontend/src/lib/components/Errors/utils.test.ts
+++ b/frontend/src/lib/components/Errors/utils.test.ts
@@ -189,6 +189,17 @@ describe('Error Display', () => {
         expect(result.level).toEqual('fatal')
     })
 
+    // Mobile SDKs report the platform in $os_name and leave $os unset, so reading $os alone left
+    // iOS and Android errors with no platform anywhere in the UI.
+    it.each([
+        ['$os_name only', { $os_name: 'iOS' }, 'iOS'],
+        ['$os only', { $os: 'Windows' }, 'Windows'],
+        ['both keys', { $os_name: 'iPadOS', $os: 'Mac OS X' }, 'iPadOS'],
+        ['neither key', {}, undefined],
+    ])('resolves os from %s', (_name, properties, expected) => {
+        expect(getExceptionAttributes(properties).os).toEqual(expected)
+    })
+
     // A non-string $session_id (e.g. a numeric timestamp from a misbehaving SDK) must not leak
     // through as a number — it used to crash the issue scene via a ts-pattern exhaustive match.
     it.each([

--- a/frontend/src/lib/components/Errors/utils.ts
+++ b/frontend/src/lib/components/Errors/utils.ts
@@ -79,7 +79,6 @@ export function getExceptionAttributes(properties: Record<string, any>): Excepti
         $lib_version: libVersion,
         $browser: browser,
         $browser_version: browserVersion,
-        $os: os,
         $os_version: osVersion,
         $sentry_url: sentryUrl,
         $exception_level: level,
@@ -111,6 +110,8 @@ export function getExceptionAttributes(properties: Record<string, any>): Excepti
     const runtime: ErrorTrackingRuntime = getRuntimeFromLib(lib)
     const appNamespace = properties.$app_namespace
     const appVersion = properties.$app_version
+    // Mobile SDKs report the platform in $os_name and leave $os unset; web and server SDKs do the opposite.
+    const os = properties.$os_name ?? properties.$os
 
     return {
         type,

--- a/products/error_tracking/frontend/components/ContextDisplay/ContextDisplay.tsx
+++ b/products/error_tracking/frontend/components/ContextDisplay/ContextDisplay.tsx
@@ -3,7 +3,7 @@ import { match } from 'ts-pattern'
 
 import { Spinner } from '@posthog/lemon-ui'
 
-import { BUILT_IN_ERROR_TRACKING_PROPERTIES } from '../builtInProperties'
+import { BUILT_IN_ERROR_TRACKING_PROPERTIES, resolveBuiltInProperty } from '../builtInProperties'
 import { ERROR_TRACKING_ISSUE_SCENE_LOGIC_KEY, issueFiltersLogic } from '../IssueFilters/issueFiltersLogic'
 import { ExceptionPropertiesTable } from './ExceptionPropertiesTable'
 
@@ -31,17 +31,15 @@ export function ContextDisplay({
             value,
             filterKey: key,
         }))
-    const builtInEntries = BUILT_IN_ERROR_TRACKING_PROPERTIES.map(
-        ({ property, title, versionProperty, fallbackProperty }) => {
-            const resolvedProperty = resolveBuiltInProperty(properties, property, fallbackProperty)
-            return {
-                key: title,
-                value: getBuiltInPropertyValue(properties, resolvedProperty, versionProperty),
-                filterKey: resolvedProperty,
-                filterValue: properties?.[resolvedProperty],
-            }
+    const builtInEntries = BUILT_IN_ERROR_TRACKING_PROPERTIES.map((builtIn) => {
+        const resolvedProperty = resolveBuiltInProperty(properties, builtIn)
+        return {
+            key: builtIn.title,
+            value: getBuiltInPropertyValue(properties, resolvedProperty, builtIn.versionProperty),
+            filterKey: resolvedProperty,
+            filterValue: properties?.[resolvedProperty],
         }
-    )
+    })
     const normalizedPropertyNameFilter = propertyNameFilter.trim().toLocaleLowerCase()
 
     return (
@@ -88,18 +86,6 @@ function filterEntriesByPropertyName<T extends { key: string; filterKey?: string
             .filter((value): value is string => typeof value === 'string')
             .some((value) => value.toLocaleLowerCase().includes(normalizedPropertyNameFilter))
     )
-}
-
-function resolveBuiltInProperty(
-    properties: Record<string, unknown> | undefined,
-    property: string,
-    fallbackProperty: string | undefined
-): string {
-    if (!fallbackProperty) {
-        return property
-    }
-    const value = properties?.[property]
-    return value === undefined || value === null || value === '' ? fallbackProperty : property
 }
 
 function getBuiltInPropertyValue(

--- a/products/error_tracking/frontend/components/ContextDisplay/ContextDisplay.tsx
+++ b/products/error_tracking/frontend/components/ContextDisplay/ContextDisplay.tsx
@@ -31,12 +31,17 @@ export function ContextDisplay({
             value,
             filterKey: key,
         }))
-    const builtInEntries = BUILT_IN_ERROR_TRACKING_PROPERTIES.map(({ property, title, versionProperty }) => ({
-        key: title,
-        value: getBuiltInPropertyValue(properties, property, versionProperty),
-        filterKey: property,
-        filterValue: properties?.[property],
-    }))
+    const builtInEntries = BUILT_IN_ERROR_TRACKING_PROPERTIES.map(
+        ({ property, title, versionProperty, fallbackProperty }) => {
+            const resolvedProperty = resolveBuiltInProperty(properties, property, fallbackProperty)
+            return {
+                key: title,
+                value: getBuiltInPropertyValue(properties, resolvedProperty, versionProperty),
+                filterKey: resolvedProperty,
+                filterValue: properties?.[resolvedProperty],
+            }
+        }
+    )
     const normalizedPropertyNameFilter = propertyNameFilter.trim().toLocaleLowerCase()
 
     return (
@@ -83,6 +88,18 @@ function filterEntriesByPropertyName<T extends { key: string; filterKey?: string
             .filter((value): value is string => typeof value === 'string')
             .some((value) => value.toLocaleLowerCase().includes(normalizedPropertyNameFilter))
     )
+}
+
+function resolveBuiltInProperty(
+    properties: Record<string, unknown> | undefined,
+    property: string,
+    fallbackProperty: string | undefined
+): string {
+    if (!fallbackProperty) {
+        return property
+    }
+    const value = properties?.[property]
+    return value === undefined || value === null || value === '' ? fallbackProperty : property
 }
 
 function getBuiltInPropertyValue(

--- a/products/error_tracking/frontend/components/ExceptionCard/Tabs/StackTraceTab/index.tsx
+++ b/products/error_tracking/frontend/components/ExceptionCard/Tabs/StackTraceTab/index.tsx
@@ -4,6 +4,7 @@ import type { ComponentProps } from 'react'
 import { errorPropertiesLogic } from 'lib/components/Errors/errorPropertiesLogic'
 import { CollapsibleExceptionList } from 'lib/components/Errors/ExceptionList/CollapsibleExceptionList'
 import { LoadingExceptionList } from 'lib/components/Errors/ExceptionList/LoadingExceptionList'
+import { concatValues } from 'lib/components/Errors/utils'
 import { TabsContent } from 'lib/ui/quill'
 import { cn } from 'lib/utils/css-classes'
 
@@ -27,7 +28,12 @@ export function StackTraceTab({ className, renderActions, ...props }: StackTrace
             <SubHeader className="justify-between shrink-0">
                 <div className="flex items-center gap-1">
                     <ExceptionAttributesPreview attributes={exceptionAttributes} loading={loading} />
-                    {release && <ReleasePreviewPill release={release} />}
+                    {release && (
+                        <ReleasePreviewPill
+                            release={release}
+                            platform={concatValues(exceptionAttributes, 'os', 'osVersion')}
+                        />
+                    )}
                 </div>
                 {renderActions?.()}
             </SubHeader>

--- a/products/error_tracking/frontend/components/ReleasesPreview/ReleasePreviewPill.tsx
+++ b/products/error_tracking/frontend/components/ReleasesPreview/ReleasePreviewPill.tsx
@@ -7,12 +7,18 @@ import { ErrorTrackingRelease } from 'lib/components/Errors/types'
 
 import { ReleasePopoverContent } from './ReleasesPopoverContent'
 
-export function ReleasePreviewPill({ release }: { release: ErrorTrackingRelease }): JSX.Element {
+export function ReleasePreviewPill({
+    release,
+    platform,
+}: {
+    release: ErrorTrackingRelease
+    platform?: string
+}): JSX.Element {
     const [isOpen, setIsOpen] = useState(false)
     return (
         <Popover
             visible={isOpen}
-            overlay={<ReleasePopoverContent release={release} />}
+            overlay={<ReleasePopoverContent release={release} platform={platform} />}
             placement="right"
             padded={false}
             showArrow

--- a/products/error_tracking/frontend/components/ReleasesPreview/ReleasesPopoverContent.tsx
+++ b/products/error_tracking/frontend/components/ReleasesPreview/ReleasesPopoverContent.tsx
@@ -20,9 +20,10 @@ import { GitMetadataParser } from './gitMetadataParser'
 
 export interface ReleasesPopoverContentProps {
     release: ErrorTrackingRelease
+    platform?: string
 }
 
-export function ReleasePopoverContent({ release }: ReleasesPopoverContentProps): JSX.Element {
+export function ReleasePopoverContent({ release, platform }: ReleasesPopoverContentProps): JSX.Element {
     return (
         <div className="overflow-hidden">
             <div className="p-2">
@@ -32,6 +33,12 @@ export function ReleasePopoverContent({ release }: ReleasesPopoverContentProps):
                         <th className="pb-1">Project</th>
                         <td className="pb-1 text-right">{release.project ?? 'Unknown'}</td>
                     </tr>
+                    {platform && (
+                        <tr>
+                            <th>Platform</th>
+                            <td className="text-right">{platform}</td>
+                        </tr>
+                    )}
                     {(() => {
                         const [displayVersion, build] = release.version.includes('+')
                             ? release.version.split('+', 2)

--- a/products/error_tracking/frontend/components/builtInProperties.test.ts
+++ b/products/error_tracking/frontend/components/builtInProperties.test.ts
@@ -1,0 +1,24 @@
+import { BREAKDOWN_PRESETS } from './Breakdowns/consts'
+import { BUILT_IN_ERROR_TRACKING_PROPERTIES, resolveBuiltInProperty } from './builtInProperties'
+
+describe('built-in error tracking properties', () => {
+    const operatingSystem = BUILT_IN_ERROR_TRACKING_PROPERTIES.find(({ title }) => title === 'Operating system')!
+
+    // getExceptionAttributes prefers $os_name, so this has to prefer it too. Otherwise one exception
+    // reports a different platform in the properties table than in the release popover.
+    it.each([
+        ['both keys are set', { $os_name: 'iPadOS', $os: 'Mac OS X' }, '$os_name'],
+        ['only $os_name is set', { $os_name: 'Android' }, '$os_name'],
+        ['only $os is set', { $os: 'Windows' }, '$os'],
+        ['$os_name is empty', { $os_name: '', $os: 'Windows' }, '$os'],
+        ['neither key is set', {}, '$os'],
+    ])('reads the operating system from $os_name first when %s', (_name, properties, expected) => {
+        expect(resolveBuiltInProperty(properties, operatingSystem)).toEqual(expected)
+    })
+
+    // Breakdowns match on `property`, so moving the OS entry onto $os_name would drop this preset
+    // and reclassify an $os breakdown as a custom property.
+    it('keeps $os as the canonical operating system key for breakdown presets', () => {
+        expect(BREAKDOWN_PRESETS).toContainEqual({ property: '$os', title: 'Operating system' })
+    })
+})

--- a/products/error_tracking/frontend/components/builtInProperties.ts
+++ b/products/error_tracking/frontend/components/builtInProperties.ts
@@ -2,18 +2,23 @@ export interface BuiltInErrorTrackingProperty {
     property: string
     title: string
     versionProperty?: string
-    /** Used when `property` is absent, for SDKs that report the same thing under another key. */
-    fallbackProperty?: string
+    /**
+     * Read in place of `property` whenever it holds a value, for SDKs that report the same thing
+     * under another key. `property` stays the canonical key, so breakdown presets are unaffected.
+     */
+    preferredProperty?: string
 }
 
 export const BUILT_IN_ERROR_TRACKING_PROPERTIES: BuiltInErrorTrackingProperty[] = [
     { property: '$browser', title: 'Browser', versionProperty: '$browser_version' },
     { property: '$device_type', title: 'Device type' },
+    // $os_name has to win here as well as in getExceptionAttributes, or one exception reports a
+    // different platform in the properties table than in the release popover.
     {
         property: '$os',
         title: 'Operating system',
         versionProperty: '$os_version',
-        fallbackProperty: '$os_name',
+        preferredProperty: '$os_name',
     },
     { property: '$pathname', title: 'Path' },
     { property: '$user_id', title: 'User ID' },
@@ -25,3 +30,15 @@ export const BUILT_IN_ERROR_TRACKING_PROPERTIES: BuiltInErrorTrackingProperty[] 
     { property: '$app_namespace', title: 'App', versionProperty: '$app_version' },
     { property: '$current_url', title: 'Current URL' },
 ]
+
+/** The property key to read a built-in entry's value and filter from. */
+export function resolveBuiltInProperty(
+    properties: Record<string, unknown> | undefined,
+    { property, preferredProperty }: BuiltInErrorTrackingProperty
+): string {
+    if (!preferredProperty) {
+        return property
+    }
+    const preferred = properties?.[preferredProperty]
+    return preferred === undefined || preferred === null || preferred === '' ? property : preferredProperty
+}

--- a/products/error_tracking/frontend/components/builtInProperties.ts
+++ b/products/error_tracking/frontend/components/builtInProperties.ts
@@ -2,12 +2,19 @@ export interface BuiltInErrorTrackingProperty {
     property: string
     title: string
     versionProperty?: string
+    /** Used when `property` is absent, for SDKs that report the same thing under another key. */
+    fallbackProperty?: string
 }
 
 export const BUILT_IN_ERROR_TRACKING_PROPERTIES: BuiltInErrorTrackingProperty[] = [
     { property: '$browser', title: 'Browser', versionProperty: '$browser_version' },
     { property: '$device_type', title: 'Device type' },
-    { property: '$os', title: 'Operating system', versionProperty: '$os_version' },
+    {
+        property: '$os',
+        title: 'Operating system',
+        versionProperty: '$os_version',
+        fallbackProperty: '$os_name',
+    },
     { property: '$pathname', title: 'Path' },
     { property: '$user_id', title: 'User ID' },
     { property: '$ip', title: 'IP address' },


### PR DESCRIPTION
## Problem

Anyone triaging a mobile error has to open the properties tab to tell iOS from Android, and on React Native the runtime icon only says "React", so the platform is invisible at a glance. This came in as a customer request.

Error tracking reads the platform from `$os`. Mobile SDKs leave `$os` unset and report the platform in `$os_name` instead, so the built-in "Operating system" row resolved to nothing for iOS, Android, and React Native exceptions. `$os_name` was not listed under "Custom properties" either, because that list drops `$`-prefixed keys.

## Changes

- The release popover now lists Platform above Version, so one hover tells you iOS from Android, with the OS version.

![Release popover before and after, showing a new Platform row](https://raw.githubusercontent.com/PostHog/pr-assets/ec1ec605aada48388e3e0fdd67597886eeb046b2/2026/08/647be5bc-a41d-4ec5-b2d3-e1aa3a29769a.png)

- The properties tab now fills the "Operating system" row for mobile errors. Its filter chip points at whichever property supplied the value, so click-to-filter still builds a filter that matches.
- `getExceptionAttributes` prefers `$os_name` over `$os`, which is the precedence session replay already uses. That also fills the `os` snack in the session recording event view.
- Both surfaces resolve the platform the same way. `$os_name` wins over `$os` in the properties table too, via a `preferredProperty` field, so an event carrying both keys cannot report one platform on hover and another in the properties tab. `$os` stays the entry's canonical key, which is what breakdown presets match on.
- Mechanical: a `platform` prop threaded from the stack trace tab through the release pill into the popover.

> [!NOTE]
> The popover only renders when the event carries release info. Errors with no release still show the platform in the properties tab, not on hover.

## How did you test this code?

- Added parameterized Jest cases pinning the `$os_name` / `$os` precedence. The regression they catch: reading `$os` alone, which leaves every iOS and Android error with no platform anywhere in the UI. No existing case covered `$os_name`.
- Ran the `lib/components/Errors` and `products/error_tracking` Jest suites, the frontend TypeScript check, and oxlint + oxfmt. The TypeScript check is clean for these files.
- Added a parameterized test for the operating-system property resolution, plus one pinning that `$os` stays the breakdown-preset key. Between them they catch the two ways this can break: the two surfaces disagreeing, and the Operating system breakdown preset silently disappearing.
- Rendered the popover and the properties table to confirm the before and after. The screenshot above is a Storybook render, from a story that was not committed. Its sample values are invented.
- Not done: no verification against real mobile data in a running instance, and no Playwright coverage. `hogli` is unavailable in this environment, so `ci:preflight` did not run.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written by Claude Code (Opus) in a PostHog cloud task, directed by the assignee.
- Repo skills invoked: `/writing-user-facing-copy`, `/writing-code-comments`, `/writing-tests`, `/writing-pr-descriptions`, `/security-audit`. Semgrep ran over the changed files with the repo rule set and reported no findings; the diff adds no new input path, since both property keys come from a hardcoded list and render as escaped React text.
- The `$os_name` fallback came out of querying real exception events over MCP rather than from reading the SDKs. That query is what showed mobile events carrying `$os_name` with `$os` empty, which is why the fallback is part of this PR instead of just a new row.
- Considered putting the platform in its own pill next to the release pill, which would avoid a hover. Kept it in the popover, because that is where it was asked for and the popover already groups project, version, and build.
- Public artifact: this work started from a customer report. Nothing from that conversation is in the diff, the commit message, or this description. The screenshot's project, version, build, branch, and commit values are invented, not the reporter's values with names swapped.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*

