### PR TITLE
fix(data-imports): always sweep abandoned staging siblings on clear

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/person_property_row_sink.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/person_property_row_sink.py
@@ -159,14 +159,23 @@ class PersonPropertyRowSink:
         wiping it would lose that sync's delta. Only prefixes older than
         ``ABANDONED_STAGED_PREFIX_TTL`` are swept, as the backstop against a consumer that never
         ran.
+
+        The two clears are independent backstops, so a failure in one (e.g. a permissions error
+        deleting the own prefix) must not skip the other — the sweep always runs, and any
+        own-prefix error is re-raised only afterward.
         """
         async with aget_s3_client() as s3_client:
+            own_prefix_error: Exception | None = None
             if not self._is_incremental:
                 try:
                     await s3_client._rm(f"s3://{self._get_path_prefix()}/", recursive=True)
                 except FileNotFoundError:
                     pass
+                except Exception as e:
+                    own_prefix_error = e
             await self._sweep_abandoned_sibling_prefixes(s3_client)
+            if own_prefix_error is not None:
+                raise own_prefix_error
 
     async def _sweep_abandoned_sibling_prefixes(self, s3_client: Any) -> None:
         try:

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/person_property_row_sink_test.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/person_property_row_sink_test.py
@@ -219,6 +219,26 @@ async def test_clear_tolerates_missing_prefixes():
         await sink.clear()
 
 
+@pytest.mark.asyncio
+async def test_clear_still_sweeps_abandoned_siblings_when_own_prefix_delete_fails():
+    # A permissions error (or any other non-FileNotFoundError) deleting the own prefix must not
+    # skip the sibling-sweep backstop, which is an independent cleanup — otherwise abandoned sibling
+    # prefixes from crashed jobs never get swept on every run where the own-prefix delete fails.
+    sink = _sink()
+    stale_file = f"{sink._get_binding_prefix()}/job-old/chunk_0.parquet"
+    s3_client = _s3_client(
+        find_result={stale_file: {"LastModified": datetime.now(UTC) - ABANDONED_STAGED_PREFIX_TTL - timedelta(days=1)}}
+    )
+    s3_client._rm = AsyncMock(side_effect=[PermissionError("Access Denied"), None])
+
+    with patch(f"{_MODULE}.aget_s3_client", return_value=_FakeS3ClientCM(s3_client)):
+        with pytest.raises(PermissionError):
+            await sink.clear()
+
+    removed = [call.args[0] for call in s3_client._rm.await_args_list]
+    assert [f"s3://{stale_file}"] in removed  # sibling sweep still ran despite the own-prefix failure
+
+
 @parameterized.expand([("schema", schema_binding("schema-1")), ("saved_query", saved_query_binding("view-1"))])
 @pytest.mark.asyncio
 async def test_stages_under_the_binding_it_was_built_for(_name, binding):


### PR DESCRIPTION
## Problem

A permissions error surfaced in [error tracking](https://us.posthog.com/project/2/error_tracking/01a01c10-c82a-7680-83ad-76a2faca21bc) while clearing person-property staging files at the start of a warehouse write. The exception is already caught at the call site, so it did not fail that run, but tracing it exposed a real bug in the shared cleanup code.

`PersonPropertyRowSink.clear()` runs two independent cleanup steps: delete the current job's own staged prefix (full refresh only), then sweep sibling prefixes abandoned by earlier crashed jobs. A failure in the first step (any error other than `FileNotFoundError`, including the S3 permission error above) skipped the second step entirely, because both ran inside one `async with` block with no isolation between them.

The sibling sweep is the backstop that cleans up staged files left behind by a job that crashed and never returned to consume them. Skipping it on every run where the first step errors means abandoned files accumulate silently.

## Changes

- `PersonPropertyRowSink.clear()` now always runs the sibling sweep, even when deleting the job's own prefix fails.
- Any error from the own-prefix delete is re-raised only after the sweep finishes, so both existing callers keep their current failure behavior: the data-modeling caller still logs a warning and reports the error without failing the run, and the data-import sink still fails the sync on a genuine cleanup error.
- Mechanical: added a docstring note that the two cleanup steps are independent.

This is a shared-pipeline fix, not a `NonRetryableErrors` change: the underlying S3 error isn't a source-side problem, and the coupling bug affected the sweep regardless of what caused the first step to fail.

## How did you test this code?

Added `test_clear_still_sweeps_abandoned_siblings_when_own_prefix_delete_fails`, which fails on master: it simulates the own-prefix delete raising `PermissionError` and asserts the sibling sweep still runs and the error still propagates.

Ran the full `person_property_row_sink_test.py` suite locally (13 passed, including the new case) and `mypy` on the changed file (clean). Not run: a live Temporal/S3 integration test, since this sandbox has no such environment.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Internal pipeline behavior fix with no documented workflow change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via the PostHog error-tracking MCP tools (issue lookup, sampled event with stack trace) to trace the exception to `PersonPropertyRowSink.clear()`, then read the surrounding pipeline code to find the coupling bug. Skills invoked: `/writing-tests` before adding the regression test, `/writing-pr-descriptions` before writing this body. No customer or session-only data appears in this PR; the linked error tracking issue is PostHog's own dogfooding project.