### PR TITLE
chore(access-control): add a ProjectAccess facade over UserAccessControl

### DIFF
--- a/posthog/api/routing.py
+++ b/posthog/api/routing.py
@@ -42,6 +42,8 @@ from posthog.rbac.user_access_control import UserAccessControl
 from posthog.scopes import APIScopeObjectOrNotSupported
 from posthog.user_permissions import UserPermissions
 
+from products.access_control.backend.facade.access import ProjectAccess
+
 if TYPE_CHECKING:
     _GenericViewSet = GenericViewSet
 else:
@@ -645,3 +647,9 @@ class TeamAndOrgViewSetMixin(_GenericViewSet):
             pass
 
         return UserAccessControl(user=cast(User, self.request.user), team=team, organization_id=self.organization_id)
+
+    @cached_property
+    def access_control(self) -> ProjectAccess:
+        """The access-control facade for this request. Shares the warmed `user_access_control`
+        so a viewset mixing old and new call sites never resolves rules twice."""
+        return ProjectAccess.from_user_access_control(self.user_access_control)

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -181,6 +181,7 @@ if TYPE_CHECKING:
     from posthog.rbac.user_access_control import UserAccessControl
     from posthog.shared_link_user import SharedLinkUser
 
+    from products.access_control.backend.facade.access import ProjectAccess
     from products.data_modeling.backend.facade.models import DataWarehouseSavedQuery
     from products.data_tools.backend.models.expression import DataWarehouseExpression
     from products.data_tools.backend.models.join import DataWarehouseJoin
