### PR TITLE
fix(replay): clarify mobile session recording triggers

### DIFF
--- a/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
+++ b/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
@@ -273,44 +273,42 @@ function Sampling(): JSX.Element {
 }
 
 function MobileSampling(): JSX.Element {
+    const { updateCurrentTeam } = useActions(teamLogic)
     const { currentTeam } = useValues(teamLogic)
 
     const storedSampleRate = currentTeam?.session_recording_sample_rate
-    const sampleRate = toDisplaySampleRate(storedSampleRate)
 
     return (
-        <div className="flex flex-col gap-2">
-            <div className="flex flex-row items-center gap-2">
-                <LemonLabel className="text-base">
-                    Sample rate{' '}
-                    <Since
-                        android={{ version: '3.34.0' }}
-                        ios={{ version: '3.42.0' }}
-                        reactNative={{ version: '4.37.0' }}
+        <PayGateMini feature={AvailableFeature.SESSION_REPLAY_SAMPLING}>
+            <div className="flex flex-col gap-2">
+                <div className="flex flex-row justify-between items-center">
+                    <LemonLabel className="text-base">
+                        Sample rate{' '}
+                        <Since
+                            android={{ version: '3.34.0' }}
+                            ios={{ version: '3.42.0' }}
+                            reactNative={{ version: '4.37.0' }}
+                        />
+                        {storedSampleRate == null && <span className="text-muted font-normal"> (default)</span>}
+                    </LemonLabel>
+                    <IngestionControls.SamplingTrigger
+                        initialSampleRate={toDisplaySampleRate(storedSampleRate)}
+                        onChange={(v) => updateCurrentTeam({ session_recording_sample_rate: v.toString() })}
                     />
-                </LemonLabel>
-                <Tooltip title="Sample rate is shared across web and mobile. Change it on the Web tab.">
-                    <span className="text-muted font-semibold">
-                        {sampleRate}%{storedSampleRate == null && <span className="font-normal"> (default)</span>}
-                    </span>
-                </Tooltip>
+                </div>
+                <p>Choose how many sessions to record. 100% = record every session, 50% = record roughly half.</p>
             </div>
-            <p className="text-muted-alt">
-                Sample rate is shared across all platforms.{' '}
-                <span className="font-semibold">Change this setting on the Web tab.</span>
-            </p>
-        </div>
+        </PayGateMini>
     )
 }
 
 function MobileEventTriggers(): JSX.Element {
     const { eventTriggerConfig } = useValues(replayTriggersLogic)
-
-    const eventCount = eventTriggerConfig?.length ?? 0
+    const { updateEventTriggerConfig } = useActions(replayTriggersLogic)
 
     return (
         <div className="flex flex-col gap-2">
-            <div className="flex flex-row items-center gap-2">
+            <div className="flex items-center gap-2 justify-between">
                 <LemonLabel className="text-base">
                     Event emitted{' '}
                     <Since
@@ -320,49 +318,51 @@ function MobileEventTriggers(): JSX.Element {
                         flutter={{ version: '5.25.0' }}
                     />
                 </LemonLabel>
-                <Tooltip title="Event triggers are shared across web and mobile. Change them on the Web tab.">
-                    <span className="text-muted font-semibold">
-                        {eventCount > 0 ? pluralize(eventCount, 'event') : 'Not configured'}
-                    </span>
-                </Tooltip>
+                <IngestionControls.EventTriggerSelect events={eventTriggerConfig} onChange={updateEventTriggerConfig} />
             </div>
-            <p className="text-muted-alt">
-                Event triggers are shared across Web and Mobile.{' '}
-                <span className="font-semibold">Change this setting on the Web tab.</span>
-            </p>
+            <p>Start recording when a PostHog event is queued.</p>
+
+            <div className="flex gap-2 flex-wrap">
+                {eventTriggerConfig?.map((trigger) => (
+                    <IngestionControls.EventTrigger
+                        key={trigger}
+                        trigger={trigger}
+                        onClose={() => updateEventTriggerConfig(eventTriggerConfig?.filter((e) => e !== trigger))}
+                    />
+                ))}
+            </div>
         </div>
     )
 }
 
 function MobileMinimumDuration(): JSX.Element {
+    const { updateCurrentTeam } = useActions(teamLogic)
     const { currentTeam } = useValues(teamLogic)
 
-    const minDurationMs = currentTeam?.session_recording_minimum_duration_milliseconds
-    const minDurationSeconds = (minDurationMs ?? 0) / 1000
-
     return (
-        <div className="flex flex-col gap-2">
-            <div className="flex flex-row items-center gap-2">
-                <LemonLabel className="text-base">
-                    Duration threshold{' '}
-                    <Since
-                        ios={{ version: '3.53.0' }}
-                        android={{ version: '3.44.0' }}
-                        reactNative={{ version: '4.52.0' }}
-                        flutter={{ version: '5.24.3' }}
+        <PayGateMini feature={AvailableFeature.REPLAY_RECORDING_DURATION_MINIMUM}>
+            <div className="flex flex-col gap-2">
+                <div className="flex flex-row justify-between items-center">
+                    <LemonLabel className="text-base">
+                        Duration threshold{' '}
+                        <Since
+                            ios={{ version: '3.53.0' }}
+                            android={{ version: '3.44.0' }}
+                            reactNative={{ version: '4.52.0' }}
+                            flutter={{ version: '5.24.3' }}
+                        />
+                    </LemonLabel>
+                    <IngestionControls.MinDuration
+                        value={currentTeam?.session_recording_minimum_duration_milliseconds}
+                        onChange={(v) => updateCurrentTeam({ session_recording_minimum_duration_milliseconds: v })}
                     />
-                </LemonLabel>
-                <Tooltip title="Minimum duration is shared across web and mobile. Change it on the Web tab.">
-                    <span className="text-muted font-semibold">
-                        {minDurationMs ? `${minDurationSeconds}s` : 'No minimum'}
-                    </span>
-                </Tooltip>
+                </div>
+                <p>
+                    Only collect sessions that last longer than this. This helps you avoid recording sessions that are
+                    too short to be useful.
+                </p>
             </div>
-            <p className="text-muted-alt">
-                Minimum duration is shared across Web and Mobile.{' '}
-                <span className="font-semibold">Change this setting on the Web tab.</span>
-            </p>
-        </div>
+        </PayGateMini>
     )
 }
 
@@ -646,6 +646,10 @@ export function ReplayTriggers(): JSX.Element {
             label: 'Mobile',
             content: (
                 <div className="flex flex-col gap-y-2">
+                    <LemonBanner type="info">
+                        Trigger groups aren't available on mobile yet. Mobile recording uses the settings below, which
+                        are shared with web. Changing a setting here also changes it on web.
+                    </LemonBanner>
                     {currentTeam && (
                         <RecordingTriggersSummary currentTeam={currentTeam} selectedPlatform={selectedPlatform} />
                     )}


### PR DESCRIPTION
## Problem

On the Session replay settings Mobile tab, sample rate, event triggers, and duration threshold were read-only. Each pointed the user to the Web tab to make the change.

The Web tab leads with trigger groups, which mobile does not support, and collapses the legacy conditions that mobile actually uses. So the pointer sent users to a section that opens with a web-only feature and hides the settings they came for.

## Changes

- Mobile tab now shows an info banner: trigger groups aren't available on mobile yet, and the settings below are shared with web, so changing one here also changes it on web.
- Sample rate, event triggers, and duration threshold are editable in place on the Mobile tab instead of redirecting to the Web tab.
- Each mobile field reuses the same control the Web tab already uses, keeping the mobile SDK version badges.
- No backend change: these settings map to the shared team fields the mobile config already reads.

![replay-mobile](https://raw.githubusercontent.com/PostHog/pr-assets/0f79ef330ca115775c059e4ce27cb6f2868cf77b/2026/08/419aa92b-b166-4f6b-ad14-01f613d6fa43.png)

## How did you test this code?

- Rendered the settings scene in Storybook (`Scenes-App/Settings/Environment` → Replay) and switched to the Mobile tab to confirm the banner and the three editable controls render. The screenshot above is that render.
- Ran `tsgo --noEmit` (typecheck) and oxlint plus oxfmt: clean.
- Not run: the change has no automated test; the redirect-to-edit swap is covered by the existing shared controls.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (Opus 4.8), directed by @ksvat.

Skills invoked: /writing-user-facing-copy (banner and field copy), /writing-ui-components (kept the mobile fields as separate components rather than a shared generic, because their only difference is the mobile SDK version badges, which is content not a variant flag), /writing-pr-descriptions.

Investigation confirmed the mobile config path already receives the shared V1 fields, so making these fields editable on mobile needed no backend change. One observation out of scope for this PR: the shared `RecordingTriggersSummary` renders "No triggers — all sessions recorded" with an em-dash, which the copy rules forbid.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*