### PR TITLE
feat(warehouse_sources): support Profound API version v2

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/profound/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/profound/source.py
@@ -38,8 +38,13 @@ from products.warehouse_sources.backend.types import ExternalDataSourceType
 @SourceRegistry.register
 class ProfoundSource(ResumableSource[ProfoundSourceConfig, ProfoundResumeConfig]):
     lists_tables_without_credentials = True  # static endpoint catalog — safe for public docs
-    # There is no version to select: `v1` on the organization lists and `v2` on the reports are
-    # per-resource path segments, not a version a caller can pin. The framework default applies.
+    # Profound versions purely by URL path segment (`/v1/...`, `/v2/...`) — no version header or
+    # account setting. The source already reads the newer v2 report surface (`/v2/reports/*`)
+    # alongside the org lists that only exist under `/v1/`, so the label is a pin recorded on the
+    # source, not a request-layer branch: every version resolves to the same requests (see
+    # settings.py). v2 is the default so new sources record the surface they actually sync.
+    supported_versions = ("v1", "v2")
+    default_version = "v2"
     api_docs_url = "https://docs.tryprofound.com/rest-api/introduction"
 
     @property

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/profound/tests/test_profound_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/profound/tests/test_profound_source.py
@@ -1,5 +1,6 @@
 import json
-from typing import Any
+from collections.abc import Iterable
+from typing import Any, cast
 from urllib.parse import urlparse
 
 from unittest import mock
@@ -160,7 +161,7 @@ class TestProfoundSource:
         manager.can_resume.return_value = False
 
         response = ProfoundSource().source_for_pipeline(_Config(), manager, inputs)  # type: ignore[arg-type]
-        list(response.items())
+        list(cast(Iterable[Any], response.items()))
 
         assert paths and paths[0] == "/v2/reports/visibility"
 
@@ -174,7 +175,7 @@ class TestProfoundSource:
         manager.can_resume.return_value = False
 
         response = ProfoundSource().source_for_pipeline(_Config(), manager, inputs)  # type: ignore[arg-type]
-        list(response.items())
+        list(cast(Iterable[Any], response.items()))
 
         assert paths and paths[0] == "/v1/org/categories"
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/profound/tests/test_profound_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/profound/tests/test_profound_source.py
@@ -1,8 +1,11 @@
+import json
 from typing import Any
+from urllib.parse import urlparse
 
 from unittest import mock
 
 from parameterized import parameterized
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.typings import SourceInputs
@@ -11,6 +14,28 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.profound.s
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
 SOURCE_MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.profound.source"
+PROFOUND_MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.profound.profound"
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+
+
+def _capture_paths(mock_session: mock.MagicMock, body: Any) -> list[str]:
+    """Wire a mock REST session that returns `body` and records each request's URL path."""
+    session = mock_session.return_value
+    session.headers = {}
+    paths: list[str] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        paths.append(urlparse(request.url).path)
+        prepared = mock.MagicMock()
+        prepared.url = request.url
+        return prepared
+
+    session.prepare_request.side_effect = _prepare
+    page = Response()
+    page.status_code = 200
+    page._content = json.dumps(body).encode()
+    session.send.return_value = page
+    return paths
 
 
 class _Config:
@@ -111,6 +136,47 @@ class TestProfoundSource:
         ProfoundSource().source_for_pipeline(_Config(), mock.MagicMock(), inputs)  # type: ignore[arg-type]
 
         assert mock_source.call_args.kwargs["db_incremental_field_last_value"] is None
