### PR TITLE
fix(cli): classify local telemetry failures

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -474,6 +474,8 @@ jobs:
               run: |
                   node -e "const { existsSync, statSync } = require('node:fs'); const path = 'cli/lib/posthog-api-cli.mjs'; if (!existsSync(path) || statSync(path).size <= 0) { console.error('::error::API CLI bundle is missing or empty: ' + path); process.exit(1); }"
             - name: Build artifacts
+              env:
+                  CARGO_PROFILE_DIST_SPLIT_DEBUGINFO: ${{ runner.os == 'macOS' && 'packed' || 'off' }}
               run: |
                   # Actually do builds and make zips and whatnot
                   dist build ${{ needs.plan-release.outputs.tag-flag }} --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
@@ -493,6 +495,41 @@ jobs:
                           exit 1
                       fi
                   done
+            - name: Upload CLI debug symbols
+              if: runner.os != 'Windows'
+              shell: bash
+              env:
+                  POSTHOG_CLI_API_KEY: ${{ secrets.POSTHOG_UPLOAD_SOURCEMAPS_CLI_API_KEY }}
+                  POSTHOG_CLI_PROJECT_ID: '2'
+                  RELEASE_VERSION: ${{ needs.release.outputs.new-version }}
+                  TARGETS: ${{ join(matrix.targets, ' ') }}
+              run: |
+                  set -euo pipefail
+
+                  if [ -z "$POSTHOG_CLI_API_KEY" ]; then
+                      echo "::error::POSTHOG_UPLOAD_SOURCEMAPS_CLI_API_KEY is required to upload CLI debug symbols"
+                      exit 1
+                  fi
+
+                  symbols_dir="$RUNNER_TEMP/posthog-cli-symbols"
+                  mkdir -p "$symbols_dir"
+
+                  for target in $TARGETS; do
+                      package_dir="target/distrib/posthog-cli-$target"
+                      target_symbols_dir="$symbols_dir/$target"
+                      mkdir -p "$target_symbols_dir"
+                      cp "$package_dir/posthog-cli" "$target_symbols_dir/posthog-cli"
+                  done
+
+                  while IFS= read -r -d '' dsym; do
+                      cp -R "$dsym" "$symbols_dir/$(basename "$(dirname "$dsym")")-posthog-cli.dSYM"
+                  done < <(find target -type d -name 'posthog-cli.dSYM' -print0)
+
+                  cargo run --manifest-path cli/Cargo.toml --profile dist -- \
+                      symbol-sets upload --directory "$symbols_dir" \
+                      --release-name posthog-cli \
+                      --release-version "$RELEASE_VERSION"
+
             - id: cargo-dist
               name: Post-build
               # We force bash here just because github makes it really hard to get values up

--- a/cli/.sampo/changesets/improve-cli-error-diagnostics.md
+++ b/cli/.sampo/changesets/improve-cli-error-diagnostics.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-cli: patch
+---
+
+Improve CLI error diagnostics with native stack symbolication metadata, release debug symbols, and structured categories for local file and parsing failures.

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -85,6 +85,7 @@ unit_bindings = "deny"
 # The profile that 'dist' will build with
 [profile.dist]
 inherits = "release"
+debug = "line-tables-only"
 lto = "thin"
 
 [package.metadata.dist]

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -88,27 +88,43 @@ impl ErrorTelemetryMetadata {
             return metadata;
         }
 
-        let Some(client_error) = error
+        if let Some(client_error) = error
             .chain()
             .find_map(|source| source.downcast_ref::<ClientError>())
-        else {
+        {
+            match client_error {
+                ClientError::ApiError(status, _, body) => {
+                    metadata.error_kind = "api_error";
+                    metadata.http_status = Some(*status);
+                    metadata.api_error_code = safe_api_error_code(body);
+                }
+                ClientError::RequestError(err) => {
+                    metadata.error_kind = "request_error";
+                    metadata.is_timeout = Some(err.is_timeout());
+                    metadata.is_connect = Some(err.is_connect());
+                }
+                ClientError::InvalidUrl(_) => {
+                    metadata.error_kind = "invalid_url";
+                }
+            }
             return metadata;
-        };
+        }
 
