### PR TITLE
fix(mcp): stop a devbox auth redirect poisoning the token cache (3/13)

### DIFF
--- a/bin/start-mcp-server
+++ b/bin/start-mcp-server
@@ -18,18 +18,23 @@ if [ ! -f .env ]; then
     fi
 fi
 
-# SITE_URL on devboxes points at the public per-workspace subdomain; rewrite
-# the three PostHog-pointing keys so MCP's OAuth metadata advertises a host
-# browsers can actually reach. Runs every start (not just first creation) so
-# .env stays in sync when the workspace subdomain changes.
+# SITE_URL on devboxes points at the public per-workspace subdomain; rewrite the
+# browser-facing keys so MCP's OAuth metadata and rendered links advertise a host
+# browsers can actually reach. Runs every start (not just first creation) so .env
+# stays in sync when the workspace subdomain changes.
+#
+# POSTHOG_API_BASE_URL deliberately stays on loopback: it is the server-to-server
+# API base, and the workspace subdomain sits behind the devbox auth proxy, which
+# answers every API call with a login redirect instead of JSON.
 loopback_re='^https?://(localhost|127\.0\.0\.1)([:/]|$)'
 if [ -n "${SITE_URL:-}" ] && ! [[ "${SITE_URL}" =~ $loopback_re ]]; then
     tmp=$(mktemp)
-    grep -Ev '^(POSTHOG_API_BASE_URL|POSTHOG_MCP_APPS_ANALYTICS_BASE_URL|POSTHOG_ANALYTICS_HOST)=' .env > "$tmp" || true
+    grep -Ev '^(POSTHOG_API_BASE_URL|POSTHOG_PUBLIC_URL|POSTHOG_MCP_APPS_ANALYTICS_BASE_URL|POSTHOG_ANALYTICS_HOST)=' .env > "$tmp" || true
     mv "$tmp" .env
     # Leading \n guards against the prior file missing a trailing newline.
-    printf '\n%s\n%s\n%s\n' \
-        "POSTHOG_API_BASE_URL=${SITE_URL}" \
+    printf '\n%s\n%s\n%s\n%s\n' \
+        "POSTHOG_API_BASE_URL=${MCP_LOCAL_API_BASE_URL:-http://localhost:8010}" \
+        "POSTHOG_PUBLIC_URL=${SITE_URL}" \
         "POSTHOG_MCP_APPS_ANALYTICS_BASE_URL=${SITE_URL}" \
         "POSTHOG_ANALYTICS_HOST=${SITE_URL}" \
         >> .env

--- a/services/mcp/src/hono/cache/RedisCache.ts
+++ b/services/mcp/src/hono/cache/RedisCache.ts
@@ -52,7 +52,18 @@ export class RedisCache<T extends Record<string, any>> extends ScopedCache<T> {
                 redisOperationsTotal.inc({ operation: 'get', status: 'success' })
                 return undefined
             }
