### PR TITLE
feat(warehouse_sources): support Azure Cost Management API version 2026-06-01

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/azure_cost_management/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/azure_cost_management/source.py
@@ -34,8 +34,12 @@ from products.warehouse_sources.backend.types import ExternalDataSourceType
 @SourceRegistry.register
 class AzureCostManagementSource(ResumableSource[AzureCostManagementSourceConfig, AzureCostManagementResumeConfig]):
     lists_tables_without_credentials = True  # static endpoint catalog — safe for public docs
-    supported_versions = ("2025-03-01",)
-    default_version = "2025-03-01"
+    # api-version is a required query param on every Cost Management call; the resolved pin flows
+    # through verbatim to `_endpoint_url`. The query/forecast/dimensions wire is identical across
+    # these versions (2026-06-01 only adds MarkupRules, which this source doesn't read), so no
+    # per-version request branching is needed.
+    supported_versions = ("2025-03-01", "2026-06-01")
+    default_version = "2026-06-01"
     api_docs_url = "https://learn.microsoft.com/en-us/rest/api/cost-management/"
 
     @property

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/azure_cost_management/tests/test_azure_cost_management.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/azure_cost_management/tests/test_azure_cost_management.py
@@ -526,6 +526,7 @@ def _run_rows(
     start_date: str | None = None,
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Any = None,
+    api_version: str = "2025-03-01",
 ) -> list[list[dict[str, Any]]]:
     with mock.patch(f"{TRANSPORT_MODULE}.make_tracked_session", return_value=session):
         return _collect(
@@ -536,7 +537,7 @@ def _run_rows(
                 scope="/subscriptions/abc/",
                 endpoint=endpoint,
                 start_date=start_date,
-                api_version="2025-03-01",
+                api_version=api_version,
                 logger=mock.MagicMock(),
                 resumable_source_manager=manager,
                 should_use_incremental_field=should_use_incremental_field,
@@ -680,6 +681,22 @@ class TestGetRows:
         assert "/forecast?" in url
         assert kwargs["json"]["timePeriod"]["from"].startswith(self.today.isoformat())
         assert kwargs["json"]["includeActualCost"] is False
+
+    @parameterized.expand([("2025-03-01",), ("2026-06-01",)])
+    def test_pinned_api_version_reaches_the_request_url(self, api_version: str) -> None:
+        # A pinned source spends its version on every call — the query/forecast/dimensions wire is
+        # identical across versions, so the only per-version difference is the api-version param.
+        session = _FakeSession([_token_response(), _query_response([])])
+
+        _run_rows(
+            session,
+            "cost_by_service",
+            _FakeResumeManager(),
+            start_date=(self.today - timedelta(days=2)).isoformat(),
+            api_version=api_version,
+        )
+
+        assert f"api-version={api_version}" in session.calls[1][1]
 
     def test_empty_page_yields_nothing(self) -> None:
         session = _FakeSession([_token_response(), _query_response([])])

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/azure_cost_management/tests/test_azure_cost_management_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/azure_cost_management/tests/test_azure_cost_management_source.py
@@ -122,8 +122,9 @@ class TestAzureCostManagementSource:
         assert self.source.connection_host_fields == ["tenant_id", "scope"]
 
     def test_api_version_metadata(self) -> None:
-        assert self.source.supported_versions == ("2025-03-01",)
-        assert self.source.default_version == "2025-03-01"
+        assert self.source.supported_versions == ("2025-03-01", "2026-06-01")
+        # New sources start on the newest stable version; existing pins are unaffected.
+        assert self.source.default_version == "2026-06-01"
         assert self.source.api_docs_url is not None and self.source.api_docs_url.startswith("https://")
 
     def test_lists_tables_without_credentials(self) -> None:
@@ -197,7 +198,7 @@ class TestAzureCostManagementSource:
             assert self.source.validate_credentials(self.config, team_id=1) == result
 
         assert probe.call_args.kwargs["scope"] == "subscriptions/abc"
-        assert probe.call_args.kwargs["api_version"] == "2025-03-01"
+        assert probe.call_args.kwargs["api_version"] == "2026-06-01"
 
     def test_get_resumable_source_manager_is_bound_to_the_resume_dataclass(self) -> None:
         manager = self.source.get_resumable_source_manager(_source_inputs())
@@ -216,7 +217,7 @@ class TestAzureCostManagementSource:
         assert kwargs["endpoint"] == "cost_by_resource"
         assert kwargs["scope"] == "subscriptions/abc"
         assert kwargs["client_secret"] == "secret"
-        assert kwargs["api_version"] == "2025-03-01"
+        assert kwargs["api_version"] == "2026-06-01"
         assert kwargs["resumable_source_manager"] is manager
 
     def test_source_for_pipeline_withholds_the_watermark_on_a_full_refresh(self) -> None:
@@ -235,7 +236,16 @@ class TestAzureCostManagementSource:
 
         assert build_source.call_args.kwargs["db_incremental_field_last_value"] == "2024-01-01"
 
-    @pytest.mark.parametrize("pinned,expected", [(None, "2025-03-01"), ("2024-08-01", "2024-08-01")])
+    @pytest.mark.parametrize(
+        "pinned,expected",
+        [
+            # No pin resolves to the current default; each supported version is honored verbatim so
+            # an existing 2025-03-01 pin keeps syncing on its own version after the default flip.
+            (None, "2026-06-01"),
+            ("2025-03-01", "2025-03-01"),
+            ("2026-06-01", "2026-06-01"),
+        ],
+    )
     def test_source_for_pipeline_honors_a_pinned_api_version(self, pinned: Optional[str], expected: str) -> None:
         inputs = _source_inputs(api_version=pinned)
 


### PR DESCRIPTION
## Problem

New Azure Cost Management data warehouse sources are created on the vendor's `2025-03-01` API version. Azure has since shipped `2026-06-01` as its newest stable version, and new sources should start on it.

- The `api-version` value is a required query parameter on every Cost Management call (query, forecast, dimensions).
- The version this source pins is the version it sends, so a stale default means new sources track an older vendor API than they need to.

## Changes

- New Azure Cost Management sources are created on `2026-06-01`; existing sources keep their current pin and sync byte-for-byte unchanged.
- `2026-06-01` joins `2025-03-01` in `supported_versions`, so a user can still select or stay pinned to the older version.
- No request-layer branching was needed: the query, forecast, and dimensions wire is identical across these versions (2026-06-01 only adds MarkupRules endpoints, which this source does not read), so the resolved pin flows through verbatim as the `api-version` query param.

This is a declaration-only version bump. The source already threads the resolved pin into every vendor call, so the change is limited to the two version declarations and the tests that cover them. Nothing user-visible changes beyond the default version stamped onto new sources.

## How did you test this code?

- Ran the source's unit tests and the registry-wide version invariant test locally: `products/warehouse_sources/backend/temporal/data_imports/sources/azure_cost_management/tests/` and `sources/tests/test_source_versions.py` (1447 passed).
- Added a parameterized request-path test asserting the pinned version reaches the request URL for both `2025-03-01` and `2026-06-01` — catches a regression where a version bump stops threading the pin into the `api-version` param.
- Extended the pinned-version test to prove an existing `2025-03-01` pin still resolves to itself after the default flip.
- Not run: no live-sync harness or stored credentials exist, so version parity was verified against the vendor's published spec, not a live sync.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude Code (Opus 4.8). Skills invoked: `/warehouse-source-new-version` (for the version-declaration and dispatch conventions), `/writing-tests`, and `/writing-pr-descriptions`.

The version-add gate in the skill applies here because `api-version` is a genuine required request input, not just a label. Diffing the vendor spec area by area showed the query, forecast, and dimensions operations unchanged between `2025-03-01` and `2026-06-01`, so this landed as a declaration-only bump rather than adding per-version request branches. No migration was written — existing pins are deliberately left untouched.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
