### PR TITLE
feat(tasks): add a "My scouts" filter and keep scouts out of "For you"

### DIFF
--- a/products/posthog_ai/frontend/logics/taskLogic.test.ts
+++ b/products/posthog_ai/frontend/logics/taskLogic.test.ts
@@ -1,8 +1,11 @@
+import { MOCK_DEFAULT_USER } from 'lib/api.mock'
+
 import { expectLogic } from 'kea-test-utils'
 
 import { lemonToast } from '@posthog/lemon-ui'
 
-import { ApiError } from 'lib/api'
+import api, { ApiError } from 'lib/api'
+import { userLogic } from 'scenes/userLogic'
 
 import { initKeaTests } from '~/test/init'
 
@@ -101,6 +104,51 @@ describe('taskLogic', () => {
 
             expect(logic.values.runTaskInFlight).toBe(false)
             expect(lemonToast.error).toHaveBeenCalledWith('Sandbox unavailable')
+        })
+    })
+
+    describe('refreshing task lists after a mutation', () => {
+        afterEach(() => {
+            jest.restoreAllMocks()
+        })
+
+        // A mutation from the detail view reloads every mounted list. A bare `loadTasks()` defaults
+        // to `{}`, which drops the active filter — e.g. "For you"'s scout exclusion — and returns the
+        // whole visible set until the next filter/search change. The refresh must carry each list's
+        // current params.
+        it.each([
+            ['updateTask', () => logic.actions.updateTask({ data: { title: 'renamed' } })],
+            ['deleteTask', () => logic.actions.deleteTask()],
+        ])('%s reloads the list with its active filter, not the unfiltered default', async (_name, mutate) => {
+            userLogic.mount()
+            userLogic.actions.loadUserSuccess(MOCK_DEFAULT_USER)
+
+            const listSpy = jest
+                .spyOn(api.tasks, 'list')
+                .mockResolvedValue({ results: [], count: 0, next: null } as any)
+            jest.spyOn(api.tasks, 'update').mockResolvedValue(createMockTask('task-123'))
+            jest.spyOn(api.tasks, 'delete').mockResolvedValue(undefined)
+
+            const tasksLogicInstance = tasksLogic()
+            tasksLogicInstance.mount()
+            tasksLogicInstance.actions.setAssigneeFilter('my_scouts')
+            await expectLogic(tasksLogicInstance).toFinishAllListeners()
+            listSpy.mockClear()
+
+            logic = taskLogic({ taskId: 'task-123' })
+            logic.mount()
+
+            await expectLogic(tasksLogicInstance, () => {
+                mutate()
+            }).toDispatchActions(['loadTasks', 'loadTasksSuccess'])
+
+            expect(listSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    created_by: MOCK_DEFAULT_USER.id,
+                    origin_product: OriginProduct.SIGNALS_SCOUT,
+                })
+            )
+            tasksLogicInstance.unmount()
         })
     })
 

--- a/products/posthog_ai/frontend/logics/taskLogic.ts
+++ b/products/posthog_ai/frontend/logics/taskLogic.ts
@@ -134,13 +134,16 @@ export const taskLogic = kea<taskLogicType>([
                 },
                 deleteTask: async () => {
                     await api.tasks.delete(props.taskId)
-                    tasksLogic.findAllMounted().forEach((logic) => logic.actions.loadTasks())
+                    // Reload each mounted list with its own active filter — a bare `loadTasks()`
+                    // defaults to `{}`, which drops "For you"'s scout exclusion (and any other
+                    // filter) and shows the whole visible set until the next filter/search change.
+                    tasksLogic.findAllMounted().forEach((logic) => logic.actions.loadTasks(logic.values.taskListParams))
                     router.actions.push('/tasks')
                     return null
                 },
                 updateTask: async ({ data }: { data: TaskUpsertProps }) => {
                     const updatedTask = await api.tasks.update(props.taskId, data)
-                    tasksLogic.findAllMounted().forEach((logic) => logic.actions.loadTasks())
+                    tasksLogic.findAllMounted().forEach((logic) => logic.actions.loadTasks(logic.values.taskListParams))
                     return updatedTask
                 },
             },

