### PR TITLE
feat(tasks): add explicit system principals

### DIFF
--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -381,6 +381,18 @@ def _user_basic_info(user: "User | None") -> contracts.TaskUserBasicInfo | None:
     )
 
 
+def _task_principal(task: Task) -> contracts.TaskPrincipalDTO | None:
+    if task.system_principal:
+        return contracts.TaskPrincipalDTO(
+            type="system",
+            name=task.system_principal,
+            label=Task.SystemPrincipal(task.system_principal).label,
+        )
+    if task.created_by_id:
+        return contracts.TaskPrincipalDTO(type="user", user=_user_basic_info(task.created_by))
+    return None
+
+
 # Presigned log URLs are cached just under their 1-hour S3 expiry to avoid regeneration.
 _TASK_RUN_LOG_URL_CACHE_TTL = 55 * 60
 
@@ -603,6 +615,7 @@ def _task_detail_to_dto(
         updated_at=task.updated_at,
         last_activity_at=task.last_activity_at or task.updated_at,
         created_by=_user_basic_info(task.created_by if task.created_by_id else None),
+        principal=_task_principal(task),
         latest_run_id=latest_run_id,
         channel=task.channel_id,
         slack_thread_references=_task_slack_thread_references(task),

--- a/products/tasks/backend/facade/contracts.py
+++ b/products/tasks/backend/facade/contracts.py
@@ -150,6 +150,16 @@ class TaskSlackUnfurlDTO:
 
 
 @dataclass(frozen=True)
+class TaskPrincipalDTO:
+    """The persisted owner of a task, distinct from its source product and interaction actors."""
+
+    type: str
+    name: str | None = None
+    label: str | None = None
+    user: "TaskUserBasicInfo | None" = None
+
+
+@dataclass(frozen=True)
 class TaskDetailDTO:
     """The HTTP detail representation of a task.
 
@@ -186,6 +196,7 @@ class TaskDetailDTO:
     updated_at: datetime | None = None
     last_activity_at: datetime | None = None
     created_by: "TaskUserBasicInfo | None" = None
+    principal: TaskPrincipalDTO | None = None
     latest_run_id: UUID | None = None
     channel: UUID | None = None
     slack_thread_references: list[SlackThreadReferenceDTO] = Field(default_factory=list)

--- a/products/tasks/backend/migrations/0101_task_system_principal.py
+++ b/products/tasks/backend/migrations/0101_task_system_principal.py
@@ -1,0 +1,22 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("tasks", "0100_alter_loop_origin_product_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="task",
+            name="system_principal",
+            field=models.CharField(
+                blank=True,
+                choices=[("signals", "Signals")],
+                editable=False,
+                help_text="Trusted system principal that owns this task. Mutually exclusive with created_by.",
+                max_length=32,
+                null=True,
+            ),
+        ),
+    ]

--- a/products/tasks/backend/migrations/0102_task_single_principal_constraint.py
+++ b/products/tasks/backend/migrations/0102_task_single_principal_constraint.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+from posthog.migration_helpers import AddConstraintNotValid
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("tasks", "0101_task_system_principal"),
+    ]
+
+    operations = [
+        AddConstraintNotValid(
+            model_name="task",
+            constraint=models.CheckConstraint(
+                condition=models.Q(created_by__isnull=True) | models.Q(system_principal__isnull=True),
+                name="posthog_task_single_principal",
+            ),
+        ),
+    ]

--- a/products/tasks/backend/migrations/0103_validate_task_single_principal.py
+++ b/products/tasks/backend/migrations/0103_validate_task_single_principal.py
@@ -1,0 +1,13 @@
+from django.db import migrations
+
+from posthog.migration_helpers import ValidateConstraint
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("tasks", "0102_task_single_principal_constraint"),
+    ]
+
+    operations = [
+        ValidateConstraint(model_name="task", name="posthog_task_single_principal"),
+    ]

--- a/products/tasks/backend/migrations/max_migration.txt
+++ b/products/tasks/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0100_alter_loop_origin_product_and_more
+0103_validate_task_single_principal

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -178,6 +178,9 @@ class TaskClientProvenance(models.TextChoices):
 
 
 class Task(DeletedMetaFields, models.Model):
+    class SystemPrincipal(models.TextChoices):
+        SIGNALS = "signals", "Signals"
+
     class Runtime(models.TextChoices):
         ACP = "acp", "ACP"
         PI = "pi", "Pi"
@@ -223,6 +226,14 @@ class Task(DeletedMetaFields, models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     team = models.ForeignKey("posthog.Team", on_delete=models.CASCADE)
     created_by = models.ForeignKey("posthog.User", on_delete=models.SET_NULL, null=True, blank=True, db_index=False)
+    system_principal = models.CharField(
+        max_length=32,
+        choices=SystemPrincipal,
+        null=True,
+        blank=True,
+        editable=False,
+        help_text="Trusted system principal that owns this task. Mutually exclusive with created_by.",
+    )
     task_number = models.IntegerField(null=True, blank=True)
     title = models.CharField(max_length=255)
     title_manually_set = models.BooleanField(default=False)
@@ -375,6 +386,10 @@ class Task(DeletedMetaFields, models.Model):
             models.Index(fields=["hog_flow_id", "-created_at"], name="posthog_task_hog_flow_idx"),
         ]
         constraints = [
+            models.CheckConstraint(
+                condition=models.Q(created_by__isnull=True) | models.Q(system_principal__isnull=True),
+                name="posthog_task_single_principal",
+            ),
             models.UniqueConstraint(
                 fields=["team", "origin_key"],
                 condition=models.Q(origin_key__isnull=False),

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -33,6 +33,7 @@ from products.tasks.backend.facade.contracts import (
     TaskActivityPageDTO,
     TaskDetailDTO,
     TaskMentionDTO,
+    TaskPrincipalDTO,
     TaskRunDetailDTO,
     TaskSummaryDTO,
     TaskThreadMessageDTO,
@@ -142,6 +143,14 @@ class TaskUserBasicInfoSerializer(DataclassSerializer):
 
     class Meta:
         dataclass = TaskUserBasicInfo
+
+
+class TaskPrincipalSerializer(DataclassSerializer):
+    user = TaskUserBasicInfoSerializer(allow_null=True, required=False)
+    type = serializers.ChoiceField(choices=("user", "system"))
+
+    class Meta:
+        dataclass = TaskPrincipalDTO
 
 
 class SlackThreadReferenceSerializer(DataclassSerializer):
@@ -416,6 +425,7 @@ class TaskSerializer(DataclassSerializer):
 
     latest_run = TaskRunDetailSerializer(allow_null=True, required=False, help_text="Latest run details for this task")
     created_by = TaskUserBasicInfoSerializer(allow_null=True, required=False)
+    principal = TaskPrincipalSerializer(allow_null=True, required=False)
     slack_thread_references = SlackThreadReferenceSerializer(many=True, read_only=True)
     # Not `read_only`, even though this is a response-only serializer: `@validated_request` re-reads
     # its own output through `to_internal_value`, which drops read-only fields, and `runtime` is
@@ -451,6 +461,7 @@ class TaskSerializer(DataclassSerializer):
             "updated_at",
             "last_activity_at",
             "created_by",
+            "principal",
             "ci_prompt",
             "channel",
             "slack_thread_references",

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -12400,6 +12400,50 @@ class TestModelCatalogueAPI(BaseTaskAPITest):
 
 
 class TestTaskSerializerResponseRoundTrip(BaseTaskAPITest):
+    def test_task_principal_serialization(self):
+        human_task = self.create_task()
+        system_task = Task.objects.create(
+            team=self.team,
+            created_by=None,
+            title="System task",
+            description="",
+            origin_product=Task.OriginProduct.SIGNAL_REPORT,
+            system_principal=Task.SystemPrincipal.SIGNALS,
+        )
+        legacy_task = Task.objects.create(
+            team=self.team,
+            created_by=None,
+            title="Legacy task",
+            description="",
+            origin_product=Task.OriginProduct.USER_CREATED,
+        )
+
+        human_response = self.client.get(f"/api/projects/@current/tasks/{human_task.id}/")
+        system_response = self.client.get(f"/api/projects/@current/tasks/{system_task.id}/")
+        legacy_response = self.client.get(f"/api/projects/@current/tasks/{legacy_task.id}/")
+
+        self.assertEqual(human_response.json()["principal"]["type"], "user")
+        self.assertEqual(human_response.json()["principal"]["user"]["id"], self.user.id)
+        self.assertEqual(
+            system_response.json()["principal"],
+            {"type": "system", "name": "signals", "label": "Signals", "user": None},
+        )
+        self.assertIsNone(legacy_response.json()["principal"])
+
+    def test_public_create_cannot_claim_system_principal(self):
+        response = self.client.post(
+            "/api/projects/@current/tasks/",
+            {
+                "title": "Claim Signals",
+                "description": "",
+                "origin_product": Task.OriginProduct.USER_CREATED,
+                "system_principal": Task.SystemPrincipal.SIGNALS,
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
     def test_task_response_can_be_read_back(self):
         # `@validated_request` re-reads its own response through `to_internal_value` whenever DEBUG is
         # on (posthog/api/mixins.py). That read drops read-only fields, so declaring one that

--- a/products/tasks/backend/tests/test_models.py
+++ b/products/tasks/backend/tests/test_models.py
@@ -67,6 +67,19 @@ class TestTask(TestCase):
         self.assertEqual(task.description, "Test Description")
         self.assertEqual(task.origin_product, origin_product)
 
+    def test_task_rejects_multiple_principals(self):
+        user = User.objects.create(email="owner@example.com")
+
+        with self.assertRaises(IntegrityError):
+            Task.objects.create(
+                team=self.team,
+                title="Invalid ownership",
+                description="",
+                origin_product=Task.OriginProduct.SIGNAL_REPORT,
+                created_by=user,
+                system_principal=Task.SystemPrincipal.SIGNALS,
+            )
+
     @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
     def test_create_and_run_minimal(self, mock_execute_workflow):
         user = User.objects.create(email="test@test.com")

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -1458,6 +1458,26 @@ export interface TaskRunDetailDTOApi {
     completed_at?: string | null
 }
 
+/**
+ * * `user` - user
+ * * `system` - system
+ */
+export type TaskPrincipalDTOTypeEnumApi = (typeof TaskPrincipalDTOTypeEnumApi)[keyof typeof TaskPrincipalDTOTypeEnumApi]
+
+export const TaskPrincipalDTOTypeEnumApi = {
+    User: 'user',
+    System: 'system',
+} as const
+
+export interface TaskPrincipalDTOApi {
+    user?: TaskUserBasicInfoApi | null
+    type: TaskPrincipalDTOTypeEnumApi
+    /** @nullable */
+    name?: string | null
+    /** @nullable */
+    label?: string | null
+}
+
 export interface SlackThreadReferenceDTOApi {
     url: string
     channel: string
@@ -1515,6 +1535,7 @@ export interface TaskDetailDTOApi {
     /** @nullable */
     last_activity_at?: string | null
     created_by?: TaskUserBasicInfoApi | null
+    principal?: TaskPrincipalDTOApi | null
     /** @nullable */
     ci_prompt: string | null
     /** @nullable */

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -54455,6 +54455,27 @@ export namespace Schemas {
       completed_at?: string | null;
     }
 
+    /**
+     * * `user` - user
+     * * `system` - system
+     */
+    export type TaskPrincipalDTOTypeEnum = typeof TaskPrincipalDTOTypeEnum[keyof typeof TaskPrincipalDTOTypeEnum];
+
+
+    export const TaskPrincipalDTOTypeEnum = {
+      User: 'user',
+      System: 'system',
+    } as const;
+
+    export interface TaskPrincipalDTO {
+      user?: TaskUserBasicInfo | null;
+      type: TaskPrincipalDTOTypeEnum;
+      /** @nullable */
+      name?: string | null;
+      /** @nullable */
+      label?: string | null;
+    }
+
     export interface SlackThreadReferenceDTO {
       url: string;
       channel: string;
@@ -54512,6 +54533,7 @@ export namespace Schemas {
       /** @nullable */
       last_activity_at?: string | null;
       created_by?: TaskUserBasicInfo | null;
+      principal?: TaskPrincipalDTO | null;
       /** @nullable */
       ci_prompt: string | null;
       /** @nullable */


### PR DESCRIPTION
## Problem

Automatic Tasks workloads cannot own tasks without borrowing a human identity or appearing as legacy ownerless data.

**Why:** System-owned workloads need explicit attribution before they can receive narrow credentials without impersonating a project member.

## Changes

- Tasks can now persist a narrow Signals system principal separately from human ownership.
- Task responses expose a typed human, system, or legacy ownerless principal while retaining `created_by` compatibility.
- The database rejects tasks with both a human owner and a system principal.
- Public task creation cannot set a system principal.
- The nullable column and ownership constraint use separate, non-blocking migrations.


### Stack order

This PR is part of the independent task-identity foundation:

1. [#86155](https://github.com/PostHog/posthog/pull/86155) adds explicit system principals.
2. [#86615](https://github.com/PostHog/posthog/pull/86615) adds task-bound system OAuth.
3. [#86616](https://github.com/PostHog/posthog/pull/86616) isolates system-owned sandbox credentials.

These layers can land independently of canvas provenance. Rebase the adoption layers after both foundations reach `master`.

## How did you test this code?

- `ruff check`, `ruff format --check`, Python compilation, and Django migration drift checks passed.
- SQL inspection confirmed a nullable column followed by separate constraint add and validation migrations.
- Added regressions cover dual ownership, all serialized principal states, and public assignment rejection.
- Database-backed tests did not complete because the local test schema migration chain stalled.
- Tasks OpenAPI types regenerated; MCP type generation lacked the workspace package link.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No user-facing workflow changes in this infrastructure layer.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented this layer with the `/django-migrations` and `/writing-pr-descriptions` skills. The change deliberately leaves OAuth, credential isolation, and Signals adoption to later reviewable layers.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*