### PR TITLE
feat(web-analytics): identify heatmap screenshot requests with a header

### DIFF
--- a/products/web_analytics/backend/tasks/heatmap_screenshot.py
+++ b/products/web_analytics/backend/tasks/heatmap_screenshot.py
@@ -32,6 +32,13 @@ HEATMAP_SCREENSHOT_TIME_LIMIT = HEATMAP_SCREENSHOT_SOFT_TIME_LIMIT + 30
 HEATMAP_SCREENSHOT_MAX_BYTES = 20 * 1024 * 1024
 HEATMAP_SCREENSHOT_STUCK_THRESHOLD_SECONDS = HEATMAP_SCREENSHOT_TIME_LIMIT + 60
 HEATMAP_SCREENSHOT_STUCK_SAMPLE_SIZE = 20
+# Identifies the render to sites behind a WAF, so they can allow it without allowing headless
+# browsers in general. Browserless loads the page from its own worker fleet rather than from
+# PostHog's egress IPs, so source IP is a poor signal for customers to write firewall rules against.
+# The name is published in the heatmaps docs, which makes it a public contract.
+# Do not put a secret in this value, because extra headers are applied to every request the page
+# makes, including cross-origin subresources.
+HEATMAP_SCREENSHOT_HEADER = "X-PostHog-Heatmap-Screenshot"
 
 HEATMAP_SCREENSHOT_SUCCEEDED = Counter(
     "heatmap_screenshot_task_succeeded",
@@ -398,6 +405,9 @@ def _browserless_screenshot(
         "gotoOptions": {"waitUntil": "networkidle2", "timeout": 30_000},
         "scrollPage": True,
         "bestAttempt": True,
+        # Part of the documented /screenshot schema, so unlike the cloud-only fields below it is
+        # also accepted by the self-hosted image.
+        "setExtraHTTPHeaders": {HEATMAP_SCREENSHOT_HEADER: "1"},
     }
     # blockConsentModals / blockAds are browserless.io cloud API extensions; the self-hosted OSS
     # image rejects unknown body fields (400 "must NOT have additional properties"), so only send

--- a/products/web_analytics/backend/tasks/test/test_heatmap_screenshot.py
+++ b/products/web_analytics/backend/tasks/test/test_heatmap_screenshot.py
@@ -318,6 +318,9 @@ class TestBrowserlessScreenshotRequest(SimpleTestCase):
         assert body["scrollPage"] is True
         assert body["blockConsentModals"] is True
         assert "blockAds" not in body
+        # Asserted as a literal because customers allow the render through their WAF by matching
+        # this exact header, so renaming it breaks their firewall rules.
+        assert body["setExtraHTTPHeaders"] == {"X-PostHog-Heatmap-Screenshot": "1"}
         # (connect, read) timeout tuple wired from settings
         assert mock_requests.post.call_args.kwargs["timeout"] == (30.0, 210.0)
 


### PR DESCRIPTION
## Problem

A site behind a WAF or bot protection cannot tell a PostHog heatmap screenshot from any other bot, so the render gets blocked and the heatmap shows the site's own error page.

Nothing identifies the request. Browserless renders the page from its own worker fleet, so it does not arrive from PostHog's published egress IPs. It carries a default `HeadlessChrome` user agent. Allowing it meant allowing headless browsers broadly.

## Changes

- Every heatmap screenshot request now sends `X-PostHog-Heatmap-Screenshot: 1`, so a WAF rule can allow the render on its own.
- The header name is documented, which makes it a public contract. The test pins the literal string rather than the constant, so a rename fails the test.
- The value must stay non-secret. Browserless applies extra headers to every request the page makes, including cross-origin subresources.

Mechanical: one key added to the existing `/screenshot` request body.

> [!NOTE]
> The docs land in PostHog/posthog.com#19592. Merge this first, because that page tells customers the header already exists.

## How did you test this code?

`TestBrowserlessScreenshotRequest` in `products/web_analytics/backend/tasks/test/test_heatmap_screenshot.py`. The new assertion catches a regression no existing test did. If the key is dropped or the header renamed, every customer WAF rule matching it silently stops matching.

`setExtraHTTPHeaders` is a documented `/screenshot` schema property, not a cloud-only extension like `blockAds`, so it needs no conditional. The adjacent comment warns that the self-hosted image rejects unknown body fields with a 400, so that was checked directly:

<details>
<summary>Checked against the pinned <code>ghcr.io/browserless/chromium:v2.51.2</code></summary>

Posted the production request body to a local container, pointed at a second container that logs the headers it receives.

- With `setExtraHTTPHeaders`: HTTP 200, valid 1024x800 JPEG, no `must NOT have additional properties` rejection. The target logged `x-posthog-heatmap-screenshot: 1`.
- Control, same body without the key: HTTP 200, and the target logged no such header.
- Both renders arrived as `Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/148.0.0.0 Safari/537.36`.

</details>

Not checked: the Browserless hosted service, and an end-to-end run of the Celery task against a real WAF.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

PostHog/posthog.com#19592.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code wrote this change. Skills invoked: `/writing-tests`, `/writing-code-comments`, and `/writing-pr-descriptions`, read from `.agents/skills/`.

The work started from a support question about heatmap screenshots being blocked by a WAF. Nothing from that conversation reached this PR. The diff carries no reported addresses, no site or customer identifiers, and no ticket reference. The header name and the test value were written for this change.

Two alternatives were dropped. Overriding `userAgent` is supported by the API, but the hosted service gates it by account tier, and replacing the Chrome user agent risks changing how pages render. A per-project secret would authenticate rather than identify, but it cannot ride on `setExtraHTTPHeaders` for the reason given in Changes.
