### PR TITLE
feat(warehouse_sources): support Bloomerang API version v2

### DIFF
--- a/products/warehouse_sources/backend/migrations/0150_repin_bloomerang_api_version.py
+++ b/products/warehouse_sources/backend/migrations/0150_repin_bloomerang_api_version.py
@@ -1,0 +1,37 @@
+from django.db import migrations
+
+# Bloomerang has deprecated its v1 REST API. This source has always spoken the current v2 REST API
+# on the wire (BASE_URL ends in `/v2`) — the framework label was the unversioned `v1` default. The
+# source now declares `v2` as the explicit default and marks the legacy `v1` label deprecated. There
+# is no per-version dispatch, so `v1` and `v2` resolve to byte-identical requests; this repins
+# existing source-level pins from `v1` to `v2` so they stop carrying a deprecated label. It is a pure
+# relabel, not a version move — no data/schema transform is needed.
+BLOOMERANG_SOURCE_TYPE = "Bloomerang"
+OLD_VERSION = "v1"
+NEW_VERSION = "v2"
+
+
+def repin_bloomerang_v1_to_v2(apps, schema_editor):
+    ExternalDataSource = apps.get_model("warehouse_sources", "ExternalDataSource")
+
+    # Only the source-level pin is touched. Schema-level `ExternalDataSchema.api_version` overrides
+    # are user-managed (a customer intentionally pinned that schema) and are left alone — the
+    # schema-level deprecation warning prompts the user to migrate those.
+    #
+    # NULL pins already resolve to the source's `default_version` (now `v2`), so they need no update.
+    # Matching only `api_version="v1"` keeps this idempotent: a second run matches nothing.
+    ExternalDataSource.objects.filter(source_type=BLOOMERANG_SOURCE_TYPE, api_version=OLD_VERSION).update(
+        api_version=NEW_VERSION
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("warehouse_sources", "0149_datawarehousetable_created_via"),
+    ]
+
+    operations = [
+        # Reverse is a no-op: once repinned, these rows are indistinguishable from natively-created
+        # ones, so a blanket downgrade would clobber legitimate `v2` pins made after this ran.
+        migrations.RunPython(repin_bloomerang_v1_to_v2, migrations.RunPython.noop, elidable=True),
+    ]

--- a/products/warehouse_sources/backend/migrations/max_migration.txt
+++ b/products/warehouse_sources/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0149_datawarehousetable_created_via
+0150_repin_bloomerang_api_version

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bloomerang/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bloomerang/source.py
@@ -18,7 +18,12 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.bloomerang
     ENDPOINTS,
     INCREMENTAL_FIELDS,
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, ResumableSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import (
+    UNVERSIONED_API_VERSION,
+    FieldType,
+    ResumableSource,
+    VersionDeprecation,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
     CanonicalDescriptions,
 )
@@ -39,8 +44,16 @@ from products.warehouse_sources.backend.types import ExternalDataSourceType
 class BloomerangSource(ResumableSource[BloomerangSourceConfig, BloomerangResumeConfig]):
     lists_tables_without_credentials = True  # static endpoint catalog — safe for public docs
 
