### PR TITLE
feat(workflows): add email priority fair-dequeue index to cyclotron

### DIFF
--- a/rust/cyclotron-node-migrations/20260820000001_add_email_priority_fair_dequeue_index.sql
+++ b/rust/cyclotron-node-migrations/20260820000001_add_email_priority_fair_dequeue_index.sql
@@ -4,11 +4,8 @@
 -- worker can serve transactional-class sends ahead of bulk/marketing-class
 -- sends while keeping the per-team interleave within each class.
 --
--- The email worker's dequeue is moving from
---     ORDER BY dequeue_seq ASC NULLS FIRST
--- to
+-- The email worker's priority dequeue orders by
 --     ORDER BY priority ASC, dequeue_seq ASC NULLS FIRST
--- (gated behind CDP_EMAIL_PRIORITY_DEQUEUE_ENABLED in the Node worker).
 -- Leading on `priority` lets that ORDER BY be satisfied by index order, and
 -- `scheduled` as a trailing key column keeps `scheduled <= NOW()` as an
 -- `Index Cond` rather than a heap-level filter, matching the rationale for

--- a/rust/cyclotron-node-migrations/20260820000001_add_email_priority_fair_dequeue_index.sql
+++ b/rust/cyclotron-node-migrations/20260820000001_add_email_priority_fair_dequeue_index.sql
@@ -1,0 +1,19 @@
+-- no-transaction
+--
+-- Adds a priority-first variant of the email fair-dequeue index, so the email
+-- worker can serve transactional-class sends ahead of bulk/marketing-class
+-- sends while keeping the per-team interleave within each class.
+--
+-- The email worker's dequeue is moving from
+--     ORDER BY dequeue_seq ASC NULLS FIRST
+-- to
+--     ORDER BY priority ASC, dequeue_seq ASC NULLS FIRST
+-- (gated behind CDP_EMAIL_PRIORITY_DEQUEUE_ENABLED in the Node worker).
+-- Leading on `priority` lets that ORDER BY be satisfied by index order, and
+-- `scheduled` as a trailing key column keeps `scheduled <= NOW()` as an
+-- `Index Cond` rather than a heap-level filter, matching the rationale for
+-- idx_cyclotron_jobs_email_fair_dequeue_v2 (which stays in place until the
+-- new ordering is enabled everywhere and is dropped in a follow-up).
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_cyclotron_jobs_email_priority_fair_dequeue
+    ON cyclotron_jobs (priority, dequeue_seq NULLS FIRST, scheduled)
+    WHERE status = 'available' AND queue_name = 'email';


### PR DESCRIPTION
## Problem

A team's own broadcast delays that same team's transactional email. The email queue's fair dequeue orders only by the per-team sequence, and a broadcast fan-out advances that sequence past any transactional send enqueued mid-broadcast.

This is the index layer of a 3-PR stack that dequeues transactional-class email first. **Why:** transactional email is low-volume and latency-sensitive, so it should never wait behind marketing backlogs.

## Changes

- Adds a partial index on `(priority, dequeue_seq NULLS FIRST, scheduled)` over available email-queue rows, so the follow-up's `ORDER BY priority, dequeue_seq` is served by index order.
- No behavior change. Nothing orders the email queue by priority until the flag-gated top layer of the stack.
- The superseded v2 index stays in place until the new ordering is enabled everywhere.

## How did you test this code?

- The migration applied cleanly to a fresh `test_cyclotron_node` via `rust/bin/migrate-entry` (local run).
- `CREATE INDEX CONCURRENTLY` with the `-- no-transaction` marker matches the v2 index migration pattern, so writes are not blocked.
- Not run: the migration against a production-scale table.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The email queue internals are not documented under `docs/`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted). The driver's GitHub handle is not known to this session, so the PR is left unassigned.

Authored with Claude Code from an analysis of transactional vs marketing email delivery in the workflows product. Skills invoked: /stacking-prs, /writing-tests, /writing-code-comments, /writing-pr-descriptions. The design keeps one email queue and one worker, and adds priority classes to the existing fair dequeue, instead of a separate transactional queue and worker fleet, because the SES rate-limit token bucket is claimed in dequeue order, so dequeue priority is already send priority.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*