### PR TITLE
feat(warehouse_sources): support Squarespace API version v2

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/squarespace/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/squarespace/source.py
@@ -9,7 +9,11 @@ from posthog.schema import (
     SourceFieldInputConfigType,
 )
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, ResumableSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import (
+    UNVERSIONED_API_VERSION,
+    FieldType,
+    ResumableSource,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
     CanonicalDescriptions,
 )
@@ -31,10 +35,21 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.squarespac
 )
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
+# Source-level vendor API version labels — opaque framework pins stored in
+# `ExternalDataSource.api_version`, distinct from the per-endpoint URL segments in
+# `SquarespaceEndpointConfig.api_version`. The source already requests each resource's newest
+# documented route — notably products via `/v2/commerce/products` (Products API v2, GA
+# 2025-12-18) — so both pins resolve to the same wire; `v2` only formalizes that generation as
+# the default for newly created sources.
+SQUARESPACE_API_VERSION_V1 = UNVERSIONED_API_VERSION
+SQUARESPACE_API_VERSION_V2 = "v2"
+
 
 @SourceRegistry.register
 class SquarespaceSource(ResumableSource[SquarespaceSourceConfig, SquarespaceResumeConfig]):
-    api_docs_url = "https://developers.squarespace.com"
+    supported_versions = (SQUARESPACE_API_VERSION_V1, SQUARESPACE_API_VERSION_V2)
+    default_version = SQUARESPACE_API_VERSION_V2
+    api_docs_url = "https://developers.squarespace.com/commerce-apis/changelog"
 
     @property
     def source_type(self) -> ExternalDataSourceType:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/squarespace/test_squarespace_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/squarespace/test_squarespace_source.py
@@ -13,7 +13,11 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.squarespac
     ENDPOINTS,
     SQUARESPACE_ENDPOINTS,
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.squarespace.source import SquarespaceSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.squarespace.source import (
+    SQUARESPACE_API_VERSION_V1,
+    SQUARESPACE_API_VERSION_V2,
+    SquarespaceSource,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.squarespace.squarespace import (
     SquarespaceResumeConfig,
 )
@@ -55,6 +59,21 @@ class TestSquarespaceSource:
         assert api_key_field.type == SourceFieldInputConfigType.PASSWORD
         assert api_key_field.required is True
         assert api_key_field.secret is True
+
+    def test_supported_versions_and_default(self) -> None:
+        # v2 is the newest generation and the default new sources start on; v1 stays supported so
+        # existing pins keep resolving. The generic registry test only checks invariants — this
+        # pins the specific labels so a reorder or a default flip-back is caught.
+        assert self.source.supported_versions == (SQUARESPACE_API_VERSION_V1, SQUARESPACE_API_VERSION_V2)
+        assert self.source.default_version == SQUARESPACE_API_VERSION_V2
+
+    @pytest.mark.parametrize("api_version", [SQUARESPACE_API_VERSION_V1, SQUARESPACE_API_VERSION_V2])
+    def test_get_schemas_table_set_is_version_independent(self, api_version: str) -> None:
+        # Discovery must expose the same tables under every pin — the source already rides each
+        # resource's newest route, so v1 and v2 build identical requests. Guards against a future
+        # version-conditional discovery silently dropping a table for an existing (v1) source.
+        schemas = self.source.get_schemas(self.config, self.team_id, api_version=api_version)
+        assert {s.name for s in schemas} == set(ENDPOINTS)
 
     def test_get_schemas_matches_endpoints(self) -> None:
         schemas = self.source.get_schemas(self.config, self.team_id)


### PR DESCRIPTION
## Problem

Someone connecting a new Squarespace warehouse source is pinned to the framework's legacy `v1` label, even though Squarespace's Products API reached v2 GA on 2025-12-18 and the connector already reads that generation. New sources should be created on `v2` so the pin reflects the wire they actually sync.

## Changes

- New Squarespace sources are now created on `v2` (`default_version`), and `v2` shows up as a selectable version in the source UI and public config API.
- `v1` stays in `supported_versions`, so every existing source keeps resolving its pin and syncing unchanged.
- No request-layer dispatch was added. The connector already builds each resource's newest documented route — products via `/v2/commerce/products`, the others via their only version — so a `v1` pin and a `v2` pin produce byte-for-byte identical requests. This is a declaration-only version add, per the `warehouse-source-new-version` skill's "already reads the newest generation under the legacy label" case.
- No migration: existing rows pinned to `v1` (and any NULL pins that resolve to the default) hit the same wire under `v2`, so they are unaffected and are deliberately left in place.
- `api_docs_url` now points at the Squarespace Commerce APIs changelog, where versions are announced.

## How did you test this code?

- Extended `test_squarespace_source.py`: one case pins the specific `("v1", "v2")` declaration and the `v2` default (catches a reorder or a default flip-back that the generic registry invariant test would not); one parameterized case guards that schema discovery returns the same table set under both pins (catches a future version-conditional discovery dropping a table for existing `v1` sources).
- Ran the Squarespace source tests, the request-layer tests, and the cross-source version-invariant suite locally: `pytest .../squarespace/test_squarespace_source.py .../squarespace/test_squarespace.py .../sources/tests/test_source_versions.py` — 1374 passed.
- Not run: live-sync verification. There is no stored-credential or live-sync harness for warehouse sources; the vendor changelog is the source of truth, and it records no field, pagination, or path change between the Products versions for the resources this source reads.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Authored by Claude Code (Opus 4.8).
- Skills invoked: `/warehouse-source-new-version` (version-declaration and dispatch conventions, plus its gate for whether the version needs request-layer dispatch), `/writing-tests`, `/writing-pr-descriptions`.
- Key decision: ran the skill's gate against the vendor changelog and the requests the source actually builds. Because the `products` endpoint already targets `/v2/commerce/products` and no other resource has a v2, a source-level `v2` cannot change any request. Declaration-only is the correct shape; adding version→URL branching would either move existing sources (forbidden) or be inert scaffolding.
- Duplicate check: no human-authored open PR adds Squarespace v2 support (searched the version string, the module path, and the maintainer's own open PRs). The only Squarespace-related open PR (#86125, `app/posthog`, draft) is unrelated resume-state work.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
