### PR TITLE
fix(logs): show an alert's notification destinations again

### DIFF
--- a/products/logs/frontend/components/LogsAlerting/LogsAlertEditModal.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertEditModal.tsx
@@ -48,7 +48,7 @@ function LogsAlertEditModalContent({
         logsAlertFormLogic(formLogicProps)
     )
     const { touchAlertFormField } = useActions(logsAlertFormLogic(formLogicProps))
-    const { destinationGroups } = useValues(logsAlertNotificationLogic(notificationLogicProps))
+    const { existingDestinations } = useValues(logsAlertNotificationLogic(notificationLogicProps))
     const { snoozingAlertIds } = useValues(logsAlertingLogic)
     const { deleteAlert, snoozeAlertUntil, toggleAlertEnabled, unsnoozeAlert } = useActions(logsAlertingLogic)
     const nameError = alertFormErrors.name as string | undefined
@@ -66,8 +66,8 @@ function LogsAlertEditModalContent({
     const summary: AlertSummaryParts = {
         fires: `count ${alertForm.thresholdOperator} ${alertForm.thresholdCount} in the last ${alertForm.windowMinutes} minutes`,
         cadence: '',
-        notifies: destinationGroups.length
-            ? `${destinationGroups.length} ${destinationGroups.length === 1 ? 'destination' : 'destinations'}`
+        notifies: existingDestinations.length
+            ? `${existingDestinations.length} ${existingDestinations.length === 1 ? 'destination' : 'destinations'}`
             : '',
         filters: filterParts.join(' '),
     }

--- a/products/logs/frontend/components/LogsAlerting/LogsAlertNotifications.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertNotifications.tsx
@@ -12,11 +12,10 @@ import {
 
 import { LOGS_ALERT_NOTIFICATION_TYPE_OPTIONS, logsAlertNotificationLogic } from './logsAlertNotificationLogic'
 import {
-    getHogFunctionEventKind,
+    destinationLabel,
     LOGS_ALERT_NOTIFICATION_TYPE_SLACK,
     LOGS_ALERT_NOTIFICATION_TYPE_TEAMS,
     PendingLogsAlertNotification,
-    resolveGroupLabel,
 } from './logsAlertUtils'
 
 function getPendingNotificationDestination(
@@ -33,8 +32,8 @@ function getPendingNotificationDestination(
 
 export function LogsAlertNotifications({ alertId }: { alertId?: string }): JSX.Element {
     const {
-        existingHogFunctionsLoading,
-        destinationGroups,
+        existingDestinationsLoading,
+        existingDestinations,
         pendingNotifications,
         integrationsLoading,
         integrationsFailed,
@@ -66,17 +65,24 @@ export function LogsAlertNotifications({ alertId }: { alertId?: string }): JSX.E
         }
     }, [firstSlackIntegration?.id, loadAllSlackChannels, firstSlackIntegration])
 
-    const existingDestinations: AlertNotificationDestinationView[] = destinationGroups.map((group) => {
-        const detailHogFunctionId =
-            group.hogFunctions.find((hogFunction) => getHogFunctionEventKind(hogFunction) === 'firing')?.id ??
-            group.hogFunctions[0]?.id
+    const slackLookup = { workspaceId: firstSlackIntegration?.id, channels: slackChannels }
+
+    const destinationViews: AlertNotificationDestinationView[] = existingDestinations.map((destination) => {
+        // Any id in the group resolves to the same destination on the detail scene.
+        const detailHogFunctionId = destination.hog_function_ids[0]
         const detailUrl =
             alertId && detailHogFunctionId ? urls.logsAlertNotificationDetail(alertId, detailHogFunctionId) : undefined
+        const label = destinationLabel(destination, slackLookup)
 
         return {
-            key: group.key,
-            title: resolveGroupLabel(group, slackChannels),
-            tags: [{ label: group.enabled ? 'Active' : 'Paused', type: group.enabled ? 'success' : 'default' }],
+            key: destination.hog_function_ids.join('|'),
+            title: label,
+            tags: [
+                {
+                    label: destination.enabled ? 'Active' : 'Paused',
+                    type: destination.enabled ? 'success' : 'default',
+                },
+            ],
             viewAction: {
                 kind: 'button',
                 label: 'View',
@@ -84,7 +90,7 @@ export function LogsAlertNotifications({ alertId }: { alertId?: string }): JSX.E
                 disabledReason: detailUrl ? undefined : 'Save the alert to view details',
                 dataAttr: 'logs-alert-destination-view',
             },
-            onDelete: () => deleteExistingDestination(group),
+            onDelete: () => deleteExistingDestination(destination, label),
         }
     })
 
@@ -101,8 +107,8 @@ export function LogsAlertNotifications({ alertId }: { alertId?: string }): JSX.E
             description="Each destination delivers notifications for all alert events: firing, resolved, and broken."
             destinations={{
                 showExisting: true,
-                existingLoading: existingHogFunctionsLoading,
-                existing: existingDestinations,
+                existingLoading: existingDestinationsLoading,
+                existing: destinationViews,
                 pending: pendingDestinations,
             }}
             notificationType={{

--- a/products/logs/frontend/components/LogsAlerting/__tests__/LogsAlertNotifications.test.tsx
+++ b/products/logs/frontend/components/LogsAlerting/__tests__/LogsAlertNotifications.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen, within } from '@testing-library/react'
+import { BindLogic } from 'kea'
+
+import { initKeaTests } from '~/test/init'
+
+import { logsAlertsDestinationsList } from 'products/logs/frontend/generated/api'
+import { LogsAlertDestinationConfigApi } from 'products/logs/frontend/generated/api.schemas'
+
+import { logsAlertNotificationLogic } from '../logsAlertNotificationLogic'
+import { LogsAlertNotifications } from '../LogsAlertNotifications'
+
+jest.mock('products/logs/frontend/generated/api', () => ({
+    __esModule: true,
+    logsAlertsDestinationsList: jest.fn(),
+    logsAlertsDestinationsCreate: jest.fn(),
+    logsAlertsDestinationsDeleteCreate: jest.fn(),
+}))
+
+const mockList = logsAlertsDestinationsList as jest.MockedFunction<typeof logsAlertsDestinationsList>
+
+function onePage(results: LogsAlertDestinationConfigApi[]): ReturnType<typeof logsAlertsDestinationsList> {
+    return Promise.resolve({ count: results.length, next: null, previous: null, results })
+}
+
+function renderNotifications(): void {
+    render(
+        <BindLogic logic={logsAlertNotificationLogic} props={{ alertId: 'alert-1' }}>
+            <LogsAlertNotifications alertId="alert-1" />
+        </BindLogic>
+    )
+}
+
+describe('LogsAlertNotifications', () => {
+    beforeEach(() => {
+        initKeaTests()
+        jest.clearAllMocks()
+    })
+
+    it("lists the alert's destinations", async () => {
+        mockList.mockReturnValue(
+            onePage([
+                {
+                    hog_function_ids: ['hf-1', 'hf-2'],
+                    type: 'webhook',
+                    enabled: true,
+                    webhook_url: 'https://one.example.com/…',
+                },
+            ])
+        )
+
+        renderNotifications()
+
+        expect(await screen.findByText('Webhook https://one.example.com/…')).toBeTruthy()
+    })
+
+    it('lists two destinations of the same type as two entries', async () => {
+        mockList.mockReturnValue(
+            onePage([
+                {
+                    hog_function_ids: ['hf-1', 'hf-2'],
+                    type: 'webhook',
+                    enabled: true,
+                    webhook_url: 'https://one.example.com/…',
+                },
+                {
+                    hog_function_ids: ['hf-3', 'hf-4'],
+                    type: 'webhook',
+                    enabled: true,
+                    webhook_url: 'https://two.example.com/…',
+                },
+            ])
+        )
+
+        renderNotifications()
+
+        expect(await screen.findByText('Webhook https://one.example.com/…')).toBeTruthy()
+        expect(screen.getByText('Webhook https://two.example.com/…')).toBeTruthy()
+    })
+
+    it('tags each destination Active or Paused from its enabled flag', async () => {
+        mockList.mockReturnValue(
+            onePage([
+                {
+                    hog_function_ids: ['hf-1', 'hf-2'],
+                    type: 'webhook',
+                    enabled: true,
+                    webhook_url: 'https://active.example.com/…',
+                },
+                {
+                    hog_function_ids: ['hf-3', 'hf-4'],
+                    type: 'teams',
+                    enabled: false,
+                    webhook_url: 'https://paused.example.com/…',
+                },
+            ])
+        )
+
+        renderNotifications()
+
+        const activeRow = (await screen.findByText('Webhook https://active.example.com/…')).closest('div')!
+        const pausedRow = screen.getByText('Microsoft Teams https://paused.example.com/…').closest('div')!
+
+        expect(within(activeRow).getByText('Active')).toBeTruthy()
+        expect(within(pausedRow).getByText('Paused')).toBeTruthy()
+    })
+})

--- a/products/logs/frontend/components/LogsAlerting/__tests__/logsAlertFormLogic.test.ts
+++ b/products/logs/frontend/components/LogsAlerting/__tests__/logsAlertFormLogic.test.ts
@@ -20,6 +20,8 @@ jest.mock('products/logs/frontend/generated/api', () => ({
     logsAlertsPartialUpdate: jest.fn(),
     logsAlertsList: jest.fn(),
     logsAlertsDestroy: jest.fn(),
+    // The alert form mounts logsAlertNotificationLogic, which lists destinations on mount.
+    logsAlertsDestinationsList: jest.fn().mockResolvedValue({ count: 0, next: null, previous: null, results: [] }),
 }))
 
 jest.mock('@posthog/lemon-ui', () => ({

--- a/products/logs/frontend/components/LogsAlerting/__tests__/logsAlertNotificationLogic.test.ts
+++ b/products/logs/frontend/components/LogsAlerting/__tests__/logsAlertNotificationLogic.test.ts
@@ -1,31 +1,23 @@
 import { expectLogic } from 'kea-test-utils'
 
-import api from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 
 import { initKeaTests } from '~/test/init'
-import { HogFunctionType } from '~/types'
 
-import { logsAlertsDestinationsCreate, logsAlertsDestinationsDeleteCreate } from 'products/logs/frontend/generated/api'
+import {
+    logsAlertsDestinationsCreate,
+    logsAlertsDestinationsDeleteCreate,
+    logsAlertsDestinationsList,
+} from 'products/logs/frontend/generated/api'
+import { LogsAlertDestinationConfigApi } from 'products/logs/frontend/generated/api.schemas'
 
 import { logsAlertNotificationLogic } from '../logsAlertNotificationLogic'
-import { buildLogsAlertFilterConfig, LogsAlertDestinationGroup } from '../logsAlertUtils'
-
-jest.mock('lib/api', () => {
-    // Keep the real module: the connected integrationsLogic calls api.integrations.list()
-    // on mount, which resolves via the MSW floor. Only hogFunctions is stubbed.
-    const actual = jest.requireActual('lib/api')
-    return {
-        ...actual,
-        __esModule: true,
-        default: { ...actual.default, hogFunctions: { list: jest.fn() } },
-    }
-})
 
 jest.mock('products/logs/frontend/generated/api', () => ({
     __esModule: true,
     logsAlertsDestinationsCreate: jest.fn(),
     logsAlertsDestinationsDeleteCreate: jest.fn(),
+    logsAlertsDestinationsList: jest.fn(),
 }))
 
 jest.mock('lib/lemon-ui/LemonToast/LemonToast', () => ({
@@ -35,23 +27,27 @@ jest.mock('lib/lemon-ui/LemonToast/LemonToast', () => ({
     },
 }))
 
-const mockApi = api as jest.Mocked<typeof api>
 const mockCreate = logsAlertsDestinationsCreate as jest.MockedFunction<typeof logsAlertsDestinationsCreate>
 const mockDelete = logsAlertsDestinationsDeleteCreate as jest.MockedFunction<typeof logsAlertsDestinationsDeleteCreate>
+const mockList = logsAlertsDestinationsList as jest.MockedFunction<typeof logsAlertsDestinationsList>
 
-const MOCK_HOG_FUNCTION = {
-    id: 'hf-1',
-    name: 'Test Notification',
+const MOCK_DESTINATION: LogsAlertDestinationConfigApi = {
+    hog_function_ids: ['hf-1', 'hf-2'],
+    type: 'slack',
     enabled: true,
-    inputs: { channel: { value: 'C123' } },
-    filters: {},
-} as unknown as HogFunctionType
+    slack_workspace_id: 1,
+    slack_channel_id: 'C123',
+}
+
+function onePage(results: LogsAlertDestinationConfigApi[]): ReturnType<typeof logsAlertsDestinationsList> {
+    return Promise.resolve({ count: results.length, next: null, previous: null, results })
+}
 
 describe('logsAlertNotificationLogic', () => {
     beforeEach(() => {
         initKeaTests()
         jest.clearAllMocks()
-        ;(mockApi.hogFunctions.list as jest.Mock).mockResolvedValue({ results: [] })
+        mockList.mockReturnValue(onePage([]))
     })
 
     describe('pending notifications', () => {
@@ -105,44 +101,68 @@ describe('logsAlertNotificationLogic', () => {
         })
     })
 
-    describe('loadExistingHogFunctions', () => {
+    describe('loadExistingDestinations', () => {
         it('returns empty array when no alertId', async () => {
             const logic = logsAlertNotificationLogic({ alertId: undefined })
             logic.mount()
 
             await expectLogic(logic, () => {
-                logic.actions.loadExistingHogFunctions()
+                logic.actions.loadExistingDestinations()
             }).toFinishAllListeners()
 
-            expect(logic.values.existingHogFunctions).toEqual([])
-            expect(mockApi.hogFunctions.list).not.toHaveBeenCalled()
+            expect(logic.values.existingDestinations).toEqual([])
+            expect(mockList).not.toHaveBeenCalled()
 
             logic.unmount()
         })
 
-        it('loads hog functions filtered by alert id only (not by event)', async () => {
-            ;(mockApi.hogFunctions.list as jest.Mock).mockResolvedValue({
-                results: [MOCK_HOG_FUNCTION],
-            })
+        it("loads the alert's destinations from the alert endpoint", async () => {
+            mockList.mockReturnValue(onePage([MOCK_DESTINATION]))
 
             const logic = logsAlertNotificationLogic({ alertId: 'alert-1' })
             logic.mount()
 
             await expectLogic(logic).toFinishAllListeners()
 
-            expect(mockApi.hogFunctions.list).toHaveBeenCalledWith({
-                types: ['internal_destination'],
-                filter_groups: [buildLogsAlertFilterConfig('alert-1')],
-                full: true,
-            })
-            // The filter must not include events — otherwise per-event HogFunctions
-            // created by the backend fan-out won't match the JSONB @> query.
-            expect(mockApi.hogFunctions.list).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    filter_groups: [expect.not.objectContaining({ events: expect.anything() })],
-                })
-            )
-            expect(logic.values.existingHogFunctions).toEqual([MOCK_HOG_FUNCTION])
+            expect(mockList).toHaveBeenCalledWith(expect.any(String), 'alert-1', { limit: 100, offset: 0 })
+            expect(logic.values.existingDestinations).toEqual([MOCK_DESTINATION])
+
+            logic.unmount()
+        })
+
+        it('keeps two Slack destinations that share a channel id in different workspaces apart', async () => {
+            const workspaceOne = { ...MOCK_DESTINATION, hog_function_ids: ['hf-1'], slack_workspace_id: 1 }
+            const workspaceTwo = { ...MOCK_DESTINATION, hog_function_ids: ['hf-2'], slack_workspace_id: 2 }
+            mockList.mockReturnValue(onePage([workspaceOne, workspaceTwo]))
+
+            const logic = logsAlertNotificationLogic({ alertId: 'alert-1' })
+            logic.mount()
+
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(logic.values.existingDestinations).toEqual([workspaceOne, workspaceTwo])
+
+            logic.unmount()
+        })
+
+        it('reads every page so a long destination list is not truncated', async () => {
+            const firstPage = Array.from({ length: 100 }, (_, index) => ({
+                ...MOCK_DESTINATION,
+                hog_function_ids: [`hf-${index}`],
+            }))
+            mockList
+                .mockReturnValueOnce(Promise.resolve({ count: 101, next: 'next', previous: null, results: firstPage }))
+                .mockReturnValueOnce(
+                    Promise.resolve({ count: 101, next: null, previous: 'prev', results: [MOCK_DESTINATION] })
+                )
+
+            const logic = logsAlertNotificationLogic({ alertId: 'alert-1' })
+            logic.mount()
+
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(mockList).toHaveBeenNthCalledWith(2, expect.any(String), 'alert-1', { limit: 100, offset: 100 })
+            expect(logic.values.existingDestinations).toHaveLength(101)
 
             logic.unmount()
         })
@@ -221,42 +241,30 @@ describe('logsAlertNotificationLogic', () => {
     })
 
     describe('deleteExistingDestination', () => {
-        it('sends the whole group of HogFunction ids in a single atomic delete call', async () => {
-            ;(mockApi.hogFunctions.list as jest.Mock).mockResolvedValue({
-                results: [MOCK_HOG_FUNCTION],
-            })
+        it('sends the listed destination’s whole group of HogFunction ids in one atomic call', async () => {
+            mockList.mockReturnValue(onePage([MOCK_DESTINATION]))
             mockDelete.mockResolvedValue(undefined as any)
 
             const logic = logsAlertNotificationLogic({ alertId: 'alert-1' })
             logic.mount()
 
             await expectLogic(logic).toFinishAllListeners()
-            expect(logic.values.existingHogFunctions).toHaveLength(1)
+            expect(logic.values.existingDestinations).toHaveLength(1)
 
-            const group: LogsAlertDestinationGroup = {
-                key: 'slack:C123',
-                type: 'slack',
-                label: 'Slack #alerts',
-                hogFunctions: [MOCK_HOG_FUNCTION, { ...MOCK_HOG_FUNCTION, id: 'hf-2' }],
-                enabled: true,
-            }
-
-            logic.actions.deleteExistingDestination(group)
+            logic.actions.deleteExistingDestination(logic.values.existingDestinations[0], 'Slack #alerts')
             await expectLogic(logic).toFinishAllListeners()
 
             expect(mockDelete).toHaveBeenCalledWith(expect.any(String), 'alert-1', {
                 hog_function_ids: ['hf-1', 'hf-2'],
             })
             expect(lemonToast.success).toHaveBeenCalledWith('Removed Slack #alerts')
-            expect(mockApi.hogFunctions.list).toHaveBeenCalledTimes(2)
+            expect(mockList).toHaveBeenCalledTimes(2)
 
             logic.unmount()
         })
 
         it('reloads from the server on delete failure so the list reflects actual state', async () => {
-            ;(mockApi.hogFunctions.list as jest.Mock).mockResolvedValue({
-                results: [MOCK_HOG_FUNCTION],
-            })
+            mockList.mockReturnValue(onePage([MOCK_DESTINATION]))
             mockDelete.mockRejectedValue(new Error('network'))
 
             const logic = logsAlertNotificationLogic({ alertId: 'alert-1' })
@@ -264,20 +272,12 @@ describe('logsAlertNotificationLogic', () => {
 
             await expectLogic(logic).toFinishAllListeners()
 
-            const group: LogsAlertDestinationGroup = {
-                key: 'slack:C123',
-                type: 'slack',
-                label: 'Slack #alerts',
-                hogFunctions: [MOCK_HOG_FUNCTION],
-                enabled: true,
-            }
-
-            logic.actions.deleteExistingDestination(group)
+            logic.actions.deleteExistingDestination(MOCK_DESTINATION, 'Slack #alerts')
             await expectLogic(logic).toFinishAllListeners()
 
             expect(lemonToast.error).toHaveBeenCalledWith(expect.stringContaining('Failed to remove Slack #alerts'))
             // List loader fired twice: once on mount, once after the error
-            expect(mockApi.hogFunctions.list).toHaveBeenCalledTimes(2)
+            expect(mockList).toHaveBeenCalledTimes(2)
 
             logic.unmount()
         })

--- a/products/logs/frontend/components/LogsAlerting/__tests__/logsAlertUtils.test.ts
+++ b/products/logs/frontend/components/LogsAlerting/__tests__/logsAlertUtils.test.ts
@@ -1,9 +1,12 @@
-import { FilterLogicalOperator, HogFunctionType, PropertyFilterType, PropertyOperator } from '~/types'
+import { FilterLogicalOperator, PropertyFilterType, PropertyOperator, SlackChannelType } from '~/types'
 
-import { LogsAlertThresholdOperatorEnumApi } from 'products/logs/frontend/generated/api.schemas'
+import {
+    LogsAlertDestinationConfigApi,
+    LogsAlertThresholdOperatorEnumApi,
+} from 'products/logs/frontend/generated/api.schemas'
 
 import { LogsAlertFormType } from '../logsAlertFormLogic'
-import { buildLogsAlertFilterConfig, groupLogsAlertDestinations, runPreEnableChecks } from '../logsAlertUtils'
+import { buildLogsAlertFilterConfig, destinationLabel, runPreEnableChecks } from '../logsAlertUtils'
 
 const baseForm = (overrides: Partial<LogsAlertFormType> = {}): LogsAlertFormType => ({
     name: 'A',
@@ -38,137 +41,58 @@ describe('logsAlertUtils', () => {
         })
     })
 
-    describe('groupLogsAlertDestinations', () => {
-        const slackHf = (id: string, channel: string, enabled = true): HogFunctionType =>
-            ({
-                id,
-                name: `slack-${id}`,
-                enabled,
-                template: { id: 'template-slack' },
-                inputs: { channel: { value: channel } },
-                filters: {},
-            }) as unknown as HogFunctionType
-
-        const webhookHf = (id: string, url: string, enabled = true): HogFunctionType =>
-            ({
-                id,
-                name: `webhook-${id}`,
-                enabled,
-                template: { id: 'template-webhook' },
-                inputs: { url: { value: url } },
-                filters: {},
-            }) as unknown as HogFunctionType
-
-        const teamsHf = (id: string, url: string, enabled = true): HogFunctionType =>
-            ({
-                id,
-                name: `teams-${id}`,
-                enabled,
-                template: { id: 'template-microsoft-teams' },
-                inputs: { webhookUrl: { value: url } },
-                filters: {},
-            }) as unknown as HogFunctionType
-
-        const resolveSlack = (channelValue: string): string | null => `channel-for-${channelValue}`
-
-        it('collapses multiple HogFunctions for the same slack channel into one group', () => {
-            const firing = slackHf('hf-1', 'C123')
-            const resolved = slackHf('hf-2', 'C123')
-
-            const groups = groupLogsAlertDestinations([firing, resolved], resolveSlack)
-
-            expect(groups).toHaveLength(1)
-            expect(groups[0]).toMatchObject({
-                key: 'slack:C123',
-                type: 'slack',
-                label: 'Slack #channel-for-C123',
-                enabled: true,
-            })
-            expect(groups[0].hogFunctions).toHaveLength(2)
+    describe('destinationLabel', () => {
+        const slackDestination = (workspaceId: number): LogsAlertDestinationConfigApi => ({
+            hog_function_ids: ['hf-1'],
+            type: 'slack',
+            enabled: true,
+            slack_workspace_id: workspaceId,
+            slack_channel_id: 'C123',
         })
 
-        it('collapses multiple HogFunctions for the same webhook url into one group', () => {
-            const a = webhookHf('hf-1', 'https://example.com/hook')
-            const b = webhookHf('hf-2', 'https://example.com/hook')
+        const channels: SlackChannelType[] = [
+            { id: 'C123', name: 'alerts', is_private: false, is_ext_shared: false, is_member: true },
+        ]
 
-            const groups = groupLogsAlertDestinations([a, b], resolveSlack)
-
-            expect(groups).toHaveLength(1)
-            expect(groups[0]).toMatchObject({
-                key: 'webhook:https://example.com/hook',
-                type: 'webhook',
-                label: 'Webhook https://example.com/hook',
-            })
-            expect(groups[0].hogFunctions).toHaveLength(2)
+        it('names a Slack destination after its channel', () => {
+            expect(destinationLabel(slackDestination(1), { workspaceId: 1, channels })).toBe('Slack #alerts')
         })
 
-        it('collapses multiple HogFunctions for the same teams url into one group', () => {
-            const teamsUrl = 'https://prod-00.westus.logic.azure.com:443/workflows/abc/triggers/manual/paths/invoke'
-            const a = teamsHf('hf-1', teamsUrl)
-            const b = teamsHf('hf-2', teamsUrl)
-
-            const groups = groupLogsAlertDestinations([a, b], resolveSlack)
-
-            expect(groups).toHaveLength(1)
-            expect(groups[0]).toMatchObject({
-                key: `teams:${teamsUrl}`,
-                type: 'teams',
-                label: `Microsoft Teams ${teamsUrl}`,
-            })
-            expect(groups[0].hogFunctions).toHaveLength(2)
+        // The server groups Slack destinations by workspace and channel. Labelling from the
+        // wrong workspace's channel list would show one destination under another's name.
+        it('does not borrow a channel name from another Slack workspace', () => {
+            expect(destinationLabel(slackDestination(2), { workspaceId: 1, channels })).toBe('Slack')
         })
 
-        it('keeps distinct slack channels and webhook urls as separate groups', () => {
-            const groups = groupLogsAlertDestinations(
-                [
-                    slackHf('a', 'C123'),
-                    slackHf('b', 'C456'),
-                    webhookHf('c', 'https://one.example'),
-                    webhookHf('d', 'https://two.example'),
-                ],
-                resolveSlack
-            )
-
-            expect(groups.map((g) => g.key).sort()).toEqual([
-                'slack:C123',
-                'slack:C456',
-                'webhook:https://one.example',
-                'webhook:https://two.example',
-            ])
+        it('falls back to a bare Slack label when the channel is not in the list', () => {
+            expect(destinationLabel(slackDestination(1), { workspaceId: 1, channels: [] })).toBe('Slack')
         })
 
-        it('marks a group as disabled when any HogFunction in it is disabled (AND semantics)', () => {
-            const firing = slackHf('hf-1', 'C123', true)
-            const resolved = slackHf('hf-2', 'C123', false)
+        it('names webhook and Teams destinations after their url', () => {
+            const slack = { workspaceId: 1, channels }
 
-            const groups = groupLogsAlertDestinations([firing, resolved], resolveSlack)
-
-            expect(groups).toHaveLength(1)
-            expect(groups[0].enabled).toBe(false)
-        })
-
-        it('falls back to a bare Slack label when the channel name cannot be resolved', () => {
-            const hf = slackHf('hf-1', 'C_UNKNOWN')
-
-            const groups = groupLogsAlertDestinations([hf], () => null)
-
-            expect(groups[0].label).toBe('Slack')
-        })
-
-        it('produces an isolated per-HogFunction group for unrecognised inputs', () => {
-            const unknown = {
-                id: 'hf-x',
-                name: 'Weird destination',
-                enabled: true,
-                inputs: {},
-                filters: {},
-            } as unknown as HogFunctionType
-
-            const groups = groupLogsAlertDestinations([unknown], resolveSlack)
-
-            expect(groups).toHaveLength(1)
-            expect(groups[0].key).toBe('unknown:hf-x')
-            expect(groups[0].label).toBe('Weird destination')
+            expect(
+                destinationLabel(
+                    {
+                        hog_function_ids: ['hf-1'],
+                        type: 'webhook',
+                        enabled: true,
+                        webhook_url: 'https://example.com/…',
+                    },
+                    slack
+                )
+            ).toBe('Webhook https://example.com/…')
+            expect(
+                destinationLabel(
+                    {
+                        hog_function_ids: ['hf-2'],
+                        type: 'teams',
+                        enabled: true,
+                        webhook_url: 'https://teams.example/…',
+                    },
+                    slack
+                )
+            ).toBe('Microsoft Teams https://teams.example/…')
         })
     })
 

--- a/products/logs/frontend/components/LogsAlerting/logsAlertNotificationLogic.ts
+++ b/products/logs/frontend/components/LogsAlerting/logsAlertNotificationLogic.ts
@@ -1,24 +1,22 @@
 import { MakeLogicType, actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 
-import api from 'lib/api'
 import { integrationsLogic } from 'lib/integrations/integrationsLogic'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { projectLogic } from 'scenes/projectLogic'
 
-import { HogFunctionType, IntegrationType } from '~/types'
+import { IntegrationType } from '~/types'
 
 import { AlertNotificationUrlInput } from 'products/alerts/frontend/components/AlertNotificationDestinationEditor'
 import { logsAlertsDestinationsCreate, logsAlertsDestinationsDeleteCreate } from 'products/logs/frontend/generated/api'
+import { LogsAlertDestinationConfigApi } from 'products/logs/frontend/generated/api.schemas'
 
 import type { UserBasicType } from '../../../../../frontend/src/types'
 import {
-    buildLogsAlertFilterConfig,
-    groupLogsAlertDestinations,
+    fetchLogsAlertDestinations,
     LOGS_ALERT_NOTIFICATION_TYPE_SLACK,
     LOGS_ALERT_NOTIFICATION_TYPE_TEAMS,
     LOGS_ALERT_NOTIFICATION_TYPE_WEBHOOK,
-    LogsAlertDestinationGroup,
     LogsAlertNotificationType,
     PendingLogsAlertNotification,
 } from './logsAlertUtils'
@@ -39,9 +37,8 @@ export interface logsAlertNotificationLogicValues {
     slackIntegrations: IntegrationType[] | undefined // integrationsLogic
     currentProjectId: number | null // projectLogic
     addDisabledReason: string | undefined
-    destinationGroups: LogsAlertDestinationGroup[]
-    existingHogFunctions: HogFunctionType[]
-    existingHogFunctionsLoading: boolean
+    existingDestinations: LogsAlertDestinationConfigApi[]
+    existingDestinationsLoading: boolean
     firstSlackIntegration: IntegrationType | undefined
     integrationsFailed: boolean
     pendingNotifications: PendingLogsAlertNotification[]
@@ -180,25 +177,29 @@ export interface logsAlertNotificationLogicActions {
     createPendingHogFunctions: (alertId: string) => {
         alertId: string
     }
-    deleteExistingDestination: (group: LogsAlertDestinationGroup) => {
-        group: LogsAlertDestinationGroup
+    deleteExistingDestination: (
+        destination: LogsAlertDestinationConfigApi,
+        label: string
+    ) => {
+        destination: LogsAlertDestinationConfigApi
+        label: string
     }
     destinationsChanged: () => {
         value: true
     }
-    loadExistingHogFunctions: (alertId?: string) => string
-    loadExistingHogFunctionsFailure: (
+    loadExistingDestinations: (alertId?: string) => string
+    loadExistingDestinationsFailure: (
         error: string,
         errorObject?: any
     ) => {
         error: string
         errorObject?: any
     }
-    loadExistingHogFunctionsSuccess: (
-        existingHogFunctions: HogFunctionType[],
+    loadExistingDestinationsSuccess: (
+        existingDestinations: LogsAlertDestinationConfigApi[],
         payload?: string
     ) => {
-        existingHogFunctions: HogFunctionType[]
+        existingDestinations: LogsAlertDestinationConfigApi[]
         payload?: string
     }
     removePendingNotification: (index: number) => {
@@ -230,7 +231,6 @@ export interface logsAlertNotificationLogicMeta {
             slackChannelValue: string | null,
             webhookUrl: string
         ) => string | undefined
-        destinationGroups: (existingHogFunctions: HogFunctionType[]) => LogsAlertDestinationGroup[]
     }
 }
 
@@ -257,7 +257,10 @@ export const logsAlertNotificationLogic = kea<logsAlertNotificationLogicType>([
         removePendingNotification: (index: number) => ({ index }),
         clearPendingNotifications: true,
         setPendingNotifications: (notifications: PendingLogsAlertNotification[]) => ({ notifications }),
-        deleteExistingDestination: (group: LogsAlertDestinationGroup) => ({ group }),
+        deleteExistingDestination: (destination: LogsAlertDestinationConfigApi, label: string) => ({
+            destination,
+            label,
+        }),
         createPendingHogFunctions: (alertId: string) => ({ alertId }),
         destinationsChanged: true,
         setSelectedType: (selectedType: LogsAlertNotificationType) => ({ selectedType }),
@@ -303,21 +306,16 @@ export const logsAlertNotificationLogic = kea<logsAlertNotificationLogicType>([
         ],
     }),
 
-    loaders(({ props }) => ({
-        existingHogFunctions: [
-            [] as HogFunctionType[],
+    loaders(({ props, values }) => ({
+        existingDestinations: [
+            [] as LogsAlertDestinationConfigApi[],
             {
-                loadExistingHogFunctions: async (alertId?: string) => {
+                loadExistingDestinations: async (alertId?: string) => {
                     const id = alertId ?? props.alertId
                     if (!id) {
                         return []
                     }
-                    const response = await api.hogFunctions.list({
-                        types: ['internal_destination'],
-                        filter_groups: [buildLogsAlertFilterConfig(id)],
-                        full: true,
-                    })
-                    return response.results
+                    return fetchLogsAlertDestinations(String(values.currentProjectId), id)
                 },
             },
         ],
@@ -361,12 +359,6 @@ export const logsAlertNotificationLogic = kea<logsAlertNotificationLogicType>([
                 return slackChannelValue ? undefined : 'Select a Slack channel'
             },
         ],
-        // Channel-name resolution happens in the view — slackChannels lives in a dynamically-keyed logic.
-        destinationGroups: [
-            (s) => [s.existingHogFunctions],
-            (hogFunctions: HogFunctionType[]): LogsAlertDestinationGroup[] =>
-                groupLogsAlertDestinations(hogFunctions, () => null),
-        ],
     }),
 
     listeners(({ actions, values, props }) => ({
@@ -401,20 +393,20 @@ export const logsAlertNotificationLogic = kea<logsAlertNotificationLogicType>([
                 actions.setSelectedType(LOGS_ALERT_NOTIFICATION_TYPE_WEBHOOK)
             }
         },
-        deleteExistingDestination: async ({ group }) => {
+        deleteExistingDestination: async ({ destination, label }) => {
             if (!props.alertId) {
                 return
             }
             try {
                 await logsAlertsDestinationsDeleteCreate(String(values.currentProjectId), props.alertId, {
-                    hog_function_ids: group.hogFunctions.map((hf) => hf.id),
+                    hog_function_ids: destination.hog_function_ids,
                 })
-                lemonToast.success(`Removed ${group.label}`)
-                actions.loadExistingHogFunctions()
+                lemonToast.success(`Removed ${label}`)
+                actions.loadExistingDestinations()
                 actions.destinationsChanged()
             } catch {
-                lemonToast.error(`Failed to remove ${group.label}`)
-                actions.loadExistingHogFunctions()
+                lemonToast.error(`Failed to remove ${label}`)
+                actions.loadExistingDestinations()
             }
         },
 
@@ -445,7 +437,7 @@ export const logsAlertNotificationLogic = kea<logsAlertNotificationLogicType>([
 
             const failedNotifications = pending.filter((_, i) => results[i].status === 'rejected')
 
-            actions.loadExistingHogFunctions(alertId)
+            actions.loadExistingDestinations(alertId)
             actions.destinationsChanged()
 
             if (failedNotifications.length > 0) {
@@ -464,7 +456,7 @@ export const logsAlertNotificationLogic = kea<logsAlertNotificationLogicType>([
 
     afterMount(({ actions, props }) => {
         if (props.alertId) {
-            actions.loadExistingHogFunctions()
+            actions.loadExistingDestinations()
         }
     }),
 ])

--- a/products/logs/frontend/components/LogsAlerting/logsAlertUtils.ts
+++ b/products/logs/frontend/components/LogsAlerting/logsAlertUtils.ts
@@ -16,7 +16,8 @@ import {
     SlackChannelType,
 } from '~/types'
 
-import { LogsAlertConfigurationApi } from 'products/logs/frontend/generated/api.schemas'
+import { logsAlertsDestinationsList } from 'products/logs/frontend/generated/api'
+import { LogsAlertConfigurationApi, LogsAlertDestinationConfigApi } from 'products/logs/frontend/generated/api.schemas'
 
 export type LogsAlertEventKind = 'firing' | 'resolved' | 'broken' | 'errored'
 
@@ -169,71 +170,44 @@ export function buildLogsAlertFilterConfig(alertId: string): CyclotronJobFilters
     }
 }
 
-export type LogsAlertDestinationGroup = {
-    key: string
-    type: LogsAlertNotificationType
-    label: string
-    hogFunctions: HogFunctionType[]
-    enabled: boolean
+// Slack channels the integrations API returned, plus the workspace they belong to. A
+// destination in another workspace must not be labelled from this list, because two
+// workspaces can use the same channel id for different channels.
+export type SlackChannelLookup = {
+    workspaceId: number | undefined
+    channels: SlackChannelType[]
 }
 
-export function slackChannelLabel(channelValue: string, slackChannels: SlackChannelType[]): string {
-    const channelId = channelValue.split('|')[0]
-    const name = slackChannels.find((c) => c.id === channelId)?.name
-    return name ? `Slack #${name}` : 'Slack'
+// The API returns a Slack channel id, never the channel name — creating a destination puts
+// the name in the HogFunction name and stores nothing else. Names come from integrations.
+export function destinationLabel(destination: LogsAlertDestinationConfigApi, slack: SlackChannelLookup): string {
+    if (destination.type === LOGS_ALERT_NOTIFICATION_TYPE_SLACK) {
+        const channelName =
+            destination.slack_workspace_id === slack.workspaceId
+                ? slack.channels.find((channel) => channel.id === destination.slack_channel_id)?.name
+                : undefined
+        return channelName ? `Slack #${channelName}` : 'Slack'
+    }
+    if (destination.type === LOGS_ALERT_NOTIFICATION_TYPE_TEAMS) {
+        return destination.webhook_url ? `Microsoft Teams ${destination.webhook_url}` : 'Microsoft Teams'
+    }
+    return destination.webhook_url ? `Webhook ${destination.webhook_url}` : 'Webhook'
 }
 
-export function resolveGroupLabel(group: LogsAlertDestinationGroup, slackChannels: SlackChannelType[]): string {
-    if (group.type === LOGS_ALERT_NOTIFICATION_TYPE_SLACK) {
-        const hf = group.hogFunctions[0]
-        const channelValue = hf?.inputs?.channel?.value
-        if (typeof channelValue === 'string') {
-            return slackChannelLabel(channelValue, slackChannels)
+const DESTINATIONS_PAGE_SIZE = 100
+
+// Walks every page. Alerts rarely hold more than a page of destinations, but a truncated
+// list would hide destinations and let the user add one that already exists.
+export async function fetchLogsAlertDestinations(
+    projectId: string,
+    alertId: string
+): Promise<LogsAlertDestinationConfigApi[]> {
+    const destinations: LogsAlertDestinationConfigApi[] = []
+    for (let offset = 0; ; offset += DESTINATIONS_PAGE_SIZE) {
+        const page = await logsAlertsDestinationsList(projectId, alertId, { limit: DESTINATIONS_PAGE_SIZE, offset })
+        destinations.push(...page.results)
+        if (page.results.length === 0 || destinations.length >= page.count) {
+            return destinations
         }
     }
-    return group.label
-}
-
-export function groupLogsAlertDestinations(
-    hogFunctions: HogFunctionType[],
-    resolveSlackLabel: (channelValue: string) => string | null
-): LogsAlertDestinationGroup[] {
-    const groups = new Map<string, LogsAlertDestinationGroup>()
-    for (const hf of hogFunctions) {
-        const templateId = hf.template_id ?? hf.template?.id
-        const slackChannelValue = hf.inputs?.channel?.value as string | undefined
-        const destinationWebhookUrl = hf.inputs?.webhookUrl?.value as string | undefined
-        const webhookUrl = hf.inputs?.url?.value as string | undefined
-        let key: string
-        let type: LogsAlertNotificationType
-        let label: string
-
-        if (templateId === 'template-slack') {
-            type = LOGS_ALERT_NOTIFICATION_TYPE_SLACK
-            key = `slack:${slackChannelValue ?? hf.id}`
-            const channelName = slackChannelValue ? resolveSlackLabel(slackChannelValue) : null
-            label = channelName ? `Slack #${channelName}` : 'Slack'
-        } else if (templateId === 'template-microsoft-teams') {
-            type = LOGS_ALERT_NOTIFICATION_TYPE_TEAMS
-            key = `teams:${destinationWebhookUrl ?? hf.id}`
-            label = destinationWebhookUrl ? `Microsoft Teams ${destinationWebhookUrl}` : 'Microsoft Teams'
-        } else if (templateId === 'template-webhook') {
-            type = LOGS_ALERT_NOTIFICATION_TYPE_WEBHOOK
-            key = `webhook:${webhookUrl ?? hf.id}`
-            label = webhookUrl ? `Webhook ${webhookUrl}` : 'Webhook'
-        } else {
-            type = LOGS_ALERT_NOTIFICATION_TYPE_WEBHOOK
-            key = `unknown:${hf.id}`
-            label = hf.name
-        }
-
-        const existing = groups.get(key)
-        if (existing) {
-            existing.hogFunctions.push(hf)
-            existing.enabled = existing.enabled && hf.enabled
-        } else {
-            groups.set(key, { key, type, label, hogFunctions: [hf], enabled: hf.enabled })
-        }
-    }
-    return Array.from(groups.values())
 }

--- a/products/logs/frontend/scenes/LogsAlertDetailScene/LogsAlertDetailScene.tsx
+++ b/products/logs/frontend/scenes/LogsAlertDetailScene/LogsAlertDetailScene.tsx
@@ -254,7 +254,7 @@ function AlertHeader(): JSX.Element {
 function AlertStatusBand(): JSX.Element | null {
     const { alert } = useValues(logsAlertDetailSceneLogic)
     const { resetAlert, unsnoozeAlert, enableAlert, setActiveTab } = useActions(logsAlertDetailSceneLogic)
-    const { destinationGroups, existingHogFunctionsLoading } = useValues(logsAlertNotificationLogic)
+    const { existingDestinations, existingDestinationsLoading } = useValues(logsAlertNotificationLogic)
 
     if (!alert) {
         return null
@@ -310,7 +310,7 @@ function AlertStatusBand(): JSX.Element | null {
         )
     }
 
-    if (alert.enabled && !existingHogFunctionsLoading && destinationGroups.length === 0) {
+    if (alert.enabled && !existingDestinationsLoading && existingDestinations.length === 0) {
         banners.push(
             <LemonBanner
                 key="no-destinations"

--- a/products/logs/frontend/scenes/LogsAlertDetailScene/__tests__/logsAlertDetailSceneLogic.test.ts
+++ b/products/logs/frontend/scenes/LogsAlertDetailScene/__tests__/logsAlertDetailSceneLogic.test.ts
@@ -75,6 +75,7 @@ jest.mock('products/logs/frontend/generated/api', () => ({
     logsAlertsSimulateCreate: jest.fn(),
     logsAlertsDestinationsCreate: jest.fn(),
     logsAlertsDestinationsDeleteCreate: jest.fn(),
+    logsAlertsDestinationsList: jest.fn().mockResolvedValue({ count: 0, next: null, previous: null, results: [] }),
 }))
 
 jest.mock('@posthog/lemon-ui', () => ({

--- a/products/logs/frontend/scenes/LogsAlertNotificationDetailScene/LogsAlertNotificationDetailScene.tsx
+++ b/products/logs/frontend/scenes/LogsAlertNotificationDetailScene/LogsAlertNotificationDetailScene.tsx
@@ -163,7 +163,7 @@ export function LogsAlertNotificationDetailScene(): JSX.Element {
                 <p className="text-sm text-muted m-0">
                     {kindToFn.size > 0
                         ? 'These hog functions only run for this alert. Open one to edit the message body, headers, filters, or destination details for the matching lifecycle event.'
-                        : 'This destination sends a notification for every alert event: firing, resolved, auto-disabled and errored. Its individual hog functions are not editable here.'}
+                        : 'This destination sends a notification for every alert event: firing, resolved, auto-disabled and errored.'}
                 </p>
 
                 {loading ? (

--- a/products/logs/frontend/scenes/LogsAlertNotificationDetailScene/LogsAlertNotificationDetailScene.tsx
+++ b/products/logs/frontend/scenes/LogsAlertNotificationDetailScene/LogsAlertNotificationDetailScene.tsx
@@ -13,11 +13,11 @@ import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { HogFunctionType } from '~/types'
 
 import {
+    destinationLabel,
     getHogFunctionEventKind,
     LOGS_ALERT_EVENT_KIND_META,
     LOGS_ALERT_EVENT_KIND_ORDER,
     LogsAlertEventKind,
-    resolveGroupLabel,
 } from 'products/logs/frontend/components/LogsAlerting/logsAlertUtils'
 
 import {
@@ -35,17 +35,18 @@ export function LogsAlertNotificationDetailScene(): JSX.Element {
     const {
         alert,
         alertLoading,
-        destinationGroup,
-        hogFunctionsLoading,
+        destination,
+        destinationsError,
+        destinationsLoading,
+        hogFunctions,
         hasLoaded,
-        hogFunctionsError,
         isDeleting,
         togglingHogFunctionIds,
         alertId,
         hogFunctionId,
         firstSlackIntegration,
     } = useValues(logsAlertNotificationDetailSceneLogic)
-    const { deleteDestination, loadHogFunctions, setHogFunctionEnabled } = useActions(
+    const { deleteDestination, loadDestinations, setHogFunctionEnabled } = useActions(
         logsAlertNotificationDetailSceneLogic
     )
 
@@ -59,11 +60,13 @@ export function LogsAlertNotificationDetailScene(): JSX.Element {
         }
     }, [firstSlackIntegration?.id, loadAllSlackChannels, firstSlackIntegration])
 
-    const loading = alertLoading || hogFunctionsLoading
-    const displayLabel = destinationGroup ? resolveGroupLabel(destinationGroup, slackChannels) : 'Destination'
+    const loading = alertLoading || destinationsLoading
+    const displayLabel = destination
+        ? destinationLabel(destination, { workspaceId: firstSlackIntegration?.id, channels: slackChannels })
+        : 'Destination'
     const editorReturnTo = encodeURIComponent(urls.logsAlertNotificationDetail(alertId, hogFunctionId))
 
-    if (hogFunctionsError) {
+    if (destinationsError) {
         return (
             <SceneContent>
                 <SceneTitleSection
@@ -74,20 +77,20 @@ export function LogsAlertNotificationDetailScene(): JSX.Element {
                             <LemonButton type="secondary" to={urls.logsAlertDetail(alertId, 'notifications')}>
                                 Back to alert
                             </LemonButton>
-                            <LemonButton type="primary" onClick={() => loadHogFunctions()}>
+                            <LemonButton type="primary" onClick={() => loadDestinations()}>
                                 Retry
                             </LemonButton>
                         </div>
                     }
                 />
                 <div className="p-8 text-muted text-center">
-                    Failed to load destination details: {hogFunctionsError}
+                    Failed to load destination details: {destinationsError}
                 </div>
             </SceneContent>
         )
     }
 
-    if (hasLoaded && !destinationGroup) {
+    if (hasLoaded && !destination) {
         return (
             <SceneContent>
                 <SceneTitleSection
@@ -107,8 +110,8 @@ export function LogsAlertNotificationDetailScene(): JSX.Element {
     }
 
     const kindToFn = new Map<LogsAlertEventKind, HogFunctionType>()
-    for (const hf of destinationGroup?.hogFunctions ?? []) {
-        const kind = getHogFunctionEventKind(hf)
+    for (const hf of hogFunctions) {
+        const kind = destination?.hog_function_ids.includes(hf.id) ? getHogFunctionEventKind(hf) : null
         if (kind) {
             kindToFn.set(kind, hf)
         }
@@ -117,15 +120,15 @@ export function LogsAlertNotificationDetailScene(): JSX.Element {
     return (
         <SceneContent>
             <SceneTitleSection
-                name={destinationGroup ? displayLabel : 'Destination'}
+                name={destination ? displayLabel : 'Destination'}
                 description={alert ? `Notifications fired for alert "${alert.name}".` : undefined}
                 resourceType={{ type: 'logs' }}
-                isLoading={loading && !destinationGroup}
+                isLoading={loading && !destination}
                 actions={
-                    destinationGroup ? (
+                    destination ? (
                         <div className="flex items-center gap-2">
-                            <LemonTag type={destinationGroup.enabled ? 'success' : 'default'}>
-                                {destinationGroup.enabled ? 'Active' : 'Paused'}
+                            <LemonTag type={destination.enabled ? 'success' : 'default'}>
+                                {destination.enabled ? 'Active' : 'Paused'}
                             </LemonTag>
                             <LemonButton
                                 size="small"
@@ -158,13 +161,14 @@ export function LogsAlertNotificationDetailScene(): JSX.Element {
             />
             <div className="flex flex-col gap-4 p-4 max-w-3xl">
                 <p className="text-sm text-muted m-0">
-                    These hog functions only run for this alert. Open one to edit the message body, headers, filters, or
-                    destination details for the matching lifecycle event.
+                    {kindToFn.size > 0
+                        ? 'These hog functions only run for this alert. Open one to edit the message body, headers, filters, or destination details for the matching lifecycle event.'
+                        : 'This destination sends a notification for every alert event: firing, resolved, auto-disabled and errored. Its individual hog functions are not editable here.'}
                 </p>
 
                 {loading ? (
                     <LemonSkeleton className="h-16" repeat={4} />
-                ) : (
+                ) : kindToFn.size === 0 ? null : (
                     <div className="flex flex-col gap-2">
                         {LOGS_ALERT_EVENT_KIND_ORDER.map((kind) => {
                             const fn = kindToFn.get(kind)

--- a/products/logs/frontend/scenes/LogsAlertNotificationDetailScene/logsAlertNotificationDetailSceneLogic.ts
+++ b/products/logs/frontend/scenes/LogsAlertNotificationDetailScene/logsAlertNotificationDetailSceneLogic.ts
@@ -16,11 +16,16 @@ import { Breadcrumb, HogFunctionType, IntegrationType } from '~/types'
 
 import {
     buildLogsAlertFilterConfig,
-    groupLogsAlertDestinations,
-    LogsAlertDestinationGroup,
+    destinationLabel,
+    fetchLogsAlertDestinations,
+    SlackChannelLookup,
 } from 'products/logs/frontend/components/LogsAlerting/logsAlertUtils'
 import { logsAlertsDestinationsDeleteCreate, logsAlertsRetrieve } from 'products/logs/frontend/generated/api'
-import { LogsAlertConfigurationApi } from 'products/logs/frontend/generated/api.schemas'
+import { LogsAlertConfigurationApi, LogsAlertDestinationConfigApi } from 'products/logs/frontend/generated/api.schemas'
+
+// Slack channel names come from a logic the scene component mounts, so the breadcrumb names a
+// Slack destination "Slack" rather than resolving its channel.
+const NO_SLACK_CHANNELS: SlackChannelLookup = { workspaceId: undefined, channels: [] }
 
 export interface LogsAlertNotificationDetailSceneLogicProps {
     alertId: string
@@ -35,12 +40,14 @@ export interface logsAlertNotificationDetailSceneLogicValues {
     alertId: string
     alertLoading: boolean
     breadcrumbs: Breadcrumb[]
-    destinationGroup: LogsAlertDestinationGroup | null
+    destination: LogsAlertDestinationConfigApi | null
+    destinations: LogsAlertDestinationConfigApi[]
+    destinationsError: string | null
+    destinationsLoading: boolean
     firstSlackIntegration: IntegrationType | undefined
     hasLoaded: boolean
     hogFunctionId: string
     hogFunctions: HogFunctionType[]
-    hogFunctionsError: string | null
     hogFunctionsLoading: boolean
     isDeleting: boolean
     togglingHogFunctionIds: string[]
@@ -67,6 +74,21 @@ export interface logsAlertNotificationDetailSceneLogicActions {
         payload?: any
     ) => {
         alert: LogsAlertConfigurationApi | null
+        payload?: any
+    }
+    loadDestinations: () => any
+    loadDestinationsFailure: (
+        error: string,
+        errorObject?: any
+    ) => {
+        error: string
+        errorObject?: any
+    }
+    loadDestinationsSuccess: (
+        destinations: LogsAlertDestinationConfigApi[],
+        payload?: any
+    ) => {
+        destinations: LogsAlertDestinationConfigApi[]
         payload?: any
     }
     loadHogFunctions: () => any
@@ -100,10 +122,13 @@ export interface logsAlertNotificationDetailSceneLogicMeta {
         alertId: (arg: any) => string
         hogFunctionId: (arg: any) => string
         firstSlackIntegration: (slackIntegrations: IntegrationType[] | undefined) => IntegrationType | undefined
-        destinationGroup: (hogFunctions: HogFunctionType[], hogFunctionId: string) => LogsAlertDestinationGroup | null
+        destination: (
+            destinations: LogsAlertDestinationConfigApi[],
+            hogFunctionId: string
+        ) => LogsAlertDestinationConfigApi | null
         breadcrumbs: (
             alert: LogsAlertConfigurationApi | null,
-            destinationGroup: LogsAlertDestinationGroup | null,
+            destination: LogsAlertDestinationConfigApi | null,
             alertId: string
         ) => Breadcrumb[]
     }
@@ -143,15 +168,15 @@ export const logsAlertNotificationDetailSceneLogic = kea<logsAlertNotificationDe
         hasLoaded: [
             false,
             {
-                loadHogFunctionsSuccess: () => true,
+                loadDestinationsSuccess: () => true,
             },
         ],
-        hogFunctionsError: [
+        destinationsError: [
             null as string | null,
             {
-                loadHogFunctions: () => null,
-                loadHogFunctionsSuccess: () => null,
-                loadHogFunctionsFailure: (_, { error }: { error: string }) => error || 'Failed to load destinations',
+                loadDestinations: () => null,
+                loadDestinationsSuccess: () => null,
+                loadDestinationsFailure: (_, { error }: { error: string }) => error || 'Failed to load destinations',
             },
         ],
         isDeleting: [
@@ -184,6 +209,20 @@ export const logsAlertNotificationDetailSceneLogic = kea<logsAlertNotificationDe
                 },
             },
         ],
+        destinations: [
+            [] as LogsAlertDestinationConfigApi[],
+            {
+                loadDestinations: async () => {
+                    if (!values.currentTeamId) {
+                        return []
+                    }
+                    return fetchLogsAlertDestinations(String(values.currentTeamId), props.alertId)
+                },
+            },
+        ],
+        // The per-event breakdown needs each HogFunction's name, event kind and enabled flag,
+        // which the destinations endpoint does not carry. The CDP list API hides managed alert
+        // destinations, so this comes back empty and the breakdown is hidden.
         hogFunctions: [
             [] as HogFunctionType[],
             {
@@ -209,18 +248,19 @@ export const logsAlertNotificationDetailSceneLogic = kea<logsAlertNotificationDe
             (s) => [s.slackIntegrations],
             (slackIntegrations: IntegrationType[] | undefined): IntegrationType | undefined => slackIntegrations?.[0],
         ],
-        destinationGroup: [
-            (s) => [s.hogFunctions, s.hogFunctionId],
-            (hogFunctions: HogFunctionType[], hogFunctionId: string): LogsAlertDestinationGroup | null => {
-                const groups = groupLogsAlertDestinations(hogFunctions, () => null)
-                return groups.find((g) => g.hogFunctions.some((hf) => hf.id === hogFunctionId)) ?? null
-            },
+        destination: [
+            (s) => [s.destinations, s.hogFunctionId],
+            (
+                destinations: LogsAlertDestinationConfigApi[],
+                hogFunctionId: string
+            ): LogsAlertDestinationConfigApi | null =>
+                destinations.find((destination) => destination.hog_function_ids.includes(hogFunctionId)) ?? null,
         ],
         breadcrumbs: [
-            (s) => [s.alert, s.destinationGroup, s.alertId],
+            (s) => [s.alert, s.destination, s.alertId],
             (
                 alert: LogsAlertConfigurationApi | null,
-                group: LogsAlertDestinationGroup | null,
+                destination: LogsAlertDestinationConfigApi | null,
                 alertId: string
             ): Breadcrumb[] => [
                 {
@@ -237,7 +277,7 @@ export const logsAlertNotificationDetailSceneLogic = kea<logsAlertNotificationDe
                 },
                 {
                     key: Scene.LogsAlertNotificationDetail,
-                    name: group?.label ?? 'Destination',
+                    name: destination ? destinationLabel(destination, NO_SLACK_CHANNELS) : 'Destination',
                     iconType: 'logs',
                 },
             ],
@@ -246,14 +286,14 @@ export const logsAlertNotificationDetailSceneLogic = kea<logsAlertNotificationDe
 
     listeners(({ actions, values, props }) => ({
         deleteDestination: async ({ displayLabel }) => {
-            const group = values.destinationGroup
-            if (!group || !values.currentTeamId) {
+            const destination = values.destination
+            if (!destination || !values.currentTeamId) {
                 actions.deleteDestinationDone()
                 return
             }
             try {
                 await logsAlertsDestinationsDeleteCreate(String(values.currentTeamId), props.alertId, {
-                    hog_function_ids: group.hogFunctions.map((hf) => hf.id),
+                    hog_function_ids: destination.hog_function_ids,
                 })
                 lemonToast.success(`Removed ${displayLabel}`)
                 router.actions.push(urls.logsAlertDetail(props.alertId, 'notifications'))
@@ -297,7 +337,8 @@ export const logsAlertNotificationDetailSceneLogic = kea<logsAlertNotificationDe
             if (!values.alert && !values.alertLoading) {
                 actions.loadAlert()
             }
-            if (!values.hasLoaded && !values.hogFunctionsLoading) {
+            if (!values.hasLoaded && !values.destinationsLoading) {
+                actions.loadDestinations()
                 actions.loadHogFunctions()
             }
         },
@@ -306,6 +347,7 @@ export const logsAlertNotificationDetailSceneLogic = kea<logsAlertNotificationDe
     afterMount(({ actions, values }) => {
         if (values.currentTeamId) {
             actions.loadAlert()
+            actions.loadDestinations()
             actions.loadHogFunctions()
         }
     }),


### PR DESCRIPTION
## Problem

A logs alert's notifications tab shows an empty list, so nobody can see or remove the destinations attached to their alert.

- The tab reads destinations from `api.hogFunctions.list`.
- That endpoint hides every HogFunction whose first filter event matches the managed alert pattern, and all four `$logs_alert_*` events match.
- The delete button renders once per listed destination, so it never appears.
- Users add a destination that already exists, without a warning.
- The alert page warns "No notifications configured — this alert will fire silently" for every enabled alert.

## Changes

> [!NOTE]
> Blocked on #84285, which adds the endpoint this PR reads. Base branch is `feat/logs-alert-destinations-read`.

- The notifications tab and the destination detail scene read `GET /api/projects/:id/logs/alerts/:alert_id/destinations/`.
- The server groups a destination's four per-event HogFunctions, so `groupLogsAlertDestinations` is gone.
- `destinationLabel` keeps the label half of that function, and Slack channel names still come from the integrations API.
- The Active/Paused tag reads `enabled`, which #84285 now returns per destination.
- The client keyed a Slack destination on the channel id alone, while the server keys it on workspace and channel.
- `destinationLabel` reads a channel name only when the destination's workspace matches the loaded channel list.
- Delete sends the `hog_function_ids` the response already carries.
- `fetchLogsAlertDestinations` reads every page, because the endpoint paginates at 100.
- The detail scene hides its per-event rows. Those rows need HogFunction reads that the CDP API still refuses, and this PR leaves that API alone.

> [!NOTE]
> Screenshots are outstanding. A frontend change gets a hogbox preview; capture the notifications tab listing two destinations, and a destination carrying the Paused tag.

## How did you test this code?

New tests, and the regression each one catches:

- The tab lists a destination (`LogsAlertNotifications.test.tsx`). Existing frontend tests stubbed `api.hogFunctions.list`, so none of them saw the exclusion that empties the tab.
- Two destinations of the same type render as two entries. No test rendered the list at all.
- The Active/Paused tag follows `enabled`. No test covered the tag.
- Two Slack destinations sharing a channel id in different workspaces stay two entries (`logsAlertNotificationLogic.test.ts`). The old client key merged them into one.
- `destinationLabel` does not name a destination from another workspace's channels (`logsAlertUtils.test.ts`). The old label read the first integration's channels whatever the workspace.
- A second page is read (`logsAlertNotificationLogic.test.ts`). No test covered pagination.
- Delete sends the listed destination's `hog_function_ids`. The old test built the group by hand, so it never checked that the ids came from the server.

Not done: no browser run, so no manual verification and no screenshots.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code wrote this PR, and the `enabled` field it depends on in #84285.
- Skills invoked: `/writing-pr-descriptions`.
- `enabled` combines as AND across a destination's HogFunctions. One disabled row means that event kind is never delivered, so the destination is not fully active.
- The detail scene keeps its HogFunction loader for the per-event rows. Deleting it would remove UI that works again as soon as the CDP exclusion is revisited.
