### PR TITLE
fix(ingestion-consumer): stop self-kill while deferred groups flush

### DIFF
--- a/rust/ingestion-consumer/src/config.rs
+++ b/rust/ingestion-consumer/src/config.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use common_continuous_profiling::ContinuousProfilingConfig;
 use envconfig::Envconfig;
 use rdkafka::ClientConfig;
@@ -6,6 +8,12 @@ use tracing::info;
 use crate::discovery::DiscoveryMode;
 use crate::kafka_config::ConsumerConfigBuilder;
 use crate::routing::RoutingStrategy;
+
+/// How often the consumer loop heartbeats the lifecycle handle while waiting on
+/// a bounded operation (a batch completing, a deferred flush draining). The
+/// heartbeat says the loop is still scheduled; whether the wait is making
+/// progress is bounded separately, by each wait's own timeout.
+pub const LIVENESS_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(10);
 
 /// Configuration for the ingestion consumer.
 ///

--- a/rust/ingestion-consumer/src/config.rs
+++ b/rust/ingestion-consumer/src/config.rs
@@ -162,6 +162,18 @@ pub struct Config {
     #[envconfig(default = "60000")]
     pub consumer_deferred_flush_timeout_ms: u64,
 
+    // ---- Consumer liveness ----
+    /// How long the consumer loop may go without a liveness heartbeat before
+    /// the lifecycle manager counts it as stalled (milliseconds).
+    #[envconfig(default = "60000")]
+    pub consumer_liveness_deadline_ms: u64,
+
+    /// Consecutive stalled health checks before the lifecycle manager shuts the
+    /// process down. Checks run every 5s, so this is the grace period on top of
+    /// `CONSUMER_LIVENESS_DEADLINE_MS` before a stalled loop exits the process.
+    #[envconfig(default = "3")]
+    pub consumer_stall_threshold: u32,
+
     /// Maximum Kafka batches to process concurrently. Matches the Node.js
     /// CONSUMER_MAX_BACKGROUND_TASKS setting used by the Kafka consumer wrapper.
     #[envconfig(from = "CONSUMER_MAX_BACKGROUND_TASKS", default = "1")]

--- a/rust/ingestion-consumer/src/config.rs
+++ b/rust/ingestion-consumer/src/config.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use common_continuous_profiling::ContinuousProfilingConfig;
 use envconfig::Envconfig;
 use rdkafka::ClientConfig;
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::discovery::DiscoveryMode;
 use crate::kafka_config::ConsumerConfigBuilder;
@@ -165,7 +165,14 @@ pub struct Config {
     // ---- Consumer liveness ----
     /// How long the consumer loop may go without a liveness heartbeat before
     /// the lifecycle manager counts it as stalled (milliseconds).
-    #[envconfig(default = "60000")]
+    ///
+    /// Must outlive `CONSUMER_DEFERRED_FLUSH_TIMEOUT_MS`, because a wedged
+    /// flush has two possible endings and only one of them is diagnosable: the
+    /// flush timeout fails the batch with a reason and replays from uncommitted
+    /// offsets, while the liveness monitor just exits the process. Whichever
+    /// fires first wins, so [`Config::consumer_liveness_deadline`] floors this
+    /// value rather than trusting the two numbers to stay ordered.
+    #[envconfig(default = "90000")]
     pub consumer_liveness_deadline_ms: u64,
 
     /// Consecutive stalled health checks before the lifecycle manager shuts the
@@ -410,6 +417,29 @@ impl Config {
         format!("{}:{}", self.bind_host, self.bind_port)
     }
 
+    /// Liveness deadline for the consumer component, floored so it always
+    /// outlives the deferred-flush timeout.
+    ///
+    /// The floor is that timeout plus two [`LIVENESS_HEARTBEAT_INTERVAL`]s:
+    /// one for how stale the loop's last heartbeat can already be when a flush
+    /// starts, one as scheduling margin. Under it, a flush that hits its own
+    /// timeout races the liveness monitor, and the process can exit before the
+    /// timeout turns the wedge into a batch error naming what was stuck.
+    pub fn consumer_liveness_deadline(&self) -> Duration {
+        let floor_ms = self
+            .consumer_deferred_flush_timeout_ms
+            .saturating_add(2 * LIVENESS_HEARTBEAT_INTERVAL.as_millis() as u64);
+        if self.consumer_liveness_deadline_ms < floor_ms {
+            warn!(
+                configured_ms = self.consumer_liveness_deadline_ms,
+                applied_ms = floor_ms,
+                deferred_flush_timeout_ms = self.consumer_deferred_flush_timeout_ms,
+                "CONSUMER_LIVENESS_DEADLINE_MS does not clear the deferred flush timeout; raising it"
+            );
+        }
+        Duration::from_millis(self.consumer_liveness_deadline_ms.max(floor_ms))
+    }
+
     pub fn worker_urls(&self) -> Vec<String> {
         self.worker_addresses
             .split(',')
@@ -477,5 +507,58 @@ impl Config {
         builder = builder.strip_classic_protocol_keys_if_consumer();
 
         builder.build()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+
+    fn config_with(overrides: &[(&str, &str)]) -> Config {
+        let env: HashMap<String, String> = overrides
+            .iter()
+            .map(|(key, value)| (key.to_string(), value.to_string()))
+            .collect();
+        Config::init_from_hashmap(&env).expect("config from defaults")
+    }
+
+    #[test]
+    fn liveness_deadline_clears_the_deferred_flush_timeout() {
+        // (flush timeout, configured deadline, expected deadline)
+        let cases = [
+            // Shipped defaults already clear the floor.
+            (None, None, 90_000),
+            // A deadline under the floor is raised to it.
+            (Some("60000"), Some("30000"), 80_000),
+            // A longer flush timeout raises the floor with it.
+            (Some("300000"), Some("90000"), 320_000),
+            // A deadline above the floor is left alone.
+            (Some("60000"), Some("600000"), 600_000),
+        ];
+
+        for (flush_timeout_ms, deadline_ms, expected_ms) in cases {
+            let mut overrides = Vec::new();
+            if let Some(value) = flush_timeout_ms {
+                overrides.push(("CONSUMER_DEFERRED_FLUSH_TIMEOUT_MS", value));
+            }
+            if let Some(value) = deadline_ms {
+                overrides.push(("CONSUMER_LIVENESS_DEADLINE_MS", value));
+            }
+            let config = config_with(&overrides);
+
+            assert_eq!(
+                config.consumer_liveness_deadline(),
+                Duration::from_millis(expected_ms),
+                "flush timeout {flush_timeout_ms:?}, deadline {deadline_ms:?}"
+            );
+            assert!(
+                config.consumer_liveness_deadline()
+                    > Duration::from_millis(config.consumer_deferred_flush_timeout_ms)
+                        + LIVENESS_HEARTBEAT_INTERVAL,
+                "deadline must outlive the flush timeout plus heartbeat staleness"
+            );
+        }
     }
 }

--- a/rust/ingestion-consumer/src/consumer.rs
+++ b/rust/ingestion-consumer/src/consumer.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, VecDeque};
+use std::future::Future;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -12,7 +13,7 @@ use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tracing::{error, info, warn};
 
-use crate::config::Config;
+use crate::config::{Config, LIVENESS_HEARTBEAT_INTERVAL};
 use crate::debug_recorder::{record_if, DebugEventKind, DebugRecorder, PartitionOffset};
 use crate::discovery::DiscoveryMode;
 use crate::dispatcher::{Dispatcher, EagerFlush, SubBatch};
@@ -350,14 +351,22 @@ impl IngestionConsumer {
             return Ok(());
         };
 
-        let batch_id = batch.batch_id.clone();
-        let mut processed = self.await_processed_batch(batch).await?;
+        let InFlightBatch { batch_id, handle } = batch;
+
+        // Both waits below run on the consumer loop and can hold it for many
+        // seconds on a saturated pool, reaching no other heartbeat site.
+        // `with_heartbeat` keeps the loop visibly scheduled so each wait's own
+        // bound — a batch error, the deferred flush timeout — decides the
+        // outcome instead of the liveness monitor exiting the process first.
+        let mut processed = self.with_heartbeat(handle).await??;
+        info!(batch_id = %batch_id, "Kafka batch processing completed");
 
         // Flush this batch's deferred groups (keys whose worker was draining/dead)
         // in order, re-routing them to healthy workers. Doing it here — serialized,
         // oldest batch first — preserves per-distinct_id order across batches. The
         // batch isn't committable until all its messages are accepted.
-        self.flush_deferred(&batch_id, &mut processed).await?;
+        self.with_heartbeat(self.flush_deferred(&batch_id, &mut processed))
+            .await?;
 
         if processed.total_accepted < processed.batch_size {
             anyhow::bail!(
@@ -390,21 +399,18 @@ impl IngestionConsumer {
         Ok(())
     }
 
-    async fn await_processed_batch(&self, batch: InFlightBatch) -> anyhow::Result<ProcessedBatch> {
-        let batch_id = batch.batch_id;
-        let mut handle = batch.handle;
-        let mut heartbeat = tokio::time::interval(Duration::from_secs(10));
-
+    /// Await `fut` while heartbeating the lifecycle handle every
+    /// [`LIVENESS_HEARTBEAT_INTERVAL`], for waits the consumer loop performs
+    /// inline. A wait that outlives the liveness deadline without a heartbeat
+    /// is read as a stalled loop and takes the process down, however healthy
+    /// the wait itself is.
+    async fn with_heartbeat<F: Future>(&self, fut: F) -> F::Output {
+        tokio::pin!(fut);
+        let mut heartbeat = tokio::time::interval(LIVENESS_HEARTBEAT_INTERVAL);
         loop {
             tokio::select! {
-                result = &mut handle => {
-                    let processed = result??;
-                    info!(batch_id = %batch_id, "Kafka batch processing completed");
-                    return Ok(processed);
-                }
-                _ = heartbeat.tick() => {
-                    self.handle.report_healthy();
-                }
+                output = &mut fut => return output,
+                _ = heartbeat.tick() => self.handle.report_healthy(),
             }
         }
     }

--- a/rust/ingestion-consumer/src/main.rs
+++ b/rust/ingestion-consumer/src/main.rs
@@ -103,7 +103,7 @@ async fn async_main(config: Config) -> Result<()> {
         "consumer",
         ComponentOptions::new()
             .with_graceful_shutdown(Duration::from_secs(60))
-            .with_liveness_deadline(Duration::from_millis(config.consumer_liveness_deadline_ms))
+            .with_liveness_deadline(config.consumer_liveness_deadline())
             .with_stall_threshold(config.consumer_stall_threshold),
     );
 

--- a/rust/ingestion-consumer/src/main.rs
+++ b/rust/ingestion-consumer/src/main.rs
@@ -103,8 +103,8 @@ async fn async_main(config: Config) -> Result<()> {
         "consumer",
         ComponentOptions::new()
             .with_graceful_shutdown(Duration::from_secs(60))
-            .with_liveness_deadline(Duration::from_secs(60))
-            .with_stall_threshold(3),
+            .with_liveness_deadline(Duration::from_millis(config.consumer_liveness_deadline_ms))
+            .with_stall_threshold(config.consumer_stall_threshold),
     );
 
     let metrics_handle =


### PR DESCRIPTION
## Problem

An ingestion consumer pod exits instead of waiting when the worker pool it feeds has no spare capacity.
The pod restarts, replays its uncommitted partitions into the same saturated pool, and adds lag to the lane it serves.

- The consumer loop waits inline while a completed batch's deferred groups re-route onto healthy workers.
- That wait reports no liveness heartbeat. Each send waits for a per-worker permit, retries 503s with backoff, and the loop sleeps 200ms between routing attempts.
- The lifecycle manager reads the silence as a stalled loop and shuts the process down.
- The wait has its own bound, `CONSUMER_DEFERRED_FLUSH_TIMEOUT_MS`, which was equal to the liveness deadline. The liveness kill won the race, so the batch error naming what was stuck never reached the logs.

## Changes

- A saturated pool now shows up as a consumer waiting, not as a restarting pod. `with_heartbeat` drives both inline waits in `complete_oldest_batch` and heartbeats every 10 seconds.
- A flush that genuinely cannot progress now fails its batch with a reason and replays from uncommitted offsets. The liveness deadline is floored at the flush timeout plus two heartbeat intervals, so the diagnosable path wins the race.
- `CONSUMER_LIVENESS_DEADLINE_MS` and `CONSUMER_STALL_THRESHOLD` now configure the consumer's health parameters, defaulting to 90000 and 3. A deadline below the floor is raised to it with a warning.
- The floor is derived from the flush timeout rather than hand-picked, so raising `CONSUMER_DEFERRED_FLUSH_TIMEOUT_MS` cannot silently reinstate the race.
- `CONSUMER_LOOP_STALL_THRESHOLD_MS` and `CONSUMER_LOOP_BASED_HEALTH_CHECK` are Node consumer settings. This binary has never read them, and this PR does not add them. Removing them from the charts is a separate change.
- Mechanical: `await_processed_batch` is gone. Its heartbeat ticker became the shared `with_heartbeat` helper.

## How did you test this code?

- One parameterized unit test in `rust/ingestion-consumer/src/config.rs` covers the floor. It catches a config change that puts the liveness deadline back at or under the deferred flush timeout, which is the ordering that made the process exit before the batch error.
- Ran in the flox environment, all scoped to `-p ingestion-consumer`: `cargo fmt --check`, `cargo clippy --all-targets`, `cargo test --lib`, `cargo build`.
- Not run: the crate's integration tests, which need Kafka on localhost and a live worker. No manual run against a running consumer.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tool: Claude Code. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- The heartbeat sits in a wrapper over both inline waits rather than in the retry loop alone. The loop's other waits, a per-worker semaphore permit and the transport's send retries, are unbounded or long enough to outlive the deadline on their own.
- The deadline invariant is a floor derived from the flush timeout, not two numbers picked to be ordered today. An operator raising the flush timeout carries the deadline with it.
- PR #85394 also edits `rust/ingestion-consumer/src/config.rs`. The field addition here is small and any conflict should be trivial.
- Public artifact: the diff, the comments, the commit messages, and this description carry nothing from the session that is not already public.
