### PR TITLE
feat(warehouse_sources): support Lightspeed Retail API version 2026-07

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/lightspeed_retail/constants.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/lightspeed_retail/constants.py
@@ -3,3 +3,4 @@
 # request layer (the `/api/<version>` path segment) share a single label — never parsed or ordered.
 LIGHTSPEED_RETAIL_API_VERSION_2_0 = "2.0"
 LIGHTSPEED_RETAIL_API_VERSION_2026_01 = "2026-01"
+LIGHTSPEED_RETAIL_API_VERSION_2026_07 = "2026-07"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/lightspeed_retail/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/lightspeed_retail/source.py
@@ -30,6 +30,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.generated_
 from products.warehouse_sources.backend.temporal.data_imports.sources.lightspeed_retail.constants import (
     LIGHTSPEED_RETAIL_API_VERSION_2_0,
     LIGHTSPEED_RETAIL_API_VERSION_2026_01,
+    LIGHTSPEED_RETAIL_API_VERSION_2026_07,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.lightspeed_retail.lightspeed_retail import (
     LightspeedRetailResumeConfig,
@@ -45,8 +46,12 @@ from products.warehouse_sources.backend.types import ExternalDataSourceType
 
 @SourceRegistry.register
 class LightspeedRetailSource(ResumableSource[LightspeedRetailSourceConfig, LightspeedRetailResumeConfig]):
-    supported_versions = (LIGHTSPEED_RETAIL_API_VERSION_2_0, LIGHTSPEED_RETAIL_API_VERSION_2026_01)
-    default_version = LIGHTSPEED_RETAIL_API_VERSION_2026_01
+    supported_versions = (
+        LIGHTSPEED_RETAIL_API_VERSION_2_0,
+        LIGHTSPEED_RETAIL_API_VERSION_2026_01,
+        LIGHTSPEED_RETAIL_API_VERSION_2026_07,
+    )
+    default_version = LIGHTSPEED_RETAIL_API_VERSION_2026_07
     api_docs_url = "https://x-series-api.lightspeedhq.com/docs/introduction"
     # X-Series deprecated the legacy 2.0 version; no firm sunset date is published (deprecated
     # endpoints increasingly return 410 Gone before an eventual retirement).

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/lightspeed_retail/tests/test_lightspeed_retail.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/lightspeed_retail/tests/test_lightspeed_retail.py
@@ -10,6 +10,7 @@ from requests import Response
 from products.warehouse_sources.backend.temporal.data_imports.sources.lightspeed_retail.constants import (
     LIGHTSPEED_RETAIL_API_VERSION_2_0,
     LIGHTSPEED_RETAIL_API_VERSION_2026_01,
+    LIGHTSPEED_RETAIL_API_VERSION_2026_07,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.lightspeed_retail.lightspeed_retail import (
     LightspeedRetailResumeConfig,
@@ -23,6 +24,12 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.lightspeed
     ENDPOINTS,
     LIGHTSPEED_RETAIL_ENDPOINTS,
 )
+
+SUPPORTED_API_VERSIONS = [
+    LIGHTSPEED_RETAIL_API_VERSION_2_0,
+    LIGHTSPEED_RETAIL_API_VERSION_2026_01,
+    LIGHTSPEED_RETAIL_API_VERSION_2026_07,
+]
 
 # RESTClient builds its session via make_tracked_session in the rest_client module.
 CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
@@ -94,7 +101,7 @@ class TestCleanDomainPrefix:
         with pytest.raises(ValueError):
             _clean_domain_prefix(value)
 
-    @pytest.mark.parametrize("api_version", [LIGHTSPEED_RETAIL_API_VERSION_2_0, LIGHTSPEED_RETAIL_API_VERSION_2026_01])
+    @pytest.mark.parametrize("api_version", SUPPORTED_API_VERSIONS)
     def test_base_url_carries_the_version_path_segment(self, api_version):
         assert _base_url("mystore", api_version) == f"https://mystore.retail.lightspeed.app/api/{api_version}"
 
@@ -133,7 +140,7 @@ class TestValidateCredentials:
 
         assert validate_credentials("mystore", "token", LIGHTSPEED_RETAIL_API_VERSION_2026_01) is expected
 
-    @pytest.mark.parametrize("api_version", [LIGHTSPEED_RETAIL_API_VERSION_2_0, LIGHTSPEED_RETAIL_API_VERSION_2026_01])
+    @pytest.mark.parametrize("api_version", SUPPORTED_API_VERSIONS)
     @mock.patch(LR_SESSION_PATCH)
     def test_validate_credentials_probes_the_pinned_version(self, mock_session, api_version):
         mock_session.return_value.get.return_value.status_code = 200
@@ -253,7 +260,7 @@ class TestGetRows:
         assert session.send.call_count == 2
         assert params[1]["after"] == 0
 
-    @pytest.mark.parametrize("api_version", [LIGHTSPEED_RETAIL_API_VERSION_2_0, LIGHTSPEED_RETAIL_API_VERSION_2026_01])
+    @pytest.mark.parametrize("api_version", SUPPORTED_API_VERSIONS)
     @mock.patch(CLIENT_SESSION_PATCH)
     def test_requests_target_the_pinned_version(self, mock_session, api_version):
         session = mock_session.return_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/lightspeed_retail/tests/test_lightspeed_retail_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/lightspeed_retail/tests/test_lightspeed_retail_source.py
@@ -10,6 +10,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.generated_
 from products.warehouse_sources.backend.temporal.data_imports.sources.lightspeed_retail.constants import (
     LIGHTSPEED_RETAIL_API_VERSION_2_0,
     LIGHTSPEED_RETAIL_API_VERSION_2026_01,
+    LIGHTSPEED_RETAIL_API_VERSION_2026_07,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.lightspeed_retail.lightspeed_retail import (
     LightspeedRetailResumeConfig,
@@ -114,15 +115,18 @@ class TestLightspeedRetailSource:
 
         assert is_valid is expected_valid
         assert error_message == expected_message
+        # An unpinned source probes the default version.
         mock_validate.assert_called_once_with(
-            self.config.domain_prefix, self.config.api_token, LIGHTSPEED_RETAIL_API_VERSION_2026_01
+            self.config.domain_prefix, self.config.api_token, LIGHTSPEED_RETAIL_API_VERSION_2026_07
         )
 
     @pytest.mark.parametrize(
         "pinned, expected",
         [
-            (None, LIGHTSPEED_RETAIL_API_VERSION_2026_01),
+            (None, LIGHTSPEED_RETAIL_API_VERSION_2026_07),
             (LIGHTSPEED_RETAIL_API_VERSION_2_0, LIGHTSPEED_RETAIL_API_VERSION_2_0),
+            (LIGHTSPEED_RETAIL_API_VERSION_2026_01, LIGHTSPEED_RETAIL_API_VERSION_2026_01),
+            (LIGHTSPEED_RETAIL_API_VERSION_2026_07, LIGHTSPEED_RETAIL_API_VERSION_2026_07),
         ],
     )
     @mock.patch(
@@ -170,8 +174,10 @@ class TestLightspeedRetailSource:
     @pytest.mark.parametrize(
         "pinned, expected",
         [
-            (None, LIGHTSPEED_RETAIL_API_VERSION_2026_01),
+            (None, LIGHTSPEED_RETAIL_API_VERSION_2026_07),
             (LIGHTSPEED_RETAIL_API_VERSION_2_0, LIGHTSPEED_RETAIL_API_VERSION_2_0),
+            (LIGHTSPEED_RETAIL_API_VERSION_2026_01, LIGHTSPEED_RETAIL_API_VERSION_2026_01),
+            (LIGHTSPEED_RETAIL_API_VERSION_2026_07, LIGHTSPEED_RETAIL_API_VERSION_2026_07),
         ],
     )
     @mock.patch(


### PR DESCRIPTION
## Problem

A team connecting Lightspeed Retail (X-Series) as a warehouse source could only start on the `2026-01` API version. Lightspeed ships quarterly date-based versions, and `2026-07` is now the newest stable one — new sources should be created on it.

## Changes

- New Lightspeed Retail sources are now created on the `2026-07` API version instead of `2026-01`.
- `2026-07` joins `supported_versions`, so a source can be pinned to it. `2.0` and `2026-01` stay fully supported.
- The version is a `/api/<version>` URL path segment already threaded through discovery, credential probing, and sync, so no new dispatch was needed — only the version label and default flip.
- Existing sources keep their current pin and their exact request path; only the default for brand-new sources moved.
- Mechanical: added the `2026-07` version constant and extended the source and request-layer tests to cover it.

The `2026-07` changelog for the eight tables this source reads (sales, customers, products, inventory, outlets, registers, users, taxes) is additive fields and write-side validation only. Pagination (keyset on the record `version`), primary keys (`id`), the endpoint set, and the response shapes we depend on are unchanged, so the compatible request path serves it without a per-version branch.

## How did you test this code?

- Ran the Lightspeed Retail source and request-layer suites plus the registry version-invariant test.
- Tests assert the pinned version reaches the client for each supported version, that `None` now resolves to `2026-07`, and that the credential probe and sync target the pinned version's path.
- Not run: a live sync against Lightspeed — there are no stored credentials or live-sync harness, so version behavior is verified against the vendor docs and mocked request boundaries.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — the supported version list is exposed via the API and rendered automatically.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Authored with Claude Code. Invoked skills: `/warehouse-source-new-version`, `/writing-tests`, `/writing-pr-descriptions`.
- Followed the version-add gate: diffed `2026-07` against the current default `2026-01` from the vendor changelog. The version has to exist because the label is a required request input (the URL path segment), but the read path needs no per-version branch, so the change is declaration-only plus tests.
- Checked for duplicates across the version string, module path, and the maintainer's open PRs — none found. The only related PR is the merged `2026-01` support (#71664).

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
