### PR TITLE
fix(stamphog): freeze the clock in the moved engine test

### DIFF
--- a/.github/workflows/ci-security.yaml
+++ b/.github/workflows/ci-security.yaml
@@ -69,6 +69,7 @@ jobs:
                         - '!products/desktop/**'
                         - 'services/llm-gateway/**'
                         - 'services/stripe-mock/**'
+                        - 'tools/**'
                         - '.semgrep/rules/security/**'
                         - '.github/workflows/ci-security.yaml'
                       go:
@@ -173,6 +174,7 @@ jobs:
                       --include /products
                       --include /services/llm-gateway
                       --include /services/stripe-mock
+                      --include /tools
                       --exclude products/desktop
                       --jobs 4
 

--- a/products/stamphog/packages/pr-approval-agent/test_review_local.py
+++ b/products/stamphog/packages/pr-approval-agent/test_review_local.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 import pytest
+from freezegun import freeze_time
 from unittest.mock import MagicMock
 
 # review_local pulls in review_pr, whose reviewer.py imports claude_agent_sdk (installed by
@@ -342,6 +343,7 @@ def test_absent_review_threads_key_is_a_clean_no_op(monkeypatch) -> None:
     assert pr.review_comments == []
 
 
+@freeze_time("2026-01-01T12:00:00Z")
 def test_fresh_trusted_bot_eyes_reach_pr_data_and_flag_in_flight(monkeypatch) -> None:
     # The hosted context now carries raw PR reactions; a fresh 👀 from an allowlisted reviewer bot
     # must reach PRData so the offline WAIT check can fire — hard-coding pr_reactions=[] meant


### PR DESCRIPTION
## Problem

- Master is red. Every push since [#85567](https://github.com/PostHog/posthog/pull/85567) merged fails the Security workflow, so a real security finding is now hidden behind a standing one.
- The `semgrep-python` job reports one blocking finding: a `datetime.now(UTC)` call in a stamphog engine test with no `freeze_time`, which the repo's `test-datetime-now-without-freeze` rule refuses.
- The violation predates that PR. It sat at `tools/pr-approval-agent/test_review_local.py`, and `semgrep-python` scans `/products` but not `/tools`, so the rule never saw it.
- Nothing under `tools/` has ever been scanned with the python pack or the repo's custom security rules. `semgrep-general` reaches the directory but carries neither ruleset.
- The move PR passed its own checks because `semgrep ci` runs diff-aware on pull requests. The baseline scan found the identical match at the old path and dropped it as pre-existing. A push has no baseline, so the full scan reports it.

## Changes

- `test_fresh_trusted_bot_eyes_reach_pr_data_and_flag_in_flight` now runs under `@freeze_time`, so its reaction timestamps come from a frozen clock. This unblocks master.
- `semgrep-python` now scans `tools/`, so a Python security or convention violation there fails CI instead of shipping.
- `tools/` stays in `semgrep-general` as well, because it holds Go and TypeScript too. `bin/` is already covered by both jobs for the same reason.
- Nothing user-visible changes. The test asserts the same behavior on the same inputs.

> [!NOTE]
> The other half of the gap stays open. Diff-aware scans still treat code moving into a scanned path as pre-existing, so a move can carry a violation past a green PR.

## How did you test this code?

- Ran the `semgrep-python` job's full ruleset against `tools/` with semgrep 1.167.0, the version CI pins: 0 findings over 256 files. So the wider scan does not turn master red again.
- Ran the same version with `test-no-datetime-now.yaml` against the changed test file: 0 findings.
- Ran `hogli lint:workflows`, which passed all 8 checks including `WF004-semgrep-services-coverage`.
- Ran the stamphog engine test file locally against the repo venv.
- Not run: the `semgrep-python` scan over the whole tree, and the diff-aware path, which needs a real PR baseline.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated and written by the PostHog Slack app from a Slack thread reporting master red. The requester is the DRI. The PR is left unassigned because a GitHub handle could not be verified from the thread.

Skills invoked: `/writing-pr-descriptions`.

Two decisions worth a reviewer's attention. The first draft deleted the real clock read; freezing it was chosen instead, because the test models a fresh reaction and the timestamp is the input under test. The `tools/` scan was added after the thread asked whether the directory should be covered, and `tools/` was deliberately left in `semgrep-general` rather than excluded, so its Go and TypeScript files keep their coverage.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AS64N6DJL/p1787225125290779?thread_ts=1787225125.290779&cid=C0AS64N6DJL)*
