### PR TITLE
fix(feature-flags): detect blanket OR-group in rollout check

### DIFF
--- a/products/feature_flags/backend/persisted_flags.py
+++ b/products/feature_flags/backend/persisted_flags.py
@@ -20,18 +20,19 @@ def is_unconditionally_fully_rolled_out(flag: FlagDefinition) -> bool:
     if filters.get("aggregation_group_type_index") is not None:
         return False
 
-    groups = filters.get("groups") or []
-    if len(groups) != 1:
-        return False
+    # Release-condition groups are OR-ed: a single blanket group (no properties,
+    # 100%-or-unset rollout, no variant override) means everyone matches, regardless
+    # of the other, more targeted groups alongside it.
+    for group in filters.get("groups") or []:
+        if group.get("properties"):
+            continue
+        if group.get("variant"):
+            continue
+        rollout_percentage = group.get("rollout_percentage")
+        if rollout_percentage is None or rollout_percentage == 100:
+            return True
 
-    group = groups[0]
-    if group.get("properties"):
-        return False
-    if group.get("variant"):
-        return False
-
-    rollout_percentage = group.get("rollout_percentage")
-    return rollout_percentage is None or rollout_percentage == 100
+    return False
 
 
 def get_dynamic_persisted_feature_flags(

--- a/products/feature_flags/backend/test/test_persisted_flags.py
+++ b/products/feature_flags/backend/test/test_persisted_flags.py
@@ -26,12 +26,36 @@ class TestIsUnconditionallyFullyRolledOut(SimpleTestCase):
                 False,
             ),
             (
-                "multiple_groups",
+                "multiple_blanket_groups",
                 _flag(
                     {
                         "groups": [
                             {"properties": [], "rollout_percentage": 100},
                             {"properties": [], "rollout_percentage": 100},
+                        ]
+                    }
+                ),
+                True,
+            ),
+            (
+                "targeted_group_plus_blanket_group",
+                _flag(
+                    {
+                        "groups": [
+                            {"properties": [{"key": "email"}], "rollout_percentage": 100},
+                            {"properties": [], "rollout_percentage": 100},
+                        ]
+                    }
+                ),
+                True,
+            ),
+            (
+                "targeted_group_plus_partial_blanket_group",
+                _flag(
+                    {
+                        "groups": [
+                            {"properties": [{"key": "email"}], "rollout_percentage": 100},
+                            {"properties": [], "rollout_percentage": 50},
                         ]
                     }
                 ),


### PR DESCRIPTION
## Problem

- A feature flag rolled out to everyone through a blanket OR-condition alongside a targeted condition was not treated as fully rolled out, so it did not default on in the frontend via `persisted_feature_flags`.
- Release-condition groups are OR-ed: a group with no properties at 100% matches every user regardless of the other groups. The rollout check in `is_unconditionally_fully_rolled_out` ignored this.
- The check returned early on any flag with more than one group (`len(groups) != 1`), so a targeted group plus a blanket group read as "not fully rolled out".

## Changes

- The rollout check now scans every group and returns true as soon as one is blanket: no properties, 100%-or-unset rollout, no variant override.
- The whole-flag guards are unchanged and still run first: multivariate, holdout, super_groups, group aggregation, active, deleted.
- Follow-up to the merged persisted-flags feature ([#84211](https://github.com/PostHog/posthog/pull/84211)), which shipped the single-group version of this check.

## How did you test this code?

- Corrected the `multiple_blanket_groups` case, which the merged version asserted as false; two blanket groups mean everyone matches, so it is now true.
- Added `targeted_group_plus_blanket_group` (true) and `targeted_group_plus_partial_blanket_group` (false) to pin the OR semantics this fix introduces.
- Ran the suite: `hogli test products/feature_flags/backend/test/test_persisted_flags.py`.
- Not run: repo-wide mypy and the database-backed suites. This change is pure-function and covered by the unit tests.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code (PostHog Desktop), directed by @frankh.
- Skills invoked: `/writing-tests` and `/writing-pr-descriptions`.
- @frankh spotted that the merged check missed a blanket OR-group. The branch for [#84211](https://github.com/PostHog/posthog/pull/84211) had already merged, so this fix goes on a fresh branch cut from master rather than onto the merged branch.
