### PR TITLE
fix(ingestion-consumer): report the shared fetch queue once, not per partition

### DIFF
--- a/rust/ingestion-consumer/src/consumer.rs
+++ b/rust/ingestion-consumer/src/consumer.rs
@@ -164,6 +164,13 @@ impl IngestionConsumer {
         }
 
         let client_config = config.build_consumer_config();
+        // After the build, so the caps reported are the ones the client runs
+        // with rather than the settings that seeded them.
+        crate::kafka_stats::export_limits(
+            &client_config,
+            config.consumer_batch_size,
+            config.consumer_batch_size_kb,
+        );
         let commit_sentinel = Arc::new(CommitSentinel::new());
         commit_sentinel.set_enabled(config.consumer_order_sentinel_enabled);
         let key_sentinel = dispatcher.key_order_sentinel();

--- a/rust/ingestion-consumer/src/kafka_stats.rs
+++ b/rust/ingestion-consumer/src/kafka_stats.rs
@@ -26,25 +26,32 @@
 //! written when a value is available is a stale gauge the moment it stops being
 //! available, so each one below is written on every invocation, including when
 //! the underlying value is absent.
+//!
+//! # Per-partition queue depths are not additive
+//!
+//! librdkafka's queue accessors follow queue forwarding, and the high-level
+//! consumer forwards every partition queue into one shared queue. A statistic
+//! that looks per-partition can therefore be the same shared total repeated
+//! once per assigned partition. Aggregate those with a maximum, not a sum — see
+//! [`fetch_queue`].
 
 use metrics::gauge;
 use rdkafka::Statistics;
 
-/// Messages sitting in librdkafka's fetch queue, summed over all partitions.
-///
-/// With the high-level consumer every partition queue forwards into one shared
-/// queue, so per-partition numbers are an attribution of a shared pool and only
-/// their sum is meaningful.
+/// Messages sitting in librdkafka's shared fetch queue. See [`fetch_queue`] for
+/// why this is a max across partitions rather than a sum.
 const FETCHQ_MESSAGES: &str = "kafka_consumer_fetchq_messages";
 
-/// Bytes sitting in librdkafka's fetch queue, summed over all partitions.
-/// Same shared-pool caveat as [`FETCHQ_MESSAGES`]. This is the memory the
-/// client holds on the consumer's behalf, bounded by
-/// `queued.max.messages.kbytes`.
+/// Bytes sitting in librdkafka's shared fetch queue — the memory the client
+/// holds on the consumer's behalf, bounded by `queued.max.messages.kbytes`.
+/// Same max-not-sum rule as [`FETCHQ_MESSAGES`].
 const FETCHQ_BYTES: &str = "kafka_consumer_fetchq_bytes";
 
-/// Operations waiting on librdkafka's main reply queue for the application to
-/// poll. Sustained growth means the consumer loop is not polling fast enough.
+/// Operations waiting for the application to poll.
+///
+/// Read from the client's main reply queue, which the high-level consumer
+/// forwards into the same shared queue the partition fetch queues feed, so this
+/// tracks [`FETCHQ_MESSAGES`] rather than counting a separate backlog.
 const REPLYQ_OPS: &str = "kafka_consumer_replyq_ops";
 
 /// Slowest average request round-trip time across the connected brokers, over
