### PR TITLE
fix(desktop): keep generating footer visible

### DIFF
--- a/products/desktop/packages/agent/src/acp-extensions.ts
+++ b/products/desktop/packages/agent/src/acp-extensions.ts
@@ -30,6 +30,9 @@ export const POSTHOG_NOTIFICATIONS = {
    * the tracked prompt lifecycle that TURN_COMPLETE drives on the agent side. */
   BACKGROUND_TURN_COMPLETE: "_posthog/background_turn_complete",
 
+  /** Background/task-notification-triggered reply started without a prompt RPC. */
+  BACKGROUND_TURN_STARTED: "_posthog/background_turn_started",
+
   /** Error occurred during task execution */
   ERROR: "_posthog/error",
 

--- a/products/desktop/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.test.ts
+++ b/products/desktop/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.test.ts
@@ -695,6 +695,33 @@ describe("CodexAppServerAgent", () => {
     });
   });
 
+  it("reports the lifecycle of a native goal turn as background generation", async () => {
+    const stub = makeStubRpc({
+      "thread/start": { thread: { id: "thr_1" } },
+    });
+    const { client, extNotifications } = makeFakeClient();
+    const agent = new CodexAppServerAgent(client, {
+      processOptions: { binaryPath: "/bundle/codex" },
+      rpcFactory: stub.factory,
+    });
+    await agent.newSession({ cwd: "/repo" } as unknown as NewSessionRequest);
+
+    stub.emit("turn/started", { turn: { id: "goal_tick_1" } });
+    stub.emit("turn/completed", {
+      turn: { id: "goal_tick_1", status: "completed" },
+    });
+    await Promise.resolve();
+
+    expect(extNotifications).toContainEqual({
+      method: "_posthog/background_turn_started",
+      params: { sessionId: "thr_1" },
+    });
+    expect(extNotifications).toContainEqual({
+      method: "_posthog/background_turn_complete",
+      params: { sessionId: "thr_1", stopReason: "end_turn" },
+    });
+  });
+
   it("interrupts a native goal turn that started before it was paused", async () => {
     const stub = makeStubRpc({
       "thread/start": { thread: { id: "thr_1" } },

--- a/products/desktop/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
+++ b/products/desktop/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
@@ -1542,6 +1542,16 @@ export class CodexAppServerAgent extends BaseAcpAgent {
       const turnId = (params as { turn?: { id?: string } })?.turn?.id;
       if (!this.turns.isPending && turnId) {
         this.nativeGoalTurnId = turnId;
+        void this.client
+          .extNotification(POSTHOG_NOTIFICATIONS.BACKGROUND_TURN_STARTED, {
+            sessionId: this.sessionId,
+          })
+          .catch((error) =>
+            this.logger.warn(
+              "Background turn start notification failed",
+              error,
+            ),
+          );
       }
       this.turns.onStarted(turnId);
       this.interruptQueuedGoalTurn(turnId);
@@ -1587,8 +1597,20 @@ export class CodexAppServerAgent extends BaseAcpAgent {
       this.commandOutputs.clear();
       const turn = (params as { turn?: { id?: string; status?: string } })
         ?.turn;
-      if (turn?.id === this.nativeGoalTurnId) {
+      const completedNativeGoalTurn = turn?.id === this.nativeGoalTurnId;
+      if (completedNativeGoalTurn) {
         this.nativeGoalTurnId = undefined;
+        void this.client
+          .extNotification(POSTHOG_NOTIFICATIONS.BACKGROUND_TURN_COMPLETE, {
+            sessionId: this.sessionId,
+            stopReason: mapTurnStopReason(turn?.status),
+          })
+          .catch((error) =>
+            this.logger.warn(
+              "Background turn completion notification failed",
+              error,
+            ),
+          );
       }
       // Drop the late completion of an already-interrupted turn (else it cancels the follow-up).
       if (this.turns.shouldDropCompletion(turn?.id)) return;

--- a/products/desktop/packages/ui/src/features/sessions/components/ConversationView.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ConversationView.tsx
@@ -149,6 +149,7 @@ export function ConversationView({
     lastTurnInfo,
     isCompacting,
     isClearing,
+    isBackgroundTurnActive,
     completedToolCallCount,
     lastActivityAt,
   } = useConversationItems(events, isPromptPending, {
@@ -497,6 +498,7 @@ export function ConversationView({
         pausedDurationMs={pausedDurationMs}
         isCompacting={isCompacting}
         isClearing={isClearing}
+        isBackgroundTurnActive={isBackgroundTurnActive}
         completedToolCallCount={completedToolCallCount}
         lastActivityAt={lastActivityAt}
       />

--- a/products/desktop/packages/ui/src/features/sessions/components/SessionFooter.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/SessionFooter.test.tsx
@@ -1,0 +1,24 @@
+import { Theme } from "@radix-ui/themes";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { SessionFooter } from "./SessionFooter";
+
+describe("SessionFooter", () => {
+  it.each([
+    ["compaction", { isCompacting: true }],
+    ["conversation clearing", { isClearing: true }],
+  ])("keeps the generating footer visible during %s", (_label, state) => {
+    render(
+      <Theme>
+        <SessionFooter
+          isPromptPending
+          promptStartedAt={Date.now()}
+          lastGenerationDuration={null}
+          {...state}
+        />
+      </Theme>,
+    );
+
+    expect(screen.getByText(/Esc to stop/)).toBeInTheDocument();
+  });
+});

--- a/products/desktop/packages/ui/src/features/sessions/components/SessionFooter.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/SessionFooter.test.tsx
@@ -7,7 +7,7 @@ describe("SessionFooter", () => {
   it.each([
     ["compaction", { isCompacting: true }],
     ["conversation clearing", { isClearing: true }],
-  ])("keeps the generating footer visible during %s", (_label, state) => {
+  ])("hides the generating footer during %s", (_label, state) => {
     render(
       <Theme>
         <SessionFooter
@@ -15,6 +15,21 @@ describe("SessionFooter", () => {
           promptStartedAt={Date.now()}
           lastGenerationDuration={null}
           {...state}
+        />
+      </Theme>,
+    );
+
+    expect(screen.queryByText(/Esc to stop/)).not.toBeInTheDocument();
+  });
+
+  it("shows the generating footer for a background Codex turn", () => {
+    render(
+      <Theme>
+        <SessionFooter
+          isPromptPending={false}
+          isBackgroundTurnActive
+          promptStartedAt={Date.now()}
+          lastGenerationDuration={null}
         />
       </Theme>,
     );

--- a/products/desktop/packages/ui/src/features/sessions/components/SessionFooter.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/SessionFooter.tsx
@@ -19,8 +19,7 @@ interface SessionFooterProps {
   hasPendingPermission?: boolean;
   pausedDurationMs?: number;
   isCompacting?: boolean;
-  /** A /clear is in flight; its dedicated "Clearing…" row replaces the
-   *  generic generating indicator, same as compaction. */
+  /** A /clear is in flight. */
   isClearing?: boolean;
   /** Number of tool calls finished so far; the generating indicator advances
    *  its status word each time this changes. */
@@ -39,8 +38,6 @@ export function SessionFooter({
   queuedCount = 0,
   hasPendingPermission = false,
   pausedDurationMs,
-  isCompacting = false,
-  isClearing = false,
   completedToolCallCount,
   lastActivityAt,
 }: SessionFooterProps) {
@@ -52,7 +49,7 @@ export function SessionFooter({
       {task && <DiffStatsChip task={task} />}
     </Flex>
   );
-  if (isPromptPending && !isCompacting && !isClearing) {
+  if (isPromptPending) {
     if (hasPendingPermission) {
       return (
         <Box className="pt-3 pb-1 opacity-50 transition-opacity group-hover/thread:opacity-100">

--- a/products/desktop/packages/ui/src/features/sessions/components/SessionFooter.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/SessionFooter.tsx
@@ -21,6 +21,7 @@ interface SessionFooterProps {
   isCompacting?: boolean;
   /** A /clear is in flight. */
   isClearing?: boolean;
+  isBackgroundTurnActive?: boolean;
   /** Number of tool calls finished so far; the generating indicator advances
    *  its status word each time this changes. */
   completedToolCallCount?: number;
@@ -38,6 +39,9 @@ export function SessionFooter({
   queuedCount = 0,
   hasPendingPermission = false,
   pausedDurationMs,
+  isCompacting = false,
+  isClearing = false,
+  isBackgroundTurnActive = false,
   completedToolCallCount,
   lastActivityAt,
 }: SessionFooterProps) {
@@ -49,7 +53,11 @@ export function SessionFooter({
       {task && <DiffStatsChip task={task} />}
     </Flex>
   );
-  if (isPromptPending) {
+  if (
+    (isPromptPending || isBackgroundTurnActive) &&
+    !isCompacting &&
+    !isClearing
+  ) {
     if (hasPendingPermission) {
       return (
         <Box className="pt-3 pb-1 opacity-50 transition-opacity group-hover/thread:opacity-100">

--- a/products/desktop/packages/ui/src/features/sessions/components/SessionFooter.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/SessionFooter.tsx
@@ -21,6 +21,8 @@ interface SessionFooterProps {
   isCompacting?: boolean;
   /** A /clear is in flight. */
   isClearing?: boolean;
+  /** A turn the agent started on its own, with no prompt RPC behind it, so
+   *  `isPromptPending` stays false while it generates. */
   isBackgroundTurnActive?: boolean;
   /** Number of tool calls finished so far; the generating indicator advances
    *  its status word each time this changes. */
@@ -94,7 +96,9 @@ export function SessionFooter({
                 ({queuedCount} queued)
               </Text>
             )}
-            <SlotMachineLever spinning={Boolean(isPromptPending)} />
+            <SlotMachineLever
+              spinning={Boolean(isPromptPending || isBackgroundTurnActive)}
+            />
           </Flex>
           {rightSide}
         </Flex>

--- a/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.test.ts
@@ -89,6 +89,18 @@ function backgroundTurnCompleteMsg(
   };
 }
 
+function backgroundTurnStartedMsg(ts: number): AcpMessage {
+  return {
+    type: "acp_message",
+    ts,
+    message: {
+      jsonrpc: "2.0",
+      method: "_posthog/background_turn_started",
+      params: { sessionId: "session-1" },
+    },
+  };
+}
+
 function agentMessageMsg(ts: number, text: string): AcpMessage {
   return {
     type: "acp_message",
@@ -1122,6 +1134,24 @@ describe("buildConversationItems", () => {
 
       expect(lastTurnInfo?.isComplete).toBe(true);
       expect(lastTurnInfo?.durationMs).toBeGreaterThan(0);
+    });
+
+    it("tracks an active background turn until its completion arrives", () => {
+      const active = buildConversationItems(
+        [backgroundTurnStartedMsg(10), agentMessageMsg(11, "Working")],
+        false,
+      );
+      const completed = buildConversationItems(
+        [
+          backgroundTurnStartedMsg(10),
+          agentMessageMsg(11, "Working"),
+          backgroundTurnCompleteMsg(12),
+        ],
+        false,
+      );
+
+      expect(active.isBackgroundTurnActive).toBe(true);
+      expect(completed.isBackgroundTurnActive).toBe(false);
     });
 
     it("does not spawn a phantom turn for a silent trailing update like usage_update", () => {

--- a/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.ts
@@ -90,6 +90,8 @@ export interface BuildResult {
    *  silent: a turn can sit minutes inside one tool call or thinking block
    *  with nothing new to render, and a frozen status word reads as a hang. */
   lastActivityAt: number | null;
+  /** A background turn started without a prompt RPC and has not completed. */
+  isBackgroundTurnActive: boolean;
 }
 
 interface ProgressCardState {
@@ -151,6 +153,7 @@ export interface ItemBuilder {
   /** Timestamp (ms) of the newest event fed to this builder. See the field of
    *  the same name on `BuildResult`. */
   lastActivityAt: number | null;
+  isBackgroundTurnActive: boolean;
   /** Runs that emitted `_posthog/run_started`; until then the setup card's
    *  "agent" step stays in_progress rather than completing at HTTP-boot time. */
   runStartedRunIds: Set<string>;
@@ -169,6 +172,7 @@ export function createItemBuilder(): ItemBuilder {
     lowestTouchedProgressIndex: Number.POSITIVE_INFINITY,
     completedToolCallCount: 0,
     lastActivityAt: null,
+    isBackgroundTurnActive: false,
     runStartedRunIds: new Set(),
   };
 }
@@ -295,6 +299,7 @@ export function buildConversationItems(
     isClearing: b.isClearing,
     completedToolCallCount: b.completedToolCallCount,
     lastActivityAt: b.lastActivityAt,
+    isBackgroundTurnActive: b.isBackgroundTurnActive,
   };
 }
 
@@ -352,6 +357,7 @@ export function buildAgentConversationItems(
     isClearing: b.isClearing,
     completedToolCallCount: b.completedToolCallCount,
     lastActivityAt: b.lastActivityAt,
+    isBackgroundTurnActive: b.isBackgroundTurnActive,
   };
 }
 
@@ -687,9 +693,17 @@ function handleNotification(
   // (see accumulateSessionResources / SessionResourcesBar).
 
   if (
+    isNotification(msg.method, POSTHOG_NOTIFICATIONS.BACKGROUND_TURN_STARTED)
+  ) {
+    b.isBackgroundTurnActive = true;
+    return;
+  }
+
+  if (
     isNotification(msg.method, POSTHOG_NOTIFICATIONS.TURN_COMPLETE) ||
     isNotification(msg.method, POSTHOG_NOTIFICATIONS.BACKGROUND_TURN_COMPLETE)
   ) {
+    b.isBackgroundTurnActive = false;
     const params = msg.params as { stopReason?: string } | undefined;
     if (!b.currentTurn) return;
     completePromptTurn(b, b.currentTurn, ts, {

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThreadFooter.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThreadFooter.tsx
@@ -53,6 +53,9 @@ export function ChatThreadFooter({
     eventFooterState.completedToolCallCount;
   const lastActivityAt =
     footerState?.lastActivityAt ?? eventFooterState.lastActivityAt;
+  const isBackgroundTurnActive =
+    footerState?.isBackgroundTurnActive ??
+    eventFooterState.isBackgroundTurnActive;
   const pendingPermissions = usePendingPermissionsForTask(taskId ?? "");
   const pendingPermissionVisible = resolvePendingPermissionVisibility(
     hasPendingPermission,
@@ -79,6 +82,7 @@ export function ChatThreadFooter({
         pausedDurationMs={pausedDurationMs}
         isCompacting={isCompacting}
         isClearing={isClearing}
+        isBackgroundTurnActive={isBackgroundTurnActive}
         completedToolCallCount={completedToolCallCount}
         lastActivityAt={lastActivityAt}
       />

--- a/products/desktop/packages/ui/src/features/sessions/components/incrementalConversationItems.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/incrementalConversationItems.ts
@@ -101,6 +101,7 @@ export function createIncrementalConversationBuilder() {
           isClearing: builder.isClearing,
           completedToolCallCount: builder.completedToolCallCount,
           lastActivityAt: builder.lastActivityAt,
+          isBackgroundTurnActive: builder.isBackgroundTurnActive,
         };
         // A finalized builder can't be safely continued; the next streaming
         // call rebuilds fresh.
@@ -183,6 +184,7 @@ export function createIncrementalConversationBuilder() {
       isClearing: builder.isClearing,
       completedToolCallCount: builder.completedToolCallCount,
       lastActivityAt: builder.lastActivityAt,
+      isBackgroundTurnActive: builder.isBackgroundTurnActive,
     };
   }
 


### PR DESCRIPTION
## Problem

Desktop users on Codex lose the "Generating…" footer while the agent is still working. The elapsed timer and the "Esc to stop" hint disappear, so a long reply reads as a hang.

The footer keys off `isPromptPending`, which the host sets from the `session/prompt` RPC. Codex also starts turns on its own, with no prompt RPC behind them, so nothing tells the UI a turn is running.

## Changes

- The generating footer now stays up for a Codex turn the agent started on its own, with a live timer and a spinning lever.
- The codex adapter emits `_posthog/background_turn_started` and `_posthog/background_turn_complete` around a native goal turn.
- `buildConversationItems` tracks that pair as `isBackgroundTurnActive`, and the footer renders for `isPromptPending || isBackgroundTurnActive`.
- Compaction and clearing still suppress the footer. Each has its own status row with a spinner and timer, and cancel is ignored during a `/clear`, so "Esc to stop" would be wrong there.

Nothing else looks different. No screenshot: the change is a footer that was already designed and is now shown in one more state.

## How did you test this code?

- `codex-app-server-agent.test.ts` gains a case asserting a native goal turn emits both notifications. It catches a regression where the adapter stops reporting the turn and the footer goes dark again.
- `buildConversationItems.test.ts` gains a case that the flag holds from start to completion. It catches a stuck-true flag, which would spin the footer forever.
- `SessionFooter.test.tsx` asserts the footer is hidden during compaction and clearing and shown for a background turn. The first two lock the gate that an earlier revision of this branch removed.
- Not run: the desktop app itself. This sandbox has no display, so the footer was not observed live.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex wrote the change. Skills invoked: `posthog-desktop`, `writing-tests`, `writing-code-comments`, `writing-pr-descriptions`.

The first revision took a shorter route: it deleted the compaction and clearing gates so any pending prompt showed the footer. ReviewHog caught that `/clear` travels as a normal prompt RPC, so that revision put a second spinner beside the "Clearing conversation…" row and offered an Esc hint the adapter ignores. The branch now adds a separate background-turn signal instead, which leaves both gates intact.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