-            const result = JSON.parse(raw) as T[K]
+            let result: T[K]
+            try {
+                result = JSON.parse(raw) as T[K]
+            } catch {
+                // An unparseable entry (e.g. `set` called with `undefined`, which the
+                // client coerces to an empty string) would otherwise throw on every
+                // read until its TTL expires, bricking the token for days. Drop it and
+                // report a miss so the caller recomputes.
+                await this.redis.del(scopedKey)
+                redisOperationsTotal.inc({ operation: 'get', status: 'error' })
+                return undefined
+            }
             redisOperationsTotal.inc({ operation: 'get', status: 'success' })
             return result
         } catch (error) {

--- a/services/mcp/src/hono/request-context.ts
+++ b/services/mcp/src/hono/request-context.ts
@@ -150,7 +150,13 @@ export class RequestContext {
         if (!userResult.success) {
             throw wrapError(`Failed to get user: ${userResult.error.message}`, userResult.error)
         }
-        const distinctId = userResult.data.distinct_id as string
+        const distinctId = userResult.data.distinct_id as string | undefined
+        if (!distinctId) {
+            // A response without `distinct_id` means we didn't reach the PostHog API
+            // (an auth redirect or proxy page parses as JSON just fine). Caching it
+            // would poison this token's cache for the full TTL.
+            throw new Error(`Failed to get user: response had no distinct_id (base URL: ${(await this.api()).baseUrl})`)
+        }
         await this.tokenCache.set('distinctId', distinctId)
         return distinctId
     }

--- a/services/mcp/src/lib/oauth-constants.ts
+++ b/services/mcp/src/lib/oauth-constants.ts
@@ -90,7 +90,9 @@ export const resolveAuthorizationServerUrl = (): string => {
     if (isCloudApi()) {
         return OAUTH_PROXY_URL
     }
-    return getCustomApiBaseUrl()!
+    // A browser follows this URL, so it must be publicly reachable — the API base
+    // may be loopback-only (devbox) or cluster-internal.
+    return getPublicBaseUrl() ?? getCustomApiBaseUrl()!
 }
 
 // Generated from `posthog/scopes.py` — keep in sync with `hogli build:openapi`.

--- a/services/mcp/tests/hono/redis-cache.test.ts
+++ b/services/mcp/tests/hono/redis-cache.test.ts
@@ -68,6 +68,14 @@ describe('RedisCache', () => {
             expect(await cache.get('region')).toBe('us')
         })
 
+        it('should drop an unparseable entry and report a miss', async () => {
+            mockRedis._store.set('mcp:token:test-user-hash:region', '')
+
+            expect(await cache.get('region')).toBeUndefined()
+            expect(mockRedis.del).toHaveBeenCalledWith('mcp:token:test-user-hash:region')
+            expect(mockRedis._store.has('mcp:token:test-user-hash:region')).toBe(false)
+        })
+
         it('should not read another user keys', async () => {
             const cacheA = new RedisCache<TestState>('user-a', mockRedis)
             const cacheB = new RedisCache<TestState>('user-b', mockRedis)

--- a/services/mcp/tests/hono/request-context.test.ts
+++ b/services/mcp/tests/hono/request-context.test.ts
@@ -163,6 +163,15 @@ describe('RequestContext', () => {
 
             await expect(ctx.getDistinctId()).rejects.toThrow('Failed to get user')
         })
+
+        it('throws without caching when the response carries no distinct_id', async () => {
+            mockMe.mockResolvedValue({ success: true, data: {} })
+            const redis = fakeRedis()
+            const ctx = new RequestContext(redis, env, makeProps())
+
+            await expect(ctx.getDistinctId()).rejects.toThrow('no distinct_id')
+            expect(await redis.get('mcp:token:test-user:distinctId')).toBeNull()
+        })
     })
 
     describe('getSessionUuid', () => {


### PR DESCRIPTION
> [!NOTE]
> Piece 3 of 13 in the split of #60081. Pieces 1-4 land prerequisites that stand alone on master. Pieces 5-13 add the autoresearch product. The map lives in #60081.

## Problem

An MCP token minted on a devbox stops working, and stays broken long after the misconfiguration that caused it is gone.

- `bin/start-mcp-server` points `POSTHOG_API_BASE_URL` at `SITE_URL`, which on a devbox is the per-workspace subdomain.
- That subdomain sits behind the devbox auth proxy, so every server-to-server API call comes back as a login page.
- A login page parses as JSON, so the user lookup succeeds with no `distinct_id` and caches an empty value for the full TTL.
- Reads of that entry then throw on every request until it expires.

## Changes

- A devbox MCP server reaches the API again, and a token that already went bad recovers on its next request instead of at TTL.
- `POSTHOG_API_BASE_URL` stays on loopback. The public subdomain moves to `POSTHOG_PUBLIC_URL`, which the OAuth metadata already prefers.
- `resolveAuthorizationServerUrl` returns the public URL, because a browser follows that one and the API base may be loopback-only.
- The user lookup rejects a response with no `distinct_id` rather than caching it.
- `RedisCache.get` deletes an unparseable entry and reports a miss, so the caller recomputes.

Nothing user-visible changes outside a devbox.

## How did you test this code?

Two vitest cases, each covering one half of the poisoning:

- `RedisCache` drops an unparseable entry and reports a miss. Without the guard, an entry written as an empty string throws on every read until its TTL expires.
- `getDistinctId` throws without writing to the cache when the response carries no `distinct_id`. Without the guard, the empty value is cached and every later call fails.

Both fail against the pre-fix source and pass after, checked by reverting the two source files and rerunning.

Not run: anything against a real devbox. This sandbox has no auth proxy in front of it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5), driven by @andrewm4894. Cut from the `autoresearch-dev` branch (#60081) as one of four off-stack PRs that carry no autoresearch dependency. The three source changes were already on that branch; the tests are new here.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

