### PR TITLE
feat(redshift-batch-export): Backend integration support

### DIFF
--- a/posthog/api/integration.py
+++ b/posthog/api/integration.py
@@ -792,10 +792,12 @@ class IntegrationSerializer(serializers.ModelSerializer, UserAccessControlSerial
                 redshift_integration: (
                     type[RedshiftIntegration] | type[AWSRedshiftIntegration] | type[AWSRedshiftRoleBasedIntegration]
                 ) = AWSRedshiftRoleBasedIntegration
+            elif any(required in config for required in ("aws_access_key_id", "aws_secret_access_key")):
+                # Checked before the plain-server keys: AWS-credential configs also carry
+                # 'user' (the database user to obtain temporary credentials for).
+                redshift_integration = AWSRedshiftIntegration
             elif any(required in config for required in ("host", "port", "user", "password")):
                 redshift_integration = RedshiftIntegration
-            elif any(required in config for required in ("aws_access_key_id", "aws_secret_access_key")):
-                redshift_integration = AWSRedshiftIntegration
             else:
                 raise ValidationError("Missing required inputs")
 

--- a/posthog/models/integration/aws.py
+++ b/posthog/models/integration/aws.py
@@ -1,8 +1,11 @@
 """AWS role/credential-based integrations (S3, Redshift, S3-compatible endpoints)."""
 
+import re
+import json
 from collections.abc import Mapping
-from typing import ClassVar, Literal
+from typing import Any, ClassVar, Literal
 
+from django.conf import settings
 from django.db import transaction
 
 from rest_framework.exceptions import ValidationError
@@ -36,13 +39,14 @@ def _create_unique_aws_integration(
     account_id: str,
     credentials: AWSKeyPair,
     created_by: "User | None",
+    **extra,
 ) -> model.Integration:
     """Create an AWS integration from credentials and an account."""
     return _create_unique_named_integration(
         team_id=team_id,
         kind=kind,
         name=name,
-        config={"name": name, "aws_account_id": account_id},
+        config={"name": name, "aws_account_id": account_id, **extra},
         sensitive_config={
             "aws_access_key_id": credentials.access_key_id,
             "aws_secret_access_key": credentials.secret_access_key,
@@ -116,6 +120,68 @@ def _return_non_empty_str_from_config_for_aws(config: Mapping, key: str, friendl
     return common._return_non_empty_str_from_config(config, key, friendly_name=friendly_name, kind="AWS")
 
 
+AWS_ROLE_ARN_RE = re.compile(r"^arn:aws(-[a-z-]+)?:iam::\d{12}:role/.+")
+
+
+def validate_aws_role_arn(aws_role_arn: str, our_aws_role_arn: str, external_id: str) -> None:
+    """Validate we can assume an AWS role ARN.
+
+    Users who have configured role based authentication must grant one of our
+    AWS roles permissions to assume their role. So, here we validate that
+    our_aws_role_arn can assume their aws_role_arn.
+
+    This requires two steps: A first step to assume our own AWS role (as the
+    current session's role may necessarilly be the one we have given our users),
+    and a second step to actually test whether we can assume our user's role.
+    """
+    import boto3  # noqa: PLC0415 — keeps botocore off the module import path (startup time)
+    from botocore.config import Config  # noqa: PLC0415
+    from botocore.exceptions import BotoCoreError, ClientError  # noqa: PLC0415
+
+    if not AWS_ROLE_ARN_RE.match(aws_role_arn):
+        raise common.IntegrationError("AWS role ARN is not valid")
+
+    sts = boto3.client(
+        "sts",
+        config=Config(connect_timeout=5, read_timeout=5, retries={"max_attempts": 1}),
+    )
+    first_response = sts.assume_role(
+        RoleArn=our_aws_role_arn,
+        RoleSessionName="PostHog-validate-aws-role-arn",
+        Policy=json.dumps(
+            # Narrow permissions to only allow assuming provided role with this
+            # session.
+            {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": ["sts:AssumeRole"],
+                        "Resource": aws_role_arn,
+                    },
+                ],
+            }
+        ),
+    )
+    external_session = boto3.Session(
+        aws_access_key_id=first_response["Credentials"]["AccessKeyId"],
+        aws_secret_access_key=first_response["Credentials"]["SecretAccessKey"],
+        aws_session_token=first_response["Credentials"]["SessionToken"],
+    )
+    external_sts = external_session.client("sts")
+
+    try:
+        _ = external_sts.assume_role(
+            RoleArn=aws_role_arn,
+            RoleSessionName="PostHog-validate-aws-role-arn",
+            ExternalId=external_id,
+        )
+    except ClientError:
+        raise common.IntegrationError("AWS role ARN is not valid")
+    except BotoCoreError:
+        raise common.IntegrationError("Could not validate AWS role ARN")
+
+
 def validate_aws_credentials(aws_access_key_id: str, aws_secret_access_key: str) -> str:
     """Validate AWS credentials via STS GetCallerIdentity, returning the AWS account id.
 
@@ -168,6 +234,11 @@ class AWSRoleBasedIntegration:
         except KeyError:
             raise common.IntegrationError("AWS integration is not valid: 'aws_role_arn' missing")
 
+    @property
+    def aws_account_id(self) -> str:
+        """The AWS account id parsed from the role ARN."""
+        return self.aws_role_arn.split(":")[4]
+
     @classmethod
     def integration_from_config(
         cls,
@@ -182,14 +253,30 @@ class AWSRoleBasedIntegration:
         if not is_unique_aws_role_by_organization_id(aws_role_arn, organization_id):
             raise ValidationError("Cannot create AWS integration: Invalid role")
 
+        # Currently, only batch exports uses this integration.
+        # If you are using this integration outside batch exports, then you should make the our_aws_role_arn and external_id configurable.
+        # TODO: Make our_aws_role_arn external_id configurable.
+        validate_aws_role_arn(
+            aws_role_arn=aws_role_arn,
+            our_aws_role_arn=settings.BATCH_EXPORT_S3_EXTERNAL_ROLE_ARN,
+            external_id=f"posthog-{organization_id}",
+        )
+
+        extra = cls.read_extra_configuration_parameters(**config)
+
         return _create_unique_named_integration(
             team_id=team_id,
             kind=cls.integration_kind,
             name=name,
-            config={"name": name, "aws_role_arn": aws_role_arn},
+            config={"name": name, "aws_role_arn": aws_role_arn, **extra},
             sensitive_config={},
             created_by=created_by,
         )
+
+    @staticmethod
+    def read_extra_configuration_parameters(**config) -> dict[str, Any]:
+        """Subclasses can override this to do further processing on the configuration."""
+        return {}
 
 
 class AWSS3RoleBasedIntegration(AWSRoleBasedIntegration):
@@ -200,12 +287,82 @@ class AWSS3RoleBasedIntegration(AWSRoleBasedIntegration):
     )
 
 
+def _return_redshift_groups(**config) -> list[str] | None:
+    if (groups := config.get("groups")) is not None:
+        if not isinstance(groups, list) or any(not isinstance(group, str) for group in groups) or len(groups) < 1:
+            raise common.IntegrationError("Groups must be a list of at least one string")
+
+        return groups
+    return None
+
+
+def _return_redshift_auto_create(**config) -> bool | None:
+    if (auto_create := config.get("auto_create")) is not None:
+        if not isinstance(auto_create, bool):
+            raise common.IntegrationError("Auto create can only be True or False")
+
+        return auto_create
+    return None
+
+
+AWS_REDSHIFT_SERVERLESS_WORKGROUP_ARN_RE = re.compile(
+    r"^arn:aws(-[a-z-]+)?:redshift-serverless:[a-z0-9-]+:\d{12}:workgroup/.+"
+)
+
+
+def _return_redshift_workgroup_arn(**config) -> str | None:
+    if (workgroup_arn := config.get("workgroup_arn")) is not None:
+        if not isinstance(workgroup_arn, str) or not AWS_REDSHIFT_SERVERLESS_WORKGROUP_ARN_RE.match(workgroup_arn):
+            raise common.IntegrationError("Workgroup ARN must be a valid Redshift Serverless workgroup ARN")
+
+        return workgroup_arn
+    return None
+
+
+def _return_extra_redshift_configuration(**config) -> dict[str, Any]:
+    user = _return_non_empty_str_from_config_for_aws(config, "user", "Username")
+
+    extra: dict[str, Any] = {"user": user}
+
+    if (groups := _return_redshift_groups(**config)) is not None:
+        extra["groups"] = groups
+
+    if (auto_create := _return_redshift_auto_create(**config)) is not None:
+        extra["auto_create"] = auto_create
+
+    if (workgroup_arn := _return_redshift_workgroup_arn(**config)) is not None:
+        extra["workgroup_arn"] = workgroup_arn
+
+    return extra
+
+
 class AWSRedshiftRoleBasedIntegration(AWSRoleBasedIntegration):
     """An AWS Redshift integration storing a customer's AWS role."""
 
     integration_kind: ClassVar[Literal[model.Integration.IntegrationKind.AWS_REDSHIFT]] = (
         model.Integration.IntegrationKind.AWS_REDSHIFT
     )
+
+    @property
+    def user(self) -> str:
+        return self.integration.config["user"]
+
+    @property
+    def groups(self) -> list[str] | None:
+        return self.integration.config.get("groups")
+
+    @property
+    def auto_create(self) -> bool | None:
+        return self.integration.config.get("auto_create")
+
+    @property
+    def workgroup_arn(self) -> str | None:
+        """ARN of a Redshift Serverless workgroup, required when the cluster is Serverless."""
+        return self.integration.config.get("workgroup_arn")
+
+    @staticmethod
+    def read_extra_configuration_parameters(**config) -> dict[str, Any]:
+        return _return_extra_redshift_configuration(**config)
 
 
 class AWSCredentialsIntegration:
@@ -267,6 +424,8 @@ class AWSCredentialsIntegration:
         # values is what they say they are. This call is safe.
         credentials = AWSKeyPair.unsafe_from_strings(aws_access_key_id, aws_secret_access_key)
 
+        extra = cls.read_extra_configuration_parameters(**config)
+
         # `name` is the unencrypted, frontend-visible identifier — never an AWS credential, which is
         # treated as a secret. The account id is non-sensitive and kept for display/debugging.
         return _create_unique_aws_integration(
@@ -276,7 +435,13 @@ class AWSCredentialsIntegration:
             account_id=account_id,
             credentials=credentials,
             created_by=created_by,
+            **extra,
         )
+
+    @staticmethod
+    def read_extra_configuration_parameters(**config) -> dict[str, Any]:
+        """Subclasses can override this to do further processing on the configuration."""
+        return {}
 
 
 class AWSS3Integration(AWSCredentialsIntegration):
@@ -297,6 +462,27 @@ class AWSRedshiftIntegration(AWSCredentialsIntegration):
     integration_kind: ClassVar[Literal[model.Integration.IntegrationKind.AWS_REDSHIFT]] = (
         model.Integration.IntegrationKind.AWS_REDSHIFT
     )
+
+    @property
+    def user(self) -> str:
+        return self.integration.config["user"]
+
+    @property
+    def groups(self) -> list[str] | None:
+        return self.integration.config.get("groups")
+
+    @property
+    def auto_create(self) -> bool | None:
+        return self.integration.config.get("auto_create")
+
+    @property
+    def workgroup_arn(self) -> str | None:
+        """ARN of a Redshift Serverless workgroup, required when the cluster is Serverless."""
+        return self.integration.config.get("workgroup_arn")
+
+    @staticmethod
+    def read_extra_configuration_parameters(**config) -> dict[str, Any]:
+        return _return_extra_redshift_configuration(**config)
 
 
 def _return_non_empty_str_from_config_for_s3_compatible(config: Mapping, key: str, friendly_name: str) -> str:

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -686,6 +686,8 @@ SPECTACULAR_SETTINGS = {
         # --- Inline value lists (type-hint enums, no x-spec-enum-id) ---
         "TileSpacingEnum": ["tight", "condensed", "standard", "relaxed", "wide"],
         "PropertyGroupOperator": ["AND", "OR"],
+        # `mode` is a generic field name; name the Redshift batch-export mode set explicitly.
+        "RedshiftExportModeEnum": ["INSERT", "COPY"],
         # `scope`/`state` are generic field names; one shared name for the canvas state scope set.
         "CanvasStateScopeEnum": ["user", "shared"],
         # `kind` is a generic field name; one shared name for the canvas kind set.

--- a/products/batch_exports/backend/api/batch_export.py
+++ b/products/batch_exports/backend/api/batch_export.py
@@ -446,6 +446,114 @@ class SnowflakeDestinationConfigSerializer(serializers.Serializer):
     )
 
 
+_AWS_CREDENTIALS_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "aws_access_key_id": {"type": "string"},
+        "aws_secret_access_key": {"type": "string"},
+    },
+    "required": ["aws_access_key_id", "aws_secret_access_key"],
+}
+
+
+@extend_schema_field(
+    {
+        "oneOf": [
+            {"type": "integer", "description": "ID of an aws-s3-kind Integration."},
+            _AWS_CREDENTIALS_SCHEMA,
+        ],
+    }
+)
+class RedshiftCopyBucketCredentialsField(serializers.JSONField):
+    """Inline AWS credentials or the id of an aws-s3-kind Integration."""
+
+    pass
+
+
+@extend_schema_field(
+    {
+        "oneOf": [
+            {"type": "integer", "description": "ID of an aws-s3-kind Integration."},
+            {"type": "string", "description": "ARN of an IAM role attached to the Redshift cluster."},
+            _AWS_CREDENTIALS_SCHEMA,
+        ],
+    }
+)
+class RedshiftCopyAuthorizationField(serializers.JSONField):
+    """IAM role ARN, inline AWS credentials, or the id of an aws-s3-kind Integration."""
+
+    pass
+
+
+class RedshiftCopyInputsSerializer(serializers.Serializer):
+    """S3 staging configuration for a Redshift batch export running in COPY mode."""
+
+    s3_bucket = serializers.CharField(help_text="S3 bucket where files are staged before the Redshift COPY.")
+    region_name = serializers.CharField(help_text="AWS region of the staging S3 bucket.")
+    s3_key_prefix = serializers.CharField(help_text="Key prefix for staged files in the S3 bucket.")
+    authorization = RedshiftCopyAuthorizationField(
+        help_text=(
+            "Authorization for Redshift to read staged files during COPY: the ARN of an IAM role attached "
+            "to the cluster, inline AWS credentials, or the id of an aws-s3-kind Integration."
+        ),
+    )
+    bucket_credentials = RedshiftCopyBucketCredentialsField(
+        help_text=(
+            "Credentials used to stage files in the S3 bucket: inline AWS credentials or the id of an "
+            "aws-s3-kind Integration."
+        ),
+    )
+
+
+class RedshiftDestinationConfigSerializer(serializers.Serializer):
+    """Typed configuration for a Redshift batch-export destination.
+
+    Connection credentials may live in a linked Integration (when one is provided) or inline in
+    this config (legacy). Mirrors the non-credential fields of `RedshiftBatchExportInputs` in
+    `products/batch_exports/backend/service.py`.
+    """
+
+    database = serializers.CharField(help_text="Redshift database name to connect to.")
+    host = serializers.CharField(
+        required=False,
+        help_text=(
+            "Redshift cluster or Serverless workgroup endpoint. Required when using an AWS Redshift "
+            "integration; plain Redshift integrations store the host themselves."
+        ),
+    )
+    schema = serializers.CharField(
+        required=False,
+        default="public",
+        help_text="Redshift schema name containing the destination table.",
+    )
+    table_name = serializers.CharField(
+        required=False,
+        default="events",
+        help_text="Redshift table name to write exported rows into.",
+    )
+    port = serializers.IntegerField(
+        required=False,
+        default=5439,
+        help_text="Port the Redshift server listens on.",
+    )
+    properties_data_type = serializers.ChoiceField(
+        choices=["varchar", "super"],
+        required=False,
+        default="varchar",
+        help_text="Data type used for JSON-like columns such as event properties.",
+    )
+    mode = serializers.ChoiceField(
+        choices=["INSERT", "COPY"],
+        required=False,
+        default="INSERT",
+        help_text="How rows reach Redshift: batched INSERT statements, or COPY from files staged in S3.",
+    )
+    copy_inputs = RedshiftCopyInputsSerializer(
+        required=False,
+        help_text="S3 staging configuration, required when mode is 'COPY'.",
+    )
+
+
 @extend_schema_field(
     PolymorphicProxySerializer(
         component_name="BatchExportDestinationConfig",
@@ -457,6 +565,7 @@ class SnowflakeDestinationConfigSerializer(serializers.Serializer):
             "AwsS3": AwsS3DestinationConfigSerializer,
             "S3Compatible": S3CompatibleDestinationConfigSerializer,
             "Snowflake": SnowflakeDestinationConfigSerializer,
+            "Redshift": RedshiftDestinationConfigSerializer,
         },
         resource_type_field_name="type",
     )
@@ -562,6 +671,20 @@ class SnowflakeDestinationRequestSerializer(serializers.Serializer):
     config = SnowflakeDestinationConfigSerializer()
 
 
