### PR TITLE
fix(google-ads): stop the lookback re-read from stalling the drain

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/typings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/typings.py
@@ -97,6 +97,10 @@ class SourceInputs:
     reset_pipeline: bool
     enabled_columns: Optional[list[str]] = None
     row_filters: Optional[list[ValidatedRowFilter]] = None
+    # Seconds `db_incremental_field_last_value` was rewound by `apply_incremental_lookback` for the
+    # rolling overlap re-read. Sources that drain a stats backlog in bounded windows need it to tell
+    # already-synced re-read windows apart from windows that advance the cursor. 0/None means no shift.
+    db_incremental_field_lookback_seconds: Optional[int] = None
     # Multi-schema import context, read by `resolve_source_location`.
     schema_metadata: Optional[dict[str, Any]] = None
     s3_folder_name: Optional[str] = None

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/google_ads.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/google_ads.py
@@ -507,6 +507,7 @@ def google_ads_source(
     db_incremental_field_last_value: typing.Any = None,
     incremental_field: str | None = None,
     incremental_field_type: IncrementalFieldType | None = None,
+    db_incremental_field_lookback_seconds: int | None = None,
 ) -> SourceResponse:
     """A data warehouse Google Ads source.
 
@@ -591,6 +592,18 @@ def google_ads_source(
             )
             # Exclusive upper bound of today+1 keeps today in range, matching the open-ended scan.
             end = dt.date.today() + dt.timedelta(days=1)
+
+            # An established cursor arrives already rewound by the user-configured lookback (the
+            # rolling overlap re-read, see `apply_incremental_lookback`), so `start` sits up to
+            # `lookback` days before the real stored watermark. Windows ending at or below that
+            # watermark only re-read already-synced data; counting them against the forward-progress
+            # budget lets a dense lookback (30 days ≈ 4+ full windows) consume nearly the whole
+            # budget, so the run stops short of today and the cursor crawls — or, past ~5 windows of
+            # lookback, freezes — while every run reports Completed. A first sync has no watermark
+            # and gets no lookback shift, so its boundary stays at `start` and every window counts.
+            resync_boundary = start
+            if db_incremental_field_last_value is not None and db_incremental_field_lookback_seconds:
+                resync_boundary = start + dt.timedelta(seconds=db_incremental_field_lookback_seconds)
             windows_with_data = 0
             first_window = True
 
@@ -605,9 +618,11 @@ def google_ads_source(
                     had_data = True
                     yield pa_table
 
-                # Empty windows don't count toward the per-run budget and don't stop the loop, so a
-                # gap in the data is crossed within a single run instead of stalling the cursor on it.
-                if had_data:
+                # Only windows that extend past the stored watermark count toward the per-run
+                # budget. Windows entirely inside the lookback re-read, and empty windows, are
+                # traversed for free, so neither the overlap re-read nor a gap in the data can
+                # stall the cursor short of today.
+                if had_data and window_end > resync_boundary:
                     windows_with_data += 1
                 first_window = False
                 start = window_end

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/source.py
@@ -243,6 +243,9 @@ class GoogleAdsSource(
             db_incremental_field_last_value=inputs.db_incremental_field_last_value
             if inputs.should_use_incremental_field
             else None,
+            db_incremental_field_lookback_seconds=inputs.db_incremental_field_lookback_seconds
+            if inputs.should_use_incremental_field
+            else None,
         )
 
     @property

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
@@ -1568,6 +1568,57 @@ class TestGoogleAdsQueryConstruction:
         lower_bounds = [re.search(r">= '(\d{4}-\d{2}-\d{2})'", q).group(1) for q in queries]  # type: ignore[union-attr]
         assert lower_bounds[:4] == ["2026-01-01", "2026-01-08", "2026-01-15", "2026-01-22"]
 
+    def test_lookback_reread_windows_do_not_stall_drain_short_of_today(self):
+        # The cursor arrives already rewound by the lookback (the rolling overlap re-read). With
+        # data every day, those ~4 re-read windows used to burn almost the whole 5-window budget,
+        # so the run stopped before reaching today and the cursor crawled a few days per run while
+        # the job reported Completed. Re-read windows must not count toward the forward-progress
+        # budget, so a run whose real backlog fits the budget always reaches today.
+        thirty_days = 30 * 24 * 60 * 60
+        stored_cursor = dt.date(2026, 7, 17)
+        shifted_cursor = stored_cursor - dt.timedelta(seconds=thirty_days)
+        window_rows = {(shifted_cursor + dt.timedelta(days=i)).isoformat(): 1 for i in range(80)}
+
+        with freeze_time("2026-07-27"):
+            _response, queries = self._run_source(
+                self._stats_table(),
+                window_rows=window_rows,
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=shifted_cursor,
+                db_incremental_field_lookback_seconds=thirty_days,
+                incremental_field="segments.date",
+                incremental_field_type=IncrementalFieldType.Date,
+            )
+
+        # The re-read windows are still traversed (the lookback exists to pick up restated rows),
+        # and the drain then continues past the stored cursor all the way to today+1.
+        lower_bounds = [re.search(r">= '(\d{4}-\d{2}-\d{2})'", q).group(1) for q in queries]  # type: ignore[union-attr]
+        upper_bounds = [re.search(r"< '(\d{4}-\d{2}-\d{2})'", q).group(1) for q in queries]  # type: ignore[union-attr]
+        assert lower_bounds[0] == "2026-06-17"
+        assert max(upper_bounds) == "2026-07-28"
+
+    def test_first_sync_budget_ignores_lookback(self):
+        # A first sync has no stored watermark, so no lookback shift was applied to its start date.
+        # Exempting a lookback-sized slice of its windows anyway would let one run extract past the
+        # per-run budget that keeps runs short enough to complete and land the cursor.
+        window_rows = {
+            (dt.date(2024, 7, 17) + dt.timedelta(days=GOOGLE_ADS_INCREMENTAL_WINDOW_DAYS * i)).isoformat(): 1
+            for i in range(12)
+        }
+
+        with freeze_time("2026-07-17"):
+            _response, queries = self._run_source(
+                self._stats_table(),
+                window_rows=window_rows,
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=None,
+                db_incremental_field_lookback_seconds=30 * 24 * 60 * 60,
+                incremental_field="segments.date",
+                incremental_field_type=IncrementalFieldType.Date,
+            )
+
+        assert len(queries) == GOOGLE_ADS_MAX_DATA_WINDOWS_PER_RUN
+
     def test_dimension_table_query_has_no_order_clause(self):
         _response, queries = self._run_source(_single_row_table())
 

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -255,6 +255,7 @@ async def _import_data_with_reporting(inputs: ImportDataActivityInputs, logger: 
 
         processed_incremental_last_value = None
         processed_incremental_earliest_value = None
+        applied_lookback_seconds: int | None = None
 
         if reset_pipeline is not True:
             processed_incremental_last_value = process_incremental_value(
@@ -271,6 +272,7 @@ async def _import_data_with_reporting(inputs: ImportDataActivityInputs, logger: 
             # overlap window and catches late or backdated rows. Incremental merge makes the
             # re-read idempotent — append would duplicate, so it's gated to incremental.
             if schema.is_incremental:
+                applied_lookback_seconds = schema.incremental_field_lookback_seconds
                 processed_incremental_last_value = apply_incremental_lookback(
                     processed_incremental_last_value,
                     schema.incremental_field_type,
@@ -322,6 +324,9 @@ async def _import_data_with_reporting(inputs: ImportDataActivityInputs, logger: 
                 if schema.should_use_incremental_field
                 else None,
                 db_incremental_field_earliest_value=processed_incremental_earliest_value
+                if schema.should_use_incremental_field
+                else None,
+                db_incremental_field_lookback_seconds=applied_lookback_seconds
                 if schema.should_use_incremental_field
                 else None,
                 logger=logger,


### PR DESCRIPTION
## Problem

Google Ads warehouse customers with an incremental stats schema see their sync report "Completed" every run while the data stays months stale: each run advances only a few days, and manual resyncs barely move it.

- The windowed drain in `google_ads.py` walks at most 5 non-empty 7-day windows per run, so a run stays short enough to complete and land the cursor.
- The cursor handed to the source is already rewound by the configured lookback (`apply_incremental_lookback`), up to 30 days on schemas covered by the earlier backfill migration.
- Stats tables have rows every day, so the ~4 re-read windows burn the budget before the drain reaches new dates. Net progress is ~5 days per run.
- A lookback of 35+ days (the form allows up to 60) covers the whole budget: the cursor never advances again, with no error anywhere.
- #84474 lowered the default for newly created schemas but left existing schemas and the budget arithmetic untouched.

Revives #73819, which was auto-closed as stale before merging. The `SourceInputs` move and the first-sync windowed backfill (#82517) landed since, so the patch is rebased and re-gated rather than reopened.

## Changes

- Syncs now catch up: windows that end at or below the stored watermark no longer count against the per-run window budget, so every run drains past the lookback re-read and reaches today.
- A first sync keeps its current budget: it has no watermark and no lookback shift, so no window is exempted. This gate is new relative to #73819, which predated first syncs entering the windowed drain.
- Mechanical: `db_incremental_field_lookback_seconds` threads from `import_data_sync.py` through `SourceInputs` into `google_ads_source`.

## How did you test this code?

- Added `test_lookback_reread_windows_do_not_stall_drain_short_of_today`: 30-day lookback with data every day; fails on the old budget (drain stops 6 days short of today), passes now. Ported from #73819.
- Added `test_first_sync_budget_ignores_lookback`: a first sync with a lookback configured still stops at 5 data windows; catches applying the boundary unconditionally.
- The agent environment had no Python 3.10+/uv/node toolchain, so these tests were not run locally — CI runs them. The window arithmetic was verified with a standalone simulation of the loop for the crawl, freeze, first-sync, and fixed scenarios, and all files pass syntax checks.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing setting or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude (PostHog Desktop task) driven by @alinph, starting from the diagnosis behind #73819 and re-verifying it against master.
- Skills/guides applied: writing-tests, writing-code-comments, writing-pr-descriptions, writing-dataclasses.
- Decisions: re-created rather than reopened #73819 because `SourceInputs` moved to `sources/common/typings.py` and the drain now also serves first syncs; added the first-sync gate and its test for that reason. A warning log on failed staged-cursor promotion was considered and left out to keep this PR to the verified defect.
- Public artifact check: the diff, tests, and this description contain only repository-derived material; test dates and values are invented.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*