### PR TITLE
feat(workflows): dequeue email queue by priority class behind a flag

### DIFF
--- a/nodejs/src/cdp/config.ts
+++ b/nodejs/src/cdp/config.ts
@@ -91,6 +91,10 @@ export type CdpConfig = ClickhouseConfig & {
     CDP_SES_RATE_LIMIT_REFILL_PER_SECOND: number
     CDP_SES_RATE_LIMIT_CAPACITY: number
     CDP_SES_RATE_LIMIT_THROTTLED_POLL_DELAY_MS: number
+    // When enabled, the email queue dequeues by priority class before the
+    // per-team fair ordering, so transactional-class sends aren't stuck behind
+    // a broadcast backlog. Requires idx_cyclotron_jobs_email_priority_fair_dequeue.
+    CDP_EMAIL_PRIORITY_DEQUEUE_ENABLED: boolean
 
     CDP_EVENT_PROCESSOR_EXECUTE_FIRST_STEP: boolean
     CDP_GOOGLE_ADWORDS_DEVELOPER_TOKEN: string
@@ -254,6 +258,7 @@ export function getDefaultCdpConfig(): CdpConfig {
         CDP_SES_RATE_LIMIT_REFILL_PER_SECOND: 100,
         CDP_SES_RATE_LIMIT_CAPACITY: 50,
         CDP_SES_RATE_LIMIT_THROTTLED_POLL_DELAY_MS: 250,
+        CDP_EMAIL_PRIORITY_DEQUEUE_ENABLED: false,
 
         CDP_EVENT_PROCESSOR_EXECUTE_FIRST_STEP: true,
         CDP_GOOGLE_ADWORDS_DEVELOPER_TOKEN: '',

--- a/nodejs/src/cdp/services/cyclotron-v2/cyclotron-v2.test.ts
+++ b/nodejs/src/cdp/services/cyclotron-v2/cyclotron-v2.test.ts
@@ -1746,13 +1746,13 @@ describe('Cyclotron V2', () => {
                 createWorker(EMAIL_QUEUE, overrides)
 
             it('dequeues the fast class before an earlier-enqueued bulk backlog when priority dequeue is enabled', async () => {
-                // A bulk broadcast (priority 10) is already queued when two fast-class
+                // A bulk broadcast (priority 1) is already queued when two fast-class
                 // sends (priority 0) arrive, one from the same team. Without priority
                 // ordering, the same-team fast job waits behind the whole backlog.
                 const teamA = 100
                 const teamB = 200
                 await manager.bulkCreateJobs([
-                    ...Array.from({ length: 5 }, () => ({ teamId: teamA, queueName: EMAIL_QUEUE, priority: 10 })),
+                    ...Array.from({ length: 5 }, () => ({ teamId: teamA, queueName: EMAIL_QUEUE, priority: 1 })),
                     { teamId: teamA, queueName: EMAIL_QUEUE, priority: 0 },
                     { teamId: teamB, queueName: EMAIL_QUEUE, priority: 0 },
                 ])
@@ -1768,8 +1768,8 @@ describe('Cyclotron V2', () => {
                 const teamA = 100
                 const teamB = 200
                 await manager.bulkCreateJobs([
-                    ...Array.from({ length: 2 }, () => ({ teamId: teamA, queueName: EMAIL_QUEUE, priority: 10 })),
-                    ...Array.from({ length: 2 }, () => ({ teamId: teamB, queueName: EMAIL_QUEUE, priority: 10 })),
+                    ...Array.from({ length: 2 }, () => ({ teamId: teamA, queueName: EMAIL_QUEUE, priority: 1 })),
+                    ...Array.from({ length: 2 }, () => ({ teamId: teamB, queueName: EMAIL_QUEUE, priority: 1 })),
                     { teamId: teamA, queueName: EMAIL_QUEUE, priority: 0 },
                 ])
 
@@ -1784,10 +1784,10 @@ describe('Cyclotron V2', () => {
 
                 expect(drained).toEqual([
                     [0, teamA],
-                    [10, teamA],
-                    [10, teamB],
-                    [10, teamA],
-                    [10, teamB],
+                    [1, teamA],
+                    [1, teamB],
+                    [1, teamA],
+                    [1, teamB],
                 ])
             })
 
@@ -1795,7 +1795,7 @@ describe('Cyclotron V2', () => {
                 const teamA = 100
                 const teamB = 200
                 await manager.bulkCreateJobs([
-                    ...Array.from({ length: 5 }, () => ({ teamId: teamA, queueName: EMAIL_QUEUE, priority: 10 })),
+                    ...Array.from({ length: 5 }, () => ({ teamId: teamA, queueName: EMAIL_QUEUE, priority: 1 })),
                     { teamId: teamA, queueName: EMAIL_QUEUE, priority: 0 },
                     { teamId: teamB, queueName: EMAIL_QUEUE, priority: 0 },
                 ])
@@ -1805,7 +1805,7 @@ describe('Cyclotron V2', () => {
 
                 // Legacy ordering is dequeue_seq only: the first fair round is team A's
                 // first bulk job and team B's fast job, so priorities stay mixed.
-                expect(jobs.map((j) => j.priority).sort((a, b) => a - b)).toEqual([0, 10])
+                expect(jobs.map((j) => j.priority).sort((a, b) => a - b)).toEqual([0, 1])
             })
 
             it('picks small-tenant jobs into the same batch as big-tenant jobs', async () => {

--- a/nodejs/src/cdp/services/cyclotron-v2/cyclotron-v2.test.ts
+++ b/nodejs/src/cdp/services/cyclotron-v2/cyclotron-v2.test.ts
@@ -1745,6 +1745,69 @@ describe('Cyclotron V2', () => {
             const createFairWorker = (overrides?: Record<string, unknown>): CyclotronV2Worker =>
                 createWorker(EMAIL_QUEUE, overrides)
 
+            it('dequeues the fast class before an earlier-enqueued bulk backlog when priority dequeue is enabled', async () => {
+                // A bulk broadcast (priority 10) is already queued when two fast-class
+                // sends (priority 0) arrive, one from the same team. Without priority
+                // ordering, the same-team fast job waits behind the whole backlog.
+                const teamA = 100
+                const teamB = 200
+                await manager.bulkCreateJobs([
+                    ...Array.from({ length: 5 }, () => ({ teamId: teamA, queueName: EMAIL_QUEUE, priority: 10 })),
+                    { teamId: teamA, queueName: EMAIL_QUEUE, priority: 0 },
+                    { teamId: teamB, queueName: EMAIL_QUEUE, priority: 0 },
+                ])
+
+                const worker = createFairWorker({ batchMaxSize: 2, priorityDequeue: true })
+                const jobs = await dequeueOneBatch(worker)
+
+                expect(jobs.map((j) => j.priority)).toEqual([0, 0])
+                expect(new Set(jobs.map((j) => j.teamId))).toEqual(new Set([teamA, teamB]))
+            })
+
+            it('keeps the per-team interleave within a priority class', async () => {
+                const teamA = 100
+                const teamB = 200
+                await manager.bulkCreateJobs([
+                    ...Array.from({ length: 2 }, () => ({ teamId: teamA, queueName: EMAIL_QUEUE, priority: 10 })),
+                    ...Array.from({ length: 2 }, () => ({ teamId: teamB, queueName: EMAIL_QUEUE, priority: 10 })),
+                    { teamId: teamA, queueName: EMAIL_QUEUE, priority: 0 },
+                ])
+
+                const drained: Array<[number, number]> = []
+                for (let i = 0; i < 5; i++) {
+                    const worker = createFairWorker({ batchMaxSize: 1, priorityDequeue: true })
+                    const batch = await dequeueOneBatch(worker)
+                    expect(batch).toHaveLength(1)
+                    drained.push([batch[0].priority, batch[0].teamId])
+                    await batch[0].ack()
+                }
+
+                expect(drained).toEqual([
+                    [0, teamA],
+                    [10, teamA],
+                    [10, teamB],
+                    [10, teamA],
+                    [10, teamB],
+                ])
+            })
+
+            it('ignores priority when priority dequeue is disabled', async () => {
+                const teamA = 100
+                const teamB = 200
+                await manager.bulkCreateJobs([
+                    ...Array.from({ length: 5 }, () => ({ teamId: teamA, queueName: EMAIL_QUEUE, priority: 10 })),
+                    { teamId: teamA, queueName: EMAIL_QUEUE, priority: 0 },
+                    { teamId: teamB, queueName: EMAIL_QUEUE, priority: 0 },
+                ])
+
+                const worker = createFairWorker({ batchMaxSize: 2 })
+                const jobs = await dequeueOneBatch(worker)
+
+                // Legacy ordering is dequeue_seq only: the first fair round is team A's
+                // first bulk job and team B's fast job, so priorities stay mixed.
+                expect(jobs.map((j) => j.priority).sort((a, b) => a - b)).toEqual([0, 10])
+            })
+
             it('picks small-tenant jobs into the same batch as big-tenant jobs', async () => {
                 // The 2M-vs-1 scenario at a smaller scale: team A enqueues 5,
                 // team B enqueues 1. With strict FIFO, B's 1 sits behind A's 5.

--- a/nodejs/src/cdp/services/cyclotron-v2/types.ts
+++ b/nodejs/src/cdp/services/cyclotron-v2/types.ts
@@ -204,6 +204,9 @@ export type CyclotronV2WorkerConfig = {
     pollDelayMs?: number
     heartbeatTimeoutMs?: number
     includeEmptyBatches?: boolean
+    // Orders the email queue's fair dequeue by priority class before dequeue_seq.
+    // Only meaningful on the email queue; other queues already order by priority.
+    priorityDequeue?: boolean
 }
 
 export type CyclotronV2JanitorConfig = {

--- a/nodejs/src/cdp/services/cyclotron-v2/worker.ts
+++ b/nodejs/src/cdp/services/cyclotron-v2/worker.ts
@@ -1,5 +1,6 @@
 import { DateTime } from 'luxon'
 import { Pool, PoolClient } from 'pg'
+import { Histogram } from 'prom-client'
 import { v7 as uuidv7 } from 'uuid'
 
 import { logger } from '~/common/utils/logger'
@@ -14,6 +15,15 @@ import {
     CyclotronV2RescheduleOptionsSchema,
     CyclotronV2WorkerConfig,
 } from './types'
+
+// Buckets range from "dequeued immediately" to "sat behind an hour-plus backlog":
+// the low end validates transactional-class latency, the high end sizes broadcast drain time.
+const emailDequeueLagMs = new Histogram({
+    name: 'cdp_cyclotron_email_dequeue_lag_ms',
+    help: 'Time between an email job becoming due and being dequeued, by priority class',
+    labelNames: ['priority'] as const,
+    buckets: [100, 500, 1000, 5000, 15000, 60000, 300000, 900000, 3600000],
+})
 
 export interface RawJobRow {
     id: string
@@ -213,6 +223,7 @@ export class CyclotronV2Worker {
     private readonly heartbeatTimeoutMs: number
     protected readonly includeEmptyBatches: boolean
     protected readonly fairDequeue: boolean
+    private readonly priorityDequeue: boolean
 
     constructor(private config: CyclotronV2WorkerConfig) {
         this.pool = new Pool({
@@ -229,6 +240,7 @@ export class CyclotronV2Worker {
         // CyclotronV2Manager), so deriving this from the queue name keeps the
         // worker's ORDER BY in lockstep with where the sort key actually exists.
         this.fairDequeue = config.queueName === 'email'
+        this.priorityDequeue = config.priorityDequeue ?? false
     }
 
     async connect(processBatch: (jobs: CyclotronV2DequeuedJob[]) => Promise<void>): Promise<void> {
@@ -356,6 +368,13 @@ export class CyclotronV2Worker {
      */
     protected async fairDequeueJobs(limit: number = this.batchMaxSize): Promise<RawJobRow[]> {
         const lockId = uuidv7()
+        // With priorityDequeue, priority class leads the sort so transactional-class
+        // sends aren't stuck behind a broadcast backlog; the per-team interleave
+        // still orders jobs within each class. Served by
+        // idx_cyclotron_jobs_email_priority_fair_dequeue.
+        const orderBy = this.priorityDequeue
+            ? 'priority ASC, dequeue_seq ASC NULLS FIRST'
+            : 'dequeue_seq ASC NULLS FIRST'
         const result = await this.pool.query<RawJobRow>(
             `WITH available AS (
                 SELECT id
@@ -363,7 +382,7 @@ export class CyclotronV2Worker {
                 WHERE status = 'available'
                   AND queue_name = $1
                   AND scheduled <= NOW()
-                ORDER BY dequeue_seq ASC NULLS FIRST
+                ORDER BY ${orderBy}
                 LIMIT $2
                 FOR UPDATE SKIP LOCKED
             )
@@ -393,6 +412,12 @@ export class CyclotronV2Worker {
                 cyclotron_jobs.lock_id`,
             [this.config.queueName, limit, lockId]
         )
+        // Lag is measured from `scheduled` rather than `created`, so intentional
+        // waits (delays, throttle retries) don't count as queue wait time.
+        const now = Date.now()
+        for (const row of result.rows) {
+            emailDequeueLagMs.labels(String(row.priority)).observe(Math.max(0, now - Date.parse(row.scheduled)))
+        }
         // Within-batch order is undefined (UPDATE...RETURNING doesn't preserve
         // the CTE's ORDER BY), but the fairness guarantee is *across* batches:
         // the CTE picks the rows with the lowest dequeue_seq values, so a

--- a/nodejs/src/cdp/services/cyclotron-v2/worker.ts
+++ b/nodejs/src/cdp/services/cyclotron-v2/worker.ts
@@ -1,6 +1,5 @@
 import { DateTime } from 'luxon'
 import { Pool, PoolClient } from 'pg'
-import { Histogram } from 'prom-client'
 import { v7 as uuidv7 } from 'uuid'
 
 import { logger } from '~/common/utils/logger'
@@ -15,15 +14,6 @@ import {
     CyclotronV2RescheduleOptionsSchema,
     CyclotronV2WorkerConfig,
 } from './types'
-
-// Buckets range from "dequeued immediately" to "sat behind an hour-plus backlog":
-// the low end validates transactional-class latency, the high end sizes broadcast drain time.
-const emailDequeueLagMs = new Histogram({
-    name: 'cdp_cyclotron_email_dequeue_lag_ms',
-    help: 'Time between an email job becoming due and being dequeued, by priority class',
-    labelNames: ['priority'] as const,
-    buckets: [100, 500, 1000, 5000, 15000, 60000, 300000, 900000, 3600000],
-})
 
 export interface RawJobRow {
     id: string
@@ -412,12 +402,6 @@ export class CyclotronV2Worker {
                 cyclotron_jobs.lock_id`,
             [this.config.queueName, limit, lockId]
         )
-        // Lag is measured from `scheduled` rather than `created`, so intentional
-        // waits (delays, throttle retries) don't count as queue wait time.
-        const now = Date.now()
-        for (const row of result.rows) {
-            emailDequeueLagMs.labels(String(row.priority)).observe(Math.max(0, now - Date.parse(row.scheduled)))
-        }
         // Within-batch order is undefined (UPDATE...RETURNING doesn't preserve
         // the CTE's ORDER BY), but the fairness guarantee is *across* batches:
         // the CTE picks the rows with the lowest dequeue_seq values, so a

--- a/nodejs/src/cdp/services/job-queue/job-queue-postgres-v2.ts
+++ b/nodejs/src/cdp/services/job-queue/job-queue-postgres-v2.ts
@@ -47,6 +47,7 @@ export class CyclotronJobQueuePostgresV2 implements JobQueue {
             | 'CDP_CYCLOTRON_INSERT_MAX_BATCH_SIZE'
             | 'CDP_CYCLOTRON_INSERT_PARALLEL_BATCHES'
             | 'CDP_CYCLOTRON_STRIP_PERSON_FROM_STATE_TEAMS'
+            | 'CDP_EMAIL_PRIORITY_DEQUEUE_ENABLED'
         >
     ) {
         this.sanitizer = createInvocationSanitizer(config)
@@ -92,6 +93,7 @@ export class CyclotronJobQueuePostgresV2 implements JobQueue {
             batchMaxSize: this.consumerBatchSize,
             pollDelayMs: this.config.CDP_CYCLOTRON_BATCH_DELAY_MS,
             includeEmptyBatches: true,
+            priorityDequeue: this.config.CDP_EMAIL_PRIORITY_DEQUEUE_ENABLED,
         })
 
         await this.worker.connect(async (jobs) => {


### PR DESCRIPTION
## Problem

Transactional email still waits behind broadcast backlogs: the classes exist (#86240) and the index exists (#86239), but the email worker dequeues by per-team order only.

Top layer of the stack. Turning on the flag is what makes a team's password reset overtake its own running broadcast.

## Changes

- With `CDP_EMAIL_PRIORITY_DEQUEUE_ENABLED`, the email worker serves transactional-class sends ahead of bulk-class ones, and the per-team interleave still holds within each class:

```diff
- ORDER BY dequeue_seq ASC NULLS FIRST
+ ORDER BY priority ASC, dequeue_seq ASC NULLS FIRST
```

- The flag defaults off, so rollout and rollback are config-only.
- The SES rate-limit token bucket is claimed at dequeue time, so dequeue priority is also send priority. No rate limiter changes.
- Rows queued before the flip carry legacy priorities: rows at 1 tie with new bulk rows (1), and degraded-flow rows at 2 drain after bulk. Bounded to the transition window.

> [!NOTE]
> After the flag is on everywhere, a follow-up should drop the superseded `idx_cyclotron_jobs_email_fair_dequeue_v2` index.

## How did you test this code?

Three new cyclotron-v2 tests, each catching a regression no existing test did:

- Flag on: a fast-class send dequeues in the first batch even when a same-team bulk backlog was enqueued earlier (the exact starvation case this stack fixes).
- Flag on: the per-team interleave holds within a class, guarding the fairness property against the new leading sort key.
- Flag off: ordering stays dequeue_seq only, guarding against the flag wiring being inverted or always-on.

Ran locally: the cyclotron-v2 and job-queue-postgres-v2 suites and the nodejs typecheck.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The email queue internals are not documented under `docs/`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted). The driver's GitHub handle is not known to this session, so the PR is left unassigned.

Authored with Claude Code. Skills invoked: /stacking-prs, /writing-tests, /writing-code-comments, /writing-pr-descriptions.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*