+class RedshiftDestinationRequestSerializer(serializers.Serializer):
+    """Request shape for creating or updating a Redshift batch-export destination."""
+
+    type = serializers.ChoiceField(choices=["Redshift"])
+    integration_id = serializers.IntegerField(
+        required=False,
+        help_text=(
+            "ID of an aws-redshift-kind Integration providing connection credentials. Preferred over "
+            "inline credentials. Use the integrations-list MCP tool to find one."
+        ),
+    )
+    config = RedshiftDestinationConfigSerializer()
+
+
 BatchExportDestinationRequest = PolymorphicProxySerializer(
     component_name="BatchExportDestinationRequest",
     serializers={
@@ -572,6 +695,7 @@ BatchExportDestinationRequest = PolymorphicProxySerializer(
         "AwsS3": AwsS3DestinationRequestSerializer,
         "S3Compatible": S3CompatibleDestinationRequestSerializer,
         "Snowflake": SnowflakeDestinationRequestSerializer,
+        "Redshift": RedshiftDestinationRequestSerializer,
     },
     resource_type_field_name="type",
 )
@@ -582,10 +706,11 @@ class BatchExportDestinationRequestField(serializers.JSONField):
     """JSONField annotated with a polymorphic OpenAPI request schema.
 
     Only integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres, AwsS3,
-    S3Compatible, Snowflake) are exposed in the schema. integration_id is required for every one of
-    those except Snowflake, where inline credentials remain supported for the time being. Existing
-    Postgres and Snowflake exports created before integrations keep their inline credentials.
-    Runtime validation remains `BatchExportDestinationSerializer.validate_destination`.
+    S3Compatible, Snowflake, Redshift) are exposed in the schema. integration_id is required for
+    every one of those except Snowflake and Redshift, where inline credentials remain supported for
+    the time being. Existing Postgres, Snowflake and Redshift exports created before integrations
+    keep their inline credentials. Runtime validation remains
+    `BatchExportDestinationSerializer.validate_destination`.
     """
 
     pass
@@ -656,21 +781,36 @@ S3_DESTINATION_TO_INTEGRATION_KIND: dict[str, Integration.IntegrationKind] = {
 }
 
 
+def _coerce_integration_id(value: typing.Any) -> int | None:
+    """Return the integration id encoded in a Redshift COPY credential value, if any.
+
+    `BatchExportDestination.config` is an `EncryptedJSONField`, which stringifies scalar
+    leaves on the decrypt round trip, so an id may arrive as an int or a numeric string.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.isdigit():
+        return int(value)
+    return None
+
+
 class BatchExportDestinationSerializer(serializers.ModelSerializer):
     """Serializer for an BatchExportDestination model.
 
     The `config` field is polymorphic and typed only for destinations that keep
     credentials in the linked Integration (currently Databricks, AzureBlob, BigQuery, Postgres,
-    AwsS3, S3Compatible, Snowflake). Other destination types accept the same JSON shape but without a
-    typed OpenAPI schema. Secret fields are stripped from `config` on read.
+    AwsS3, S3Compatible, Snowflake, Redshift). Other destination types accept the same JSON shape
+    but without a typed OpenAPI schema. Secret fields are stripped from `config` on read.
     """
 
     config = TypedBatchExportDestinationConfigField(
         help_text=(
             "Destination-specific configuration. Fields depend on `type`. Credentials for "
             "integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres, AwsS3, S3Compatible, "
-            "Snowflake) are NOT stored here — they live in the linked Integration. Secret fields are stripped "
-            "from responses."
+            "Snowflake, Redshift) are NOT stored here — they live in the linked Integration. Secret fields are "
+            "stripped from responses."
         ),
     )
     integration = TeamScopedPrimaryKeyRelatedField(
@@ -688,7 +828,7 @@ class BatchExportDestinationSerializer(serializers.ModelSerializer):
         help_text=(
             "ID of a team-scoped Integration providing credentials. Required when creating Databricks, "
             "AzureBlob, BigQuery, Postgres, AwsS3, and S3Compatible destinations; optional for Snowflake "
-            "(inline credentials remain supported); unused for other types."
+            "and Redshift (inline credentials remain supported); unused for other types."
         ),
     )
 
@@ -730,7 +870,8 @@ class BatchExportDestinationSerializer(serializers.ModelSerializer):
         # resolve them at run time), so they must be required here only when no Integration is linked.
         # For the S3 family this is only possible when updating an export that predates integrations:
         # creating one without an Integration is rejected in `validate_destination`.
-        # TODO: remove this code once inline credentials are gone for S3 and integrations are enforced for Snowflake
+        # TODO: remove this code once inline credentials are gone for S3 and integrations are enforced
+        # for Snowflake and Redshift
         conditionally_required: set[str] = set()
         if attrs.get("integration") is None:
             if export_type in S3_FAMILY_TYPES:
@@ -739,6 +880,8 @@ class BatchExportDestinationSerializer(serializers.ModelSerializer):
                     conditionally_required.add("endpoint_url")
             elif export_type == BatchExportDestination.Destination.SNOWFLAKE:
                 conditionally_required = {"account", "user"}
+            elif export_type == BatchExportDestination.Destination.REDSHIFT:
+                conditionally_required = {"user", "password", "host"}
 
         for destination_field in destination_fields:
             is_required = (
@@ -1400,6 +1543,29 @@ class BatchExportSerializer(serializers.ModelSerializer):
                 )
 
         if destination_type == BatchExportDestination.Destination.REDSHIFT:
+            integration = destination_attrs.get("integration")
+
+            # Sticky integration: an export that uses one cannot drop back to inline credentials.
+            # TODO: remove this guard once integrations are mandatory for Redshift and inline credentials are gone.
+            if instance is not None and instance.destination.integration is not None and integration is None:
+                raise serializers.ValidationError(
+                    "Cannot remove the integration from a Redshift batch export that uses one. "
+                    "Re-send its `integration` to keep it (or a different one to swap)."
+                )
+
+            if integration is not None:
+                # (Team ownership is already enforced by the team-scoped `integration` field.)
+                if integration.kind != Integration.IntegrationKind.AWS_REDSHIFT:
+                    raise serializers.ValidationError("Integration is not a Redshift integration.")
+
+                # Only plain Redshift integrations store a host; AWS-flavor ones obtain
+                # temporary credentials for a cluster endpoint that stays in the export config.
+                if "host" not in integration.config and not merged_config.get("host"):
+                    raise serializers.ValidationError(
+                        "A 'host' is required when using an AWS Redshift integration: "
+                        "set it to the cluster or workgroup endpoint."
+                    )
+
             mode = merged_config.get("mode")
 
             if mode == "COPY":
@@ -1412,15 +1578,40 @@ class BatchExportSerializer(serializers.ModelSerializer):
                     raise serializers.ValidationError("Missing required input for 'COPY'")
 
                 credential_keys = {"aws_access_key_id", "aws_secret_access_key"}
-                if credential_keys - copy_inputs["bucket_credentials"].keys():
+
+                bucket_credentials = copy_inputs["bucket_credentials"]
+                bucket_integration_id = _coerce_integration_id(bucket_credentials)
+                authorization = copy_inputs.get("authorization")
+                authorization_integration_id = _coerce_integration_id(authorization)
+
+                for field_name, copy_integration_id in (
+                    ("bucket_credentials", bucket_integration_id),
+                    ("authorization", authorization_integration_id),
+                ):
+                    if copy_integration_id is None:
+                        continue
+                    # These ids live inside `config` rather than the team-scoped `integration`
+                    # field, so team ownership must be checked here.
+                    if not Integration.objects.filter(
+                        id=copy_integration_id,
+                        team_id=self.context["team_id"],
+                        kind=Integration.IntegrationKind.AWS_S3,
+                    ).exists():
+                        raise serializers.ValidationError(
+                            f"'{field_name}' does not reference an AWS S3 integration of this project."
+                        )
+
+                if bucket_integration_id is None and (
+                    not isinstance(bucket_credentials, dict) or credential_keys - bucket_credentials.keys()
+                ):
                     raise serializers.ValidationError("Missing required bucket credentials for 'COPY'")
 
-                authorization = copy_inputs.get("authorization")
-                if isinstance(authorization, dict):
-                    if credential_keys - authorization.keys():
-                        raise serializers.ValidationError("Missing required credentials for 'COPY'")
-                elif isinstance(authorization, str) and not authorization.strip():
-                    raise serializers.ValidationError("Missing required IAM role for 'COPY'")
+                if authorization_integration_id is None:
+                    if isinstance(authorization, dict):
+                        if credential_keys - authorization.keys():
+                            raise serializers.ValidationError("Missing required credentials for 'COPY'")
+                    elif isinstance(authorization, str) and not authorization.strip():
+                        raise serializers.ValidationError("Missing required IAM role for 'COPY'")
 
         if destination_type == BatchExportDestination.Destination.WORKFLOWS:
             team_id = self.context["team_id"]
@@ -1444,14 +1635,13 @@ class BatchExportSerializer(serializers.ModelSerializer):
             BatchExportDestination.Destination.POSTGRES,
             BatchExportDestination.Destination.REDSHIFT,
         ):
-            # Integration-backed Postgres exports keep the host in the linked Integration
-            # rather than in `config`; inline configs (Redshift, legacy Postgres) keep it in
-            # `config`. Prefer the Integration's host when one is provided so we don't skip
+            # PostgreSQL-server integrations (Postgres, plain Redshift) keep the host in the
+            # linked Integration; AWS Redshift integrations and inline configs keep it in
+            # `config`. Prefer the Integration's host when it has one so we don't skip
             # SSRF validation (and don't `KeyError` on a `config` that has no `host`).
             integration = destination_attrs.get("integration")
-            if integration is not None:
-                host = integration.config.get("host")
-            else:
+            host = integration.config.get("host") if integration is not None else None
+            if host is None:
                 host = merged_config.get("host")
 
             if host is not None:

--- a/products/batch_exports/backend/service.py
+++ b/products/batch_exports/backend/service.py
@@ -29,6 +29,7 @@ from temporalio.client import (
 from posthog.hogql.database.database import Database
 from posthog.hogql.hogql import HogQLContext
 
+from posthog.dataclasses import frozen
 from posthog.temporal.common.client import sync_connect
 from posthog.temporal.common.schedule import (
     a_pause_schedule,
@@ -400,6 +401,7 @@ class PostgresBatchExportInputs(BaseBatchExportInputs):
 
 
 IAMRole = str
+IntegrationID = int
 
 
 @dataclass(frozen=False)
@@ -409,27 +411,27 @@ class AWSCredentials:
     aws_session_token: str | None = field(default=None, repr=False)
 
 
-@dataclass
+@frozen
 class RedshiftCopyInputs:
     s3_bucket: str
     region_name: str
     s3_key_prefix: str
-    # Authorization role or credentials for Redshift to COPY data from bucket.
-    authorization: IAMRole | AWSCredentials
-    # S3 batch export credentials.
-    # TODO: Also support RBAC for S3 batch export, then we could take
-    # `IAMRole | AWSCredentials` here too.
-    bucket_credentials: AWSCredentials
+    # Authorization for Redshift to COPY data from the bucket: an IAM role ARN,
+    # inline credentials, or the id of a team-scoped aws-s3 integration.
+    authorization: IAMRole | AWSCredentials | IntegrationID
+    # Credentials used to stage files in the S3 bucket: inline credentials or
+    # the id of a team-scoped aws-s3 integration.
+    bucket_credentials: AWSCredentials | IntegrationID
 
 
 @dataclass(frozen=False, kw_only=True)
 class RedshiftBatchExportInputs(BaseBatchExportInputs):
     """Inputs for Redshift export workflow."""
 
-    user: str
-    password: str = field(repr=False)
-    host: str
     database: str
+    user: str | None = None
+    password: str | None = field(default=None, repr=False)
+    host: str | None = None
     schema: str = "public"
     table_name: str = "events"
     port: int = 5439
@@ -451,17 +453,31 @@ class RedshiftBatchExportInputs(BaseBatchExportInputs):
             else:
                 raise TypeError(f"Invalid type for copy inputs: '{type(self.copy_inputs)}'")
 
-            bucket_credentials = AWSCredentials(
-                aws_access_key_id=raw_inputs["bucket_credentials"]["aws_access_key_id"],
-                aws_secret_access_key=raw_inputs["bucket_credentials"]["aws_secret_access_key"],
-            )
+            # `BatchExportDestination.config` is an `EncryptedJSONField`, which stringifies scalar
+            # leaves on the decrypt round trip: an integration id saved as an int reads back as a
+            # numeric string, so both forms must be accepted here.
+            raw_bucket_credentials = raw_inputs["bucket_credentials"]
+            bucket_credentials: AWSCredentials | IntegrationID
+            if isinstance(raw_bucket_credentials, IntegrationID):
+                bucket_credentials = raw_bucket_credentials
+            elif isinstance(raw_bucket_credentials, str) and raw_bucket_credentials.isdigit():
+                bucket_credentials = IntegrationID(raw_bucket_credentials)
+            else:
+                bucket_credentials = AWSCredentials(
+                    aws_access_key_id=raw_bucket_credentials["aws_access_key_id"],
+                    aws_secret_access_key=raw_bucket_credentials["aws_secret_access_key"],
+                )
 
-            if isinstance(raw_inputs["authorization"], str):
-                authorization: IAMRole | AWSCredentials = raw_inputs["authorization"]
+            raw_authorization = raw_inputs["authorization"]
+            authorization: IAMRole | AWSCredentials | IntegrationID
+            if isinstance(raw_authorization, IntegrationID):
+                authorization = raw_authorization
+            elif isinstance(raw_authorization, str):
+                authorization = IntegrationID(raw_authorization) if raw_authorization.isdigit() else raw_authorization
             else:
                 authorization = AWSCredentials(
-                    aws_access_key_id=raw_inputs["authorization"]["aws_access_key_id"],
-                    aws_secret_access_key=raw_inputs["authorization"]["aws_secret_access_key"],
+                    aws_access_key_id=raw_authorization["aws_access_key_id"],
+                    aws_secret_access_key=raw_authorization["aws_secret_access_key"],
                 )
 
             self.copy_inputs = RedshiftCopyInputs(

--- a/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
@@ -12,6 +12,7 @@ from django.conf import settings
 
 import psycopg
 import pyarrow as pa
+import aioboto3
 import botocore.exceptions
 from psycopg import sql
 from structlog.contextvars import bind_contextvars
@@ -20,7 +21,18 @@ from temporalio.common import RetryPolicy
 
 from posthog.dataclasses import frozen
 from posthog.models import Team
-from posthog.models.integration import TLS, Authority, Credentials
+from posthog.models.integration import (
+    TLS,
+    Authority,
+    AWSRedshiftIntegration,
+    AWSRedshiftRoleBasedIntegration,
+    AWSS3Integration,
+    AWSS3RoleBasedIntegration,
+    Credentials,
+    Integration,
+    IntegrationError,
+    RedshiftIntegration,
+)
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.common.logger import get_logger, get_write_only_logger
@@ -32,6 +44,7 @@ from products.batch_exports.backend.service import (
     BatchExportModel,
     BatchExportSchema,
     IAMRole,
+    IntegrationID,
     RedshiftBatchExportInputs,
 )
 from products.batch_exports.backend.temporal.batch_exports import (
@@ -45,6 +58,7 @@ from products.batch_exports.backend.temporal.destinations.postgres_batch_export 
     Fields,
     PostgreSQLClient,
     PostgreSQLField,
+    _PostgreSQLClientInputsProtocol,
 )
 from products.batch_exports.backend.temporal.destinations.s3_batch_export import (
     ConcurrentS3Consumer,
@@ -71,8 +85,10 @@ from products.batch_exports.backend.temporal.utils import (
 LOGGER = get_write_only_logger(__name__)
 EXTERNAL_LOGGER = get_logger()
 
-
 NON_RETRYABLE_ERROR_TYPES = (
+    # The integration backing this export is missing, of the wrong kind, or
+    # misconfigured. Retrying can never recover it.
+    "IntegrationError",
     # Raised on errors that are related to database operation.
     # For example: unexpected disconnect, database or other object not found.
     "OperationalError",
@@ -632,18 +648,18 @@ def get_redshift_fields_from_record_schema(
     return pg_schema
 
 
-@dataclasses.dataclass
+@frozen
 class S3StageBucketParameters:
     name: str
     region_name: str
-    credentials: IAMRole | AWSCredentials
+    credentials: IAMRole | AWSCredentials | IntegrationID
 
 
-@dataclasses.dataclass
+@frozen
 class CopyParameters:
     s3_bucket: S3StageBucketParameters
     s3_key_prefix: str
-    authorization: IAMRole | AWSCredentials
+    authorization: IAMRole | AWSCredentials | IntegrationID
 
 
 @frozen
@@ -669,6 +685,18 @@ class ConnectionParameters:
         return TLS(ssl_mode="prefer" if settings.TEST else "require")
 
 
+@frozen
+class ServerConnectionParameters:
+    """Location of a Redshift server for exports whose credentials live in an integration.
+
+    `host` is None when a plain Redshift integration carries the host itself.
+    """
+
+    database: str
+    port: int
+    host: str | None = None
+
+
 @dataclasses.dataclass
 class TableParameters:
     schema_name: str
@@ -676,23 +704,25 @@ class TableParameters:
     properties_data_type: str = "varchar"
 
 
-@dataclasses.dataclass
+@frozen
 class RedshiftCopyActivityInputs:
     """Inputs for Redshift copy activity."""
 
     batch_export: BatchExportInsertInputs
-    connection: ConnectionParameters
+    connection: ConnectionParameters | ServerConnectionParameters
     table: TableParameters
     copy: CopyParameters
+    integration_id: IntegrationID | None = None
 
 
-@dataclasses.dataclass
+@frozen
 class RedshiftInsertInputs:
     """Inputs for Redshift insert activity."""
 
     batch_export: BatchExportInsertInputs
-    connection: ConnectionParameters
+    connection: ConnectionParameters | ServerConnectionParameters
     table: TableParameters
+    integration_id: IntegrationID | None = None
 
 
 class RedshiftConsumer(Consumer):
@@ -877,6 +907,318 @@ def _get_merge_settings(
         return NotRequiredMergeSettings(requires_merge=False)
 
 
+async def _get_redshift_integration(
+    integration_id: int, team_id: int
+) -> AWSRedshiftRoleBasedIntegration | AWSRedshiftIntegration | RedshiftIntegration:
+    """Fetch a Redshift integration from the database."""
+    try:
+        integration = await Integration.objects.aget(id=integration_id, team_id=team_id)
+    except Integration.DoesNotExist:
+        raise IntegrationError(f"Redshift integration with ID '{integration_id}' not found for team '{team_id}'")
+
+    if integration.kind != Integration.IntegrationKind.AWS_REDSHIFT:
+        raise IntegrationError(
+            f"Integration with ID '{integration_id}' for team '{team_id}' is not a Redshift integration "
+            f"(kind='{integration.kind}')"
+        )
+    if "aws_role_arn" in integration.config:
+        return AWSRedshiftRoleBasedIntegration(integration)
+    elif "aws_access_key_id" in integration.sensitive_config:
+        return AWSRedshiftIntegration(integration)
+    else:
+        return RedshiftIntegration(integration)
+
+
+async def _get_aws_s3_integration(integration_id: int, team_id: int) -> AWSS3RoleBasedIntegration | AWSS3Integration:
+    """Fetch an AWS S3 integration from the database."""
+    try:
+        integration = await Integration.objects.aget(id=integration_id, team_id=team_id)
+    except Integration.DoesNotExist:
+        raise IntegrationError(f"AWS S3 integration with ID '{integration_id}' not found for team '{team_id}'")
+
+    if integration.kind != Integration.IntegrationKind.AWS_S3:
+        raise IntegrationError(
+            f"Integration with ID '{integration_id}' for team '{team_id}' is not an S3 integration "
+            f"(kind='{integration.kind}')"
+        )
+    if "aws_role_arn" in integration.config:
+        return AWSS3RoleBasedIntegration(integration)
+    else:
+        return AWSS3Integration(integration)
+
+
+@frozen
+class RedshiftCredentials:
+    user: str
+    password: str
+
+
+@frozen
+class ProvisionedCluster:
+    """A provisioned Redshift cluster parsed from its endpoint hostname."""
+
+    cluster_identifier: str
+    region: str
+
+
+@frozen
+class ServerlessWorkgroup:
+    """A Redshift Serverless workgroup parsed from its endpoint hostname."""
+
+    workgroup: str
+    account_id: str
+    region: str
+
+
+def _parse_redshift_host(host: str) -> ProvisionedCluster | ServerlessWorkgroup:
+    """Parse a Redshift endpoint hostname into its cluster or workgroup location."""
+    match host.split("."):
+        case [cluster_identifier, _, region, "redshift", "amazonaws", *_]:
+            return ProvisionedCluster(cluster_identifier=cluster_identifier, region=region)
+        case [workgroup, account_id, region, "redshift-serverless", "amazonaws", *_]:
+            return ServerlessWorkgroup(workgroup=workgroup, account_id=account_id, region=region)
+        case _:
+            raise IntegrationError(
+                f"Redshift host '{host}' is not a recognized AWS Redshift endpoint. Expected "
+                "'<cluster>.<id>.<region>.redshift.amazonaws.com' or "
+                "'<workgroup>.<account>.<region>.redshift-serverless.amazonaws.com'"
+            )
+
+
+def _get_host_from_connection(connection: ConnectionParameters | ServerConnectionParameters) -> str:
+    if connection.host is None:
+        raise IntegrationError(
+            "An AWS Redshift integration requires the cluster endpoint to be set as 'host' in the "
+            "batch export configuration"
+        )
+    return connection.host
+
+
+async def _get_temporary_redshift_credentials(
+    aws_credentials: AWSCredentials,
+    *,
+    server: ProvisionedCluster | ServerlessWorkgroup,
+    user: str,
+    database: str,
+    auto_create: bool | None = None,
+    groups: list[str] | None = None,
+) -> RedshiftCredentials:
+    """Use AWS APIs to obtain temporary Redshift credentials.
+
+    This will return a username and password to be used to authenticate to
+    Redshift. Note that the returned user will be the same as user but it will
+    include the prefix IAM: or IAMA: (depending on the value of `auto_create`).
+    This prefix must be preserved when authenticating.
+
+    If auto_create is True, then the user or role given by aws_credentials must
+    also be allowed to redshift:CreateClusterUser on the dbuser resource. If the
+    user already exists then no new users will be created, even if
+    auto_create=True.
+
+    Automatically created users do not have any permissions. Thus, usually
+    groups should be set when auto_create=True. This parameter indicates which
+    groups is the user meant to join on creation, which is usually needed when
+    the user is automatically created. However, this is not a strict
+    requirement.
+
+    The AWS role or user requires redshift:JoinGroup on each dbgroup resource
+    whenever groups is set.
+
+    Serverless workgroups use `redshift-serverless:GetCredentials` instead of
+    `redshift:GetClusterCredentials`. There, the database user is derived from
+    the IAM identity, so `user`, `auto_create`, and `groups` do not apply.
+    """
+    session = aioboto3.Session(
+        aws_access_key_id=aws_credentials.aws_access_key_id,
+        aws_secret_access_key=aws_credentials.aws_secret_access_key,
+        aws_session_token=aws_credentials.aws_session_token,
+    )
+
+    match server:
+        case ProvisionedCluster():
+            optional: dict[str, typing.Any] = {}
+            if auto_create is not None:
+                optional["AutoCreate"] = auto_create
+            if groups is not None:
+                optional["DbGroups"] = groups
+
+            async with session.client("redshift", region_name=server.region) as redshift:
+                response = await redshift.get_cluster_credentials(
+                    DbUser=user,
+                    DbName=database,
+                    ClusterIdentifier=server.cluster_identifier,
+                    # TODO: Refreshable credentials
+                    DurationSeconds=3600,
+                    **optional,
+                )
+
+            return RedshiftCredentials(user=response["DbUser"], password=response["DbPassword"])
+
+        case ServerlessWorkgroup():
+            async with session.client("redshift-serverless", region_name=server.region) as redshift_serverless:
+                response = await redshift_serverless.get_credentials(
+                    workgroupName=server.workgroup,
+                    dbName=database,
+                    durationSeconds=3600,
+                )
+
+            return RedshiftCredentials(user=response["dbUser"], password=response["dbPassword"])
+
+        case _:
+            typing.assert_never(server)
+
+
+async def _get_redshift_client_inputs(
+    inputs: RedshiftInsertInputs | RedshiftCopyActivityInputs,
+) -> _PostgreSQLClientInputsProtocol:
+    if inputs.integration_id is not None:
+        integration = await _get_redshift_integration(inputs.integration_id, inputs.batch_export.team_id)
+        return await _get_redshift_client_inputs_from_integration(integration, inputs)
+
+    if not isinstance(inputs.connection, ConnectionParameters):
+        raise IntegrationError(
+            "Redshift connection credentials are missing: the batch export has no linked integration "
+            "and no inline user and password configured"
+        )
+
+    return inputs.connection
+
+
+def _get_redshift_credentials_policy_statements(
+    integration: AWSRedshiftRoleBasedIntegration,
+    server: ProvisionedCluster | ServerlessWorkgroup,
+    database: str,
+) -> list[PolicyStatement]:
+    """Build policy statements scoping an assumed role to obtaining Redshift credentials."""
+    match server:
+        case ProvisionedCluster():
+            account_id = integration.aws_account_id
+            get_cluster_credentials_policy = PolicyStatement(
+                Effect="Allow",
+                Action=["redshift:GetClusterCredentials"],
+                Resource=[
+                    f"arn:aws:redshift:{server.region}:{account_id}:dbuser:{server.cluster_identifier}/{integration.user}",
+                    f"arn:aws:redshift:{server.region}:{account_id}:dbname:{server.cluster_identifier}/{database}",
+                ],
+            )
+            if integration.auto_create is True:
+                get_cluster_credentials_policy["Action"].append("redshift:CreateClusterUser")
+
+            policy_statements = [get_cluster_credentials_policy]
+            if integration.groups is not None:
+                policy_statements.append(
+                    PolicyStatement(
+                        Effect="Allow",
+                        Action=["redshift:JoinGroup"],
+                        Resource=[
+                            f"arn:aws:redshift:{server.region}:{account_id}:dbgroup:{server.cluster_identifier}/{group}"
+                            for group in integration.groups
+                        ],
+                    )
+                )
+            return policy_statements
+
+        case ServerlessWorkgroup():
+            # Workgroup ARNs contain a UUID that cannot be derived from the endpoint hostname,
+            # so Serverless requires the ARN on the integration to scope the policy exactly.
+            workgroup_arn = integration.workgroup_arn
+            if workgroup_arn is None:
+                raise IntegrationError(
+                    "A Redshift Serverless workgroup requires 'workgroup_arn' to be set on the integration"
+                )
+
+            _, _, _, arn_region, arn_account_id, _ = workgroup_arn.split(":", maxsplit=5)
+            if arn_region != server.region or arn_account_id != server.account_id:
+                raise IntegrationError(
+                    f"The integration's workgroup ARN '{workgroup_arn}' does not match the region or account "
+                    f"of the Redshift Serverless host (region '{server.region}', account '{server.account_id}')"
+                )
+
+            return [
+                PolicyStatement(
+                    Effect="Allow",
+                    Action=["redshift-serverless:GetCredentials"],
+                    Resource=[workgroup_arn],
+                )
+            ]
+
+        case _:
+            typing.assert_never(server)
+
+
+async def _get_redshift_client_inputs_from_integration(
+    integration: AWSRedshiftRoleBasedIntegration | AWSRedshiftIntegration | RedshiftIntegration,
+    inputs: RedshiftInsertInputs | RedshiftCopyActivityInputs,
+) -> _PostgreSQLClientInputsProtocol:
+    client_inputs: _PostgreSQLClientInputsProtocol
+
+    match integration:
+        case AWSRedshiftRoleBasedIntegration():
+            host = _get_host_from_connection(inputs.connection)
+            server = _parse_redshift_host(host)
+
+            team = await Team.objects.aget(id=inputs.batch_export.team_id)
+            external_id = f"posthog-{team.organization_id}"
+
+            policy_statements = _get_redshift_credentials_policy_statements(
+                integration, server, inputs.connection.database
+            )
+
+            credentials = await get_credentials_using_user_aws_role(
+                integration.aws_role_arn,
+                external_id,
+                session_name=f"PostHog-batch-exports-{inputs.batch_export.batch_export_id}",
+                policy_statements=policy_statements,
+            )
+
+            redshift_credentials = await _get_temporary_redshift_credentials(
+                credentials,
+                server=server,
+                user=integration.user,
+                database=inputs.connection.database,
+                groups=integration.groups,
+                auto_create=integration.auto_create,
+            )
+            client_inputs = ConnectionParameters(
+                user=redshift_credentials.user,
+                password=redshift_credentials.password,
+                host=host,
+                port=inputs.connection.port,
+                database=inputs.connection.database,
+            )
+
+        case AWSRedshiftIntegration():
+            host = _get_host_from_connection(inputs.connection)
+            server = _parse_redshift_host(host)
+
+            redshift_credentials = await _get_temporary_redshift_credentials(
+                AWSCredentials(
+                    aws_access_key_id=integration.aws_access_key_id,
+                    aws_secret_access_key=integration.aws_secret_access_key,
+                ),
+                server=server,
+                user=integration.user,
+                database=inputs.connection.database,
+                groups=integration.groups,
+                auto_create=integration.auto_create,
+            )
+            client_inputs = ConnectionParameters(
+                user=redshift_credentials.user,
+                password=redshift_credentials.password,
+                host=host,
+                port=inputs.connection.port,
+                database=inputs.connection.database,
+            )
+
+        case RedshiftIntegration():
+            client_inputs = integration
+
+        case _:
+            typing.assert_never(integration)
+
+    return client_inputs
+
+
 @activity.defn
 @handle_non_retryable_errors(NON_RETRYABLE_ERROR_TYPES)
 async def insert_into_redshift_activity_from_stage(inputs: RedshiftInsertInputs) -> BatchExportResult:
@@ -906,6 +1248,7 @@ async def insert_into_redshift_activity_from_stage(inputs: RedshiftInsertInputs)
     bind_contextvars(
         team_id=inputs.batch_export.team_id,
         destination="Redshift",
+        integration_id=inputs.integration_id,
         data_interval_start=inputs.batch_export.data_interval_start,
         data_interval_end=inputs.batch_export.data_interval_end,
         database=inputs.connection.database,
@@ -969,8 +1312,10 @@ async def insert_into_redshift_activity_from_stage(inputs: RedshiftInsertInputs)
             else inputs.table.name
         )
 
+        client_inputs = await _get_redshift_client_inputs(inputs)
+
         async with RedshiftClient.from_inputs(
-            inputs.connection, database=inputs.connection.database
+            client_inputs, database=inputs.connection.database
         ).connect() as redshift_client:
             remove_duplicates = True
             # filter out fields that are not in the destination table
@@ -1249,6 +1594,104 @@ async def check_and_raise_redshift_copy_error(
         raise RedshiftS3CopyError(bucket) from err
 
 
+async def _resolve_aws_s3_integration(integration_id: IntegrationID, team_id: int) -> IAMRole | AWSCredentials:
+    """Resolve an AWS S3 integration into its role ARN or stored credentials."""
+    integration = await _get_aws_s3_integration(integration_id, team_id=team_id)
+
+    match integration:
+        case AWSS3RoleBasedIntegration():
+            return integration.aws_role_arn
+        case AWSS3Integration():
+            return AWSCredentials(
+                aws_access_key_id=integration.aws_access_key_id,
+                aws_secret_access_key=integration.aws_secret_access_key,
+            )
+        case _:
+            typing.assert_never(integration)
+
+
+async def _assume_role_for_stage_bucket(
+    aws_role_arn: IAMRole, inputs: RedshiftCopyActivityInputs, policy_statements: list[PolicyStatement]
+) -> AWSCredentials:
+    team = await Team.objects.aget(id=inputs.batch_export.team_id)
+    external_id = f"posthog-{team.organization_id}"
+
+    return await get_credentials_using_user_aws_role(
+        aws_role_arn,
+        external_id,
+        session_name=f"PostHog-batch-exports-{inputs.batch_export.batch_export_id}",
+        policy_statements=policy_statements,
+    )
+
+
+async def _get_s3_bucket_aws_credentials(inputs: RedshiftCopyActivityInputs) -> AWSCredentials:
+    """Resolve the credentials used to stage files in the user's S3 bucket."""
+    credentials = inputs.copy.s3_bucket.credentials
+    if isinstance(credentials, IntegrationID):
+        credentials = await _resolve_aws_s3_integration(credentials, inputs.batch_export.team_id)
+
+    if isinstance(credentials, AWSCredentials):
+        return credentials
+
+    bucket_name = inputs.copy.s3_bucket.name
+    key_prefix = get_absolute_key_prefix(
+        inputs.copy.s3_key_prefix,
+        inputs.batch_export.data_interval_start,
+        inputs.batch_export.data_interval_end,
+        inputs.batch_export.batch_export_model,
+    )
+    policy_statements = [
+        PolicyStatement(
+            Effect="Allow",
+            Action=["s3:PutObject", "s3:GetObject", "s3:DeleteObject", "s3:AbortMultipartUpload"],
+            Resource=f"arn:aws:s3:::{bucket_name}{key_prefix}*",
+        ),
+        PolicyStatement(
+            Effect="Allow",
+            Action=["s3:ListBucket"],
+            Resource=f"arn:aws:s3:::{bucket_name}",
+        ),
+    ]
+    return await _assume_role_for_stage_bucket(credentials, inputs, policy_statements)
+
+
+async def _resolve_copy_authorization(inputs: RedshiftCopyActivityInputs) -> IAMRole | AWSCredentials:
+    """Resolve the authorization Redshift uses to read staged files during COPY.
+
+    An integration id resolves to temporary AWS credentials scoped to reading the
+    staged files: a customer role ARN from an integration cannot be passed as
+    `IAM_ROLE` in the COPY statement, since it is not attached to the cluster.
+    """
+    authorization = inputs.copy.authorization
+    if not isinstance(authorization, IntegrationID):
+        return authorization
+
+    resolved = await _resolve_aws_s3_integration(authorization, inputs.batch_export.team_id)
+    if isinstance(resolved, AWSCredentials):
+        return resolved
+
+    bucket_name = inputs.copy.s3_bucket.name
+    key_prefix = get_absolute_key_prefix(
+        inputs.copy.s3_key_prefix,
+        inputs.batch_export.data_interval_start,
+        inputs.batch_export.data_interval_end,
+        inputs.batch_export.batch_export_model,
+    )
+    policy_statements = [
+        PolicyStatement(
+            Effect="Allow",
+            Action=["s3:GetObject"],
+            Resource=f"arn:aws:s3:::{bucket_name}{key_prefix}*",
+        ),
+        PolicyStatement(
+            Effect="Allow",
+            Action=["s3:ListBucket", "s3:GetBucketLocation"],
+            Resource=f"arn:aws:s3:::{bucket_name}",
+        ),
+    ]
+    return await _assume_role_for_stage_bucket(resolved, inputs, policy_statements)
+
+
 @activity.defn
 @handle_non_retryable_errors(NON_RETRYABLE_ERROR_TYPES)
 async def copy_into_redshift_activity_from_stage(inputs: RedshiftCopyActivityInputs) -> BatchExportResult:
