### PR TITLE
feat(data-warehouse): read integer timestamp columns as unix epochs

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/menu/DwhFlow.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/DwhFlow.tsx
@@ -88,7 +88,8 @@ const ALLOWED_COLUMN_TYPES_BY_FIELD_KEY: Record<string, DatabaseSerializedFieldT
  *  `EDITABLE_FIELD_EXPLANATIONS` table. */
 const DEFAULT_FIELD_DESCRIPTIONS: Record<string, string> = {
     aggregation_target_field: 'Used to match people or groups across funnel steps.',
-    timestamp_field: 'Used to order step timing and apply the funnel date range. Integer columns are read as Unix timestamps.',
+    timestamp_field:
+        'Used to order step timing and apply the funnel date range. Integer columns are read as Unix timestamps.',
     id_field: 'Used as the unique row ID to detect duplicate records.',
     distinct_id_field: 'Used to associate this row with a person via distinct_id.',
 }

--- a/frontend/src/lib/components/TaxonomicFilter/menu/DwhFlow.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/DwhFlow.tsx
@@ -76,7 +76,7 @@ import { CommitFn, MenuFilterEntry, TaxonomicFilterGroup } from './types'
  *  the dropdowns surface the same options as the funnel popover. */
 const ALLOWED_COLUMN_TYPES_BY_FIELD_KEY: Record<string, DatabaseSerializedFieldType[]> = {
     aggregation_target_field: ['string'],
-    timestamp_field: ['datetime', 'date', 'string'],
+    timestamp_field: ['datetime', 'date', 'string', 'integer'],
     id_field: ['string', 'integer', 'decimal', 'float'],
     distinct_id_field: ['string'],
 }
@@ -88,7 +88,7 @@ const ALLOWED_COLUMN_TYPES_BY_FIELD_KEY: Record<string, DatabaseSerializedFieldT
  *  `EDITABLE_FIELD_EXPLANATIONS` table. */
 const DEFAULT_FIELD_DESCRIPTIONS: Record<string, string> = {
     aggregation_target_field: 'Used to match people or groups across funnel steps.',
-    timestamp_field: 'Used to order step timing and apply the funnel date range.',
+    timestamp_field: 'Used to order step timing and apply the funnel date range. Integer columns are read as Unix timestamps.',
     id_field: 'Used as the unique row ID to detect duplicate records.',
     distinct_id_field: 'Used to associate this row with a person via distinct_id.',
 }

