### PR TITLE
feat(warehouse_sources): deprecate MailerLite API version v1

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mailerlite/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mailerlite/source.py
@@ -13,6 +13,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.bas
     ExternalWebhookInfo,
     FieldType,
     ResumableSource,
+    VersionDeprecation,
     WebhookCreationResult,
     WebhookDeletionResult,
     WebhookSource,
@@ -42,6 +43,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.mailerlite
     DEFAULT_VERSION,
     ENDPOINTS,
     MAILERLITE_ENDPOINTS,
+    MAILERLITE_V1,
     SCHEMA_TO_WEBHOOK_EVENTS,
     SUPPORTED_VERSIONS,
     WEBHOOK_RESOURCE_MAP,
@@ -62,6 +64,14 @@ class MailerLiteSource(
 
     supported_versions = SUPPORTED_VERSIONS
     default_version = DEFAULT_VERSION
+
+    # v1 sends no `X-Version` header, so connect.mailerlite.com serves whatever it treats as
+    # "latest" — the drift the pin exists to stop; v2 pins the documented version date. The vendor
+    # is deprecating v1 with no announced sunset date (`sunset_at=None`), so this is advisory: it
+    # lights up the generic in-product banner. Existing v1 pins are left in place — the vendor still
+    # serves them, and repinning would silently move a customer to a different wire — so the user
+    # repins from the source config when ready.
+    deprecated_versions = (VersionDeprecation(version=MAILERLITE_V1),)
 
     lists_tables_without_credentials = True  # static endpoint catalog — safe for public docs
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mailerlite/tests/test_mailerlite_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mailerlite/tests/test_mailerlite_source.py
@@ -102,6 +102,16 @@ class TestMailerLiteSourceClass:
         assert set(source.supported_versions) == {MAILERLITE_V1, MAILERLITE_V2}
         assert source.default_version in source.supported_versions
 
+    def test_v1_is_deprecated_without_sunset(self) -> None:
+        # Guards the in-product deprecation banner: v1 must stay flagged, and with no announced
+        # sunset date (a fabricated one would flip the framework into "sunsetting" behaviour and
+        # invite a repin off a version MailerLite still serves).
+        source = MailerLiteSource()
+        deprecation = source.get_version_deprecation(MAILERLITE_V1)
+        assert deprecation is not None
+        assert deprecation.sunset_at is None
+        assert source.get_version_deprecation(MAILERLITE_V2) is None
+
     @pytest.mark.parametrize(
         ("pin", "expected_version"),
         [(None, MAILERLITE_V2), (MAILERLITE_V1, MAILERLITE_V1), (MAILERLITE_V2, MAILERLITE_V2)],


### PR DESCRIPTION
## Problem

A MailerLite warehouse source that has never picked a version syncs under the `v1` label, which sends no `X-Version` header. MailerLite then serves whatever it treats as "latest", so the response shape can shift under the source without warning. The vendor is deprecating that legacy behaviour, with no announced sunset date.

The `v2` label (pinned to MailerLite's documented version date `2038-01-19`) already exists and is the default for new sources, but nothing told existing `v1` users to move.

## Changes

- A source pinned to MailerLite `v1` now shows the generic in-product deprecation banner, prompting the user to repin to `v2` from the source config.
- `v1` is declared in `deprecated_versions` with no sunset date (`sunset_at=None`), so the deprecation is advisory — the banner appears, but nothing forces a move.
- No data migration ships. `v1` and `v2` send different requests (`v1` sends no version header and tracks "latest"; `v2` pins the date), and MailerLite still serves `v1`. Repinning rows automatically would be exactly the silent version move the pinning framework exists to prevent, and could change synced response shapes. Users repin when ready; the manual path is below.
- Mechanical: adds one test and two imports; no request-layer or webhook behaviour changes.

The `v1`/`v2` versioning and `X-Version` dispatch were already implemented and tested — this PR only adds the deprecation metadata.

### Manual migration path

There is no automated repin. When a `v1`-pinned customer is ready to move, a human updates that source's `ExternalDataSource.api_version` to `v2` (support runbook: "Updating a warehouse source to a new vendor API version"). Schema-level `api_version` overrides are user-managed and left untouched.

## How did you test this code?

- Added `test_v1_is_deprecated_without_sunset`: catches a silently dropped `v1` deprecation (banner stops warning legacy users) and a fabricated sunset date (which would flip the framework into "sunsetting" behaviour and invite an unwanted repin). No existing test asserts MailerLite's specific deprecation contract — `test_source_versions.py` only checks registry-wide invariants.
- Ran the MailerLite source and client suites plus the version-invariant suite locally; all passed. `ci:preflight --fix` reports 0 failures.
- Not run: database-backed suites (not needed for this declaration-only change).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — the deprecation banner is generic framework UI; no source-specific docs change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Authored by Claude (Claude Code).
- Skills invoked: `/warehouse-source-new-version`, `/writing-tests`, `/writing-pr-descriptions`.
- Decision: the versioning work was already present, so the task reduced to the deprecation. The deprecation was kept advisory and no migration was scripted, following the skill's rule that an advisory (no-sunset) deprecation over a version the vendor still serves — and where the versions differ on the wire — must not auto-repin customers. EmailOctopus is the in-repo precedent for this advisory-only shape.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