@@ -1288,6 +1731,7 @@ async def copy_into_redshift_activity_from_stage(inputs: RedshiftCopyActivityInp
     bind_contextvars(
         team_id=inputs.batch_export.team_id,
         destination="Redshift",
+        integration_id=inputs.integration_id,
         data_interval_start=inputs.batch_export.data_interval_start,
         data_interval_end=inputs.batch_export.data_interval_end,
         database=inputs.connection.database,
@@ -1344,39 +1788,6 @@ async def copy_into_redshift_activity_from_stage(inputs: RedshiftCopyActivityInp
         # TODO: Maybe derive this from user's input?
         max_file_size_mb = 100
 
-        if isinstance(inputs.copy.s3_bucket.credentials, IAMRole):
-            team = await Team.objects.aget(id=inputs.batch_export.team_id)
-            organization_id = str(team.organization_id)
-
-            bucket_name = inputs.copy.s3_bucket.name
-            key_prefix = get_absolute_key_prefix(
-                inputs.copy.s3_key_prefix,
-                inputs.batch_export.data_interval_start,
-                inputs.batch_export.data_interval_end,
-                inputs.batch_export.batch_export_model,
-            )
-            policy_statements = [
-                PolicyStatement(
-                    Effect="Allow",
-                    Action=["s3:PutObject", "s3:GetObject", "s3:DeleteObject", "s3:AbortMultipartUpload"],
-                    Resource=f"arn:aws:s3:::{bucket_name}{key_prefix}*",
-                ),
-                PolicyStatement(
-                    Effect="Allow",
-                    Action=["s3:ListBucket"],
-                    Resource=f"arn:aws:s3:::{bucket_name}",
-                ),
-            ]
-
-            credentials = await get_credentials_using_user_aws_role(
-                inputs.copy.s3_bucket.credentials,
-                organization_id,
-                session_name=f"PostHog-batch-exports-{inputs.batch_export.batch_export_id}",
-                policy_statements=policy_statements,
-            )
-        else:
-            credentials = inputs.copy.s3_bucket.credentials
-
         table_schemas = _get_table_schemas(
             model=model,
             record_batch_schema=record_batch_schema,
@@ -1401,6 +1812,8 @@ async def copy_into_redshift_activity_from_stage(inputs: RedshiftCopyActivityInp
             else inputs.table.name
         )
 
+        client_inputs = await _get_redshift_client_inputs(inputs)
+
         if not merge_settings.requires_merge:
             # Without a stage table, Parquet files are copied directly into the final
             # table, and the COPY column list names every column in the files. Pre-set
@@ -1408,7 +1821,7 @@ async def copy_into_redshift_activity_from_stage(inputs: RedshiftCopyActivityInp
             # as COPY would otherwise fail on them.
             try:
                 async with RedshiftClient.from_inputs(
-                    inputs.connection, database=inputs.connection.database
+                    client_inputs, database=inputs.connection.database
                 ).connect() as redshift_client:
                     existing_columns = set(
                         await redshift_client.aget_table_columns(inputs.table.schema_name, inputs.table.name)
@@ -1422,6 +1835,8 @@ async def copy_into_redshift_activity_from_stage(inputs: RedshiftCopyActivityInp
                     transformer.schema = cast_record_batch_schema_json_columns(
                         pa.schema(filtered_fields), json_columns=table_schemas.super_columns
                     )
+
+        credentials = await _get_s3_bucket_aws_credentials(inputs)
 
         async with s3_client(
             credentials.aws_access_key_id,
@@ -1458,8 +1873,12 @@ async def copy_into_redshift_activity_from_stage(inputs: RedshiftCopyActivityInp
         if result.error is not None:
             return result
 
+        # Re-resolved after uploads finish: temporary credentials from an integration
+        # are valid for one hour, which a long upload could outlive.
+        client_inputs = await _get_redshift_client_inputs(inputs)
+
         async with RedshiftClient.from_inputs(
-            inputs.connection, database=inputs.connection.database
+            client_inputs, database=inputs.connection.database
         ).connect() as redshift_client:
             remove_duplicates = True
 
@@ -1517,6 +1936,10 @@ async def copy_into_redshift_activity_from_stage(inputs: RedshiftCopyActivityInp
                     manifest_key=manifest_key,
                 )
 
+                # Resolved after uploads finish: temporary credentials from an assumed
+                # role last one hour, which a long upload could outlive.
+                copy_authorization = await _resolve_copy_authorization(inputs)
+
                 try:
                     external_logger.info(f"Copying {len(consumer.files_uploaded)} file/s into Redshift")
 
@@ -1527,12 +1950,12 @@ async def copy_into_redshift_activity_from_stage(inputs: RedshiftCopyActivityInp
                             schema_name=inputs.table.schema_name,
                             s3_bucket=inputs.copy.s3_bucket.name,
                             manifest_key=manifest_key,
-                            authorization=inputs.copy.authorization,
+                            authorization=copy_authorization,
                         )
                     except psycopg.errors.InternalError_ as err:
                         await check_and_raise_redshift_copy_error(
                             err,
-                            authorization=inputs.copy.authorization,
+                            authorization=copy_authorization,
                             bucket=inputs.copy.s3_bucket.name,
                             region_name=inputs.copy.s3_bucket.region_name,
                             manifest_key=manifest_key,
@@ -1633,13 +2056,24 @@ class RedshiftBatchExportWorkflow(PostHogWorkflow):
             batch_export_id=inputs.batch_export_id,
             destination_default_fields=redshift_default_fields(),
         )
-        connection_parameters = ConnectionParameters(
-            user=inputs.user,
-            password=inputs.password,
-            host=inputs.host,
-            port=inputs.port,
-            database=inputs.database,
-        )
+        connection_parameters: ConnectionParameters | ServerConnectionParameters
+        if inputs.user is not None and inputs.password is not None and inputs.host is not None:
+            connection_parameters = ConnectionParameters(
+                user=inputs.user,
+                password=inputs.password,
+                host=inputs.host,
+                port=inputs.port,
+                database=inputs.database,
+            )
+        else:
+            # Credentials live in the linked integration. The activity raises a clear,
+            # non-retryable error if there is no integration either; raising here would
+            # retry the workflow task forever.
+            connection_parameters = ServerConnectionParameters(
+                database=inputs.database,
+                port=inputs.port,
+                host=inputs.host,
+            )
         table_parameters = TableParameters(
             schema_name=inputs.schema,
             name=inputs.table_name,
@@ -1662,6 +2096,7 @@ class RedshiftBatchExportWorkflow(PostHogWorkflow):
                         s3_key_prefix=inputs.copy_inputs.s3_key_prefix,
                         authorization=inputs.copy_inputs.authorization,
                     ),
+                    integration_id=inputs.integration_id,
                 ),
                 interval=inputs.interval,
                 maximum_retry_interval_seconds=240,
@@ -1673,6 +2108,7 @@ class RedshiftBatchExportWorkflow(PostHogWorkflow):
                     batch_export=batch_export_inputs,
                     connection=connection_parameters,
                     table=table_parameters,
+                    integration_id=inputs.integration_id,
                 ),
                 interval=inputs.interval,
                 # TODO: Temporarily bump start to close timeout until we speed up

--- a/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
@@ -368,7 +368,7 @@ class S3BatchExportResult(BatchExportResult):
 class PolicyStatement(typing.TypedDict):
     Effect: typing.Literal["Allow", "Deny"]
     Action: list[str]
-    Resource: str
+    Resource: list[str] | str
 
 
 async def get_credentials_using_user_aws_role(

--- a/products/batch_exports/backend/tests/api/test_create_redshift.py
+++ b/products/batch_exports/backend/tests/api/test_create_redshift.py
@@ -4,6 +4,9 @@ from django.test.client import Client as HttpClient
 
 from rest_framework import status
 
+from posthog.models.integration import Integration
+
+from products.batch_exports.backend.tests.api.fixtures import create_organization, create_team, create_user
 from products.batch_exports.backend.tests.api.operations import create_batch_export
 
 pytestmark = [
@@ -156,3 +159,168 @@ def test_create_redshift_batch_export_validates_copy_inputs(
 
     if expected_status == status.HTTP_400_BAD_REQUEST:
         assert "Missing required" in response.json()["detail"]
+
+
+def create_aws_redshift_role_integration(team, user) -> Integration:
+    return Integration.objects.create(
+        team=team,
+        kind=Integration.IntegrationKind.AWS_REDSHIFT,
+        integration_id="prod-redshift-role",
+        config={
+            "name": "prod-redshift-role",
+            "aws_role_arn": "arn:aws:iam::123456789012:role/posthog-batch-exports",
+            "user": "awsuser",
+        },
+        created_by=user,
+    )
+
+
+def test_create_redshift_batch_export_with_aws_integration(client: HttpClient, temporal, organization, team, user):
+    integration = create_aws_redshift_role_integration(team, user)
+
+    batch_export_data = {
+        "name": "my-integration-backed-redshift-destination",
+        "interval": "hour",
+        "destination": {
+            "type": "Redshift",
+            # No user/password inline: credentials come from the integration. Only the
+            # cluster endpoint stays in the config.
+            "config": {"database": "my-db", "host": "8.8.8.8"},
+            "integration": integration.pk,
+        },
+    }
+
+    client.force_login(user)
+    response = create_batch_export(client, team.pk, batch_export_data)
+
+    assert response.status_code == status.HTTP_201_CREATED, response.json()
+
+
+def test_create_redshift_batch_export_with_plain_integration(client: HttpClient, temporal, organization, team, user):
+    integration = Integration.objects.create(
+        team=team,
+        kind=Integration.IntegrationKind.AWS_REDSHIFT,
+        integration_id="prod-redshift-plain",
+        config={"host": "8.8.8.8", "port": 5439, "user": "posthog", "ssl_mode": "require"},
+        sensitive_config={"password": "very-secret"},
+        created_by=user,
+    )
+
+    batch_export_data = {
+        "name": "my-integration-backed-redshift-destination",
+        "interval": "hour",
+        "destination": {
+            "type": "Redshift",
+            # Plain Redshift integrations store the host themselves, so none is needed here.
+            "config": {"database": "my-db"},
+            "integration": integration.pk,
+        },
+    }
+
+    client.force_login(user)
+    response = create_batch_export(client, team.pk, batch_export_data)
+
+    assert response.status_code == status.HTTP_201_CREATED, response.json()
+
+
+@pytest.mark.parametrize(
+    "failure,expected_error",
+    [
+        ("wrong_kind", "not a Redshift integration"),
+        ("aws_integration_without_host", "host"),
+        ("no_integration_no_credentials", "missing required field"),
+    ],
+)
+def test_create_redshift_batch_export_validates_integration(
+    client: HttpClient, failure, expected_error, temporal, organization, team, user, aws_s3_integration
+):
+    config: dict = {"database": "my-db"}
+    integration_pk = None
+
+    if failure == "wrong_kind":
+        integration_pk = aws_s3_integration.pk
+    elif failure == "aws_integration_without_host":
+        integration_pk = create_aws_redshift_role_integration(team, user).pk
+
+    destination_data: dict = {"type": "Redshift", "config": config}
+    if integration_pk is not None:
+        destination_data["integration"] = integration_pk
+
+    batch_export_data = {
+        "name": "my-integration-backed-redshift-destination",
+        "interval": "hour",
+        "destination": destination_data,
+    }
+
+    client.force_login(user)
+    response = create_batch_export(client, team.pk, batch_export_data)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+    assert expected_error in response.json()["detail"]
+
+
+@pytest.mark.parametrize(
+    "copy_credential_source",
+    ["own_integration", "other_team_integration", "wrong_kind_integration", "nonexistent_integration"],
+)
+def test_create_redshift_batch_export_validates_copy_integration_ids(
+    client: HttpClient, copy_credential_source, temporal, organization, team, user, aws_s3_integration
+):
+    # These ids live inside `config` rather than the team-scoped `integration` field, so
+    # tenant scoping is enforced by validation: a foreign or wrong-kind id must 400, not 500.
+    expected_status: int
+    if copy_credential_source == "own_integration":
+        integration_id = aws_s3_integration.pk
+        expected_status = status.HTTP_201_CREATED
+    elif copy_credential_source == "other_team_integration":
+        other_organization = create_organization("Other Org")
+        other_team = create_team(other_organization)
+        other_user = create_user("other@user.com", "Other User", other_organization)
+        other_integration = Integration.objects.create(
+            team=other_team,
+            kind=Integration.IntegrationKind.AWS_S3,
+            integration_id="other-prod-aws",
+            config={"name": "other-prod-aws", "aws_account_id": "999999999999"},
+            sensitive_config={"aws_access_key_id": "key", "aws_secret_access_key": "secret"},
+            created_by=other_user,
+        )
+        integration_id = other_integration.pk
+        expected_status = status.HTTP_400_BAD_REQUEST
+    elif copy_credential_source == "wrong_kind_integration":
+        integration_id = create_aws_redshift_role_integration(team, user).pk
+        expected_status = status.HTTP_400_BAD_REQUEST
+    else:
+        integration_id = 999999
+        expected_status = status.HTTP_400_BAD_REQUEST
+
+    destination_data = {
+        "type": "Redshift",
+        "config": {
+            "user": "user",
+            "password": "my-password",
+            "database": "my-db",
+            "host": "localhost",
+            "mode": "COPY",
+            "copy_inputs": {
+                "s3_bucket": "my-production-s3-bucket",
+                "region_name": "us-east-1",
+                "s3_key_prefix": "posthog-events/",
+                "bucket_credentials": integration_id,
+                "authorization": integration_id,
+            },
+        },
+    }
+
+    batch_export_data = {
+        "name": "my-production-redshift-destination",
+        "destination": destination_data,
+        "interval": "hour",
+    }
+
+    client.force_login(user)
+    response = create_batch_export(client, team.pk, batch_export_data)
+
+    assert response.status_code == expected_status, response.json()
+
+    if expected_status == status.HTTP_400_BAD_REQUEST:
+        assert "does not reference an AWS S3 integration" in response.json()["detail"]

--- a/products/batch_exports/backend/tests/temporal/destinations/redshift/test_redshift_utils.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/redshift/test_redshift_utils.py
@@ -12,11 +12,17 @@ import aioboto3
 import pytest_asyncio
 import botocore.exceptions
 
+from posthog.models.integration import AWSRedshiftRoleBasedIntegration, Integration, IntegrationError
+
 from products.batch_exports.backend.service import AWSCredentials
 from products.batch_exports.backend.temporal.destinations.redshift_batch_export import (
     ClientErrorGroup,
     InsufficientS3PermissionsError,
+    ProvisionedCluster,
     RedshiftS3CopyError,
+    ServerlessWorkgroup,
+    _get_redshift_credentials_policy_statements,
+    _parse_redshift_host,
     check_and_raise_redshift_copy_error,
     is_s3_read_access_denied,
     upload_manifest_file,
@@ -289,3 +295,99 @@ async def test_check_and_raise_redshift_copy_error_iam_role(error, should_raise)
             await call
     else:
         await call  # should not raise
+
+
+@pytest.mark.parametrize(
+    "host,expected",
+    [
+        (
+            "examplecluster.abc123xyz789.us-west-2.redshift.amazonaws.com",
+            ProvisionedCluster(cluster_identifier="examplecluster", region="us-west-2"),
+        ),
+        (
+            "default-wg.123456789012.us-east-1.redshift-serverless.amazonaws.com",
+            ServerlessWorkgroup(workgroup="default-wg", account_id="123456789012", region="us-east-1"),
+        ),
+    ],
+)
+def test_parse_redshift_host(host, expected):
+    assert _parse_redshift_host(host) == expected
+
+
+@pytest.mark.parametrize("host", ["localhost", "my-redshift.example.com", "8.8.8.8", ""])
+def test_parse_redshift_host_rejects_unrecognized_endpoints(host):
+    with pytest.raises(IntegrationError):
+        _parse_redshift_host(host)
+
+
+def _aws_redshift_role_integration(**extra_config) -> AWSRedshiftRoleBasedIntegration:
+    integration = Integration(
+        kind=Integration.IntegrationKind.AWS_REDSHIFT,
+        config={
+            "aws_role_arn": "arn:aws:iam::123456789012:role/posthog-batch-exports",
+            "user": "awsuser",
+            **extra_config,
+        },
+    )
+    return AWSRedshiftRoleBasedIntegration(integration)
+
+
+def test_provisioned_cluster_credentials_policy_scopes_to_exact_resources():
+    integration = _aws_redshift_role_integration(groups=["exporters"], auto_create=True)
+    server = ProvisionedCluster(cluster_identifier="examplecluster", region="us-west-2")
+
+    statements = _get_redshift_credentials_policy_statements(integration, server, "posthog")
+
+    assert statements[0]["Action"] == ["redshift:GetClusterCredentials", "redshift:CreateClusterUser"]
+    assert statements[0]["Resource"] == [
+        "arn:aws:redshift:us-west-2:123456789012:dbuser:examplecluster/awsuser",
+        "arn:aws:redshift:us-west-2:123456789012:dbname:examplecluster/posthog",
+    ]
+    assert statements[1]["Action"] == ["redshift:JoinGroup"]
+    assert statements[1]["Resource"] == [
+        "arn:aws:redshift:us-west-2:123456789012:dbgroup:examplecluster/exporters",
+    ]
+    assert all("*" not in resource for statement in statements for resource in statement["Resource"])
+
+
+def test_serverless_workgroup_credentials_policy_scopes_to_workgroup_arn():
+    workgroup_arn = "arn:aws:redshift-serverless:us-east-1:123456789012:workgroup/abc-123"
+    integration = _aws_redshift_role_integration(workgroup_arn=workgroup_arn)
+    server = ServerlessWorkgroup(workgroup="default-wg", account_id="123456789012", region="us-east-1")
+
+    statements = _get_redshift_credentials_policy_statements(integration, server, "posthog")
+
+    assert statements == [
+        {
+            "Effect": "Allow",
+            "Action": ["redshift-serverless:GetCredentials"],
+            "Resource": [workgroup_arn],
+        }
+    ]
+
+
+def test_serverless_workgroup_credentials_policy_requires_workgroup_arn():
+    # There must never be a wildcard fallback here: without the exact workgroup ARN
+    # the policy cannot be scoped, so credentials must not be requested at all.
+    integration = _aws_redshift_role_integration()
+    server = ServerlessWorkgroup(workgroup="default-wg", account_id="123456789012", region="us-east-1")
+
+    with pytest.raises(IntegrationError):
+        _get_redshift_credentials_policy_statements(integration, server, "posthog")
+
+
+@pytest.mark.parametrize(
+    "workgroup_arn",
+    [
+        # Region mismatch.
+        "arn:aws:redshift-serverless:us-west-2:123456789012:workgroup/abc-123",
+        # Account mismatch.
+        "arn:aws:redshift-serverless:us-east-1:999999999999:workgroup/abc-123",
+    ],
+)
+def test_serverless_workgroup_credentials_policy_rejects_mismatched_arn(workgroup_arn):
+    integration = _aws_redshift_role_integration(workgroup_arn=workgroup_arn)
+    server = ServerlessWorkgroup(workgroup="default-wg", account_id="123456789012", region="us-east-1")
+
+    with pytest.raises(IntegrationError):
+        _get_redshift_credentials_policy_statements(integration, server, "posthog")

--- a/products/batch_exports/backend/tests/test_service.py
+++ b/products/batch_exports/backend/tests/test_service.py
@@ -10,11 +10,13 @@ from products.batch_exports.backend.models.batch_export import (
     BatchExportRun,
 )
 from products.batch_exports.backend.service import (
+    AWSCredentials,
     AzureBlobBatchExportInputs,
     BigQueryBatchExportInputs,
     DatabricksBatchExportInputs,
     PostgresBatchExportInputs,
     RedshiftBatchExportInputs,
+    RedshiftCopyInputs,
     S3BatchExportInputs,
     aget_or_create_batch_export_backfill,
     align_timestamp_to_interval,
@@ -282,3 +284,41 @@ async def test_creates_backfill_without_id_does_not_deduplicate(ateam, batch_exp
 def test_align_timestamp_to_interval(timestamp, interval, interval_offset, timezone, expected):
     batch_export = BatchExport(interval=interval, interval_offset=interval_offset, timezone=timezone)
     assert align_timestamp_to_interval(timestamp, batch_export) == expected
+
+
+class TestRedshiftCopyInputsCredentials:
+    # EncryptedJSONField stringifies scalar leaves on the decrypt round trip, so an
+    # integration id saved as an int can read back as a numeric string.
+    @pytest.mark.parametrize(
+        "authorization,bucket_credentials,expected_authorization,expected_bucket_credentials",
+        [
+            (123, 456, 123, 456),
+            ("123", "456", 123, 456),
+            (
+                "arn:aws:iam::123456789012:role/my-role",
+                {"aws_access_key_id": "key", "aws_secret_access_key": "secret"},
+                "arn:aws:iam::123456789012:role/my-role",
+                AWSCredentials(aws_access_key_id="key", aws_secret_access_key="secret"),
+            ),
+        ],
+    )
+    def test_copy_credentials_are_parsed(
+        self, authorization, bucket_credentials, expected_authorization, expected_bucket_credentials
+    ):
+        inputs = RedshiftBatchExportInputs(
+            batch_export_id="test",
+            team_id=1,
+            database="db",
+            mode="COPY",
+            copy_inputs={  # type: ignore
+                "s3_bucket": "bucket",
+                "region_name": "us-east-1",
+                "s3_key_prefix": "prefix/",
+                "authorization": authorization,
+                "bucket_credentials": bucket_credentials,
+            },
+        )
+
+        assert isinstance(inputs.copy_inputs, RedshiftCopyInputs)
+        assert inputs.copy_inputs.authorization == expected_authorization
+        assert inputs.copy_inputs.bucket_credentials == expected_bucket_credentials

--- a/products/batch_exports/frontend/generated/api.schemas.ts
+++ b/products/batch_exports/frontend/generated/api.schemas.ts
@@ -335,6 +335,105 @@ export interface SnowflakeDestinationConfigApi {
     type: SnowflakeDestinationConfigApiType
 }
 
+/**
+ * * `varchar` - varchar
+ * * `super` - super
+ */
+export type PropertiesDataTypeEnumApi = (typeof PropertiesDataTypeEnumApi)[keyof typeof PropertiesDataTypeEnumApi]
+
+export const PropertiesDataTypeEnumApi = {
+    Varchar: 'varchar',
+    Super: 'super',
+} as const
+
+/**
+ * * `INSERT` - INSERT
+ * * `COPY` - COPY
+ */
+export type RedshiftExportModeEnumApi = (typeof RedshiftExportModeEnumApi)[keyof typeof RedshiftExportModeEnumApi]
+
+export const RedshiftExportModeEnumApi = {
+    Insert: 'INSERT',
+    Copy: 'COPY',
+} as const
+
+/**
+ * Authorization for Redshift to read staged files during COPY: the ARN of an IAM role attached to the cluster, inline AWS credentials, or the id of an aws-s3-kind Integration.
+ */
+export type RedshiftCopyInputsApiAuthorization =
+    | number
+    | string
+    | {
+          aws_access_key_id: string
+          aws_secret_access_key: string
+      }
+
+/**
+ * Credentials used to stage files in the S3 bucket: inline AWS credentials or the id of an aws-s3-kind Integration.
+ */
+export type RedshiftCopyInputsApiBucketCredentials =
+    | number
+    | {
+          aws_access_key_id: string
+          aws_secret_access_key: string
+      }
+
+/**
+ * S3 staging configuration for a Redshift batch export running in COPY mode.
+ */
+export interface RedshiftCopyInputsApi {
+    /** S3 bucket where files are staged before the Redshift COPY. */
+    s3_bucket: string
+    /** AWS region of the staging S3 bucket. */
+    region_name: string
+    /** Key prefix for staged files in the S3 bucket. */
+    s3_key_prefix: string
+    /** Authorization for Redshift to read staged files during COPY: the ARN of an IAM role attached to the cluster, inline AWS credentials, or the id of an aws-s3-kind Integration. */
+    authorization: RedshiftCopyInputsApiAuthorization
+    /** Credentials used to stage files in the S3 bucket: inline AWS credentials or the id of an aws-s3-kind Integration. */
+    bucket_credentials: RedshiftCopyInputsApiBucketCredentials
+}
+
+export type RedshiftDestinationConfigApiType =
+    (typeof RedshiftDestinationConfigApiType)[keyof typeof RedshiftDestinationConfigApiType]
+
+export const RedshiftDestinationConfigApiType = {
+    Redshift: 'Redshift',
+} as const
+
+/**
+ * Typed configuration for a Redshift batch-export destination.
+ *
+ * Connection credentials may live in a linked Integration (when one is provided) or inline in
+ * this config (legacy). Mirrors the non-credential fields of `RedshiftBatchExportInputs` in
+ * `products/batch_exports/backend/service.py`.
+ */
+export interface RedshiftDestinationConfigApi {
+    /** Redshift database name to connect to. */
+    database: string
+    /** Redshift cluster or Serverless workgroup endpoint. Required when using an AWS Redshift integration; plain Redshift integrations store the host themselves. */
+    host?: string
+    /** Redshift schema name containing the destination table. */
+    schema?: string
+    /** Redshift table name to write exported rows into. */
+    table_name?: string
+    /** Port the Redshift server listens on. */
+    port?: number
+    /** Data type used for JSON-like columns such as event properties.
+     *
+     * * `varchar` - varchar
+     * * `super` - super */
+    properties_data_type?: PropertiesDataTypeEnumApi
+    /** How rows reach Redshift: batched INSERT statements, or COPY from files staged in S3.
+     *
+     * * `INSERT` - INSERT
+     * * `COPY` - COPY */
+    mode?: RedshiftExportModeEnumApi
+    /** S3 staging configuration, required when mode is 'COPY'. */
+    copy_inputs?: RedshiftCopyInputsApi
+    type: RedshiftDestinationConfigApiType
+}
+
 export type BatchExportDestinationConfigApi =
     | DatabricksDestinationConfigApi
     | AzureBlobDestinationConfigApi
@@ -343,14 +442,15 @@ export type BatchExportDestinationConfigApi =
     | AwsS3DestinationConfigApi
     | S3CompatibleDestinationConfigApi
     | SnowflakeDestinationConfigApi
+    | RedshiftDestinationConfigApi
 
 /**
  * Serializer for an BatchExportDestination model.
  *
  * The `config` field is polymorphic and typed only for destinations that keep
  * credentials in the linked Integration (currently Databricks, AzureBlob, BigQuery, Postgres,
- * AwsS3, S3Compatible, Snowflake). Other destination types accept the same JSON shape but without a
- * typed OpenAPI schema. Secret fields are stripped from `config` on read.
+ * AwsS3, S3Compatible, Snowflake, Redshift). Other destination types accept the same JSON shape
+ * but without a typed OpenAPI schema. Secret fields are stripped from `config` on read.
  */
 export interface BatchExportDestinationApi {
     /** A choice of supported BatchExportDestination types.
@@ -369,7 +469,7 @@ export interface BatchExportDestinationApi {
      * * `NoOp` - Noop
      * * `FileDownload` - File Download */
     type: BatchExportDestinationTypeEnumApi
-    /** Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres, AwsS3, S3Compatible, Snowflake) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses. */
+    /** Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres, AwsS3, S3Compatible, Snowflake, Redshift) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses. */
     config: BatchExportDestinationConfigApi
     /**
      * The integration for this destination.
@@ -377,7 +477,7 @@ export interface BatchExportDestinationApi {
      */
     integration?: number | null
     /**
-     * ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, BigQuery, Postgres, AwsS3, and S3Compatible destinations; optional for Snowflake (inline credentials remain supported); unused for other types.
+     * ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, BigQuery, Postgres, AwsS3, and S3Compatible destinations; optional for Snowflake and Redshift (inline credentials remain supported); unused for other types.
      * @nullable
      */
     integration_id?: number | null
@@ -1313,6 +1413,23 @@ export interface SnowflakeDestinationRequestApi {
     config: SnowflakeDestinationConfigApi
 }
 
+export type RedshiftDestinationRequestApiType =
+    (typeof RedshiftDestinationRequestApiType)[keyof typeof RedshiftDestinationRequestApiType]
+
+export const RedshiftDestinationRequestApiType = {
+    Redshift: 'Redshift',
+} as const
+
+/**
+ * Request shape for creating or updating a Redshift batch-export destination.
+ */
+export interface RedshiftDestinationRequestApi {
+    type: RedshiftDestinationRequestApiType
+    /** ID of an aws-redshift-kind Integration providing connection credentials. Preferred over inline credentials. Use the integrations-list MCP tool to find one. */
+    integration_id?: number
+    config: RedshiftDestinationConfigApi
+}
+
 export type BatchExportDestinationRequestApi =
     | DatabricksDestinationRequestApi
     | AzureBlobDestinationRequestApi
@@ -1321,6 +1438,7 @@ export type BatchExportDestinationRequestApi =
     | AwsS3DestinationRequestApi
     | S3CompatibleDestinationRequestApi
     | SnowflakeDestinationRequestApi
+    | RedshiftDestinationRequestApi
 
 /**
  * Request body for create/partial_update on BatchExportViewSet.
@@ -1912,6 +2030,16 @@ export type SnowflakeDestinationRequestTypeEnumApi =
 
 export const SnowflakeDestinationRequestTypeEnumApi = {
     Snowflake: 'Snowflake',
+} as const
+
+/**
+ * * `Redshift` - Redshift
+ */
+export type RedshiftDestinationRequestTypeEnumApi =
+    (typeof RedshiftDestinationRequestTypeEnumApi)[keyof typeof RedshiftDestinationRequestTypeEnumApi]
+
+export const RedshiftDestinationRequestTypeEnumApi = {
+    Redshift: 'Redshift',
 } as const
 
 export type BatchExportsListParams = {

--- a/products/batch_exports/frontend/generated/api.zod.ts
+++ b/products/batch_exports/frontend/generated/api.zod.ts
@@ -22,6 +22,11 @@ export const batchExportsCreateBodyDestinationOneFiveConfigFileFormatDefault = `
 export const batchExportsCreateBodyDestinationOneSixConfigFileFormatDefault = `JSONLines`
 export const batchExportsCreateBodyDestinationOneSixConfigUseVirtualStyleAddressingDefault = false
 export const batchExportsCreateBodyDestinationOneSevenConfigTableNameDefault = `events`
+export const batchExportsCreateBodyDestinationOneEightConfigSchemaDefault = `public`
+export const batchExportsCreateBodyDestinationOneEightConfigTableNameDefault = `events`
+export const batchExportsCreateBodyDestinationOneEightConfigPortDefault = 5439
+export const batchExportsCreateBodyDestinationOneEightConfigPropertiesDataTypeDefault = `varchar`
+export const batchExportsCreateBodyDestinationOneEightConfigModeDefault = `INSERT`
 export const batchExportsCreateBodyOffsetDayMin = 0
 export const batchExportsCreateBodyOffsetDayMax = 6
 
@@ -320,6 +325,97 @@ export const BatchExportsCreateBody = /* @__PURE__ */ zod
                             ),
                     })
                     .describe('Request shape for creating or updating a Snowflake batch-export destination.'),
+                zod
+                    .object({
+                        type: zod.enum(['Redshift']),
+                        integration_id: zod
+                            .number()
+                            .optional()
+                            .describe(
+                                'ID of an aws-redshift-kind Integration providing connection credentials. Preferred over inline credentials. Use the integrations-list MCP tool to find one.'
+                            ),
+                        config: zod
+                            .object({
+                                database: zod.string().describe('Redshift database name to connect to.'),
+                                host: zod
+                                    .string()
+                                    .optional()
+                                    .describe(
+                                        'Redshift cluster or Serverless workgroup endpoint. Required when using an AWS Redshift integration; plain Redshift integrations store the host themselves.'
+                                    ),
+                                schema: zod
+                                    .string()
+                                    .default(batchExportsCreateBodyDestinationOneEightConfigSchemaDefault)
+                                    .describe('Redshift schema name containing the destination table.'),
+                                table_name: zod
+                                    .string()
+                                    .default(batchExportsCreateBodyDestinationOneEightConfigTableNameDefault)
+                                    .describe('Redshift table name to write exported rows into.'),
+                                port: zod
+                                    .number()
+                                    .default(batchExportsCreateBodyDestinationOneEightConfigPortDefault)
+                                    .describe('Port the Redshift server listens on.'),
+                                properties_data_type: zod
+                                    .enum(['varchar', 'super'])
+                                    .describe('\* `varchar` - varchar\n\* `super` - super')
+                                    .default(batchExportsCreateBodyDestinationOneEightConfigPropertiesDataTypeDefault)
+                                    .describe(
+                                        'Data type used for JSON-like columns such as event properties.\n\n\* `varchar` - varchar\n\* `super` - super'
+                                    ),
+                                mode: zod
+                                    .enum(['INSERT', 'COPY'])
+                                    .describe('\* `INSERT` - INSERT\n\* `COPY` - COPY')
+                                    .default(batchExportsCreateBodyDestinationOneEightConfigModeDefault)
+                                    .describe(
+                                        'How rows reach Redshift: batched INSERT statements, or COPY from files staged in S3.\n\n\* `INSERT` - INSERT\n\* `COPY` - COPY'
+                                    ),
+                                copy_inputs: zod
+                                    .object({
+                                        s3_bucket: zod
+                                            .string()
+                                            .describe('S3 bucket where files are staged before the Redshift COPY.'),
+                                        region_name: zod.string().describe('AWS region of the staging S3 bucket.'),
+                                        s3_key_prefix: zod
+                                            .string()
+                                            .describe('Key prefix for staged files in the S3 bucket.'),
+                                        authorization: zod
+                                            .union([
+                                                zod.number().describe('ID of an aws-s3-kind Integration.'),
+                                                zod
+                                                    .string()
+                                                    .describe('ARN of an IAM role attached to the Redshift cluster.'),
+                                                zod.object({
+                                                    aws_access_key_id: zod.string(),
+                                                    aws_secret_access_key: zod.string(),
+                                                }),
+                                            ])
+                                            .describe(
+                                                'Authorization for Redshift to read staged files during COPY: the ARN of an IAM role attached to the cluster, inline AWS credentials, or the id of an aws-s3-kind Integration.'
+                                            ),
+                                        bucket_credentials: zod
+                                            .union([
+                                                zod.number().describe('ID of an aws-s3-kind Integration.'),
+                                                zod.object({
+                                                    aws_access_key_id: zod.string(),
+                                                    aws_secret_access_key: zod.string(),
+                                                }),
+                                            ])
+                                            .describe(
+                                                'Credentials used to stage files in the S3 bucket: inline AWS credentials or the id of an aws-s3-kind Integration.'
+                                            ),
+                                    })
+                                    .describe(
+                                        'S3 staging configuration for a Redshift batch export running in COPY mode.'
+                                    )
+                                    .optional()
+                                    .describe("S3 staging configuration, required when mode is 'COPY'."),
+                                type: zod.enum(['Redshift']),
+                            })
+                            .describe(
+                                'Typed configuration for a Redshift batch-export destination.\n\nConnection credentials may live in a linked Integration (when one is provided) or inline in\nthis config (legacy). Mirrors the non-credential fields of `RedshiftBatchExportInputs` in\n`products\/batch_exports\/backend\/service.py`.'
+                            ),
+                    })
+                    .describe('Request shape for creating or updating a Redshift batch-export destination.'),
             ])
             .describe('Destination configuration. Required integration_id is enforced per destination type.'),
         interval: zod
@@ -624,6 +720,11 @@ export const batchExportsUpdateBodyDestinationOneFiveConfigFileFormatDefault = `
 export const batchExportsUpdateBodyDestinationOneSixConfigFileFormatDefault = `JSONLines`
 export const batchExportsUpdateBodyDestinationOneSixConfigUseVirtualStyleAddressingDefault = false
 export const batchExportsUpdateBodyDestinationOneSevenConfigTableNameDefault = `events`
+export const batchExportsUpdateBodyDestinationOneEightConfigSchemaDefault = `public`
+export const batchExportsUpdateBodyDestinationOneEightConfigTableNameDefault = `events`
+export const batchExportsUpdateBodyDestinationOneEightConfigPortDefault = 5439
+export const batchExportsUpdateBodyDestinationOneEightConfigPropertiesDataTypeDefault = `varchar`
+export const batchExportsUpdateBodyDestinationOneEightConfigModeDefault = `INSERT`
 export const batchExportsUpdateBodyOffsetDayMin = 0
 export const batchExportsUpdateBodyOffsetDayMax = 6
 
@@ -922,6 +1023,97 @@ export const BatchExportsUpdateBody = /* @__PURE__ */ zod
                             ),
                     })
                     .describe('Request shape for creating or updating a Snowflake batch-export destination.'),
+                zod
+                    .object({
+                        type: zod.enum(['Redshift']),
+                        integration_id: zod
+                            .number()
+                            .optional()
+                            .describe(
+                                'ID of an aws-redshift-kind Integration providing connection credentials. Preferred over inline credentials. Use the integrations-list MCP tool to find one.'
+                            ),
+                        config: zod
+                            .object({
+                                database: zod.string().describe('Redshift database name to connect to.'),
+                                host: zod
+                                    .string()
+                                    .optional()
+                                    .describe(
+                                        'Redshift cluster or Serverless workgroup endpoint. Required when using an AWS Redshift integration; plain Redshift integrations store the host themselves.'
+                                    ),
+                                schema: zod
+                                    .string()
+                                    .default(batchExportsUpdateBodyDestinationOneEightConfigSchemaDefault)
+                                    .describe('Redshift schema name containing the destination table.'),
+                                table_name: zod
+                                    .string()
+                                    .default(batchExportsUpdateBodyDestinationOneEightConfigTableNameDefault)
+                                    .describe('Redshift table name to write exported rows into.'),
+                                port: zod
+                                    .number()
+                                    .default(batchExportsUpdateBodyDestinationOneEightConfigPortDefault)
+                                    .describe('Port the Redshift server listens on.'),
+                                properties_data_type: zod
+                                    .enum(['varchar', 'super'])
+                                    .describe('\* `varchar` - varchar\n\* `super` - super')
+                                    .default(batchExportsUpdateBodyDestinationOneEightConfigPropertiesDataTypeDefault)
+                                    .describe(
+                                        'Data type used for JSON-like columns such as event properties.\n\n\* `varchar` - varchar\n\* `super` - super'
+                                    ),
+                                mode: zod
+                                    .enum(['INSERT', 'COPY'])
+                                    .describe('\* `INSERT` - INSERT\n\* `COPY` - COPY')
+                                    .default(batchExportsUpdateBodyDestinationOneEightConfigModeDefault)
+                                    .describe(
+                                        'How rows reach Redshift: batched INSERT statements, or COPY from files staged in S3.\n\n\* `INSERT` - INSERT\n\* `COPY` - COPY'
+                                    ),
+                                copy_inputs: zod
+                                    .object({
+                                        s3_bucket: zod
+                                            .string()
+                                            .describe('S3 bucket where files are staged before the Redshift COPY.'),
+                                        region_name: zod.string().describe('AWS region of the staging S3 bucket.'),
+                                        s3_key_prefix: zod
+                                            .string()
+                                            .describe('Key prefix for staged files in the S3 bucket.'),
+                                        authorization: zod
+                                            .union([
+                                                zod.number().describe('ID of an aws-s3-kind Integration.'),
+                                                zod
+                                                    .string()
+                                                    .describe('ARN of an IAM role attached to the Redshift cluster.'),
+                                                zod.object({
+                                                    aws_access_key_id: zod.string(),
+                                                    aws_secret_access_key: zod.string(),
+                                                }),
+                                            ])
+                                            .describe(
+                                                'Authorization for Redshift to read staged files during COPY: the ARN of an IAM role attached to the cluster, inline AWS credentials, or the id of an aws-s3-kind Integration.'
+                                            ),
+                                        bucket_credentials: zod
+                                            .union([
+                                                zod.number().describe('ID of an aws-s3-kind Integration.'),
+                                                zod.object({
+                                                    aws_access_key_id: zod.string(),
+                                                    aws_secret_access_key: zod.string(),
+                                                }),
+                                            ])
+                                            .describe(
+                                                'Credentials used to stage files in the S3 bucket: inline AWS credentials or the id of an aws-s3-kind Integration.'
+                                            ),
+                                    })
+                                    .describe(
+                                        'S3 staging configuration for a Redshift batch export running in COPY mode.'
+                                    )
+                                    .optional()
+                                    .describe("S3 staging configuration, required when mode is 'COPY'."),
+                                type: zod.enum(['Redshift']),
+                            })
+                            .describe(
+                                'Typed configuration for a Redshift batch-export destination.\n\nConnection credentials may live in a linked Integration (when one is provided) or inline in\nthis config (legacy). Mirrors the non-credential fields of `RedshiftBatchExportInputs` in\n`products\/batch_exports\/backend\/service.py`.'
+                            ),
+                    })
+                    .describe('Request shape for creating or updating a Redshift batch-export destination.'),
             ])
             .describe('Destination configuration. Required integration_id is enforced per destination type.'),
         interval: zod
@@ -979,6 +1171,11 @@ export const batchExportsPartialUpdateBodyDestinationOneFiveConfigFileFormatDefa
 export const batchExportsPartialUpdateBodyDestinationOneSixConfigFileFormatDefault = `JSONLines`
 export const batchExportsPartialUpdateBodyDestinationOneSixConfigUseVirtualStyleAddressingDefault = false
 export const batchExportsPartialUpdateBodyDestinationOneSevenConfigTableNameDefault = `events`
+export const batchExportsPartialUpdateBodyDestinationOneEightConfigSchemaDefault = `public`
+export const batchExportsPartialUpdateBodyDestinationOneEightConfigTableNameDefault = `events`
+export const batchExportsPartialUpdateBodyDestinationOneEightConfigPortDefault = 5439
+export const batchExportsPartialUpdateBodyDestinationOneEightConfigPropertiesDataTypeDefault = `varchar`
+export const batchExportsPartialUpdateBodyDestinationOneEightConfigModeDefault = `INSERT`
 export const batchExportsPartialUpdateBodyOffsetDayMin = 0
 export const batchExportsPartialUpdateBodyOffsetDayMax = 6
 
@@ -1279,6 +1476,99 @@ export const BatchExportsPartialUpdateBody = /* @__PURE__ */ zod
                             ),
                     })
                     .describe('Request shape for creating or updating a Snowflake batch-export destination.'),
+                zod
+                    .object({
+                        type: zod.enum(['Redshift']),
+                        integration_id: zod
+                            .number()
+                            .optional()
+                            .describe(
+                                'ID of an aws-redshift-kind Integration providing connection credentials. Preferred over inline credentials. Use the integrations-list MCP tool to find one.'
+                            ),
+                        config: zod
+                            .object({
+                                database: zod.string().describe('Redshift database name to connect to.'),
+                                host: zod
+                                    .string()
+                                    .optional()
+                                    .describe(
+                                        'Redshift cluster or Serverless workgroup endpoint. Required when using an AWS Redshift integration; plain Redshift integrations store the host themselves.'
+                                    ),
+                                schema: zod
+                                    .string()
+                                    .default(batchExportsPartialUpdateBodyDestinationOneEightConfigSchemaDefault)
+                                    .describe('Redshift schema name containing the destination table.'),
+                                table_name: zod
+                                    .string()
+                                    .default(batchExportsPartialUpdateBodyDestinationOneEightConfigTableNameDefault)
+                                    .describe('Redshift table name to write exported rows into.'),
+                                port: zod
+                                    .number()
+                                    .default(batchExportsPartialUpdateBodyDestinationOneEightConfigPortDefault)
+                                    .describe('Port the Redshift server listens on.'),
+                                properties_data_type: zod
+                                    .enum(['varchar', 'super'])
+                                    .describe('\* `varchar` - varchar\n\* `super` - super')
+                                    .default(
+                                        batchExportsPartialUpdateBodyDestinationOneEightConfigPropertiesDataTypeDefault
+                                    )
+                                    .describe(
+                                        'Data type used for JSON-like columns such as event properties.\n\n\* `varchar` - varchar\n\* `super` - super'
+                                    ),
+                                mode: zod
+                                    .enum(['INSERT', 'COPY'])
+                                    .describe('\* `INSERT` - INSERT\n\* `COPY` - COPY')
+                                    .default(batchExportsPartialUpdateBodyDestinationOneEightConfigModeDefault)
+                                    .describe(
+                                        'How rows reach Redshift: batched INSERT statements, or COPY from files staged in S3.\n\n\* `INSERT` - INSERT\n\* `COPY` - COPY'
+                                    ),
+                                copy_inputs: zod
+                                    .object({
+                                        s3_bucket: zod
+                                            .string()
+                                            .describe('S3 bucket where files are staged before the Redshift COPY.'),
+                                        region_name: zod.string().describe('AWS region of the staging S3 bucket.'),
+                                        s3_key_prefix: zod
+                                            .string()
+                                            .describe('Key prefix for staged files in the S3 bucket.'),
+                                        authorization: zod
+                                            .union([
+                                                zod.number().describe('ID of an aws-s3-kind Integration.'),
+                                                zod
+                                                    .string()
+                                                    .describe('ARN of an IAM role attached to the Redshift cluster.'),
+                                                zod.object({
+                                                    aws_access_key_id: zod.string(),
+                                                    aws_secret_access_key: zod.string(),
+                                                }),
+                                            ])
+                                            .describe(
+                                                'Authorization for Redshift to read staged files during COPY: the ARN of an IAM role attached to the cluster, inline AWS credentials, or the id of an aws-s3-kind Integration.'
+                                            ),
+                                        bucket_credentials: zod
+                                            .union([
+                                                zod.number().describe('ID of an aws-s3-kind Integration.'),
+                                                zod.object({
+                                                    aws_access_key_id: zod.string(),
+                                                    aws_secret_access_key: zod.string(),
+                                                }),
+                                            ])
+                                            .describe(
+                                                'Credentials used to stage files in the S3 bucket: inline AWS credentials or the id of an aws-s3-kind Integration.'
+                                            ),
+                                    })
+                                    .describe(
+                                        'S3 staging configuration for a Redshift batch export running in COPY mode.'
+                                    )
+                                    .optional()
+                                    .describe("S3 staging configuration, required when mode is 'COPY'."),
+                                type: zod.enum(['Redshift']),
+                            })
+                            .describe(
+                                'Typed configuration for a Redshift batch-export destination.\n\nConnection credentials may live in a linked Integration (when one is provided) or inline in\nthis config (legacy). Mirrors the non-credential fields of `RedshiftBatchExportInputs` in\n`products\/batch_exports\/backend\/service.py`.'
+                            ),
+                    })
+                    .describe('Request shape for creating or updating a Redshift batch-export destination.'),
             ])
             .optional()
             .describe('Destination configuration. Required integration_id is enforced per destination type.'),
@@ -1341,6 +1631,11 @@ export const batchExportsPauseCreateBodyDestinationOneConfigOneFiveFileFormatDef
 export const batchExportsPauseCreateBodyDestinationOneConfigOneSixFileFormatDefault = `JSONLines`
 export const batchExportsPauseCreateBodyDestinationOneConfigOneSixUseVirtualStyleAddressingDefault = false
 export const batchExportsPauseCreateBodyDestinationOneConfigOneSevenTableNameDefault = `events`
+export const batchExportsPauseCreateBodyDestinationOneConfigOneEightSchemaDefault = `public`
+export const batchExportsPauseCreateBodyDestinationOneConfigOneEightTableNameDefault = `events`
+export const batchExportsPauseCreateBodyDestinationOneConfigOneEightPortDefault = 5439
+export const batchExportsPauseCreateBodyDestinationOneConfigOneEightPropertiesDataTypeDefault = `varchar`
+export const batchExportsPauseCreateBodyDestinationOneConfigOneEightModeDefault = `INSERT`
 export const batchExportsPauseCreateBodyOffsetDayMin = 0
 export const batchExportsPauseCreateBodyOffsetDayMax = 6
 
@@ -1601,20 +1896,102 @@ export const BatchExportsPauseCreateBody = /* @__PURE__ */ zod
                             .describe(
                                 'Typed configuration for a Snowflake batch-export destination.\n\nAccount, user, authentication type and credentials may live in a linked Integration (when one is\nprovided) or inline in this config (legacy). Mirrors the non-credential fields of\n`SnowflakeBatchExportInputs` in `products\/batch_exports\/backend\/service.py`.'
                             ),
+                        zod
+                            .object({
+                                database: zod.string().describe('Redshift database name to connect to.'),
+                                host: zod
+                                    .string()
+                                    .optional()
+                                    .describe(
+                                        'Redshift cluster or Serverless workgroup endpoint. Required when using an AWS Redshift integration; plain Redshift integrations store the host themselves.'
+                                    ),
+                                schema: zod
+                                    .string()
+                                    .default(batchExportsPauseCreateBodyDestinationOneConfigOneEightSchemaDefault)
+                                    .describe('Redshift schema name containing the destination table.'),
+                                table_name: zod
+                                    .string()
+                                    .default(batchExportsPauseCreateBodyDestinationOneConfigOneEightTableNameDefault)
+                                    .describe('Redshift table name to write exported rows into.'),
+                                port: zod
+                                    .number()
+                                    .default(batchExportsPauseCreateBodyDestinationOneConfigOneEightPortDefault)
+                                    .describe('Port the Redshift server listens on.'),
+                                properties_data_type: zod
+                                    .enum(['varchar', 'super'])
+                                    .describe('\* `varchar` - varchar\n\* `super` - super')
+                                    .default(
+                                        batchExportsPauseCreateBodyDestinationOneConfigOneEightPropertiesDataTypeDefault
+                                    )
+                                    .describe(
+                                        'Data type used for JSON-like columns such as event properties.\n\n\* `varchar` - varchar\n\* `super` - super'
+                                    ),
+                                mode: zod
+                                    .enum(['INSERT', 'COPY'])
+                                    .describe('\* `INSERT` - INSERT\n\* `COPY` - COPY')
+                                    .default(batchExportsPauseCreateBodyDestinationOneConfigOneEightModeDefault)
+                                    .describe(
+                                        'How rows reach Redshift: batched INSERT statements, or COPY from files staged in S3.\n\n\* `INSERT` - INSERT\n\* `COPY` - COPY'
+                                    ),
+                                copy_inputs: zod
+                                    .object({
+                                        s3_bucket: zod
+                                            .string()
+                                            .describe('S3 bucket where files are staged before the Redshift COPY.'),
+                                        region_name: zod.string().describe('AWS region of the staging S3 bucket.'),
+                                        s3_key_prefix: zod
+                                            .string()
+                                            .describe('Key prefix for staged files in the S3 bucket.'),
+                                        authorization: zod
+                                            .union([
+                                                zod.number().describe('ID of an aws-s3-kind Integration.'),
+                                                zod
+                                                    .string()
+                                                    .describe('ARN of an IAM role attached to the Redshift cluster.'),
+                                                zod.object({
+                                                    aws_access_key_id: zod.string(),
+                                                    aws_secret_access_key: zod.string(),
+                                                }),
+                                            ])
+                                            .describe(
+                                                'Authorization for Redshift to read staged files during COPY: the ARN of an IAM role attached to the cluster, inline AWS credentials, or the id of an aws-s3-kind Integration.'
+                                            ),
+                                        bucket_credentials: zod
+                                            .union([
+                                                zod.number().describe('ID of an aws-s3-kind Integration.'),
+                                                zod.object({
+                                                    aws_access_key_id: zod.string(),
+                                                    aws_secret_access_key: zod.string(),
+                                                }),
+                                            ])
+                                            .describe(
+                                                'Credentials used to stage files in the S3 bucket: inline AWS credentials or the id of an aws-s3-kind Integration.'
+                                            ),
+                                    })
+                                    .describe(
+                                        'S3 staging configuration for a Redshift batch export running in COPY mode.'
+                                    )
+                                    .optional()
+                                    .describe("S3 staging configuration, required when mode is 'COPY'."),
+                                type: zod.enum(['Redshift']),
+                            })
+                            .describe(
+                                'Typed configuration for a Redshift batch-export destination.\n\nConnection credentials may live in a linked Integration (when one is provided) or inline in\nthis config (legacy). Mirrors the non-credential fields of `RedshiftBatchExportInputs` in\n`products\/batch_exports\/backend\/service.py`.'
+                            ),
                     ])
                     .describe(
-                        'Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres, AwsS3, S3Compatible, Snowflake) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses.'
+                        'Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres, AwsS3, S3Compatible, Snowflake, Redshift) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses.'
                     ),
                 integration: zod.number().nullish().describe('The integration for this destination.'),
                 integration_id: zod
                     .number()
                     .nullish()
                     .describe(
-                        'ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, BigQuery, Postgres, AwsS3, and S3Compatible destinations; optional for Snowflake (inline credentials remain supported); unused for other types.'
+                        'ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, BigQuery, Postgres, AwsS3, and S3Compatible destinations; optional for Snowflake and Redshift (inline credentials remain supported); unused for other types.'
                     ),
             })
             .describe(
-                'Serializer for an BatchExportDestination model.\n\nThe `config` field is polymorphic and typed only for destinations that keep\ncredentials in the linked Integration (currently Databricks, AzureBlob, BigQuery, Postgres,\nAwsS3, S3Compatible, Snowflake). Other destination types accept the same JSON shape but without a\ntyped OpenAPI schema. Secret fields are stripped from `config` on read.'
+                'Serializer for an BatchExportDestination model.\n\nThe `config` field is polymorphic and typed only for destinations that keep\ncredentials in the linked Integration (currently Databricks, AzureBlob, BigQuery, Postgres,\nAwsS3, S3Compatible, Snowflake, Redshift). Other destination types accept the same JSON shape\nbut without a typed OpenAPI schema. Secret fields are stripped from `config` on read.'
             )
             .describe('Destination configuration (type, config, and optional integration).'),
         interval: zod
@@ -1681,6 +2058,11 @@ export const batchExportsRunTestStepCreateBodyDestinationOneConfigOneFiveFileFor
 export const batchExportsRunTestStepCreateBodyDestinationOneConfigOneSixFileFormatDefault = `JSONLines`
 export const batchExportsRunTestStepCreateBodyDestinationOneConfigOneSixUseVirtualStyleAddressingDefault = false
 export const batchExportsRunTestStepCreateBodyDestinationOneConfigOneSevenTableNameDefault = `events`
+export const batchExportsRunTestStepCreateBodyDestinationOneConfigOneEightSchemaDefault = `public`
+export const batchExportsRunTestStepCreateBodyDestinationOneConfigOneEightTableNameDefault = `events`
+export const batchExportsRunTestStepCreateBodyDestinationOneConfigOneEightPortDefault = 5439
+export const batchExportsRunTestStepCreateBodyDestinationOneConfigOneEightPropertiesDataTypeDefault = `varchar`
+export const batchExportsRunTestStepCreateBodyDestinationOneConfigOneEightModeDefault = `INSERT`
 export const batchExportsRunTestStepCreateBodyOffsetDayMin = 0
 export const batchExportsRunTestStepCreateBodyOffsetDayMax = 6
 
@@ -1957,20 +2339,104 @@ export const BatchExportsRunTestStepCreateBody = /* @__PURE__ */ zod
                             .describe(
                                 'Typed configuration for a Snowflake batch-export destination.\n\nAccount, user, authentication type and credentials may live in a linked Integration (when one is\nprovided) or inline in this config (legacy). Mirrors the non-credential fields of\n`SnowflakeBatchExportInputs` in `products\/batch_exports\/backend\/service.py`.'
                             ),
+                        zod
+                            .object({
+                                database: zod.string().describe('Redshift database name to connect to.'),
+                                host: zod
+                                    .string()
+                                    .optional()
+                                    .describe(
+                                        'Redshift cluster or Serverless workgroup endpoint. Required when using an AWS Redshift integration; plain Redshift integrations store the host themselves.'
+                                    ),
+                                schema: zod
+                                    .string()
+                                    .default(batchExportsRunTestStepCreateBodyDestinationOneConfigOneEightSchemaDefault)
+                                    .describe('Redshift schema name containing the destination table.'),
+                                table_name: zod
+                                    .string()
+                                    .default(
+                                        batchExportsRunTestStepCreateBodyDestinationOneConfigOneEightTableNameDefault
+                                    )
+                                    .describe('Redshift table name to write exported rows into.'),
+                                port: zod
+                                    .number()
+                                    .default(batchExportsRunTestStepCreateBodyDestinationOneConfigOneEightPortDefault)
+                                    .describe('Port the Redshift server listens on.'),
+                                properties_data_type: zod
+                                    .enum(['varchar', 'super'])
+                                    .describe('\* `varchar` - varchar\n\* `super` - super')
+                                    .default(
+                                        batchExportsRunTestStepCreateBodyDestinationOneConfigOneEightPropertiesDataTypeDefault
+                                    )
+                                    .describe(
+                                        'Data type used for JSON-like columns such as event properties.\n\n\* `varchar` - varchar\n\* `super` - super'
+                                    ),
+                                mode: zod
+                                    .enum(['INSERT', 'COPY'])
+                                    .describe('\* `INSERT` - INSERT\n\* `COPY` - COPY')
+                                    .default(batchExportsRunTestStepCreateBodyDestinationOneConfigOneEightModeDefault)
+                                    .describe(
+                                        'How rows reach Redshift: batched INSERT statements, or COPY from files staged in S3.\n\n\* `INSERT` - INSERT\n\* `COPY` - COPY'
+                                    ),
+                                copy_inputs: zod
+                                    .object({
+                                        s3_bucket: zod
+                                            .string()
+                                            .describe('S3 bucket where files are staged before the Redshift COPY.'),
+                                        region_name: zod.string().describe('AWS region of the staging S3 bucket.'),
+                                        s3_key_prefix: zod
+                                            .string()
+                                            .describe('Key prefix for staged files in the S3 bucket.'),
+                                        authorization: zod
+                                            .union([
+                                                zod.number().describe('ID of an aws-s3-kind Integration.'),
+                                                zod
+                                                    .string()
+                                                    .describe('ARN of an IAM role attached to the Redshift cluster.'),
+                                                zod.object({
+                                                    aws_access_key_id: zod.string(),
+                                                    aws_secret_access_key: zod.string(),
+                                                }),
+                                            ])
+                                            .describe(
+                                                'Authorization for Redshift to read staged files during COPY: the ARN of an IAM role attached to the cluster, inline AWS credentials, or the id of an aws-s3-kind Integration.'
+                                            ),
+                                        bucket_credentials: zod
+                                            .union([
+                                                zod.number().describe('ID of an aws-s3-kind Integration.'),
+                                                zod.object({
+                                                    aws_access_key_id: zod.string(),
+                                                    aws_secret_access_key: zod.string(),
+                                                }),
+                                            ])
+                                            .describe(
+                                                'Credentials used to stage files in the S3 bucket: inline AWS credentials or the id of an aws-s3-kind Integration.'
+                                            ),
+                                    })
+                                    .describe(
+                                        'S3 staging configuration for a Redshift batch export running in COPY mode.'
+                                    )
+                                    .optional()
+                                    .describe("S3 staging configuration, required when mode is 'COPY'."),
+                                type: zod.enum(['Redshift']),
+                            })
+                            .describe(
+                                'Typed configuration for a Redshift batch-export destination.\n\nConnection credentials may live in a linked Integration (when one is provided) or inline in\nthis config (legacy). Mirrors the non-credential fields of `RedshiftBatchExportInputs` in\n`products\/batch_exports\/backend\/service.py`.'
+                            ),
                     ])
                     .describe(
-                        'Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres, AwsS3, S3Compatible, Snowflake) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses.'
+                        'Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres, AwsS3, S3Compatible, Snowflake, Redshift) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses.'
                     ),
                 integration: zod.number().nullish().describe('The integration for this destination.'),
                 integration_id: zod
                     .number()
                     .nullish()
                     .describe(
-                        'ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, BigQuery, Postgres, AwsS3, and S3Compatible destinations; optional for Snowflake (inline credentials remain supported); unused for other types.'
+                        'ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, BigQuery, Postgres, AwsS3, and S3Compatible destinations; optional for Snowflake and Redshift (inline credentials remain supported); unused for other types.'
                     ),
             })
             .describe(
-                'Serializer for an BatchExportDestination model.\n\nThe `config` field is polymorphic and typed only for destinations that keep\ncredentials in the linked Integration (currently Databricks, AzureBlob, BigQuery, Postgres,\nAwsS3, S3Compatible, Snowflake). Other destination types accept the same JSON shape but without a\ntyped OpenAPI schema. Secret fields are stripped from `config` on read.'
+                'Serializer for an BatchExportDestination model.\n\nThe `config` field is polymorphic and typed only for destinations that keep\ncredentials in the linked Integration (currently Databricks, AzureBlob, BigQuery, Postgres,\nAwsS3, S3Compatible, Snowflake, Redshift). Other destination types accept the same JSON shape\nbut without a typed OpenAPI schema. Secret fields are stripped from `config` on read.'
             )
             .describe('Destination configuration (type, config, and optional integration).'),
         interval: zod
