### PR TITLE
fix(workflows): drop stale hogFunctionState when rehydrating reruns

### DIFF
--- a/nodejs/src/cdp/rerun/rerun-paginator.replay-fidelity.test.ts
+++ b/nodejs/src/cdp/rerun/rerun-paginator.replay-fidelity.test.ts
@@ -16,7 +16,10 @@ import { RerunPaginatorService } from './rerun-paginator.service'
 // where the executor resumes from. If rerun rehydration dropped it, the flow
 // would restart from the trigger and re-send emails that already went out. These
 // tests pin the fix: the rehydrated invocation carries `currentAction` forward,
-// so replay resumes after the already-completed actions.
+// so replay resumes after the already-completed actions — but WITHOUT its parked
+// `hogFunctionState`, whose `globals.inputs` was stripped on persist; restoring
+// it verbatim skips the input re-render and message actions then fail with
+// "No recipient identifier found".
 describe('RerunPaginatorService replay fidelity (hog_flow)', () => {
     const teamId = 42
     const functionId = 'flow-1'
@@ -78,8 +81,17 @@ describe('RerunPaginatorService replay fidelity (hog_flow)', () => {
             event: { uuid: 'evt-1', distinct_id: 'd-1', properties: {}, timestamp: '2026-06-01T09:00:00Z' },
             actionStepCount: 3,
             variables: { ticket_id: '123' },
-            // The flow had already advanced to (and parked at) the wait step.
-            currentAction: { id: 'wait_condition', startedAtTimestamp: 999 },
+            // The flow had already advanced to (and parked at) this action. The parked
+            // hogFunctionState is stored as `stripInputs` wrote it: `globals.inputs` gone.
+            currentAction: {
+                id: 'send_email',
+                startedAtTimestamp: 999,
+                hogFunctionState: {
+                    globals: { event: { uuid: 'evt-1' }, source: { name: 'Email', url: '' } },
+                    timings: [],
+                    attempts: 0,
+                },
+            },
             personId: 'person-1',
         }
         const rows = [
@@ -106,8 +118,10 @@ describe('RerunPaginatorService replay fidelity (hog_flow)', () => {
         expect(opts).toEqual({ overwriteExisting: true })
         const invocation = enqueued[0] as CyclotronJobInvocationHogFlow
         expect(invocation.id).toBe('inv-1')
-        // The resume point and per-actor context survive the round-trip.
-        expect(invocation.state?.currentAction).toEqual(persistedState.currentAction)
+        // The resume point and per-actor context survive the round-trip, but the
+        // input-stripped hogFunctionState does not — the action re-enters fresh so
+        // inputs re-render against the current config instead of the stale snapshot.
+        expect(invocation.state?.currentAction).toEqual({ id: 'send_email', startedAtTimestamp: 999 })
         expect(invocation.state?.personId).toBe('person-1')
         expect(invocation.state?.actionStepCount).toBe(3)
         expect(invocation.state?.variables).toEqual({ ticket_id: '123' })

--- a/nodejs/src/cdp/rerun/rerun-paginator.service.ts
+++ b/nodejs/src/cdp/rerun/rerun-paginator.service.ts
@@ -787,6 +787,16 @@ export class RerunPaginatorService {
                 hogFlow,
                 filterGlobals
             )
+            // The parked per-action hog function state is not replayable:
+            // `stripInputs` removed its `globals.inputs` (resolved secrets)
+            // before the row was written, and `buildHogFunctionInvocation`
+            // reuses a present `hogFunctionState` verbatim instead of
+            // re-rendering inputs — a message action resumed with it fails
+            // with "No recipient identifier found". Dropping it makes the
+            // action re-enter fresh, so inputs re-render against the current
+            // config, which is what a rerun intends anyway.
+            const { hogFunctionState: _stripped, ...restoredCurrentAction } = persistedState.currentAction ?? {}
+
             invocation.id = row.invocation_id
             invocation.parentRunId = row.parent_run_id || null
             invocation.state = {
@@ -802,7 +812,9 @@ export class RerunPaginatorService {
                 // wait_until_condition the janitor gave up on) resume safely.
                 // `personId` is carried for the same reason — the worker needs it
                 // to reload person data for batch/manual triggers on resume.
-                currentAction: persistedState.currentAction,
+                currentAction: persistedState.currentAction
+                    ? (restoredCurrentAction as CyclotronJobInvocationHogFlow['state']['currentAction'])
+                    : undefined,
                 personId: persistedState.personId,
                 // Sticky rerun counter — mirror the hog function path so the
                 // lifecycle row producer can derive `attempts` / `is_retry`


### PR DESCRIPTION
## Problem

Replaying a failed workflow run only works if the run died before its email step got parked. A run that failed mid-email-send — the common case in the recent replay batches — resumes at the email action and immediately dies again with "No recipient identifier found for message action…", even though the person and their email address are fine.

Root cause: the failed run's lifecycle row stores the flow state with every `inputs` key stripped (resolved secrets, see `stripInputs`). The rerun paginator restored `currentAction` verbatim, stripped `hogFunctionState` included. `buildHogFunctionInvocation` treats a present `hogFunctionState` as "inputs already rendered" and skips the rebuild, so the recipient gate reads `globals.inputs.email.to.email` from a state that has no `inputs` at all and throws.

## Changes

- Rerun rehydration now drops the parked `hogFunctionState` from the restored `currentAction`. The action re-enters fresh and re-renders inputs against the current config — the behavior the rerun design already promises for plain hog functions.
- The resume point itself (`currentAction.id`, `startedAtTimestamp`) still survives, so completed actions are not re-run and already-sent emails stay sent.
- No backfill needed: the stored rows were always fine, only rehydration misread them. Re-running the affected runs after deploy just works.

## How did you test this code?

- Extended the replay-fidelity jest test: the persisted `currentAction` now carries an input-stripped `hogFunctionState` (exactly as the producer writes it), and the assertion pins that the resume point survives while the stale state is dropped. Verified the test fails against the unfixed paginator and passes with the fix — it is exactly the shipped regression.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code. Skills invoked: /writing-tests, /writing-pr-descriptions. Root cause traced from customer-visible rerun logs through the persist path (`stripInputs`) and the rehydrate path (`rerun-paginator`) to the input-rebuild skip in `buildHogFunctionInvocation`. No customer identifiers in the diff or this description.
