### PR TITLE
feat(warehouse_sources): support pandadoc API version v2

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/pandadoc/pandadoc.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/pandadoc/pandadoc.py
@@ -21,6 +21,14 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.pandadoc.s
     PandaDocEndpointConfig,
 )
 
+# PandaDoc versions its API per endpoint via a URL segment (/public/v1, /public/v2), not
+# globally: /public/v2 is a small, growing set of new endpoints (API logs, document audit
+# trail), NOT a mirror of v1. Every resource this source reads — documents, templates, forms,
+# contacts, members, folders — is served only under /public/v1 and has no v2 route, so both
+# pins resolve to the same wire here and the base URL stays on v1 regardless of the pin.
+API_VERSION_V1 = "v1"
+API_VERSION_V2 = "v2"
+
 PANDADOC_BASE_URL = "https://api.pandadoc.com/public/v1"
 # PandaDoc list pages cap at 100 items.
 PAGE_SIZE = 100

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/pandadoc/pandadoc.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/pandadoc/pandadoc.py
@@ -23,8 +23,8 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.pandadoc.s
 
 # PandaDoc versions its API per endpoint via a URL segment (/public/v1, /public/v2), not
 # globally: /public/v2 is a small, growing set of new endpoints (API logs, document audit
-# trail), NOT a mirror of v1. Every resource this source reads — documents, templates, forms,
-# contacts, members, folders — is served only under /public/v1 and has no v2 route, so both
+# trail), NOT a mirror of v1. Every resource this source reads (documents, templates, forms,
+# contacts, members, folders) is served only under /public/v1 and has no v2 route, so both
 # pins resolve to the same wire here and the base URL stays on v1 regardless of the pin.
 API_VERSION_V1 = "v1"
 API_VERSION_V2 = "v2"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/pandadoc/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/pandadoc/source.py
