### PR TITLE
chore(ci): prune dead nodeids from .test_durations via junit scoping

### DIFF
--- a/.github/scripts/optimize_test_durations.py
+++ b/.github/scripts/optimize_test_durations.py
@@ -825,6 +825,12 @@ def main():
         if not junit_shards:
             logger.error("--scope-to-junit requires --junit-dir with matching artifacts")
             sys.exit(1)
+        # A timing shard whose JUnit never uploaded would read as "nothing ran"
+        # and lose every nodeid it owns, so scoping needs one JUnit per shard.
+        # The workflow retries unscoped on this exit.
+        if not shard_sets_match(shards, junit_shards):
+            logger.error("--scope-to-junit needs a JUnit artifact for every timing shard")
+            sys.exit(1)
         ran = set().union(*(s.call_times.keys() for s in junit_shards))
         before_count = len(durations)
         durations = {k: v for k, v in durations.items() if k in ran}

--- a/.github/scripts/optimize_test_durations.py
+++ b/.github/scripts/optimize_test_durations.py
@@ -825,11 +825,13 @@ def main():
         if not junit_shards:
             logger.error("--scope-to-junit requires --junit-dir with matching artifacts")
             sys.exit(1)
-        # A timing shard whose JUnit never uploaded would read as "nothing ran"
-        # and lose every nodeid it owns, so scoping needs one JUnit per shard.
-        # The workflow retries unscoped on this exit.
-        if not shard_sets_match(shards, junit_shards):
-            logger.error("--scope-to-junit needs a JUnit artifact for every timing shard")
+        # A timing shard whose JUnit never uploaded, or uploaded truncated (the
+        # parser turns that into an empty shard), would read as "nothing ran" and
+        # lose every nodeid it owns, so scoping needs one readable JUnit per
+        # shard. The workflow retries unscoped on this exit.
+        unreadable = [shard.name for shard in junit_shards if not shard.call_times]
+        if not shard_sets_match(shards, junit_shards) or unreadable:
+            logger.error("--scope-to-junit needs a readable JUnit artifact for every timing shard: %s", unreadable)
             sys.exit(1)
         ran = set().union(*(s.call_times.keys() for s in junit_shards))
         before_count = len(durations)

--- a/.github/scripts/optimize_test_durations.py
+++ b/.github/scripts/optimize_test_durations.py
@@ -86,6 +86,7 @@ _JUNIT_ARTIFACT_PREFIX = {
     "CorePOE": "junit-results-backend-core-poe",
     "Temporal": "junit-results-backend-temporal",
     "Products": "product-junit-results",
+    "Dagster": "junit-results-dagster",
 }
 
 
@@ -111,18 +112,34 @@ class JUnitShard:
         Segment match is anchored at the artifact prefix so "Core" doesn't
         accidentally pick up "core-poe" or any future "*-core-*" name, and
         "CorePOE" matches "core-poe" instead of the absent substring "corepoe".
