### PR TITLE
fix(cli): upload native symbols during releases

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -474,6 +474,8 @@ jobs:
               run: |
                   node -e "const { existsSync, statSync } = require('node:fs'); const path = 'cli/lib/posthog-api-cli.mjs'; if (!existsSync(path) || statSync(path).size <= 0) { console.error('::error::API CLI bundle is missing or empty: ' + path); process.exit(1); }"
             - name: Build artifacts
+              env:
+                  CARGO_PROFILE_DIST_SPLIT_DEBUGINFO: ${{ runner.os == 'macOS' && 'packed' || 'off' }}
               run: |
                   # Actually do builds and make zips and whatnot
                   dist build ${{ needs.plan-release.outputs.tag-flag }} --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
@@ -493,6 +495,41 @@ jobs:
                           exit 1
                       fi
                   done
+            - name: Upload CLI debug symbols
+              if: runner.os != 'Windows'
+              shell: bash
+              env:
+                  POSTHOG_CLI_API_KEY: ${{ secrets.POSTHOG_UPLOAD_SOURCEMAPS_CLI_API_KEY }}
+                  POSTHOG_CLI_PROJECT_ID: '2'
+                  RELEASE_VERSION: ${{ needs.release.outputs.new-version }}
+                  TARGETS: ${{ join(matrix.targets, ' ') }}
+              run: |
+                  set -euo pipefail
+
+                  if [ -z "$POSTHOG_CLI_API_KEY" ]; then
+                      echo "::error::POSTHOG_UPLOAD_SOURCEMAPS_CLI_API_KEY is required to upload CLI debug symbols"
+                      exit 1
+                  fi
+
+                  symbols_dir="$RUNNER_TEMP/posthog-cli-symbols"
+                  mkdir -p "$symbols_dir"
+
+                  for target in $TARGETS; do
+                      package_dir="target/distrib/posthog-cli-$target"
+                      target_symbols_dir="$symbols_dir/$target"
+                      mkdir -p "$target_symbols_dir"
+                      cp "$package_dir/posthog-cli" "$target_symbols_dir/posthog-cli"
+                  done
+
+                  while IFS= read -r -d '' dsym; do
+                      cp -R "$dsym" "$symbols_dir/$(basename "$(dirname "$dsym")")-posthog-cli.dSYM"
+                  done < <(find target -type d -name 'posthog-cli.dSYM' -print0)
+
+                  cargo run --manifest-path cli/Cargo.toml --profile dist -- \
+                      symbol-sets upload --directory "$symbols_dir" \
+                      --release-name posthog-cli \
+                      --release-version "$RELEASE_VERSION"
+
             - id: cargo-dist
               name: Post-build
               # We force bash here just because github makes it really hard to get values up

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -85,6 +85,7 @@ unit_bindings = "deny"
 # The profile that 'dist' will build with
 [profile.dist]
 inherits = "release"
+debug = "line-tables-only"
 lto = "thin"
 
 [package.metadata.dist]


### PR DESCRIPTION
## Problem

CLI maintainers still see unresolved release stacks because the release pipeline publishes binaries without uploading their Linux or macOS symbols.

```mermaid
flowchart LR
    Build[Build release] --> Artifact[(GitHub artifact)]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class Build phBlue;
    class Artifact phGray;
```

## Changes

- Linux releases upload each packaged ELF before publication.
- macOS releases generate and upload a dSYM for each architecture.
- Windows remains unchanged because the native symbol store does not accept PDB uploads.
- Uploads are associated with the `posthog-cli` release and its semantic version.
- The upload fails closed when `POSTHOG_UPLOAD_SOURCEMAPS_CLI_API_KEY` is unavailable.

```mermaid
flowchart LR
    Build[Build release] --> Stage[Stage native symbols]
    Stage --> PostHog[PostHog symbol store]
    Stage --> Artifact[(GitHub artifact)]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class Build,Stage phBlue;
    class PostHog phRed;
    class Artifact phGray;
```

## How did you test this code?

- `actionlint .github/workflows/release-cli.yml`
- `hogli lint:workflows`
- Not run: the release workflow requires release approval and the scoped upload secret.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- OpenAI Codex inspected cargo-dist output and the CLI symbol uploader.
- Skills invoked: `/authoring-ci-workflows`, `/stacking-prs`, `/writing-code-comments`, `/writing-pr-descriptions`.
- The workflow uploads only formats that the symbol store supports.