### PR TITLE
fix(data-imports): read Campaign Monitor sent campaigns as a paged envelope

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/campaign_monitor/campaign_monitor.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/campaign_monitor/campaign_monitor.py
@@ -157,15 +157,30 @@ def _fan_out_resource(
     """Fan a list-/campaign-scoped endpoint out over every parent via a dependent resource: the
     framework fetches the client's lists (or sent campaigns), pages each parent's child endpoint,
     and injects the parent id into every row."""
+    parent_endpoint: Endpoint
     if config.fan_out_over_lists:
         parent_name = "lists"
         parent_path = f"clients/{client_id}/lists.json"
         resolve_param, parent_id_field = "list_id", "ListID"
+        # The subscriber-lists endpoint returns a bare JSON array.
+        parent_endpoint = {
+            "path": parent_path,
+            "paginator": SinglePagePaginator(),
+            "data_selector_required": True,
+        }
     else:
-        # Only sent campaigns have reports, which is exactly what campaigns.json returns.
+        # Only sent campaigns have reports, which is exactly what campaigns.json returns —
+        # in the standard paged envelope (`{"Results": [...], "NumberOfPages": N, ...}`), not a
+        # bare array like the draft/scheduled campaign endpoints.
         parent_name = "campaigns"
         parent_path = f"clients/{client_id}/campaigns.json"
         resolve_param, parent_id_field = "campaign_id", "CampaignID"
+        parent_endpoint = {
+            "path": parent_path,
+            "params": {"pagesize": DEFAULT_PAGE_SIZE},
+            "paginator": _paginator(),
+            "data_selector": "Results",
+        }
 
     child_params: dict[str, Any] = {
         resolve_param: {"type": "resolve", "resource": parent_name, "field": parent_id_field},
@@ -193,11 +208,7 @@ def _fan_out_resource(
         "resources": [
             {
                 "name": parent_name,
-                "endpoint": {
-                    "path": parent_path,
-                    "paginator": SinglePagePaginator(),
-                    "data_selector_required": True,
-                },
+                "endpoint": parent_endpoint,
             },
             {
                 "name": config.name,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/campaign_monitor/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/campaign_monitor/settings.py
@@ -53,6 +53,8 @@ CAMPAIGN_MONITOR_ENDPOINTS: dict[str, CampaignMonitorEndpointConfig] = {
         name="campaigns",
         path="clients/{client_id}/campaigns.json",
         primary_keys=["CampaignID"],
+        # Sent campaigns come back in the paged envelope, unlike the draft/scheduled endpoints.
+        paginated=True,
         partition_key="SentDate",
     ),
     "scheduled_campaigns": CampaignMonitorEndpointConfig(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/campaign_monitor/tests/test_campaign_monitor.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/campaign_monitor/tests/test_campaign_monitor.py
@@ -181,6 +181,19 @@ class TestPaginatedEndpoints:
         assert snapshots[0][1]["page"] == 2
 
     @mock.patch(CLIENT_SESSION_PATCH)
+    def test_sent_campaigns_endpoint_reads_paged_envelope(self, MockSession) -> None:
+        # The sent-campaigns endpoint returns the paged envelope, not a bare array — a dict body
+        # was raising "Required a list response body" and failing every campaign sync.
+        session = MockSession.return_value
+        snapshots = _wire(session, [_envelope([{"CampaignID": "c1"}, {"CampaignID": "c2"}])])
+
+        rows = _rows(_source("campaigns"))
+
+        assert [r["CampaignID"] for r in rows] == ["c1", "c2"]
+        assert snapshots[0][0].endswith("clients/client-abc/campaigns.json")
+        assert snapshots[0][1]["pagesize"] == 1000
+
+    @mock.patch(CLIENT_SESSION_PATCH)
     def test_missing_results_key_yields_nothing(self, MockSession) -> None:
         # Campaign Monitor's paged envelope without Results is treated as a zero-row page.
         session = MockSession.return_value
@@ -335,7 +348,7 @@ class TestCampaignFanOut:
         snapshots = _wire(
             session,
             [
-                _response([{"CampaignID": "c1"}, {"CampaignID": "c2"}]),  # campaigns.json
+                _envelope([{"CampaignID": "c1"}, {"CampaignID": "c2"}]),  # campaigns.json (paged envelope)
                 _envelope([{"EmailAddress": "a@x.com"}]),  # c1
                 _envelope([{"EmailAddress": "b@x.com"}]),  # c2
             ],
@@ -357,7 +370,7 @@ class TestCampaignFanOut:
         snapshots = _wire(
             session,
             [
-                _response([{"CampaignID": "c1"}, {"CampaignID": "c2"}]),
+                _envelope([{"CampaignID": "c1"}, {"CampaignID": "c2"}]),
                 _response({"Name": "Newsletter", "Recipients": 100, "UniqueOpened": 40}),  # c1 summary
                 _response({"Name": "Promo", "Recipients": 50, "UniqueOpened": 10}),  # c2 summary
             ],
@@ -383,7 +396,7 @@ class TestCampaignFanOut:
     def test_empty_summary_object_yields_no_row(self, MockSession) -> None:
         # An empty summary body is not a row — no record carrying only the injected CampaignID.
         session = MockSession.return_value
-        _wire(session, [_response([{"CampaignID": "c1"}]), _response({})])
+        _wire(session, [_envelope([{"CampaignID": "c1"}]), _response({})])
 
         assert _rows(_source("campaign_summary")) == []
 
@@ -393,7 +406,7 @@ class TestCampaignFanOut:
         snapshots = _wire(
             session,
             [
-                _response([{"CampaignID": "c1"}, {"CampaignID": "c2"}]),  # campaigns.json re-fetched
+                _envelope([{"CampaignID": "c1"}, {"CampaignID": "c2"}]),  # campaigns.json re-fetched
                 _envelope([{"EmailAddress": "b@x.com"}]),  # c2 only
             ],
         )


### PR DESCRIPTION
## Problem

A Campaign Monitor sync fails for every campaign-report table (opens, clicks, bounces, unsubscribes, spam complaints, and summary): each errors with `ValueError: Required a list response body, got dict`. Reported via error tracking: [issue 01a01d31](https://us.posthog.com/project/2/error_tracking/01a01d31-df2c-7993-b140-5618dfba0920).

- The sent-campaigns endpoint (`clients/{client_id}/campaigns.json`) returns the standard paged envelope (`{"Results": [...], "NumberOfPages": N, ...}`), like `suppressionlist` and the subscriber endpoints.
- The source declared it as a bare JSON array — both as the top-level `campaigns` schema and as the hardcoded fan-out parent.
- Every campaign-report schema fans out over that parent, so the shared `data_selector_required` guard rejected the dict body and raised, failing all six report syncs at once.

The API shape did not change; the endpoint config was wrong from the start. The draft and scheduled campaign endpoints do return bare arrays, which is likely why the distinction was missed.

## Changes

- Campaign-report tables now sync instead of failing: the fan-out parent reads `campaigns.json` as a paged envelope (`Results` selector plus the page-number paginator) and pages through every sent campaign.
- The top-level `campaigns` schema now reads the same paged envelope (`paginated=True`) instead of expecting a bare array.
- The subscriber-lists fan-out parent stays a bare array — that endpoint really does return one.

## How did you test this code?

- `products/warehouse_sources/backend/temporal/data_imports/sources/campaign_monitor/tests/` — all pass locally.
- Corrected the four `TestCampaignFanOut` cases that fed a bare array for `campaigns.json`; they now feed the real envelope. They catch a revert of the parent to the bare-array config: the guard would raise on the dict body and fail the test.
- Added `test_sent_campaigns_endpoint_reads_paged_envelope`, covering the top-level `campaigns` schema directly — the exact path that raised the reported error. No existing test synced `campaigns` end to end.
- Not run: the full warehouse-sources suite and any live Campaign Monitor account (no credentials in this environment).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triaged from an error-tracking issue. Scoped the failure with the `warehouse_sources_*` exception properties (source, schema, sync type), which pointed at the six `fan_out_over_campaigns` schemas sharing one parent fetch. Confirmed the endpoint's real response shape against the Campaign Monitor API docs.
- Concluded this is a source-config bug, not a shared-pipeline defect or an upstream change: the shared `_extract_response` guard behaved correctly by rejecting a body shape the source told it not to expect.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
