### PR TITLE
fix(desktop): update sidebar space tree when a task is renamed

### DIFF
--- a/products/desktop/packages/core/src/tasks/taskRename.ts
+++ b/products/desktop/packages/core/src/tasks/taskRename.ts
@@ -52,6 +52,17 @@ export function applyRenameToDetail<T extends TitledTask>(
   return { ...detail, title: newTitle, title_manually_set: true };
 }
 
+export function applyRenameToPage<
+  T extends TitledTask,
+  P extends { tasks: T[] },
+>(page: P | undefined, taskId: string, newTitle: string): P | undefined {
+  if (!page) {
+    return page;
+  }
+  const tasks = applyRenameToList(page.tasks, taskId, newTitle);
+  return tasks ? { ...page, tasks } : page;
+}
+
 export function rollbackListData<T extends TitledTask>(
   current: T[] | undefined,
   previous: T[],
@@ -74,6 +85,18 @@ export function rollbackSummaryData<T extends TitledSummary>(
     return previous;
   }
   return getTaskSummaryTitle(current, taskId) === newTitle ? previous : current;
+}
+
+export function rollbackPageData<P extends { tasks: TitledTask[] }>(
+  current: P | undefined,
+  previous: P,
+  taskId: string,
+  newTitle: string,
+): P {
+  if (!current) {
+    return previous;
+  }
+  return getTaskTitle(current.tasks, taskId) === newTitle ? previous : current;
 }
 
 export function rollbackDetailData<T extends TitledTask>(

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useRecentSpaceTasks.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useRecentSpaceTasks.ts
@@ -23,10 +23,14 @@ import {
 /**
  * Its own key rather than the channel feed's: the tree asks for a short page,
  * and handing that truncated list to the space's own feed through a shared
- * cache would quietly cut it off at the same length.
+ * cache would quietly cut it off at the same length. The root is exported so
+ * task mutations (rename) can write through these pages the way they do the
+ * feed's — a tree row polls too slowly to catch up on its own.
  */
+export const spaceTreeTasksQueryRoot = ["space-tree-tasks"] as const;
+
 const spaceTreeTasksQueryKey = (spaceId: string) =>
-  ["space-tree-tasks", spaceId] as const;
+  [...spaceTreeTasksQueryRoot, spaceId] as const;
 
 /** How many sessions a space shows when expanded in the list. */
 export const RECENT_TASKS_PER_SPACE = 5;
@@ -39,7 +43,7 @@ export const RECENT_TASKS_PER_SPACE = 5;
 const TREE_FETCH_LIMIT = 20;
 
 /** One page of a space's sessions, with the total the page was cut from. */
-interface SpaceTaskPage {
+export interface SpaceTaskPage {
   tasks: Task[];
   count: number;
 }

--- a/products/desktop/packages/ui/src/features/tasks/useTaskMutations.test.tsx
+++ b/products/desktop/packages/ui/src/features/tasks/useTaskMutations.test.tsx
@@ -6,7 +6,7 @@ import {
   spaceTreeTasksQueryRoot,
 } from "@posthog/ui/features/canvas/hooks/useRecentSpaceTasks";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { renderHook } from "@testing-library/react";
+import { renderHook, waitFor } from "@testing-library/react";
 import { act, type ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -206,7 +206,12 @@ describe("useRenameTask", () => {
 
   it("skips rollback when a newer rename has advanced the title past ours", async () => {
     const failure = new Error("network down");
-    mockUpdateTask.mockRejectedValue(failure);
+    let failUpdate: (() => void) | undefined;
+    mockUpdateTask.mockReturnValue(
+      new Promise((_, reject) => {
+        failUpdate = () => reject(failure);
+      }),
+    );
     const { result, queryClient } = renderRenameHook();
 
     const listKey = taskKeys.list();
@@ -228,6 +233,14 @@ describe("useRenameTask", () => {
       newTitle: "First rename",
     });
 
+    // Our own optimistic write has to land before the newer rename overtakes
+    // it, or the test states the opposite of what it names.
+    await waitFor(() => {
+      expect(queryClient.getQueryData<Task[]>(listKey)?.[0].title).toBe(
+        "First rename",
+      );
+    });
+
     queryClient.setQueryData<Task[]>(listKey, [
       createTask({ title: "Second rename", title_manually_set: true }),
     ]);
@@ -245,6 +258,7 @@ describe("useRenameTask", () => {
 
     let caught: unknown;
     await act(async () => {
+      failUpdate?.();
       try {
         await renamePromise;
       } catch (error) {
@@ -270,6 +284,43 @@ describe("useRenameTask", () => {
       TASK_ID,
       "Original title",
     );
+  });
+
+  it("keeps the new title when a poll that was already in flight resolves with the old one", async () => {
+    mockUpdateTask.mockResolvedValue(undefined);
+    const { result, queryClient } = renderRenameHook();
+
+    queryClient.setQueryData<SpaceTaskPage>(SPACE_TREE_KEY, {
+      tasks: [createTask()],
+      count: 7,
+    });
+    let resolvePoll: ((page: SpaceTaskPage) => void) | undefined;
+    const inFlightPoll = queryClient
+      .fetchQuery<SpaceTaskPage>({
+        queryKey: SPACE_TREE_KEY,
+        queryFn: () =>
+          new Promise<SpaceTaskPage>((resolve) => {
+            resolvePoll = resolve;
+          }),
+      })
+      .catch(() => undefined);
+
+    await act(async () => {
+      await result.current.renameTask({
+        taskId: TASK_ID,
+        currentTitle: "Original title",
+        newTitle: "Renamed",
+      });
+    });
+
+    await act(async () => {
+      resolvePoll?.({ tasks: [createTask()], count: 7 });
+      await inFlightPoll;
+    });
+
+    expect(
+      queryClient.getQueryData<SpaceTaskPage>(SPACE_TREE_KEY)?.tasks[0].title,
+    ).toBe("Renamed");
   });
 
   it("does not write to the detail cache when no detail entry exists", async () => {

--- a/products/desktop/packages/ui/src/features/tasks/useTaskMutations.test.tsx
+++ b/products/desktop/packages/ui/src/features/tasks/useTaskMutations.test.tsx
@@ -1,6 +1,10 @@
 import type { Schemas } from "@posthog/api-client";
 import type { Task } from "@posthog/shared/domain-types";
 import { channelFeedQueryKey } from "@posthog/ui/features/canvas/hooks/useChannelFeed";
+import {
+  type SpaceTaskPage,
+  spaceTreeTasksQueryRoot,
+} from "@posthog/ui/features/canvas/hooks/useRecentSpaceTasks";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook } from "@testing-library/react";
 import { act, type ReactNode } from "react";
@@ -25,6 +29,7 @@ import { useRenameTask } from "./useTaskMutations";
 
 const TASK_ID = "task-1";
 const OTHER_TASK_ID = "task-2";
+const SPACE_TREE_KEY = [...spaceTreeTasksQueryRoot, "space-1"] as const;
 
 function createTask(overrides: Partial<Task> = {}): Task {
   return {
@@ -82,6 +87,10 @@ describe("useRenameTask", () => {
     ]);
     queryClient.setQueryData<Task>(detailKey, createTask());
     queryClient.setQueryData<Task[]>(channelFeedKey, [createTask()]);
+    queryClient.setQueryData<SpaceTaskPage>(SPACE_TREE_KEY, {
+      tasks: [createTask()],
+      count: 7,
+    });
 
     await act(async () => {
       await result.current.renameTask({
@@ -116,6 +125,12 @@ describe("useRenameTask", () => {
         title_manually_set: true,
       },
     );
+    expect(
+      queryClient.getQueryData<SpaceTaskPage>(SPACE_TREE_KEY),
+    ).toMatchObject({
+      tasks: [{ title: "Renamed", title_manually_set: true }],
+      count: 7,
+    });
 
     expect(mockUpdateTask).toHaveBeenCalledWith(TASK_ID, {
       title: "Renamed",
@@ -139,6 +154,10 @@ describe("useRenameTask", () => {
     ]);
     queryClient.setQueryData<Task>(detailKey, createTask());
     queryClient.setQueryData<Task[]>(channelFeedKey, [createTask()]);
+    queryClient.setQueryData<SpaceTaskPage>(SPACE_TREE_KEY, {
+      tasks: [createTask()],
+      count: 7,
+    });
 
     let caught: unknown;
     await act(async () => {
@@ -169,6 +188,9 @@ describe("useRenameTask", () => {
     expect(queryClient.getQueryData<Task[]>(channelFeedKey)?.[0].title).toBe(
       "Original title",
     );
+    expect(
+      queryClient.getQueryData<SpaceTaskPage>(SPACE_TREE_KEY)?.tasks[0].title,
+    ).toBe("Original title");
 
     expect(mockUpdateSessionTaskTitle).toHaveBeenNthCalledWith(
       1,
@@ -195,6 +217,10 @@ describe("useRenameTask", () => {
       createSummary(),
     ]);
     queryClient.setQueryData<Task>(detailKey, createTask());
+    queryClient.setQueryData<SpaceTaskPage>(SPACE_TREE_KEY, {
+      tasks: [createTask()],
+      count: 7,
+    });
 
     const renamePromise = result.current.renameTask({
       taskId: TASK_ID,
@@ -212,6 +238,10 @@ describe("useRenameTask", () => {
       detailKey,
       createTask({ title: "Second rename", title_manually_set: true }),
     );
+    queryClient.setQueryData<SpaceTaskPage>(SPACE_TREE_KEY, {
+      tasks: [createTask({ title: "Second rename", title_manually_set: true })],
+      count: 7,
+    });
 
     let caught: unknown;
     await act(async () => {
@@ -232,6 +262,9 @@ describe("useRenameTask", () => {
     expect(queryClient.getQueryData<Task>(detailKey)?.title).toBe(
       "Second rename",
     );
+    expect(
+      queryClient.getQueryData<SpaceTaskPage>(SPACE_TREE_KEY)?.tasks[0].title,
+    ).toBe("Second rename");
 
     expect(mockUpdateSessionTaskTitle).not.toHaveBeenCalledWith(
       TASK_ID,

--- a/products/desktop/packages/ui/src/features/tasks/useTaskMutations.ts
+++ b/products/desktop/packages/ui/src/features/tasks/useTaskMutations.ts
@@ -51,6 +51,7 @@ export function useUpdateTask() {
         queryClient.invalidateQueries({ queryKey: taskKeys.detail(taskId) });
         queryClient.invalidateQueries({ queryKey: taskKeys.allSummaries() });
         queryClient.invalidateQueries({ queryKey: spaceTreeTasksQueryRoot });
+        queryClient.invalidateQueries({ queryKey: channelFeedQueryRoot });
       },
     },
   );
@@ -71,6 +72,22 @@ export function useRenameTask() {
       currentTitle: string;
       newTitle: string;
     }) => {
+      // Every one of these caches is polled. A fetch already in flight resolves
+      // with a title from before the rename and writes it over the optimistic
+      // one, so the row goes back to the old name until the next poll — the
+      // stale sidebar this rename path exists to avoid. Cancelling first also
+      // keeps the rollback honest: it reads these caches to decide whether our
+      // write is still the one on screen.
+      await Promise.all(
+        [
+          taskKeys.lists(),
+          channelFeedQueryRoot,
+          taskKeys.allSummaries(),
+          spaceTreeTasksQueryRoot,
+          taskKeys.detail(taskId),
+        ].map((queryKey) => queryClient.cancelQueries({ queryKey })),
+      );
+
       const previousListQueries = queryClient.getQueriesData<Task[]>({
         queryKey: taskKeys.lists(),
       });

--- a/products/desktop/packages/ui/src/features/tasks/useTaskMutations.ts
+++ b/products/desktop/packages/ui/src/features/tasks/useTaskMutations.ts
@@ -6,16 +6,22 @@ import {
 import {
   applyRenameToDetail,
   applyRenameToList,
+  applyRenameToPage,
   applyRenameToSummaries,
   getTaskTitle,
   rollbackDetailData,
   rollbackListData,
+  rollbackPageData,
   rollbackSummaryData,
   shouldRollbackSessionTitle,
 } from "@posthog/core/tasks/taskRename";
 import { useService } from "@posthog/di/react";
 import type { Task } from "@posthog/shared/domain-types";
 import { channelFeedQueryRoot } from "@posthog/ui/features/canvas/hooks/useChannelFeed";
+import {
+  type SpaceTaskPage,
+  spaceTreeTasksQueryRoot,
+} from "@posthog/ui/features/canvas/hooks/useRecentSpaceTasks";
 import { taskKeys } from "@posthog/ui/features/tasks/taskKeys";
 import { useAuthenticatedMutation } from "@posthog/ui/hooks/useAuthenticatedMutation";
 import { useQueryClient } from "@tanstack/react-query";
@@ -44,6 +50,7 @@ export function useUpdateTask() {
         queryClient.invalidateQueries({ queryKey: taskKeys.lists() });
         queryClient.invalidateQueries({ queryKey: taskKeys.detail(taskId) });
         queryClient.invalidateQueries({ queryKey: taskKeys.allSummaries() });
+        queryClient.invalidateQueries({ queryKey: spaceTreeTasksQueryRoot });
       },
     },
   );
@@ -75,6 +82,10 @@ export function useRenameTask() {
       >({
         queryKey: taskKeys.allSummaries(),
       });
+      const previousSpaceTreeQueries =
+        queryClient.getQueriesData<SpaceTaskPage>({
+          queryKey: spaceTreeTasksQueryRoot,
+        });
       const previousDetail = queryClient.getQueryData<Task>(
         taskKeys.detail(taskId),
       );
@@ -90,6 +101,10 @@ export function useRenameTask() {
       queryClient.setQueriesData<Schemas.TaskSummary[]>(
         { queryKey: taskKeys.allSummaries() },
         (old) => applyRenameToSummaries(old, taskId, newTitle),
+      );
+      queryClient.setQueriesData<SpaceTaskPage>(
+        { queryKey: spaceTreeTasksQueryRoot },
+        (old) => applyRenameToPage(old, taskId, newTitle),
       );
 
       if (previousDetail) {
@@ -113,10 +128,13 @@ export function useRenameTask() {
         const channelFeedTitles = queryClient
           .getQueriesData<Task[]>({ queryKey: channelFeedQueryRoot })
           .map(([, tasks]) => getTaskTitle(tasks, taskId));
+        const spaceTreeTitles = queryClient
+          .getQueriesData<SpaceTaskPage>({ queryKey: spaceTreeTasksQueryRoot })
+          .map(([, page]) => getTaskTitle(page?.tasks, taskId));
         const rollbackSession = shouldRollbackSessionTitle({
           detailTitle: queryClient.getQueryData<Task>(taskKeys.detail(taskId))
             ?.title,
-          listTitles: [...listTitles, ...channelFeedTitles],
+          listTitles: [...listTitles, ...channelFeedTitles, ...spaceTreeTitles],
           newTitle,
         });
 
@@ -135,6 +153,14 @@ export function useRenameTask() {
             queryKey,
             (current) =>
               rollbackSummaryData(current, data ?? [], taskId, newTitle),
+          );
+        }
+        for (const [queryKey, data] of previousSpaceTreeQueries) {
+          if (!data) continue;
+          queryClient.setQueryData<SpaceTaskPage | undefined>(
+            queryKey,
+            (current) =>
+              rollbackPageData<SpaceTaskPage>(current, data, taskId, newTitle),
           );
         }
         if (previousDetail) {


### PR DESCRIPTION
## TL;DR

Rename a session and every sidebar list now shows the new name right away. Before, the space list in the sidebar kept the old name for up to 30 seconds.

## Problem

- Renaming a task from the top bar (or a sidebar row) leaves the sidebar's space tree showing the old title for up to 30 seconds.
- The rename writes the new title into the task list, summaries, channel feed, and detail caches, but not into the space tree's task pages, which only catch up on their 30-second poll.
- The space hover card reads the same pages, so it lags too.
- A poll already in flight when the rename starts resolves with the title from before it and writes that over the optimistic one. The row goes back to the old name, and nothing refetches it until the next poll.

## Changes

- The space tree rows and the space hover card show a new title the moment the rename is submitted.
- A rename that races an in-flight poll keeps the new title, because `useRenameTask` cancels those fetches before it snapshots and writes.
- `useRenameTask` writes the title through the `space-tree-tasks` pages, rolls them back when the request fails, and keeps a newer rename that lands mid-flight.
- `useUpdateTask` invalidates the space tree pages and the channel feed after any task update, so the server's answer replaces the optimistic one.
- Mechanical: `useRecentSpaceTasks` exports its query-key root and page type, and `taskRename` gains page-shaped apply and rollback helpers.
- Nothing looks different beyond the stale name going away, so there are no screenshots.

## How did you test this code?

- A new test seeds a space-tree poll that is in flight when the rename lands and resolves it with the old title. It fails without the cancel: the cache reverts to the old title and stays there.
- The three existing `useRenameTask` tests now seed a space-tree page. They fail without the cache write because the page keeps the stale title.
- The newer-rename test wrote its second title synchronously, which with the awaited cancel lands before the optimistic write and states the opposite of what the test names. It now waits for that write first, then advances the title.
- `pnpm typecheck`, Biome, and the `@posthog/core` and `@posthog/ui` vitest suites pass.
- Not run: the app against a live backend. The change is exercised at the query-cache level.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code cloud task; skills invoked: `/posthog-desktop`, `/writing-tests`, `/writing-pr-descriptions`.
- The session traced every sidebar surface that renders a task title back to its query. The space-tree pages were the one source the rename flow missed; the fix mirrors the channel feed's existing coverage.
- Greptile flagged the in-flight poll race on the space-tree write. It reproduced in a test, so the cancel covers every cache this path writes rather than the space tree alone.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
