### PR TITLE
fix(warehouse_sources): guide users to a valid Jira subdomain

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/jira/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/jira/source.py
@@ -20,6 +20,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.typ
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs.jira import JiraSourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.jira.jira import (
     JiraResumeConfig,
+    is_valid_subdomain,
     jira_source,
     validate_credentials as validate_jira_credentials,
 )
@@ -119,6 +120,14 @@ The token authenticates as your Atlassian account, so the data we can sync is li
     def validate_credentials(
         self, config: JiraSourceConfig, team_id: int, schema_name: Optional[str] = None, api_version: str | None = None
     ) -> tuple[bool, str | None]:
+        if not is_valid_subdomain(config.subdomain):
+            # A common mistake is pasting the full host or URL; the probe would just return the
+            # generic "could not connect", so name the fix here instead of a network round-trip.
+            return False, (
+                'That doesn\'t look like a Jira subdomain. Enter only the subdomain, such as "acme" '
+                "from acme.atlassian.net, not the full domain or URL."
+            )
+
         ok, status_code = validate_jira_credentials(config.subdomain, config.email, config.api_token)
         if ok:
             return True, None

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/jira/tests/test_jira_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/jira/tests/test_jira_source.py
@@ -110,6 +110,22 @@ class TestJiraSource:
         assert error_message == expected_message
         mock_validate.assert_called_once_with(self.config.subdomain, self.config.email, self.config.api_token)
 
+    @pytest.mark.parametrize(
+        "bad_subdomain",
+        ["acme.atlassian.net", "https://acme.atlassian.net", "acme.example.com", ""],
+    )
+    @mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.jira.source.validate_jira_credentials"
+    )
+    def test_validate_credentials_rejects_malformed_subdomain_without_probing(
+        self, mock_validate, bad_subdomain
+    ) -> None:
+        config = JiraSourceConfig(subdomain=bad_subdomain, email="e@x.com", api_token="token")
+        is_valid, error_message = self.source.validate_credentials(config, self.team_id)
+        assert is_valid is False
+        assert error_message is not None and "subdomain" in error_message
+        mock_validate.assert_not_called()
+
     def test_get_resumable_source_manager_binds_resume_config(self) -> None:
         manager = self.source.get_resumable_source_manager(mock.MagicMock())
         assert isinstance(manager, ResumableSourceManager)


### PR DESCRIPTION
## Problem

A user setting up a Jira data warehouse source who types the full host (`acme.atlassian.net`) or a URL into the subdomain field only saw the generic "Could not connect to Jira. Check your subdomain, email, and API token." That message arrived after a network probe and did not point at the actual mistake, so users retried the same wrong value. Pasting the full domain is a common error: the field's own placeholder hints the format, and `is_valid_subdomain` already rejects anything with a dot.

## Changes

- Jira source setup now rejects a malformed subdomain up front with a specific message: enter only the subdomain, such as "acme" from acme.atlassian.net, not the full domain or URL.
- The check runs before the credential probe, so a malformed subdomain no longer costs a network round-trip that returns a vague error.

## How did you test this code?

Added a parameterized case to `test_jira_source.py` covering a full host, a URL, a non-Atlassian host, and an empty value. It asserts the specific message is returned and that the credential probe is never called, guarding against a regression where the pre-check is removed or the probe fires anyway. No existing case exercised the malformed-subdomain branch.

Ran locally: `products/warehouse_sources/backend/temporal/data_imports/sources/jira/tests/test_jira_source.py` (24 passed). Ruff check and format clean on the touched files.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude Code (Opus 4.8) while reviewing anonymized data warehouse onboarding session summaries for recurring friction. Repeated failures connecting Jira surfaced the vague connection error as a self-contained copy fix.

Skills invoked: `/writing-user-facing-copy` (error string), `/writing-tests` (test gate), `/writing-pr-descriptions` (this body).

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
