### PR TITLE
fix(desktop): sign out instead of looping on tokens without API scopes

### DIFF
--- a/products/desktop/packages/core/src/auth/auth.test.ts
+++ b/products/desktop/packages/core/src/auth/auth.test.ts
@@ -81,6 +81,7 @@ function mockTokenResponse(
     accessToken?: string;
     refreshToken?: string | null;
     expiresIn?: number;
+    scope?: string;
     scopedOrgs?: string[];
     scopedTeams?: number[];
   } = {},
@@ -89,6 +90,7 @@ function mockTokenResponse(
     overrides.refreshToken === undefined
       ? "refresh-token"
       : overrides.refreshToken;
+  const scope = "scope" in overrides ? overrides.scope : "openid project:read";
   return {
     success: true as const,
     data: {
@@ -96,7 +98,7 @@ function mockTokenResponse(
       ...(refreshToken ? { refresh_token: refreshToken } : {}),
       expires_in: overrides.expiresIn ?? 3600,
       token_type: "Bearer",
-      scope: "",
+      ...(scope !== undefined ? { scope } : {}),
       scoped_organizations: overrides.scopedOrgs ?? ["org-1"],
       ...(overrides.scopedTeams ? { scoped_teams: overrides.scopedTeams } : {}),
     },
@@ -1078,6 +1080,47 @@ describe("AuthService", () => {
         currentProjectId: 42,
       });
       expect(oauthFlow.refreshToken).toHaveBeenCalledTimes(1);
+      expect(sessionPort.getCurrent()).toBeNull();
+    });
+
+    it.each(["", "openid profile email"])(
+      "forces logout when a refreshed token's scope %j grants no resource access",
+      async (scope) => {
+        seedStoredSession({ selectedProjectId: 42 });
+        oauthFlow.refreshToken.mockResolvedValue(mockTokenResponse({ scope }));
+
+        await service.initialize();
+
+        expect(service.getState()).toMatchObject({
+          status: "anonymous",
+          cloudRegion: "us",
+          currentProjectId: 42,
+        });
+        expect(sessionPort.getCurrent()).toBeNull();
+      },
+    );
+
+    it("accepts a refreshed token whose scope is omitted from the response", async () => {
+      seedStoredSession();
+      oauthFlow.refreshToken.mockResolvedValue(
+        mockTokenResponse({ scope: undefined }),
+      );
+      stubAuthFetch({
+        orgs: { "org-1": { name: "Org 1", projects: [{ id: 1, name: "P" }] } },
+      });
+
+      await service.initialize();
+
+      expect(service.getState().status).toBe("authenticated");
+    });
+
+    it("rejects a sign-in whose token carries no resource scopes", async () => {
+      oauthFlow.startFlow.mockResolvedValue(mockTokenResponse({ scope: "" }));
+
+      await expect(service.login("us")).rejects.toThrow(
+        "Sign in again to continue",
+      );
+      expect(service.getState().status).toBe("anonymous");
       expect(sessionPort.getCurrent()).toBeNull();
     });
 

--- a/products/desktop/packages/core/src/auth/auth.ts
+++ b/products/desktop/packages/core/src/auth/auth.ts
@@ -41,6 +41,24 @@ import {
 } from "./schemas";
 
 const TOKEN_EXPIRY_SKEW_MS = 60_000;
+
+const NO_API_ACCESS_ERROR_MESSAGE =
+  "Your session lost access to the PostHog API. Sign in again to continue.";
+
+/**
+ * Whether a token response's scope grants any API resource access.
+ *
+ * The server can mint a token whose scope is empty (a refresh racing the
+ * server's token-reuse revocation produces one). Such a token authenticates
+ * but 403s on every resource call, so accepting it strands the session in a
+ * permanent retry loop instead of surfacing a re-login. An omitted scope
+ * means "identical to what was requested" (RFC 6749 §5.1) and passes; `*`
+ * is the legacy wildcard grant.
+ */
+function hasResourceScopes(scope: string | undefined): boolean {
+  if (scope === undefined) return true;
+  return scope.split(" ").some((entry) => entry === "*" || entry.includes(":"));
+}
 const AUTH_FETCH_TIMEOUT_MS = 30_000;
 const AUTH_BOOTSTRAP_DEADLINE_MS = 20_000;
 export type FetchLike = (
@@ -666,6 +684,21 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
       );
 
       if (result.success && result.data) {
+        if (!hasResourceScopes(result.data.scope)) {
+          // Accepting the token would strand the session: every resource call
+          // 403s and every refresh returns the same empty grant, so the only
+          // way out is a fresh sign-in. Same forced logout as auth_error.
+          this.logger.warn(
+            "Refreshed token carries no resource scopes, forcing logout",
+          );
+          this.authSession.clearCurrent();
+          this.session = null;
+          this.setAnonymousState({
+            cloudRegion: input.cloudRegion,
+            currentProjectId: input.selectedProjectId,
+          });
+          throw new Error(NO_API_ACCESS_ERROR_MESSAGE);
+        }
         return await this.createSessionFromTokenResponse(result.data, {
           ...input,
           fallbackRefreshToken: input.refreshToken,
@@ -975,6 +1008,11 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
     const result = await runFlow();
     if (!result.success || !result.data) {
       throw new Error(result.error || fallbackError);
+    }
+    if (!hasResourceScopes(result.data.scope)) {
+      // Failing here keeps the broken token out of the session store, so the
+      // user sees a sign-in error instead of an app that silently 403s.
+      throw new Error(NO_API_ACCESS_ERROR_MESSAGE);
     }
 
     const session = await this.createSessionFromTokenResponse(result.data, {

--- a/products/desktop/packages/core/src/auth/auth.ts
+++ b/products/desktop/packages/core/src/auth/auth.ts
@@ -45,16 +45,6 @@ const TOKEN_EXPIRY_SKEW_MS = 60_000;
 const NO_API_ACCESS_ERROR_MESSAGE =
   "Your session lost access to the PostHog API. Sign in again to continue.";
 
-/**
- * Whether a token response's scope grants any API resource access.
- *
- * The server can mint a token whose scope is empty (a refresh racing the
- * server's token-reuse revocation produces one). Such a token authenticates
- * but 403s on every resource call, so accepting it strands the session in a
- * permanent retry loop instead of surfacing a re-login. An omitted scope
- * means "identical to what was requested" (RFC 6749 §5.1) and passes; `*`
- * is the legacy wildcard grant.
- */
 function hasResourceScopes(scope: string | undefined): boolean {
   if (scope === undefined) return true;
   return scope.split(" ").some((entry) => entry === "*" || entry.includes(":"));
@@ -685,9 +675,6 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
 
       if (result.success && result.data) {
         if (!hasResourceScopes(result.data.scope)) {
-          // Accepting the token would strand the session: every resource call
-          // 403s and every refresh returns the same empty grant, so the only
-          // way out is a fresh sign-in. Same forced logout as auth_error.
           this.logger.warn(
             "Refreshed token carries no resource scopes, forcing logout",
           );
@@ -1010,8 +997,6 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
       throw new Error(result.error || fallbackError);
     }
     if (!hasResourceScopes(result.data.scope)) {
-      // Failing here keeps the broken token out of the session store, so the
-      // user sees a sign-in error instead of an app that silently 403s.
       throw new Error(NO_API_ACCESS_ERROR_MESSAGE);
     }
 

--- a/products/desktop/packages/core/src/auth/oauth.schemas.ts
+++ b/products/desktop/packages/core/src/auth/oauth.schemas.ts
@@ -22,7 +22,10 @@ export const oAuthTokenResponse = z.object({
   access_token: z.string(),
   expires_in: z.number(),
   token_type: z.string(),
-  scope: z.string().optional().default(""),
+  // No default: an omitted scope means "identical to what was requested"
+  // (RFC 6749 §5.1) and must stay distinguishable from an explicit empty
+  // scope, which is a broken token that grants no API access.
+  scope: z.string().optional(),
   refresh_token: z.string().optional(),
   scoped_organizations: z.array(z.string()).optional(),
   scoped_teams: z.array(z.number()).optional(),

--- a/products/desktop/packages/core/src/auth/oauth.schemas.ts
+++ b/products/desktop/packages/core/src/auth/oauth.schemas.ts
@@ -22,9 +22,6 @@ export const oAuthTokenResponse = z.object({
   access_token: z.string(),
   expires_in: z.number(),
   token_type: z.string(),
-  // No default: an omitted scope means "identical to what was requested"
-  // (RFC 6749 §5.1) and must stay distinguishable from an explicit empty
-  // scope, which is a broken token that grants no API access.
   scope: z.string().optional(),
   refresh_token: z.string().optional(),
   scoped_organizations: z.array(z.string()).optional(),


### PR DESCRIPTION
## Problem

When the OAuth server hands PostHog Code a token whose scope is empty, the app looks signed in but every API call 403s. The app retries project fetches and refreshes the token in a tight loop, forever, and never shows the user an error. The only way out is a manual sign-out the user has no reason to attempt.

The server can mint such a token as a corruption artifact, for example when two app processes race a refresh into the server's token-reuse revocation. The client never inspected the `scope` field of a token response, so it accepted and stored the broken token.

Companion server fix: #86115.

## Changes

- A user whose refreshed token carries no resource scopes is now signed out, through the same path as a rejected refresh token, so they see the sign-in screen instead of a silently broken app.
- A sign-in that returns such a token fails with "Your session lost access to the PostHog API. Sign in again to continue." and stores nothing.
- A token response that omits `scope` entirely still passes: RFC 6749 §5.1 defines omitted as "identical to what was requested". The response schema no longer collapses omitted to `""`, keeping the two cases distinguishable.
- Legacy `*` wildcard tokens pass.
- Mechanical: the auth test fixture's default token scope changes from `""` to a realistic value.

## How did you test this code?

- New tests: empty and identity-only scopes on refresh force a logout, catching reintroduction of the silent 403 loop; an empty-scope sign-in is rejected before anything persists.
- New test: an omitted scope still authenticates, guarding against the opposite regression where the guard fires on RFC-valid responses.
- All 58 existing auth tests pass with the fixture's new realistic scope, showing the guard stays quiet on healthy tokens.
- Ran the `@posthog/core` auth Vitest suite and Biome. Scoped typecheck reports no errors in the changed files; the package-wide run fails only on pre-existing pi-runtime errors from locally unbuilt workspace packages.
- Not run: the Electron app end to end against a server minting empty-scope tokens.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code in a session driven by the assignee, who found the failure mode while investigating a spike in 403 responses on the web tier. The guard lives in `AuthService` because both sign-in and refresh funnel through it; the alternative of validating in the OAuth flow service would have missed the stored-session restore path. All test data is invented. Skills invoked: `/posthog-desktop`, `/writing-tests`, `/writing-code-comments`, `/writing-user-facing-copy`, `/writing-pr-descriptions`.