+
+    def test_version_declaration_defaults_to_v2_with_v1_supported(self) -> None:
+        # Profound versions by URL path segment, so both labels resolve to the same requests;
+        # the default tracks the newest label without deprecating the old one.
+        source = ProfoundSource()
+
+        assert source.supported_versions == ("v1", "v2")
+        assert source.default_version == "v2"
+        assert source.deprecated_versions == ()
+
+    @parameterized.expand([("unpinned", None), ("pinned_v1", "v1"), ("pinned_v2", "v2")])
+    @mock.patch(f"{PROFOUND_MODULE}.fetch_category_ids", return_value=["c1"])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_report_path_is_fixed_regardless_of_pin(
+        self, _name: str, pinned: str | None, MockSession, _mock_categories
+    ) -> None:
+        # The version is never sent on the wire — a v1 pin (existing sources) and the v2 default
+        # both POST to the same `/v2/reports/...` route. This guards the byte-for-byte promise.
+        paths = _capture_paths(MockSession, {"info": {"next_cursor": None}, "data": []})
+        inputs = _inputs(schema_name="Visibility", api_version=pinned)
+        manager = mock.MagicMock()
+        manager.can_resume.return_value = False
+
+        response = ProfoundSource().source_for_pipeline(_Config(), manager, inputs)  # type: ignore[arg-type]
+        list(response.items())
+
+        assert paths and paths[0] == "/v2/reports/visibility"
+
+    @parameterized.expand([("unpinned", None), ("pinned_v1", "v1"), ("pinned_v2", "v2")])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_reference_path_is_fixed_regardless_of_pin(self, _name: str, pinned: str | None, MockSession) -> None:
+        # The org lists only exist under `/v1/`, and no pin moves them.
+        paths = _capture_paths(MockSession, [{"id": "1"}])
+        inputs = _inputs(schema_name="Categories", api_version=pinned)
+        manager = mock.MagicMock()
+        manager.can_resume.return_value = False
+
+        response = ProfoundSource().source_for_pipeline(_Config(), manager, inputs)  # type: ignore[arg-type]
+        list(response.items())
+
+        assert paths and paths[0] == "/v1/org/categories"
 
     def test_source_is_visible_and_labelled_alpha(self) -> None:
         # unreleasedSource=True hides the connector from users entirely; this source is finished.


### PR DESCRIPTION
## Problem

New Profound warehouse sources are stamped with the API version `v1`, but the source already syncs Profound's newer v2 report surface (`/v2/reports/visibility`, `/v2/reports/citations`) alongside the org lists that only exist under `/v1/`. The recorded pin misrepresents the surface a new source actually reads.

## Changes

- New Profound sources are created on `v2`, so the pin and the `data_warehouse_sources` table report the report surface the source syncs.
- `v1` stays supported; existing sources pinned to it are unaffected.
- Profound versions by URL path segment, with no version header or account setting, so both `v1` and `v2` pins resolve to identical requests. No request-layer dispatch is added — the version is a label recorded on the source, not a branch (mirrors the Kustomer source).
- Mechanical: declaration-only change to `supported_versions`/`default_version` and an updated comment; the sync code path is untouched.

## How did you test this code?

- Added `test_version_declaration_defaults_to_v2_with_v1_supported` — catches a default that fails to track the newest label or an accidental deprecation.
- Added `test_report_path_is_fixed_regardless_of_pin` and `test_reference_path_is_fixed_regardless_of_pin`, parameterized over unpinned/`v1`/`v2` — catch a future per-version path branch silently diverging existing pins from the byte-for-byte promise.
- Ran the Profound source, Profound unit, and registry version-invariant suites locally; ruff clean on the touched files.
- Not run: any live Profound sync — there are no stored credentials, and vendor docs are the sole source of truth per the version skill.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (Opus 4.8). Invoked `/warehouse-source-new-version`, `/writing-tests`, and `/writing-pr-descriptions`.

The version skill's gate turns on what the source actually requests, not the vendor's headline version. The vendor docs (`https://docs.tryprofound.com/rest-api/introduction`) confirm Profound versions purely by path segment — no header, no account setting — and the source already reads the `/v2/reports/*` routes under the legacy `v1` label. That is the skill's blessed declaration-only case: declare and default to `v2` for new rows, add no dispatch, and leave every existing request byte-for-byte identical. An earlier bot PR for this source was not found; the original source landed in #85631.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
