### PR TITLE
fix(workflows): incident replay banner missed workflows in large projects

### DIFF
--- a/products/workflows/frontend/workflowsIncidentReplayLogic.test.ts
+++ b/products/workflows/frontend/workflowsIncidentReplayLogic.test.ts
@@ -7,6 +7,7 @@ import { workflowsIncidentReplayLogic } from './workflowsIncidentReplayLogic'
 
 const AFFECTED_FLOW_ID = '019d244c-42c9-0000-ec6c-752c8b265c4f'
 const DELETED_FLOW_ID = '019d9146-223a-0000-8165-1a3489e88b3d'
+const FLAKY_FLOW_ID = '019f3834-8dbd-0000-4b19-073031109b21'
 
 describe('workflowsIncidentReplayLogic', () => {
     let logic: ReturnType<typeof workflowsIncidentReplayLogic.build>
@@ -21,6 +22,7 @@ describe('workflowsIncidentReplayLogic', () => {
                     {
                         results: [
                             [224, AFFECTED_FLOW_ID],
+                            [29, FLAKY_FLOW_ID],
                             [3, DELETED_FLOW_ID],
                         ],
                     },
@@ -30,6 +32,9 @@ describe('workflowsIncidentReplayLogic', () => {
                 '/api/projects/:team_id/hog_flows/:id/': (req) => {
                     if (req.params.id === AFFECTED_FLOW_ID) {
                         return [200, { id: AFFECTED_FLOW_ID, name: 'Order confirmation', user_access_level: 'editor' }]
+                    }
+                    if (req.params.id === FLAKY_FLOW_ID) {
+                        return [500, { detail: 'Internal server error.' }]
                     }
                     return [404, { detail: 'Not found.' }]
                 },
@@ -44,12 +49,13 @@ describe('workflowsIncidentReplayLogic', () => {
         logic.mount()
     })
 
-    it('resolves affected workflows by id and drops ones that 404', async () => {
+    it('resolves workflows by id, drops 404s, keeps rows whose retrieve fails transiently', async () => {
         await expectLogic(logic, () => logic.actions.loadAffectedWorkflows()).toDispatchActions([
             'loadAffectedWorkflowsSuccess',
         ])
         expect(logic.values.affectedWorkflows).toEqual([
             { id: AFFECTED_FLOW_ID, name: 'Order confirmation', failedCount: 12, userAccessLevel: 'editor' },
+            { id: FLAKY_FLOW_ID, name: '', failedCount: 12, userAccessLevel: null },
         ])
     })
 

--- a/products/workflows/frontend/workflowsIncidentReplayLogic.test.ts
+++ b/products/workflows/frontend/workflowsIncidentReplayLogic.test.ts
@@ -1,0 +1,63 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+
+import { workflowsIncidentReplayLogic } from './workflowsIncidentReplayLogic'
+
+const AFFECTED_FLOW_ID = '019d244c-42c9-0000-ec6c-752c8b265c4f'
+const DELETED_FLOW_ID = '019d9146-223a-0000-8165-1a3489e88b3d'
+
+describe('workflowsIncidentReplayLogic', () => {
+    let logic: ReturnType<typeof workflowsIncidentReplayLogic.build>
+    let remainingCount: number
+
+    beforeEach(() => {
+        remainingCount = 12
+        useMocks({
+            post: {
+                '/api/environments/:team_id/query/:query_kind/': () => [
+                    200,
+                    {
+                        results: [
+                            [224, AFFECTED_FLOW_ID],
+                            [3, DELETED_FLOW_ID],
+                        ],
+                    },
+                ],
+            },
+            get: {
+                '/api/projects/:team_id/hog_flows/:id/': (req) => {
+                    if (req.params.id === AFFECTED_FLOW_ID) {
+                        return [200, { id: AFFECTED_FLOW_ID, name: 'Order confirmation', user_access_level: 'editor' }]
+                    }
+                    return [404, { detail: 'Not found.' }]
+                },
+                '/api/projects/:team_id/hog_flows/:id/invocation_results_count/': () => [
+                    200,
+                    { count: remainingCount },
+                ],
+            },
+        })
+        initKeaTests()
+        logic = workflowsIncidentReplayLogic()
+        logic.mount()
+    })
+
+    it('resolves affected workflows by id and drops ones that 404', async () => {
+        await expectLogic(logic, () => logic.actions.loadAffectedWorkflows()).toDispatchActions([
+            'loadAffectedWorkflowsSuccess',
+        ])
+        expect(logic.values.affectedWorkflows).toEqual([
+            { id: AFFECTED_FLOW_ID, name: 'Order confirmation', failedCount: 12, userAccessLevel: 'editor' },
+        ])
+    })
+
+    it('drops workflows whose remaining failed count is zero', async () => {
+        remainingCount = 0
+        await expectLogic(logic, () => logic.actions.loadAffectedWorkflows()).toDispatchActions([
+            'loadAffectedWorkflowsSuccess',
+        ])
+        expect(logic.values.affectedWorkflows).toEqual([])
+    })
+})

--- a/products/workflows/frontend/workflowsIncidentReplayLogic.ts
+++ b/products/workflows/frontend/workflowsIncidentReplayLogic.ts
@@ -12,9 +12,10 @@ import { AccessControlLevel } from '~/types'
 
 import {
     hogFlowsInvocationResultsCountRetrieve,
-    hogFlowsList,
     hogFlowsRerunCreate,
+    hogFlowsRetrieve,
 } from 'products/workflows/frontend/generated/api'
+import type { HogFlowApi } from 'products/workflows/frontend/generated/api.schemas'
 
 // The window of the 2026-08-17 email send incident (UTC), padded around the first and last
 // observed failures. Both the affected-workflow lookup and the rerun filter use it, so a
@@ -137,12 +138,25 @@ export const workflowsIncidentReplayLogic = kea<workflowsIncidentReplayLogicType
                         return []
                     }
 
-                    // Keep only workflows the list endpoint returns: it applies object-level
-                    // access control, so this never names a workflow the user can't see, and it
-                    // drops deleted workflows, which can't be replayed anyway.
+                    // Fetch each affected workflow by ID rather than intersecting with the list
+                    // endpoint: the list caps at a page size, so in projects with more workflows
+                    // than one page the affected ones can fall outside it and silently drop off
+                    // the banner. Per-ID retrieval keeps the same gates exactly - object-level
+                    // access control (403) and hard-deleted workflows (404, can't be replayed)
+                    // drop the row.
                     const projectId = String(values.currentProjectId)
-                    const flows = await hogFlowsList(projectId, { limit: 300 })
-                    const flowsById = new Map((flows.results ?? []).map((flow) => [flow.id, flow]))
+                    const flows = await Promise.all(
+                        affected.map(async (row) => {
+                            try {
+                                return await hogFlowsRetrieve(projectId, row.id)
+                            } catch {
+                                return null
+                            }
+                        })
+                    )
+                    const flowsById = new Map(
+                        flows.filter((flow): flow is HogFlowApi => flow !== null).map((flow) => [flow.id, flow])
+                    )
                     const visible = affected.filter((row) => flowsById.has(row.id))
 
                     if (visible.length === 0) {

--- a/products/workflows/frontend/workflowsIncidentReplayLogic.ts
+++ b/products/workflows/frontend/workflowsIncidentReplayLogic.ts
@@ -141,15 +141,21 @@ export const workflowsIncidentReplayLogic = kea<workflowsIncidentReplayLogicType
                     // Fetch each affected workflow by ID rather than intersecting with the list
                     // endpoint: the list caps at a page size, so in projects with more workflows
                     // than one page the affected ones can fall outside it and silently drop off
-                    // the banner. Per-ID retrieval keeps the same gates exactly - object-level
-                    // access control (403) and hard-deleted workflows (404, can't be replayed)
-                    // drop the row.
+                    // the banner. Only a definitive 403 (no access) or 404 (hard-deleted, can't
+                    // be replayed) drops a row - the same gates the list applied. A transient
+                    // retrieve failure (network, 429, 5xx) keeps the row with fallback fields,
+                    // so a blip never hides the recovery path.
                     const projectId = String(values.currentProjectId)
+                    const dropped = new Set<string>()
                     const flows = await Promise.all(
                         affected.map(async (row) => {
                             try {
                                 return await hogFlowsRetrieve(projectId, row.id)
-                            } catch {
+                            } catch (error) {
+                                const status = (error as { status?: number }).status
+                                if (status === 403 || status === 404) {
+                                    dropped.add(row.id)
+                                }
                                 return null
                             }
                         })
@@ -157,7 +163,7 @@ export const workflowsIncidentReplayLogic = kea<workflowsIncidentReplayLogicType
                     const flowsById = new Map(
                         flows.filter((flow): flow is HogFlowApi => flow !== null).map((flow) => [flow.id, flow])
                     )
-                    const visible = affected.filter((row) => flowsById.has(row.id))
+                    const visible = affected.filter((row) => !dropped.has(row.id))
 
                     if (visible.length === 0) {
                         return []


### PR DESCRIPTION
## Problem

Follow-up to #85156: the incident replay banner never shows in projects with more workflows than one list page — precisely the bigger senders the incident hit hardest.

Root cause: the affected-workflow lookup intersected the app-metrics hits with the **first 300 rows** of the workflows list. In a project with 462 workflows the affected ones fell outside that page, the intersection came up empty, and the banner silently concluded "nothing to replay" while the failed sends sat right there in ClickHouse. Every gate before it worked — flag on, discovery query returning the affected workflows — and then the last step threw the result away.

## Changes

- The banner now resolves each affected workflow **by ID** instead of scanning the list. Same gates as before — hard-deleted workflows 404, access control 403s, both drop the row — just without the page-size ceiling.
- Only those two definitive statuses drop a row. A transient retrieve failure (network error, 429, 5xx) keeps it with fallback fields — the count request still runs, so the number stays right — matching the count step's existing "never hide the recovery path on a transient failure" stance.
- The affected set is capped by the metrics query (100), so this is a handful of point reads. No user-visible change beyond the banner actually appearing where it should.

## How did you test this code?

- New jest logic test: affected workflows resolve by ID with a 404 dropped — this fails against the old list-intersection code, it's exactly the shipped regression. Second case: a zero remaining count drops the row (banner clears after replay).
- Diagnosed live on prod: discovery query returned the affected workflows, no count requests fired, banner hidden. Live re-verification after deploy pending.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code. Skills invoked: /writing-kea-logics, /writing-tests, /writing-pr-descriptions. Root cause isolated by walking the banner's gate chain live on prod (flag → metrics discovery → list intersection → counts) and finding the chain died at the intersection. No customer identifiers in the diff or this description.

