### PR TITLE
feat(frontend): render mermaid diagrams in the PostHog data palette (2/13)

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonMarkdown/MermaidDiagram.tsx
+++ b/frontend/src/lib/lemon-ui/LemonMarkdown/MermaidDiagram.tsx
@@ -24,6 +24,84 @@ function loadMermaid(): Promise<MermaidApi> {
 let initializedTheme: boolean | null = null
 let diagramCounter = 0
 
+// PostHog data-viz palette (frontend/src/styles/base.scss `--data-color-*`). Read live from the
+// CSS variables so charts stay in sync with the theme; the hex fallbacks match base.scss in case
+// the variables can't be resolved (e.g. a detached render).
+const DATA_COLOR_FALLBACKS = [
+    '#1d4aff',
+    '#621da6',
+    '#42827e',
+    '#ce0e74',
+    '#f14f58',
+    '#7c440e',
+    '#529a0a',
+    '#0476fb',
+    '#fe729e',
+    '#35416b',
+    '#41cbc4',
+    '#b64b02',
+]
+
+function cssVar(name: string, fallback: string): string {
+    if (typeof document === 'undefined') {
+        return fallback
+    }
+    return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback
+}
+
+// Build a PostHog-suited mermaid config: the brand data palette for series, theme-aware text, and
+// a transparent background so diagrams sit cleanly on whatever surface renders them.
+function buildMermaidConfig(isDarkModeOn: boolean): Record<string, unknown> {
+    const palette = DATA_COLOR_FALLBACKS.map((fallback, i) => cssVar(`--data-color-${i + 1}`, fallback))
+    const text = cssVar('--text-3000', isDarkModeOn ? '#ffffff' : '#111827')
+    // --border-bold is a single translucent black, so it disappears on dark surfaces; the
+    // -3000 variable is the theme-switched one.
+    const line = cssVar('--border-bold-3000', isDarkModeOn ? '#3f4046' : '#c1c2b9')
+
+    const seriesVars = palette.reduce<Record<string, string>>((acc, color, i) => {
+        acc[`pie${i + 1}`] = color
+        acc[`cScale${i}`] = color
+        return acc
+    }, {})
+
+    return {
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'strict',
+        fontFamily: 'inherit',
+        themeVariables: {
+            darkMode: isDarkModeOn,
+            background: 'transparent',
+            primaryColor: palette[0],
+            primaryBorderColor: palette[1],
+            // Node labels sit on a saturated palette fill in both themes, so they follow the fill
+            // rather than the page. `textColor` still themes the labels drawn on the background.
+            primaryTextColor: '#ffffff',
+            secondaryColor: palette[1],
+            tertiaryColor: palette[2],
+            lineColor: line,
+            textColor: text,
+            ...seriesVars,
+            // xychart-beta reads none of the variables above: its palette, its plot background and
+            // every axis color live under `xyChart`. Left alone it paints a pale-cream plot
+            // (#FFF4DD) on an opaque white card, which reads as a hole in a dark page.
+            xyChart: {
+                plotColorPalette: palette.join(', '),
+                backgroundColor: 'transparent',
+                titleColor: text,
+                xAxisLabelColor: text,
+                xAxisTitleColor: text,
+                xAxisTickColor: line,
+                xAxisLineColor: line,
+                yAxisLabelColor: text,
+                yAxisTitleColor: text,
+                yAxisTickColor: line,
+                yAxisLineColor: line,
+            },
+        },
+    }
+}
+
 export interface MermaidDiagramProps {
     code: string
     className?: string
@@ -70,12 +148,7 @@ export function MermaidDiagram({ code, className, naturalWidth = false }: Mermai
                     return null
                 }
                 if (initializedTheme !== isDarkModeOn) {
-                    mermaid.initialize({
-                        startOnLoad: false,
-                        theme: isDarkModeOn ? 'dark' : 'default',
-                        securityLevel: 'strict',
-                        fontFamily: 'inherit',
-                    })
+                    mermaid.initialize(buildMermaidConfig(isDarkModeOn))
                     initializedTheme = isDarkModeOn
                 }
                 return mermaid.render(diagramId, code)


### PR DESCRIPTION
> [!NOTE]
> Piece 2 of 13 in the split of #60081. Pieces 1-4 land prerequisites that stand alone on master. Pieces 5-13 add the autoresearch product. The map lives in #60081.

## Problem

Anyone reading a mermaid diagram in PostHog sees mermaid's stock colors, which match nothing else on the page.

- Flowchart nodes come out lavender in light mode and near-black in dark mode.
- `xychart-beta` is worse. It reads none of mermaid's normal theme variables, so it paints a pale cream plot (`#FFF4DD`) on an opaque white card, which reads as a hole in a dark page.

## Changes

- Diagrams now draw in the same colors as insight series, in both themes.
- `MermaidDiagram` reads the `--data-color-*` variables at init time, so a palette change in `base.scss` reaches diagrams without a second edit. Hex fallbacks cover a detached render where the variables do not resolve.
- The plot area is transparent, so a diagram sits on whatever surface renders it.
- Node labels are white rather than the page text color. They sit on a saturated palette fill in both themes, so following the page would put dark text on strong blue.
- Nothing else changes. The render path, the caching of `initializedTheme`, and the component API are untouched.

Before, mermaid stock theme:

![mermaid-before](https://raw.githubusercontent.com/PostHog/pr-assets/b22c17fa27bb09777f682709b9000e111dcb5516/2026/08/aa088fad-12ce-43b1-bc49-bf9d602d726a.png)

After, PostHog data palette:

![mermaid-after](https://raw.githubusercontent.com/PostHog/pr-assets/68dfbb365ad5763d8bf598e03c0209f192fa799d/2026/08/30a0bc7e-4bf1-4b89-8c55-ae563d9dda2a.png)

## How did you test this code?

No new tests. The change is a config object handed to mermaid, and a test over it would assert the object back at itself; what matters is the rendered pixels, which the screenshots above carry.

The screenshots come from a headless Chromium rendering the same two diagrams through the local `mermaid` package, once with the stock config and once with the config in this PR, in both palettes.

Not run: Storybook and the Jest suite for `LemonMarkdown`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5), driven by @andrewm4894. Cut from the `autoresearch-dev` branch (#60081) as one of four off-stack PRs that carry no autoresearch dependency.

Rendering the diagrams surfaced two defects in the version on that branch: node labels took the page text color, which put dark text on a saturated fill in light mode, and the xychart plot kept an opaque white background in dark mode. Both are fixed here, which is why the diff is larger than the branch's.

Skills invoked: `/writing-pr-descriptions`, `/writing-code-comments`, `/writing-tests`.