@@ -24,6 +24,8 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.generated_
     PandaDocSourceConfig,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.pandadoc.pandadoc import (
+    API_VERSION_V1,
+    API_VERSION_V2,
     PandaDocResumeConfig,
     pandadoc_source,
     validate_credentials as validate_pandadoc_credentials,
@@ -37,9 +39,11 @@ from products.warehouse_sources.backend.types import ExternalDataSourceType
 
 @SourceRegistry.register
 class PandaDocSource(ResumableSource[PandaDocSourceConfig, PandaDocResumeConfig]):
-    supported_versions = ("v1",)
-    default_version = "v1"
-    api_docs_url = "https://developers.pandadoc.com"
+    # v2 is declared so new sources are stamped with the vendor's current API generation, but the
+    # endpoints this source reads are v1-only (see pandadoc.py) — both pins resolve to the same wire.
+    supported_versions = (API_VERSION_V1, API_VERSION_V2)
+    default_version = API_VERSION_V2
+    api_docs_url = "https://developers.pandadoc.com/reference/version"
 
     lists_tables_without_credentials = True  # static endpoint catalog — safe for public docs
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/pandadoc/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/pandadoc/source.py
@@ -40,7 +40,7 @@ from products.warehouse_sources.backend.types import ExternalDataSourceType
 @SourceRegistry.register
 class PandaDocSource(ResumableSource[PandaDocSourceConfig, PandaDocResumeConfig]):
     # v2 is declared so new sources are stamped with the vendor's current API generation, but the
-    # endpoints this source reads are v1-only (see pandadoc.py) — both pins resolve to the same wire.
+    # endpoints this source reads are v1-only (see pandadoc.py), so both pins resolve to the same wire.
     supported_versions = (API_VERSION_V1, API_VERSION_V2)
     default_version = API_VERSION_V2
     api_docs_url = "https://developers.pandadoc.com/reference/version"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/pandadoc/tests/test_pandadoc.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/pandadoc/tests/test_pandadoc.py
@@ -10,6 +10,7 @@ from requests import Response
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.auth import APIKeyAuth
 from products.warehouse_sources.backend.temporal.data_imports.sources.pandadoc.pandadoc import (
     PAGE_SIZE,
+    PANDADOC_BASE_URL,
     PandaDocResumeConfig,
     _build_query_params,
     _format_date_filter,
@@ -218,6 +219,27 @@ class TestPagination:
         assert isinstance(auth[0], APIKeyAuth)
         assert auth[0].api_key == "API-Key secret-key"
         assert auth[0].name == "Authorization"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_requests_target_public_v1(self, MockSession):
+        # PandaDoc serves this source's endpoints only under /public/v1; v2 has no route for them,
+        # so the wire must stay on v1 even though v2 is the source's default pin. Guards against a
+        # future edit repointing the base URL to /public/v2, which would 404 every sync.
+        session = MockSession.return_value
+        session.headers = {}
+        urls: list[str] = []
+
+        def _prepare(request):
+            urls.append(request.url)
+            return mock.MagicMock()
+
+        session.prepare_request.side_effect = _prepare
+        session.send.side_effect = [_response([{"id": "a"}])]
+
+        _rows(pandadoc_source("key", "documents", team_id=1, job_id="j", resumable_source_manager=_make_manager()))
+
+        assert PANDADOC_BASE_URL == "https://api.pandadoc.com/public/v1"
+        assert urls[0].startswith("https://api.pandadoc.com/public/v1/documents")
 
     @mock.patch(CLIENT_SESSION_PATCH)
     def test_resumes_from_saved_page(self, MockSession):

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/pandadoc/tests/test_pandadoc_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/pandadoc/tests/test_pandadoc_source.py
@@ -25,6 +25,13 @@ class TestPandaDocSource:
     def test_source_type(self):
         assert self.source.source_type == ExternalDataSourceType.PANDADOC
 
+    def test_declares_v1_and_v2_with_v2_default(self):
+        # v2 must be the default (new sources stamp it) while v1 stays supported. The registry
+        # invariant test only checks default == supported[-1], so it would still pass if v2 were
+        # dropped — this locks in the actual bump.
+        assert self.source.supported_versions == ("v1", "v2")
+        assert self.source.default_version == "v2"
+
     def test_get_source_config(self):
         config = self.source.get_source_config
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/pandadoc/tests/test_pandadoc_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/pandadoc/tests/test_pandadoc_source.py
@@ -28,7 +28,7 @@ class TestPandaDocSource:
     def test_declares_v1_and_v2_with_v2_default(self):
         # v2 must be the default (new sources stamp it) while v1 stays supported. The registry
         # invariant test only checks default == supported[-1], so it would still pass if v2 were
-        # dropped — this locks in the actual bump.
+        # dropped; this test locks in the actual bump.
         assert self.source.supported_versions == ("v1", "v2")
         assert self.source.default_version == "v2"
 


### PR DESCRIPTION
## Problem

New PandaDoc data-warehouse sources are pinned to API version `v1`, even though the vendor now runs a `v2` generation of its API. New sources should start on the current version.

- PandaDoc versions its API per endpoint via a URL segment (`/public/v1`, `/public/v2`).
- `/public/v2` is a small, growing set of new endpoints (API logs, document audit trail), not a mirror of `v1`.
- Every resource this source reads — documents, templates, forms, contacts, members, folders — is served only under `/public/v1` and has no `v2` route.

## Changes

- New PandaDoc sources are created on version `v2`; existing sources keep their pin and sync exactly as before.
- `v1` stays fully supported.
- `api_docs_url` now points at the vendor's version reference page.
- The request path stays on `/public/v1` for both pins. Mechanical: no dispatch code, because a `v2` pin resolves to the same wire here.

> [!NOTE]
> This is a declaration-only bump. The tables this source reads are v1-only, so adding `v2` changes no request; it formalizes the current API generation for new rows and lets the version be pinned. If reviewers would rather not carry a label with no wire effect, it can be dropped.

## How did you test this code?

- Added `test_declares_v1_and_v2_with_v2_default`: guards the default flip and that `v1` stays supported. The registry invariant test only checks `default == supported[-1]`, so it would still pass if `v2` were dropped.
- Added `test_requests_target_public_v1`: sends a request under the default and asserts it hits `/public/v1/documents`. Guards against repointing the base URL to `/public/v2`, which would 404 every sync.
- Ran the pandadoc suites and the cross-source version invariant test locally.
- Not run: database-backed and live-sync suites. There are no vendor credentials or sync harness, so version verification is docs-only.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude (claude-opus-4-8) via the PostHog Desktop cloud task runner. The directing human's GitHub handle was not verifiable in this session, so the assignee is left for team triage.
- Skills invoked: `/warehouse-source-new-version`, `/writing-tests`, `/writing-pr-descriptions`.
- The task asked for v2 support with v2 as the default. The skill's "does the version need to exist" gate, run against the vendor changelog, found the endpoints this source reads are v1-only, so v2 offers no divergent wire. Wiring a v2 pin to `/public/v2` would 404, so a full URL-dispatch approach was rejected; the non-breaking declaration-only bump is what ships here.
- No customer data or session material is included; all evidence is from public PandaDoc docs.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
