### PR TITLE
chore(desktop): report knip findings in ci

### DIFF
--- a/.github/workflows/desktop-typecheck.yml
+++ b/.github/workflows/desktop-typecheck.yml
@@ -117,6 +117,12 @@ jobs:
             - name: Run type check
               run: pnpm run typecheck
 
+            - name: Check workspace dependencies
+              # Advisory while the existing findings are triaged. Older PR branches
+              # may not have the Knip script yet.
+              continue-on-error: true
+              run: pnpm run --if-present knip
+
     # Collation job for the required status check; must be registered as the
     # required check instead of the individual jobs.
     desktop-typecheck-pass:

--- a/products/desktop/knip.json
+++ b/products/desktop/knip.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://unpkg.com/knip@latest/schema.json",
+  "ignoreWorkspaces": ["apps/mobile"],
   "workspaces": {
     ".": {
       "entry": ["mprocs.yaml", "scripts/*.{mjs,js,ts}"]
@@ -27,11 +28,6 @@
         "node-addon-api",
         "@vitest/coverage-v8"
       ]
-    },
-    "apps/mobile": {
-      "entry": ["index.js"],
-      "project": ["src/**/*.{ts,tsx}"],
-      "metro": false
     },
     "packages/agent": {
       "project": ["src/**/*.ts"],

--- a/products/desktop/knip.json
+++ b/products/desktop/knip.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/knip@latest/schema.json",
-  "ignoreWorkspaces": ["apps/mobile"],
+  "ignoreWorkspaces": ["apps/mobile", "apps/web"],
   "workspaces": {
     ".": {
       "entry": ["mprocs.yaml", "scripts/*.{mjs,js,ts}"]

--- a/products/desktop/knip.json
+++ b/products/desktop/knip.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://unpkg.com/knip@latest/schema.json",
-  "ignoreWorkspaces": ["apps/mobile", "apps/web"],
   "workspaces": {
     ".": {
       "entry": ["mprocs.yaml", "scripts/*.{mjs,js,ts}"]
@@ -28,6 +27,11 @@
         "node-addon-api",
         "@vitest/coverage-v8"
       ]
+    },
+    "apps/mobile": {
+      "entry": ["index.js"],
+      "project": ["src/**/*.{ts,tsx}"],
+      "metro": false
     },
     "packages/agent": {
       "project": ["src/**/*.ts"],


### PR DESCRIPTION
## Problem

Desktop contributors do not see Knip findings in pull request checks.

**Why:** Advisory output makes dependency cleanup visible without blocking CI on existing findings.

## Changes

- Desktop CI now runs the existing Knip configuration after typechecking.
- Knip remains non-blocking while existing findings are triaged.
- Mobile and web remain excluded.

Before:

```mermaid
flowchart LR
    A[Desktop change] --> B[Typecheck]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phBlue;
    class B phGray;
```

After:

```mermaid
flowchart LR
    A[Desktop change] --> B[Typecheck]
    B --> C[Advisory Knip report]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phBlue;
    class B,C phGray;
```

## How did you test this code?

- Ran the existing Knip configuration.
- Ran Biome against the Knip configuration.
- Ran CI preflight.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation change. This only changes internal tooling.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex made this change with the posthog-desktop, authoring-ci-workflows, writing-tests, and writing-pr-descriptions skills. The final scope only adds advisory CI reporting.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*