@@ -2040,6 +2506,11 @@ export const batchExportsUnpauseCreateBodyDestinationOneConfigOneFiveFileFormatD
 export const batchExportsUnpauseCreateBodyDestinationOneConfigOneSixFileFormatDefault = `JSONLines`
 export const batchExportsUnpauseCreateBodyDestinationOneConfigOneSixUseVirtualStyleAddressingDefault = false
 export const batchExportsUnpauseCreateBodyDestinationOneConfigOneSevenTableNameDefault = `events`
+export const batchExportsUnpauseCreateBodyDestinationOneConfigOneEightSchemaDefault = `public`
+export const batchExportsUnpauseCreateBodyDestinationOneConfigOneEightTableNameDefault = `events`
+export const batchExportsUnpauseCreateBodyDestinationOneConfigOneEightPortDefault = 5439
+export const batchExportsUnpauseCreateBodyDestinationOneConfigOneEightPropertiesDataTypeDefault = `varchar`
+export const batchExportsUnpauseCreateBodyDestinationOneConfigOneEightModeDefault = `INSERT`
 export const batchExportsUnpauseCreateBodyOffsetDayMin = 0
 export const batchExportsUnpauseCreateBodyOffsetDayMax = 6
 
@@ -2304,20 +2775,102 @@ export const BatchExportsUnpauseCreateBody = /* @__PURE__ */ zod
                             .describe(
                                 'Typed configuration for a Snowflake batch-export destination.\n\nAccount, user, authentication type and credentials may live in a linked Integration (when one is\nprovided) or inline in this config (legacy). Mirrors the non-credential fields of\n`SnowflakeBatchExportInputs` in `products\/batch_exports\/backend\/service.py`.'
                             ),
