### PR TITLE
fix(ci): skip rust and node image builds on merge-queue branches

### DIFF
--- a/.github/workflows/ci-nodejs-container.yml
+++ b/.github/workflows/ci-nodejs-container.yml
@@ -35,7 +35,11 @@ jobs:
             contents: read
             pull-requests: read
         timeout-minutes: 5
-        if: github.repository_owner == 'PostHog'
+        # Skip merge-queue attempts: this check is not required, the PR branch already
+        # built the same diff, and each attempt pushes the image to GHCR, which
+        # throttles the whole org when the queue churns. The build job requires this
+        # job's outputs, so skipping here skips the build too.
+        if: github.repository_owner == 'PostHog' && !startsWith(github.head_ref, 'trunk-merge/')
         name: Determine need to run node Docker build
         outputs:
             node_files: ${{ steps.filter.outputs.node_files }}

--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -39,8 +39,12 @@ jobs:
         runs-on: ubuntu-24.04
         timeout-minutes: 10
         # Skip on workflow_dispatch — always build everything (escape hatch)
+        # Skip merge-queue attempts: this check is not required, the PR branch already
+        # built the same diff, and each attempt pushes every affected image to GHCR,
+        # which throttles the whole org when the queue churns.
         if: >-
             github.event_name != 'workflow_dispatch' &&
+            !startsWith(github.head_ref, 'trunk-merge/') &&
             (github.event_name != 'pull_request' ||
              github.event.pull_request.head.repo.full_name == github.repository)
         permissions:
@@ -80,6 +84,7 @@ jobs:
         # Run unless affected explicitly found zero images ('none') or failed.
         if: |
             !cancelled() &&
+            !startsWith(github.head_ref, 'trunk-merge/') &&
             (github.event_name != 'pull_request' ||
              github.event.pull_request.head.repo.full_name == github.repository) &&
             needs.affected.result != 'failure' &&


### PR DESCRIPTION
## Problem

- GHCR started throttling our image pushes on Aug 18, failing the rust and node container image workflows with `no active sessions` and `failed to push ghcr.io/… after 5 retries` (for example [run 32239443247](https://github.com/PostHog/posthog/actions/runs/32239443247) and [run 32282435561](https://github.com/PostHog/posthog/actions/runs/32282435561)).
- Every Trunk merge-queue attempt re-runs these two non-required workflows and pushes every affected image to GHCR, duplicating the PR-branch run.
- Queue churn multiplies the attempts: the rust workflow ran 44 times on Aug 17 and 312 times on Aug 19, mostly on `trunk-merge/*` branches.
- The extra builds also load the shared Depot builders, which feeds back into more queue ejections and more attempts.

## Changes

- Merge-queue attempts no longer build or push the rust and node container images. A job-level guard on `github.head_ref` skips `trunk-merge/*` branches.
- Neither check is required by branch protection, so nothing about merge gating changes.
- PR branches, master pushes, and `workflow_dispatch` behave exactly as before.
- The e2e suite already falls back to the `master` capture image when no PR-tagged image exists, so queue e2e runs keep working through that existing fallback.

## How did you test this code?

- `bin/hogli lint:workflows` passes (all 8 checks across 126 workflows).
- `actionlint` reports only shellcheck notes at `ci-nodejs-container.yml:158`, which exist on master's version of the file too.
- Not run: the workflows themselves. The guard only takes effect on merge-queue events after this merges, so the first queued rust or node PR afterwards should show these workflows as skipped.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated a Depot support thread about a container build volume spike and GHCR push throttling. Measured per-day run counts through the GitHub API, traced the multiplier to `pull_request` runs on merge-queue branches that push images "for validation", and confirmed the only PR-image consumer (e2e capture tag) degrades gracefully. Skills invoked: /depot-container-builds, /authoring-ci-workflows, /writing-code-comments, /writing-pr-descriptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
