### PR TITLE
fix(desktop): raise custom instructions limit to 20k characters

### DIFF
--- a/products/desktop/packages/shared/src/constants.ts
+++ b/products/desktop/packages/shared/src/constants.ts
@@ -7,6 +7,14 @@ export {
 export const SELF_DRIVING_SETUP_TASK_FLAG =
   "posthog-code-self-driving-setup-task";
 export const BRANCH_PREFIX = "posthog/";
+
+// Cap on personalization instructions, hand-typed or synced from an
+// AGENTS.md/CLAUDE.md. Shared by the settings textarea, `OsService`'s file
+// truncation and the session-start Zod validators (`startSessionInput`/
+// `reconnectSessionInput`) so the three stay equal — a synced file truncated
+// to this length must not then fail the session-start length check.
+export const USER_AGENT_INSTRUCTIONS_MAX_LENGTH = 20_000;
+
 export const POSTHOG_CODE_INTERNAL_CHILD_ENV = "POSTHOG_CODE_INTERNAL_CHILD";
 
 // Mirrors --color-background (dark) in packages/ui globals.css, for surfaces

--- a/products/desktop/packages/ui/src/features/settings/sections/PersonalizationSettings.stories.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/PersonalizationSettings.stories.tsx
@@ -43,7 +43,7 @@ const meta: Meta<typeof PersonalizationSettingsView> = {
 export default meta;
 type Story = StoryObj<typeof PersonalizationSettingsView>;
 
-/** Sync off: the editable box with its character counter. */
+/** Sync off: the editable box, well under the cap so no counter shows. */
 export const Default: Story = {
   args: {
     instructions:
@@ -51,8 +51,15 @@ export const Default: Story = {
   },
 };
 
-/** Sync off with nothing typed yet: placeholder text and a 0/2000 counter. */
+/** Sync off with nothing typed yet: just the placeholder text. */
 export const Empty: Story = {};
+
+/** Within 10% of the cap: the counter appears so the ceiling is visible. */
+export const NearCharacterLimit: Story = {
+  args: {
+    instructions: "Keep responses terse. ".repeat(900),
+  },
+};
 
 /**
  * Sync on and a CLAUDE.md was found: the box is disabled and greyed out (the

--- a/products/desktop/packages/ui/src/features/settings/sections/PersonalizationSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/PersonalizationSettings.tsx
@@ -82,24 +82,22 @@ export function PersonalizationSettingsView({
             }
             disabled={syncFromFile}
           />
-          {syncFromFile ? (
-            synced && (
-              <span className="text-right text-[12px] text-gray-10">
-                Using{" "}
-                <span className="font-mono text-[11px]">
-                  {synced.displayPath}
+          {syncFromFile
+            ? synced && (
+                <span className="text-right text-[12px] text-gray-10">
+                  Using{" "}
+                  <span className="font-mono text-[11px]">
+                    {synced.displayPath}
+                  </span>
+                  {synced.truncated ? " (truncated)" : ""}. Edit that file to
+                  change your personalization.
                 </span>
-                {synced.truncated ? " (truncated)" : ""}. Edit that file to
-                change your personalization.
-              </span>
-            )
-          ) : (
-            instructions.length >= COUNTER_VISIBLE_FROM && (
-              <span className="text-right text-[12px] text-gray-10 tabular-nums">
-                {instructions.length}/{MAX_INSTRUCTIONS_LENGTH}
-              </span>
-            )
-          )}
+              )
+            : instructions.length >= COUNTER_VISIBLE_FROM && (
+                <span className="text-right text-[12px] text-gray-10 tabular-nums">
+                  {instructions.length}/{MAX_INSTRUCTIONS_LENGTH}
+                </span>
+              )}
         </div>
       </SettingsCard>
     </SettingsSection>

--- a/products/desktop/packages/ui/src/features/settings/sections/PersonalizationSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/PersonalizationSettings.tsx
@@ -1,6 +1,7 @@
 import { buildPostHogUrl } from "@posthog/core/settings/posthogUrl";
 import { Switch, Textarea } from "@posthog/quill";
 import { ANALYTICS_EVENTS } from "@posthog/shared";
+import { USER_AGENT_INSTRUCTIONS_MAX_LENGTH } from "@posthog/shared/constants";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
 import {
   SettingsCard,
@@ -15,7 +16,12 @@ import { useDebounce } from "@posthog/ui/primitives/hooks/useDebounce";
 import { track } from "@posthog/ui/shell/analytics";
 import { useCallback, useEffect, useState } from "react";
 
-const MAX_INSTRUCTIONS_LENGTH = 2000;
+// Same cap the synced-file path uses, so typing and syncing hold the same
+// amount of text.
+const MAX_INSTRUCTIONS_LENGTH = USER_AGENT_INSTRUCTIONS_MAX_LENGTH;
+
+// A running count is noise until the cap is in reach.
+const COUNTER_VISIBLE_FROM = Math.floor(MAX_INSTRUCTIONS_LENGTH * 0.9);
 
 export interface PersonalizationSettingsViewProps {
   instructions: string;
@@ -88,9 +94,11 @@ export function PersonalizationSettingsView({
               </span>
             )
           ) : (
-            <span className="text-right text-[12px] text-gray-10 tabular-nums">
-              {instructions.length}/{MAX_INSTRUCTIONS_LENGTH}
-            </span>
+            instructions.length >= COUNTER_VISIBLE_FROM && (
+              <span className="text-right text-[12px] text-gray-10 tabular-nums">
+                {instructions.length}/{MAX_INSTRUCTIONS_LENGTH}
+              </span>
+            )
           )}
         </div>
       </SettingsCard>

--- a/products/desktop/packages/workspace-server/src/services/agent/schemas.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/schemas.ts
@@ -3,9 +3,9 @@ import type {
   PermissionOption as SdkPermissionOption,
 } from "@agentclientprotocol/sdk";
 import { BEDROCK_GATEWAY_VARIANTS } from "@posthog/shared";
+import { USER_AGENT_INSTRUCTIONS_MAX_LENGTH } from "@posthog/shared/constants";
 import { effortLevelSchema } from "@posthog/shared/domain-types";
 import { z } from "zod";
-import { USER_AGENT_INSTRUCTIONS_MAX_LENGTH } from "../os/schemas";
 
 export { effortLevelSchema };
 export type { EffortLevel } from "@posthog/shared/domain-types";
@@ -42,11 +42,9 @@ export const sessionConfigSchema = z.object({
 
 export type SessionConfig = z.infer<typeof sessionConfigSchema>;
 
-// Sized for personalization synced from an AGENTS.md/CLAUDE.md file, which
-// can be far larger than the 2000-char hand-typed settings field. Kept equal
-// to OsService's truncation length (USER_AGENT_INSTRUCTIONS_MAX_LENGTH) or a
-// synced file gets truncated to fit but still fails this check. Shared by
-// startSessionInput and reconnectSessionInput below.
+// Kept equal to OsService's truncation length, or a synced file gets
+// truncated to fit but still fails this check. Shared by startSessionInput
+// and reconnectSessionInput below.
 const customInstructionsField = z
   .string()
   .max(USER_AGENT_INSTRUCTIONS_MAX_LENGTH)

--- a/products/desktop/packages/workspace-server/src/services/os/os.ts
+++ b/products/desktop/packages/workspace-server/src/services/os/os.ts
@@ -29,6 +29,7 @@ import {
   IMAGE_MIME_TYPES,
   isRasterImageFile,
 } from "@posthog/shared";
+import { USER_AGENT_INSTRUCTIONS_MAX_LENGTH } from "@posthog/shared/constants";
 import { inject, injectable } from "inversify";
 import type {
   ClaudePermissions,
@@ -40,7 +41,6 @@ import type {
   SelectedAttachment,
   UserAgentInstructions,
 } from "./schemas";
-import { USER_AGENT_INSTRUCTIONS_MAX_LENGTH } from "./schemas";
 
 const fsPromises = fs.promises;
 

--- a/products/desktop/packages/workspace-server/src/services/os/schemas.ts
+++ b/products/desktop/packages/workspace-server/src/services/os/schemas.ts
@@ -7,14 +7,6 @@ export const claudePermissionsOutput = z.object({
 });
 export type ClaudePermissions = z.infer<typeof claudePermissionsOutput>;
 
-// Personalization synced from a file can be much larger than hand-typed
-// instructions, but the prompt it lands in must stay bounded. Shared by
-// `OsService`'s truncation and the session-start Zod validators
-// (`startSessionInput`/`reconnectSessionInput` in ../agent/schemas) so the two
-// stay equal — a synced file truncated to this length must not then fail the
-// session-start length check.
-export const USER_AGENT_INSTRUCTIONS_MAX_LENGTH = 20_000;
-
 export const userAgentInstructionsSchema = z.object({
   path: z.string(),
   /** Home-relative form of `path` (e.g. `~/.claude/CLAUDE.md`), for display. */


### PR DESCRIPTION
## TL;DR

The settings box for custom instructions stopped accepting text at 2000 characters, so longer personalization got cut off mid-sentence. It now holds 20,000, the same as the file-sync path already did.

## Problem

Anyone writing custom instructions in Settings > Personalization hit a silent wall: the box stopped taking input at 2000 characters, and a longer paste landed truncated mid-word with no message. Every agent session then ran on half a sentence.

Nothing else in the path had that limit. `OsService` truncates a synced AGENTS.md/CLAUDE.md at 20,000 characters, and the session-start schema accepts up to the same number. Only the textarea was set to 2000.

## Changes

- The instructions box now holds 20,000 characters, so typing and syncing from a file carry the same amount of text.
- The character counter shows only within 10% of the cap, instead of on every keystroke.
- Mechanical: the 20,000 constant moves from `workspace-server` to `@posthog/shared/constants`, which is the only place `packages/ui` can read it from.

No other visual change. The box, its caption, and the sync toggle render as before.

## How did you test this code?

No new tests. The change is a constant swap plus one render condition; the condition is covered by a new `NearCharacterLimit` story.

Ran locally: `@posthog/shared`, `@posthog/workspace-server` and `@posthog/ui` typecheck clean, Biome clean on the six changed files, and the existing `os.test.ts` (53) and `features/settings` (85) suites pass.

Not checked: the packaged app. No desktop build ran in this sandbox, so the counter threshold and the new cap are unverified against a real window.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Opus in PostHog Code. The task started as a question about whether cloud runs still receive the user's custom instructions. They do, and comparing the delivered text against the source showed it ending mid-word at exactly 2000 characters, which located the cap.

Skills invoked: `/writing-pr-descriptions`.

The alternative was to leave the textarea at 2000 and only lift the file-sync path. That keeps two different answers to the same question, so the caps were unified on the number the rest of the path already used.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
