### PR TITLE
fix(desktop): restore multi-repo selection on space new task

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/components/WebsiteNewTask.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/WebsiteNewTask.test.tsx
@@ -47,6 +47,8 @@ vi.mock("@posthog/ui/features/canvas/hooks/useTaskChannels", () => ({
         name: "project-bluebird",
         channel_type: "public",
         starred: false,
+        repositories: ["PostHog/posthog"],
+        github_integration: 7,
       },
     ],
   }),
@@ -126,11 +128,17 @@ describe("WebsiteNewTask context panel", () => {
     );
   });
 
-  it("uses the standard repository and branch selectors", () => {
+  it("passes the space's repository defaults so cloud tasks can span repos", () => {
     useFolderInstructions.mockReturnValue({ data: undefined });
     renderNewTask();
 
-    expect(taskInputProps.mock.lastCall?.[0]).not.toHaveProperty("allowNoRepo");
+    expect(taskInputProps).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        allowNoRepo: true,
+        channelRepositories: ["PostHog/posthog"],
+        channelGithubIntegration: 7,
+      }),
+    );
   });
 
   it("opens the context panel and tracks view_context when the chip is clicked", async () => {

--- a/products/desktop/packages/ui/src/features/canvas/components/WebsiteNewTask.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/WebsiteNewTask.tsx
@@ -146,9 +146,6 @@ export function WebsiteNewTask({ channelId }: { channelId: string }) {
           channelName={channelName}
           channelId={channelId}
           channelContextId={channelId}
-          // Cloud tasks filed into a space can span several repositories, so the
-          // composer offers the multi-repository chip there. In local mode
-          // TaskInput falls back to the repo + branch pickers a worktree needs.
           allowNoRepo
           channelRepositories={channel?.repositories}
           channelGithubIntegration={channel?.github_integration}

--- a/products/desktop/packages/ui/src/features/canvas/components/WebsiteNewTask.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/WebsiteNewTask.tsx
@@ -146,6 +146,12 @@ export function WebsiteNewTask({ channelId }: { channelId: string }) {
           channelName={channelName}
           channelId={channelId}
           channelContextId={channelId}
+          // Cloud tasks filed into a space can span several repositories, so the
+          // composer offers the multi-repository chip there. In local mode
+          // TaskInput falls back to the repo + branch pickers a worktree needs.
+          allowNoRepo
+          channelRepositories={channel?.repositories}
+          channelGithubIntegration={channel?.github_integration}
           // So a prompt handed to openTaskInput survives routing into a channel.
           initialPrompt={view.initialPrompt}
           initialPromptKey={view.taskInputRequestId}

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -142,9 +142,10 @@ interface TaskInputProps {
    */
   channelContextId?: string;
   /**
-   * Channels "generic chat box" mode: hide the repo/branch pickers and let the
-   * task be submitted without a repo. The agent decides at runtime whether it
-   * needs a repo and attaches one lazily.
+   * Channels "generic chat box" mode: in cloud mode, swap the repo/branch
+   * pickers for the multi-repository chip and let the task be submitted without
+   * a repo. The agent decides at runtime whether it needs a repo and attaches
+   * one lazily. Local mode keeps the repo + branch pickers a worktree needs.
    */
   allowNoRepo?: boolean;
   channelRepositories?: string[];
@@ -795,6 +796,12 @@ export function TaskInput({
 
   const effectiveWorkspaceMode = workspaceMode;
 
+  // Only cloud runs can span several repositories, so that's where the
+  // multi-repository chip belongs. A worktree run still needs one concrete
+  // checkout and a base branch, so it keeps the repo + branch pickers even on
+  // surfaces that opt into repo-optional mode.
+  const repoOptional = !!allowNoRepo && workspaceMode === "cloud";
+
   // Get current values from preview config options for task creation.
   // Defaults ensure values are always passed even before the preview config loads.
   const currentModel =
@@ -862,11 +869,11 @@ export function TaskInput({
   useWarmTask({
     workspaceMode,
     selectedRepository: selectedCloudRepository,
-    repositories: allowNoRepo ? taskRepositories : undefined,
-    githubIntegrationId: allowNoRepo
+    repositories: repoOptional ? taskRepositories : undefined,
+    githubIntegrationId: repoOptional
       ? (taskGithubIntegration ?? undefined)
       : orgGithubIntegrationId,
-    allowNoRepo,
+    allowNoRepo: repoOptional,
     branch: workspaceMode === "cloud" ? selectedBranch : null,
     editorIsEmpty,
     runtimeAdapter: adapter ?? null,
@@ -984,14 +991,12 @@ export function TaskInput({
   } = useTaskCreation({
     editorRef,
     sessionId,
-    selectedDirectory: allowNoRepo ? taskFolder : selectedDirectory,
+    selectedDirectory: repoOptional ? taskFolder : selectedDirectory,
     selectedRepository: selectedCloudRepository,
-    repositories:
-      allowNoRepo && workspaceMode === "cloud" ? taskRepositories : undefined,
-    githubIntegrationId:
-      allowNoRepo && workspaceMode === "cloud"
-        ? (taskGithubIntegration ?? undefined)
-        : undefined,
+    repositories: repoOptional ? taskRepositories : undefined,
+    githubIntegrationId: repoOptional
+      ? (taskGithubIntegration ?? undefined)
+      : undefined,
     githubUserIntegrationId: selectedGithubUserIntegrationId,
     workspaceMode: effectiveWorkspaceMode,
     branch: branchForTaskCreation,
@@ -1019,7 +1024,7 @@ export function TaskInput({
     channelName,
     channelId,
     channelContextId,
-    allowNoRepo,
+    allowNoRepo: repoOptional,
   });
 
   // Wraps the prompt in the autoresearch kickoff: protocol preamble first,
@@ -1293,7 +1298,7 @@ export function TaskInput({
                   onCustomImageChange={setSelectedCustomImageId}
                   size="1"
                 />
-                {allowNoRepo && (
+                {repoOptional && (
                   <TaskRepositoryChip
                     cloud={workspaceMode === "cloud"}
                     repositoryCount={taskRepositories.length}
@@ -1302,7 +1307,7 @@ export function TaskInput({
                     onOpen={() => setRepositoryDialogOpen(true)}
                   />
                 )}
-                {!allowNoRepo && workspaceMode === "worktree" && (
+                {!repoOptional && workspaceMode === "worktree" && (
                   <EnvironmentSelector
                     repoPath={effectiveRepoPath ?? null}
                     value={selectedEnvironment}
@@ -1315,7 +1320,7 @@ export function TaskInput({
                     }
                   />
                 )}
-                {!allowNoRepo && (
+                {!repoOptional && (
                   <ButtonGroup
                     ref={buttonGroupRef}
                     data-tour="folder-picker"
@@ -1405,7 +1410,7 @@ export function TaskInput({
                     />
                   </ButtonGroup>
                 )}
-                {!allowNoRepo && workspaceMode !== "cloud" && (
+                {!repoOptional && workspaceMode !== "cloud" && (
                   <AdditionalDirectoriesButton
                     values={additionalDirectories}
                     onChange={setAdditionalDirectories}
@@ -1656,7 +1661,7 @@ export function TaskInput({
         </Box>
       </Flex>
 
-      {allowNoRepo && (
+      {repoOptional && (
         <TaskRepositoryDialog
           open={repositoryDialogOpen}
           onOpenChange={setRepositoryDialogOpen}

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -796,10 +796,6 @@ export function TaskInput({
 
   const effectiveWorkspaceMode = workspaceMode;
 
-  // Only cloud runs can span several repositories, so that's where the
-  // multi-repository chip belongs. A worktree run still needs one concrete
-  // checkout and a base branch, so it keeps the repo + branch pickers even on
-  // surfaces that opt into repo-optional mode.
   const repoOptional = !!allowNoRepo && workspaceMode === "cloud";
 
   // Get current values from preview config options for task creation.


### PR DESCRIPTION
## Problem

The full-page space **New task** composer only lets you pick one repository. It shows "Select repository…" and a branch picker, so a cloud task that should span several repos in a space cannot be created from that screen. The space home composer still offers the multi-repository chip, so the two entry points disagree.

The chip disappeared when repo-optional mode was turned off for the whole screen in [#85923](https://github.com/PostHog/posthog/pull/85923)

## Changes

- The space New task page offers the multi-repository chip again in Cloud mode, so a task can carry several repos from the space's defaults.
- In Local mode the same page keeps the repository, branch, environment, and additional-directory controls a worktree run needs.
- Mechanical: `TaskInput` now derives a `repoOptional` flag from `allowNoRepo` plus the workspace mode, and gates the chip, dialog, and pickers on that instead of the raw prop.


