### PR TITLE
feat(error-tracking): show os and browser pills on the stack trace bar

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -2069,9 +2069,9 @@ snapshots:
     errortracking-exceptioncard--exception-card-base--light:
         hash: v1.k794b7964.40a5fd88410919603dc60b886450c6011806a70502e144dfc559380eec5cd9cf.LXtqQwhm5OiXOmRO3LnQdS-BtoNHpRABg21xA3_FthY
     errortracking-exceptioncard--exception-card-no-in-app--dark:
-        hash: v1.k794b7964.dfe3f9887bc6d9a4dfe224d568112ce764e47fec5650c00a78858927e7286033.XpCzNrmb7acFXFqAix8ISjA_85Dcg_mEN90QGGSPaqE
+        hash: v1.k794b7964.987406687c04214cccecfc03b95f4dcdf9e61a3d708044b579947fb64ed7f33b.nHnR6ColGUC_O2UKa723xfi18hJ3F7EyQCdfEmLKe2I
     errortracking-exceptioncard--exception-card-no-in-app--light:
-        hash: v1.k794b7964.6bf5f16a4ad53b8e27dab8e8d1378f7731b8576c1c1d3eb93afea002c5169b4b.nWg3Um6I5RanwPFqFQYnlaNDZoV4c1kSCmD8B0Apvrs
+        hash: v1.k794b7964.aeb6a0fdfc3ee6a36ed0b8ffb227bbffc70398b761cdf0e569b1b74e24f0e6cf.ynKxPybKcGzAJaplIMN5QLhKe_Hf-SuDimf2S4_H3uU
     errortracking-exceptioncard--exception-card-no-session-with-steps--dark:
         hash: v1.k794b7964.2c67f5577a9ae3066abf9ff5d7a5e269097a54821edb9ac31b10d09d4c14193f.Z56yUwOin21Cx-b62kB78xLQbbjivvhRcdtaCbNEto4
     errortracking-exceptioncard--exception-card-no-session-with-steps--light:
@@ -2097,9 +2097,9 @@ snapshots:
     errortracking-exceptioncard--exception-card-session-timeline-without-steps--light:
         hash: v1.k794b7964.638735982d9901d6aa27dbe6affc87c1ec56d3260fa99dc2680045f3b0ec423a.MqdrzbQlSeSod_jU23rgJCkmbQWDowXHv_3Ds68-5Ww
     errortracking-exceptioncard--exception-card-with-footer--dark:
-        hash: v1.k794b7964.5d91622107f82603e78adeb5238b4245e29e66e5185a873b90ee8df884e1da6c.GGksKImwPhKm472TGFj6SK35G88DwZumZEFuZUBY_fg
+        hash: v1.k794b7964.501916ce06f1ad37217cebd74b549700653ce1ad06deb2087ca813a42a9bfeb2.5UwJuY0r0cQJ3-K6CYskHSqgeKJp1-Fs9R0YH6Vbo7g
     errortracking-exceptioncard--exception-card-with-footer--light:
-        hash: v1.k794b7964.1c6a6263fce61d823835d6d6e04f31ba040fcf8f2aee7620ed9b04064f0ae80b.80a7MjP_Dp-z18eNIp0bBrRJuO-OaHvehegDAhptYQQ
+        hash: v1.k794b7964.b37a3656195d9cb6c787446c89afac9137f670182826fa035e377ed7ec5cda8a.k2uzwq4sHNjvkn2lNPpOM9ic7aap3sxbozVk8gI5cho
     errortracking-exceptionpropertiestable--default--dark:
         hash: v1.k794b7964.d3fe66e6fe85d6e4da00ee8f41e6aadd3b056ad0fd6669aa4803e527c6e4244b.WZyU9f9-17LRZgIlwsQcAB5W8UnklBqT0w1YT7_VOwI
     errortracking-exceptionpropertiestable--default--light:

