### PR TITLE
feat(warehouse_sources): support braintree API version 2026-08-13

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/braintree/braintree.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/braintree/braintree.py
@@ -23,6 +23,7 @@ BRAINTREE_HOSTS = {
 BRAINTREE_VERSION_2019_01_01 = "2019-01-01"
 BRAINTREE_VERSION_2026_07_14 = "2026-07-14"
 BRAINTREE_VERSION_2026_08_04 = "2026-08-04"
+BRAINTREE_VERSION_2026_08_13 = "2026-08-13"
 # Braintree's GraphQL search fields reject `first` above 50, so this is a vendor
 # ceiling rather than a tuning knob.
 MAX_PAGE_SIZE = 50

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/braintree/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/braintree/source.py
@@ -15,6 +15,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.braintree.
     BRAINTREE_VERSION_2019_01_01,
     BRAINTREE_VERSION_2026_07_14,
     BRAINTREE_VERSION_2026_08_04,
+    BRAINTREE_VERSION_2026_08_13,
     BraintreeResumeConfig,
     braintree_source,
     validate_credentials as validate_braintree_credentials,
@@ -43,8 +44,13 @@ from products.warehouse_sources.backend.types import ExternalDataSourceType
 @SourceRegistry.register
 class BraintreeSource(ResumableSource[BraintreeSourceConfig, BraintreeResumeConfig]):
     lists_tables_without_credentials = True  # static endpoint catalog — safe for public docs
-    supported_versions = (BRAINTREE_VERSION_2019_01_01, BRAINTREE_VERSION_2026_07_14, BRAINTREE_VERSION_2026_08_04)
-    default_version = BRAINTREE_VERSION_2026_08_04
+    supported_versions = (
+        BRAINTREE_VERSION_2019_01_01,
+        BRAINTREE_VERSION_2026_07_14,
+        BRAINTREE_VERSION_2026_08_04,
+        BRAINTREE_VERSION_2026_08_13,
+    )
+    default_version = BRAINTREE_VERSION_2026_08_13
     api_docs_url = "https://graphql.braintreepayments.com/"
 
     @property

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/braintree/tests/test_braintree.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/braintree/tests/test_braintree.py
@@ -8,6 +8,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.braintree.
     BRAINTREE_VERSION_2019_01_01,
     BRAINTREE_VERSION_2026_07_14,
     BRAINTREE_VERSION_2026_08_04,
+    BRAINTREE_VERSION_2026_08_13,
     MAX_PAGE_SIZE,
     BraintreeGraphQLError,
     BraintreeResumeConfig,
@@ -197,7 +198,12 @@ class TestGetRows:
 
     @pytest.mark.parametrize(
         "api_version",
-        [BRAINTREE_VERSION_2019_01_01, BRAINTREE_VERSION_2026_07_14, BRAINTREE_VERSION_2026_08_04],
+        [
+            BRAINTREE_VERSION_2019_01_01,
+            BRAINTREE_VERSION_2026_07_14,
+            BRAINTREE_VERSION_2026_08_04,
+            BRAINTREE_VERSION_2026_08_13,
+        ],
     )
     @mock.patch(f"{_MODULE}.make_tracked_session")
     def test_session_uses_basic_auth_and_version_header(self, mock_session, api_version):

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/braintree/tests/test_braintree_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/braintree/tests/test_braintree_source.py
@@ -7,6 +7,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.braintree.
     BRAINTREE_VERSION_2019_01_01,
     BRAINTREE_VERSION_2026_07_14,
     BRAINTREE_VERSION_2026_08_04,
+    BRAINTREE_VERSION_2026_08_13,
     BraintreeResumeConfig,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.braintree.settings import (
@@ -118,7 +119,7 @@ class TestBraintreeSource:
 
         assert is_valid is expected_valid
         assert error_message == expected_message
-        mock_validate.assert_called_once_with("production", "pub", "priv", "2026-08-04")
+        mock_validate.assert_called_once_with("production", "pub", "priv", "2026-08-13")
 
     def test_get_resumable_source_manager_binds_resume_config(self):
         inputs = mock.MagicMock()
@@ -159,9 +160,9 @@ class TestBraintreeSource:
         assert mock_bt_source.call_args.kwargs["db_incremental_field_last_value"] is None
 
     def test_supported_versions_and_default(self):
-        assert self.source.supported_versions == ("2019-01-01", "2026-07-14", "2026-08-04")
+        assert self.source.supported_versions == ("2019-01-01", "2026-07-14", "2026-08-04", "2026-08-13")
         # New sources start on the latest version; the default must stay in supported.
-        assert self.source.default_version == "2026-08-04"
+        assert self.source.default_version == "2026-08-13"
         assert self.source.default_version in self.source.supported_versions
 
     @pytest.mark.parametrize(
@@ -170,8 +171,9 @@ class TestBraintreeSource:
             ("2019-01-01", "2019-01-01"),
             ("2026-07-14", "2026-07-14"),
             ("2026-08-04", "2026-08-04"),
-            (None, "2026-08-04"),
-            ("", "2026-08-04"),
+            ("2026-08-13", "2026-08-13"),
+            (None, "2026-08-13"),
+            ("", "2026-08-13"),
         ],
     )
     def test_resolve_api_version(self, pinned, expected):
@@ -183,7 +185,8 @@ class TestBraintreeSource:
             ("2019-01-01", "2019-01-01"),
             ("2026-07-14", "2026-07-14"),
             ("2026-08-04", "2026-08-04"),
-            (None, "2026-08-04"),
+            ("2026-08-13", "2026-08-13"),
+            (None, "2026-08-13"),
         ],
     )
     @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.braintree.source.braintree_source")
