### PR TITLE
feat(warehouse_sources): support Instagram API version v26.0

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/instagram/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/instagram/source.py
@@ -59,8 +59,8 @@ class InstagramSource(ResumableSource[InstagramSourceConfig, InstagramResumeConf
     api_docs_url = "https://developers.facebook.com/docs/instagram-platform"
     # Meta pins the Graph API by URL path segment and keeps each version alive for
     # roughly two years, so the pin is a real choice rather than a constant.
-    supported_versions = ("v22.0", "v23.0")
-    default_version = "v23.0"
+    supported_versions = ("v22.0", "v23.0", "v26.0")
+    default_version = "v26.0"
 
     lists_tables_without_credentials = True
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/instagram/tests/test_instagram_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/instagram/tests/test_instagram_source.py
@@ -115,7 +115,10 @@ class TestInstagramSource:
 
     def test_the_graph_api_version_is_pinned_to_something_the_code_calls(self) -> None:
         assert self.source.default_version in self.source.supported_versions
-        assert self.source.resolve_api_version(None) == "v23.0"
+        # New sources land on the newest Graph API version; an unpinned row resolves to it too.
+        assert self.source.resolve_api_version(None) == "v26.0"
+        # An existing pin is honored verbatim so older sources keep hitting their own version path.
+        assert self.source.resolve_api_version("v23.0") == "v23.0"
         assert self.source.api_docs_url is not None and self.source.api_docs_url.startswith("https://")
 
     def test_get_schemas_lists_every_endpoint(self) -> None:
@@ -189,7 +192,7 @@ class TestInstagramSource:
 
         assert validate.call_args.kwargs["access_token"] == "refreshed-token"
         assert validate.call_args.kwargs["instagram_account_id"] == ACCOUNT_ID
-        assert validate.call_args.kwargs["api_version"] == "v23.0"
+        assert validate.call_args.kwargs["api_version"] == "v26.0"
 
     def test_validate_credentials_fails_cleanly_when_the_connection_is_gone(self) -> None:
         with (
@@ -252,7 +255,10 @@ class TestInstagramSource:
         # Each table checkpoints a URL built for its own edge, so the Redis slots differ.
         assert media._key != comments._key
 
-    def test_source_for_pipeline_syncs_with_the_connection_token(self) -> None:
+    # Each supported version's pin must reach the request layer verbatim, so a source pinned to
+    # an older Graph API version keeps hitting its own path once v26.0 is the default.
+    @pytest.mark.parametrize("pinned_version", ["v22.0", "v23.0", "v26.0"])
+    def test_source_for_pipeline_syncs_with_the_connection_token(self, pinned_version: str) -> None:
         config = InstagramSourceConfig(
             instagram_integration_id=7, instagram_account_id=ACCOUNT_ID, start_date="2024-01-01"
         )
@@ -260,7 +266,7 @@ class TestInstagramSource:
             "media",
             should_use_incremental_field=True,
             db_incremental_field_last_value="2024-06-01T00:00:00+0000",
-            api_version="v22.0",
+            api_version=pinned_version,
         )
 
         with (
@@ -272,7 +278,7 @@ class TestInstagramSource:
         kwargs = build_source.call_args.kwargs
         assert kwargs["access_token"] == "refreshed-token"
         assert kwargs["endpoint"] == "media"
-        assert kwargs["api_version"] == "v22.0"
+        assert kwargs["api_version"] == pinned_version
         assert kwargs["instagram_account_id"] == ACCOUNT_ID
         assert kwargs["start_date"] == "2024-01-01"
         assert kwargs["should_use_incremental_field"] is True


### PR DESCRIPTION
## Problem

New Instagram data warehouse sources are pinned to Graph API v23.0, two versions behind Meta's newest GA release. Meta keeps each version alive for roughly two years, so new sources should start on the current version to get the longest runway before their pin is retired.

## Changes

- New Instagram sources are created on Graph API v26.0 instead of v23.0.
- `v26.0` joins `supported_versions`, and `default_version` flips to it.
- Sources already pinned to v22.0 or v23.0 are unaffected. The source resolves each row's pin into the Graph API URL path segment, so an existing pin keeps hitting its own version path. No sources are repinned.
- No request-layer branching was needed: the version was already threaded into every Graph API call. The v26.0 changelog adds no fields, renames, or metric retirements for the endpoints this source reads (media, stories, comments, media and account insights, account profile), so the change is declaration-only.

## How did you test this code?

- Extended `test_instagram_source.py`: `resolve_api_version(None)` now returns v26.0, and validation defaults to v26.0. Guards the default bump.
- Parameterized the `source_for_pipeline` dispatch test over v22.0, v23.0, and v26.0. Catches a regression where a pinned version stops reaching the request layer once the default moves off it.
- Ran `test_instagram_source.py` and the registry invariant `test_source_versions.py`: 1337 passed. Not run: a live sync against Meta, since there are no stored credentials or sync harness; version behavior is verified against the vendor changelog per the source-versioning skill.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (PostHog Desktop). Skills invoked: `/warehouse-source-new-version`, `/writing-tests`, `/writing-pr-descriptions`.

The source is versioned by Meta Graph API URL path segment and already threaded the resolved pin through `source_for_pipeline`, `validate_credentials`, and the client. Per the versioning skill's gate, the version is a required request input (the URL segment), so adding the new label and flipping the default is the correct minimal shape — no per-version code branch is warranted because v26.0's wire is identical to v23.0 for the endpoints read here. Duplicate check: no human-authored open PR for Instagram v26.0 (searched by version string, module path, and the maintainer's own open PRs); no earlier bot PR found either.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