+
+        Re-run attempts upload as `<shard>-attempt<N>` (attempt 1 carries no
+        suffix). When a shard was re-run, only its newest attempt reflects the
+        run's final state, so superseded attempt dirs are dropped here; the
+        newest attempt dir is renamed to the base shard name so downstream
+        shard-set matching sees one entry per shard.
         """
-        shards = []
+        # Collapse re-run attempt dirs: key each shard by its base name and
+        # keep the highest attempt number (attempt 1 is the unsuffixed dir).
+        by_base: dict[str, tuple[int, Path]] = {}
         for shard_dir in sorted(junit_dir.iterdir()):
             if not shard_dir.is_dir():
                 continue
+            match = re.match(r"^(.*?)(?:-attempt(\d+))?$", shard_dir.name.lower())
+            if not match:
+                continue
+            base, attempt_n = match.group(1), int(match.group(2) or 1)
+            if base not in by_base or attempt_n > by_base[base][0]:
+                by_base[base] = (attempt_n, shard_dir)
 
+        shards = []
+        for base, (_attempt_n, shard_dir) in sorted(by_base.items()):
             if segment:
                 artifact_prefix = _JUNIT_ARTIFACT_PREFIX.get(segment, f"junit-results-backend-{segment.lower()}")
                 # Anchor with `\d+$` so the Core prefix doesn't accidentally
                 # eat core-poe-N (which also starts with junit-results-backend-core-).
                 pattern = re.compile(rf"^{re.escape(artifact_prefix)}-\d+$")
-                if not pattern.match(shard_dir.name.lower()):
+                if not pattern.match(base):
                     continue
 
             xml_files = sorted(shard_dir.glob("*.xml"))
@@ -133,7 +150,7 @@ class JUnitShard:
             for xml_file in xml_files:
                 for test_id, call_time in cls._parse_call_times(xml_file).items():
                     call_times[test_id] = max(call_times.get(test_id, 0.0), call_time)
-            shards.append(cls(name=shard_dir.name, call_times=call_times))
+            shards.append(cls(name=base, call_times=call_times))
 
         return shards
 

--- a/.github/scripts/optimize_test_durations.py
+++ b/.github/scripts/optimize_test_durations.py
@@ -114,14 +114,15 @@ class JUnitShard:
         "CorePOE" matches "core-poe" instead of the absent substring "corepoe".
 
         Re-run attempts upload as `<shard>-attempt<N>` (attempt 1 carries no
-        suffix). When a shard was re-run, only its newest attempt reflects the
-        run's final state, so superseded attempt dirs are dropped here; the
-        newest attempt dir is renamed to the base shard name so downstream
-        shard-set matching sees one entry per shard.
+        suffix). Attempts of one shard merge into one entry under the base
+        shard name, so downstream shard-set matching sees one entry per shard.
+        The newest attempt's time wins for a test every attempt ran; a test
+        only an earlier attempt ran stays, because a rerun without the pinned
+        plan can reshard it into a shard that is not rerun at all.
         """
-        # Collapse re-run attempt dirs: key each shard by its base name and
-        # keep the highest attempt number (attempt 1 is the unsuffixed dir).
-        by_base: dict[str, tuple[int, Path]] = {}
+        # Group re-run attempt dirs by base shard name (attempt 1 is the
+        # unsuffixed dir), oldest attempt first.
+        by_base: dict[str, list[tuple[int, Path]]] = defaultdict(list)
         for shard_dir in sorted(junit_dir.iterdir()):
             if not shard_dir.is_dir():
                 continue
@@ -129,11 +130,10 @@ class JUnitShard:
             if not match:
                 continue
             base, attempt_n = match.group(1), int(match.group(2) or 1)
-            if base not in by_base or attempt_n > by_base[base][0]:
-                by_base[base] = (attempt_n, shard_dir)
+            by_base[base].append((attempt_n, shard_dir))
 
         shards = []
-        for base, (_attempt_n, shard_dir) in sorted(by_base.items()):
+        for base, attempts in sorted(by_base.items()):
             if segment:
                 artifact_prefix = _JUNIT_ARTIFACT_PREFIX.get(segment, f"junit-results-backend-{segment.lower()}")
                 # Anchor with `\d+$` so the Core prefix doesn't accidentally
@@ -142,14 +142,17 @@ class JUnitShard:
                 if not pattern.match(base):
                     continue
 
-            xml_files = sorted(shard_dir.glob("*.xml"))
-            if not xml_files:
-                continue
-
             call_times: dict[str, float] = {}
-            for xml_file in xml_files:
-                for test_id, call_time in cls._parse_call_times(xml_file).items():
-                    call_times[test_id] = max(call_times.get(test_id, 0.0), call_time)
+            found_xml = False
+            for _attempt_n, shard_dir in sorted(attempts):
+                attempt_times: dict[str, float] = {}
+                for xml_file in sorted(shard_dir.glob("*.xml")):
+                    found_xml = True
+                    for test_id, call_time in cls._parse_call_times(xml_file).items():
+                        attempt_times[test_id] = max(attempt_times.get(test_id, 0.0), call_time)
+                call_times.update(attempt_times)
+            if not found_xml:
+                continue
             shards.append(cls(name=base, call_times=call_times))
 
         return shards