@@ -206,6 +209,7 @@ class TestValidateCredentialsResolvedPin:
             (BRAINTREE_VERSION_2019_01_01, BRAINTREE_VERSION_2019_01_01),
             (BRAINTREE_VERSION_2026_07_14, BRAINTREE_VERSION_2026_07_14),
             (BRAINTREE_VERSION_2026_08_04, BRAINTREE_VERSION_2026_08_04),
+            (BRAINTREE_VERSION_2026_08_13, BRAINTREE_VERSION_2026_08_13),
         ],
     )
     @mock.patch(


### PR DESCRIPTION
## Problem

New Braintree data-warehouse sources are created on the `2026-08-04` API version, one release behind the vendor's newest dated version, `2026-08-13`. Braintree pins the API version through a required `Braintree-Version` request header, so a new source should start on the latest version.

## Changes

- New sources now default to the `2026-08-13` Braintree GraphQL API version; existing sources keep their current pin and are unaffected.
- `2026-08-13` joins `supported_versions`, so it is a selectable pin.
- The version reaches the vendor as the `Braintree-Version` header, already built from the resolved pin, so no per-version request branching is needed.
- The `2026-08-13` changelog only adds and removes fields on `MerchantAccountSearchInput`. This source reads transactions, refunds, and disputes, none of which change, so the wire is identical for what it syncs.
- Mechanical: version constant added in `braintree.py`, imported in `source.py`.

## How did you test this code?

- Extended the existing parameterized tests so every supported version, including `2026-08-13`, is exercised for version resolution, the new default, the dispatched `source_for_pipeline` path, the credential probe pin, and the `Braintree-Version` request header.
- Ran the Braintree source tests and the registry invariant test (`test_source_versions.py`) locally; both pass.
- Not run: live sync against Braintree — there are no stored credentials and no live-sync harness, so the vendor changelog is the sole source of truth for the version diff.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude Code. Invoked the `/warehouse-source-new-version` skill for the version-declaration and dispatch conventions, and `/writing-pr-descriptions` for this body.

The skill's gate was applied before implementing: the `2026-08-13` diff was checked against the current default (`2026-08-04`) area by area from the vendor changelog. Only `MerchantAccountSearchInput` changed, which this source does not read, but the source sends the version as a required header (a genuine request input) and already dispatches on the resolved pin, so the correct shape is declaration plus default bump with no new request branch. Existing pins are deliberately left untouched — no migration, no deprecation.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