@@ -68,16 +75,9 @@ const REBALANCE_TOTAL: &str = "kafka_consumer_rebalance_total";
 pub fn export(stats: &Statistics) {
     gauge!(REPLYQ_OPS).set(stats.replyq as f64);
 
-    let mut fetchq_messages: i64 = 0;
-    let mut fetchq_bytes: u64 = 0;
-    for topic in stats.topics.values() {
-        for partition in topic.partitions.values() {
-            fetchq_messages += partition.fetchq_cnt;
-            fetchq_bytes += partition.fetchq_size;
-        }
-    }
-    gauge!(FETCHQ_MESSAGES).set(fetchq_messages as f64);
-    gauge!(FETCHQ_BYTES).set(fetchq_bytes as f64);
+    let fetchq = fetch_queue(stats);
+    gauge!(FETCHQ_MESSAGES).set(fetchq.messages as f64);
+    gauge!(FETCHQ_BYTES).set(fetchq.bytes as f64);
 
     let mut outbuf_requests: i64 = 0;
     let mut waitresp_requests: i64 = 0;
@@ -98,4 +98,78 @@ pub fn export(stats: &Statistics) {
     // Written even before the group is joined, so the series never goes stale.
     let rebalance_count = stats.cgrp.as_ref().map_or(0, |cgrp| cgrp.rebalance_cnt);
     gauge!(REBALANCE_TOTAL).set(rebalance_count as f64);
+}
+
+/// Depth of the one queue librdkafka holds fetched messages in.
+struct FetchQueue {
+    messages: i64,
+    bytes: u64,
+}
+
+/// Read the shared fetch queue's depth from a statistics snapshot.
+///
+/// Takes the maximum across partitions, never the sum. librdkafka fills each
+/// partition's `fetchq_cnt` and `fetchq_size` from that partition's queue
+/// handle, and those accessors follow queue forwarding. The high-level consumer
+/// forwards every partition queue into a single shared queue, so each assigned
+/// partition reports the whole shared queue rather than a disjoint slice of it.
+/// Summing therefore multiplies the real depth by the assigned partition count,
+/// and can report more memory than the process has. A partition that is not
+/// forwarding yet reports its own empty queue, which the maximum ignores.
+fn fetch_queue(stats: &Statistics) -> FetchQueue {
+    let mut messages = 0i64;
+    let mut bytes = 0u64;
+    for topic in stats.topics.values() {
+        for partition in topic.partitions.values() {
+            messages = messages.max(partition.fetchq_cnt);
+            bytes = bytes.max(partition.fetchq_size);
+        }
+    }
+    FetchQueue { messages, bytes }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use rdkafka::statistics::{Partition, Topic};
+
+    use super::*;
+
+    fn partition(id: i32, fetchq_cnt: i64, fetchq_size: u64) -> Partition {
+        Partition {
+            partition: id,
+            fetchq_cnt,
+            fetchq_size,
+            ..Default::default()
+        }
+    }
+
+    fn statistics(partitions: Vec<Partition>) -> Statistics {
+        let partitions = partitions.into_iter().map(|p| (p.partition, p)).collect();
+        Statistics {
+            topics: HashMap::from([(
+                "t".to_string(),
+                Topic {
+                    partitions,
+                    ..Default::default()
+                },
+            )]),
+            ..Default::default()
+        }
+    }
+
+    /// Every forwarding partition reports the whole shared queue, so the depth
+    /// is one partition's figure — not the total across them.
+    #[test]
+    fn fetch_queue_does_not_multiply_shared_queue_by_partition_count() {
+        let mut partitions: Vec<Partition> = (0..6).map(|id| partition(id, 100, 1_000)).collect();
+        // Assigned but not fetching yet: reports its own still-empty queue.
+        partitions.push(partition(6, 0, 0));
+
+        let fetchq = fetch_queue(&statistics(partitions));
+
+        assert_eq!(fetchq.messages, 100);
+        assert_eq!(fetchq.bytes, 1_000);
+    }
 }

--- a/rust/ingestion-consumer/src/kafka_stats.rs
+++ b/rust/ingestion-consumer/src/kafka_stats.rs
@@ -36,7 +36,7 @@
 //! [`fetch_queue`].
 
 use metrics::gauge;
-use rdkafka::Statistics;
+use rdkafka::{ClientConfig, Statistics};
 
 /// Messages sitting in librdkafka's shared fetch queue. See [`fetch_queue`] for
 /// why this is a max across partitions rather than a sum.
@@ -70,6 +70,29 @@ const BROKER_WAITRESP_REQUESTS: &str = "kafka_consumer_broker_waitresp_requests"
 /// it with `changes()` or `delta()` rather than `rate()`. Reads `0` until the
 /// client joins its consumer group.
 const REBALANCE_TOTAL: &str = "kafka_consumer_rebalance_total";
+
+/// Cap on [`FETCHQ_BYTES`], from the resolved `queued.max.messages.kbytes`.
+/// A config mirror, set once at startup.
+const FETCHQ_BYTES_LIMIT: &str = "kafka_consumer_fetchq_bytes_limit";
+
+/// Cap on [`FETCHQ_MESSAGES`], from the resolved `queued.min.messages`.
+/// A config mirror, set once at startup.
+const FETCHQ_MESSAGES_LIMIT: &str = "kafka_consumer_fetchq_messages_limit";
+
+/// Cap on `consumer_batch_size`, in messages, from `CONSUMER_BATCH_SIZE`.
+/// A config mirror, set once at startup.
+const BATCH_SIZE_LIMIT: &str = "consumer_batch_size_limit";
+
+/// Cap on `consumer_batch_size_kb`, from `CONSUMER_BATCH_SIZE_KB`. A config
+/// mirror, set once at startup. `0` means the byte bound is off, so a dashboard
+/// can tell "unset" from a real cap.
+const BATCH_SIZE_KB_LIMIT: &str = "consumer_batch_size_kb_limit";
+
+/// librdkafka's own default for `queued.max.messages.kbytes`.
+const DEFAULT_QUEUED_MAX_MESSAGES_KBYTES: f64 = 102_400.0;
+
+/// librdkafka's own default for `queued.min.messages`.
+const DEFAULT_QUEUED_MIN_MESSAGES: f64 = 100_000.0;
 
 /// Export the gauges described in the module docs from one statistics snapshot.
 pub fn export(stats: &Statistics) {
@@ -126,6 +149,42 @@ fn fetch_queue(stats: &Statistics) -> FetchQueue {
         }
     }
     FetchQueue { messages, bytes }
+}
+
+/// Publish the configured caps that bound the live gauges above.
+///
+/// Config mirrors, set once at startup because none of them change while the
+/// process runs. They exist so a dashboard can compute utilization against the
+/// cap per deployment, rather than hardcoding limits that differ per lane.
+///
+/// The librdkafka caps come from the built [`ClientConfig`], not from the typed
+/// settings that seeded it. The generic `KAFKA_CONSUMER_*` passthrough can
+/// override any property, so only the built config states what the client
+/// actually runs with.
+pub fn export_limits(client_config: &ClientConfig, batch_size: usize, batch_size_kb: usize) {
+    let queued_max_kbytes = property(
+        client_config,
+        "queued.max.messages.kbytes",
+        DEFAULT_QUEUED_MAX_MESSAGES_KBYTES,
+    );
+    gauge!(FETCHQ_BYTES_LIMIT).set(queued_max_kbytes * 1024.0);
+    gauge!(FETCHQ_MESSAGES_LIMIT).set(property(
+        client_config,
+        "queued.min.messages",
+        DEFAULT_QUEUED_MIN_MESSAGES,
+    ));
+    gauge!(BATCH_SIZE_LIMIT).set(batch_size as f64);
+    gauge!(BATCH_SIZE_KB_LIMIT).set(batch_size_kb as f64);
+}
+
+/// Read a numeric librdkafka property from the built config, falling back to
+/// librdkafka's own default when the key is unset. A value librdkafka would
+/// reject also falls back here, and fails the client creation that follows.
+fn property(client_config: &ClientConfig, key: &str, default: f64) -> f64 {
+    client_config
+        .get(key)
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Problem

`kafka_consumer_fetchq_bytes` overstates the consumer's queued memory by the number of partitions the pod is assigned.
A pod reported more queued bytes than its container working set allowed, which is impossible.

- librdkafka fills each partition's `fetchq_cnt` and `fetchq_size` from that partition's queue handle.
- Those accessors follow queue forwarding ([`rdkafka_queue.h`](https://github.com/confluentinc/librdkafka/blob/v2.12.1/src/rdkafka_queue.h#L638-L667)), and the high-level consumer forwards every partition queue into one shared queue.
- Each assigned partition therefore reports the whole shared queue, so the sum multiplies the real depth by the partition count.

Separately, a dashboard plotting queue or batch utilization has to hardcode each lane's caps, because nothing exports them.

## Changes

- `kafka_consumer_fetchq_bytes` and `kafka_consumer_fetchq_messages` now report the shared queue's real depth. Both take the maximum across partitions instead of the sum.
- A dashboard can now draw the cap line from a series. Four new gauges mirror the configured limits, set once at startup.
- The aggregation moves into a `fetch_queue` function that documents why a sum is wrong, so the next reader does not convert it back.

The metric was always meant to report the shared queue. Summing was the defect, so the names stay.
A partition that is not fetching yet reports its own empty queue, which the maximum ignores.

### New limit gauges

Each pairs with its live counterpart by the `_limit` suffix, so utilization is one division.

| Metric | Source | Default |
| --- | --- | --- |
| `kafka_consumer_fetchq_bytes_limit` | `queued.max.messages.kbytes` x 1024 | 104857600 |
| `kafka_consumer_fetchq_messages_limit` | `queued.min.messages` | 100000 |
| `consumer_batch_size_limit` | `CONSUMER_BATCH_SIZE` | 500 |
| `consumer_batch_size_kb_limit` | `CONSUMER_BATCH_SIZE_KB` | 0 |

The two librdkafka caps are read back from the built `ClientConfig`, not from the typed settings that seeded it.
The generic `KAFKA_CONSUMER_*` passthrough can override any property, so only the built config states what the client runs with.
A key the passthrough leaves unset falls back to librdkafka's own default.

`consumer_batch_size_kb_limit` reports `0` when the byte bound is off, so a dashboard can tell "unset" from a real cap.

> [!NOTE]
> `kafka_consumer_replyq_ops` reads the client's main reply queue, which `rd_kafka_poll_set_consumer` forwards into that same shared queue.
> It therefore tracks `kafka_consumer_fetchq_messages` rather than measuring a separate backlog.
> This PR corrects its documentation and leaves the series in place; whether to keep a duplicate is worth deciding separately.

Values recorded before this fix are inflated by the pod's partition count.
The metric shipped a day ago, so the only consumer is the ingestion-lane autoscaling panel, corrected separately.

The broker gauges are unaffected: `outbuf_cnt` and `waitresp_cnt` come from per-broker counters, not forwarding queues, so summing them stays correct.

## How did you test this code?

Added one unit test over `fetch_queue`, using a synthetic `Statistics` with six partitions reporting identical forwarded totals plus one partition still empty.
It catches a sum reintroduced in place of the maximum, which is the defect this PR fixes and the most likely way it returns.

Verified the test fails against the old aggregation before keeping it: reverting to `+=` produced `left: 600, right: 100`, the same 6x inflation seen in production.

Ran `cargo fmt --check`, `cargo clippy --all-targets`, `cargo test --lib`, and `cargo build` for `ingestion-consumer`.

Ran the built binary against an unreachable broker and scraped `/metrics` twice.

<details>
<summary>Limit gauges, defaults and overrides</summary>

Defaults:

```text
consumer_batch_size_kb_limit 0
consumer_batch_size_limit 500
kafka_consumer_fetchq_bytes_limit 104857600
kafka_consumer_fetchq_messages_limit 100000
```

With `KAFKA_CONSUMER_QUEUED_MAX_MESSAGES_KBYTES=51200`, `KAFKA_CONSUMER_QUEUED_MIN_MESSAGES=25000`, `CONSUMER_BATCH_SIZE=750`, `CONSUMER_BATCH_SIZE_KB=8192`:

```text
consumer_batch_size_kb_limit 8192
consumer_batch_size_limit 750
kafka_consumer_fetchq_bytes_limit 52428800
kafka_consumer_fetchq_messages_limit 25000
```

</details>

All seven live gauges still emit. That rig has no partition assignment, so it cannot exercise the max-versus-sum path — the unit test covers it.

Not run: the crate's Kafka integration and e2e suites, which need a broker this environment does not have. They compile under `clippy --all-targets`.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. Skills invoked: `/writing-pr-descriptions`, `/writing-tests`.

The reported diagnosis was confirmed against the vendored librdkafka 2.12.1 in `rdkafka-sys` rather than taken on trust: the stats emission reads `rd_kafka_q_len`/`rd_kafka_q_size` on `rktp_fetchq`, both accessors recurse into a forwarded queue, and `rd_kafka_toppar_op_fetch_start` sets that forward to the group's shared queue on assignment.

Tracing the same forwarding rule through the rest of the module surfaced the `replyq` finding noted above, which was not part of the original report.

Nothing in this PR draws on material outside this repository.