--- a/.github/scripts/optimize_test_durations.py
+++ b/.github/scripts/optimize_test_durations.py
@@ -103,6 +103,8 @@ class JUnitShard:
 
     name: str
     call_times: dict[str, float]
+    # An XML of this shard (any attempt) did not parse, so call_times is incomplete.
+    unreadable: bool = False
 
     @classmethod
     def load_all(cls, junit_dir: Path, segment: str | None = None) -> list["JUnitShard"]:
@@ -144,27 +146,32 @@ class JUnitShard:
 
             call_times: dict[str, float] = {}
             found_xml = False
+            unreadable = False
             for _attempt_n, shard_dir in sorted(attempts):
                 attempt_times: dict[str, float] = {}
                 for xml_file in sorted(shard_dir.glob("*.xml")):
                     found_xml = True
-                    for test_id, call_time in cls._parse_call_times(xml_file).items():
+                    parsed = cls._parse_call_times(xml_file)
+                    if parsed is None:
+                        unreadable = True
+                        continue
+                    for test_id, call_time in parsed.items():
                         attempt_times[test_id] = max(attempt_times.get(test_id, 0.0), call_time)
                 call_times.update(attempt_times)
             if not found_xml:
                 continue
-            shards.append(cls(name=base, call_times=call_times))
+            shards.append(cls(name=base, call_times=call_times, unreadable=unreadable))
 
         return shards
 
     @staticmethod
-    def _parse_call_times(xml_path: Path) -> dict[str, float]:
-        """Extract {pytest_id: call_time} for every parseable testcase."""
+    def _parse_call_times(xml_path: Path) -> dict[str, float] | None:
+        """Extract {pytest_id: call_time} for every parseable testcase, None when the XML does not parse."""
         try:
             tree = ET.parse(xml_path)
         except ParseError as e:
             logger.warning("  Could not parse JUnit XML %s: %s", xml_path, e)
-            return {}
+            return None
         call_times: dict[str, float] = {}
         for tc in tree.getroot().iter("testcase"):
             pytest_id = _junit_to_pytest_id(tc.get("classname", ""), tc.get("name", ""))
@@ -832,7 +839,7 @@ def main():
         # parser turns that into an empty shard), would read as "nothing ran" and
         # lose every nodeid it owns, so scoping needs one readable JUnit per
         # shard. The workflow retries unscoped on this exit.
-        unreadable = [shard.name for shard in junit_shards if not shard.call_times]
+        unreadable = [shard.name for shard in junit_shards if shard.unreadable or not shard.call_times]
         if not shard_sets_match(shards, junit_shards) or unreadable:
             logger.error("--scope-to-junit needs a readable JUnit artifact for every timing shard: %s", unreadable)
             sys.exit(1)

--- a/.github/scripts/test_optimize_test_durations.py
+++ b/.github/scripts/test_optimize_test_durations.py
@@ -138,11 +138,22 @@ class TestAverageDurations:
             main()
         assert not out.exists()
 