+                        zod
+                            .object({
+                                database: zod.string().describe('Redshift database name to connect to.'),
+                                host: zod
+                                    .string()
+                                    .optional()
+                                    .describe(
+                                        'Redshift cluster or Serverless workgroup endpoint. Required when using an AWS Redshift integration; plain Redshift integrations store the host themselves.'
+                                    ),
+                                schema: zod
+                                    .string()
+                                    .default(batchExportsUnpauseCreateBodyDestinationOneConfigOneEightSchemaDefault)
+                                    .describe('Redshift schema name containing the destination table.'),
+                                table_name: zod
+                                    .string()
+                                    .default(batchExportsUnpauseCreateBodyDestinationOneConfigOneEightTableNameDefault)
+                                    .describe('Redshift table name to write exported rows into.'),
+                                port: zod
+                                    .number()
+                                    .default(batchExportsUnpauseCreateBodyDestinationOneConfigOneEightPortDefault)
+                                    .describe('Port the Redshift server listens on.'),
+                                properties_data_type: zod
+                                    .enum(['varchar', 'super'])
+                                    .describe('\* `varchar` - varchar\n\* `super` - super')
+                                    .default(
+                                        batchExportsUnpauseCreateBodyDestinationOneConfigOneEightPropertiesDataTypeDefault
+                                    )
+                                    .describe(
+                                        'Data type used for JSON-like columns such as event properties.\n\n\* `varchar` - varchar\n\* `super` - super'
+                                    ),
+                                mode: zod
+                                    .enum(['INSERT', 'COPY'])
+                                    .describe('\* `INSERT` - INSERT\n\* `COPY` - COPY')
+                                    .default(batchExportsUnpauseCreateBodyDestinationOneConfigOneEightModeDefault)
+                                    .describe(
+                                        'How rows reach Redshift: batched INSERT statements, or COPY from files staged in S3.\n\n\* `INSERT` - INSERT\n\* `COPY` - COPY'
+                                    ),
+                                copy_inputs: zod
+                                    .object({
+                                        s3_bucket: zod
+                                            .string()
+                                            .describe('S3 bucket where files are staged before the Redshift COPY.'),
+                                        region_name: zod.string().describe('AWS region of the staging S3 bucket.'),
+                                        s3_key_prefix: zod
+                                            .string()
+                                            .describe('Key prefix for staged files in the S3 bucket.'),
+                                        authorization: zod
+                                            .union([
+                                                zod.number().describe('ID of an aws-s3-kind Integration.'),
+                                                zod
+                                                    .string()
+                                                    .describe('ARN of an IAM role attached to the Redshift cluster.'),
+                                                zod.object({
+                                                    aws_access_key_id: zod.string(),
+                                                    aws_secret_access_key: zod.string(),
+                                                }),
+                                            ])
+                                            .describe(
+                                                'Authorization for Redshift to read staged files during COPY: the ARN of an IAM role attached to the cluster, inline AWS credentials, or the id of an aws-s3-kind Integration.'
+                                            ),
+                                        bucket_credentials: zod
+                                            .union([
+                                                zod.number().describe('ID of an aws-s3-kind Integration.'),
+                                                zod.object({
+                                                    aws_access_key_id: zod.string(),
+                                                    aws_secret_access_key: zod.string(),
+                                                }),
+                                            ])
+                                            .describe(
+                                                'Credentials used to stage files in the S3 bucket: inline AWS credentials or the id of an aws-s3-kind Integration.'
+                                            ),
+                                    })
+                                    .describe(
+                                        'S3 staging configuration for a Redshift batch export running in COPY mode.'
+                                    )
+                                    .optional()
+                                    .describe("S3 staging configuration, required when mode is 'COPY'."),
+                                type: zod.enum(['Redshift']),
+                            })
+                            .describe(
+                                'Typed configuration for a Redshift batch-export destination.\n\nConnection credentials may live in a linked Integration (when one is provided) or inline in\nthis config (legacy). Mirrors the non-credential fields of `RedshiftBatchExportInputs` in\n`products\/batch_exports\/backend\/service.py`.'
+                            ),
                     ])
                     .describe(
-                        'Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres, AwsS3, S3Compatible, Snowflake) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses.'
+                        'Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres, AwsS3, S3Compatible, Snowflake, Redshift) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses.'
                     ),
                 integration: zod.number().nullish().describe('The integration for this destination.'),
                 integration_id: zod
                     .number()
                     .nullish()
                     .describe(
-                        'ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, BigQuery, Postgres, AwsS3, and S3Compatible destinations; optional for Snowflake (inline credentials remain supported); unused for other types.'
+                        'ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, BigQuery, Postgres, AwsS3, and S3Compatible destinations; optional for Snowflake and Redshift (inline credentials remain supported); unused for other types.'
                     ),
             })
             .describe(
-                'Serializer for an BatchExportDestination model.\n\nThe `config` field is polymorphic and typed only for destinations that keep\ncredentials in the linked Integration (currently Databricks, AzureBlob, BigQuery, Postgres,\nAwsS3, S3Compatible, Snowflake). Other destination types accept the same JSON shape but without a\ntyped OpenAPI schema. Secret fields are stripped from `config` on read.'
+                'Serializer for an BatchExportDestination model.\n\nThe `config` field is polymorphic and typed only for destinations that keep\ncredentials in the linked Integration (currently Databricks, AzureBlob, BigQuery, Postgres,\nAwsS3, S3Compatible, Snowflake, Redshift). Other destination types accept the same JSON shape\nbut without a typed OpenAPI schema. Secret fields are stripped from `config` on read.'
             )
             .describe('Destination configuration (type, config, and optional integration).'),
         interval: zod
