### PR TITLE
fix(desktop): respect theme in object reference popovers

### DIFF
--- a/products/desktop/packages/ui/src/features/editor/components/EvidenceRefChip.test.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/EvidenceRefChip.test.tsx
@@ -104,7 +104,9 @@ describe("EvidenceRefChip", () => {
     fireEvent.focus(link);
     // The card is a focus-managed dialog, not a tooltip: its controls are
     // real elements a keyboard user can Tab to.
-    expect(screen.getByRole("dialog")).toBeDefined();
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toBeDefined();
+    expect(dialog.classList.contains("dark")).toBe(false);
     expect(
       screen.getByRole("button", { name: /Open in PostHog/ }),
     ).toBeDefined();

--- a/products/desktop/packages/ui/src/features/editor/components/EvidenceRefChip.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/EvidenceRefChip.tsx
@@ -410,7 +410,7 @@ export function EvidenceRefChip({
           <Popover.Positioner side="top" sideOffset={8} className="z-[9999]">
             <Popover.Popup
               data-testid="evidence-hover-card"
-              className="dark rounded-[6px] border border-(--gray-4) bg-(--gray-2) text-(--gray-12) outline-none"
+              className="rounded-[6px] border border-(--gray-4) bg-(--gray-2) text-(--gray-12) outline-none"
               style={{ boxShadow: "0 4px 12px rgba(0, 0, 0, 0.25)" }}
             >
               <EvidenceHoverCardLoader target={target} url={url}>


### PR DESCRIPTION
## Problem

Light mode users see a dark PostHog object reference popover because the popup forces the dark theme.

## Changes

- Object reference popovers now inherit the active Desktop theme.
- The change removes the popup’s forced dark class without changing its layout or behavior.

### Light

![posthog-object-reference-theme-light](https://raw.githubusercontent.com/PostHog/pr-assets/85eb07ce51efb66a5af48163b22b86f55dc860a4/2026/08/872d5a4c-361b-49c2-b3fd-c7c486b79561.png)

### Dark

![posthog-object-reference-theme-dark](https://raw.githubusercontent.com/PostHog/pr-assets/515757ebad6e292b3766936b436081d66ec35dbc/2026/08/ac3f4cb6-9656-4f1d-9095-55a86054c8b5.png)

## How did you test this code?

- Extended the existing component test to catch a forced dark popup class.
- Ran the focused EvidenceRefChip Vitest suite and `@posthog/ui` typecheck.
- Built Storybook and rendered the open popover in light and dark themes with Playwright.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This corrects theme inheritance without changing the documented workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi authored and visually verified this independent theme fix.

Skills invoked: `/posthog-desktop`, `/writing-user-facing-copy`, `/writing-tests`, `/writing-code-comments`, `/writing-ui-components`, `/writing-simplified-technical-english`, `/writing-pr-descriptions`, and the Desktop `quill-code` guide.
