### PR TITLE
fix(warehouse-sources): send Etsy token refresh as form-encoded, not JSON

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/etsy/etsy.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/etsy/etsy.py
@@ -87,7 +87,10 @@ class EtsyClient:
     def _mint_token(self) -> str:
         response = self._session.post(
             ETSY_TOKEN_URL,
-            json={
+            # Etsy's token endpoint requires application/x-www-form-urlencoded per RFC 6749; a JSON
+            # body is rejected (and Etsy's resulting error talks about the x-api-key header instead,
+            # since it can't read client_id out of the body it got).
+            data={
                 "grant_type": "refresh_token",
                 "client_id": self._api_key,
                 "refresh_token": self._refresh_token,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/etsy/tests/test_etsy.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/etsy/tests/test_etsy.py
@@ -77,8 +77,8 @@ class _FakeSession:
             raise AssertionError(f"unexpected extra GET: {url} {params}")
         return self._get_responses.pop(0)
 
-    def post(self, url: str, json: Optional[dict[str, Any]] = None, timeout: Optional[float] = None) -> Response:  # noqa: A002 — matches requests' keyword name
-        self.post_bodies.append(dict(json or {}))
+    def post(self, url: str, data: Optional[dict[str, Any]] = None, timeout: Optional[float] = None) -> Response:
+        self.post_bodies.append(dict(data or {}))
         if not self._post_responses:
             raise AssertionError("unexpected extra token request")
         return self._post_responses.pop(0)


### PR DESCRIPTION
## Problem

Fixes #76014. The Etsy data warehouse source cannot be connected — creation always fails with "Could not authenticate with Etsy. Check your API keystring and refresh token." even with a valid keystring and an unused, fully-scoped 90-day refresh token.

`EtsyClient._mint_token()` posts to Etsy's OAuth2 token endpoint using `json=`, which sends `Content-Type: application/json`. Etsy's token endpoint requires `application/x-www-form-urlencoded` per [Etsy's auth docs](https://developers.etsy.com/documentation/essentials/authentication/#step-1-request-an-authorization-code) and RFC 6749, and rejects the JSON body. Because Etsy can't read `client_id` out of the JSON body it received, it falls back to complaining about the `x-api-key` header format instead of surfacing the real grant/encoding problem — which is why this looks like a credentials issue rather than an encoding issue.

The original issue includes side-by-side live `curl` calls against the real Etsy endpoint with identical credentials and headers, where the only variable is body encoding — form-encoded succeeds, JSON fails. Credit to the issue reporter for that verification; this PR applies the fix they diagnosed.

## Fix

- `_mint_token()`: `json={...}` → `data={...}`, which makes `requests` send the body form-encoded instead of as JSON. Verified locally that this produces `Content-Type: application/x-www-form-urlencoded` with body `grant_type=refresh_token&client_id=...&refresh_token=...`, matching the working `curl` example in the issue exactly.
- `tests/test_etsy.py`: `_FakeSession.post()` only accepted a `json=` kwarg, which is how the original bug shipped without any test catching it (the issue calls this out directly — the existing assertions check body *content*, never encoding). Changed the fake to accept `data=` instead, matching what the real code now sends. This isn't just cosmetic: since the fake's signature no longer accepts `json=`, a future regression back to `json=` in `_mint_token()` now fails immediately with a `TypeError` in every test that mints a token (which is nearly all of them), rather than silently passing.

## Test plan

- [x] `python3 -m py_compile` on both changed files.
- [x] Verified with a standalone `requests.Request(...).prepare()` call that `data={...}` produces `Content-Type: application/x-www-form-urlencoded` and the exact body shape Etsy's working `curl` example in the issue uses, while `json={...}` reproduces the broken `application/json` behavior.
- [ ] Not run against the full test suite or a live Etsy account in this environment — the change is intentionally minimal (one keyword argument) and mirrors the encoding fix already verified live in the issue, but please run `pytest` on `products/warehouse_sources/backend/temporal/data_imports/sources/etsy/` before merging.

Deliberately left `validate_credentials()`'s swallowed-exception message alone (the issue's "additional context" section flags it as compounding the diagnosis problem) — surfacing the raw exception text didn't seem obviously safe to bundle in here given how carefully this codebase already treats credential redaction elsewhere (e.g. `rest_source`'s exception-redaction tests), and it's not the actual cause of the bug. Happy to open a separate PR for that if it's wanted.