### PR TITLE
fix(mcp-store): stop failed connects from exhausting the OAuth rate limit

### DIFF
--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -1175,9 +1175,13 @@ class RefundableRateThrottleMixin:
         # Re-read the window rather than writing back the snapshot this request captured at
         # throttle time. A concurrent request from the same user may have been charged since,
         # and restoring the snapshot would erase that charge and let the window run over its
-        # limit. This narrows the race to the gap between get and set rather than closing it,
-        # because Django's cache API has no atomic list operation; closing it fully would mean
-        # moving this scope onto a Redis-side token bucket.
+        # limit.
+        # This narrows the race rather than closing it, and closing it here is not reachable.
+        # SimpleRateThrottle.throttle_success() charges the window with the same unsynchronized
+        # get/modify/set, so there is no atomic writer to serialize against, and the window is
+        # stored as a pickled Python list, so no server-side Redis operation can edit it in
+        # place. Removing the race means replacing the sliding window with a token bucket,
+        # which changes throttling behavior well beyond this scope.
         current = self.cache.get(key, [])  # type: ignore[attr-defined]
         try:
             current.remove(charged_at)

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -1167,13 +1167,24 @@ class RefundableRateThrottleMixin:
         return allowed
 
     def refund(self) -> None:
-        # SimpleRateThrottle.throttle_success() puts the timestamp it just charged at index 0.
         key = getattr(self, "key", None)
-        history = getattr(self, "history", None)
-        if not key or not history:
+        # SimpleRateThrottle.throttle_success() charges the window by inserting self.now.
+        charged_at = getattr(self, "now", None)
+        if not key or charged_at is None:
             return
-        history.pop(0)
-        self.cache.set(key, history, self.duration)  # type: ignore[attr-defined]
+        # Re-read the window rather than writing back the snapshot this request captured at
+        # throttle time. A concurrent request from the same user may have been charged since,
+        # and restoring the snapshot would erase that charge and let the window run over its
+        # limit. This narrows the race to the gap between get and set rather than closing it,
+        # because Django's cache API has no atomic list operation; closing it fully would mean
+        # moving this scope onto a Redis-side token bucket.
+        current = self.cache.get(key, [])  # type: ignore[attr-defined]
+        try:
+            current.remove(charged_at)
+        except ValueError:
+            # Already aged out of the window, so there is nothing left to give back.
+            return
+        self.cache.set(key, current, self.duration)  # type: ignore[attr-defined]
 
 
 def refund_rate_limit(request: "Request") -> None:

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -1144,14 +1144,55 @@ class SymbolSetUploadSustainedRateThrottle(PersonalApiKeyRateThrottle):
     rate = "12000/hour"
 
 
+class RefundableRateThrottleMixin:
+    """Lets a view hand back the slot a request took once it knows the request did no work.
+
+    DRF charges a request the moment it passes the throttle, before the view body runs, so a
+    failed attempt costs the same as a successful one. That is the wrong shape for a flow where
+    failures are expected and the user's only recourse is to retry: a broken upstream drains the
+    budget, and the resulting 429 then hides the error that actually needs fixing.
+
+    Apply this to the long-window throttle only. The short-window one should still charge for
+    failures, since that is what stops a retry loop from hammering an upstream provider.
+    """
+
+    def allow_request(self, request: "Request", view: "APIView") -> bool:
+        allowed = super().allow_request(request, view)  # type: ignore[misc]
+        if allowed:
+            refundable = getattr(request, "_refundable_throttles", None)
+            if refundable is None:
+                refundable = []
+                request._refundable_throttles = refundable  # type: ignore[attr-defined]
+            refundable.append(self)
+        return allowed
+
+    def refund(self) -> None:
+        # SimpleRateThrottle.throttle_success() puts the timestamp it just charged at index 0.
+        key = getattr(self, "key", None)
+        history = getattr(self, "history", None)
+        if not key or not history:
+            return
+        history.pop(0)
+        self.cache.set(key, history, self.duration)  # type: ignore[attr-defined]
+
+
+def refund_rate_limit(request: "Request") -> None:
+    """Give back every refundable throttle slot this request consumed."""
+    for throttle in getattr(request, "_refundable_throttles", []):
+        throttle.refund()
+
+
 class MCPOAuthBurstThrottle(UserRateThrottle):
     scope = "mcp_oauth_burst"
     rate = "10/minute"
 
 
-class MCPOAuthSustainedThrottle(UserRateThrottle):
+class MCPOAuthSustainedThrottle(RefundableRateThrottleMixin, UserRateThrottle):
     scope = "mcp_oauth_sustained"
