### PR TITLE
fix(warehouse_sources): floor Apple Search Ads report lookback within Apple's API limit

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/apple_search_ads/apple_search_ads.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/apple_search_ads/apple_search_ads.py
@@ -308,8 +308,8 @@ def _report_start_date(
 
     configured = _to_date(start_date) if start_date else None
     if configured is not None:
-        # Floor the configured date so an implausibly old start can't fan the report out over
-        # thousands of empty windows and exhaust the import worker.
+        # Apple rejects a DAILY-granularity report whose startTime is more than 24 months in
+        # the past with a 400, so a configured date older than that is floored here.
         return max(configured, today - timedelta(days=MAX_INITIAL_LOOKBACK_DAYS))
     return today - timedelta(days=DEFAULT_INITIAL_LOOKBACK_DAYS)
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/apple_search_ads/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/apple_search_ads/settings.py
@@ -29,10 +29,11 @@ REPORT_LOOKBACK_SECONDS = REPORT_WINDOW_DAYS * 24 * 60 * 60
 # How far back the first sync of a report table reaches when the user gives no start date.
 DEFAULT_INITIAL_LOOKBACK_DAYS = 365
 
-# The earliest a configured start date may reach. Apple Search Ads has held no reporting data
-# from before it launched, so a start date older than this is a typo — clamp it rather than fan
-# a report out over thousands of empty windows (one report request per window per campaign).
-MAX_INITIAL_LOOKBACK_DAYS = 11 * 365
+# The earliest a configured start date may reach. Apple's Reporting API rejects a DAILY-
+# granularity report (the only granularity this source requests) whose startTime is more than
+# 24 months in the past with a 400 — treating a month as 30 days keeps this clamp safely inside
+# that limit despite calendar-month variation.
+MAX_INITIAL_LOOKBACK_DAYS = 24 * 30
 
 
 @dataclass(frozen=True)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/apple_search_ads/tests/test_apple_search_ads.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/apple_search_ads/tests/test_apple_search_ads.py
@@ -406,6 +406,11 @@ class TestReportWindows:
         else:
             assert resolved == (expected or today - timedelta(days=DEFAULT_INITIAL_LOOKBACK_DAYS))
 
+    def test_max_initial_lookback_stays_within_apples_daily_report_limit(self) -> None:
+        # Apple's Reporting API rejects a DAILY-granularity report whose startTime is more than
+        # 24 months in the past with a 400 — this guards against re-widening the floor past it.
+        assert MAX_INITIAL_LOOKBACK_DAYS <= 24 * 30
+
 
 class TestFlattenReportRows:
     def test_granularity_buckets_become_one_row_per_day(self) -> None:


### PR DESCRIPTION
## Problem

An Apple Search Ads warehouse sync fails with a 400 Bad Request against Apple's reporting endpoints ([error tracking issue](https://us.posthog.com/project/2/error_tracking/01a01c88-de0f-7811-bcbe-53a80c04467f)). Apple's Reporting API rejects any DAILY-granularity report request whose `startTime` is more than 24 months in the past.

The source's configured-start-date floor allowed a start date up to 11 years back, far past that limit, so a user-entered start date (or a first sync fanning out from one) sent report requests Apple always rejects.

## Changes

- Floors a configured Apple Search Ads report start date at 24 months back instead of 11 years, matching Apple's documented per-report date-range limit.
- Everything else is mechanical: updated comments explaining the new floor's reason.

## How did you test this code?

- `pytest products/warehouse_sources/backend/temporal/data_imports/sources/apple_search_ads/tests/test_apple_search_ads.py` — 61 passed.
- Added `test_max_initial_lookback_stays_within_apples_daily_report_limit`, which fails if the floor is ever widened back past Apple's 24-month limit — no existing test guarded that bound.
- `hogli ci:preflight --fix` — lint, format, and mypy all clean.
- Not run: a live sync against the Apple Search Ads API, since this sandbox has no credentials for it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no documented behavior changed, only an internal safety bound.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog error tracking MCP tools (stack trace, sample events, impact) to confirm the failure originates in `apple_search_ads.py`'s `request_json`. Fetched Apple's public Campaign Management API 3.0 PDF to find the documented 24-month lookback limit for DAILY-granularity reports, which the existing `MAX_INITIAL_LOOKBACK_DAYS` constant (11 years) violated. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.