### PR TITLE
fix(data-imports): stop reporting transient db blips from repartition detection

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/repartition_controller.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/repartition_controller.py
@@ -27,6 +27,9 @@ from posthog.utils import get_machine_id
 from products.warehouse_sources.backend.models.external_data_job import ExternalDataJob
 from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
 from products.warehouse_sources.backend.models.oom_event import ExternalDataSchemaOOMEvent
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.errors import (
+    is_transient_maintenance_error,
+)
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.repartition import (
     measure_partition_bytes,
     select_coarsen_target,
@@ -576,6 +579,16 @@ async def maybe_flag_for_repartition(
             target_size=target.partition_size,
         )
     except Exception as e:
-        # Detection is best-effort; never fail post-load over it.
+        # Detection is best-effort; never fail post-load over it. `record_partition_measurement` and
+        # the other DB writes above can hit a transient app-DB blip (pgbouncer pooler drop, or its
+        # server_login_retry cooldown outliving retry_on_db_connection_drop's single retry) — the
+        # same class of noise `_maybe_flag_pre_extraction` (repartition_table.py) already filters
+        # out with this same classifier, so this best-effort detection function should too.
+        if is_transient_maintenance_error(e):
+            await logger.awarning(
+                f"repartition: detection failed with a transient infra error schema_id={schema.id}",
+                schema_id=str(schema.id),
+            )
+            return
         await logger.aexception(f"repartition: detection failed schema_id={schema.id}", schema_id=str(schema.id))
         capture_exception(e)

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test_repartition_controller.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test_repartition_controller.py
@@ -107,6 +107,30 @@ class TestRepartitionDetection:
         assert pending["trigger_reason"] == "proactive_threshold"
         assert capture.call_args.args[0] == "warehouse_repartition_flagged"
 
+    def test_transient_db_error_during_measurement_save_is_not_captured(self, team):
+        # A pgbouncer pooler drop (or its server_login_retry cooldown outliving the single retry in
+        # retry_on_db_connection_drop) must not mint an error-tracking issue for a condition nobody
+        # can act on — only a genuine detection bug should reach capture_exception.
+        schema = _make_schema(
+            team,
+            {"partitioning_enabled": True, "partition_mode": "md5", "partition_count": 2, "partitioning_keys": ["id"]},
+        )
+        with tempfile.TemporaryDirectory() as d:
+            delta = _write_partitioned_delta(f"{d}/t", ["0", "0", "1", "1"])
+            with (
+                patch.object(
+                    ExternalDataSchema,
+                    "record_partition_measurement",
+                    side_effect=OperationalError(
+                        "server login has been failing, cached error: server conn crashed? (server_login_retry)"
+                    ),
+                ),
+                patch.object(ctrl, "capture_exception") as mock_capture_exception,
+            ):
+                self._detect(team, schema, delta)
+
+        mock_capture_exception.assert_not_called()
+
     def test_unpartitioned_table_flags_auto_target_scheme(self, team):
         # An unpartitioned table's target legitimately has mode None (auto-detect at rewrite time),
         # but the flagged event must report "auto" — a null here NULL-poisons dashboard strings —


### PR DESCRIPTION
## Problem

Repartition detection mints an error-tracking issue for a plain Postgres connection blip, even though the sync it runs inside completes fine. [The issue](https://us.posthog.com/project/2/error_tracking/01a01ba0-ea3b-7702-af69-734e77e24fce) fired for a Stripe sync's post-load partition-size measurement, from an `OperationalError` a pgbouncer login-retry cooldown produced.

`maybe_flag_for_repartition` (`repartition_controller.py`) reports every exception from its detection step, with no distinction between a real detection bug and a self-healing connection drop.

## Changes

- `maybe_flag_for_repartition` now checks `is_transient_maintenance_error` before calling `capture_exception`, the same check its sibling `_maybe_flag_pre_extraction` (`repartition_table.py`) already applies to the same "detection is best-effort" pattern.
- A transient blip now logs a warning and returns; a genuine detection failure still reports as before.
- Mechanical: added a regression test in `test_repartition_controller.py`.

## How did you test this code?

- Added `test_transient_db_error_during_measurement_save_is_not_captured`, which makes `record_partition_measurement` raise the same `OperationalError` seen in the linked issue and asserts `capture_exception` is not called. No existing test exercised this except block's transient-vs-genuine distinction.
- Ran the full `test_repartition_controller.py` file and `test_db_errors.py` locally against the dev stack; both pass.
- Ran `ruff check`/`ruff format` and a targeted `mypy` pass on the two changed files; both clean. A repo-wide `mypy` run was not completed in this sandbox (killed for memory), so that broader check is left to CI.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal error-tracking behavior only, no documented workflow changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog's error-tracking MCP tools (issue lookup, sampled exception events, HogQL) to pull the stack trace and confirm the failure was a one-off pgbouncer login-retry cooldown, not a recurring pattern. Traced the call path from `maybe_flag_for_repartition` down to the Django `.save()` that raised, and compared against sibling call sites in `repartition_table.py` that already classify this failure class before reporting it. Skills invoked: `/writing-tests` before adding the regression test, `/writing-pr-descriptions` before writing this body. Checked for a duplicate fix first: no open human-authored PR addresses this; an open bot-authored PR (#83890) adding a related `db_errors.py` marker is superseded by already-merged work and doesn't touch this call site.