### PR TITLE
fix(cli): emit native symbolication metadata

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -810,6 +810,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
 
 [[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2130,13 +2142,14 @@ dependencies = [
 
 [[package]]
 name = "posthog-rs"
-version = "0.15.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78a4557dd7d995d8c86c74d9f0b5116db21ac3fd207413fbca820aaa6910b22b"
+checksum = "38c087af2df10d14fbb44f303298896bb40d751831ed72ed69a560c75fa175c4"
 dependencies = [
  "backtrace",
  "chrono",
  "derive_builder",
+ "findshlibs",
  "flate2",
  "os_info",
  "regex",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -53,7 +53,7 @@ tracing = "0.1.41"
 uuid = { version = "1.16.0", features = ["v5", "v7"] }
 thiserror = "2.0.12"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
-posthog-rs = { version = "0.15.0", default-features = false, features = ["error-tracking"] }
+posthog-rs = { version = "0.24.0", default-features = false, features = ["error-tracking"] }
 sha2 = "0.10.9"
 urlencoding = "2.1.3"
 rayon = "1.11.0"


### PR DESCRIPTION
## Problem

CLI maintainers cannot symbolicate native failures because error events omit instruction addresses and loaded module identifiers.

## Changes

- CLI error events now include the native metadata required to match uploaded symbols.
- The Rust SDK moves from 0.15 to 0.24 without changing CLI command behavior.

## How did you test this code?

- `cargo check --manifest-path cli/Cargo.toml --all-targets`
- The complete stack passed `cargo test --manifest-path cli/Cargo.toml --all-targets` and Clippy.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- OpenAI Codex used repository and web research.
- Skills invoked: `/stacking-prs`, `/writing-pr-descriptions`.
- This is the bottom layer of a four-PR CLI diagnostics stack.