### PR TITLE
feat(warehouse_sources): deprecate Github API version 2022-11-28

### DIFF
--- a/products/warehouse_sources/backend/migrations/0155_repin_github_api_version.py
+++ b/products/warehouse_sources/backend/migrations/0155_repin_github_api_version.py
@@ -1,0 +1,36 @@
+from django.db import migrations
+
+# GitHub is deprecating the 2022-11-28 REST API version (its X-GitHub-Api-Version header value),
+# which returns 410 Gone at least 24 months after the 2026-03-10 release. This repins existing
+# source-level pins from "2022-11-28" to "2026-03-10" (the current default) so they stop sending a
+# header GitHub will stop accepting. The response shapes GitHub serves for the endpoints this source
+# reads are unchanged across the two versions, so only the pin moves — no data/schema transform.
+SOURCE_TYPE = "Github"
+DEPRECATED_VERSION = "2022-11-28"
+NEW_VERSION = "2026-03-10"
+
+
+def repin_github_2022_to_2026(apps, schema_editor):
+    ExternalDataSource = apps.get_model("warehouse_sources", "ExternalDataSource")
+
+    # Source-level pin only. Schema-level `ExternalDataSchema.api_version` overrides are user-managed
+    # (a customer intentionally pinned that schema) and are left alone — the schema-level deprecation
+    # banner prompts the user to migrate those.
+    #
+    # NULL pins already resolve to the source's `default_version` (already "2026-03-10"), so they need
+    # no update. Matching only `api_version="2022-11-28"` keeps this idempotent: a second run matches
+    # nothing. ExternalDataSource is one row per configured source, so a single bulk update is quick.
+    ExternalDataSource.objects.filter(source_type=SOURCE_TYPE, api_version=DEPRECATED_VERSION).update(
+        api_version=NEW_VERSION
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [("warehouse_sources", "0154_repin_mem0_api_version")]
+
+    operations = [
+        # Reverse is a no-op: once repinned, these rows are indistinguishable from natively-created
+        # ones, so a blanket downgrade would clobber legitimate "2026-03-10" pins and move customers
+        # back onto the sunset header.
+        migrations.RunPython(repin_github_2022_to_2026, migrations.RunPython.noop, elidable=True),
+    ]

--- a/products/warehouse_sources/backend/migrations/max_migration.txt
+++ b/products/warehouse_sources/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0154_repin_mem0_api_version
+0155_repin_github_api_version

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/github/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/github/source.py
@@ -1,4 +1,5 @@
 import secrets
+import datetime
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any, Optional, TypeVar, cast
@@ -26,6 +27,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.bas
     ExternalWebhookInfo,
     FieldType,
     ResumableSource,
+    VersionDeprecation,
     WebhookCreationResult,
     WebhookDeletionResult,
     WebhookSource,
@@ -141,6 +143,10 @@ class GithubSource(
     supported_versions = ("2022-11-28", "2026-03-10")
     default_version = "2026-03-10"
     api_docs_url = "https://docs.github.com/en/rest/about-the-rest-api/api-versions"
+    # GitHub keeps a REST API version answerable for at least 24 months after the next one ships,
+    # then returns 410 Gone. 2022-11-28 is superseded by the 2026-03-10 default, so its earliest
+    # sunset is 2028-03-10 (24 months after that release).
+    deprecated_versions = (VersionDeprecation(version="2022-11-28", sunset_at=datetime.date(2028, 3, 10)),)
 
     @property
     def source_type(self) -> ExternalDataSourceType:
@@ -309,6 +315,11 @@ If automatic creation failed with a permissions error, the fix depends on how yo
             # deleted repository or one the connection can no longer see.
             "GitHub repository is not accessible": "This repository is no longer available on GitHub. It may have been deleted, or your connection may have lost access to it. Update the source with a repository you can still reach, or reconnect your GitHub account.",
             "404 Client Error": "GitHub couldn't find this repository. Check that it still exists and that your connection can access it.",
+            # Every GitHub call carries the source's pinned version in the X-GitHub-Api-Version
+            # header, and GitHub answers 410 Gone once a version is sunset (2022-11-28 reaches this
+            # 24 months after the 2026-03-10 release). 410 is permanent, so retrying loops forever;
+            # disable the schema and point the user at the version repin instead.
+            "410 Client Error": "GitHub no longer serves the API version this source is pinned to. Update the source to a supported version, then sync again.",
             "Bad credentials": "Your GitHub connection is invalid or expired. Please reconnect.",
             # The GitHub App isn't configured on this PostHog instance, so an OAuth source can't mint
             # the App JWT to refresh its installation token. Deterministic — retrying never resolves it.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_source_class.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_source_class.py
@@ -1,3 +1,5 @@
+import datetime
+
 import pytest
 from unittest import mock
 
@@ -115,10 +117,22 @@ class TestGithubSource:
             "Integration not found",
             "Missing integration ID",
             "This installation has been suspended",
+            # A sunset API version pinned in X-GitHub-Api-Version returns 410 Gone permanently, so it
+            # must disable the schema rather than retry forever.
+            "410 Client Error",
         ],
     )
     def test_non_retryable_errors(self, expected_key):
         assert expected_key in self.source.get_non_retryable_errors()