-    @pytest.mark.parametrize("broken_shard", [None, b"<testsuite><testcase"])
-    def test_scope_to_junit_refuses_a_shard_without_readable_junit(self, tmp_path, monkeypatch, broken_shard):
-        # Shard 2's JUnit never uploaded (None) or uploaded truncated. Scoping to
-        # shard 1 alone would drop every nodeid shard 2 owns, so the script must
-        # exit and let the workflow retry unscoped.
+    @pytest.mark.parametrize(
+        "shard_two_uploads",
+        [
+            {},
+            {"junit-results-backend-core-2": b"<testsuite><testcase"},
+            {
+                "junit-results-backend-core-2": _MIN_JUNIT_XML,
+                "junit-results-backend-core-2-attempt2": b"<testsuite><testcase",
+            },
+        ],
+    )
+    def test_scope_to_junit_refuses_a_shard_without_readable_junit(self, tmp_path, monkeypatch, shard_two_uploads):
+        # Shard 2's JUnit never uploaded, uploaded truncated, or reran with a
+        # truncated attempt on top of a good one. Scoping to what parsed would
+        # drop nodeids shard 2 owns, so the script must exit and let the
+        # workflow retry unscoped.
         artifacts = tmp_path / "timing_artifacts"
         for shard, test_id in (
             ("1", "posthog/test_foo.py::TestThing::test_one"),
@@ -154,9 +165,9 @@ class TestAverageDurations:
         junit_dir = tmp_path / "junit_artifacts"
         (junit_dir / "junit-results-backend-core-1").mkdir(parents=True)
         (junit_dir / "junit-results-backend-core-1" / "junit.xml").write_bytes(_MIN_JUNIT_XML)
-        if broken_shard is not None:
-            (junit_dir / "junit-results-backend-core-2").mkdir()
-            (junit_dir / "junit-results-backend-core-2" / "junit.xml").write_bytes(broken_shard)
+        for name, xml in shard_two_uploads.items():
+            (junit_dir / name).mkdir()
+            (junit_dir / name / "junit.xml").write_bytes(xml)
         out = tmp_path / "core_durations"
         monkeypatch.setattr(
             sys,

--- a/.github/scripts/test_optimize_test_durations.py
+++ b/.github/scripts/test_optimize_test_durations.py
@@ -162,6 +162,7 @@ class TestJUnitShardSegmentFilter:
             "junit-results-backend-core-poe-1",
             "junit-results-backend-temporal-1",
             "product-junit-results-1",
+            "junit-results-dagster-1",
             "junit-results-backend-compat-1",  # unrelated, shouldn't match anything
         ):
             shard = tmp_path / name
@@ -193,6 +194,25 @@ class TestJUnitShardSegmentFilter:
             "posthog/test_foo.py::TestThing::test_one",
             "products/tasks/test_two.py::TestThing::test_two",
         }
+
+    def test_dagster_matches_junit_results_dagster_prefix(self, junit_dir: Path) -> None:
+        names = {s.name for s in JUnitShard.load_all(junit_dir, segment="Dagster")}
+        assert names == {"junit-results-dagster-1"}
+
+    def test_rerun_attempt_supersedes_earlier_attempts(self, junit_dir: Path) -> None:
+        # The fixture's core-1 dir has time=0.5; an attempt-2 rerun of the same
+        # shard must replace it, not sit alongside or be dropped.
+        shard = junit_dir / "junit-results-backend-core-1-attempt2"
+        shard.mkdir()
+        (shard / "junit.xml").write_bytes(
+            b'<testsuite><testcase classname="posthog.test_foo.TestThing" name="test_one" time="1.5"/></testsuite>'
+        )
+
+        shards = JUnitShard.load_all(junit_dir, segment="Core")
+
+        assert [shard.name for shard in shards] == ["junit-results-backend-core-1", "junit-results-backend-core-2"]
+        base = next(shard for shard in shards if shard.name == "junit-results-backend-core-1")
+        assert base.call_times["posthog/test_foo.py::TestThing::test_one"] == 1.5
 
     def test_unknown_segment_does_not_panic(self, junit_dir: Path):
         # Unknown segments fall back to lowercase passthrough — should just

--- a/.github/scripts/test_optimize_test_durations.py
+++ b/.github/scripts/test_optimize_test_durations.py
@@ -138,6 +138,39 @@ class TestAverageDurations:
             main()
         assert not out.exists()
 
+    def test_scope_to_junit_refuses_a_missing_junit_shard(self, tmp_path, monkeypatch):
+        # Shard 2's JUnit never uploaded. Scoping to shard 1 alone would drop every
+        # nodeid shard 2 owns, so the script must exit and let the workflow retry unscoped.
+        artifacts = tmp_path / "timing_artifacts"
+        for shard, test_id in (
+            ("1", "posthog/test_foo.py::TestThing::test_one"),
+            ("2", "posthog/test_bar.py::test_two"),
+        ):
+            shard_dir = artifacts / f"timing_data-Core-{shard}"
+            shard_dir.mkdir(parents=True)
+            (shard_dir / ".test_durations").write_text(json.dumps({test_id: 1.0}))
+        junit_dir = tmp_path / "junit_artifacts"
+        (junit_dir / "junit-results-backend-core-1").mkdir(parents=True)
+        (junit_dir / "junit-results-backend-core-1" / "junit.xml").write_bytes(_MIN_JUNIT_XML)
+        out = tmp_path / "core_durations"
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "optimize_test_durations.py",
+                str(artifacts),
+                str(out),
+                "--segment",
+                "Core",
+                "--junit-dir",
+                str(junit_dir),
+                "--scope-to-junit",
+            ],
+        )
+        with pytest.raises(SystemExit):
+            main()
+        assert not out.exists()
+
     def test_run_average_files_refuses_empty_result(self, tmp_path):
         # Newest (anchor) run scoped to nothing must not silently wipe the plan,
         # even when older runs still carry data — refuse to write, don't emit {}.

