### PR TITLE
fix(desktop): render MCP app cards for Codex results

### DIFF
--- a/products/desktop/packages/agent/src/adapters/codex-app-server/mapping.test.ts
+++ b/products/desktop/packages/agent/src/adapters/codex-app-server/mapping.test.ts
@@ -670,6 +670,36 @@ describe("mapHistoryItem", () => {
     ]);
   });
 
+  it("replays an MCP app result with its UI metadata", () => {
+    const rawOutput = {
+      content: [{ type: "text", text: "Review this loop" }],
+      structuredContent: { name: "Nightly review" },
+      _meta: { ui: { resourceUri: "ui://posthog/loops-review.html" } },
+    };
+
+    expect(
+      mapHistoryItem("s-1", {
+        type: "mcpToolCall",
+        id: "m1",
+        server: "posthog",
+        tool: "exec",
+        status: "completed",
+        arguments: { command: "call loops-review {}" },
+        result: rawOutput,
+      }),
+    ).toEqual([
+      {
+        sessionId: "s-1",
+        update: expect.objectContaining({
+          sessionUpdate: "tool_call",
+          toolCallId: "m1",
+          status: "completed",
+          rawOutput,
+        }),
+      },
+    ]);
+  });
+
   it("replays a fileChange as a tool_call with diff content", () => {
     const [update] = mapHistoryItem("s-1", {
       type: "fileChange",
@@ -709,7 +739,13 @@ describe("parseUnifiedDiff", () => {
 });
 
 describe("mcpToolCall result rendering", () => {
-  it("renders a completed mcpToolCall's result content as text", () => {
+  it("preserves a completed MCP app result while rendering its text", () => {
+    const rawOutput = {
+      content: [{ type: "text", text: "42 rows" }],
+      structuredContent: { results: [{ value: 42 }] },
+      _meta: { ui: { resourceUri: "ui://posthog/query.html" } },
+    };
+
     expect(
       mapAppServerNotification("s-1", APP_SERVER_NOTIFICATIONS.ITEM_COMPLETED, {
         item: {
@@ -719,7 +755,7 @@ describe("mcpToolCall result rendering", () => {
           tool: "query",
           status: "completed",
           arguments: { sql: "SELECT 1" },
-          result: { content: [{ type: "text", text: "42 rows" }] },
+          result: rawOutput,
         },
       }),
     ).toEqual({
@@ -728,6 +764,7 @@ describe("mcpToolCall result rendering", () => {
         sessionUpdate: "tool_call_update",
         toolCallId: "m1",
         status: "completed",
+        rawOutput,
         content: [
           { type: "content", content: { type: "text", text: "42 rows" } },
         ],

--- a/products/desktop/packages/agent/src/adapters/codex-app-server/mapping.ts
+++ b/products/desktop/packages/agent/src/adapters/codex-app-server/mapping.ts
@@ -192,7 +192,11 @@ export type AppServerItem = {
   arguments?: unknown;
   aggregatedOutput?: string | null;
   changes?: Array<{ path?: string; diff?: string; kind?: unknown }>;
-  result?: { content?: unknown } | null;
+  result?: {
+    content?: unknown;
+    structuredContent?: unknown;
+    _meta?: unknown;
+  } | null;
   error?: { message?: string } | null;
   // Present on message/reasoning items replayed from thread history.
   text?: string;
@@ -304,6 +308,9 @@ export function mapHistoryItem(
             kind: tool.kind,
             status: mapStatus(item.status),
             ...(tool.rawInput !== undefined ? { rawInput: tool.rawInput } : {}),
+            ...(item.type === "mcpToolCall" && item.result != null
+              ? { rawOutput: item.result }
+              : {}),
             ...(tool.locations?.length ? { locations: tool.locations } : {}),
             ...(item.type === "collabAgentToolCall"
               ? {
@@ -554,6 +561,9 @@ function mapItem(
       sessionUpdate: "tool_call_update",
       toolCallId: item.id,
       status: mapStatus(item.status),
+      ...(item.type === "mcpToolCall" && item.result != null
+        ? { rawOutput: item.result }
+        : {}),
       ...(content ? { content } : {}),
     },
   };


### PR DESCRIPTION
## Problem

Desktop users running Codex do not see MCP App confirmation cards after PostHog `exec` calls.

The Codex adapter kept result text but dropped the structured content and UI metadata that select the card.

## Changes

- Desktop now renders interactive MCP App cards from completed Codex calls.
- The Codex adapter preserves raw MCP results during live updates and history replay.
- The card UI is unchanged; this fix restores its protocol data.

## How did you test this code?

- A focused mapping test guards against dropping MCP structured content and UI metadata.
- `pnpm --filter @posthog/agent exec vitest run src/adapters/codex-app-server/mapping.test.ts`
- `pnpm --filter @posthog/agent typecheck`
- Not verified: the full agent suite. The signed-commit guard blocks unrelated tests that create local commits.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation changes are needed for this bug fix.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex investigated the [PostHog task thread](https://us.posthog.com/code/channel/49f043ff-52a8-46be-8612-83e0f2d20d21/tasks/85819893-20b3-4454-8d48-a6189a55ef17) with shell tools, task-run logs, and public Codex protocol documentation.

Skills invoked: `/working-with-task-comments`, `/writing-tests`, and `/writing-pr-descriptions`. Test fixtures are synthetic and contain no task content.