-    # Bloomerang's v2 REST API has no dated/numbered version token to pin (the "v2" is a fixed
-    # path segment, not a documented choice among several) — only the docs link is set.
+    # The source has always spoken Bloomerang's current v2 REST API on the wire (BASE_URL ends in
+    # `/v2`); the framework label was just the unversioned default. Bloomerang has now deprecated
+    # its v1 REST API, so `v2` is declared as the explicit default and the legacy unversioned `v1`
+    # label is marked deprecated. There is no per-version dispatch — `/v2` is a fixed path segment,
+    # not a request input — so both labels resolve to identical requests. Existing `v1`-pinned rows
+    # keep working unchanged and are repinned to `v2` by data migration (a pure relabel, not a move).
+    # No calendar sunset date is published for v1.
+    supported_versions = (UNVERSIONED_API_VERSION, "v2")
+    default_version = "v2"
+    deprecated_versions = (VersionDeprecation(version=UNVERSIONED_API_VERSION, sunset_at=None),)
     api_docs_url = "https://bloomerang.com/api/rest-api"
 
     @property

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bloomerang/tests/test_bloomerang_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bloomerang/tests/test_bloomerang_source.py
@@ -4,6 +4,7 @@ from unittest import mock
 from posthog.schema import ReleaseStatus, SourceFieldInputConfig, SourceFieldInputConfigType
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.bloomerang.bloomerang import (
+    BASE_URL,
     BloomerangResumeConfig,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.bloomerang.settings import (
@@ -156,3 +157,22 @@ class TestBloomerangSource:
         self.source.source_for_pipeline(self.config, mock.MagicMock(), inputs)
 
         assert mock_bloomerang_source.call_args.kwargs["db_incremental_field_last_value"] is None
+
+    @pytest.mark.parametrize(
+        "pinned, expected_version",
+        [("v1", "v1"), ("v2", None), (None, None)],
+    )
+    def test_deprecation_flags_legacy_v1_only(self, pinned, expected_version):
+        deprecation = self.source.get_version_deprecation(pinned)
+        if expected_version is None:
+            assert deprecation is None
+        else:
+            assert deprecation is not None
+            assert deprecation.version == expected_version
+            assert deprecation.sunset_at is None  # vendor published no sunset date
+
+    def test_request_layer_stays_on_the_v2_wire(self):
+        # No per-version dispatch: `/v2` is a fixed path segment, so a legacy v1 pin rides the same
+        # wire as v2. Regressing this URL to v1 would move every v1-pinned source onto the vendor's
+        # deprecated API.
+        assert BASE_URL == "https://api.bloomerang.co/v2"


### PR DESCRIPTION
## Problem

- A customer connecting Bloomerang sees the source pinned to the framework's unversioned `v1` label, which now reads as the vendor's deprecated REST API, even though every sync already runs against Bloomerang's current v2 API (`api.bloomerang.co/v2`).
- Bloomerang has deprecated its v1 REST API. No sunset date is published.

## Changes

- New Bloomerang sources pin the explicit `v2` version. `BloomerangSource` now declares `supported_versions = ("v1", "v2")` with `v2` as the default.
- Sources still pinned to `v1` show the generic in-product deprecation warning. `v1` is added to `deprecated_versions` with no sunset date.
- Migration `0147` repins source-level `ExternalDataSource.api_version` from `v1` to `v2`. It is written, not run: a human reviews and executes it.
- No wire change. `/v2` is a fixed path segment, not a request input, so there is no per-version dispatch and both labels resolve to byte-identical requests. Existing `v1` pins keep working, so the repin is a relabel, not a version move.
- Schema-level `api_version` overrides are left untouched. They are user-managed by design.
- Mechanical: version-metadata and wire-guard tests.

> [!NOTE]
> The migration is idempotent (it matches only `api_version="v1"`) and its reverse is a no-op. NULL pins already resolve to the new `v2` default, so they are left alone.

## How did you test this code?

- Added two cases in `test_bloomerang_source.py`. One asserts the `v1` label is flagged deprecated with no sunset while `v2` and NULL pins are not, which catches a default flip-back or a dropped deprecation that would stop warning `v1` customers. The other asserts the request layer stays on the v2 wire, which catches a regression that points `v1` at the vendor's deprecated API and silently moves pinned sources.
- Ran the Bloomerang source suite, the request-layer suite, and the cross-source version invariant test locally.
- Not run: the migration itself (written-not-run by design) and the database-backed suites, because this sandbox has no database.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The version metadata drives the generic deprecation warning; no source-specific UI or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Skills invoked: `/warehouse-source-new-version`, `/django-migrations`, `/writing-tests`, `/writing-pr-descriptions`.
- The vendor headline said "add v2", but diffing the wire showed the source already targets `api.bloomerang.co/v2` under the framework's unversioned `v1` label. This is therefore a declaration-only relabel-and-repin, not a new request path. Adding a real v1 request path would move existing pins backward onto the deprecated API, the exact failure the version-pinning framework prevents.
- The repin runs even without a published sunset date because both labels are a pure alias: byte-identical requests with no per-version dispatch.
- Public artifact: no customer data or agent-session material is present in the diff or this description.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