-    rate = "50/hour"
+    # Connecting a server is interactive and often takes several rounds against the provider, so
+    # the hourly budget only needs to be high enough that ordinary use never reaches it. The
+    # 10/minute burst above is what actually bounds abuse.
+    rate = "200/hour"
 
 
 class MCPOAuthRedirectBurstThrottle(SimpleRateThrottle):

--- a/products/mcp_store/backend/presentation/views.py
+++ b/products/mcp_store/backend/presentation/views.py
@@ -718,8 +718,13 @@ class MCPServerInstallationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet
         # An attempt that errored left the user with no server connected, so it shouldn't spend
         # their hourly budget. Charging for it means a provider that keeps rejecting the handshake
         # exhausts the budget within a few clicks, and the 429 then replaces the error the user
-        # needs to see. 429 is excluded because refunding it would undo the limit being enforced.
-        if response.status_code >= 400 and response.status_code != status.HTTP_429_TOO_MANY_REQUESTS:
+        # needs to see.
+        # A 429 refunds too. DRF evaluates every throttle on the view, so the burst throttle
+        # rejecting a request does not stop the sustained one from charging it first, and without
+        # this a one-minute burst lockout would still drain the hourly budget. Refunding cannot
+        # undo the limit that fired, because a throttle only becomes refundable when it allowed
+        # the request.
+        if response.status_code >= 400:
             refund_rate_limit(request)
         return super().finalize_response(request, response, *args, **kwargs)
 

--- a/products/mcp_store/backend/presentation/views.py
+++ b/products/mcp_store/backend/presentation/views.py
@@ -45,6 +45,7 @@ from posthog.rate_limit import (
     MCPOAuthSustainedThrottle,
     MCPProxyBurstThrottle,
     MCPProxySustainedThrottle,
+    refund_rate_limit,
 )
 from posthog.security.url_validation import is_url_allowed
 
@@ -712,6 +713,15 @@ class MCPServerInstallationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet
         if self.action in self._USER_SCOPED_ACTIONS:
             return ["project:read"]
         return None
