### PR TITLE
feat(mcp): add product and integration context to env prompt

### DIFF
--- a/services/mcp/src/hono/instructions.ts
+++ b/services/mcp/src/hono/instructions.ts
@@ -65,6 +65,7 @@ export class InstructionsBuilder {
                 }),
             renderUiEnabled: state.renderUiEnabled,
             metadata: state.metadata,
+            metadataCompact: state.metadataCompact,
             groupTypes: state.groupTypes,
             dataCatalogEnabled: state.toolFeatureFlags?.[PRODUCT_DATA_CATALOG_FLAG] === true,
         }

--- a/services/mcp/src/hono/request-state-resolver.ts
+++ b/services/mcp/src/hono/request-state-resolver.ts
@@ -60,6 +60,12 @@ export interface ResolvedState {
     // the model like Codex, or ignore it like Claude web/desktop) the exec command
     // reference. Resolved once here so every render path reads the same source.
     metadata: string | undefined
+    // Variant of `metadata` without the product/integration context lines, for the
+    // claude.ai exec command reference: that surface counts against the ~16 KiB
+    // connector-registry cap on the serialized inputSchema, which already sits
+    // within tens of characters of the worst-case env context. Every uncapped
+    // surface renders the full `metadata`.
+    metadataCompact: string | undefined
     groupTypes: GroupType[] | undefined
 }
 