@@ -2384,6 +2937,11 @@ export const batchExportsRunTestStepNewCreateBodyDestinationOneConfigOneFiveFile
 export const batchExportsRunTestStepNewCreateBodyDestinationOneConfigOneSixFileFormatDefault = `JSONLines`
 export const batchExportsRunTestStepNewCreateBodyDestinationOneConfigOneSixUseVirtualStyleAddressingDefault = false
 export const batchExportsRunTestStepNewCreateBodyDestinationOneConfigOneSevenTableNameDefault = `events`
+export const batchExportsRunTestStepNewCreateBodyDestinationOneConfigOneEightSchemaDefault = `public`
+export const batchExportsRunTestStepNewCreateBodyDestinationOneConfigOneEightTableNameDefault = `events`
+export const batchExportsRunTestStepNewCreateBodyDestinationOneConfigOneEightPortDefault = 5439
+export const batchExportsRunTestStepNewCreateBodyDestinationOneConfigOneEightPropertiesDataTypeDefault = `varchar`
+export const batchExportsRunTestStepNewCreateBodyDestinationOneConfigOneEightModeDefault = `INSERT`
 export const batchExportsRunTestStepNewCreateBodyOffsetDayMin = 0
 export const batchExportsRunTestStepNewCreateBodyOffsetDayMax = 6
 