+
+    def finalize_response(self, request: Request, response: Any, *args: Any, **kwargs: Any) -> Any:
+        # An attempt that errored left the user with no server connected, so it shouldn't spend
+        # their hourly budget. Charging for it means a provider that keeps rejecting the handshake
+        # exhausts the budget within a few clicks, and the 429 then replaces the error the user
+        # needs to see. 429 is excluded because refunding it would undo the limit being enforced.
+        if response.status_code >= 400 and response.status_code != status.HTTP_429_TOO_MANY_REQUESTS:
+            refund_rate_limit(request)
+        return super().finalize_response(request, response, *args, **kwargs)
 
     def safely_get_queryset(self, queryset: QuerySet) -> QuerySet:
         return (

--- a/products/mcp_store/backend/test/test_api.py
+++ b/products/mcp_store/backend/test/test_api.py
@@ -21,6 +21,7 @@ from rest_framework.test import APIClient
 from posthog.models import Organization, Team, User
 from posthog.models.oauth import OAuthAccessToken, OAuthApplication
 from posthog.models.organization import OrganizationMembership
+from posthog.rate_limit import MCPOAuthSustainedThrottle
 
 from products.mcp_store.backend.agents import create_gateway_agent_token, sync_built_in_agents
 from products.mcp_store.backend.models import (
@@ -3969,6 +3970,37 @@ class TestInstallTemplateAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest
         assert not MCPOAuthState.objects.filter(team=self.team).exists()
 
 
+class TestRefundableRateThrottle(SimpleTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        cache.clear()
+        self.addCleanup(cache.clear)
+
+    def test_refund_keeps_a_charge_made_after_this_request_passed(self) -> None:
+        throttle = MCPOAuthSustainedThrottle()
+        throttle.key = "test-mcp-oauth-sustained"
+        throttle.now = 100.0
+        # The snapshot this request captured when it passed the throttle.
+        throttle.history = [100.0]
+        # A second request from the same user was charged while this one was still running.
+        cache.set(throttle.key, [200.0, 100.0], 3600)
+
+        throttle.refund()
+
+        assert cache.get(throttle.key) == [200.0]
+
+    def test_refund_is_a_no_op_once_the_charge_aged_out(self) -> None:
+        throttle = MCPOAuthSustainedThrottle()
+        throttle.key = "test-mcp-oauth-sustained"
+        throttle.now = 100.0
+        throttle.history = [100.0]
+        cache.set(throttle.key, [300.0], 3600)
+
+        throttle.refund()
+
+        assert cache.get(throttle.key) == [300.0]
+
+
 class TestInstallTemplateRateLimit(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
     def setUp(self) -> None:
         super().setUp()
@@ -3976,11 +4008,10 @@ class TestInstallTemplateRateLimit(ClickhouseTestMixin, APIBaseTest, QueryMatchi
         self.addCleanup(cache.clear)
 
     def _template(self, **overrides) -> MCPServerTemplate:
-        import uuid as _uuid
-
+        self._sequence = getattr(self, "_sequence", 0) + 1
         defaults = {
-            "name": f"Template-{_uuid.uuid4().hex[:6]}",
-            "url": f"https://mcp-{_uuid.uuid4().hex[:8]}.test.example.com/mcp",
+            "name": f"Throttle-template-{self._sequence}",
+            "url": f"https://mcp-throttle-{self._sequence}.test.example.com/mcp",
             "auth_type": "oauth",
             "is_active": True,
             "oauth_metadata": {
@@ -4031,6 +4062,23 @@ class TestInstallTemplateRateLimit(ClickhouseTestMixin, APIBaseTest, QueryMatchi
 
         assert first.status_code == status.HTTP_404_NOT_FOUND
         assert second.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+
+    def test_burst_rejection_does_not_spend_the_hourly_budget(self) -> None:
+        # DRF evaluates every throttle, so the sustained one charges even when the burst one
+        # rejects. Without a refund on 429 a burst lockout would also drain the hourly budget.
+        allowed = self._template()
+        blocked = self._template()
+        after_lockout = self._template()
+
+        with patch("posthog.rate_limit.MCPOAuthSustainedThrottle.rate", "2/hour"):
+            first = self._install(allowed)
+            with patch("posthog.rate_limit.MCPOAuthBurstThrottle.rate", "1/minute"):
+                second = self._install(blocked)
+            third = self._install(after_lockout)
+
+        assert first.status_code == status.HTTP_200_OK, first.content
+        assert second.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+        assert third.status_code == status.HTTP_200_OK, third.content
 
 
 class TestInstallationToolsAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):

--- a/products/mcp_store/backend/test/test_api.py
+++ b/products/mcp_store/backend/test/test_api.py
@@ -3969,6 +3969,70 @@ class TestInstallTemplateAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest
         assert not MCPOAuthState.objects.filter(team=self.team).exists()
 
 
+class TestInstallTemplateRateLimit(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
+    def setUp(self) -> None:
+        super().setUp()
+        cache.clear()
+        self.addCleanup(cache.clear)
+
+    def _template(self, **overrides) -> MCPServerTemplate:
+        import uuid as _uuid
+
+        defaults = {
+            "name": f"Template-{_uuid.uuid4().hex[:6]}",
+            "url": f"https://mcp-{_uuid.uuid4().hex[:8]}.test.example.com/mcp",
+            "auth_type": "oauth",
+            "is_active": True,
+            "oauth_metadata": {
+                "authorization_endpoint": "https://auth.test.example.com/authorize",
+                "token_endpoint": "https://auth.test.example.com/token",
+            },
+            "oauth_credentials": {"client_id": "template-client-id"},
+        }
+        defaults.update(overrides)
+        return MCPServerTemplate.objects.create(**defaults)
+
+    def _install(self, template: MCPServerTemplate) -> HttpResponse:
+        return self.client.post(
+            f"/api/environments/{self.team.id}/mcp_server_installations/install_template/",
+            data={"template_id": str(template.id)},
+            format="json",
+        )
+
+    def test_failed_install_does_not_spend_the_hourly_budget(self) -> None:
+        inactive = self._template(is_active=False)
+        working = self._template()
+
+        with patch("posthog.rate_limit.MCPOAuthSustainedThrottle.rate", "1/hour"):
+            first = self._install(inactive)
+            second = self._install(working)
+
+        assert first.status_code == status.HTTP_404_NOT_FOUND
+        assert second.status_code == status.HTTP_200_OK, second.content
+
+    def test_successful_install_spends_the_hourly_budget(self) -> None:
+        first_template = self._template()
+        second_template = self._template()
+
+        with patch("posthog.rate_limit.MCPOAuthSustainedThrottle.rate", "1/hour"):
+            first = self._install(first_template)
+            second = self._install(second_template)
+
+        assert first.status_code == status.HTTP_200_OK, first.content
+        assert second.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+
+    def test_failed_install_still_spends_the_burst_budget(self) -> None:
+        inactive = self._template(is_active=False)
+        working = self._template()
+
+        with patch("posthog.rate_limit.MCPOAuthBurstThrottle.rate", "1/minute"):
+            first = self._install(inactive)
+            second = self._install(working)
+
+        assert first.status_code == status.HTTP_404_NOT_FOUND
+        assert second.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+
+
 class TestInstallationToolsAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
     def _installation(self, **kwargs) -> MCPServerInstallation:
         import uuid as _uuid


### PR DESCRIPTION
## Problem

Connecting an MCP server from Settings → MCP servers fails with "Request was throttled. Expected available in N seconds.", and the user waits up to an hour before the next attempt.

- The connect actions (`install_template`, `install_custom`, `authorize`) allow 50 requests per hour per user.
- DRF charges the throttle before the view body runs, so an attempt that errored costs the same as one that connected.
- A provider that keeps rejecting the handshake therefore drains the budget in a few clicks, and the 429 then replaces the error that explains the real failure.

A catalog entry whose provider does not support Dynamic Client Registration reproduces this exactly. Every attempt returns 400, each 400 spends a slot, and after 50 attempts the user gets the throttle message instead of the 400 that told them what was wrong.

## Changes

- A connect attempt that fails no longer counts against the hourly limit, so the user can retry and the underlying error keeps surfacing.
- The hourly limit rises from 50 to 200, which leaves headroom for ordinary interactive use.
- The 10/minute burst limit is unchanged and still charges for failures, so a retry loop cannot hammer an upstream provider. That is why the refund applies to the hourly throttle alone. Raising the cap on its own would not fix this, because a failing provider still exhausts whatever number is set.
- `RefundableRateThrottleMixin` in `posthog/rate_limit.py` records which throttles a request passed. `MCPServerInstallationViewSet.finalize_response` hands the slot back on any response over 400 except 429.
- The IP-based throttle on the public OAuth callback is unchanged. Refunding errors there would remove its abuse protection, since probing an invalid state token also returns a 400.
- No frontend change. Nothing looks different until a connect attempt that used to be blocked goes through.

This does not make any individual connect attempt succeed. It stops a failing provider from hiding its own error behind a 429.

Known limitation: a successful `authorize` returns 200 before the provider is contacted, so a round trip that fails at the provider or on the callback still spends its slot. Refunding that case means persisting the originating user's throttle key onto the OAuth state and refunding it from the public callback endpoint, which is a larger surface than this change should carry.

> [!NOTE]
> The 429 case refunds too. DRF evaluates every throttle on a view without short-circuiting, so the burst throttle rejecting a request does not stop the sustained one from charging it first. A throttle only becomes refundable when it allowed the request, so this cannot undo the limit that fired.

## How did you test this code?

Three cases in `TestInstallTemplateRateLimit`, each aimed at one way this fix can regress:

- A failed install does not spend the hourly budget. This catches the refund being dropped.
- A successful install does spend it. This catches a refund that disables the hourly limit outright.
- A failed install still spends the burst budget. This catches the refund being applied to the wrong throttle.
- A burst-rejected 429 does not spend the hourly budget. This catches the hourly budget draining during a one-minute burst lockout.
- A refund keeps a charge made after this request passed the throttle. This catches the refund writing back a stale history snapshot and erasing a concurrent charge.

Ran `products/mcp_store/backend/test/test_api.py` against a local dev stack, and `hogli build:openapi`, which regenerates with no drift.

Not run: repo-wide mypy, which the sandbox OOM-killed. mypy passes on the two changed modules. No manual browser testing.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The limit is not documented.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app (Claude Opus) after a report of the throttle message on the MCP servers settings page. The throttle scope was traced from the settings page back to `MCPOAuthSustainedThrottle` by matching the reported wait against DRF's `SimpleRateThrottle.wait()`, which only an hour-window scope can produce.

The reporter's repeated failures were then reproduced against a live provider: its authorization server metadata advertises no `registration_endpoint`, so `register_dcr_client` raises and the install returns 400 every time. That confirmed the refund, rather than a larger cap, is the part that fixes the loop. Making that provider connectable needs operator-seeded OAuth credentials and is out of scope here.

Skills invoked: `/writing-code-comments`, `/writing-tests`, `/writing-pr-descriptions`.

No assignee is set: the reporter's GitHub handle was not verifiable from the originating thread, and guessing one risks tagging an unrelated account. The owning team should assign the DRI.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1787221570078289)*