--- a/.github/scripts/test_optimize_test_durations.py
+++ b/.github/scripts/test_optimize_test_durations.py
@@ -138,9 +138,11 @@ class TestAverageDurations:
             main()
         assert not out.exists()
 
-    def test_scope_to_junit_refuses_a_missing_junit_shard(self, tmp_path, monkeypatch):
-        # Shard 2's JUnit never uploaded. Scoping to shard 1 alone would drop every
-        # nodeid shard 2 owns, so the script must exit and let the workflow retry unscoped.
+    @pytest.mark.parametrize("broken_shard", [None, b"<testsuite><testcase"])
+    def test_scope_to_junit_refuses_a_shard_without_readable_junit(self, tmp_path, monkeypatch, broken_shard):
+        # Shard 2's JUnit never uploaded (None) or uploaded truncated. Scoping to
+        # shard 1 alone would drop every nodeid shard 2 owns, so the script must
+        # exit and let the workflow retry unscoped.
         artifacts = tmp_path / "timing_artifacts"
         for shard, test_id in (
             ("1", "posthog/test_foo.py::TestThing::test_one"),
@@ -152,6 +154,9 @@ class TestAverageDurations:
         junit_dir = tmp_path / "junit_artifacts"
         (junit_dir / "junit-results-backend-core-1").mkdir(parents=True)
         (junit_dir / "junit-results-backend-core-1" / "junit.xml").write_bytes(_MIN_JUNIT_XML)
+        if broken_shard is not None:
+            (junit_dir / "junit-results-backend-core-2").mkdir()
+            (junit_dir / "junit-results-backend-core-2" / "junit.xml").write_bytes(broken_shard)
         out = tmp_path / "core_durations"
         monkeypatch.setattr(
             sys,

--- a/.github/scripts/test_optimize_test_durations.py
+++ b/.github/scripts/test_optimize_test_durations.py
@@ -252,6 +252,25 @@ class TestJUnitShardSegmentFilter:
         base = next(shard for shard in shards if shard.name == "junit-results-backend-core-1")
         assert base.call_times["posthog/test_foo.py::TestThing::test_one"] == 1.5
 
+    def test_rerun_attempt_keeps_tests_only_an_earlier_attempt_ran(self, junit_dir: Path) -> None:
+        # A rerun without the pinned plan can reshard a test into a shard that is
+        # not rerun, so attempt 2 of shard 1 no longer lists it. Its attempt-1
+        # membership must survive or scoping drops a test that ran.
+        shard = junit_dir / "junit-results-backend-core-1-attempt2"
+        shard.mkdir()
+        (shard / "junit.xml").write_bytes(
+            b'<testsuite><testcase classname="posthog.test_bar" name="test_two" time="2.0"/></testsuite>'
+        )
+
+        base = next(
+            s for s in JUnitShard.load_all(junit_dir, segment="Core") if s.name == "junit-results-backend-core-1"
+        )
+
+        assert base.call_times == {
+            "posthog/test_foo.py::TestThing::test_one": 0.5,
+            "posthog/test_bar.py::test_two": 2.0,
+        }
+
     def test_unknown_segment_does_not_panic(self, junit_dir: Path):
         # Unknown segments fall back to lowercase passthrough — should just
         # match nothing in this fixture, not crash.

--- a/.github/workflows/ci-backend-update-test-timing.yml
+++ b/.github/workflows/ci-backend-update-test-timing.yml
@@ -209,6 +209,10 @@ jobs:
                   if [ -n "$DAGSTER_RUN_ID" ]; then
                       gh run download "$DAGSTER_RUN_ID" --pattern "timing_data-Dagster-*" --dir timing_artifacts
                       echo "Downloaded Dagster timing artifacts"
+                      # JUnit too, so the Dagster segment can prune dead nodeids like the others.
+                      # Naming differs from the backend artifacts: junit-results-dagster-N.
+                      gh run download "$DAGSTER_RUN_ID" --pattern "junit-results-dagster-*" --dir junit_artifacts || \
+                          echo "::warning::No Dagster JUnit artifacts found — Dagster runs unscoped"
                   else
                       echo "Skipping Dagster timing artifacts (no suitable run found)"
                   fi
@@ -220,17 +224,37 @@ jobs:
               run: |
                   # Process each segment separately with migration tax correction, then merge.
                   # Core, Temporal, and Products use JUnit for precise carrier detection.
-                  uv run .github/scripts/optimize_test_durations.py timing_artifacts /tmp/core_durations \
-                      --segment Core --junit-dir junit_artifacts
-                  uv run .github/scripts/optimize_test_durations.py timing_artifacts /tmp/temporal_durations \
-                      --segment Temporal --junit-dir junit_artifacts
+                  # Scope Core, Temporal, and Dagster to the nodeids their run's JUnit saw run.
+                  # Every shard restores the merged union and refreshes only its own slice, so
+                  # without scoping a deleted or renamed test rides every refresh and never
+                  # leaves these files, and the union merge below keeps inflating sharding
+                  # budgets with dead nodeids. --scope-to-junit hard-fails when JUnit artifacts
+                  # are missing, so retry unscoped to keep the existing behavior.
+                  if ! uv run .github/scripts/optimize_test_durations.py timing_artifacts /tmp/core_durations \
+                      --segment Core --junit-dir junit_artifacts --scope-to-junit; then
+                      echo "::warning::Scoped Core durations failed, retrying unscoped"
+                      uv run .github/scripts/optimize_test_durations.py timing_artifacts /tmp/core_durations \
+                          --segment Core --junit-dir junit_artifacts
+                  fi
+                  if ! uv run .github/scripts/optimize_test_durations.py timing_artifacts /tmp/temporal_durations \
+                      --segment Temporal --junit-dir junit_artifacts --scope-to-junit; then
+                      echo "::warning::Scoped Temporal durations failed, retrying unscoped"
+                      uv run .github/scripts/optimize_test_durations.py timing_artifacts /tmp/temporal_durations \
+                          --segment Temporal --junit-dir junit_artifacts
+                  fi
+                  # Products has its own guarded scoping inside the script (only scopes when the
+                  # JUnit shard set is complete), so no flag here.
                   uv run .github/scripts/optimize_test_durations.py timing_artifacts /tmp/products_durations \
                       --segment Products --junit-dir junit_artifacts
 
                   # Process Dagster segment if available
                   if [ -n "$DAGSTER_RUN_ID" ]; then
-                      uv run .github/scripts/optimize_test_durations.py timing_artifacts /tmp/dagster_durations \
-                          --segment Dagster
+                      if ! uv run .github/scripts/optimize_test_durations.py timing_artifacts /tmp/dagster_durations \
+                          --segment Dagster --junit-dir junit_artifacts --scope-to-junit; then
+                          echo "::warning::Scoped Dagster durations failed, retrying unscoped"
+                          uv run .github/scripts/optimize_test_durations.py timing_artifacts /tmp/dagster_durations \
+                              --segment Dagster
+                      fi
                       echo "Processed Dagster timing data"
                   fi
 

--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -624,6 +624,8 @@ jobs:
                   else
                       TEST_TARGETS=(posthog/dags products/*/dags)
                   fi
+                  # Call-only times so the timing-update workflow's migration-tax corrector
+                  # sees the same setup-free signal it gets from the backend segments.
                   pytest "${TEST_TARGETS[@]}" \
                       --reuse-db \
                       --splits ${{ matrix.concurrency }} --group ${{ matrix.group }} \
@@ -632,6 +634,7 @@ jobs:
                       "${SPLIT_GRANULARITY[@]}" \
                       --reruns 2 --reruns-delay 1 \
                       -r fEsxX \
+                      -o junit_duration_report=call \
                       --junitxml=junit-dagster-${{ matrix.group }}.xml
 
             - name: Upload test results


### PR DESCRIPTION
🤖 This PR and its description were written by a robot (a PostHog cloud agent task directed by pauldambra).

## Problem

Engineers' backend CI shards are balanced against timings that no longer describe real tests: 47% of the recorded seconds in `.test_durations` belong to deleted or renamed tests, so pytest-split budgets phantom work and mis-balances shards.

Reproducible from the committed `.test_durations` on master:

- 35,473 of 121,765 timing entries (29%) point at files that no longer exist: 3.81h of 8.13h recorded.
- Renamed parameterizations rot in place: `test_system_tables.py` records 818s, of which 810s are dead node ids. A warm local run of the actual file: 195 tests, ~55s.
- Same shape in `test_funnel.py` (79% of recorded seconds dead) and `test_usage_report.py` (40% dead).

Root cause: every CI shard restores the merged union and refreshes only its own slice, so a deleted test is never removed from the per-segment files this workflow rebuilds daily, and the union merge is append-only. `--scope-to-junit` already cleans the per-segment file-mode plans; it never ran on the single-run Core/Temporal/Dagster files that feed the union.

## Changes

- The daily timing workflow now scopes Core, Temporal, and Dagster outputs to the node ids their run's JUnit actually recorded. Deleted or renamed tests fall out of `.test_durations` on the next refresh.
- The Dagster segment needed its artifact prefix mapped (`junit-results-dagster-N`) in `optimize_test_durations.py`; the lowercase fallback matched nothing, so Dagster JUnit was unreachable. One unscoped input would defeat scoping for every other segment, because merge membership is a union.
- Each scoped call retries unscoped on failure, preserving the existing tolerate-missing-JUnit behavior (and its warnings).
- Products is unchanged: it already scopes when its JUnit shard set is verifiably complete.

Nothing user-visible; this touches internal CI timing only. The committed `.test_durations` still needs a one-time prune to be useful today; the daily cache self-cleans after this merges and the next monthly commit of the repo fallback carries the clean file.

## How did you test this code?

- `.github/scripts/test_optimize_test_durations.py`: 35 passed, including a new regression test pinning the Dagster prefix mapping (catches the silent no-match this PR fixes).
- `bin/hogli lint:workflows` passes (8 checks across 126 workflows) and `actionlint` v1.7.12 is clean on the edited workflow.
- Extracted both edited run blocks and checked them with `bash -n`: syntax OK.
- End-to-end against real master artifacts (backend run 32297965827, dagster run 32297965678): the four scoped per-segment files merged to a union of 130,227 entries totaling 4.15h (was 121,765 entries / 8.13h), with `test_system_tables.py` at 57s (was 818s) and genuinely slow live tests preserved. Not committed here; see follow-up PR for the data refresh.
- Not run: the timing workflow itself in CI, since it needs a master backend run's artifacts. The scoped behavior reuses the `--scope-to-junit` path already exercised daily for the per-segment files, and the unscoped retry preserves current failure behavior.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None: internal CI plumbing, candidate for `skip-inkeep-docs`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tools: PostHog cloud agent task directed by pauldambra; session is the reporting task linked from this branch's artifacts.
- Skills invoked: /authoring-ci-workflows, /writing-code-comments, /writing-pr-descriptions.
- Session path: a request to speed up `test_system_tables.py` showed its 818s recorded cost to be 810s of dead nodeids rather than real test time, which led to the union's append-only merge. Building the follow-up data-refresh PR then exposed the Dagster gap: with one unscoped segment in the merge, union membership kept every dead id, which is why this PR grew the prefix mapping and the Dagster download step. The retry-wrapper design was chosen over changing the script's failure contract so the guarded multi-run path stays intact.