### PR TITLE
feat(warehouse_sources): deprecate Mem0 v1 API version

### DIFF
--- a/products/warehouse_sources/backend/migrations/0154_repin_mem0_api_version.py
+++ b/products/warehouse_sources/backend/migrations/0154_repin_mem0_api_version.py
@@ -1,0 +1,34 @@
+from django.db import migrations
+
+# Mem0 dropped the legacy v1 API generation in its 2.0.0 SDK release, so "v1" is now deprecated.
+# For the tables this source reads, our "v1" label and the "v3" default resolve to byte-identical
+# requests (memories on /v3/, entities and events on /v1/ — no version header, no per-version
+# dispatch), so this repin is a pure relabel: it moves existing source-level pins from "v1" to "v3"
+# without changing a single byte on the wire. No data or schema transform is needed.
+MEM0_SOURCE_TYPE = "Mem0"
+OLD_VERSION = "v1"
+NEW_VERSION = "v3"
+
+
+def repin_mem0_v1_to_v3(apps, schema_editor):
+    ExternalDataSource = apps.get_model("warehouse_sources", "ExternalDataSource")
+
+    # Only the source-level pin is touched. Schema-level `ExternalDataSchema.api_version` overrides
+    # are user-managed (a customer intentionally pinned that schema) and are left alone — the
+    # schema-level deprecation warning prompts the user to migrate those.
+    #
+    # NULL pins already resolve to the source's `default_version` ("v3"), so they need no update.
+    # Matching only `api_version="v1"` keeps this idempotent: a second run matches nothing.
+    ExternalDataSource.objects.filter(source_type=MEM0_SOURCE_TYPE, api_version=OLD_VERSION).update(
+        api_version=NEW_VERSION
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [("warehouse_sources", "0153_repin_meta_ads_api_version")]
+
+    operations = [
+        # Reverse is a no-op: once repinned, these rows are indistinguishable from natively-created
+        # ones, so a blanket downgrade would clobber legitimate "v3" pins.
+        migrations.RunPython(repin_mem0_v1_to_v3, migrations.RunPython.noop, elidable=False),
+    ]

--- a/products/warehouse_sources/backend/migrations/max_migration.txt
+++ b/products/warehouse_sources/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0153_repin_meta_ads_api_version
+0154_repin_mem0_api_version

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mem0/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mem0/source.py
@@ -9,7 +9,12 @@ from posthog.schema import (
     SourceFieldInputConfigType,
 )
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, ResumableSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import (
+    UNVERSIONED_API_VERSION,
+    FieldType,
+    ResumableSource,
+    VersionDeprecation,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
     CanonicalDescriptions,
 )
@@ -50,6 +55,10 @@ class Mem0Source(ResumableSource[Mem0SourceConfig, Mem0ResumeConfig]):
 
     supported_versions = SUPPORTED_VERSIONS
     default_version = DEFAULT_VERSION
+    # Mem0 dropped the legacy v1 API generation in its 2.0.0 SDK release; no calendar sunset date is
+    # published, so this is advisory. The legacy "v1" label and the "v3" default resolve to
+    # byte-identical requests here (see settings.py), so repinning is a pure relabel, not a version move.
+    deprecated_versions = (VersionDeprecation(version=UNVERSIONED_API_VERSION, sunset_at=None),)
 
     @property
     def source_type(self) -> ExternalDataSourceType:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mem0/tests/test_mem0_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mem0/tests/test_mem0_source.py
@@ -98,6 +98,17 @@ class TestMem0SourceVersions:
         assert source.resolve_api_version(None) == MEM0_API_VERSION_V3
         assert source.resolve_api_version(UNVERSIONED_API_VERSION) == UNVERSIONED_API_VERSION
 
+    def test_v1_is_deprecated_without_sunset_and_v3_is_not(self):
+        # The in-product deprecation banner and the repin migration both key off this metadata; the
+        # registry invariant test only checks generic relationships, not the v1-deprecated/v3-current
+        # split or the (absent) sunset date this PR pins.
+        source = Mem0Source()
+
+        deprecation = source.get_version_deprecation(UNVERSIONED_API_VERSION)
+        assert deprecation is not None
+        assert deprecation.sunset_at is None
+        assert source.get_version_deprecation(MEM0_API_VERSION_V3) is None
+
 
 class TestMem0SourceCredentials:
     @patch(f"{_SOURCE_MODULE}.validate_mem0_credentials", return_value=True)


### PR DESCRIPTION
## Problem

A customer whose Mem0 warehouse source is pinned to the legacy `v1` API label gets no signal that the label is going away. Mem0 dropped the v1 API generation in its 2.0.0 SDK release, so the label needs to be marked deprecated so the in-product warning surfaces on those sources.

**Why:** the vendor is deprecating v1, and we want pinned customers warned and moved onto the current version without changing what they sync.

## Changes

- A Mem0 source still pinned to `v1` now shows the generic in-product deprecation warning. `v1` is added to `deprecated_versions` with `sunset_at=None` (advisory — the vendor has published no calendar sunset date).
- `v3` is already the source's default and supported version, so no version-implementation change was needed; every currently-supported version keeps working.
- A written-not-run migration (`0147_repin_mem0_api_version`) repins source-level `ExternalDataSource.api_version` from `v1` to `v3`. A human reviews and runs it.

For the tables this source reads, `v1` and `v3` resolve to byte-identical requests (memories on `/v3/`, entities and events on `/v1/`; no version header, no per-version dispatch). So the repin is a pure relabel, not a version move, and needs no data or schema transform — which is why scripting it is safe under an advisory deprecation.

> [!NOTE]
> The migration touches only the source-level pin. Schema-level `ExternalDataSchema.api_version` overrides are user-managed and left alone. It matches only rows on `api_version="v1"`, so it is idempotent; NULL pins already resolve to the `v3` default and are skipped. The reverse is a no-op, since a repinned row is indistinguishable from a natively-created `v3` one.

## How did you test this code?

- Added `test_v1_is_deprecated_without_sunset_and_v3_is_not` to the source's version tests. It catches a regression where `v1` is dropped from `deprecated_versions`, the `v3` default is deprecated by mistake, or an unintended sunset date is set — none of which the existing version test or the generic registry invariant test covers.
- Ran the mem0 source suite and the registry version-invariant suite locally; both pass.
- Not run: `sqlmigrate` / `makemigrations --check` need a Postgres connection this sandbox lacks. The migration is a hand-written `RunPython` data migration with no model changes, so there is no schema drift to check.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tools: Claude Code.
- Skills invoked: `/warehouse-source-new-version`, `/django-migrations`, `/writing-tests`, `/writing-pr-descriptions`.
- The `warehouse-source-new-version` skill routed the decision: `v3` already exists and is the default, so this reduced to a deprecation plus migration. Under an advisory deprecation (no sunset date) the skill withholds a migration by default, but permits it for the "pure alias" case — `v1` and `v3` here produce byte-identical requests — which is why the repin is scripted rather than documented as manual.
- No source-specific UI was added; the deprecation warning keys off the version metadata.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
