### PR TITLE
fix(capture): report producer queue bytes, not the message-count cap

### DIFF
--- a/rust/capture-logs/src/kafka.rs
+++ b/rust/capture-logs/src/kafka.rs
@@ -35,7 +35,7 @@ impl rdkafka::ClientContext for KafkaContext {
         gauge!("capture_kafka_callback_queue_depth",).set(stats.replyq as f64);
         gauge!("capture_kafka_producer_queue_depth",).set(stats.msg_cnt as f64);
         gauge!("capture_kafka_producer_queue_depth_limit",).set(stats.msg_max as f64);
-        gauge!("capture_kafka_producer_queue_bytes",).set(stats.msg_max as f64);
+        gauge!("capture_kafka_producer_queue_bytes",).set(stats.msg_size as f64);
         gauge!("capture_kafka_producer_queue_bytes_limit",).set(stats.msg_size_max as f64);
 
         for (topic, stats) in stats.topics {

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -98,7 +98,7 @@ impl rdkafka::ClientContext for KafkaContext {
         gauge!("capture_kafka_callback_queue_depth",).set(stats.replyq as f64);
         gauge!("capture_kafka_producer_queue_depth",).set(stats.msg_cnt as f64);
         gauge!("capture_kafka_producer_queue_depth_limit",).set(stats.msg_max as f64);
-        gauge!("capture_kafka_producer_queue_bytes",).set(stats.msg_max as f64);
+        gauge!("capture_kafka_producer_queue_bytes",).set(stats.msg_size as f64);
         gauge!("capture_kafka_producer_queue_bytes_limit",).set(stats.msg_size_max as f64);
 
         for (topic, stats) in stats.topics {


### PR DESCRIPTION
## Problem

Anyone watching capture's producer memory sees a flat line where the queued-bytes graph should be.

`capture_kafka_producer_queue_bytes` is set from `stats.msg_max`, the ceiling on queued message *count*, instead of `stats.msg_size`, the current queued *bytes*.
The gauge reports a constant, in the wrong unit, and never moves as the queue fills.

The four gauges are meant to pair up as value and ceiling. The third one repeats the second one's field.

```rust
gauge!("capture_kafka_producer_queue_depth",).set(stats.msg_cnt as f64);
gauge!("capture_kafka_producer_queue_depth_limit",).set(stats.msg_max as f64);
gauge!("capture_kafka_producer_queue_bytes",).set(stats.msg_max as f64);       // <- msg_size
gauge!("capture_kafka_producer_queue_bytes_limit",).set(stats.msg_size_max as f64);
```

Two crates carry the same line: `capture` (the default sink path in `create_sink`) and `capture-logs`.

## Changes

- `capture_kafka_producer_queue_bytes` now tracks the bytes actually queued, in both crates.

Two one-line changes, nothing else.

Two existing implementations of this metric already read `msg_size`, which is what makes this a typo rather than a judgment call: the v1 sink context in `capture/src/v1/sinks/kafka/context.rs`, and the Node producer metrics in `nodejs/src/common/kafka/kafka-producer-metrics.ts`.

> [!NOTE]
> Recorded history for this series is meaningless, not merely wrong-by-a-factor: it held the configured `queue.buffering.max.messages` ceiling the whole time.
> Any dashboard panel or alert reading it was reading a constant.

`rdkafka::Statistics` documents the four fields as: `msg_cnt` current queued messages, `msg_size` current queued bytes, `msg_max` maximum messages allowed, `msg_size_max` maximum bytes allowed.

## How did you test this code?

Ran `cargo fmt --check`, `cargo clippy --all-targets`, and `cargo build` for `capture` and `capture-logs`. All clean.

`cargo test -p capture --lib` reports 1213 passed and 5 failed.
The 5 failures are in `event_restrictions::repository::integration_tests` and need Redis, which this environment does not have.
Confirmed pre-existing rather than assumed: stashing this diff and re-running the same filter on pristine master fails the same 5.

No test added. The change substitutes one struct field for another in a metric emission, and a test asserting which field feeds a gauge would restate the line it guards.

Not verified: the live value against a running broker, which needs a Kafka cluster this environment does not have.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. Skills invoked: `/writing-pr-descriptions`.

Found while auditing every librdkafka statistics consumer in the Rust workspace for a queue-forwarding aggregation trap fixed separately in the ingestion consumer.
This is a different defect class — a wrong field, not a wrong aggregation — and the only one the audit found in shipping code.

Nothing in this PR draws on material outside this repository.
