### PR TITLE
fix(flags): label override lookup metrics by pool

### DIFF
--- a/rust/feature-flags/src/database/mod.rs
+++ b/rust/feature-flags/src/database/mod.rs
@@ -1,4 +1,5 @@
 pub mod connection;
+pub mod pool_names;
 pub mod postgres_router;
 
 pub use connection::{

--- a/rust/feature-flags/src/database/pool_names.rs
+++ b/rust/feature-flags/src/database/pool_names.rs
@@ -1,0 +1,13 @@
+//! Canonical names for the database pools, used as the `pool` label on metrics.
+//!
+//! These are constants because a wrong label fails nothing. The code compiles, the query
+//! runs, and the metric is emitted under a second time series whose name differs from the
+//! intended one by a character or a word, while the original series keeps reporting as if
+//! that traffic had stopped. Nobody sees an error, so the first sign of trouble is a
+//! dashboard that disagrees with the database. Referring to a constant turns that into a
+//! compile error.
+
+pub const PERSONS_READER: &str = "persons_reader";
+pub const PERSONS_WRITER: &str = "persons_writer";
+pub const NON_PERSONS_READER: &str = "non_persons_reader";
+pub const NON_PERSONS_WRITER: &str = "non_persons_writer";

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -6,7 +6,7 @@ use crate::cohorts::cohort_operations::{
     apply_cohort_membership_logic, evaluate_dynamic_cohorts, record_stamp_policy_divergence,
 };
 use crate::cohorts::membership::{CohortMembershipProvider, NoOpCohortMembershipProvider};
-use crate::database::PostgresRouter;
+use crate::database::{pool_names, PostgresRouter};
 use crate::flags::flag_group_type_mapping::{
     GroupTypeCacheManager, GroupTypeIndex, GroupTypeMapping,
 };
@@ -717,14 +717,21 @@ impl FeatureFlagMatcher {
         // When we're writing a hash_key_override, we query the main database (writer), not the replica (reader)
         // This is because we need to make sure the write is successful before we read it back
         // to avoid read-after-write consistency issues with database replication lag
-        let database_for_reading = if writing_hash_key_override {
-            self.router.get_persons_writer().clone()
+        let (database_for_reading, pool_name) = if writing_hash_key_override {
+            (
+                self.router.get_persons_writer().clone(),
+                pool_names::PERSONS_WRITER,
+            )
         } else {
-            self.router.get_persons_reader().clone()
+            (
+                self.router.get_persons_reader().clone(),
+                pool_names::PERSONS_READER,
+            )
         };
 
         match get_feature_flag_hash_key_overrides(
             database_for_reading,
+            pool_name,
             self.team_id,
             target_distinct_ids,
         )
@@ -2378,6 +2385,7 @@ impl FeatureFlagMatcher {
                     None => {
                         match get_feature_flag_hash_key_overrides(
                             self.router.get_persons_reader().clone(),
+                            pool_names::PERSONS_READER,
                             self.team_id,
                             vec![self.distinct_id.clone()],
                         )

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -8,7 +8,7 @@ use tokio_retry::{
 };
 
 use crate::database::{
-    get_connection_with_metrics, get_writer_connection_with_metrics, PostgresRouter,
+    get_connection_with_metrics, get_writer_connection_with_metrics, pool_names, PostgresRouter,
 };
 use common_database::PostgresReader;
 use common_types::{Person, PersonId, TeamId};
@@ -200,8 +200,12 @@ async fn fetch_person_and_cohorts(
     static_cohort_ids: &[CohortId],
 ) -> Result<PersonCohortResult, FlagError> {
     let conn_acquisition_start = Instant::now();
-    let conn_result =
-        get_connection_with_metrics(reader, "persons_reader", "fetch_person_properties").await;
+    let conn_result = get_connection_with_metrics(
+        reader,
+        pool_names::PERSONS_READER,
+        "fetch_person_properties",
+    )
+    .await;
     let conn_acquisition_duration = conn_acquisition_start.elapsed();
 
     let mut conn = match conn_result {
@@ -238,7 +242,7 @@ async fn fetch_person_and_cohorts(
     };
 
     let query_labels = [
-        ("pool".to_string(), "persons_reader".to_string()),
+        ("pool".to_string(), pool_names::PERSONS_READER.to_string()),
         ("team_id".to_string(), team_id.to_string()),
     ];
 
@@ -372,7 +376,8 @@ async fn fetch_group_properties(
 ) -> Result<GroupResult, FlagError> {
     let conn_acquisition_start = Instant::now();
     let conn_result =
-        get_connection_with_metrics(reader, "persons_reader", "fetch_group_properties").await;
+        get_connection_with_metrics(reader, pool_names::PERSONS_READER, "fetch_group_properties")
+            .await;
     let conn_acquisition_duration = conn_acquisition_start.elapsed();
 
     let mut conn = match conn_result {
@@ -409,7 +414,7 @@ async fn fetch_group_properties(
     };
 
     let query_labels = [
-        ("pool".to_string(), "persons_reader".to_string()),
+        ("pool".to_string(), pool_names::PERSONS_READER.to_string()),
         ("team_id".to_string(), team_id.to_string()),
     ];
 
@@ -763,8 +768,12 @@ pub fn match_flag_value_to_flag_filter(
 /// for the given distinct IDs. It handles priority by giving precedence to the first
 /// distinct ID in the list. The operation is retried once (2 total attempts) with
 /// exponential backoff on transient database errors.
+///
+/// `pool_name` labels the connection metrics. Callers pass either the persons reader or the
+/// persons writer, and both arrive here as the same type, so only the caller knows which.
 pub async fn get_feature_flag_hash_key_overrides(
     reader: PostgresReader,
+    pool_name: &'static str,
     team_id: TeamId,
     distinct_id_and_hash_key_override: Vec<String>,
 ) -> Result<HashMap<String, String>, FlagError> {
@@ -781,6 +790,7 @@ pub async fn get_feature_flag_hash_key_overrides(
     Retry::spawn(retry_strategy, || async {
         let result = try_get_feature_flag_hash_key_overrides(
             &reader,
+            pool_name,
             team_id,
             &distinct_id_and_hash_key_override,
         )
@@ -825,16 +835,14 @@ pub async fn get_feature_flag_hash_key_overrides(
 /// This is separated to make it easy to retry with tokio-retry.
 async fn try_get_feature_flag_hash_key_overrides(
     reader: &PostgresReader,
+    pool_name: &'static str,
     team_id: TeamId,
     distinct_id_and_hash_key_override: &[String],
 ) -> Result<HashMap<String, String>, FlagError> {
     let mut feature_flag_hash_key_overrides = HashMap::new();
-    let mut conn = get_connection_with_metrics(
-        reader,
-        "persons_reader",
-        "get_feature_flag_hash_key_overrides",
-    )
-    .await?;
+    let mut conn =
+        get_connection_with_metrics(reader, pool_name, "get_feature_flag_hash_key_overrides")
+            .await?;
 
     // Get person data and their hash key overrides in one query
     let hash_override_query = r#"
@@ -1010,7 +1018,7 @@ async fn try_set_feature_flag_hash_key_overrides(
     // Get connection from persons writer for the transaction
     let mut persons_conn = get_writer_connection_with_metrics(
         router.get_persons_writer(),
-        "persons_writer",
+        pool_names::PERSONS_WRITER,
         "set_feature_flag_hash_key_overrides",
     )
     .await?;
@@ -1061,7 +1069,7 @@ async fn try_set_feature_flag_hash_key_overrides(
                 "operation".to_string(),
                 "set_hash_key_overrides".to_string(),
             ),
-            ("pool".to_string(), "persons_writer".to_string()),
+            ("pool".to_string(), pool_names::PERSONS_WRITER.to_string()),
             ("team_id".to_string(), team_id.to_string()),
         ];
         let person_query_start = Instant::now();
@@ -1117,7 +1125,7 @@ async fn try_set_feature_flag_hash_key_overrides(
         // Get separate connection for non-persons query
         let mut non_persons_conn = get_connection_with_metrics(
             router.get_non_persons_reader(),
-            "non_persons_reader",
+            pool_names::NON_PERSONS_READER,
             "set_hash_key_overrides",
         )
         .await
@@ -1136,7 +1144,10 @@ async fn try_set_feature_flag_hash_key_overrides(
                 "operation".to_string(),
                 "set_hash_key_overrides".to_string(),
             ),
-            ("pool".to_string(), "non_persons_reader".to_string()),
+            (
+                "pool".to_string(),
+                pool_names::NON_PERSONS_READER.to_string(),
+            ),
             ("team_id".to_string(), team_id.to_string()),
         ];
         let flags_query_start = Instant::now();
@@ -1201,7 +1212,7 @@ async fn try_set_feature_flag_hash_key_overrides(
                 "operation".to_string(),
                 "set_hash_key_overrides".to_string(),
             ),
-            ("pool".to_string(), "persons_writer".to_string()),
+            ("pool".to_string(), pool_names::PERSONS_WRITER.to_string()),
             ("team_id".to_string(), team_id.to_string()),
         ];
         let insert_start = Instant::now();
@@ -1379,7 +1390,7 @@ async fn try_should_write_hash_key_override(
         let persons_conn_start = Instant::now();
         let mut persons_conn = get_connection_with_metrics(
             router.get_persons_reader(),
-            "persons_reader",
+            pool_names::PERSONS_READER,
             "should_write_check",
         )
         .await
@@ -1389,7 +1400,7 @@ async fn try_should_write_hash_key_override(
         if persons_conn_acquisition_time > Duration::from_millis(100) {
             warn!(
                 team_id = %team_id,
-                pool = "persons_reader",
+                pool = pool_names::PERSONS_READER,
                 acquisition_ms = persons_conn_acquisition_time.as_millis(),
                 "Slow connection acquisition from persons_reader pool"
             );
@@ -1401,7 +1412,7 @@ async fn try_should_write_hash_key_override(
                 "person_data_with_overrides".to_string(),
             ),
             ("operation".to_string(), "should_write_check".to_string()),
-            ("pool".to_string(), "persons_reader".to_string()),
+            ("pool".to_string(), pool_names::PERSONS_READER.to_string()),
             ("team_id".to_string(), team_id.to_string()),
         ];
         let person_query_timer =
@@ -1422,7 +1433,7 @@ async fn try_should_write_hash_key_override(
                         &[
                             ("error_type".to_string(), "timeout".to_string()),
                             ("timeout_type".to_string(), timeout_type.to_string()),
-                            ("pool".to_string(), "persons_reader".to_string()),
+                            ("pool".to_string(), pool_names::PERSONS_READER.to_string()),
                             (
                                 "operation".to_string(),
                                 "should_write_hash_key_override".to_string(),
@@ -1433,7 +1444,7 @@ async fn try_should_write_hash_key_override(
 
                     warn!(
                         team_id = %team_id,
-                        pool = "persons_reader",
+                        pool = pool_names::PERSONS_READER,
                         timeout_type = timeout_type,
                         error = ?e,
                         "Query timed out on persons_reader pool"
@@ -1462,7 +1473,7 @@ async fn try_should_write_hash_key_override(
         let non_persons_conn_start = Instant::now();
         let mut non_persons_conn = get_connection_with_metrics(
             router.get_non_persons_reader(),
-            "non_persons_reader",
+            pool_names::NON_PERSONS_READER,
             "should_write_check",
         )
         .await
@@ -1472,7 +1483,7 @@ async fn try_should_write_hash_key_override(
         if non_persons_conn_acquisition_time > Duration::from_millis(100) {
             warn!(
                 team_id = %team_id,
-                pool = "non_persons_reader",
+                pool = pool_names::NON_PERSONS_READER,
                 acquisition_ms = non_persons_conn_acquisition_time.as_millis(),
                 "Slow connection acquisition from non_persons_reader pool"
             );
@@ -1484,7 +1495,10 @@ async fn try_should_write_hash_key_override(
                 "active_flags_with_continuity".to_string(),
             ),
             ("operation".to_string(), "should_write_check".to_string()),
-            ("pool".to_string(), "non_persons_reader".to_string()),
+            (
+                "pool".to_string(),
+                pool_names::NON_PERSONS_READER.to_string(),
+            ),
             ("team_id".to_string(), team_id.to_string()),
         ];
         let flags_query_timer =
@@ -1504,7 +1518,10 @@ async fn try_should_write_hash_key_override(
                         &[
                             ("error_type".to_string(), "timeout".to_string()),
                             ("timeout_type".to_string(), timeout_type.to_string()),
-                            ("pool".to_string(), "non_persons_reader".to_string()),
+                            (
+                                "pool".to_string(),
+                                pool_names::NON_PERSONS_READER.to_string(),
+                            ),
                             (
                                 "operation".to_string(),
                                 "should_write_hash_key_override".to_string(),
@@ -1515,7 +1532,7 @@ async fn try_should_write_hash_key_override(
 
                     warn!(
                         team_id = %team_id,
-                        pool = "non_persons_reader",
+                        pool = pool_names::NON_PERSONS_READER,
                         timeout_type = timeout_type,
                         error = ?e,
                         "Query timed out on non_persons_reader pool"

--- a/rust/feature-flags/src/utils/test_utils.rs
+++ b/rust/feature-flags/src/utils/test_utils.rs
@@ -1383,6 +1383,7 @@ impl TestContext {
     {
         super::super::flags::flag_matching_utils::get_feature_flag_hash_key_overrides(
             self.persons_reader.clone(),
+            crate::database::pool_names::PERSONS_READER,
             team_id,
             distinct_ids,
         )


### PR DESCRIPTION
## Problem

The hash key override lookup labels its database metrics `pool="persons_reader"` no matter which pool it used. One caller hands it the persons writer, so writer connections get counted as reader traffic. Split this query's connection metrics by pool and only a reader series comes back.

The function takes a `PostgresReader`, and the writer pool has the same type, so nothing catches the mismatch.

## Changes

- The metrics now name the pool the call actually used.
- **The fix**, in `flag_matching.rs`, `test_utils.rs`, and two signatures in `flag_matching_utils.rs`: `get_feature_flag_hash_key_overrides` and its retry helper take a `pool_name` instead of hardcoding one, and three call sites pass the pool they selected. In the branch that picks writer or reader at runtime, the pool and the label come from the same arm. Check each site against the pool accessor on the line above it, because nothing else will catch a wrong one.
- **Mechanical**, about two thirds of the diff: a new `database::pool_names` module, and the other 19 pool-name literals in `flag_matching_utils.rs` swapped for its constants. Each constant holds the same value as the literal it replaced. Roughly 40 literals elsewhere in the crate are left for a separate PR.
- Nothing else changes. Same pools, same queries, same retries.

> [!NOTE]
> Metric series shift on deploy. Some traffic under `pool="persons_reader"` for this operation moves to a new `persons_writer` series. On a dashboard keyed to the old label it looks like a step change.
>
> Two panels on [Feature Flags - Performance](https://grafana.prod-us.posthog.dev/d/feature-flags-performance/feature-flags-performance) show it. [Connection Hold Time](https://grafana.prod-us.posthog.dev/d/feature-flags-performance/feature-flags-performance?viewPanel=24) filters on `pool="persons_reader"` and drops the writer slice it currently includes, which also makes its title accurate. [Pool Acquisition Timeouts](https://grafana.prod-us.posthog.dev/d/feature-flags-performance/feature-flags-performance?viewPanel=26) groups by pool and operation, so it gains a `persons_writer` series for this operation.

Context: PostHog/posthog#80026 changes which pool one of these callers reads from. This fix is what makes that change measurable.

## How did you test this code?

- `cargo fmt` and `cargo clippy -p feature-flags --all-targets -- -D warnings` pass.
- `cargo test -p feature-flags --lib`: 1598 pass, 13 fail, identical before and after the change.
- Those 13 are pre-existing. 12 need a local GeoIP file, and one fails on a missing `cohort_membership` relation.
- That baseline is not perfectly stable. `test_partial_property_overrides_fallback_behavior` fails intermittently on a duplicate distinct ID insert, in a file this PR does not touch. Read the result as no new failures rather than an exact count.
- No manual testing, and no runtime check that the emitted labels changed.
- No new tests. The change moves a metric label that nothing exposes through a public interface.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Opus 5). Skills used: `/writing-code-comments` and `/writing-pr-descriptions`.
- The function cannot tell which pool it was given, so the caller has to name it. That is why the parameter exists.
- Constants rather than a plain string, because the same file held 19 more pool-name literals and a wrong label fails no test.
- Each call site was labeled by reading the pool accessor above it. Inverting the conditional one would reintroduce the bug pointing the other way.
- Nothing in this PR comes from outside this repository.
