### PR TITLE
fix(quill): let people select the text in a toast

### DIFF
--- a/packages/quill/packages/primitives/AGENTS.md
+++ b/packages/quill/packages/primitives/AGENTS.md
@@ -1095,6 +1095,9 @@ toast.dismiss(id)
 toast({ title: 'Item archived', action: { label: 'Undo', onClick: () => restore() } })
 ```
 
+The title and description are selectable, so a user can copy an error message out of a toast, while the rest of the card is not, so a drag across it still reads as swipe-to-dismiss.
+Custom content you put inside a `ToastCard` needs `data-base-ui-swipe-ignore` for the same treatment, or Base UI takes a drag on it as a swipe and suppresses the selection.
+
 `anchoredToast` positions a toast next to an element instead of stacking it in the corner. It takes the same
 options plus an anchor. An anchored toast with an action also gets a close button, so give it `timeout: 0`
 when the user needs time to decide:

--- a/packages/quill/packages/primitives/src/toast.css
+++ b/packages/quill/packages/primitives/src/toast.css
@@ -14,6 +14,15 @@
         box-shadow: var(--shadow-md);
     }
 
+    /* The card is unselectable so a drag across it reads as a swipe-to-dismiss. The message itself
+       opts back in, and carries data-base-ui-swipe-ignore so a drag there starts a selection
+       instead of a swipe. */
+    .quill-toast-card__title,
+    .quill-toast-card__description {
+        cursor: text;
+        user-select: text;
+    }
+
     .quill-toast-card__title {
         font-size: var(--text-xs, 0.75rem);
         font-weight: 500;

--- a/packages/quill/packages/primitives/src/toast.tsx
+++ b/packages/quill/packages/primitives/src/toast.tsx
@@ -76,8 +76,16 @@ const ToastCard = React.forwardRef<HTMLDivElement, ToastCardProps>(
                         </span>
                     )}
                     <div className="flex-1 min-w-0">
-                        {toastTitle && <div className="quill-toast-card__title">{toastTitle}</div>}
-                        {toastDescription && <div className="quill-toast-card__description">{toastDescription}</div>}
+                        {toastTitle && (
+                            <div className="quill-toast-card__title" data-base-ui-swipe-ignore>
+                                {toastTitle}
+                            </div>
+                        )}
+                        {toastDescription && (
+                            <div className="quill-toast-card__description" data-base-ui-swipe-ignore>
+                                {toastDescription}
+                            </div>
+                        )}
                     </div>
                 </div>
                 {action && (

--- a/products/desktop/packages/ui/src/styles/globals.css
+++ b/products/desktop/packages/ui/src/styles/globals.css
@@ -1419,6 +1419,18 @@ button,
 }
 
 /*
+ * @posthog/quill toast — the pinned version sets `user-select: none` on the whole card, so an
+ * error message cannot be selected and copied out of the app at all. Quill carries the same rule
+ * now, plus `data-base-ui-swipe-ignore` on the message so a drag there selects instead of swiping
+ * the toast away, which CSS alone cannot do. Drop this block once the catalog version ships it.
+ */
+.quill-toast-card__title,
+.quill-toast-card__description {
+  cursor: text;
+  user-select: text;
+}
+
+/*
  * @posthog/quill Dialog — make the backdrop visible against this app's
  * dark theme (Quill defaults to opacity-20/dark:opacity-70 which barely
  * shows), and center the popup vertically (Quill anchors to ~10vh).


### PR DESCRIPTION
## Problem

Text in a PostHog Desktop toast cannot be selected, so an error message cannot be copied into an agent, a ticket, or a chat. Dragging across it highlights nothing and triple-clicking it does nothing.

- Quill's `.quill-toast-card` sets `user-select: none`, which the title and description inherit.
- The rule is there for a reason: Base UI treats a drag across the card as swipe-to-dismiss, and a selection would fight it.
- Desktop's own answer today is the "Details" action on error toasts, which opens a dialog with a copyable code block. It only exists on errors raised through `toastError`, and it costs two clicks.

## Changes

- Toast text is selectable in every app that uses quill toasts. Drag across it, double-click a word, or triple-click the line, then copy.
- Swipe-to-dismiss is unchanged. The card stays unselectable, so a drag that starts on the padding or the icon still throws the toast away.
- The title and description carry `data-base-ui-swipe-ignore`, Base UI's opt-out, so a drag on the message starts a selection instead of a swipe.
- PostHog Desktop pins a published quill version, so `globals.css` repeats the CSS half of the fix and it works there before the next quill release. The attribute has no CSS equivalent, so drag-selection in desktop waits for the version bump; double-click and triple-click work as soon as this merges. The block carries a note to delete it at that point.
- Mechanical: the Toast section of `packages/quill/packages/primitives/AGENTS.md` gains the rule for custom card content.

Selecting the description of a toast, which was not possible before:

![quill-shot-after](https://raw.githubusercontent.com/PostHog/pr-assets/44b0e5535f69df7655bc3b2ca1b6cbd732b5be3b/2026/08/a42c3559-7f95-47a1-9e19-05e5dabe12d2.png)

Nothing else looks different. The only other visual change is the I-beam cursor over the message.

## How did you test this code?

No automated tests. `packages/quill/packages/primitives/src` has no test runner, and the change is a CSS rule plus a data attribute, so the cheapest honest guard is the comment next to each.

Checked by hand in headless Chromium against the quill Storybook (`Primitives/Toast` → `Types`) and the desktop Storybook, reading computed styles rather than trusting the screenshot:

<details>
<summary>What each run showed</summary>

Quill Storybook, before the change: `user-select` computed `none` on both the card and the description, and a drag across a live toast produced an empty selection.

Quill Storybook, after: the card stays `none`, the description computes `text`, dragging a live toast selects `"Something went wrong"`, the toast survives the drag, and dragging from the card's padding strip still dismisses it. Double-click selects a word, triple-click selects the line.

Desktop Storybook, with `globals.css` applied: the card computes `none`, the title and description compute `text`, and triple-click selects the whole description.

</details>

Not checked: the packaged Electron app, and any browser other than Chromium. One known gap either way, and not something this PR changes: a drag that overshoots below the card collapses the selection, because the toast viewport is `position: fixed` and outside the page flow. Triple-click is unaffected.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Raised in a Slack thread by a PostHog engineer who could not copy toast text into an agent. No GitHub handle was verified for them this session, so the PR is left unassigned.

Written by the PostHog Slack app (Claude Code). Skills invoked: `/quill-code`, `/writing-user-facing-copy`, `/writing-code-comments`, `/writing-tests`, `/writing-pr-descriptions`.

The session first fixed the main web app's `LemonToast`, which turned out to be the wrong surface once the report was narrowed to desktop. That work is [#86272](https://github.com/PostHog/posthog/pull/86272) and stands on its own.

The first shape considered here was removing `user-select: none` from the card outright. Reading Base UI's `ToastRoot` showed why that is wrong and pointed at `data-base-ui-swipe-ignore`, which the pinned 1.3.0 and current 1.6.0 both honour.

Nothing in this PR carries material from the originating thread.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1787218434832809?thread_ts=1787218434.832809&cid=C09G8Q32R6F)*