@@ -535,8 +536,10 @@ def _compute_system_table_access_decision(
     Pass user_access_control when it's already preloaded to reuse the instance and avoid an extra query."""
     # Lazy imports keep the Django ORM off this module's import path.
     from posthog.models.organization import OrganizationMembership  # noqa: PLC0415
-    from posthog.rbac.user_access_control import NO_ACCESS_LEVEL, UserAccessControl  # noqa: PLC0415
+    from posthog.rbac.user_access_control import UserAccessControl  # noqa: PLC0415
     from posthog.shared_link_user import SharedLinkUser  # noqa: PLC0415
+
+    from products.access_control.backend.facade.access import ProjectAccess  # noqa: PLC0415
 
     scoped_tables = _scoped_system_tables()
     # Applies to every principal below, admins included - an entitlement the organization does not
@@ -560,13 +563,13 @@ def _compute_system_table_access_decision(
     # serves those routes and narrows the rows to the grants; the printer guard does the same, so the
     # table stays queryable here instead of disappearing (see build_access_control_guard).
     allowlisted_scopes = user_access_control.allowlisted_resource_ids_by_scope
+    project_access = ProjectAccess.from_user_access_control(user_access_control)
 
     denied: set[str] = set(unentitled)
     for name, table in scoped_tables.items():
         access_scope = cast(APIScopeObject, table.access_scope)
-        access = user_access_control.access_level_for_resource(access_scope)
-        if access and access.access_level != NO_ACCESS_LEVEL:
-            continue  # User has access, keep it
+        if project_access.check("view", access_scope):
+            continue
         # Keep the table only when the guard can actually narrow its rows to the grant, so a table
         # whose ids don't key those grants (resource_level_access_only) still fails closed.
         if access_scope in allowlisted_scopes and table.access_control_id is not None:
@@ -879,15 +882,23 @@ class Database(BaseModel):
 
         self._denied_tables = {f"system.{name}" for name in removed}
 
+    def _project_access(self) -> ProjectAccess | None:
+        """Facade over the warmed `user_access_control`, so the object-level checks below ask the
+        same question every other call site asks. Userless context returns None and fails closed."""
+        if self.user_access_control is None:
+            return None
+        # Imported here like the other ORM-backed modules in this file, to keep Django off its import path.
+        from products.access_control.backend.facade.access import ProjectAccess  # noqa: PLC0415
+
+        return ProjectAccess.from_user_access_control(self.user_access_control)
+
     def _is_warehouse_table_denied(self, table: DataWarehouseTable) -> bool:
         """
         Returns True if the user can't query this warehouse table.
         Userless context (no UserAccessControl) fails closed - every table is denied.
         """
-        uac = self.user_access_control
-        if uac is not None and (
-            uac.is_organization_admin or uac.check_access_level_for_object(table, required_level="viewer")
-        ):
+        access = self._project_access()
+        if access is not None and access.check("view", table):
             return False
 
         # Add table names to denied tables so the query raises "You don't have access" instead of "Unknown table"
@@ -904,10 +915,8 @@ class Database(BaseModel):
         through a non-materialized view that references it.
         Userless context (no UserAccessControl) fails closed - every view is denied.
         """
-        uac = self.user_access_control
-        if uac is not None and (
-            uac.is_organization_admin or uac.check_access_level_for_object(saved_query, required_level="viewer")
-        ):
+        access = self._project_access()
+        if access is not None and access.check("view", saved_query):
             return False
 
         # Add view names to denied tables so the query raises "You don't have access" instead of "Unknown table"
@@ -920,11 +929,8 @@ class Database(BaseModel):
         expression doesn't get its virtual field injected, so their queries see "Field not found".
         Userless context (no UserAccessControl) fails closed - every expression is denied.
         """
-        uac = self.user_access_control
-        return not (
-            uac is not None
-            and (uac.is_organization_admin or uac.check_access_level_for_object(expression, required_level="viewer"))
-        )
+        access = self._project_access()
+        return not (access is not None and access.check("view", expression))
 
     def serialize(
         self,

--- a/posthog/rbac/user_access_control.py
+++ b/posthog/rbac/user_access_control.py
@@ -1539,24 +1539,29 @@ class UserAccessControl:
         parent = RESOURCE_FALLBACK_MAP.get(resource)
         return fallback_parent_object_id(obj, parent) if parent else None
 
-    def get_user_access_level(self, obj: Model, explicit=False) -> Optional[AccessControlLevel]:
+    def resolve_object_access(self, obj: Model, explicit: bool = False) -> Optional[ResolvedAccess]:
+        """Object access with provenance: the level plus which rule supplied it. The access-control
+        facade builds its decisions from this; `get_user_access_level` is the level-only view."""
         resource = model_to_resource(obj)
         if not resource:
             return None
 
         resolved, access = self._object_access_level_precheck(resource, self._is_creator(obj), explicit=explicit)
         if resolved:
-            return access.access_level if access else None
+            return access
 
         object_access_controls = self._get_access_controls(
             self._access_controls_filters_for_object(resource, str(obj.id))  # type: ignore
         )
-        access = self._object_access_level_from_rows(
+        return self._object_access_level_from_rows(
             resource,
             object_access_controls,
             explicit=explicit,
             fallback_parent_id=self._fallback_parent_id(obj, resource),
         )
+
+    def get_user_access_level(self, obj: Model, explicit=False) -> Optional[AccessControlLevel]:
+        access = self.resolve_object_access(obj, explicit=explicit)
         return access.access_level if access else None
 
     def bulk_object_access_levels(

--- a/posthog/taxonomy/property_definition_api.py
+++ b/posthog/taxonomy/property_definition_api.py
@@ -789,8 +789,6 @@ class PropertyDefinitionViewSet(
 
     def _get_restricted_property_names(self, prop_type: str) -> set[str]:
         """Returns the set of property names that are restricted for the current user and property type."""
-        from products.access_control.backend.property_access_control import get_restricted_property_names
-
         type_map = {
             "event": PropertyDefinition.Type.EVENT,
             "person": PropertyDefinition.Type.PERSON,
@@ -800,8 +798,7 @@ class PropertyDefinitionViewSet(
         pd_type = type_map.get(prop_type)
         if pd_type is None:
             return set()
-        user = self.request.user if self.request.user.is_authenticated else None
-        return get_restricted_property_names(team_id=self.team_id, user=user, property_type=pd_type)
+        return self.access_control.restricted_property_names(pd_type)
 
     def safely_get_object(self, queryset):
         id = self.kwargs["id"]

--- a/products/access_control/backend/facade/access.py
+++ b/products/access_control/backend/facade/access.py
@@ -1,0 +1,230 @@
+"""The access-control entry point for application code.
+
+Callers ask `ProjectAccess` whether a principal can perform an action on a resource. They never
+import `UserAccessControl` (the resolver that walks the rules) or the `AccessControl` rows. That
+keeps one place for "what does 'edit' require", one place to log decisions, and one seam behind
+which the resolver can change or be replaced.
+
+    access_control = ProjectAccess.for_request(request, team)   # viewsets get this as `self.access_control`
+    access_control.check("edit", dashboard)                      # object
+    access_control.check("create", "dashboard")                  # resource type
+    access_control.require("view", insight)                      # raises PermissionDenied
+    access_control.decide("edit", dashboard)                     # AccessDecision with provenance
+    access_control.filter(Dashboard.objects.filter(team=team), "view")
+"""
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Protocol, cast
+
+from django.db.models import Model, QuerySet
+
+from rest_framework.exceptions import PermissionDenied
+
+from posthog.constants import AccessControlLevel
+from posthog.rbac.user_access_control import (
+    RESOURCE_INHERITANCE_MAP,
+    ResolvedAccess,
+    UserAccessControl,
+    access_level_satisfied_for_resource,
+    model_to_resource,
+    ordered_access_levels,
+)
+from posthog.scopes import APIScopeObject
+
+from products.access_control.backend.facade.contracts import AccessDecision, Action, PropertyAccessLevel
+from products.access_control.backend.property_access_control import (
+    get_property_access_level,
+    get_restricted_property_names,
+)
+
+if TYPE_CHECKING:
+    from rest_framework.request import Request
+
+    from posthog.models import PropertyDefinition, Team, User
+
+
+# Rung on the resource's level ladder each action needs, counted from the bottom (0 = "none").
+# Clamped to the ladder's top, so on the member ladder (none, member, admin) "edit" means admin,
+# and on resources capped at viewer "edit" is never satisfiable.
+_ACTION_RUNG: dict[Action, int] = {
+    "view": 1,
+    "list": 1,
+    "edit": 2,
+    "create": 2,
+    "manage": 3,
+}
+
+
+def required_level_for(resource: APIScopeObject, action: Action) -> AccessControlLevel:
+    ladder = ordered_access_levels(resource)
+    return ladder[min(_ACTION_RUNG[action], len(ladder) - 1)]
+
+
+class AccessResolver(Protocol):
+    """What the facade needs from whatever resolves rules. `UserAccessControl` is the only
+    implementation; a different engine would implement the same four calls."""
+
+    def resolve_object(self, obj: Model) -> ResolvedAccess | None: ...
+    def resolve_resource(self, resource: APIScopeObject) -> ResolvedAccess | None: ...
+    def filter_queryset(self, queryset: QuerySet, resource: APIScopeObject | None) -> QuerySet: ...
+    def preload(self, objects: Sequence[Model]) -> None: ...
+
+
+class UserAccessControlResolver:
+    def __init__(self, user_access_control: UserAccessControl) -> None:
+        self.user_access_control = user_access_control
+
+    def resolve_object(self, obj: Model) -> ResolvedAccess | None:
+        return self.user_access_control.resolve_object_access(obj)
+
+    def resolve_resource(self, resource: APIScopeObject) -> ResolvedAccess | None:
+        return self.user_access_control.access_level_for_resource(resource)
+
+    def filter_queryset(self, queryset: QuerySet, resource: APIScopeObject | None) -> QuerySet:
+        return self.user_access_control.filter_queryset_by_access_level(queryset, resource=resource)
+
+    def preload(self, objects: Sequence[Model]) -> None:
+        self.user_access_control.preload_object_access_controls(list(objects))
+
+
+class ProjectAccess:
+    """A principal's access within one project. Build one per request (or per task run) and ask
+    it many questions; the resolver behind it caches and preloads, so repeated checks are cheap."""
+
+    def __init__(self, *, resolver: AccessResolver | None, user: "User | None", team: "Team | None") -> None:
+        self._resolver = resolver
+        self._user = user
+        self._team = team
+
+    @classmethod
+    def for_user(cls, user: "User", team: "Team | None") -> "ProjectAccess":
+        return cls(resolver=UserAccessControlResolver(UserAccessControl(user=user, team=team)), user=user, team=team)
+
+    @classmethod
+    def for_request(cls, request: "Request", team: "Team | None") -> "ProjectAccess":
+        """Authenticated users resolve normally. Any other principal (anonymous, API-key-only,
+        sharing token) gets a closed handle until those principals are modelled here; their
+        existing permission classes keep enforcing in the meantime."""
+        user = request.user
+        if getattr(user, "is_authenticated", False) and not getattr(user, "is_anonymous", True):
+            return cls.for_user(cast("User", user), team)
+        return cls.denied(team)
+
+    @classmethod
+    def from_user_access_control(cls, user_access_control: UserAccessControl) -> "ProjectAccess":
+        """For code that already holds a warmed resolver and must not build a second one
+        (HogQL threads its preloaded instance through the whole schema build)."""
+        return cls(
+            resolver=UserAccessControlResolver(user_access_control),
+            user=user_access_control.user,
+            team=user_access_control.team,
+        )
+
+    @classmethod
+    def denied(cls, team: "Team | None") -> "ProjectAccess":
+        return cls(resolver=None, user=None, team=team)
+
+    # --- decisions ---
+
+    def check(self, action: Action, target: Model | APIScopeObject) -> bool:
+        return self.decide(action, target).allowed
+
+    def require(self, action: Action, target: Model | APIScopeObject, *, message: str | None = None) -> None:
+        if not self.check(action, target):
+            raise PermissionDenied(message or self._denied_message(action, target))
+
+    def check_each(self, action: Action, objects: Sequence[Model]) -> list[bool]:
+        if self._resolver is not None and objects:
+            self._resolver.preload(objects)
+        return [self.check(action, obj) for obj in objects]
+
+    def decide(self, action: Action, target: Model | APIScopeObject) -> AccessDecision:
+        if isinstance(target, Model):
+            return self._decide_object(action, target)
+        return self._decide_resource(action, target)
+
+    def _decide_object(self, action: Action, obj: Model) -> AccessDecision:
+        resource = model_to_resource(obj)
+        object_id = str(getattr(obj, "id", "")) or None
+        if resource is None:
+            # Models outside the access-control scope list have no rules, matching the resolver's
+            # "permissions do not apply" answer for them.
+            return AccessDecision(
+                allowed=True,
+                action=action,
+                resource=obj.__class__.__name__.lower(),
+                object_id=object_id,
+                level=None,
+                required_level=None,
+                source=None,
+                source_subject=None,
+            )
+        required = required_level_for(resource, action)
+        resolved = self._resolver.resolve_object(obj) if self._resolver is not None else None
+        return self._decision(action, resource, object_id, required, resolved, comparison_resource=resource)
+
+    def _decide_resource(self, action: Action, resource: APIScopeObject) -> AccessDecision:
+        # Inherited resources compare on the parent's ladder, as the resolver's own check does.
+        comparison_resource = RESOURCE_INHERITANCE_MAP.get(resource, resource)
+        required = required_level_for(comparison_resource, action)
+        resolved = self._resolver.resolve_resource(resource) if self._resolver is not None else None
+        return self._decision(action, resource, None, required, resolved, comparison_resource=comparison_resource)
+
+    @staticmethod
+    def _decision(
+        action: Action,
+        resource: APIScopeObject,
+        object_id: str | None,
+        required: AccessControlLevel,
+        resolved: ResolvedAccess | None,
+        *,
+        comparison_resource: APIScopeObject,
+    ) -> AccessDecision:
+        allowed = resolved is not None and access_level_satisfied_for_resource(
+            comparison_resource, resolved.access_level, required
+        )
+        return AccessDecision(
+            allowed=allowed,
+            action=action,
+            resource=resource,
+            object_id=object_id,
+            level=resolved.access_level if resolved else None,
+            required_level=required,
+            source=resolved.source if resolved else None,
+            source_subject=resolved.source_subject if resolved else None,
+        )
+
+    @staticmethod
+    def _denied_message(action: Action, target: Model | APIScopeObject) -> str:
+        name = target.__class__.__name__.lower() if isinstance(target, Model) else target
+        return f"You don't have permission to {action} this {name}."
+
+    # --- sets ---
+
+    def filter(self, queryset: QuerySet, action: Action = "view") -> QuerySet:
+        """Rows the principal may see. Only "view" is supported: the resolver filters on visibility,
+        not on a required level, so asking for "edit" here would silently over-include."""
+        if action != "view":
+            raise ValueError("filter() only supports the 'view' action")
+        if self._resolver is None:
+            return queryset.none()
+        return self._resolver.filter_queryset(queryset, model_to_resource(cast(Model, queryset.model)))
+
+    # --- property access control ---
+
+    def property_access_level(self, property_definition: "PropertyDefinition") -> PropertyAccessLevel:
+        return get_property_access_level(property=property_definition, user=self._property_user())
+
+    def restricted_property_names(self, property_type: int) -> set[str]:
+        """Names of properties of this type the principal may not read, for stripping from query results."""
+        if self._team is None:
+            return set()
+        return get_restricted_property_names(
+            team_id=self._team.id, user=self._property_user(), property_type=property_type
+        )
+
+    def _property_user(self) -> "User | None":
+        # Property rules key on membership and roles, which synthetic and anonymous principals lack.
+        if self._user is not None and getattr(self._user, "is_authenticated", False):
+            return self._user
+        return None

--- a/products/access_control/backend/facade/contracts.py
+++ b/products/access_control/backend/facade/contracts.py
@@ -8,6 +8,7 @@ exposes to the rest of the codebase. No Django/DRF imports here.
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
+from typing import Literal
 from uuid import UUID
 
 
@@ -69,3 +70,35 @@ class DeletePropertyAccessControlInput:
     property_definition_id: str
     organization_member_id: UUID | None = None
     role_id: UUID | None = None
+
+
+# --- Access decisions ---
+
+# The verbs callers ask about. Each maps to a rung on the resource's access-level ladder
+# (see facade/access.py); new verbs need a rung before they can be checked.
+Action = Literal["view", "edit", "manage", "create", "list"]
+
+AccessSource = Literal[
+    "object",
+    "parent_object",
+    "resource",
+    "parent_resource",
+    "system_default",
+    "org_admin",
+    "creator",
+    "org_membership",
+]
+
+
+@dataclass(frozen=True)
+class AccessDecision:
+    """Why a principal can or cannot perform an action: the resolved level and the rule that supplied it."""
+
+    allowed: bool
+    action: Action
+    resource: str
+    object_id: str | None
+    level: str | None
+    required_level: str | None
+    source: AccessSource | None
+    source_subject: Literal["member", "role", "default"] | None

--- a/products/access_control/backend/tests/test_facade_access.py
+++ b/products/access_control/backend/tests/test_facade_access.py
@@ -1,0 +1,91 @@
+import pytest
+from posthog.test.base import BaseTest
+
+from parameterized import parameterized
+from rest_framework.exceptions import PermissionDenied
+
+from posthog.constants import AvailableFeature
+from posthog.models.organization import OrganizationMembership
+from posthog.models.user import User
+
+from products.access_control.backend.facade.access import ProjectAccess, required_level_for
+from products.dashboards.backend.models.dashboard import Dashboard
+
+from ee.models.rbac.access_control import AccessControl
+
+
+class TestProjectAccess(BaseTest):
+    def setUp(self) -> None:
+        super().setUp()
+        self.organization.available_product_features = [
+            {"key": AvailableFeature.ACCESS_CONTROL, "name": AvailableFeature.ACCESS_CONTROL},
+            {"key": AvailableFeature.ROLE_BASED_ACCESS, "name": AvailableFeature.ROLE_BASED_ACCESS},
+        ]
+        self.organization.save()
+        self.member = User.objects.create_and_join(self.organization, "member@posthog.com", "testtest")
+        self.membership = OrganizationMembership.objects.get(user=self.member, organization=self.organization)
+        self.dashboard = Dashboard.objects.create(team=self.team, created_by=self.user)
+        self.member_access = ProjectAccess.for_user(self.member, self.team)
+
+    @parameterized.expand(
+        [
+            ("view", "dashboard", "viewer"),
+            ("edit", "dashboard", "editor"),
+            ("manage", "dashboard", "manager"),
+            ("view", "project", "member"),
+            ("edit", "project", "admin"),
+            ("manage", "project", "admin"),
+        ]
+    )
+    def test_required_level_is_a_rung_on_the_resource_ladder(self, action, resource, expected) -> None:
+        assert required_level_for(resource, action) == expected
+
+    def test_object_rule_decides_object_checks_but_not_resource_checks(self) -> None:
+        AccessControl.objects.create(
+            team=self.team,
+            resource="dashboard",
+            resource_id=str(self.dashboard.id),
+            organization_member=self.membership,
+            access_level="none",
+        )
+
+        assert self.member_access.check("view", self.dashboard) is False
+        assert self.member_access.check("edit", "dashboard") is True
+
+        decision = self.member_access.decide("view", self.dashboard)
+        assert (
+            decision.allowed,
+            decision.level,
+            decision.required_level,
+            decision.source,
+            decision.source_subject,
+        ) == (
+            False,
+            "none",
+            "viewer",
+            "object",
+            "member",
+        )
+        with pytest.raises(PermissionDenied):
+            self.member_access.require("view", self.dashboard)
+
+    def test_creator_bypasses_object_rules_and_filter_hides_denied_objects(self) -> None:
+        AccessControl.objects.create(
+            team=self.team, resource="dashboard", resource_id=str(self.dashboard.id), access_level="none"
+        )
+        creator_access = ProjectAccess.for_user(self.user, self.team)
+
+        assert creator_access.decide("edit", self.dashboard).source == "creator"
+        assert list(creator_access.filter(Dashboard.objects.filter(team=self.team))) == [self.dashboard]
+        assert list(self.member_access.filter(Dashboard.objects.filter(team=self.team))) == []
+
+    def test_unauthenticated_request_gets_a_closed_handle(self) -> None:
+        class AnonymousRequest:
+            class user:
+                is_authenticated = False
+                is_anonymous = True
+
+        access = ProjectAccess.for_request(AnonymousRequest(), self.team)  # type: ignore[arg-type]
+
+        assert access.check("view", self.dashboard) is False
+        assert list(access.filter(Dashboard.objects.filter(team=self.team))) == []

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -2806,9 +2806,12 @@ class DashboardsViewSet(
             raise exceptions.ValidationError("Destination must be a different dashboard than the source.")
 
         source_dashboard = get_object_or_404(Dashboard, id=from_dashboard_id, team__project_id=self.team.project_id)
-        user_access_control = UserAccessControl(user=cast(User, request.user), team=self.team)
-        if not user_access_control.check_access_level_for_object(source_dashboard, "viewer"):
-            raise exceptions.PermissionDenied("You don't have permission to view the source dashboard.")
+        self.access_control.require(
+            "view", source_dashboard, message="You don't have permission to view the source dashboard."
+        )
+        # Widget and shared-dashboard helpers still take the resolver directly; they move to the
+        # facade with the rest of this file.
+        user_access_control = self.user_access_control
 
         tile = get_object_or_404(
             DashboardTile.objects.select_related("widget"),
@@ -2840,8 +2843,7 @@ class DashboardsViewSet(
             raise exceptions.ValidationError("Only insight, text, and widget tiles can be copied between dashboards.")
 
         if tile.insight is not None:
-            if not user_access_control.check_access_level_for_object(tile.insight, "viewer"):
-                raise exceptions.PermissionDenied("You don't have permission to view this insight.")
+            self.access_control.require("view", tile.insight, message="You don't have permission to view this insight.")
 
             if DashboardTile.objects.filter(dashboard=destination, insight=tile.insight).exists():
                 raise exceptions.ValidationError("This insight is already on the destination dashboard.")


### PR DESCRIPTION
## Problem

Engineers adding an access check today pick between `check_access_level_for_object`, `access_level_for_resource`, `filter_queryset_by_access_level`, and hand-written level comparisons, and each call site chooses the required level itself. HogQL, the property-definition API and the dashboards API all encode "what does viewing require" separately.

This PR is a shape proposal for the facade discussed in [RFC #594](https://github.com/PostHog/requests-for-comments-public/pull/594): one entry point with a small verb set, no engine and no extra network hop. The resolver stays `UserAccessControl`.

## Changes

- Adds `ProjectAccess` in `products/access_control/backend/facade/access.py`: `check`, `require`, `decide`, `check_each`, `filter`, plus `property_access_level` and `restricted_property_names`.
- Adds `TeamAndOrgViewSetMixin.access_control`, sharing the request's warmed `user_access_control`.
- The action to level mapping lives in one place (`required_level_for`), as a rung on the resource's ladder.
- `decide` returns `AccessDecision` with provenance (`source`, `source_subject`) from the resolver's `ResolvedAccess`.
- `AccessResolver` protocol with one implementation over `UserAccessControl`; a different engine would implement the same four calls.
- Routes three call sites through the facade, behavior unchanged: HogQL system/warehouse table, view and expression access; `PropertyDefinitionViewSet` restricted-name lookup; dashboard `copy_tile` source checks.
- Adds `UserAccessControl.resolve_object_access`; `get_user_access_level` delegates to it.

Nothing user-visible changes. Not in scope: the `AccessControlPermission` classes, list filtering in the mixin, non-user principals (`for_request` returns a closed handle for them), decision logging.

## How did you test this code?

- `products/access_control/backend/tests/test_facade_access.py`: action to required level across the resource and member ladders; an object rule deciding object checks but not resource checks, with provenance; creator bypass and `filter` hiding denied rows; anonymous requests getting a closed handle. Each guards a dispatch or mapping regression no resolver test covers.
- Ran `ruff check`, `ruff format` and the pre-push preflight locally. Not run: the Django test suites and mypy, because this branch lives in a worktree without a stack; relying on CI.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5), session linked in the commit. Skills invoked: `/writing-dataclasses`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`. Design choices during the session: the facade composes `UserAccessControl` rather than replacing it; `filter` accepts only `"view"` because the resolver filters on visibility, not level; the HogQL database builds the facade from its already-warmed resolver so the schema build stays query-free.