### PR TITLE
chore(logs): hide the list/grid toggle on the services tab

### DIFF
--- a/products/logs/frontend/components/LogsServices/LogsServicesV2.tsx
+++ b/products/logs/frontend/components/LogsServices/LogsServicesV2.tsx
@@ -1,11 +1,10 @@
 import { useActions, useValues } from 'kea'
 
-import { LemonBanner, LemonInput, LemonSegmentedButton, LemonSelect } from '@posthog/lemon-ui'
-import type { LemonSegmentedButtonOption } from '@posthog/lemon-ui'
+import { LemonBanner, LemonInput, LemonSelect } from '@posthog/lemon-ui'
 
 import { humanFriendlyNumber } from 'lib/utils/numbers'
 
-import { logsServicesLogic, ServicesViewMode } from './logsServicesLogic'
+import { logsServicesLogic } from './logsServicesLogic'
 import { ServicesList } from './ServicesList'
 
 const DATE_OPTIONS = [
@@ -13,11 +12,6 @@ const DATE_OPTIONS = [
     { value: '-24h', label: 'Last 24 hours' },
     { value: '-7d', label: 'Last 7 days' },
     { value: '-30d', label: 'Last 30 days' },
-]
-
-const VIEW_MODE_OPTIONS: LemonSegmentedButtonOption<ServicesViewMode>[] = [
-    { value: 'list', label: 'List', 'data-attr': 'logs-services-view-mode-list' },
-    { value: 'grid', label: 'Grid', 'data-attr': 'logs-services-view-mode-grid' },
 ]
 
 function ServicesGrid(): JSX.Element {
@@ -31,7 +25,7 @@ function ServicesGrid(): JSX.Element {
 export function LogsServicesV2(): JSX.Element {
     const { sortedServices, services, totalServices, servicesDataLoading, searchTerm, dateFrom, viewMode } =
         useValues(logsServicesLogic)
-    const { setDateFrom, setSearchTerm, setViewMode } = useActions(logsServicesLogic)
+    const { setDateFrom, setSearchTerm } = useActions(logsServicesLogic)
 
     return (
         <div className="flex flex-col gap-2 py-2 flex-1 min-h-0">
@@ -42,28 +36,20 @@ export function LogsServicesV2(): JSX.Element {
                     {searchTerm ? 'Refine your search to see the rest.' : 'Use search to find the rest.'}
                 </LemonBanner>
             )}
-            <div className="flex items-center justify-between gap-2">
-                <LemonSegmentedButton
+            <div className="flex items-center justify-end gap-2">
+                <LemonInput
                     size="small"
-                    value={viewMode}
-                    onChange={setViewMode}
-                    options={VIEW_MODE_OPTIONS}
+                    type="search"
+                    placeholder="Search services"
+                    value={searchTerm}
+                    onChange={setSearchTerm}
                 />
-                <div className="flex items-center gap-2">
-                    <LemonInput
-                        size="small"
-                        type="search"
-                        placeholder="Search services"
-                        value={searchTerm}
-                        onChange={setSearchTerm}
-                    />
-                    <LemonSelect
-                        size="small"
-                        value={dateFrom}
-                        onChange={(value) => value && setDateFrom(value)}
-                        options={DATE_OPTIONS}
-                    />
-                </div>
+                <LemonSelect
+                    size="small"
+                    value={dateFrom}
+                    onChange={(value) => value && setDateFrom(value)}
+                    options={DATE_OPTIONS}
+                />
             </div>
             {/* The scene container is a fixed height and does not scroll, so this region has to. */}
             <div className="flex-1 min-h-0 overflow-y-auto" data-attr="logs-services-v2">


### PR DESCRIPTION
## Problem

The Services tab in Logs offered a List/Grid toggle, but grid view was never built. Anyone who picked Grid lost their services table and got the placeholder text "Grid view is not built yet. Switch to List to see your services."

## Changes

- The List/Grid toggle no longer appears on the Services tab. Search and the date range stay where they were, right-aligned above the table.
- Grid scaffolding stays in place: the `viewMode` reducer, the `setViewMode` action, and the `ServicesGrid` placeholder are untouched, so re-adding the button is all it takes to resume the work. The reducer defaults to `list` and nothing sets it now, so the grid branch is unreachable.
- Mechanical: removed the toggle's options const and its now-unused imports, and collapsed a wrapper div that had one child left.

**Before**

![before](https://raw.githubusercontent.com/PostHog/pr-assets/4b9b2db22cab38e23d74c9cf50a37c141f6f2b42/2026/08/e295b622-d8f7-486f-92a5-8a50c01d94f7.png)

**After**

![after](https://raw.githubusercontent.com/PostHog/pr-assets/91bf86995b3be5e55d1994e8566eb500dcea3caa/2026/08/64b69013-06f0-4b08-b5be-b768fc2fe836.png)

## How did you test this code?

No new tests — the change removes a control and adds no behavior worth a regression test.

The screenshots above are the verification: the `Scenes-App/Logs → LogsSceneServicesTabV2` story rendered in a local Storybook, captured before and after the change. The services table renders identically.

Existing `products/logs/frontend/components/LogsServices` Jest suites were run locally and pass; CI reports those with more authority.

Not checked: the change was not exercised against a live PostHog instance, only Storybook with its mocked services API.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no documented behavior changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code (Opus) in PostHog Desktop. No repo skills applied — the change is a plain component edit outside the mandatory-skill areas.

One decision worth flagging for review: the alternative was deleting grid mode outright, including `ServicesViewMode`, the reducer, and the placeholder component. Hiding the button was chosen instead so the scaffolding survives for whoever builds grid view.
