### PR TITLE
fix(warehouse_sources): stop retrying a 400 on the Reddit Ads profiles fan-out

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/reddit_ads/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/reddit_ads/source.py
@@ -72,6 +72,11 @@ class RedditAdsSource(ResumableSource[RedditAdsSourceConfig, RedditAdsResumeConf
             # request can never succeed without the user reconnecting, so stop retrying.
             "403 Client Error": "PostHog is not authorized to access this Reddit Ads account. Please make sure the connected Reddit account has access to the ad account, then reconnect.",
             "404 Client Error": None,
+            # `structured_posts` fans out over `profiles` (see REDDIT_ADS_FANOUT in settings.py), so
+            # this parent fetch runs for that schema too. Reddit rejects it with 400 for ad accounts
+            # that don't have the profiles feature enabled — every retry replays the same request
+            # against the same account, so it can never turn into data.
+            "/profiles?page.size=100": "Reddit Ads rejected the request for this account's profiles. This ad account may not have Reddit's community profiles feature enabled.",
             # Raised by OAuthMixin.get_oauth_integration when the connected Reddit Ads
             # account has been deleted or disconnected. The integration row is gone, so
             # retrying can never recover it — stop and ask the user to reconnect.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/reddit_ads/tests/test_reddit_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/reddit_ads/tests/test_reddit_source.py
@@ -141,6 +141,10 @@ class TestRedditAdsSource:
             "403 Client Error: Forbidden for url: https://ads-api.reddit.com/api/v3/ad_accounts/09663b71-f301-484f-9b15-8d0e6fe69124/reports?page.size=100",
             "404 Client Error: Not Found for url: https://ads-api.reddit.com/api/v3/ad_accounts/789/campaigns",
             "ValueError: Integration not found: 154683",
+            # A 400 on the profiles fan-out parent fetch (used by both the `profiles` schema and
+            # the `structured_posts` fan-out) never recovers on retry — the account id varies but
+            # the path/params suffix is stable across accounts.
+            "400 Client Error: Bad Request for url: https://ads-api.reddit.com/api/v3/ad_accounts/d56c38c6-058a-4196-9795-284f820d27a6/profiles?page.size=100 | api error: code=400",
         ],
     )
     def test_non_retryable_errors_match_known_failures(self, observed_error):
@@ -153,6 +157,9 @@ class TestRedditAdsSource:
         [
             "500 Server Error for url: https://ads-api.reddit.com/api/v3/ad_accounts/789/campaigns",
             "ConnectionError: Connection reset by peer",
+            # A 400 on a different endpoint is not covered by the profiles-specific pattern above —
+            # only the profiles fan-out parent fetch is known to fail deterministically like this.
+            "400 Client Error: Bad Request for url: https://ads-api.reddit.com/api/v3/ad_accounts/789/campaigns",
         ],
     )
     def test_non_retryable_errors_does_not_match_transient(self, other_error):


### PR DESCRIPTION
## Problem

A Reddit Ads sync for one team failed nine times in four minutes, each attempt reported as a fresh error, because Temporal kept retrying an ad account's profiles request that can never succeed ([error tracking issue](https://us.posthog.com/project/2/error_tracking/01a01dee-af9f-7372-a237-02772f0469af)).

Reddit's ad account profiles endpoint returns 400 for accounts that don't have Reddit's community profiles feature enabled. This endpoint is the fan-out parent for the `structured_posts` schema, so any sync of that schema for such an account fails the same way every time.

## Changes

- `RedditAdsSource.get_non_retryable_errors` now recognizes the profiles-endpoint 400 and stops the job instead of retrying it.
- Added two parametrized cases to the existing `get_non_retryable_errors` test: a matching profiles 400, and a non-matching 400 on a different endpoint to keep the pattern scoped.

## How did you test this code?

Ran the source's test file locally: `pytest products/warehouse_sources/backend/temporal/data_imports/sources/reddit_ads/tests/test_reddit_source.py` — 47 passed, including the new cases.
Not run: a live sync against Reddit's API (no test credentials in this environment).

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog's error tracking MCP tools (issue details, sampled exception events with full stack trace, and a HogQL breakdown of the `warehouse_sources_*` properties) to trace the exception to `_send_request` in the shared REST client, then read the shared retry-classification logic in `import_data_sync.py` and the Reddit Ads source config to confirm the endpoint and scope the fix. Skills invoked: `investigating-error-issue`, `writing-tests`, `writing-pr-descriptions`.

The breakdown showed all nine occurrences came from a single team's account, so the fix follows the codebase's existing pattern of scoping 400 handling per source and endpoint (matching how `culture_amp`, `zoho_crm`, and `llama_cloud` already handle their own 400 cases) rather than adding a blanket 400 rule to shared code.