### PR TITLE
fix(warehouse_sources): classify GA4 connection resets as retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/source.py
@@ -79,7 +79,12 @@ class GoogleAnalyticsSource(ResumableSource[GoogleAnalyticsSourceConfig, GoogleA
         # still exhausted once those retries run out, the property's token quota refills over
         # time and the resumable source picks up from the last saved chunk, so let Temporal
         # retry the activity without paging it as a bug.
-        return {"(retryable)"}
+        #
+        # "Connection aborted"/"Connection reset by peer" are transport-level blips from `requests`
+        # raised directly by `session.post()` in `_run_report`, outside its own retry loop (which only
+        # handles `RefreshError` and HTTP-level failures). The resumable source picks up from the last
+        # saved chunk on the next Temporal retry, same as ClickHouse's source classifies this text.
+        return {"(retryable)", "Connection aborted", "Connection reset by peer"}
 
     def get_schemas(
         self,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/tests/test_google_analytics_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/tests/test_google_analytics_source.py
@@ -354,3 +354,12 @@ def test_retryable_errors_cover_exhausted_quota_retries():
     error_msg = "Data API quota for property '123456789' still exhausted after 5 retries (retryable)"
     patterns = GoogleAnalyticsSource().get_retryable_errors()
     assert any(pattern in error_msg for pattern in patterns)
+
+
+def test_retryable_errors_cover_connection_reset():
+    # `session.post()` in `_run_report` can raise this transport-level `requests.ConnectionError`
+    # directly, outside its own retry loop (which only handles `RefreshError` and HTTP-level
+    # failures) — must stay classified as retryable so it doesn't page as a bug.
+    error_msg = "('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer'))"
+    patterns = GoogleAnalyticsSource().get_retryable_errors()
+    assert error_message_matches(error_msg, patterns)


### PR DESCRIPTION
## Problem

A Google Analytics warehouse sync can hit a transport-level connection reset while calling the GA4 Data API. That failure gets reported to error tracking as a bug, even though the sync already recovers on the next Temporal retry.

Confirmed in [error tracking](https://us.posthog.com/project/2/error_tracking/01a01c0b-b4cb-7cd2-9263-9c0baf06c96a): `ConnectionError: ('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer'))`, raised from `session.post()` inside `_run_report` in `google_analytics.py`.

## Changes

- `GoogleAnalyticsSource.get_retryable_errors()` now also matches "Connection aborted" and "Connection reset by peer".
- This is a transient network blip, not a customer credential or config problem, so it is not added to `get_non_retryable_errors()`. The resumable source already picks up from the last saved chunk on the next Temporal retry; this only stops the noisy exception report, matching how the ClickHouse source already classifies the identical error text.

## How did you test this code?

Added `test_retryable_errors_cover_connection_reset`, asserting the observed error text is classified as retryable — guards against this connection-reset text silently falling out of `get_retryable_errors()` again. Ran the full `test_google_analytics_source.py` suite locally: 42 passed.

Not run: end-to-end Temporal workflow retry against a live GA4 connection.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated with Claude Code, pulling the issue and sampled event/stack trace via the PostHog MCP error-tracking tools. Confirmed the stack trace originates in this source's own code (`google_analytics.py:210` / `:377`), then read `_run_report`'s existing retry loop (quota/5xx/`RefreshError` handling) and the shared REST client's `RESTClientRetryableError` contract to find the precedent for excluding self-recovering transport errors from error tracking. Grepped other sources' `get_retryable_errors()` implementations and found ClickHouse already classifies this exact error text, which set the pattern applied here.