--- a/frontend/src/scenes/insights/EditorFilters/FunnelDataWarehouseStepDefinitionPopover.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/FunnelDataWarehouseStepDefinitionPopover.tsx
@@ -18,7 +18,8 @@ import {
 
 const EDITABLE_FIELD_EXPLANATIONS: Record<FunnelFieldKey, string> = {
     aggregation_target_field: 'Used to match people or groups across funnel steps.',
-    timestamp_field: 'Used to order step timing and apply the funnel date range. Integer columns are read as Unix timestamps.',
+    timestamp_field:
+        'Used to order step timing and apply the funnel date range. Integer columns are read as Unix timestamps.',
     id_field: 'Used as the unique row ID to detect duplicate records.',
 }
 

--- a/frontend/src/scenes/insights/EditorFilters/FunnelDataWarehouseStepDefinitionPopover.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/FunnelDataWarehouseStepDefinitionPopover.tsx
@@ -18,7 +18,7 @@ import {
 
 const EDITABLE_FIELD_EXPLANATIONS: Record<FunnelFieldKey, string> = {
     aggregation_target_field: 'Used to match people or groups across funnel steps.',
-    timestamp_field: 'Used to order step timing and apply the funnel date range.',
+    timestamp_field: 'Used to order step timing and apply the funnel date range. Integer columns are read as Unix timestamps.',
     id_field: 'Used as the unique row ID to detect duplicate records.',
 }
 

--- a/frontend/src/scenes/insights/EditorFilters/funnelDataWarehouseStepDefinitionPopoverLogic.ts
+++ b/frontend/src/scenes/insights/EditorFilters/funnelDataWarehouseStepDefinitionPopoverLogic.ts
@@ -30,7 +30,7 @@ export type FunnelFieldKey = 'id_field' | 'timestamp_field' | 'aggregation_targe
 export const EDITABLE_FIELD_ORDER: FunnelFieldKey[] = ['aggregation_target_field', 'timestamp_field', 'id_field']
 const ALLOWED_COLUMN_TYPES_BY_FIELD_KEY: Record<FunnelFieldKey, DatabaseSerializedFieldType[]> = {
     aggregation_target_field: ['string'],
-    timestamp_field: ['datetime', 'date', 'string'],
+    timestamp_field: ['datetime', 'date', 'string', 'integer'],
     id_field: ['string', 'integer', 'decimal', 'float'],
 }
 const HIDDEN_FIELD_TYPES: DatabaseSerializedFieldType[] = ['lazy_table', 'virtual_table', 'view', 'materialized_view']

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -22,6 +22,7 @@ from posthog.hogql import ast
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.data_catalog_metrics import record_catalog_read, record_catalog_read_failure
 from posthog.hogql.database.direct_sql_table import DirectSQLTable
+from posthog.hogql.database.epoch_timestamps import epoch_to_datetime_expr, is_integer_clickhouse_type
 from posthog.hogql.database.lazy_join_tags import (
     DATA_WAREHOUSE,
     DATA_WAREHOUSE_EXPERIMENTS,
@@ -2055,6 +2056,11 @@ class Database(BaseModel):
                 else:
                     if modifier_timestamp_field_is_timestamp:
                         table.fields["timestamp"] = UnknownDatabaseField(name="timestamp")
+                    elif is_integer_clickhouse_type(timestamp_field_type):
+                        table.fields["timestamp"] = ExpressionField(
+                            name="timestamp",
+                            expr=epoch_to_datetime_expr(ast.Field(chain=[warehouse_modifier.timestamp_field])),
+                        )
                     else:
                         table.fields["timestamp"] = ExpressionField(
                             name="timestamp",

--- a/posthog/hogql/database/epoch_timestamps.py
+++ b/posthog/hogql/database/epoch_timestamps.py
@@ -1,0 +1,76 @@
+"""Reading integer warehouse columns as epoch timestamps.
+
+Sources routinely deliver time columns as raw epoch integers (Stripe and Clerk among
+them), and an integer column alone doesn't say whether it holds seconds, milliseconds,
+microseconds, or nanoseconds. The unit is recoverable from magnitude instead: for any
+timestamp between 1973 and 5138 the four units occupy disjoint bands, so each value can
+be converted by the band it falls in rather than by guessing a single unit up front.
+"""
+
+from posthog.hogql import ast
+from posthog.hogql.visitor import clone_expr
+
+# Band boundaries: 1e11 is 1973-03 in milliseconds but the year 5138 in seconds, and the
+# same thousand-fold relation separates each unit from the next one up.
+_MILLISECONDS_LOWER_BOUND = 100_000_000_000
+_MICROSECONDS_LOWER_BOUND = 100_000_000_000_000
+_NANOSECONDS_LOWER_BOUND = 100_000_000_000_000_000
+
+_INTEGER_CLICKHOUSE_TYPES = {
+    "Int8",
+    "Int16",
+    "Int32",
+    "Int64",
+    "Int128",
+    "Int256",
+    "UInt8",
+    "UInt16",
+    "UInt32",
+    "UInt64",
+    "UInt128",
+    "UInt256",
+}
+
+
+def is_integer_clickhouse_type(clickhouse_type: str | None) -> bool:
+    """Whether a ClickHouse column type string, optionally Nullable-wrapped, is an integer type."""
+    if clickhouse_type is None:
+        return False
+    unwrapped = clickhouse_type.strip()
+    if unwrapped.startswith("Nullable(") and unwrapped.endswith(")"):
+        unwrapped = unwrapped[len("Nullable(") : -1]
+    return unwrapped in _INTEGER_CLICKHOUSE_TYPES
+
+
+def epoch_to_datetime_expr(expr: ast.Expr) -> ast.Expr:
+    """Convert an integer epoch expression to a DateTime, picking the unit per value by magnitude.
+
+    Sub-second units are truncated to whole seconds with intDiv, which is enough for
+    insight bucketing and date range filters.
+    """
+
+    def _at_least(bound: int) -> ast.Expr:
+        return ast.CompareOperation(
+            op=ast.CompareOperationOp.GtEq,
+            left=clone_expr(expr),
+            right=ast.Constant(value=bound),
+        )
+
+    def _seconds_scaled_by(divisor: int) -> ast.Expr:
+        return ast.Call(
+            name="toDateTime",
+            args=[ast.Call(name="intDiv", args=[clone_expr(expr), ast.Constant(value=divisor)])],
+        )
+
+    return ast.Call(
+        name="multiIf",
+        args=[
+            _at_least(_NANOSECONDS_LOWER_BOUND),
+            _seconds_scaled_by(1_000_000_000),
+            _at_least(_MICROSECONDS_LOWER_BOUND),
+            _seconds_scaled_by(1_000_000),
+            _at_least(_MILLISECONDS_LOWER_BOUND),
+            _seconds_scaled_by(1_000),
+            ast.Call(name="toDateTime", args=[clone_expr(expr)]),
+        ],
+    )

--- a/posthog/hogql/database/test/test_epoch_timestamps.py
+++ b/posthog/hogql/database/test/test_epoch_timestamps.py
@@ -1,0 +1,37 @@
+from posthog.test.base import BaseTest, ClickhouseTestMixin
+
+from parameterized import parameterized
+
+from posthog.hogql import ast
+from posthog.hogql.database.epoch_timestamps import epoch_to_datetime_expr, is_integer_clickhouse_type
+from posthog.hogql.query import execute_hogql_query
+
+
+class TestEpochTimestamps(ClickhouseTestMixin, BaseTest):
+    @parameterized.expand(
+        [
+            ("int64", "Int64", True),
+            ("uint32", "UInt32", True),
+            ("nullable_int64", "Nullable(Int64)", True),
+            ("datetime", "DateTime64(3, 'UTC')", False),
+            ("nullable_string", "Nullable(String)", False),
+            ("interval", "IntervalSecond", False),
+            ("none", None, False),
+        ]
+    )
+    def test_is_integer_clickhouse_type(self, _name: str, clickhouse_type: str | None, expected: bool) -> None:
+        assert is_integer_clickhouse_type(clickhouse_type) is expected
+
+    def test_epoch_to_datetime_expr_reads_each_unit_as_the_same_instant(self) -> None:
+        seconds = 1_762_419_600  # 2025-11-06 09:00:00 UTC
+        select = ast.SelectQuery(
+            select=[
+                ast.Call(
+                    name="toUnixTimestamp",
+                    args=[epoch_to_datetime_expr(ast.Constant(value=seconds * scale))],
+                )
+                for scale in (1, 10**3, 10**6, 10**9)
+            ]
+        )
+        response = execute_hogql_query(query=select, team=self.team)
+        assert response.results == [(seconds, seconds, seconds, seconds)]

--- a/posthog/hogql_queries/insights/funnels/funnel_event_query.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_event_query.py
@@ -18,9 +18,11 @@ from posthog.schema import (
 )
 
 from posthog.hogql import ast
+from posthog.hogql.database.epoch_timestamps import epoch_to_datetime_expr
 from posthog.hogql.database.models import (
     DateDatabaseField,
     DateTimeDatabaseField,
+    IntegerDatabaseField,
     StringDatabaseField,
     UUIDDatabaseField,
 )
@@ -232,6 +234,8 @@ class FunnelEventQuery(DataWarehouseSchemaMixin):
             return ast.Call(
                 name="toDateTime", args=[ast.Field(chain=[self.EVENT_TABLE_ALIAS, table_entity.timestamp_field])]
             )
+        elif isinstance(field, IntegerDatabaseField):
+            return epoch_to_datetime_expr(ast.Field(chain=[self.EVENT_TABLE_ALIAS, table_entity.timestamp_field]))
         else:
             raise ValidationError(
                 detail=f"Unsupported timestamp field type for {table_entity.table_name}.{table_entity.timestamp_field}"

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_data_warehouse.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_data_warehouse.py
@@ -1,3 +1,5 @@
+import csv
+import tempfile
 from datetime import datetime
 from pathlib import Path
 
@@ -210,6 +212,51 @@ class TestFunnelDataWarehouse(ClickhouseTestMixin, BaseTest):
 
         results = response.results
         assert results[0]["count"] == 5
+        assert results[1]["count"] == 1
+
+    def test_funnels_data_warehouse_integer_timestamp_field(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            csv_path = Path(temp_dir) / "epoch_funnels_data.csv"
+            with open(csv_path, "w", newline="") as csv_file:
+                writer = csv.writer(csv_file)
+                writer.writerow(["uuid", "user_id", "created_ms"])
+                writer.writerows(
+                    [
+                        ["a-1", "user-1", 1762160400000],  # 2025-11-03 09:00:00 UTC
+                        ["a-2", "user-1", 1762246800000],  # 2025-11-04 09:00:00 UTC
+                        ["b-1", "user-2", 1762160400000],
+                    ]
+                )
+            table, _source, _credential, _df, self.cleanUpDataWarehouse = create_data_warehouse_table_from_csv(
+                csv_path=csv_path,
+                table_name="epoch_events",
+                table_columns={
+                    "uuid": {"clickhouse": "String", "hogql": "StringDatabaseField"},
+                    "user_id": {"clickhouse": "String", "hogql": "StringDatabaseField"},
+                    "created_ms": {"clickhouse": "Int64", "hogql": "IntegerDatabaseField"},
+                },
+                test_bucket=TEST_BUCKET,
+                team=self.team,
+            )
+
+        node = FunnelsDataWarehouseNode(
+            id=table.name,
+            table_name=table.name,
+            id_field="uuid",
+            aggregation_target_field="user_id",
+            timestamp_field="created_ms",
+        )
+        funnels_query = FunnelsQuery(
+            kind="FunnelsQuery",
+            dateRange=DateRange(date_from="2025-11-01"),
+            series=[node, node],
+        )
+
+        with freeze_time("2025-11-07"):
+            response = FunnelsQueryRunner(query=funnels_query, team=self.team, just_summarize=True).calculate()
+
+        results = response.results
+        assert results[0]["count"] == 2
         assert results[1]["count"] == 1
 
     def _days_of_week_trends_query(self, table_name: str, days_of_week: list[int] | None) -> FunnelsQuery:

--- a/posthog/hogql_queries/insights/lifecycle/lifecycle_query_runner.py
+++ b/posthog/hogql_queries/insights/lifecycle/lifecycle_query_runner.py
@@ -34,6 +34,7 @@ from posthog.clickhouse.query_tagging import tag_contains_user_hogql
 from posthog.hogql_queries.insights.lifecycle.lifecycle_validation_rules import (
     RequireLifecycleDataWarehouseSeriesForCustomAggregationTarget,
 )
+from posthog.hogql_queries.insights.utils.data_warehouse_schema_mixin import resolve_warehouse_field_or_none
 from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange, compare_interval_length
 from posthog.hogql_queries.utils.timestamp_utils import format_label_date, get_earliest_timestamp_from_series
@@ -314,7 +315,7 @@ class LifecycleQueryRunner(AnalyticsQueryRunner[LifecycleQueryResponse]):
     def timestamp_field(self) -> ast.Expr:
         if self.is_data_warehouse_series:
             series = self.data_warehouse_series
-            field = self._warehouse_database.get_table(series.table_name).fields.get(series.timestamp_field)
+            field = resolve_warehouse_field_or_none(self._warehouse_database, series.table_name, series.timestamp_field)
             if isinstance(field, IntegerDatabaseField):
                 return epoch_to_datetime_expr(ast.Field(chain=[series.timestamp_field]))
             # Not a plain integer column, so parse as HogQL to keep expression timestamp fields working.

--- a/posthog/hogql_queries/insights/lifecycle/lifecycle_query_runner.py
+++ b/posthog/hogql_queries/insights/lifecycle/lifecycle_query_runner.py
@@ -21,6 +21,9 @@ from posthog.schema import (
 )
 
 from posthog.hogql import ast
+from posthog.hogql.database.database import Database
+from posthog.hogql.database.epoch_timestamps import epoch_to_datetime_expr
+from posthog.hogql.database.models import IntegerDatabaseField
 from posthog.hogql.parser import parse_expr, parse_select
 from posthog.hogql.printer import to_printed_hogql
 from posthog.hogql.property import action_to_expr, property_to_expr
@@ -303,11 +306,20 @@ class LifecycleQueryRunner(AnalyticsQueryRunner[LifecycleQueryResponse]):
             raise ValueError("Expected a data warehouse series")
         return series
 
+    @cached_property
+    def _warehouse_database(self) -> Database:
+        return Database.create_for(team=self.team, user=self.user, modifiers=self.modifiers)
+
     @property
     def timestamp_field(self) -> ast.Expr:
         if self.is_data_warehouse_series:
+            series = self.data_warehouse_series
+            field = self._warehouse_database.get_table(series.table_name).fields.get(series.timestamp_field)
+            if isinstance(field, IntegerDatabaseField):
+                return epoch_to_datetime_expr(ast.Field(chain=[series.timestamp_field]))
+            # Not a plain integer column, so parse as HogQL to keep expression timestamp fields working.
             tag_contains_user_hogql()
-            return parse_expr(self.data_warehouse_series.timestamp_field)
+            return parse_expr(series.timestamp_field)
         return ast.Field(chain=["events", "timestamp"])
 
     @cached_property

--- a/posthog/hogql_queries/insights/lifecycle/test/test_lifecycle_data_warehouse.py
+++ b/posthog/hogql_queries/insights/lifecycle/test/test_lifecycle_data_warehouse.py
@@ -284,6 +284,92 @@ class TestLifecycleDataWarehouse(ClickhouseTestMixin, APIBaseTest):
 
                     self.assertEqual([[expected_name]], actors_response.results)
 
+    def test_lifecycle_data_warehouse_integer_timestamp_field(self):
+        person_ids = self._create_persons()
+
+        sent_messages_path = self._write_csv(
+            "sent_messages_epoch.csv",
+            ["user_id", "sent_at_ms", "text"],
+            [
+                [1, 1762506000000, "new"],  # 2025-11-07 09:00:00 UTC
+                [2, 1762419600000, "returning previous"],  # 2025-11-06 09:00:00 UTC
+                [2, 1762506000000, "returning current"],
+                [3, 1762506000000, "resurrecting"],
+                [4, 1762419600000, "dormant"],
+            ],
+        )
+        users_path = self._write_csv(
+            "users_epoch.csv",
+            ["id", "signed_up", "person_id"],
+            [
+                [1, "2025-11-07 08:00:00", person_ids[1]],
+                [2, "2025-11-06 08:00:00", person_ids[2]],
+                [3, "2025-11-06 08:00:00", person_ids[3]],
+                [4, "2025-11-06 08:00:00", person_ids[4]],
+            ],
+        )
+
+        sent_messages_table, source, credential, _df, sent_messages_cleanup = create_data_warehouse_table_from_csv(
+            csv_path=sent_messages_path,
+            table_name="sent_messages_epoch",
+            table_columns={
+                "user_id": "Int64",
+                "sent_at_ms": "Int64",
+                "text": "String",
+            },
+            test_bucket=TEST_BUCKET,
+            team=self.team,
+        )
+        self.cleanup_fns.append(sent_messages_cleanup)
+
+        users_table, _source, _credential, _df, users_cleanup = create_data_warehouse_table_from_csv(
+            csv_path=users_path,
+            table_name="users_epoch",
+            table_columns={
+                "id": "Int64",
+                "signed_up": "DateTime64(3, 'UTC')",
+                "person_id": "UUID",
+            },
+            test_bucket=TEST_BUCKET,
+            team=self.team,
+            source=source,
+            credential=credential,
+        )
+        self.cleanup_fns.append(users_cleanup)
+
+        DataWarehouseJoin.objects.create(
+            team=self.team,
+            source_table_name=sent_messages_table.name,
+            source_table_key="user_id",
+            joining_table_name=users_table.name,
+            joining_table_key="id",
+            field_name="users",
+        )
+
+        with freeze_time("2025-11-07T12:00:00Z"):
+            query = LifecycleQuery(
+                dateRange=DateRange(date_from="-1d"),
+                interval=IntervalType.DAY,
+                series=[
+                    LifecycleDataWarehouseNode(
+                        id=sent_messages_table.name,
+                        table_name=sent_messages_table.name,
+                        timestamp_field="sent_at_ms",
+                        aggregation_target_field="users.person_id",
+                        created_at_field="users.signed_up",
+                    )
+                ],
+            )
+            response = LifecycleQueryRunner(team=self.team, query=query).calculate()
+
+        results_by_status = {result["status"]: result for result in response.results}
+
+        self.assertEqual(["2025-11-06", "2025-11-07"], results_by_status["new"]["days"])
+        self.assertEqual([2.0, 1.0], results_by_status["new"]["data"])
+        self.assertEqual([0.0, 1.0], results_by_status["returning"]["data"])
+        self.assertEqual([0.0, 1.0], results_by_status["resurrecting"]["data"])
+        self.assertEqual([0.0, -1.0], results_by_status["dormant"]["data"])
+
     def test_lifecycle_data_warehouse_group_aggregation_target(self):
         """Data warehouse source matching a group aggregation target."""
         table_name = self._setup_group_data_warehouse()

--- a/posthog/hogql_queries/insights/retention/retention_base_query_builder.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_builder.py
@@ -16,7 +16,7 @@ from posthog.hogql.property import entity_to_expr, property_to_expr
 
 from posthog.clickhouse.query_tagging import tag_contains_user_hogql
 from posthog.hogql_queries.insights.retention.utils import breakdown_extract_expr
-from posthog.hogql_queries.insights.utils.data_warehouse_schema_mixin import resolve_warehouse_field
+from posthog.hogql_queries.insights.utils.data_warehouse_schema_mixin import resolve_warehouse_field_or_none
 
 if TYPE_CHECKING:
     from posthog.schema import RetentionEntity, RetentionQuery
@@ -79,7 +79,9 @@ class RetentionBaseQueryBuilder(ABC):
             if not entity.table_name or not entity.timestamp_field:
                 # ValidationError so a half-configured entity surfaces as HTTP 400; a bare ValueError becomes a 500.
                 raise ValidationError("A data warehouse retention series requires table_name and timestamp_field.")
-            field = resolve_warehouse_field(self.runner.warehouse_database, entity.table_name, entity.timestamp_field)
+            field = resolve_warehouse_field_or_none(
+                self.runner.warehouse_database, entity.table_name, entity.timestamp_field
+            )
             if isinstance(field, IntegerDatabaseField):
                 return epoch_to_datetime_expr(ast.Field(chain=[entity.table_name, entity.timestamp_field]))
             return ast.Field(chain=[entity.table_name, entity.timestamp_field])

--- a/posthog/hogql_queries/insights/retention/retention_base_query_builder.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_builder.py
@@ -9,11 +9,14 @@ from rest_framework.exceptions import ValidationError
 from posthog.schema import EntityType
 
 from posthog.hogql import ast
+from posthog.hogql.database.epoch_timestamps import epoch_to_datetime_expr
+from posthog.hogql.database.models import IntegerDatabaseField
 from posthog.hogql.parser import parse_expr
 from posthog.hogql.property import entity_to_expr, property_to_expr
 
 from posthog.clickhouse.query_tagging import tag_contains_user_hogql
 from posthog.hogql_queries.insights.retention.utils import breakdown_extract_expr
+from posthog.hogql_queries.insights.utils.data_warehouse_schema_mixin import resolve_warehouse_field
 
 if TYPE_CHECKING:
     from posthog.schema import RetentionEntity, RetentionQuery
@@ -76,6 +79,9 @@ class RetentionBaseQueryBuilder(ABC):
             if not entity.table_name or not entity.timestamp_field:
                 # ValidationError so a half-configured entity surfaces as HTTP 400; a bare ValueError becomes a 500.
                 raise ValidationError("A data warehouse retention series requires table_name and timestamp_field.")
+            field = resolve_warehouse_field(self.runner.warehouse_database, entity.table_name, entity.timestamp_field)
+            if isinstance(field, IntegerDatabaseField):
+                return epoch_to_datetime_expr(ast.Field(chain=[entity.table_name, entity.timestamp_field]))
             return ast.Field(chain=[entity.table_name, entity.timestamp_field])
         return ast.Field(chain=["events", "timestamp"])
 

--- a/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
@@ -498,9 +498,12 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
 
         actor_field = self.coerce_actor_id_expr(self.entity_actor_id_expr(entity))
 
-        timestamp_column_name = entity.timestamp_field if entity_is_dwh else "timestamp"
-        assert timestamp_column_name
-        timestamp_field = ast.Field(chain=[timestamp_column_name])
+        timestamp_field: ast.Expr
+        if entity_is_dwh:
+            # Routes through the shared resolver so integer epoch columns get converted.
+            timestamp_field = self.entity_timestamp_field(entity)
+        else:
+            timestamp_field = ast.Field(chain=["timestamp"])
 
         start_of_interval_sql = self.query_date_range.get_start_of_interval_hogql(source=timestamp_field)
         entity_expr = self._get_dwh_retention_entity_expr(entity=entity, legacy_entity_expr=legacy_entity_expr)

--- a/posthog/hogql_queries/insights/retention/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/retention_query_runner.py
@@ -27,6 +27,7 @@ from posthog.hogql.constants import (
     LimitContext,
     get_breakdown_limit_for_context,
 )
+from posthog.hogql.database.database import Database
 from posthog.hogql.parser import parse_expr, parse_select
 from posthog.hogql.printer import to_printed_hogql
 from posthog.hogql.property import entity_to_expr, property_to_expr
@@ -152,6 +153,10 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
             DisallowUnsupportedDataWarehouseSettings(),
             DisallowUnsupportedDataWarehouseTimestampField(),
         )
+
+    @cached_property
+    def warehouse_database(self) -> Database:
+        return Database.create_for(team=self.team, user=self.user, modifiers=self.modifiers)
 
     @cached_property
     def property_aggregation_expr(self) -> ast.Expr | None:

--- a/posthog/hogql_queries/insights/retention/retention_validation_rules.py
+++ b/posthog/hogql_queries/insights/retention/retention_validation_rules.py
@@ -3,7 +3,7 @@ from rest_framework.exceptions import ValidationError
 from posthog.schema import AggregationType, EntityType, RetentionQuery
 
 from posthog.hogql.database.database import Database
-from posthog.hogql.database.models import DateDatabaseField, DateTimeDatabaseField
+from posthog.hogql.database.models import DateDatabaseField, DateTimeDatabaseField, IntegerDatabaseField
 
 from posthog.hogql_queries.insights.utils.breakdowns import has_breakdown_filter
 from posthog.hogql_queries.insights.utils.data_warehouse_schema_mixin import resolve_warehouse_field
@@ -72,8 +72,9 @@ class DisallowUnsupportedDataWarehouseTimestampField:
     cannot be a datetime fails deep inside ClickHouse, quoting generated SQL the user never wrote. Resolving
     the column type up front turns that into a 400 naming the column they picked.
 
-    An integer is rejected rather than converted because it could hold seconds, milliseconds or microseconds
-    since the epoch, and guessing wrong shifts every bucket instead of failing."""
+    Integer columns are accepted and read as Unix epochs: the query builder picks seconds, milliseconds,
+    microseconds, or nanoseconds per value by magnitude (see epoch_to_datetime_expr), so no single unit
+    has to be guessed."""
 
     code = "retention_data_warehouse_timestamp_field_unsupported"
 
@@ -93,11 +94,11 @@ class DisallowUnsupportedDataWarehouseTimestampField:
                 # A half-configured entity raises its own error while building the query.
                 continue
             field = resolve_warehouse_field(database, entity.table_name, entity.timestamp_field)
-            if not isinstance(field, DateTimeDatabaseField | DateDatabaseField):
+            if not isinstance(field, DateTimeDatabaseField | DateDatabaseField | IntegerDatabaseField):
                 raise ValidationError(
                     f"{entity.table_name}.{entity.timestamp_field} can't be used as the retention timestamp, "
-                    "because it isn't a date or datetime column. Pick a different column, "
-                    "or convert this one in a saved query first.",
+                    "because it isn't a date, datetime, or integer (Unix timestamp) column. Pick a different "
+                    "column, or convert this one in a saved query first.",
                     code=self.code,
                 )
 

--- a/posthog/hogql_queries/insights/retention/test/test_retention_data_warehouse.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_data_warehouse.py
@@ -277,20 +277,42 @@ class TestRetentionDataWarehouse(ClickhouseTestMixin, APIBaseTest):
 
     @parameterized.expand(
         [
-            ("integer", "Int64", [1735722000, 1735725600, 1735815600, 1735905600]),
-            (
-                "string",
-                "String",
-                ["2025-01-01 09:00:00", "2025-01-01 10:00:00", "2025-01-02 12:00:00", "2025-01-03 12:00:00"],
-            ),
+            ("seconds", [1735722000, 1735725600, 1735815600, 1735905600]),
+            ("milliseconds", [1735722000000, 1735725600000, 1735815600000, 1735905600000]),
         ]
     )
-    def test_non_datetime_timestamp_field_is_rejected(self, _name: str, column_type: str, occurred_at: list[object]):
-        # Both types reach toStartOfInterval and fail inside ClickHouse without this check, quoting
-        # generated SQL rather than naming the column the user picked.
-        table = self._activity_table_with_timestamp_type(column_type, occurred_at)
+    def test_integer_timestamp_field_is_read_as_unix_epoch(self, _name: str, occurred_at: list[object]):
+        # Same instants as the datetime fixtures: signups on 2025-01-01, renewals on 01-02 and 01-03.
+        table = self._activity_table_with_timestamp_type("Int64", occurred_at)
 
-        with self.assertRaisesMessage(ValidationError, "isn't a date or datetime column"):
+        result = self.run_query(
+            query={
+                "dateRange": {"date_from": "2025-01-01T00:00:00Z", "date_to": "2025-01-05T00:00:00Z"},
+                "retentionFilter": self._activity_retention_filter(table),
+            }
+        )
+
+        self.assertEqual(
+            pluck(result, "values", "count"),
+            pad(
+                [
+                    [2, 1, 1, 0],
+                    [0, 0, 0],
+                    [0, 0],
+                    [0],
+                    [0],
+                ]
+            ),
+        )
+
+    def test_non_datetime_timestamp_field_is_rejected(self):
+        # A string reaches toStartOfInterval and fails inside ClickHouse without this check, quoting
+        # generated SQL rather than naming the column the user picked.
+        table = self._activity_table_with_timestamp_type(
+            "String", ["2025-01-01 09:00:00", "2025-01-01 10:00:00", "2025-01-02 12:00:00", "2025-01-03 12:00:00"]
+        )
+
+        with self.assertRaisesMessage(ValidationError, "isn't a date, datetime, or integer (Unix timestamp) column"):
             self.run_query(
                 query={
                     "dateRange": {"date_from": "2025-01-01T00:00:00Z", "date_to": "2025-01-05T00:00:00Z"},

--- a/posthog/hogql_queries/insights/trends/test/test_trends_data_warehouse_query.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_data_warehouse_query.py
@@ -1,3 +1,5 @@
+import csv
+import tempfile
 from datetime import datetime
 from pathlib import Path
 
@@ -96,6 +98,57 @@ class TestTrendsDataWarehouseQuery(ClickhouseTestMixin, BaseTest):
             timings=timings,
             modifiers=modifiers,
         )
+
+    def setup_epoch_data_warehouse(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            csv_path = Path(temp_dir) / "epoch_trends_data.csv"
+            with open(csv_path, "w", newline="") as csv_file:
+                writer = csv.writer(csv_file)
+                writer.writerow(["id", "created_s", "created_ms"])
+                writer.writerows(
+                    [
+                        ["1", 1672531200, 1672531200000],  # 2023-01-01 00:00:00 UTC
+                        ["2", 1672531200, 1672531200000],
+                        ["3", 1672617600, 1672617600000],  # 2023-01-02 00:00:00 UTC
+                        ["4", 1672704000, 1672704000000],  # 2023-01-03 00:00:00 UTC
+                    ]
+                )
+            table, _source, _credential, _df, self.cleanUpDataWarehouse = create_data_warehouse_table_from_csv(
+                csv_path=csv_path,
+                table_name="epoch_table",
+                table_columns={
+                    "id": {"clickhouse": "String", "hogql": "StringDatabaseField"},
+                    "created_s": {"clickhouse": "Int64", "hogql": "IntegerDatabaseField"},
+                    "created_ms": {"clickhouse": "Int64", "hogql": "IntegerDatabaseField"},
+                },
+                test_bucket=TEST_BUCKET,
+                team=self.team,
+            )
+
+        return table.name
+
+    @parameterized.expand([("seconds", "created_s"), ("milliseconds", "created_ms")])
+    def test_trends_data_warehouse_integer_timestamp_field(self, _name: str, timestamp_field: str) -> None:
+        table_name = self.setup_epoch_data_warehouse()
+
+        trends_query = TrendsQuery(
+            kind="TrendsQuery",
+            dateRange=DateRange(date_from="2023-01-01"),
+            series=[
+                DataWarehouseNode(
+                    id=table_name,
+                    table_name=table_name,
+                    id_field="id",
+                    timestamp_field=timestamp_field,
+                    distinct_id_field="id",
+                )
+            ],
+        )
+
+        with freeze_time("2023-01-07"):
+            response = TrendsQueryRunner(team=self.team, query=trends_query).calculate()
+
+        assert response.results[0]["data"] == [2, 1, 1, 0, 0, 0, 0]
 
     def setup_data_warehouse(self):
         table, _source, _credential, _df, self.cleanUpDataWarehouse = create_data_warehouse_table_from_csv(

--- a/posthog/hogql_queries/insights/utils/data_warehouse_schema_mixin.py
+++ b/posthog/hogql_queries/insights/utils/data_warehouse_schema_mixin.py
@@ -2,6 +2,7 @@ from rest_framework.exceptions import ValidationError
 
 from posthog.hogql.database.database import Database
 from posthog.hogql.database.models import DatabaseField, Table
+from posthog.hogql.errors import QueryError
 
 from posthog.hogql_queries.insights.query_context import QueryContextProtocol
 
@@ -15,6 +16,19 @@ def resolve_warehouse_field(database: Database, table_name: str, field_name: str
         raise ValidationError(detail=f"{table_name}.{field_name} points to a table, not a field")
     assert isinstance(field, DatabaseField)
     return field
+
+
+def resolve_warehouse_field_or_none(database: Database, table_name: str, field_name: str) -> DatabaseField | None:
+    """Best-effort variant of resolve_warehouse_field, so callers that only want to inspect a
+    column's type can leave error surfacing for unresolvable configs to their existing paths."""
+    try:
+        table = database.get_table(table_name)
+    except QueryError:
+        return None
+    if not isinstance(table, Table):
+        return None
+    field = table.fields.get(field_name)
+    return field if isinstance(field, DatabaseField) else None
 
 
 class DataWarehouseSchemaMixin(QueryContextProtocol):


### PR DESCRIPTION
## Problem

A team whose warehouse table stores time as epoch integers cannot use that table in insights. Stripe, Clerk, RevenueCat, and many custom sources deliver time columns this way, and a large share of connected warehouse tables have no other time column.

- The timestamp field picker hides integer columns, so the table dead-ends into a raw SQL expression input with no guidance.
- Trends and stickiness cast the column with a bare `toDateTime`, which reads epoch milliseconds as the year ~56000 and silently draws empty charts.
- Funnels and retention reject the column with a 400. Lifecycle fails with a raw ClickHouse `ILLEGAL_TYPE_OF_ARGUMENT` error.

Sized in an internal telemetry review (thread in the data-warehouse-improvements channel); most affected teams today work around it with hand-written `fromUnixTimestamp` views.

## Changes

- Users can now pick an integer column as a warehouse timestamp field in trends, stickiness, funnels, lifecycle, and retention.
- Each value converts by magnitude: seconds, milliseconds, microseconds, or nanoseconds. Every unit is unambiguous for timestamps between 1973 and 5138. `epoch_to_datetime_expr` in `posthog/hogql/database/epoch_timestamps.py` builds the expression.
- Trends and stickiness now chart epoch-millisecond columns on the correct dates (previously silently wrong via `toDateTime`).
- Lifecycle and retention resolve the column type best-effort: integer columns convert, unresolvable configs keep their previous error paths.
- Retention accepts integer timestamp fields. Its rejection message for remaining unsupported types now names integers as allowed.
- Mechanical: picker allow-lists and field description strings in `DwhFlow` and the legacy funnel popover.

> [!NOTE]
> Sub-second precision truncates to whole seconds (`intDiv`), which insight bucketing and range filters do not use.

No screenshot: the visible change adds integer columns to the existing timestamp-field dropdown; rendering it needs a running app with a seeded warehouse table, which this session could not do.

## How did you test this code?

New automated tests, one per previously broken path:

- `test_epoch_timestamps.py` executes the conversion in ClickHouse for the same instant in all four units; catches any boundary or simplification regression.
- Trends: parameterized seconds + milliseconds; milliseconds previously bucketed as year ~56000 and returned zero counts.
- Funnels: integer timestamp funnel completes; previously a 400 "Unsupported timestamp field type".
- Lifecycle: integer timestamp series returns correct statuses; previously a raw ClickHouse type error.
- Retention: integer seconds + milliseconds produce the correct retention matrix (previously rejected); a string column is still rejected with the updated message.

All new tests and the full touched suites (warehouse tests for the four insights, `test_database.py`, the retention builder suites) pass locally against the dev stack. The retention tests caught a second unconverted path, the fixed-interval single-scan builder, fixed in 10f6f1a. Repo-wide mypy, the frontend TypeScript check, and `hogli ci:preflight --fix` are clean locally. Not run locally: suites outside the touched paths; CI covers them.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No doc names the allowed timestamp-field column types; none updated.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Driven by Thomas Obermueller; assignee not set because no verified GitHub handle was available in this session.
- Authored in a Claude Code cloud task. The sizing investigation used PostHog MCP aggregate telemetry; no customer data appears in code, fixtures, or this description. Fixture data is invented.
- Skills invoked: /writing-tests, /writing-user-facing-copy, /writing-code-comments, /writing-pr-descriptions.
- Design decision: per-value magnitude detection instead of a user-selected unit setting; it needs no schema change and resolves the unit ambiguity that retention's validation previously rejected integers over.
- Branch not updated from master in-session (the update-branch tool was denied); use "Update branch" if CI needs it.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