@@ -2664,20 +3222,110 @@ export const BatchExportsRunTestStepNewCreateBody = /* @__PURE__ */ zod
                             .describe(
                                 'Typed configuration for a Snowflake batch-export destination.\n\nAccount, user, authentication type and credentials may live in a linked Integration (when one is\nprovided) or inline in this config (legacy). Mirrors the non-credential fields of\n`SnowflakeBatchExportInputs` in `products\/batch_exports\/backend\/service.py`.'
                             ),
+                        zod
+                            .object({
+                                database: zod.string().describe('Redshift database name to connect to.'),
+                                host: zod
+                                    .string()
+                                    .optional()
+                                    .describe(
+                                        'Redshift cluster or Serverless workgroup endpoint. Required when using an AWS Redshift integration; plain Redshift integrations store the host themselves.'
+                                    ),
+                                schema: zod
+                                    .string()
+                                    .default(
+                                        batchExportsRunTestStepNewCreateBodyDestinationOneConfigOneEightSchemaDefault
+                                    )
+                                    .describe('Redshift schema name containing the destination table.'),
+                                table_name: zod
+                                    .string()
+                                    .default(
+                                        batchExportsRunTestStepNewCreateBodyDestinationOneConfigOneEightTableNameDefault
+                                    )
+                                    .describe('Redshift table name to write exported rows into.'),
+                                port: zod
+                                    .number()
+                                    .default(
+                                        batchExportsRunTestStepNewCreateBodyDestinationOneConfigOneEightPortDefault
+                                    )
+                                    .describe('Port the Redshift server listens on.'),
+                                properties_data_type: zod
+                                    .enum(['varchar', 'super'])
+                                    .describe('\* `varchar` - varchar\n\* `super` - super')
+                                    .default(
+                                        batchExportsRunTestStepNewCreateBodyDestinationOneConfigOneEightPropertiesDataTypeDefault
+                                    )
+                                    .describe(
+                                        'Data type used for JSON-like columns such as event properties.\n\n\* `varchar` - varchar\n\* `super` - super'
+                                    ),
+                                mode: zod
+                                    .enum(['INSERT', 'COPY'])
+                                    .describe('\* `INSERT` - INSERT\n\* `COPY` - COPY')
+                                    .default(
+                                        batchExportsRunTestStepNewCreateBodyDestinationOneConfigOneEightModeDefault
+                                    )
+                                    .describe(
+                                        'How rows reach Redshift: batched INSERT statements, or COPY from files staged in S3.\n\n\* `INSERT` - INSERT\n\* `COPY` - COPY'
+                                    ),
+                                copy_inputs: zod
+                                    .object({
+                                        s3_bucket: zod
+                                            .string()
+                                            .describe('S3 bucket where files are staged before the Redshift COPY.'),
+                                        region_name: zod.string().describe('AWS region of the staging S3 bucket.'),
+                                        s3_key_prefix: zod
+                                            .string()
+                                            .describe('Key prefix for staged files in the S3 bucket.'),
+                                        authorization: zod
+                                            .union([
+                                                zod.number().describe('ID of an aws-s3-kind Integration.'),
+                                                zod
+                                                    .string()
+                                                    .describe('ARN of an IAM role attached to the Redshift cluster.'),
+                                                zod.object({
+                                                    aws_access_key_id: zod.string(),
+                                                    aws_secret_access_key: zod.string(),
+                                                }),
+                                            ])
+                                            .describe(
+                                                'Authorization for Redshift to read staged files during COPY: the ARN of an IAM role attached to the cluster, inline AWS credentials, or the id of an aws-s3-kind Integration.'
+                                            ),
+                                        bucket_credentials: zod
+                                            .union([
+                                                zod.number().describe('ID of an aws-s3-kind Integration.'),
+                                                zod.object({
+                                                    aws_access_key_id: zod.string(),
+                                                    aws_secret_access_key: zod.string(),
+                                                }),
+                                            ])
+                                            .describe(
+                                                'Credentials used to stage files in the S3 bucket: inline AWS credentials or the id of an aws-s3-kind Integration.'
+                                            ),
+                                    })
+                                    .describe(
+                                        'S3 staging configuration for a Redshift batch export running in COPY mode.'
+                                    )
+                                    .optional()
+                                    .describe("S3 staging configuration, required when mode is 'COPY'."),
+                                type: zod.enum(['Redshift']),
+                            })
+                            .describe(
+                                'Typed configuration for a Redshift batch-export destination.\n\nConnection credentials may live in a linked Integration (when one is provided) or inline in\nthis config (legacy). Mirrors the non-credential fields of `RedshiftBatchExportInputs` in\n`products\/batch_exports\/backend\/service.py`.'
+                            ),
                     ])
                     .describe(
-                        'Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres, AwsS3, S3Compatible, Snowflake) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses.'
+                        'Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres, AwsS3, S3Compatible, Snowflake, Redshift) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses.'
                     ),
                 integration: zod.number().nullish().describe('The integration for this destination.'),
                 integration_id: zod
                     .number()
                     .nullish()
                     .describe(
-                        'ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, BigQuery, Postgres, AwsS3, and S3Compatible destinations; optional for Snowflake (inline credentials remain supported); unused for other types.'
+                        'ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, BigQuery, Postgres, AwsS3, and S3Compatible destinations; optional for Snowflake and Redshift (inline credentials remain supported); unused for other types.'
                     ),
             })
             .describe(
-                'Serializer for an BatchExportDestination model.\n\nThe `config` field is polymorphic and typed only for destinations that keep\ncredentials in the linked Integration (currently Databricks, AzureBlob, BigQuery, Postgres,\nAwsS3, S3Compatible, Snowflake). Other destination types accept the same JSON shape but without a\ntyped OpenAPI schema. Secret fields are stripped from `config` on read.'
+                'Serializer for an BatchExportDestination model.\n\nThe `config` field is polymorphic and typed only for destinations that keep\ncredentials in the linked Integration (currently Databricks, AzureBlob, BigQuery, Postgres,\nAwsS3, S3Compatible, Snowflake, Redshift). Other destination types accept the same JSON shape\nbut without a typed OpenAPI schema. Secret fields are stripped from `config` on read.'
             )
             .describe('Destination configuration (type, config, and optional integration).'),
         interval: zod

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -11592,15 +11592,111 @@ export namespace Schemas {
       type: SnowflakeDestinationConfigType;
     }
 
-    export type BatchExportDestinationConfig = DatabricksDestinationConfig | AzureBlobDestinationConfig | BigQueryDestinationConfig | PostgresDestinationConfig | AwsS3DestinationConfig | S3CompatibleDestinationConfig | SnowflakeDestinationConfig;
+    /**
+     * * `varchar` - varchar
+     * * `super` - super
+     */
+    export type PropertiesDataTypeEnum = typeof PropertiesDataTypeEnum[keyof typeof PropertiesDataTypeEnum];
+
+
+    export const PropertiesDataTypeEnum = {
+      Varchar: 'varchar',
+      Super: 'super',
+    } as const;
+
+    /**
+     * * `INSERT` - INSERT
+     * * `COPY` - COPY
+     */
+    export type RedshiftExportModeEnum = typeof RedshiftExportModeEnum[keyof typeof RedshiftExportModeEnum];
+
+
+    export const RedshiftExportModeEnum = {
+      Insert: 'INSERT',
+      Copy: 'COPY',
+    } as const;
+
+    /**
+     * Authorization for Redshift to read staged files during COPY: the ARN of an IAM role attached to the cluster, inline AWS credentials, or the id of an aws-s3-kind Integration.
+     */
+    export type RedshiftCopyInputsAuthorization = number | string | {
+      aws_access_key_id: string;
+      aws_secret_access_key: string;
+    };
+
+    /**
+     * Credentials used to stage files in the S3 bucket: inline AWS credentials or the id of an aws-s3-kind Integration.
+     */
+    export type RedshiftCopyInputsBucketCredentials = number | {
+      aws_access_key_id: string;
+      aws_secret_access_key: string;
+    };
+
+    /**
+     * S3 staging configuration for a Redshift batch export running in COPY mode.
+     */
+    export interface RedshiftCopyInputs {
+      /** S3 bucket where files are staged before the Redshift COPY. */
+      s3_bucket: string;
+      /** AWS region of the staging S3 bucket. */
+      region_name: string;
+      /** Key prefix for staged files in the S3 bucket. */
+      s3_key_prefix: string;
+      /** Authorization for Redshift to read staged files during COPY: the ARN of an IAM role attached to the cluster, inline AWS credentials, or the id of an aws-s3-kind Integration. */
+      authorization: RedshiftCopyInputsAuthorization;
+      /** Credentials used to stage files in the S3 bucket: inline AWS credentials or the id of an aws-s3-kind Integration. */
+      bucket_credentials: RedshiftCopyInputsBucketCredentials;
+    }
+
+    export type RedshiftDestinationConfigType = typeof RedshiftDestinationConfigType[keyof typeof RedshiftDestinationConfigType];
+
+
+    export const RedshiftDestinationConfigType = {
+      Redshift: 'Redshift',
+    } as const;
+
+    /**
+     * Typed configuration for a Redshift batch-export destination.
+     *
+     * Connection credentials may live in a linked Integration (when one is provided) or inline in
+     * this config (legacy). Mirrors the non-credential fields of `RedshiftBatchExportInputs` in
+     * `products/batch_exports/backend/service.py`.
+     */
+    export interface RedshiftDestinationConfig {
+      /** Redshift database name to connect to. */
+      database: string;
+      /** Redshift cluster or Serverless workgroup endpoint. Required when using an AWS Redshift integration; plain Redshift integrations store the host themselves. */
+      host?: string;
+      /** Redshift schema name containing the destination table. */
+      schema?: string;
+      /** Redshift table name to write exported rows into. */
+      table_name?: string;
+      /** Port the Redshift server listens on. */
+      port?: number;
+      /** Data type used for JSON-like columns such as event properties.
+       *
+       * * `varchar` - varchar
+       * * `super` - super */
+      properties_data_type?: PropertiesDataTypeEnum;
+      /** How rows reach Redshift: batched INSERT statements, or COPY from files staged in S3.
+       *
+       * * `INSERT` - INSERT
+       * * `COPY` - COPY */
+      mode?: RedshiftExportModeEnum;
+      /** S3 staging configuration, required when mode is 'COPY'. */
+      copy_inputs?: RedshiftCopyInputs;
+      type: RedshiftDestinationConfigType;
+    }
+
+    export type BatchExportDestinationConfig = DatabricksDestinationConfig | AzureBlobDestinationConfig | BigQueryDestinationConfig | PostgresDestinationConfig | AwsS3DestinationConfig | S3CompatibleDestinationConfig | SnowflakeDestinationConfig | RedshiftDestinationConfig;
 
     /**
      * Serializer for an BatchExportDestination model.
      *
      * The `config` field is polymorphic and typed only for destinations that keep
      * credentials in the linked Integration (currently Databricks, AzureBlob, BigQuery, Postgres,
-     * AwsS3, S3Compatible, Snowflake). Other destination types accept the same JSON shape but without a
-     * typed OpenAPI schema. Secret fields are stripped from `config` on read.
+     * AwsS3, S3Compatible, Snowflake, Redshift). Other destination types accept the same JSON shape
+     * but without a typed OpenAPI schema. Secret fields are stripped from `config` on read.
      */
     export interface BatchExportDestination {
       /** A choice of supported BatchExportDestination types.
@@ -11619,7 +11715,7 @@ export namespace Schemas {
        * * `NoOp` - Noop
        * * `FileDownload` - File Download */
       type: BatchExportDestinationTypeEnum;
-      /** Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres, AwsS3, S3Compatible, Snowflake) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses. */
+      /** Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres, AwsS3, S3Compatible, Snowflake, Redshift) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses. */
       config: BatchExportDestinationConfig;
       /**
          * The integration for this destination.
@@ -11627,7 +11723,7 @@ export namespace Schemas {
          */
       integration?: number | null;
       /**
-         * ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, BigQuery, Postgres, AwsS3, and S3Compatible destinations; optional for Snowflake (inline credentials remain supported); unused for other types.
+         * ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, BigQuery, Postgres, AwsS3, and S3Compatible destinations; optional for Snowflake and Redshift (inline credentials remain supported); unused for other types.
          * @nullable
          */
       integration_id?: number | null;
@@ -12613,7 +12709,24 @@ export namespace Schemas {
       config: SnowflakeDestinationConfig;
     }
 
-    export type BatchExportDestinationRequest = DatabricksDestinationRequest | AzureBlobDestinationRequest | BigQueryDestinationRequest | PostgresDestinationRequest | AwsS3DestinationRequest | S3CompatibleDestinationRequest | SnowflakeDestinationRequest;
+    export type RedshiftDestinationRequestType = typeof RedshiftDestinationRequestType[keyof typeof RedshiftDestinationRequestType];
+
+
+    export const RedshiftDestinationRequestType = {
+      Redshift: 'Redshift',
+    } as const;
+
+    /**
+     * Request shape for creating or updating a Redshift batch-export destination.
+     */
+    export interface RedshiftDestinationRequest {
+      type: RedshiftDestinationRequestType;
+      /** ID of an aws-redshift-kind Integration providing connection credentials. Preferred over inline credentials. Use the integrations-list MCP tool to find one. */
+      integration_id?: number;
+      config: RedshiftDestinationConfig;
+    }
+
+    export type BatchExportDestinationRequest = DatabricksDestinationRequest | AzureBlobDestinationRequest | BigQueryDestinationRequest | PostgresDestinationRequest | AwsS3DestinationRequest | S3CompatibleDestinationRequest | SnowflakeDestinationRequest | RedshiftDestinationRequest;
 
     /**
      * Request body for create/partial_update on BatchExportViewSet.
@@ -69896,6 +70009,16 @@ export namespace Schemas {
       /** True once today's visit row exists for the user. */
       recorded: boolean;
     }