-        match client_error {
-            ClientError::ApiError(status, _, body) => {
-                metadata.error_kind = "api_error";
-                metadata.http_status = Some(*status);
-                metadata.api_error_code = safe_api_error_code(body);
-            }
-            ClientError::RequestError(err) => {
-                metadata.error_kind = "request_error";
-                metadata.is_timeout = Some(err.is_timeout());
-                metadata.is_connect = Some(err.is_connect());
-            }
-            ClientError::InvalidUrl(_) => {
-                metadata.error_kind = "invalid_url";
-            }
+        if let Some(io_error) = find_error::<std::io::Error>(error) {
+            metadata.error_kind = "io_error";
+            metadata.io_error_kind = Some(format!("{:?}", io_error.kind()));
+        } else if find_error::<serde_json::Error>(error).is_some() {
+            metadata.error_kind = "json_error";
+        } else if find_error::<serde_yaml::Error>(error).is_some() {
+            metadata.error_kind = "yaml_error";
+        } else if find_error::<plist::Error>(error).is_some() {
+            metadata.error_kind = "plist_error";
+        } else if find_error::<sourcemap::Error>(error).is_some() {
+            metadata.error_kind = "sourcemap_error";
+        } else if find_error::<globset::Error>(error).is_some() {
+            metadata.error_kind = "glob_error";
+        } else if find_error::<zip::result::ZipError>(error).is_some() {
+            metadata.error_kind = "zip_error";
         }
 
         metadata
@@ -143,6 +159,13 @@ impl ErrorTelemetryMetadata {
 
         parts.join(":")
     }
+}
+
+fn find_error<T>(error: &Error) -> Option<&T>
+where
+    T: StdError + Send + Sync + 'static,
+{
+    error.chain().find_map(|source| source.downcast_ref::<T>())
 }
 
 #[derive(Deserialize)]
@@ -257,6 +280,31 @@ fn capture_exception(metadata: ErrorTelemetryMetadata) {
 mod tests {
     use super::*;
     use crate::api_proxy::{ApiProxyError, MaterializeStep};
+
+    #[test]
+    fn local_errors_produce_structured_telemetry() {
+        let cases = [
+            (
+                anyhow::Error::new(std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    "denied",
+                )),
+                "io_error",
+                Some("PermissionDenied"),
+            ),
+            (
+                anyhow::Error::new(serde_json::from_str::<serde_json::Value>("{").unwrap_err()),
+                "json_error",
+                None,
+            ),
+        ];
+
+        for (error, expected_kind, expected_io_kind) in cases {
+            let metadata = ErrorTelemetryMetadata::from_error(&error);
+            assert_eq!(metadata.error_kind, expected_kind);
+            assert_eq!(metadata.io_error_kind.as_deref(), expected_io_kind);
+        }
+    }
 
     #[test]
     fn proxy_launch_errors_produce_structured_telemetry() {


### PR DESCRIPTION
## Problem

CLI maintainers cannot distinguish common local failures because sanitized I/O and parser errors share the generic `other` category.

## Changes

- Error telemetry now separates I/O, JSON, YAML, plist, source map, glob, and ZIP failures.
- I/O telemetry includes the safe standard error kind without sending paths or messages.
- The CLI patch changeset covers the complete diagnostics stack.

## How did you test this code?

- `cargo test --manifest-path cli/Cargo.toml --all-targets`
- `cargo clippy --manifest-path cli/Cargo.toml --all-targets -- -D warnings`
- The new unit cases catch regressions that collapse I/O and JSON failures into `other`.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [x] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- OpenAI Codex used repository tests and error telemetry inspection.
- Skills invoked: `/stacking-prs`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-pr-descriptions`.
- The taxonomy keeps raw error messages out of telemetry.