### PR TITLE
feat(warehouse_sources): support Mailgun API version v4

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mailgun/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mailgun/source.py
@@ -62,8 +62,14 @@ class MailgunSource(
 ):
     lists_tables_without_credentials = True  # static endpoint catalog — safe for public docs
 
-    supported_versions = ("v3",)
-    default_version = "v3"
+    # Mailgun versions each resource in its own URL path (no account or header version), so the
+    # per-endpoint paths in settings.py already target the newest route Mailgun serves for each
+    # resource — /v4 for the domains listing, /v3 everywhere v4 doesn't exist. The source-level
+    # label is therefore a pin recorded on the source, not a request-layer branch: every supported
+    # version resolves to the same requests. Defaulting to v4 only stamps new sources; pinned v3
+    # rows are byte-for-byte unaffected.
+    supported_versions = ("v3", "v4")
+    default_version = "v4"
     api_docs_url = "https://documentation.mailgun.com/"
 
     @property

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mailgun/tests/test_mailgun_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mailgun/tests/test_mailgun_source.py
@@ -1,3 +1,7 @@
+from collections.abc import Iterable
+from typing import Any, cast
+from urllib.parse import urlsplit
+
 import pytest
 from unittest import mock
 
@@ -24,6 +28,15 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.mailgun.so
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
 WEBHOOK_URL = "https://us.posthog.com/public/webhooks/abc"
+
+
+def _response(payload: dict[str, Any]) -> mock.MagicMock:
+    response = mock.MagicMock()
+    response.json.return_value = payload
+    response.status_code = 200
+    response.ok = True
+    response.headers = {}
+    return response
 
 
 class TestMailgunSource:
@@ -134,6 +147,53 @@ class TestMailgunSource:
         assert is_valid is expected_valid
         assert error_message == expected_message
         mock_validate.assert_called_once_with(self.config.api_key, self.config.region)
+
+    def test_version_declaration_defaults_to_v4_with_v3_supported(self):
+        # Mailgun versions each resource by URL path; both labels resolve to the same requests
+        # (see test_request_paths_are_version_independent), so the default tracks the newest label.
+        assert self.source.supported_versions == ("v3", "v4")
+        assert self.source.default_version == "v4"
+        assert self.source.deprecated_versions == ()
+
+    @pytest.mark.parametrize("pinned_version", [None, "v3", "v4"])
+    @pytest.mark.parametrize(
+        "endpoint, expected_paths",
+        [
+            # domains lists at /v4 under every pin; the resources with no v4 route stay /v3.
+            ("domains", ["/v4/domains"]),
+            ("events", ["/v4/domains", "/v3/a.com/events"]),
+            ("bounces", ["/v4/domains", "/v3/a.com/bounces"]),
+            ("mailing_lists", ["/v3/lists/pages"]),
+        ],
+    )
+    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.mailgun.mailgun.make_tracked_session")
+    def test_request_paths_are_version_independent(self, mock_session, endpoint, expected_paths, pinned_version):
+        # The pin is declaration-only: a v3 and a v4 source must hit the exact same URLs, so a
+        # future accidental per-version URL branch (or a repin silently switching a table's route)
+        # would fail here.
+        requests_made: list[str] = []
+
+        def fake_get(url, **kwargs):
+            requests_made.append(url)
+            if "/v4/domains" in url:
+                return _response({"items": [{"name": "a.com"}]})
+            return _response({"items": [], "paging": {}})
+
+        mock_session.return_value.get.side_effect = fake_get
+
+        inputs = mock.MagicMock()
+        inputs.schema_name = endpoint
+        inputs.api_version = pinned_version
+        inputs.should_use_incremental_field = False
+        inputs.db_incremental_field_last_value = None
+        inputs.incremental_field = None
+        manager = mock.MagicMock()
+        manager.can_resume.return_value = False
+
+        response = self.source.source_for_pipeline(self.config, manager, inputs)
+        list(cast(Iterable[Any], response.items()))
+
+        assert [urlsplit(url).path for url in requests_made] == expected_paths
 
     def test_get_resumable_source_manager_binds_resume_config(self):
         inputs = mock.MagicMock()


### PR DESCRIPTION
## Problem

A team setting up a new Mailgun warehouse source is pinned to the `v3` label, even though Mailgun's current API is versioned per resource and the source already reads the newest route each resource offers. New sources should start on `v4`, the label Mailgun advances its domain APIs under, while every existing `v3`-pinned source keeps working unchanged.

Mailgun uses URI path versioning with no account or header version, and rolls v4 out per resource: the domains listing is `/v4/domains`, while events, suppressions, mailing lists, tags, and templates have no v4 route and stay `/v3`. The source's per-endpoint paths already reflect this, so the source-level label never drives request construction.

## Changes

- New Mailgun sources are created on `v4`; existing `v3` sources are untouched and keep their pin.
- `supported_versions` becomes `("v3", "v4")` and `default_version` becomes `v4`.
- No request-layer dispatch is added: a `v3` pin and a `v4` pin resolve to byte-identical requests, because each endpoint's path is fixed and already targets the newest route Mailgun serves. Adding a version branch here would be inert.
- No migration and no repin: this is a plain default bump, not a deprecation or sunset.

This diff is a declaration change plus tests. There is no user-visible UI change beyond the version now selectable on the source.

## How did you test this code?

- `test_version_declaration_defaults_to_v4_with_v3_supported` guards the new default and supported set against an accidental flip-back.
- `test_request_paths_are_version_independent` runs the source under `None`, `v3`, and `v4` pins across representative endpoints and asserts the request URLs are identical — catching a future per-version URL branch or a repin that silently switches a table's route.
- Ran the source and registry-invariant suites locally: `test_mailgun_source.py` and `test_source_versions.py` pass.
- Not run: the webhook-template tests in this source, which need a Postgres connection this sandbox lacks; this change does not touch webhook payloads or the template.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude Code. Skills invoked: `/warehouse-source-new-version` (version-declaration and dispatch conventions), `/writing-pr-descriptions`, `/writing-tests`.

Key decision: the skill's gate distinguishes a wire-diverging version bump (needs dispatch) from a declaration-only one. Vendor docs confirmed Mailgun versions per resource by URL path and that v4 exists only for domain management, which the source's domains listing already uses. Everything else the source reads has no v4 route. So both pins resolve to the same requests, and the correct shape is a declaration-only bump — adding version dispatch would be inert scaffolding. This mirrors the existing Kustomer source, which declares two labels resolving to one request path.

No human-authored open PR addresses Mailgun v4 (checked the maintainer's open PRs and searched by version string and module path). No earlier `app/posthog` bot PR for Mailgun v4 exists either.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