+
+    /**
+     * * `Redshift` - Redshift
+     */
+    export type RedshiftDestinationRequestTypeEnum = typeof RedshiftDestinationRequestTypeEnum[keyof typeof RedshiftDestinationRequestTypeEnum];
+
+
+    export const RedshiftDestinationRequestTypeEnum = {
+      Redshift: 'Redshift',
+    } as const;
 
     export interface RelationshipReject {
       /** Why the proposal is rejected. Persisted so it is never re-proposed. */

--- a/services/mcp/src/generated/batch_exports/api.ts
+++ b/services/mcp/src/generated/batch_exports/api.ts
@@ -42,6 +42,11 @@ export const batchExportsCreateBodyDestinationOneFiveConfigFileFormatDefault = `
 export const batchExportsCreateBodyDestinationOneSixConfigFileFormatDefault = `JSONLines`
 export const batchExportsCreateBodyDestinationOneSixConfigUseVirtualStyleAddressingDefault = false
 export const batchExportsCreateBodyDestinationOneSevenConfigTableNameDefault = `events`
+export const batchExportsCreateBodyDestinationOneEightConfigSchemaDefault = `public`
+export const batchExportsCreateBodyDestinationOneEightConfigTableNameDefault = `events`
+export const batchExportsCreateBodyDestinationOneEightConfigPortDefault = 5439
+export const batchExportsCreateBodyDestinationOneEightConfigPropertiesDataTypeDefault = `varchar`
+export const batchExportsCreateBodyDestinationOneEightConfigModeDefault = `INSERT`
 export const batchExportsCreateBodyOffsetDayMin = 0
 export const batchExportsCreateBodyOffsetDayMax = 6
 
@@ -333,6 +338,96 @@ export const BatchExportsCreateBody = /* @__PURE__ */ zod
                             ),
                     })
                     .describe('Request shape for creating or updating a Snowflake batch-export destination.'),
+                zod
+                    .object({
+                        type: zod.enum(['Redshift']),
+                        integration_id: zod
+                            .number()
+                            .optional()
+                            .describe(
+                                'ID of an aws-redshift-kind Integration providing connection credentials. Preferred over inline credentials. Use the integrations-list MCP tool to find one.'
+                            ),
+                        config: zod
+                            .object({
+                                database: zod.string().describe('Redshift database name to connect to.'),
+                                host: zod
+                                    .string()
+                                    .optional()
+                                    .describe(
+                                        'Redshift cluster or Serverless workgroup endpoint. Required when using an AWS Redshift integration; plain Redshift integrations store the host themselves.'
+                                    ),
+                                schema: zod
+                                    .string()
+                                    .default(batchExportsCreateBodyDestinationOneEightConfigSchemaDefault)
+                                    .describe('Redshift schema name containing the destination table.'),
+                                table_name: zod
+                                    .string()
+                                    .default(batchExportsCreateBodyDestinationOneEightConfigTableNameDefault)
+                                    .describe('Redshift table name to write exported rows into.'),
+                                port: zod
+                                    .number()
+                                    .default(batchExportsCreateBodyDestinationOneEightConfigPortDefault)
+                                    .describe('Port the Redshift server listens on.'),
+                                properties_data_type: zod
+                                    .enum(['varchar', 'super'])
+                                    .describe('\* `varchar` - varchar\n\* `super` - super')
+                                    .default(batchExportsCreateBodyDestinationOneEightConfigPropertiesDataTypeDefault)
+                                    .describe(
+                                        'Data type used for JSON-like columns such as event properties.\n\n\* `varchar` - varchar\n\* `super` - super'
+                                    ),
+                                mode: zod
+                                    .enum(['INSERT', 'COPY'])
+                                    .describe('\* `INSERT` - INSERT\n\* `COPY` - COPY')
+                                    .default(batchExportsCreateBodyDestinationOneEightConfigModeDefault)
+                                    .describe(
+                                        'How rows reach Redshift: batched INSERT statements, or COPY from files staged in S3.\n\n\* `INSERT` - INSERT\n\* `COPY` - COPY'
+                                    ),
+                                copy_inputs: zod
+                                    .object({
+                                        s3_bucket: zod
+                                            .string()
+                                            .describe('S3 bucket where files are staged before the Redshift COPY.'),
+                                        region_name: zod.string().describe('AWS region of the staging S3 bucket.'),
+                                        s3_key_prefix: zod
+                                            .string()
+                                            .describe('Key prefix for staged files in the S3 bucket.'),
+                                        authorization: zod
+                                            .union([
+                                                zod.number().describe('ID of an aws-s3-kind Integration.'),
+                                                zod
+                                                    .string()
+                                                    .describe('ARN of an IAM role attached to the Redshift cluster.'),
+                                                zod.object({
+                                                    aws_access_key_id: zod.string(),
+                                                    aws_secret_access_key: zod.string(),
+                                                }),
+                                            ])
+                                            .describe(
+                                                'Authorization for Redshift to read staged files during COPY: the ARN of an IAM role attached to the cluster, inline AWS credentials, or the id of an aws-s3-kind Integration.'
+                                            ),
+                                        bucket_credentials: zod
+                                            .union([
+                                                zod.number().describe('ID of an aws-s3-kind Integration.'),
+                                                zod.object({
+                                                    aws_access_key_id: zod.string(),
+                                                    aws_secret_access_key: zod.string(),
+                                                }),
+                                            ])
+                                            .describe(
+                                                'Credentials used to stage files in the S3 bucket: inline AWS credentials or the id of an aws-s3-kind Integration.'
+                                            ),
+                                    })
+                                    .describe(
+                                        'S3 staging configuration for a Redshift batch export running in COPY mode.'
+                                    )
+                                    .optional()
+                                    .describe("S3 staging configuration, required when mode is 'COPY'."),
+                            })
+                            .describe(
+                                'Typed configuration for a Redshift batch-export destination.\n\nConnection credentials may live in a linked Integration (when one is provided) or inline in\nthis config (legacy). Mirrors the non-credential fields of `RedshiftBatchExportInputs` in\n`products\/batch_exports\/backend\/service.py`.'
+                            ),
+                    })
+                    .describe('Request shape for creating or updating a Redshift batch-export destination.'),
             ])
             .describe('Destination configuration. Required integration_id is enforced per destination type.'),
         interval: zod
@@ -398,6 +493,11 @@ export const batchExportsPartialUpdateBodyDestinationOneFiveConfigFileFormatDefa
 export const batchExportsPartialUpdateBodyDestinationOneSixConfigFileFormatDefault = `JSONLines`
 export const batchExportsPartialUpdateBodyDestinationOneSixConfigUseVirtualStyleAddressingDefault = false
 export const batchExportsPartialUpdateBodyDestinationOneSevenConfigTableNameDefault = `events`
+export const batchExportsPartialUpdateBodyDestinationOneEightConfigSchemaDefault = `public`
+export const batchExportsPartialUpdateBodyDestinationOneEightConfigTableNameDefault = `events`
+export const batchExportsPartialUpdateBodyDestinationOneEightConfigPortDefault = 5439
+export const batchExportsPartialUpdateBodyDestinationOneEightConfigPropertiesDataTypeDefault = `varchar`
+export const batchExportsPartialUpdateBodyDestinationOneEightConfigModeDefault = `INSERT`
 export const batchExportsPartialUpdateBodyOffsetDayMin = 0
 export const batchExportsPartialUpdateBodyOffsetDayMax = 6
 
@@ -691,6 +791,98 @@ export const BatchExportsPartialUpdateBody = /* @__PURE__ */ zod
                             ),
                     })
                     .describe('Request shape for creating or updating a Snowflake batch-export destination.'),
+                zod
+                    .object({
+                        type: zod.enum(['Redshift']),
+                        integration_id: zod
+                            .number()
+                            .optional()
+                            .describe(
+                                'ID of an aws-redshift-kind Integration providing connection credentials. Preferred over inline credentials. Use the integrations-list MCP tool to find one.'
+                            ),
+                        config: zod
+                            .object({
+                                database: zod.string().describe('Redshift database name to connect to.'),
+                                host: zod
+                                    .string()
+                                    .optional()
+                                    .describe(
+                                        'Redshift cluster or Serverless workgroup endpoint. Required when using an AWS Redshift integration; plain Redshift integrations store the host themselves.'
+                                    ),
+                                schema: zod
+                                    .string()
+                                    .default(batchExportsPartialUpdateBodyDestinationOneEightConfigSchemaDefault)
+                                    .describe('Redshift schema name containing the destination table.'),
+                                table_name: zod
+                                    .string()
+                                    .default(batchExportsPartialUpdateBodyDestinationOneEightConfigTableNameDefault)
+                                    .describe('Redshift table name to write exported rows into.'),
+                                port: zod
+                                    .number()
+                                    .default(batchExportsPartialUpdateBodyDestinationOneEightConfigPortDefault)
+                                    .describe('Port the Redshift server listens on.'),
+                                properties_data_type: zod
+                                    .enum(['varchar', 'super'])
+                                    .describe('\* `varchar` - varchar\n\* `super` - super')
+                                    .default(
+                                        batchExportsPartialUpdateBodyDestinationOneEightConfigPropertiesDataTypeDefault
+                                    )
+                                    .describe(
+                                        'Data type used for JSON-like columns such as event properties.\n\n\* `varchar` - varchar\n\* `super` - super'
+                                    ),
+                                mode: zod
+                                    .enum(['INSERT', 'COPY'])
+                                    .describe('\* `INSERT` - INSERT\n\* `COPY` - COPY')
+                                    .default(batchExportsPartialUpdateBodyDestinationOneEightConfigModeDefault)
+                                    .describe(
+                                        'How rows reach Redshift: batched INSERT statements, or COPY from files staged in S3.\n\n\* `INSERT` - INSERT\n\* `COPY` - COPY'
+                                    ),
+                                copy_inputs: zod
+                                    .object({
+                                        s3_bucket: zod
+                                            .string()
+                                            .describe('S3 bucket where files are staged before the Redshift COPY.'),
+                                        region_name: zod.string().describe('AWS region of the staging S3 bucket.'),
+                                        s3_key_prefix: zod
+                                            .string()
+                                            .describe('Key prefix for staged files in the S3 bucket.'),
+                                        authorization: zod
+                                            .union([
+                                                zod.number().describe('ID of an aws-s3-kind Integration.'),
+                                                zod
+                                                    .string()
+                                                    .describe('ARN of an IAM role attached to the Redshift cluster.'),
+                                                zod.object({
+                                                    aws_access_key_id: zod.string(),
+                                                    aws_secret_access_key: zod.string(),
+                                                }),
+                                            ])
+                                            .describe(
+                                                'Authorization for Redshift to read staged files during COPY: the ARN of an IAM role attached to the cluster, inline AWS credentials, or the id of an aws-s3-kind Integration.'
+                                            ),
+                                        bucket_credentials: zod
+                                            .union([
+                                                zod.number().describe('ID of an aws-s3-kind Integration.'),
+                                                zod.object({
+                                                    aws_access_key_id: zod.string(),
+                                                    aws_secret_access_key: zod.string(),
+                                                }),
+                                            ])
+                                            .describe(
+                                                'Credentials used to stage files in the S3 bucket: inline AWS credentials or the id of an aws-s3-kind Integration.'
+                                            ),
+                                    })
+                                    .describe(
+                                        'S3 staging configuration for a Redshift batch export running in COPY mode.'
+                                    )
+                                    .optional()
+                                    .describe("S3 staging configuration, required when mode is 'COPY'."),
+                            })
+                            .describe(
+                                'Typed configuration for a Redshift batch-export destination.\n\nConnection credentials may live in a linked Integration (when one is provided) or inline in\nthis config (legacy). Mirrors the non-credential fields of `RedshiftBatchExportInputs` in\n`products\/batch_exports\/backend\/service.py`.'
+                            ),
+                    })
+                    .describe('Request shape for creating or updating a Redshift batch-export destination.'),
             ])
             .optional()
             .describe('Destination configuration. Required integration_id is enforced per destination type.'),

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/batch-export-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/batch-export-create.json
@@ -394,6 +394,134 @@
                     },
                     "required": ["type", "config"],
                     "type": "object"
+                },
+                {
+                    "description": "Request shape for creating or updating a Redshift batch-export destination.",
+                    "properties": {
+                        "config": {
+                            "description": "Typed configuration for a Redshift batch-export destination.\n\nConnection credentials may live in a linked Integration (when one is provided) or inline in\nthis config (legacy). Mirrors the non-credential fields of `RedshiftBatchExportInputs` in\n`products/batch_exports/backend/service.py`.",
+                            "properties": {
+                                "copy_inputs": {
+                                    "description": "S3 staging configuration, required when mode is 'COPY'.",
+                                    "properties": {
+                                        "authorization": {
+                                            "anyOf": [
+                                                {
+                                                    "description": "ID of an aws-s3-kind Integration.",
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "description": "ARN of an IAM role attached to the Redshift cluster.",
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "aws_access_key_id": {
+                                                            "type": "string"
+                                                        },
+                                                        "aws_secret_access_key": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": ["aws_access_key_id", "aws_secret_access_key"],
+                                                    "type": "object"
+                                                }
+                                            ],
+                                            "description": "Authorization for Redshift to read staged files during COPY: the ARN of an IAM role attached to the cluster, inline AWS credentials, or the id of an aws-s3-kind Integration."
+                                        },
+                                        "bucket_credentials": {
+                                            "anyOf": [
+                                                {
+                                                    "description": "ID of an aws-s3-kind Integration.",
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "aws_access_key_id": {
+                                                            "type": "string"
+                                                        },
+                                                        "aws_secret_access_key": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": ["aws_access_key_id", "aws_secret_access_key"],
+                                                    "type": "object"
+                                                }
+                                            ],
+                                            "description": "Credentials used to stage files in the S3 bucket: inline AWS credentials or the id of an aws-s3-kind Integration."
+                                        },
+                                        "region_name": {
+                                            "description": "AWS region of the staging S3 bucket.",
+                                            "type": "string"
+                                        },
+                                        "s3_bucket": {
+                                            "description": "S3 bucket where files are staged before the Redshift COPY.",
+                                            "type": "string"
+                                        },
+                                        "s3_key_prefix": {
+                                            "description": "Key prefix for staged files in the S3 bucket.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "s3_bucket",
+                                        "region_name",
+                                        "s3_key_prefix",
+                                        "authorization",
+                                        "bucket_credentials"
+                                    ],
+                                    "type": "object"
+                                },
+                                "database": {
+                                    "description": "Redshift database name to connect to.",
+                                    "type": "string"
+                                },
+                                "host": {
+                                    "description": "Redshift cluster or Serverless workgroup endpoint. Required when using an AWS Redshift integration; plain Redshift integrations store the host themselves.",
+                                    "type": "string"
+                                },
+                                "mode": {
+                                    "default": "INSERT",
+                                    "description": "How rows reach Redshift: batched INSERT statements, or COPY from files staged in S3.\n\n* `INSERT` - INSERT\n* `COPY` - COPY",
+                                    "enum": ["INSERT", "COPY"],
+                                    "type": "string"
+                                },
+                                "port": {
+                                    "default": 5439,
+                                    "description": "Port the Redshift server listens on.",
+                                    "type": "number"
+                                },
+                                "properties_data_type": {
+                                    "default": "varchar",
+                                    "description": "Data type used for JSON-like columns such as event properties.\n\n* `varchar` - varchar\n* `super` - super",
+                                    "enum": ["varchar", "super"],
+                                    "type": "string"
+                                },
+                                "schema": {
+                                    "default": "public",
+                                    "description": "Redshift schema name containing the destination table.",
+                                    "type": "string"
+                                },
+                                "table_name": {
+                                    "default": "events",
+                                    "description": "Redshift table name to write exported rows into.",
+                                    "type": "string"
+                                }
+                            },
+                            "required": ["database"],
+                            "type": "object"
+                        },
+                        "integration_id": {
+                            "description": "ID of an aws-redshift-kind Integration providing connection credentials. Preferred over inline credentials. Use the integrations-list MCP tool to find one.",
+                            "type": "number"
+                        },
+                        "type": {
+                            "enum": ["Redshift"],
+                            "type": "string"
+                        }
+                    },
+                    "required": ["type", "config"],
+                    "type": "object"
                 }
             ],
             "description": "Destination configuration. Required integration_id is enforced per destination type."

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/batch-export-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/batch-export-update.json
@@ -393,6 +393,134 @@
                     },
                     "required": ["type", "config"],
                     "type": "object"
+                },
+                {
+                    "description": "Request shape for creating or updating a Redshift batch-export destination.",
+                    "properties": {
+                        "config": {
+                            "description": "Typed configuration for a Redshift batch-export destination.\n\nConnection credentials may live in a linked Integration (when one is provided) or inline in\nthis config (legacy). Mirrors the non-credential fields of `RedshiftBatchExportInputs` in\n`products/batch_exports/backend/service.py`.",
+                            "properties": {
+                                "copy_inputs": {
+                                    "description": "S3 staging configuration, required when mode is 'COPY'.",
+                                    "properties": {
+                                        "authorization": {
+                                            "anyOf": [
+                                                {
+                                                    "description": "ID of an aws-s3-kind Integration.",
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "description": "ARN of an IAM role attached to the Redshift cluster.",
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "aws_access_key_id": {
+                                                            "type": "string"
+                                                        },
+                                                        "aws_secret_access_key": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": ["aws_access_key_id", "aws_secret_access_key"],
+                                                    "type": "object"
+                                                }
+                                            ],
+                                            "description": "Authorization for Redshift to read staged files during COPY: the ARN of an IAM role attached to the cluster, inline AWS credentials, or the id of an aws-s3-kind Integration."
+                                        },
+                                        "bucket_credentials": {
+                                            "anyOf": [
+                                                {
+                                                    "description": "ID of an aws-s3-kind Integration.",
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "aws_access_key_id": {
+                                                            "type": "string"
+                                                        },
+                                                        "aws_secret_access_key": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": ["aws_access_key_id", "aws_secret_access_key"],
+                                                    "type": "object"
+                                                }
+                                            ],
+                                            "description": "Credentials used to stage files in the S3 bucket: inline AWS credentials or the id of an aws-s3-kind Integration."
+                                        },
+                                        "region_name": {
+                                            "description": "AWS region of the staging S3 bucket.",
+                                            "type": "string"
+                                        },
+                                        "s3_bucket": {
+                                            "description": "S3 bucket where files are staged before the Redshift COPY.",
+                                            "type": "string"
+                                        },
+                                        "s3_key_prefix": {
+                                            "description": "Key prefix for staged files in the S3 bucket.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "s3_bucket",
+                                        "region_name",
+                                        "s3_key_prefix",
+                                        "authorization",
+                                        "bucket_credentials"
+                                    ],
+                                    "type": "object"
+                                },
+                                "database": {
+                                    "description": "Redshift database name to connect to.",
+                                    "type": "string"
+                                },
+                                "host": {
+                                    "description": "Redshift cluster or Serverless workgroup endpoint. Required when using an AWS Redshift integration; plain Redshift integrations store the host themselves.",
+                                    "type": "string"
+                                },
+                                "mode": {
+                                    "default": "INSERT",
+                                    "description": "How rows reach Redshift: batched INSERT statements, or COPY from files staged in S3.\n\n* `INSERT` - INSERT\n* `COPY` - COPY",
+                                    "enum": ["INSERT", "COPY"],
+                                    "type": "string"
+                                },
+                                "port": {
+                                    "default": 5439,
+                                    "description": "Port the Redshift server listens on.",
+                                    "type": "number"
+                                },
+                                "properties_data_type": {
+                                    "default": "varchar",
+                                    "description": "Data type used for JSON-like columns such as event properties.\n\n* `varchar` - varchar\n* `super` - super",
+                                    "enum": ["varchar", "super"],
+                                    "type": "string"
+                                },
+                                "schema": {
+                                    "default": "public",
+                                    "description": "Redshift schema name containing the destination table.",
+                                    "type": "string"
+                                },
+                                "table_name": {
+                                    "default": "events",
+                                    "description": "Redshift table name to write exported rows into.",
+                                    "type": "string"
+                                }
+                            },
+                            "required": ["database"],
+                            "type": "object"
+                        },
+                        "integration_id": {
+                            "description": "ID of an aws-redshift-kind Integration providing connection credentials. Preferred over inline credentials. Use the integrations-list MCP tool to find one.",
+                            "type": "number"
+                        },
+                        "type": {
+                            "enum": ["Redshift"],
+                            "type": "string"
+                        }
+                    },
+                    "required": ["type", "config"],
+                    "type": "object"
                 }
             ],
             "description": "Destination configuration. Required integration_id is enforced per destination type."


### PR DESCRIPTION
<!-- This has to stand on its own: a reader who opens no files should still know why the PR is necessary and what it does. Length tracks the change, so a small diff gets a few bullets rather than a full-length body, and a section you have nothing for gets one line or "None". -->

## Problem

Redshift does not currently support integrations, like all other destinations, and additionally users are still having to provide us plain text credentials.

<!-- Who are we building for, what are their needs, why is this important? -->
<!-- First line: what is different for a person, and who they are. A fix says what breaks; a feature says what someone can now do; a chore says who is blocked. The code path goes underneath. -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

As setup, I had to update the role-based integration models introduced in #76745. I should have probably tried to use the classes then to avoid the small refactor here. But regardless, the role-based integration classes now support an extra set of parameters, and can return an aws account id. Redshift uses a bunch of parameters (like `groups`, `user` and `auto_create`) and the account id in AWS API requests to obtain credentials.

We also now validate the AWS role ARN when creating the integration, so that we can later rely on it (e.g. to parse the account id). This matches the work done by regular AWS integrations, so I think it's nice to be consistent.

API now supports configuring Redshift integrations. I had the robot help out with all the boilerplate here, as everything should match the existing patterns. Once the frontend is done (in a follow-up PR), I'll require integrations for new batch exports, but for now they are optional.

There is a lot going on in `redshift_batch_export.py`: The gist of it is that we need to do a `GetCredentials` or a `GetClusterCredentials` request (depending if Redshift is serverless or not) after assuming the role provided by the user. Additionally, we also need S3 temporary credentials for the COPY export, which is the same as what we do in `s3_batch_export.py`.


<!-- For each change a person can notice, say what they will now see or do differently, not only the code path that does it. Mark the rest as mechanical so a reviewer knows nothing user-visible is hiding in it. -->

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Ran existing tests, added new ones.

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->
<!-- Don't recite pass counts for suites CI runs; the checks report those with more authority. Link the evidence instead (run, permalink, error tracking issue), and say what you did not check. Long transcripts go in a <details> block. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
Not yet, once frontend is out.

## Docs update

Not yet, once frontend is out.
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

I wrote the initial implementation myself (sans-API). Had the robot review, which ended up fixing a lot of issues here and there, but none that required substantial changes to the code I had already written.

The fully automated parts were the API boilerplate and the new tests. I figured API is well-covered by tests that can run without external services, so the robot should do a good job here.
 
<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
     - Public artifact: nothing in this PR — code, fixtures and sample data, comments, commit messages, or this description — carries material from the agent session that isn't already public. If the work drew on a customer conversation, ticket, or log, say so here and state that the committed data is invented. Renaming people, hosts, and identifiers does not clear real material; see AGENTS.md "Public open source repo guidance".
-->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way: what changed across the session. The reason the shipped design beats the obvious alternative goes in Changes instead, where a reviewer will actually see it.
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session — that applies to every part of this PR, not just this section.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Voice: the subject of every sentence is the change, never its author. No "I", "me" or "my" anywhere in the body. "I (actually Claude)" is worse than either half: it hands the assignee an account of work they did not do. Authorship is one stated fact in the Agent context section below.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Flow and topology changes: include separate before-and-after Mermaid `flowchart` blocks with PostHog colors. This includes CI wiring, pipelines, state machines, and request paths. Use `/writing-pr-descriptions` for the palette and role mapping.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Stack instead of stuffing: if the diff holds two or more separable steps (migration then behavior, rename then rewrite), open a stack rather than one big PR. See AGENTS.md, "Stacked PRs" and /stacking-prs.
- Simplify before opening: if your agent has a behavior-preserving cleanup pass (Claude Code: `/simplify`), run it on a non-trivial diff before final tests and preflight, since it edits the tree. Skip it for small mechanical changes.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- Shape and style: invoke the `/writing-pr-descriptions` skill before writing this body. In short: lead with the effect a person sees rather than the code path behind it, make the body stand alone for a reader who opens no files, size it to the change, link evidence rather than asserting what CI already reports, then hold what's left to one fact per bullet in under 25 words. A body that got longer as bullets was not cut.
-->