+
+    def test_deprecated_api_version_metadata(self):
+        # The generic registry test only checks deprecated ⊆ supported and default ∉ deprecated; this
+        # locks GitHub's specific deprecation — 2022-11-28 sunset on 2028-03-10, 2026-03-10 current —
+        # which drives the in-product warning and the source-level repin migration.
+        deprecation = self.source.get_version_deprecation("2022-11-28")
+        assert deprecation is not None
+        assert deprecation.sunset_at == datetime.date(2028, 3, 10)
+        assert self.source.get_version_deprecation("2026-03-10") is None
 
     def test_rate_limit_error_is_retryable_not_non_retryable(self):
         # A GitHubRateLimitError that exhausts _fetch_page's tenacity retry must stay retryable


### PR DESCRIPTION
## Problem

Data warehouse sources pinned to the GitHub REST API version `2022-11-28` will break: GitHub keeps a version answerable for at least 24 months after the next one ships, then returns `410 Gone`. The `2026-03-10` version is already supported and is the default for new sources, but existing pins on `2022-11-28` are still live and have no deprecation signal or migration path.

**Why:** the vendor is retiring `2022-11-28`, so sources still pinned to it need to move to a supported version before the sunset.

## Changes

- Sources pinned to `2022-11-28` now show the in-product deprecation warning with the `2028-03-10` sunset date, driven by new `deprecated_versions` metadata on `GithubSource`. No source-specific UI was added.
- A `410 Gone` from GitHub is now classified non-retryable, so a sunset pin fails with a clear message instead of looping the retry cadence forever.
- Migration `0147` repins `ExternalDataSource.api_version` from `2022-11-28` to `2026-03-10` at the source level only. It is written, not run: a human reviews and executes it.

The version bump itself needs no request-layer change: `2026-03-10` and its `X-GitHub-Api-Version` threading already exist, and GitHub serves identical response shapes for both versions on the endpoints this source reads, so only the pin moves. No data or schema transform is required.

> [!NOTE]
> The migration touches source-level pins only. Schema-level `ExternalDataSchema.api_version` overrides are user-managed by design and left untouched; the schema-level deprecation banner prompts those. `NULL` pins already resolve to the `2026-03-10` default, so the migration matches only rows explicitly on `2022-11-28`, which keeps it idempotent. Its reverse is a no-op so a rollback cannot clobber native `2026-03-10` pins.

## How did you test this code?

Automated only. This sandbox has no database, so the migration was not applied and the DB-backed webhook-template tests were not run.

- Added `test_deprecated_api_version_metadata`: catches a regression where the sunset date or which version is deprecated changes. The generic registry test only checks `deprecated ⊆ supported` and `default ∉ deprecated`, not the specific values.
- Extended `test_non_retryable_errors` with the `410 Client Error` case: catches removal of the sunset-version error classification.
- Ran the GitHub source-class and version-registry suites locally (no DB needed); the migration graph stays linear and the migration file parses.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (via PostHog Desktop). Skills invoked: `/warehouse-source-new-version`, `/django-migrations`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-code-comments`, `/writing-pr-descriptions`.

The `2026-03-10` version and its dispatch were already implemented, so the work was scoped to deprecation plus migration. Following the versioning skill, the migration repins only source-level pins explicitly on `2022-11-28` (not `NULL` pins, since the default is already `2026-03-10`) and leaves schema-level overrides alone. The `410` non-retryable classification was added because GitHub sends the pinned version on every call, so a retired pin would otherwise loop.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