--- a/frontend/src/lib/components/Errors/utils.test.ts
+++ b/frontend/src/lib/components/Errors/utils.test.ts
@@ -191,13 +191,25 @@ describe('Error Display', () => {
 
     // Mobile SDKs report the platform in $os_name and leave $os unset, so reading $os alone left
     // iOS, Android, and React Native errors with no OS anywhere in the UI.
+    // Non-string values must resolve to undefined: they reach PropertyIcon, whose lowercase lookup
+    // would throw and take down the whole exception card.
     it.each([
         ['$os_name only', { $os_name: 'iOS' }, 'iOS'],
         ['$os only', { $os: 'Windows' }, 'Windows'],
         ['both keys', { $os_name: 'iPadOS', $os: 'Mac OS X' }, 'iPadOS'],
         ['neither key', {}, undefined],
+        ['an empty $os_name', { $os_name: '', $os: 'Windows' }, 'Windows'],
+        ['a non-string $os_name', { $os_name: 42, $os: 'Windows' }, 'Windows'],
+        ['non-string values in both keys', { $os_name: 42, $os: {} }, undefined],
     ])('resolves os from %s', (_name, properties, expected) => {
         expect(getExceptionAttributes(properties).os).toEqual(expected)
+    })
+
+    it.each([
+        ['a string $browser', { $browser: 'Chrome' }, 'Chrome'],
+        ['a non-string $browser', { $browser: 42 }, undefined],
+    ])('resolves browser from %s', (_name, properties, expected) => {
+        expect(getExceptionAttributes(properties).browser).toEqual(expected)
     })
 
     // A non-string $session_id (e.g. a numeric timestamp from a misbehaving SDK) must not leak

--- a/frontend/src/lib/components/Errors/utils.test.ts
+++ b/frontend/src/lib/components/Errors/utils.test.ts
@@ -189,6 +189,17 @@ describe('Error Display', () => {
         expect(result.level).toEqual('fatal')
     })
 
+    // Mobile SDKs report the platform in $os_name and leave $os unset, so reading $os alone left
+    // iOS, Android, and React Native errors with no OS anywhere in the UI.
+    it.each([
+        ['$os_name only', { $os_name: 'iOS' }, 'iOS'],
+        ['$os only', { $os: 'Windows' }, 'Windows'],
+        ['both keys', { $os_name: 'iPadOS', $os: 'Mac OS X' }, 'iPadOS'],
+        ['neither key', {}, undefined],
+    ])('resolves os from %s', (_name, properties, expected) => {
+        expect(getExceptionAttributes(properties).os).toEqual(expected)
+    })
+
     // A non-string $session_id (e.g. a numeric timestamp from a misbehaving SDK) must not leak
     // through as a number — it used to crash the issue scene via a ts-pattern exhaustive match.
     it.each([

--- a/frontend/src/lib/components/Errors/utils.ts
+++ b/frontend/src/lib/components/Errors/utils.ts
@@ -79,7 +79,6 @@ export function getExceptionAttributes(properties: Record<string, any>): Excepti
         $lib_version: libVersion,
         $browser: browser,
         $browser_version: browserVersion,
-        $os: os,
         $os_version: osVersion,
         $sentry_url: sentryUrl,
         $exception_level: level,
@@ -111,6 +110,8 @@ export function getExceptionAttributes(properties: Record<string, any>): Excepti
     const runtime: ErrorTrackingRuntime = getRuntimeFromLib(lib)
     const appNamespace = properties.$app_namespace
     const appVersion = properties.$app_version
+    // Mobile SDKs report the platform in $os_name and leave $os unset; web SDKs do the opposite.
+    const os = properties.$os_name ?? properties.$os
 
     return {
         type,

--- a/frontend/src/lib/components/Errors/utils.ts
+++ b/frontend/src/lib/components/Errors/utils.ts
@@ -73,11 +73,14 @@ export function concatValues(
     return definedKeys.map((key) => attrs[key]).join(' ')
 }
 
+function nonEmptyString(value: unknown): string | undefined {
+    return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
 export function getExceptionAttributes(properties: Record<string, any>): ExceptionAttributes {
     const {
         $lib: lib,
         $lib_version: libVersion,
-        $browser: browser,
         $browser_version: browserVersion,
         $os_version: osVersion,
         $sentry_url: sentryUrl,
@@ -110,8 +113,10 @@ export function getExceptionAttributes(properties: Record<string, any>): Excepti
     const runtime: ErrorTrackingRuntime = getRuntimeFromLib(lib)
     const appNamespace = properties.$app_namespace
     const appVersion = properties.$app_version
+    // Misbehaving SDKs can send non-string values, which would crash PropertyIcon's lowercase lookup.
+    const browser = nonEmptyString(properties.$browser)
     // Mobile SDKs report the platform in $os_name and leave $os unset; web SDKs do the opposite.
-    const os = properties.$os_name ?? properties.$os
+    const os = nonEmptyString(properties.$os_name) ?? nonEmptyString(properties.$os)
 
     return {
         type,

--- a/products/error_tracking/frontend/components/ExceptionAttributesPreview/ExceptionAttributesPreview.tsx
+++ b/products/error_tracking/frontend/components/ExceptionAttributesPreview/ExceptionAttributesPreview.tsx
@@ -4,8 +4,6 @@ import { IconBug, IconCheckCircle, IconSparkles, IconWarning } from '@posthog/ic
 import { LemonTag, Spinner } from '@posthog/lemon-ui'
 
 import { ExceptionAttributes } from 'lib/components/Errors/types'
-import { concatValues } from 'lib/components/Errors/utils'
-import { PropertyIcon } from 'lib/components/PropertyIcon/PropertyIcon'
 
 export interface ExceptionAttributesPreviewProps {
     attributes: ExceptionAttributes | null
@@ -46,18 +44,6 @@ export function ExceptionAttributesPreview({
                                     <LemonTag className="gap-1.5 bg-fill-primary">
                                         <IconSparkles />
                                         Synthetic
-                                    </LemonTag>
-                                ) : null}
-                                {attributes.browser ? (
-                                    <LemonTag className="gap-1.5 bg-fill-primary">
-                                        <PropertyIcon property="$browser" value={attributes.browser} />
-                                        <span>{concatValues(attributes, 'browser', 'browserVersion')}</span>
-                                    </LemonTag>
-                                ) : null}
-                                {attributes.os ? (
-                                    <LemonTag className="gap-1.5 bg-fill-primary">
-                                        <PropertyIcon property="$os" value={attributes.os} />
-                                        <span>{concatValues(attributes, 'os', 'osVersion')}</span>
                                     </LemonTag>
                                 ) : null}
                             </>

--- a/products/error_tracking/frontend/components/ExceptionAttributesPreview/ExceptionAttributesPreview.tsx
+++ b/products/error_tracking/frontend/components/ExceptionAttributesPreview/ExceptionAttributesPreview.tsx
@@ -4,6 +4,8 @@ import { IconBug, IconCheckCircle, IconSparkles, IconWarning } from '@posthog/ic
 import { LemonTag, Spinner } from '@posthog/lemon-ui'
 
 import { ExceptionAttributes } from 'lib/components/Errors/types'
+import { concatValues } from 'lib/components/Errors/utils'
+import { PropertyIcon } from 'lib/components/PropertyIcon/PropertyIcon'
 
 export interface ExceptionAttributesPreviewProps {
     attributes: ExceptionAttributes | null
@@ -44,6 +46,18 @@ export function ExceptionAttributesPreview({
                                     <LemonTag className="gap-1.5 bg-fill-primary">
                                         <IconSparkles />
                                         Synthetic
+                                    </LemonTag>
+                                ) : null}
+                                {attributes.browser ? (
+                                    <LemonTag className="gap-1.5 bg-fill-primary">
+                                        <PropertyIcon property="$browser" value={attributes.browser} />
+                                        <span>{concatValues(attributes, 'browser', 'browserVersion')}</span>
+                                    </LemonTag>
+                                ) : null}
+                                {attributes.os ? (
+                                    <LemonTag className="gap-1.5 bg-fill-primary">
+                                        <PropertyIcon property="$os" value={attributes.os} />
+                                        <span>{concatValues(attributes, 'os', 'osVersion')}</span>
                                     </LemonTag>
                                 ) : null}
                             </>

--- a/products/error_tracking/frontend/components/ExceptionAttributesPreview/ExceptionPlatformPills.tsx
+++ b/products/error_tracking/frontend/components/ExceptionAttributesPreview/ExceptionPlatformPills.tsx
@@ -1,0 +1,31 @@
+import { LemonTag } from '@posthog/lemon-ui'
+
+import { ExceptionAttributes } from 'lib/components/Errors/types'
+import { concatValues } from 'lib/components/Errors/utils'
+import { PropertyIcon } from 'lib/components/PropertyIcon/PropertyIcon'
+
+export interface ExceptionPlatformPillsProps {
+    attributes: ExceptionAttributes | null
+}
+
+export function ExceptionPlatformPills({ attributes }: ExceptionPlatformPillsProps): JSX.Element | null {
+    if (!attributes) {
+        return null
+    }
+    return (
+        <>
+            {attributes.browser ? (
+                <LemonTag className="gap-1.5 bg-fill-primary">
+                    <PropertyIcon property="$browser" value={attributes.browser} />
+                    <span>{concatValues(attributes, 'browser', 'browserVersion')}</span>
+                </LemonTag>
+            ) : null}
+            {attributes.os ? (
+                <LemonTag className="gap-1.5 bg-fill-primary">
+                    <PropertyIcon property="$os" value={attributes.os} />
+                    <span>{concatValues(attributes, 'os', 'osVersion')}</span>
+                </LemonTag>
+            ) : null}
+        </>
+    )
+}

--- a/products/error_tracking/frontend/components/ExceptionCard/Tabs/StackTraceTab/index.tsx
+++ b/products/error_tracking/frontend/components/ExceptionCard/Tabs/StackTraceTab/index.tsx
@@ -8,6 +8,7 @@ import { TabsContent } from 'lib/ui/quill'
 import { cn } from 'lib/utils/css-classes'
 
 import { ExceptionAttributesPreview } from '../../../ExceptionAttributesPreview'
+import { ExceptionPlatformPills } from '../../../ExceptionAttributesPreview/ExceptionPlatformPills'
 import { ReleasePreviewPill } from '../../../ReleasesPreview/ReleasePreviewPill'
 import { exceptionCardLogic } from '../../exceptionCardLogic'
 import { SubHeader } from './../SubHeader'
@@ -28,6 +29,7 @@ export function StackTraceTab({ className, renderActions, ...props }: StackTrace
                 <div className="flex items-center gap-1">
                     <ExceptionAttributesPreview attributes={exceptionAttributes} loading={loading} />
                     {release && <ReleasePreviewPill release={release} />}
+                    {!loading && <ExceptionPlatformPills attributes={exceptionAttributes} />}
                 </div>
                 {renderActions?.()}
             </SubHeader>


### PR DESCRIPTION
## Problem

Anyone triaging an error has to open the properties tab to tell which OS and browser it happened on.
The stack trace header only shows the level, handled, and synthetic pills.

For mobile errors it is worse: the SDKs report the platform in `$os_name` and leave `$os` unset, so the UI resolved no OS at all for iOS, Android, and React Native exceptions.

#85986 addressed this by adding a Platform row to the release popover.
That hides the platform behind a hover, and only for events that carry release info.
This PR shows it as first-class pills instead and supersedes that one.

## Changes

- The stack trace bar now shows the OS and browser as pills with their brand icons, next to the existing pills.

Web exception:

![pr-web-pills](https://raw.githubusercontent.com/PostHog/pr-assets/d077ef3dc1ac1336312dc71bf3aebc7031e371e4/2026/08/c4a19df1-9989-44e6-be10-eff7cf07f490.png)

Android exception, after the release pill:

![pr-android-pills](https://raw.githubusercontent.com/PostHog/pr-assets/5393e94460956e172113c73346f9c25a6b9c9f9e/2026/08/e5e71271-9f6d-4ba5-9ec5-ae35740ab7e4.png)

- `getExceptionAttributes` reads `$os_name` before `$os`, which is the precedence session replay already uses. This also fills the previously empty "os" snack in the session recording event view for mobile errors.
- The pills reuse `PropertyIcon`, the same OS and browser icon map session replay uses, so no new icon mapping is introduced.
- Each pill renders only when the event carries the property. What each SDK sets, verified against the SDK sources:

| SDK | Properties set | Pills shown |
| --- | --- | --- |
| posthog-js (web) | `$os` + `$os_version`, `$browser` + `$browser_version` | browser and OS |
| iOS, Android, React Native | `$os_name` + `$os_version` | OS only |
| Node and other server SDKs | none | none |

## How did you test this code?

- Added parameterized Jest cases pinning the `$os_name` over `$os` precedence. The regression they catch: reading `$os` alone, which leaves every mobile error with no OS anywhere in the UI. No existing case covered `$os_name`.
- Rendered the existing `ExceptionCard` Storybook stories in headless Chromium. The screenshots above are those renders; the fixtures already cover the web, mobile, and no-OS cases, so visual regression snapshots cover the pills too.
- The frontend TypeScript check and oxlint/oxfmt are clean.
- Not run: Playwright, and no verification against a live instance with real mobile data.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written by Claude Code, directed by the assignee as an alternative execution of #85986: pills in the bar instead of a row in the release popover.
- Skills invoked: `/writing-ui-components`, `/writing-tests`, `/writing-code-comments`, `/writing-user-facing-copy` guidance was not needed (the pills render property values, no authored copy), `/writing-pr-descriptions`.
- The per-SDK property table comes from reading the local posthog-js (browser, react-native, node), posthog-ios, and posthog-android repos, not from live data.
- The screenshots are Storybook renders of the repo's committed mock fixtures.
- The commit was created via the GitHub API because the local signing agent required interactive approval; the tree is identical to the locally tested one.