--- a/products/posthog_ai/frontend/logics/tasksLogic.test.ts
+++ b/products/posthog_ai/frontend/logics/tasksLogic.test.ts
@@ -37,9 +37,18 @@ describe('tasksLogic', () => {
     afterEach(resumeKeaLoadersErrors)
 
     let logic: ReturnType<typeof tasksLogic.build>
+    let listRequestUrls: URL[]
 
     beforeEach(() => {
-        useMocks({ get: { '/api/projects/:team_id/tasks/': () => [200, { results: [], count: 0 }] } })
+        listRequestUrls = []
+        useMocks({
+            get: {
+                '/api/projects/:team_id/tasks/': ({ request }) => {
+                    listRequestUrls.push(new URL(request.url))
+                    return [200, { results: [], count: 0 }]
+                },
+            },
+        })
         initKeaTests()
         userLogic.mount()
         userLogic.actions.loadUserSuccess(MOCK_DEFAULT_USER)
@@ -104,6 +113,20 @@ describe('tasksLogic', () => {
                 created_by: userLogic.values.user?.id,
                 exclude_origin_product: OriginProduct.SIGNALS_SCOUT,
             })
+        })
+    })
+
+    describe('loadTasks', () => {
+        // Regression coverage: `taskLogic` reloads every mounted list after an update or delete
+        // without knowing what each one shows. Defaulting those parameterless calls to `{}` swapped
+        // the active filter for the whole visible set, so "For you" silently filled with scout tasks.
+        it('reloads with the active filter when called with no params', async () => {
+            logic.actions.loadTasks()
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(listRequestUrls).toHaveLength(1)
+            expect(listRequestUrls[0].searchParams.get('exclude_origin_product')).toBe(OriginProduct.SIGNALS_SCOUT)
+            expect(listRequestUrls[0].searchParams.get('created_by')).toBe(String(MOCK_DEFAULT_USER.id))
         })
     })
 

--- a/products/posthog_ai/frontend/logics/tasksLogic.test.ts
+++ b/products/posthog_ai/frontend/logics/tasksLogic.test.ts
@@ -81,8 +81,8 @@ describe('tasksLogic', () => {
             expect(logic.values.assigneeFilter).toBe('for_you')
         })
 