@@ -225,11 +231,12 @@ export class RequestStateResolver {
         // only exists in single-exec mode — skip the extra scan otherwise.
         const scopeGatedTools = useSingleExec ? getScopeGatedTools(apiKeyScopes, filterOptions) : []
 
-        const [groupTypes, metadata] = await Promise.all([
+        const [groupTypes, metadata, metadataCompact] = await Promise.all([
             cachedProjectId && hasScope(apiKeyScopes, 'group:read')
                 ? context.stateManager.getOrFetchGroupTypes(cachedProjectId).catch(() => undefined)
                 : undefined,
             context.stateManager.getEnvironmentPrompt(),
+            context.stateManager.getEnvironmentPrompt({ includeProductContext: false }),
         ])
 
         return {
@@ -248,6 +255,7 @@ export class RequestStateResolver {
             distinctId,
             renderUiEnabled,
             metadata,
+            metadataCompact,
             groupTypes,
         }
     }

--- a/services/mcp/src/lib/StateManager.ts
+++ b/services/mcp/src/lib/StateManager.ts
@@ -400,6 +400,31 @@ export class StateManager {
     }
 
     /**
+     * Integration kinds (github, slack, ...) connected in the project, for the
+     * environment prompt. Returns undefined when the key lacks `integration:read`
+     * so the prompt renders nothing rather than a false "none connected".
+     */
+    async getOrFetchIntegrationKinds(projectId: string): Promise<string[] | undefined> {
+        const apiKey = await this.getApiKey()
+        if (!hasScope(apiKey.scopes, 'integration:read')) {
+            return undefined
+        }
+        return this.getOrFetchCached({
+            name: 'integration_kinds',
+            cacheKey: `integrationKinds:${projectId}` as const,
+            fetchedAtKey: `integrationKindsFetchedAt:${projectId}` as const,
+            fetcher: async () => {
+                const result = await this._api.request<Schemas.PaginatedIntegrationConfigList>({
+                    method: 'GET',
+                    path: `/api/projects/${encodeURIComponent(projectId)}/integrations/`,
+                    query: { limit: 100 },
+                })
+                return [...new Set((result.results ?? []).map((integration) => String(integration.kind)))].sort()
+            },
+        })
+    }
+
+    /**
      * The third-party MCP tools this user can reach, from the gateway.
      *
      * Shorter TTL than the other cached entities: connecting a server is a deliberate
@@ -416,13 +441,21 @@ export class StateManager {
         })
     }
 
-    async getEnvironmentPrompt(): Promise<string | undefined> {
+    async getEnvironmentPrompt(opts?: { includeProductContext?: boolean }): Promise<string | undefined> {
+        const includeProductContext = opts?.includeProductContext !== false
         const [user, org, project] = await Promise.all([
             this.getCachedOrFetchUser().catch(() => undefined),
             this.getCachedOrFetchOrg().catch(() => undefined),
             this.getCachedOrFetchProject().catch(() => undefined),
         ])
-        return buildActiveEnvironmentContextPrompt(user, org, project, this._api.publicBaseUrl)
+        const integrationKinds =
+            includeProductContext && project
+                ? await this.getOrFetchIntegrationKinds(String(project.id)).catch(() => undefined)
+                : undefined
+        return buildActiveEnvironmentContextPrompt(user, org, project, this._api.publicBaseUrl, {
+            integrationKinds,
+            includeProductContext,
+        })
     }
 
     /**

--- a/services/mcp/src/lib/instructions-formatter.ts
+++ b/services/mcp/src/lib/instructions-formatter.ts
@@ -38,6 +38,10 @@ export interface InstructionsContext {
     guidelines: string
     groupTypes?: GroupType[] | undefined
     metadata?: string | undefined
+    /** `metadata` without the product/integration context lines, for the claude.ai
+     *  exec command reference, which counts against the ~16 KiB registry cap on the
+     *  serialized inputSchema. Falls back to `metadata` when unset. */
+    metadataCompact?: string | undefined
     tools?: ToolInfo[] | undefined
     queryTools?: QueryToolInfo[] | undefined
     /** Whether `render-ui` is actually available to this client (i.e. the client is
@@ -170,7 +174,7 @@ export class InstructionsFormatter {
         const helpSection = formatPrompt(EXEC_LEARN, { help_topics: helpTopics })
         const renderCtx: InstructionsContext = {
             guidelines: ctx.guidelines,
-            metadata: ctx.metadata,
+            metadata: ctx.metadataCompact ?? ctx.metadata,
             groupTypes: ctx.groupTypes,
             tools: ctx.tools,
         }

--- a/services/mcp/src/lib/instructions.ts
+++ b/services/mcp/src/lib/instructions.ts
@@ -8,11 +8,82 @@ export function buildDefinedGroupsBlock(groupTypes?: GroupType[]): string {
     return `Defined group types: ${groupTypes.map((gt) => gt.group_type).join(', ')}`
 }
 
+/** Bounds the onboarded-products line for intent-heavy teams; the environment
+ *  prompt is repeated context, so the tail is summarized as a count instead. */
+const MAX_ONBOARDED_PRODUCTS = 12
+
+/**
+ * Per-product enablement facts for the active project, so an agent knows which
+ * PostHog products it can rely on (and which are off) without calling
+ * `project-get` and interpreting a raw settings payload. Facts only, stated
+ * neutrally: whether to recommend enabling something is the agent's call.
+ */
+function buildProductLines(project: CachedProject): string[] {
+    // Only flag-backed products get an enabled/not-enabled verdict, because their
+    // Team opt-in is an authoritative on/off switch. Products with no such switch
+    // (feature flags, experiments, ...) are reported via completed onboarding below.
+    const optIns = [
+        { label: 'session replay', enabled: project.session_recording_opt_in },
+        { label: 'exception autocapture (error tracking)', enabled: project.autocapture_exceptions_opt_in },
+        { label: 'surveys', enabled: project.surveys_opt_in },
+        { label: 'heatmaps', enabled: project.heatmaps_opt_in },
+    ]
+    const lines: string[] = []
+    const enabled = optIns.filter((p) => p.enabled === true).map((p) => p.label)
+    const notEnabled = optIns.filter((p) => p.enabled !== true).map((p) => p.label)
+    if (enabled.length > 0) {
+        lines.push(`Products enabled in this project: ${enabled.join(', ')}.`)
+    }
+    if (notEnabled.length > 0) {
+        lines.push(`Products not enabled: ${notEnabled.join(', ')}.`)
+    }
+    // Intent rows without `onboarding_completed_at` can be a single abandoned
+    // click, so only completed onboarding counts as "set up".
+    const onboarded = [
+        ...new Set(
+            (project.product_intents ?? [])
+                .filter((intent) => intent.onboarding_completed_at && intent.product_type)
+                .map((intent) => (intent.product_type as string).replace(/_/g, ' '))
+        ),
+    ].sort()
+    if (onboarded.length > 0) {
+        const shown = onboarded.slice(0, MAX_ONBOARDED_PRODUCTS)
+        const more = onboarded.length - shown.length
+        lines.push(`Products set up (onboarding completed): ${shown.join(', ')}${more > 0 ? ` (+${more} more)` : ''}.`)
+    }
+    return lines
+}
+
+/**
+ * `undefined` means unknown (key lacks `integration:read`, or the fetch failed):
+ * say nothing rather than a false "none". An empty list is a real answer and is
+ * rendered, since "no integrations connected" is itself useful to an agent.
+ */
+function buildIntegrationsLine(integrationKinds?: string[]): string | undefined {
+    if (!integrationKinds) {
+        return undefined
+    }
+    if (integrationKinds.length === 0) {
+        return 'Integrations connected: none.'
+    }
+    return `Integrations connected: ${[...new Set(integrationKinds)].sort().join(', ')}.`
+}
+
+export interface EnvironmentContextOptions {
+    /** Integration kinds connected in the active project; `undefined` means unknown. */
+    integrationKinds?: string[]
+    /** Set to false for character-budgeted surfaces (the claude.ai exec command
+     *  reference counts against a ~16 KiB registry cap on the serialized
+     *  inputSchema) where the product/integration lines do not fit. */
+    includeProductContext?: boolean
+}
+
 export function buildActiveEnvironmentContextPrompt(
     user?: CachedUser,
     org?: CachedOrg,
     project?: CachedProject,
-    regionalBaseUrl?: string
+    regionalBaseUrl?: string,
+    opts?: EnvironmentContextOptions
 ): string | undefined {
     if (!user && !org && !project) {
         return undefined
@@ -57,6 +128,13 @@ export function buildActiveEnvironmentContextPrompt(
             lines.push(
                 "Person properties are query-time in this project. `person.properties.*` on the events table always returns the person's current (latest) value, regardless of when the event occurred."
             )
+        }
+        if (opts?.includeProductContext !== false) {
+            lines.push(...buildProductLines(project))
+            const integrationsLine = buildIntegrationsLine(opts?.integrationKinds)
+            if (integrationsLine) {
+                lines.push(integrationsLine)
+            }
         }
     }
     if (user) {

--- a/services/mcp/src/tools/organizations/setActive.ts
+++ b/services/mcp/src/tools/organizations/setActive.ts
@@ -32,7 +32,12 @@ export const setActiveHandler: ToolBase<typeof schema, Result>['handler'] = asyn
     const user = (await context.cache.get(`cachedUser:${distinctId}` as const)) as CachedUser | undefined
     const project = (await context.cache.get(`cachedProject:${projectId}` as const)) as CachedProject | undefined
 
-    const metadata = buildActiveEnvironmentContextPrompt(user, org, project, context.api.publicBaseUrl)
+    const integrationKinds = project
+        ? await context.stateManager.getOrFetchIntegrationKinds(String(project.id)).catch(() => undefined)
+        : undefined
+    const metadata = buildActiveEnvironmentContextPrompt(user, org, project, context.api.publicBaseUrl, {
+        integrationKinds,
+    })
     const text = metadata
         ? `Switched to organization ${orgId}.\n\nCurrent context:\n${metadata}`
         : `Switched to organization ${orgId}`

--- a/services/mcp/src/tools/projects/setActive.ts
+++ b/services/mcp/src/tools/projects/setActive.ts
@@ -75,7 +75,10 @@ export const setActiveHandler: ToolBase<typeof schema, Result>['handler'] = asyn
     }
 
     const orgNote = switchedOrg ? ` (also switched the active organization to ${orgId} to match)` : ''
-    const metadata = buildActiveEnvironmentContextPrompt(user, org, project, context.api.publicBaseUrl)
+    const integrationKinds = await context.stateManager.getOrFetchIntegrationKinds(projectIdStr).catch(() => undefined)
+    const metadata = buildActiveEnvironmentContextPrompt(user, org, project, context.api.publicBaseUrl, {
+        integrationKinds,
+    })
     const text = metadata
         ? `Switched to project ${projectId}${orgNote}.\n\nCurrent context:\n${metadata}`
         : `Switched to project ${projectId}${orgNote}`

--- a/services/mcp/src/tools/types.ts
+++ b/services/mcp/src/tools/types.ts
@@ -41,6 +41,8 @@ export type State = {
     Record<PrefixedString<'cachedOrgFetchedAt'>, number | undefined> &
     Record<PrefixedString<'cachedProject'>, CachedProject | undefined> &
     Record<PrefixedString<'cachedProjectFetchedAt'>, number | undefined> &
+    Record<PrefixedString<'integrationKinds'>, string[] | undefined> &
+    Record<PrefixedString<'integrationKindsFetchedAt'>, number | undefined> &
     Record<PrefixedString<'gatewayTools'>, Schemas.AvailableToolsResponse | undefined> &
     Record<PrefixedString<'gatewayToolsFetchedAt'>, number | undefined>
 

--- a/services/mcp/tests/hono/analytics.test.ts
+++ b/services/mcp/tests/hono/analytics.test.ts
@@ -67,6 +67,7 @@ function makeState(overrides: Partial<ResolvedState> = {}): ResolvedState {
         distinctId: 'distinct-id',
         renderUiEnabled: false,
         metadata: undefined,
+        metadataCompact: undefined,
         groupTypes: undefined,
         ...overrides,
     }

--- a/services/mcp/tests/hono/tool-executor-intent.test.ts
+++ b/services/mcp/tests/hono/tool-executor-intent.test.ts
@@ -72,6 +72,7 @@ function makeState(tools: { name: string }[], overrides: Partial<ResolvedState> 
         distinctId: 'test-distinct-id',
         renderUiEnabled: false,
         metadata: undefined,
+        metadataCompact: undefined,
         groupTypes: undefined,
         ...overrides,
     }

--- a/services/mcp/tests/hono/tool-executor-metrics.test.ts
+++ b/services/mcp/tests/hono/tool-executor-metrics.test.ts
@@ -104,6 +104,7 @@ function makeState(tools: { name: string }[], overrides: Partial<ResolvedState> 
         distinctId: 'test-distinct-id',
         renderUiEnabled: false,
         metadata: undefined,
+        metadataCompact: undefined,
         groupTypes: undefined,
         ...overrides,
     }

--- a/services/mcp/tests/hono/tool-executor-tokens.test.ts
+++ b/services/mcp/tests/hono/tool-executor-tokens.test.ts
@@ -75,6 +75,7 @@ function makeState(tools: { name: string }[], overrides: Partial<ResolvedState> 
         distinctId: 'test-distinct-id',
         renderUiEnabled: false,
         metadata: undefined,
+        metadataCompact: undefined,
         groupTypes: undefined,
         ...overrides,
     }

--- a/services/mcp/tests/hono/tool-executor.test.ts
+++ b/services/mcp/tests/hono/tool-executor.test.ts
@@ -70,6 +70,7 @@ function makeState(tools: { name: string }[], overrides: Partial<ResolvedState> 
         distinctId: 'test-distinct-id',
         renderUiEnabled: false,
         metadata: undefined,
+        metadataCompact: undefined,
         groupTypes: undefined,
         ...overrides,
     }

--- a/services/mcp/tests/unit/StateManager.test.ts
+++ b/services/mcp/tests/unit/StateManager.test.ts
@@ -868,6 +868,36 @@ describe('StateManager', () => {
         })
     })
 
+    describe('getOrFetchIntegrationKinds', () => {
+        const projectId = '42'
+
+        it('returns undefined without calling the API when the key lacks integration:read', async () => {
+            await cache.set('apiKey', { scopes: ['project:read'], scoped_organizations: [], scoped_teams: [] })
+            const request = vi.fn()
+            ;(stateManager as any)._api = { request }
+
+            const result = await stateManager.getOrFetchIntegrationKinds(projectId)
+
+            expect(result).toBeUndefined()
+            expect(request).not.toHaveBeenCalled()
+        })
+
+        it('fetches, dedupes, and sorts integration kinds when the scope is present', async () => {
+            await cache.set('apiKey', { scopes: ['integration:read'], scoped_organizations: [], scoped_teams: [] })
+            const request = vi.fn().mockResolvedValue({
+                results: [{ kind: 'slack' }, { kind: 'github' }, { kind: 'github' }],
+            })
+            ;(stateManager as any)._api = { request }
+
+            const result = await stateManager.getOrFetchIntegrationKinds(projectId)
+
+            expect(result).toEqual(['github', 'slack'])
+            expect(request).toHaveBeenCalledWith(
+                expect.objectContaining({ method: 'GET', path: `/api/projects/${projectId}/integrations/` })
+            )
+        })
+    })
+
     describe('getAnalyticsContext', () => {
         it('returns organization, project, UUID, and name from the cached project', async () => {
             await cache.set('orgId', 'org-1')

--- a/services/mcp/tests/unit/instructions-formatter-snapshot.test.ts
+++ b/services/mcp/tests/unit/instructions-formatter-snapshot.test.ts
@@ -164,21 +164,35 @@ describe('InstructionsFormatter prompt snapshots', () => {
         // (Team.name 200, Organization.name 64, email 254, Django names 150) plus
         // the longer person-on-events branch, so a long org/project/user cannot
         // push the real schema past the cap while this test passes.
+        const worstCaseUser = {
+            first_name: 'F'.repeat(150),
+            last_name: 'L'.repeat(150),
+            email: `${'e'.repeat(242)}@example.com`,
+        } as CachedUser
+        const worstCaseOrg = { name: 'O'.repeat(64), id: '00000000-0000-0000-0000-000000000000' } as CachedOrg
+        const worstCaseProject = {
+            name: 'P'.repeat(200),
+            id: 9_999_999,
+            api_token: `phc_${'x'.repeat(43)}`,
+            timezone: 'America/Argentina/ComodRivadavia',
+            person_on_events_querying_enabled: true,
+        } as CachedProject
         const worstCaseMetadata = buildActiveEnvironmentContextPrompt(
-            {
-                first_name: 'F'.repeat(150),
-                last_name: 'L'.repeat(150),
-                email: `${'e'.repeat(242)}@example.com`,
-            } as CachedUser,
-            { name: 'O'.repeat(64), id: '00000000-0000-0000-0000-000000000000' } as CachedOrg,
-            {
-                name: 'P'.repeat(200),
-                id: 9_999_999,
-                api_token: `phc_${'x'.repeat(43)}`,
-                timezone: 'America/Argentina/ComodRivadavia',
-                person_on_events_querying_enabled: true,
-            } as CachedProject,
+            worstCaseUser,
+            worstCaseOrg,
+            worstCaseProject,
             'https://us.posthog.com'
+        )
+        // The claude.ai reference renders the compact metadata variant: the
+        // product/integration context lines are excluded from this surface by
+        // design because they do not fit under the cap (see
+        // `buildClaudeExecCommandReference` and `ResolvedState.metadataCompact`).
+        const worstCaseMetadataCompact = buildActiveEnvironmentContextPrompt(
+            worstCaseUser,
+            worstCaseOrg,
+            worstCaseProject,
+            'https://us.posthog.com',
+            { includeProductContext: false }
         )
         // Five group types (the product cap) with generously long names.
         const worstCaseGroupTypes = Array.from({ length: 5 }, (_, i) => ({
@@ -195,6 +209,7 @@ describe('InstructionsFormatter prompt snapshots', () => {
             toolFeatureFlags: { [PRODUCT_DATA_CATALOG_FLAG]: true },
             renderUiEnabled: true,
             metadata: worstCaseMetadata,
+            metadataCompact: worstCaseMetadataCompact,
             groupTypes: worstCaseGroupTypes,
         } as unknown as ResolvedState
         const entry = new InstructionsBuilder('').buildExecToolEntry(state)

--- a/services/mcp/tests/unit/instructions.test.ts
+++ b/services/mcp/tests/unit/instructions.test.ts
@@ -345,4 +345,75 @@ describe('buildActiveEnvironmentContextPrompt', () => {
             'You are currently in project "Unknown" (id: unknown, token: unknown) within organization "Acme" (id: org_1).'
         )
     })
+
+    it('buckets flag-backed products strictly, so only an explicit true counts as enabled', () => {
+        const result = buildActiveEnvironmentContextPrompt(user, org, {
+            ...project,
+            session_recording_opt_in: true,
+            autocapture_exceptions_opt_in: false,
+            surveys_opt_in: null,
+            heatmaps_opt_in: undefined,
+        } as CachedProject)
+        expect(result).toContain('Products enabled in this project: session replay.')
+        expect(result).toContain('Products not enabled: exception autocapture (error tracking), surveys, heatmaps.')
+    })
+
+    it('lists only onboarding-completed product intents, with underscores humanized', () => {
+        const result = buildActiveEnvironmentContextPrompt(user, org, {
+            ...project,
+            product_intents: [
+                { product_type: 'feature_flags', onboarding_completed_at: '2026-01-01T00:00:00Z' },
+                { product_type: 'experiments', onboarding_completed_at: null },
+            ],
+        } as CachedProject)
+        expect(result).toContain('Products set up (onboarding completed): feature flags.')
+        expect(result).not.toContain('experiments')
+    })
+
+    it('caps the onboarded products line and summarizes the tail as a count', () => {
+        const intents = Array.from({ length: 13 }, (_, i) => ({
+            product_type: `product_${String(i).padStart(2, '0')}`,
+            onboarding_completed_at: '2026-01-01T00:00:00Z',
+        }))
+        const result = buildActiveEnvironmentContextPrompt(user, org, {
+            ...project,
+            product_intents: intents,
+        } as CachedProject)
+        expect(result).toContain('(+1 more).')
+        expect(result).not.toContain('product 12')
+    })
+
+    it.each<[string, string[] | undefined, string | undefined]>([
+        ['unknown', undefined, undefined],
+        ['an empty list', [], 'Integrations connected: none.'],
+        ['a duplicated unsorted list', ['slack', 'github', 'github'], 'Integrations connected: github, slack.'],
+    ])('renders the integrations line for %s', (_name, kinds, expectedLine) => {
+        const result = buildActiveEnvironmentContextPrompt(user, org, project, undefined, {
+            integrationKinds: kinds,
+        })
+        if (expectedLine) {
+            expect(result).toContain(expectedLine)
+        } else {
+            // Unknown (missing scope or failed fetch) must not read as "none connected".
+            expect(result).not.toContain('Integrations connected')
+        }
+    })
+
+    it('omits all product and integration lines when includeProductContext is false', () => {
+        // The claude.ai exec command reference sits within tens of characters of the
+        // registry's inputSchema cap; the compact variant must add nothing to it.
+        const result = buildActiveEnvironmentContextPrompt(
+            user,
+            org,
+            {
+                ...project,
+                session_recording_opt_in: true,
+                product_intents: [{ product_type: 'feature_flags', onboarding_completed_at: '2026-01-01T00:00:00Z' }],
+            } as CachedProject,
+            undefined,
+            { integrationKinds: ['github'], includeProductContext: false }
+        )
+        expect(result).not.toContain('Products')
+        expect(result).not.toContain('Integrations connected')
+    })
 })

--- a/services/mcp/tests/unit/switch-project.test.ts
+++ b/services/mcp/tests/unit/switch-project.test.ts
@@ -27,6 +27,7 @@ function createMockContext(overrides: {
         stateManager: {
             getOrgID: overrides.getOrgID ?? vi.fn().mockResolvedValue(ACTIVE_ORG),
             getCachedOrFetchOrg,
+            getOrFetchIntegrationKinds: vi.fn().mockResolvedValue(undefined),
         },
         env: {},
         sessionManager: {},


### PR DESCRIPTION
## Problem

An agent connected to the PostHog MCP cannot tell which PostHog products the active project uses — it reasons blind about **all** of them. The available signals differ in strength by product: four products have an authoritative Team opt-in switch (session replay, exception autocapture, surveys, heatmaps); the rest have only weaker onboarding/intent records. This PR surfaces the strongest signal available per product rather than claiming complete coverage.

The signals already exist in the API (`project-get` returns the full settings payload), but nothing surfaces them. An agent would have to fetch a raw settings dump and interpret it.

## Changes

- The "Active environment" context block now tells the agent, in neutral one-line facts, what the project has:

```
Products enabled in this project: session replay, exception autocapture (error tracking).
Products not enabled: surveys, heatmaps.
Products set up (onboarding completed): experiments, feature flags.
Integrations connected: github, slack.
```

### How the server detects each product

This section uses Simplified Technical English (short sentences, one meaning per word), so agents and reviewers parse it the same way.

The two product sections read the cached project payload (`GET /api/projects/{id}/`, 10-minute cache). They add no API calls.

**Products with an opt-in flag.** The server reads four boolean flags. If the flag value is `true`, the product goes on the "Products enabled" line. If the value is `false`, `null`, or unset, the product goes on the "Products not enabled" line. These flags show the current project configuration.

| Product | Flag the server reads | Note |
|---|---|---|
| Session replay | `session_recording_opt_in` | — |
| Error tracking | `autocapture_exceptions_opt_in` | This flag controls exception autocapture in the web SDK. A project can send exceptions from a server SDK while this flag is off. The block label says "exception autocapture (error tracking)" for this reason. |
| Surveys | `surveys_opt_in` | — |
| Heatmaps | `heatmaps_opt_in` | — |

**All other products.** One rule covers every product without an opt-in flag. The server reads the `product_intents` list on the same payload. A product goes on the "Products set up (onboarding completed)" line only when its intent row has a value in `onboarding_completed_at`. The possible `product_type` values are the keys of the `ProductKey` enum (about 57 keys). Examples: `product_analytics`, `web_analytics`, `feature_flags`, `experiments`, `llm_analytics`, `data_warehouse`, `logs`, `workflows`. The block replaces the underscores with spaces. The line shows each product one time, in alphabetical order, with a maximum of 12 names. It shows the count of the rest as "(+N more)". Two caveats:

- The timestamp records a past event. It does not show current usage. A project can complete onboarding for a product and later stop all use of that product.
- This line is under discussion on the task thread. A signal from data freshness (for example, `last_seen_at` on the product's event definitions) is the candidate replacement.

**Integrations.** The server calls `GET /api/projects/{id}/integrations/`. This is the one new fetch in this PR. The server caches the result for 10 minutes and reads a maximum of 100 rows. From each row, the server reads the `kind` field (`github`, `slack`, `linear`, `jira`, and other kinds). The call needs the `integration:read` scope on the API key. Three outcomes are possible:

- The key has the scope, and integrations exist: the line shows each kind one time, in alphabetical order.
- The key has the scope, and no integrations exist: the line shows "Integrations connected: none."
- The key does not have the scope, or the call fails: the block omits the line. The agent never reads "none" when the truth is unknown.

### Other changes

- The block states facts only. The agent decides if a recommendation to enable a product is appropriate.
- claude.ai drops a tool when its serialized `inputSchema` crosses approximately 16,384 characters. The worst-case environment context already sits within tens of characters of that cap. The claude.ai exec command reference therefore keeps the previous compact metadata. All other surfaces render the new lines: Claude Code, Codex, tools-mode clients, and the `switch-project` / `switch-organization` tool results.
- Mechanical: `metadataCompact` plumbing through `ResolvedState` and `InstructionsContext`, plus the new field in five hono test fixtures.

## How did you test this code?

- New `instructions.test.ts` cases guard: a null or undefined opt-in never counting as enabled, intent rows without completed onboarding staying out of the block, the cap on the onboarded-products line, and unknown integrations rendering differently from none connected.
- New `StateManager.test.ts` cases guard the `integration:read` scope gate (no API call without it) and kind dedupe/sort.
- The claude.ai registry-cap test now renders both metadata variants the way production does, and stays under the 16,384-char budget.
- Not run: integration suites that need live API credentials, and `hogli ci:preflight` (unavailable in this sandbox). Typecheck matches the master baseline; the remaining errors are the pre-existing unbuilt `@posthog/quill` ones.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude in a PostHog Desktop cloud task at the assignee's direction, after an exploration of what product-enablement config the MCP could expose to agents.
- Skills invoked: /writing-tests, /writing-code-comments, /writing-pr-descriptions, /establishing-code-ownership, /querying-posthog-data, /asd-ste100 (the detection section is written in Simplified Technical English at the assignee's request).
- Session decisions: the first draft added the lines to every surface; the claude.ai registry-cap test failed with only tens of characters of pre-existing headroom, so the claude.ai reference got a compact metadata variant instead of shrinking shared prompt content. The onboarding-completed line was then validated against internal analytics (are intents fresh, do they correlate with data actually flowing); findings live in the task thread and may lead to that line being dropped or replaced with a data-freshness signal.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
