### PR TITLE
fix(cli): retain line tables in release binaries

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -85,6 +85,7 @@ unit_bindings = "deny"
 # The profile that 'dist' will build with
 [profile.dist]
 inherits = "release"
+debug = "line-tables-only"
 lto = "thin"
 
 [package.metadata.dist]


### PR DESCRIPTION
## Problem

CLI maintainers cannot resolve native stack frames to source lines because distribution builds discard DWARF line tables.

## Changes

- Distribution binaries now retain compact line-table debug information.
- The build keeps optimized code and thin LTO.

## How did you test this code?

- `cargo build --manifest-path cli/Cargo.toml --profile dist`
- `readelf` confirmed that the Linux binary contains a GNU build ID and DWARF line sections.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- OpenAI Codex used repository and build artifact inspection.
- Skills invoked: `/stacking-prs`, `/writing-pr-descriptions`.
- This layer prepares release artifacts for the symbol upload in the next PR.