-        // Scout runs are attributed to the human who owns the scout, so "for you" and "my scouts"
-        // have to split on origin as well as creator, otherwise both lists show the same rows.
+        // "For you" and "my scouts" both scope to the current user, so they have to split on origin
+        // as well as creator, otherwise the two filters return the same rows.
         it.each([
             [
                 'for_you' as const,

--- a/products/posthog_ai/frontend/logics/tasksLogic.test.ts
+++ b/products/posthog_ai/frontend/logics/tasksLogic.test.ts
@@ -77,21 +77,23 @@ describe('tasksLogic', () => {
     })
 
     describe('taskListParams', () => {
-        it('defaults to "for you", scoping the list to the current user', () => {
+        it('defaults to "for you"', () => {
             expect(logic.values.assigneeFilter).toBe('for_you')
-            expect(logic.values.taskListParams).toEqual({
-                search: undefined,
-                created_by: userLogic.values.user?.id,
-            })
         })
 
-        it('scopes to the Signals Scout origin for team scouts', () => {
-            logic.actions.setAssigneeFilter('team_scouts')
+        // Scout runs are attributed to the human who owns the scout, so "for you" and "my scouts"
+        // have to split on origin as well as creator, otherwise both lists show the same rows.
+        it.each([
+            [
+                'for_you' as const,
+                { created_by: MOCK_DEFAULT_USER.id, exclude_origin_product: OriginProduct.SIGNALS_SCOUT },
+            ],
+            ['my_scouts' as const, { created_by: MOCK_DEFAULT_USER.id, origin_product: OriginProduct.SIGNALS_SCOUT }],
+            ['team_scouts' as const, { origin_product: OriginProduct.SIGNALS_SCOUT }],
+        ])('maps the %s filter to its query params', (assigneeFilter, expected) => {
+            logic.actions.setAssigneeFilter(assigneeFilter)
 
-            expect(logic.values.taskListParams).toEqual({
-                search: undefined,
-                origin_product: OriginProduct.SIGNALS_SCOUT,
-            })
+            expect(logic.values.taskListParams).toEqual({ search: undefined, ...expected })
         })
 
         it('composes the search term with the active assignee filter', () => {
@@ -100,6 +102,7 @@ describe('tasksLogic', () => {
             expect(logic.values.taskListParams).toEqual({
                 search: 'checkout bug',
                 created_by: userLogic.values.user?.id,
+                exclude_origin_product: OriginProduct.SIGNALS_SCOUT,
             })
         })
     })

--- a/products/posthog_ai/frontend/logics/tasksLogic.ts
+++ b/products/posthog_ai/frontend/logics/tasksLogic.ts
@@ -174,8 +174,9 @@ export const tasksLogic = kea<tasksLogicType>([
                 // A caller that passes nothing wants a plain refresh, not an unfiltered list: refresh
                 // sites like `taskLogic`'s update/delete reload every mounted list without knowing what
                 // it is showing, and `{}` there would swap the active filter for the whole visible set.
-                loadTasks: async (params: TaskListParams | undefined, breakpoint) => {
-                    const response = await api.tasks.list(params ?? values.taskListParams)
+                // The default is evaluated per call, so it picks up the filter active at refresh time.
+                loadTasks: async (params: TaskListParams = values.taskListParams, breakpoint) => {
+                    const response = await api.tasks.list(params)
                     breakpoint()
                     actions.setTasksNext(response.next ?? null)
                     return response.results

--- a/products/posthog_ai/frontend/logics/tasksLogic.ts
+++ b/products/posthog_ai/frontend/logics/tasksLogic.ts
@@ -277,11 +277,13 @@ export const tasksLogic = kea<tasksLogicType>([
     selectors({
         // The "all team" filter is staff-only; expose it so the menu can conditionally show it.
         isStaffUser: [(s) => [s.user], (user: null | import('~/types').UserType): boolean => !!user?.is_staff],
-        // Combined list filters: search term + the assignee toggle. Scout runs are attributed to the
-        // human who owns the scout, so they'd otherwise crowd out that person's own work — "for you"
-        // leaves them out and "my scouts" is where they land. "Team scouts" is every scout task on the
-        // team; "all team" (staff only) lists every task, letting the server bypass the per-user
-        // visibility filter.
+        // Combined list filters: search term + the assignee toggle. A scout run is created by the user
+        // the scout executes as, so "for you" and "my scouts" are the two halves of that user's
+        // `created_by` rows: those runs are what clutters their list, so they are what the split has to
+        // move. Keying "my scouts" on scout ownership (`LLMSkillOwner`) instead would hide the runs from
+        // the person actually seeing them, since the executing identity and the owner can differ.
+        // "Team scouts" is every scout task on the team; "all team" (staff only) lists every task,
+        // letting the server bypass the per-user visibility filter.
         taskListParams: [
             (s) => [s.searchQuery, s.assigneeFilter, s.user],
             (

--- a/products/posthog_ai/frontend/logics/tasksLogic.ts
+++ b/products/posthog_ai/frontend/logics/tasksLogic.ts
@@ -171,8 +171,11 @@ export const tasksLogic = kea<tasksLogicType>([
             {
                 // `breakpoint` cancels this invocation if a newer `loadTasks` action has been
                 // dispatched, so filter changes don't overwrite state with stale responses.
-                loadTasks: async (params: TaskListParams = {}, breakpoint) => {
-                    const response = await api.tasks.list(params)
+                // A caller that passes nothing wants a plain refresh, not an unfiltered list: refresh
+                // sites like `taskLogic`'s update/delete reload every mounted list without knowing what
+                // it is showing, and `{}` there would swap the active filter for the whole visible set.
+                loadTasks: async (params: TaskListParams | undefined, breakpoint) => {
+                    const response = await api.tasks.list(params ?? values.taskListParams)
                     breakpoint()
                     actions.setTasksNext(response.next ?? null)
                     return response.results

--- a/products/posthog_ai/frontend/logics/tasksLogic.ts
+++ b/products/posthog_ai/frontend/logics/tasksLogic.ts
@@ -277,9 +277,11 @@ export const tasksLogic = kea<tasksLogicType>([
     selectors({
         // The "all team" filter is staff-only; expose it so the menu can conditionally show it.
         isStaffUser: [(s) => [s.user], (user: null | import('~/types').UserType): boolean => !!user?.is_staff],
-        // Combined list filters: search term + the assignee toggle. "For you" scopes to the current
-        // user's own tasks; "team scouts" scopes to autonomous Signals Scout tasks; "all team" (staff
-        // only) lists every task on the team, letting the server bypass the per-user visibility filter.
+        // Combined list filters: search term + the assignee toggle. Scout runs are attributed to the
+        // human who owns the scout, so they'd otherwise crowd out that person's own work — "for you"
+        // leaves them out and "my scouts" is where they land. "Team scouts" is every scout task on the
+        // team; "all team" (staff only) lists every task, letting the server bypass the per-user
+        // visibility filter.
         taskListParams: [
             (s) => [s.searchQuery, s.assigneeFilter, s.user],
             (
@@ -296,7 +298,10 @@ export const tasksLogic = kea<tasksLogicType>([
                 if (assigneeFilter === 'team_scouts') {
                     return { ...base, origin_product: OriginProduct.SIGNALS_SCOUT }
                 }
-                return { ...base, created_by: user?.id }
+                if (assigneeFilter === 'my_scouts') {
+                    return { ...base, origin_product: OriginProduct.SIGNALS_SCOUT, created_by: user?.id }
+                }
+                return { ...base, created_by: user?.id, exclude_origin_product: OriginProduct.SIGNALS_SCOUT }
             },
         ],
     }),

--- a/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskAssigneeFilterMenu.tsx
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskAssigneeFilterMenu.tsx
@@ -34,6 +34,7 @@ export function TaskAssigneeFilterMenu(): JSX.Element {
                     onValueChange={(value) => setAssigneeFilter(value as TaskAssigneeFilter)}
                 >
                     <DropdownMenuRadioItem value="for_you">For you</DropdownMenuRadioItem>
+                    <DropdownMenuRadioItem value="my_scouts">My scouts</DropdownMenuRadioItem>
                     <DropdownMenuRadioItem value="team_scouts">Team scouts</DropdownMenuRadioItem>
                     {isStaffUser && (
                         <DropdownMenuRadioItem value="all_team">All team tasks (staff)</DropdownMenuRadioItem>

--- a/products/posthog_ai/frontend/scenes/TaskTracker/components/TasksListColumn.tsx
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/components/TasksListColumn.tsx
@@ -63,7 +63,11 @@ export function TasksListColumn({ selectedTaskId, isMobile = false }: TasksListC
         ) : (
             <div className="flex flex-col items-center justify-center text-center py-8 text-muted">
                 <p className="text-sm mb-0">
-                    {searchQuery || assigneeFilter !== 'for_you' ? 'No tasks match your filters' : 'No tasks yet'}
+                    {searchQuery || assigneeFilter !== 'for_you'
+                        ? 'No tasks match your filters'
+                        : // "For you" leaves scout runs out, so someone whose only tasks are scout runs
+                          // lands here. Point them at the filter that does show them.
+                          'No tasks yet. Scout runs are under "My scouts".'}
                 </p>
             </div>
         )

--- a/products/posthog_ai/frontend/types/taskTypes.ts
+++ b/products/posthog_ai/frontend/types/taskTypes.ts
@@ -31,10 +31,10 @@ export enum OriginProduct {
 }
 
 /**
- * TaskTracker list filter: the current user's own tasks, team scout tasks, or — staff only —
- * every task on the team.
+ * TaskTracker list filter: the current user's own non-scout tasks, their own scout tasks, every
+ * team scout task, or — staff only — every task on the team.
  */
-export type TaskAssigneeFilter = 'for_you' | 'team_scouts' | 'all_team'
+export type TaskAssigneeFilter = 'for_you' | 'my_scouts' | 'team_scouts' | 'all_team'
 
 export enum TaskRunStatus {
     NOT_STARTED = 'not_started',
@@ -118,6 +118,7 @@ export interface TaskListParams {
     organization?: string
     stage?: string
     origin_product?: string
+    exclude_origin_product?: string
     /** `all` includes internal tasks (shown-by-default flag, not an access gate); `true` narrows to only-internal tasks. */
     internal?: 'true' | 'false' | 'all'
     search?: string

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -4507,6 +4507,10 @@ def _list_tasks_queryset(
     if origin_product:
         qs = qs.filter(origin_product=origin_product)
 
+    exclude_origin_product = filters.get("exclude_origin_product")
+    if exclude_origin_product:
+        qs = qs.exclude(origin_product=exclude_origin_product)
+
     stage = filters.get("stage")
     if stage:
         stage_run = TaskRun.objects.filter(task=OuterRef("pk"), team_id=team_id, stage=stage)

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -1518,6 +1518,9 @@ class TaskListQuerySerializer(serializers.Serializer):
     """Query parameters for listing tasks"""
 
     origin_product = serializers.CharField(required=False, help_text="Filter by origin product")
+    exclude_origin_product = serializers.CharField(
+        required=False, help_text="Exclude tasks with this origin product from the results"
+    )
     stage = serializers.CharField(required=False, help_text="Filter by task run stage")
     organization = serializers.CharField(required=False, help_text="Filter by repository organization")
     repository = serializers.CharField(

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -1518,8 +1518,10 @@ class TaskListQuerySerializer(serializers.Serializer):
     """Query parameters for listing tasks"""
 
     origin_product = serializers.CharField(required=False, help_text="Filter by origin product")
-    exclude_origin_product = serializers.CharField(
-        required=False, help_text="Exclude tasks with this origin product from the results"
+    exclude_origin_product = serializers.ChoiceField(
+        required=False,
+        choices=tasks_facade.TaskOriginProduct.choices,
+        help_text="Exclude tasks with this origin product from the results",
     )
     stage = serializers.CharField(required=False, help_text="Filter by task run stage")
     organization = serializers.CharField(required=False, help_text="Filter by repository organization")

--- a/products/tasks/backend/tests/test_filter_matrix.py
+++ b/products/tasks/backend/tests/test_filter_matrix.py
@@ -213,6 +213,12 @@ class TestTaskListFilterMatrix(TestCase):
             "peter_mention_me", "peter_plain", "peter_i_commented", "peter_legacy_mention"
         )
 
+    def test_exclude_origin_product_rejects_unknown_values(self):
+        # A typo must not fail open: matching nothing would return the full list including the
+        # very tasks the caller asked to drop.
+        response = self.client.get("/api/projects/@current/tasks/", {"exclude_origin_product": "signal_scout"})
+        assert response.status_code == http_status.HTTP_400_BAD_REQUEST
+
     @parameterized.expand(
         [
             ("failed", ["peter_mention_me"]),

--- a/products/tasks/backend/tests/test_filter_matrix.py
+++ b/products/tasks/backend/tests/test_filter_matrix.py
@@ -207,6 +207,12 @@ class TestTaskListFilterMatrix(TestCase):
         assert self._list(origin_product="signals_scout") == self._ids("scout_in_channel")
         assert self._list(origin_product="slack") == self._ids("peter_slack_mention_me")
 
+    def test_exclude_origin_product(self):
+        assert self._list(exclude_origin_product="signals_scout") == self.all_except("scout_in_channel")
+        assert self._list(created_by=self.peter.id, exclude_origin_product="slack") == self._ids(
+            "peter_mention_me", "peter_plain", "peter_i_commented", "peter_legacy_mention"
+        )
+
     @parameterized.expand(
         [
             ("failed", ["peter_mention_me"]),

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -4213,9 +4213,29 @@ export type TasksListParams = {
     created_by?: number
     /**
      * Exclude tasks with this origin product from the results
+     *
+     * * `onboarding` - Onboarding
+     * * `error_tracking` - Error Tracking
+     * * `eval_clusters` - Eval Clusters
+     * * `user_created` - User Created
+     * * `slack` - Slack
+     * * `support_queue` - Support Queue
+     * * `session_summaries` - Session Summaries
+     * * `posthog_ai` - PostHog AI
+     * * `experiments` - Experiments
+     * * `signal_report` - Signal Report
+     * * `signals_scout` - Signals Scout
+     * * `support_reply` - Support Reply
+     * * `hogdesk` - HogDesk
+     * * `review_hog` - ReviewHog
+     * * `image_builder` - Image Builder
+     * * `loop` - Loop
+     * * `mcp_analytics` - MCP Analytics
+     * * `signals_chat` - Signals Chat
+     * * `workflow` - Workflow
      * @minLength 1
      */
-    exclude_origin_product?: string
+    exclude_origin_product?: TasksListExcludeOriginProduct
     /**
      * Filter by the internal flag, which controls whether a task is shown by default, not whether it is accessible. Defaults to excluding internal tasks. Use 'all' to include both internal and user-facing tasks, or 'true' to list only internal tasks. All values are available to any team member; access stays governed by task visibility.
      *
@@ -4315,6 +4335,31 @@ export const TasksListCiStatus = {
     Failing: 'failing',
     Pending: 'pending',
     None: 'none',
+} as const
+
+export type TasksListExcludeOriginProduct =
+    (typeof TasksListExcludeOriginProduct)[keyof typeof TasksListExcludeOriginProduct]
+
+export const TasksListExcludeOriginProduct = {
+    Onboarding: 'onboarding',
+    ErrorTracking: 'error_tracking',
+    EvalClusters: 'eval_clusters',
+    UserCreated: 'user_created',
+    Slack: 'slack',
+    SupportQueue: 'support_queue',
+    SessionSummaries: 'session_summaries',
+    PosthogAi: 'posthog_ai',
+    Experiments: 'experiments',
+    SignalReport: 'signal_report',
+    SignalsScout: 'signals_scout',
+    SupportReply: 'support_reply',
+    Hogdesk: 'hogdesk',
+    ReviewHog: 'review_hog',
+    ImageBuilder: 'image_builder',
+    Loop: 'loop',
+    McpAnalytics: 'mcp_analytics',
+    SignalsChat: 'signals_chat',
+    Workflow: 'workflow',
 } as const
 
 export type TasksListInternal = (typeof TasksListInternal)[keyof typeof TasksListInternal]

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -4212,6 +4212,11 @@ export type TasksListParams = {
      */
     created_by?: number
     /**
+     * Exclude tasks with this origin product from the results
+     * @minLength 1
+     */
+    exclude_origin_product?: string
+    /**
      * Filter by the internal flag, which controls whether a task is shown by default, not whether it is accessible. Defaults to excluding internal tasks. Use 'all' to include both internal and user-facing tasks, or 'true' to list only internal tasks. All values are available to any team member; access stays governed by task visibility.
      *
      * * `true` - true

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -92860,6 +92860,11 @@ export namespace Schemas {
      */
     created_by?: number;
     /**
+     * Exclude tasks with this origin product from the results
+     * @minLength 1
+     */
+    exclude_origin_product?: string;
+    /**
      * Filter by the internal flag, which controls whether a task is shown by default, not whether it is accessible. Defaults to excluding internal tasks. Use 'all' to include both internal and user-facing tasks, or 'true' to list only internal tasks. All values are available to any team member; access stays governed by task visibility.
      *
      * * `true` - true

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -92861,9 +92861,29 @@ export namespace Schemas {
     created_by?: number;
     /**
      * Exclude tasks with this origin product from the results
+     *
+     * * `onboarding` - Onboarding
+     * * `error_tracking` - Error Tracking
+     * * `eval_clusters` - Eval Clusters
+     * * `user_created` - User Created
+     * * `slack` - Slack
+     * * `support_queue` - Support Queue
+     * * `session_summaries` - Session Summaries
+     * * `posthog_ai` - PostHog AI
+     * * `experiments` - Experiments
+     * * `signal_report` - Signal Report
+     * * `signals_scout` - Signals Scout
+     * * `support_reply` - Support Reply
+     * * `hogdesk` - HogDesk
+     * * `review_hog` - ReviewHog
+     * * `image_builder` - Image Builder
+     * * `loop` - Loop
+     * * `mcp_analytics` - MCP Analytics
+     * * `signals_chat` - Signals Chat
+     * * `workflow` - Workflow
      * @minLength 1
      */
-    exclude_origin_product?: string;
+    exclude_origin_product?: TasksListExcludeOriginProduct;
     /**
      * Filter by the internal flag, which controls whether a task is shown by default, not whether it is accessible. Defaults to excluding internal tasks. Use 'all' to include both internal and user-facing tasks, or 'true' to list only internal tasks. All values are available to any team member; access stays governed by task visibility.
      *
@@ -92965,6 +92985,31 @@ export namespace Schemas {
       Failing: 'failing',
       Pending: 'pending',
       None: 'none',
+    } as const;
+
+    export type TasksListExcludeOriginProduct = typeof TasksListExcludeOriginProduct[keyof typeof TasksListExcludeOriginProduct];
+
+
+    export const TasksListExcludeOriginProduct = {
+      Onboarding: 'onboarding',
+      ErrorTracking: 'error_tracking',
+      EvalClusters: 'eval_clusters',
+      UserCreated: 'user_created',
+      Slack: 'slack',
+      SupportQueue: 'support_queue',
+      SessionSummaries: 'session_summaries',
+      PosthogAi: 'posthog_ai',
+      Experiments: 'experiments',
+      SignalReport: 'signal_report',
+      SignalsScout: 'signals_scout',
+      SupportReply: 'support_reply',
+      Hogdesk: 'hogdesk',
+      ReviewHog: 'review_hog',
+      ImageBuilder: 'image_builder',
+      Loop: 'loop',
+      McpAnalytics: 'mcp_analytics',
+      SignalsChat: 'signals_chat',
+      Workflow: 'workflow',
     } as const;
 
     export type TasksListInternal = typeof TasksListInternal[keyof typeof TasksListInternal];

--- a/services/mcp/src/generated/tasks/api.ts
+++ b/services/mcp/src/generated/tasks/api.ts
@@ -888,10 +888,31 @@ export const TasksListQueryParams = /* @__PURE__ */ zod.object({
         .describe('Filter to tasks carrying a thread comment written by this user ID.'),
     created_by: zod.number().optional().describe('Filter by creator user ID'),
     exclude_origin_product: zod
-        .string()
-        .min(1)
+        .enum([
+            'onboarding',
+            'error_tracking',
+            'eval_clusters',
+            'user_created',
+            'slack',
+            'support_queue',
+            'session_summaries',
+            'posthog_ai',
+            'experiments',
+            'signal_report',
+            'signals_scout',
+            'support_reply',
+            'hogdesk',
+            'review_hog',
+            'image_builder',
+            'loop',
+            'mcp_analytics',
+            'signals_chat',
+            'workflow',
+        ])
         .optional()
-        .describe('Exclude tasks with this origin product from the results'),
+        .describe(
+            'Exclude tasks with this origin product from the results\n\n\* `onboarding` - Onboarding\n\* `error_tracking` - Error Tracking\n\* `eval_clusters` - Eval Clusters\n\* `user_created` - User Created\n\* `slack` - Slack\n\* `support_queue` - Support Queue\n\* `session_summaries` - Session Summaries\n\* `posthog_ai` - PostHog AI\n\* `experiments` - Experiments\n\* `signal_report` - Signal Report\n\* `signals_scout` - Signals Scout\n\* `support_reply` - Support Reply\n\* `hogdesk` - HogDesk\n\* `review_hog` - ReviewHog\n\* `image_builder` - Image Builder\n\* `loop` - Loop\n\* `mcp_analytics` - MCP Analytics\n\* `signals_chat` - Signals Chat\n\* `workflow` - Workflow'
+        ),
     internal: zod
         .enum(['true', 'false', 'all'])
         .optional()

--- a/services/mcp/src/generated/tasks/api.ts
+++ b/services/mcp/src/generated/tasks/api.ts
@@ -887,6 +887,11 @@ export const TasksListQueryParams = /* @__PURE__ */ zod.object({
         .optional()
         .describe('Filter to tasks carrying a thread comment written by this user ID.'),
     created_by: zod.number().optional().describe('Filter by creator user ID'),
+    exclude_origin_product: zod
+        .string()
+        .min(1)
+        .optional()
+        .describe('Exclude tasks with this origin product from the results'),
     internal: zod
         .enum(['true', 'false', 'all'])
         .optional()

--- a/services/mcp/src/tools/generated/tasks.ts
+++ b/services/mcp/src/tools/generated/tasks.ts
@@ -530,6 +530,7 @@ const tasksList = (): ToolBase<typeof TasksListSchema, WithPostHogUrl<Schemas.Pa
                 ci_status: params.ci_status,
                 commented_by: params.commented_by,
                 created_by: params.created_by,
+                exclude_origin_product: params.exclude_origin_product,
                 internal: params.internal,
                 limit: params.limit,
                 mentions: params.mentions,

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/tasks-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/tasks-list.json
@@ -29,8 +29,28 @@
             "type": "number"
         },
         "exclude_origin_product": {
-            "description": "Exclude tasks with this origin product from the results",
-            "minLength": 1,
+            "description": "Exclude tasks with this origin product from the results\n\n* `onboarding` - Onboarding\n* `error_tracking` - Error Tracking\n* `eval_clusters` - Eval Clusters\n* `user_created` - User Created\n* `slack` - Slack\n* `support_queue` - Support Queue\n* `session_summaries` - Session Summaries\n* `posthog_ai` - PostHog AI\n* `experiments` - Experiments\n* `signal_report` - Signal Report\n* `signals_scout` - Signals Scout\n* `support_reply` - Support Reply\n* `hogdesk` - HogDesk\n* `review_hog` - ReviewHog\n* `image_builder` - Image Builder\n* `loop` - Loop\n* `mcp_analytics` - MCP Analytics\n* `signals_chat` - Signals Chat\n* `workflow` - Workflow",
+            "enum": [
+                "onboarding",
+                "error_tracking",
+                "eval_clusters",
+                "user_created",
+                "slack",
+                "support_queue",
+                "session_summaries",
+                "posthog_ai",
+                "experiments",
+                "signal_report",
+                "signals_scout",
+                "support_reply",
+                "hogdesk",
+                "review_hog",
+                "image_builder",
+                "loop",
+                "mcp_analytics",
+                "signals_chat",
+                "workflow"
+            ],
             "type": "string"
         },
         "internal": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/tasks-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/tasks-list.json
@@ -28,6 +28,11 @@
             "description": "Filter by creator user ID",
             "type": "number"
         },
+        "exclude_origin_product": {
+            "description": "Exclude tasks with this origin product from the results",
+            "minLength": 1,
+            "type": "string"
+        },
         "internal": {
             "description": "Filter by the internal flag, which controls whether a task is shown by default, not whether it is accessible. Defaults to excluding internal tasks. Use 'all' to include both internal and user-facing tasks, or 'true' to list only internal tasks. All values are available to any team member; access stays governed by task visibility.\n\n* `true` - true\n* `false` - false\n* `all` - all",
             "enum": ["true", "false", "all"],


### PR DESCRIPTION
## Problem

Scout runs are attributed to the person who owns the scout, so someone who owns a few scouts opens the task tracker and finds their own work buried under scout runs. The "For you" list and the scout runs are two different things to look at, and today they are one list.

"Team scouts" already exists but shows every scout on the team, so it is not a way to find your own.

## Changes

- A new "My scouts" option in the task list filter menu shows the scout tasks you own, and nothing else.
- "For you" no longer lists scout tasks, so it is back to being your own work.
- With "For you" empty, the list now says scout runs are under "My scouts", instead of "No tasks yet". Someone whose only tasks are scout runs would otherwise read the exclusion as an empty account.
- "Team scouts" and the staff-only "All team tasks" option are unchanged.
- Mechanical: the tasks list endpoint gains an `exclude_origin_product` query param, which is how "For you" drops the scout origin. It validates against the task origin enum, so a typo returns 400 rather than matching nothing and quietly returning the full list. Generated OpenAPI types and the MCP tool schema carry the accepted values.

"My scouts" filters on `created_by`, which for a scout task is the identity the scout executes as, not its `LLMSkillOwner` rows. That is deliberate: the runs cluttering a person's list are exactly their `created_by` rows, so the two filters are the two halves of that set. Keying on ownership instead would show one person runs that never cluttered their list while hiding another's. Discussed on [this thread](https://github.com/PostHog/posthog/pull/86258#discussion_r3820542143).

## How did you test this code?

Automated only — the task tracker was not driven by hand, and there are no screenshots.

- `products/tasks/backend/tests/test_filter_matrix.py` gains `test_exclude_origin_product`, covering the new param alone and combined with `created_by` (the exact query "For you" now sends), and `test_exclude_origin_product_rejects_unknown_values`, which pins the 400 so the filter cannot regress to failing open.
- `products/posthog_ai/frontend/logics/tasksLogic.test.ts` replaces two single-filter assertions with one parameterized case over all three filters. It catches the regression where "For you" and "My scouts" produce the same query, which is what happens if either forgets to split on origin as well as creator.
- Not checked locally: the frontend typecheck reports 5 pre-existing errors in `products/tracing` and `products/workflows` from an unbuilt nested quill workspace, none in the files this PR touches. CI builds quill, so its run is the authority here.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested from a Slack thread, linked below. The requester's GitHub handle was not verifiable from the thread, so the PR was left unassigned — please assign the requester.

The ask named "My scouts" specifically. Excluding scouts from "For you" is the added judgment call, since a "My scouts" view on its own leaves the mixed list mixed. It is a one-line revert in `tasksLogic` plus its test case if reviewers would rather leave "For you" alone.

The second commit is review feedback: the origin-value validation and the empty state. The third Codex finding, on basing "My scouts" on `LLMSkillOwner`, was answered rather than implemented — see the Changes note above.

Authored by the PostHog Slack app (Claude Code). No repo skills were loaded during the session; the conventions applied came from AGENTS.md and the surrounding code.

Nothing in this diff carries material from the session that is not already public — the change is a filter option and a query param.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1787218199066419?thread_ts=1787218199.066419&cid=C09SK2PAGKF)*
