### PR TITLE
fix(dashboards): refresh after AI insight additions

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardHeader.test.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.test.tsx
@@ -10,14 +10,21 @@ import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 import { AccessControlLevel, DashboardMode, DashboardType, QueryBasedInsightModel } from '~/types'
 
-import { DashboardHeader } from './DashboardHeader'
-import { dashboardLogic } from './dashboardLogic'
+import { useMcpToolApplyBack } from 'products/posthog_ai/frontend/api/logics'
+import type { ToolStreamEvent } from 'products/posthog_ai/frontend/types/streamTypes'
+
+import { DashboardHeader, insightIsAddedToDashboard } from './DashboardHeader'
+import { DashboardLoadAction, dashboardLogic } from './dashboardLogic'
 
 jest.mock('lib/components/FullScreen', () => ({
     FullScreen: () => null,
 }))
 jest.mock('scenes/max/MaxTool', () => ({
     MaxTool: ({ children }: any) => <>{children}</>,
+}))
+
+jest.mock('products/posthog_ai/frontend/api/logics', () => ({
+    useMcpToolApplyBack: jest.fn(),
 }))
 
 const MOCK_DASHBOARD: DashboardType<QueryBasedInsightModel> = {
@@ -77,7 +84,8 @@ describe('DashboardHeader', () => {
         dashboardMode?: DashboardMode | null
         dashboardModeSource?: DashboardEventSource
         loading?: boolean
-    }): { logic: ReturnType<typeof dashboardLogic.build> } {
+        spyOnLoadDashboard?: boolean
+    }): { logic: ReturnType<typeof dashboardLogic.build>; loadDashboard?: jest.SpyInstance } {
         const {
             dashboard = MOCK_DASHBOARD,
             dashboardMode = null,
@@ -87,6 +95,9 @@ describe('DashboardHeader', () => {
 
         const logic = dashboardLogic({ id: dashboard?.id ?? MOCK_DASHBOARD.id, dashboard: dashboard ?? undefined })
         logic.mount()
+        const loadDashboard = opts.spyOnLoadDashboard
+            ? jest.spyOn(logic.actions, 'loadDashboard').mockImplementation()
+            : undefined
 
         if (dashboardMode) {
             logic.actions.setDashboardMode(dashboardMode, dashboardModeSource)
@@ -101,7 +112,7 @@ describe('DashboardHeader', () => {
             </BindLogic>
         )
 
-        return { logic }
+        return { logic, loadDashboard }
     }
 
     it('keeps the scene header visible while the dashboard is loading', () => {
@@ -109,6 +120,25 @@ describe('DashboardHeader', () => {
 
         expect(document.querySelector('.scene-title-section')).toBeInTheDocument()
 
+        logic.unmount()
+    })
+
+    it('recognizes sandbox insight calls that add to the open dashboard', () => {
+        expect(insightIsAddedToDashboard({ dashboards: ['5', 8] }, 5)).toBe(true)
+        expect(insightIsAddedToDashboard({ dashboards: [8] }, 5)).toBe(false)
+        expect(insightIsAddedToDashboard({ dashboards: '5' }, 5)).toBe(false)
+    })
+
+    it('reloads the open dashboard when sandbox AI adds an insight to it', () => {
+        const { logic, loadDashboard } = renderHeader({ dashboard: MOCK_DASHBOARD, spyOnLoadDashboard: true })
+        const applyBackOptions = jest
+            .mocked(useMcpToolApplyBack)
+            .mock.calls.map(([options]) => options)
+            .find((options) => options.targetKey === `dashboard:${MOCK_DASHBOARD.id}`)
+
+        applyBackOptions?.onApply({} as ToolStreamEvent, { innerInput: { dashboards: [MOCK_DASHBOARD.id] } })
+
+        expect(loadDashboard).toHaveBeenCalledWith({ action: DashboardLoadAction.Update })
         logic.unmount()
     })
 

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -10,6 +10,8 @@ import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { dashboardsModel } from '~/models/dashboardsModel'
 import { DashboardMode } from '~/types'
 
+import { useMcpToolApplyBack } from 'products/posthog_ai/frontend/api/logics'
+
 import { EditModeActions, FullscreenModeActions, ViewModeActions } from './DashboardHeaderActions'
 import { DashboardLoadAction, dashboardLogic } from './dashboardLogic'
 import { DashboardModals } from './DashboardModals'
@@ -19,12 +21,29 @@ import { DashboardScenePanel } from './DashboardScenePanel'
 export const DASHBOARD_CANNOT_EDIT_MESSAGE =
     "You don't have edit permissions for this dashboard. Ask a dashboard collaborator with edit access to add you."
 
+export function insightIsAddedToDashboard(input: Record<string, unknown> | null, dashboardId: number): boolean {
+    return Array.isArray(input?.dashboards) && input.dashboards.some((id) => Number(id) === dashboardId)
+}
+
 export function DashboardHeader({ loading = false }: { loading?: boolean }): JSX.Element | null {
     const { dashboard, dashboardLoading, dashboardMode, canEditDashboard } = useValues(dashboardLogic)
     const { setDashboardMode, loadDashboard } = useActions(dashboardLogic)
     const { updateDashboard } = useActions(dashboardsModel)
 
     const isLoading = !dashboard && (loading || dashboardLoading)
+
+    // Sandbox PostHog AI adds insights through insight-create/insight-update, rather than the legacy
+    // upsert_dashboard tool. Reload only when that tool explicitly targets the dashboard being viewed.
+    useMcpToolApplyBack({
+        tools: ['insight-create', 'insight-update'],
+        targetKey: `dashboard:${dashboard?.id ?? 'unloaded'}`,
+        active: !!dashboard && canEditDashboard,
+        onApply: (_event, { innerInput }) => {
+            if (dashboard && insightIsAddedToDashboard(innerInput, dashboard.id)) {
+                loadDashboard({ action: DashboardLoadAction.Update })
+            }
+        },
+    })
 
     if (!dashboard && !isLoading) {
         return null


### PR DESCRIPTION
## Problem

People viewing a dashboard do not see a chart added by the sandbox PostHog AI flow until refreshing the page.

## Changes

- Reload the open dashboard after a successful AI insight creation or update that explicitly targets it.
- Keep refreshes scoped to the dashboard named in the tool input.

**Why:** The sandbox AI flow persists chart-to-dashboard changes through insight tools, which were not connected to the dashboard refresh callback.

## How did you test this code?

- `pnpm --filter=@posthog/frontend exec jest --runInBand src/scenes/dashboard/DashboardHeader.test.tsx`
- `pnpm --filter=@posthog/frontend exec tsc --noEmit`

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs update needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Slack app investigated the sandbox tool path and added a scoped dashboard reload with regression coverage.

---

*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B9A53J8RF/p1787153897948719)*