### PR TITLE
feat(autoresearch): add the dataset layer (6/13)

### DIFF
--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -48,6 +48,7 @@ def is_api_key_access_method(access_method: AccessMethod | str | None) -> bool:
 
 class Product(StrEnum):
     API = "api"
+    AUTORESEARCH = "autoresearch"
     BATCH_EXPORT = "batch_export"
     COHORTS = "cohorts"
     CONVERSATIONS = "conversations"

--- a/products/autoresearch/backend/dataset/AGENTS.md
+++ b/products/autoresearch/backend/dataset/AGENTS.md
@@ -1,0 +1,68 @@
+# Dataset
+
+What the prediction problem actually _is_: who is in the population, what counts as a positive example, and whether the question is answerable at all.
+
+This package landed ahead of its callers. `../training/`, `../inference/`, and `../api/` arrive in later pieces of the split tracked in [#60081](https://github.com/PostHog/posthog/pull/60081), so the references to them below describe where they will sit.
+
+Nothing here trains or scores anything. It is the shared vocabulary that `../training/` and `../inference/` both compile against — which is the whole point. If the trainer and the scorer disagreed about what a row means, the resulting model would be quietly wrong rather than loudly broken.
+
+## What lives here
+
+- `labeling.py`
+  The single source of truth for "what does a training example look like?", and the most load-bearing module in the product.
+
+  A training example is a `(person, T0, label)` triple: pick an anchor time `T0` for a person, then `label = 1` if the target event fires in `[T0, T0 + horizon_days)`.
+  `T0` is a **deterministic hash of `person_id`**, so it is stable across runs and spread across the full lookback rather than clustered at the most-recent feasible point — one row per person, sampled once in their history.
+
+  Three call sites share this module so they cannot drift: the wizard's live estimate (sampled), the trainer (full materialization with fold split), and inference (per-person cutoff = `now()`).
+  That is why the training-side `labeled_anchors` CTE (inside `build_training_features_sql()`) and `build_inference_anchors_sql()` live here rather than next to their callers.
+
+  Also here: `_build_population_conditions()` (property filters → HogQL), `_build_population_kind_conditions()` (semantic population kinds → HogQL, see below), `build_target_condition()` (event or action target → predicate), `NUM_FOLDS = 5` with fold 0 as holdout, and `IDENTIFIED_USERS_ONLY`.
+
+- `validation.py`
+  Pre-flight viability. `validate_pipeline_definition()` answers "is there enough here to learn anything?" before a run is launched — `MIN_TRAINING_ROWS` (100), `MIN_POSITIVE_EXAMPLES` (20), `MIN_IDENTIFIED_FRACTION` (0.5).
+  Returns a `ValidationResult` carrying `ValidationWarning`s rather than raising, because the API surfaces them as advice.
+- `templates.py`
+  Built-in starting points. A template resolves to the same pipeline config shape as a fully custom pipeline, so creation and validation behave identically either way — there is no separate template code path downstream.
+  Population specs use a semantic format (`performed_event_within_days`, `person_first_seen_within_days`, `active_not_performed_target`, `ever_performed_event`) that is compiled to HogQL by `labeling.py`.
+  `resolve_activity_event()` picks the team's real activity event, preferring `$pageview` → `$screen` → `$autocapture`, because "active user" means different things on web and mobile.
+
+## Mental model
+
+A pipeline definition is declarative. This package is what turns it into SQL.
+
+```text
+pipeline (target, population, horizon, lookback)
+   │
+   ├─ build_training_features_sql  → labeled_anchors CTE: one T0 per person, hashed,
+   │    └─ + labels + fold             spread over lookback — the trainer's labeled population
+   │
+   └─ build_inference_anchors_sql  → cutoff = now(), no labels, no folds
+        └─ the scorer's population
+```
+
+The two branches differ only in cutoff and whether labels and folds are attached. Everything else — population filters, identified-user restriction, target predicate — is shared code, deliberately.
+
+## Things that bite
+
+- **`IDENTIFIED_USERS_ONLY` is on.** Autoresearch trains on identified users only, so raw event counts badly overstate available training data on anonymous-heavy datasets. A target with thousands of events can yield a few dozen usable rows.
+- **Validation is advisory, not enforcing.** `autoresearch_train` does not call it. A target that fails on volume will still train — deliberately, so thin local datasets are workable, but it means "the run completed" does not mean "the data was sufficient."
+- **Random `T0` is a modeling decision, not an implementation detail.** Spreading anchors across the lookback keeps the model from over-fitting to one moment in calendar time. Changing it to most-recent-feasible would change what every model in the product means.
+- **Everything keys on `person_id`.** See `../inference/AGENTS.md` for what goes wrong when a caller keys on `distinct_id` instead — it fails silently.
+
+## Where the rest of the system meets this package
+
+- **Trainer** — `../training/` materializes the labeled population from `build_training_features_sql()`.
+- **Scorer** — `../inference/` materializes the unlabeled population from `build_inference_features_sql()`.
+- **API** — `../api/views.py` calls `validate_pipeline_definition()` for the pre-create check and `resolve_template()` for template-backed creation; `resolve_target()` lives in `../api/serializers.py` and pairs with `build_target_condition()`.
+- **Command** — `autoresearch_validate` is the headless entry to `validation.py`.
+- **Agent-authored SQL** — the agent's `feature_sql` is spliced against these anchors via `_substitute_anchors()`. The `{anchors}` placeholder is part of the agent's contract, so it is documented in the brief in `../training/runner.py`.
+
+## When editing this flow
+
+- **Any change to what a row means goes here and only here.** If you add a cutoff rule, a population kind, or a label variant next to a caller instead, the trainer and scorer will drift and the failure will be silent.
+- Keep the training-side `labeled_anchors` CTE and `build_inference_anchors_sql()` symmetrical. They should differ in cutoff, labels, and folds — nothing else.
+- New population kinds need the semantic spec in `templates.py`, the compiler branch in `_build_population_kind_conditions()` in `labeling.py`, and the required-key rules in the `PopulationDefinitionField` validator in `../api/serializers.py`. `POPULATION_KINDS` in `labeling.py` is the shared registry; a kind missing its compiler branch is rejected at creation and raises at query time.
+- Target-relative population kinds are evaluated **per user at T0** during training (the `HAVING` refinement in the labeled CTE), and **as of the cutoff** at inference. Excluding "ever performed the target" users with a plain row filter at training time would delete exactly the users whose post-T0 adoption provides the positive labels.
+- Fold 0 is the holdout everywhere. If you change `NUM_FOLDS` or the holdout fold, every recorded `holdout_score` in the database becomes incomparable to new ones.
+- **If you change the anchor, label, or population contract, update this file to match.**

--- a/products/autoresearch/backend/dataset/CLAUDE.md
+++ b/products/autoresearch/backend/dataset/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/products/autoresearch/backend/dataset/labeling.py
+++ b/products/autoresearch/backend/dataset/labeling.py
@@ -1,0 +1,695 @@
+"""
+Labeling: build (user, T0, label) triples for horizon-based prediction.
+
+Single source of truth for "what does a training example look like?" Used by
+the wizard's live estimate (sampled), the trainer (full materialization with
+fold split), and inference (per-user cutoff = now). The three call sites share
+this module so they cannot drift apart — the wizard previews the same labels
+the trainer will actually see, and inference scores against the same cutoff
+contract the feature SQL was trained against.
+
+Strategy: random T0 per user (deterministic hash of person_id), one row per
+user. Each user is sampled at a single point in their history; label = whether
+the target event fires in [T0, T0 + horizon_days). Random T0 (rather than
+most-recent-feasible) keeps T0s spread across the full lookback so the model
+generalises across time, not just the trailing horizon window.
+
+Per-user T0 cascades through the rest of the ML pipeline:
+- Feature SQL must read events with `timestamp < cutoff_ts` per user, where
+  cutoff_ts comes from a joined anchors table (the labeled_anchors CTE at
+  training time, build_inference_anchors_sql at scoring time).
+- Holdout split is by user (fold = hash(person_id) % 5) so the same person
+  never appears in both train and holdout.
+- Inference re-uses the same feature SQL with anchors = (person_id, now()).
+
+Integer handling notes:
+- toUnixTimestamp returns UInt32; we cast to Int64 via toInt so subtractions
+  and modulo work in signed space (HogQL exposes toInt → Int64; toUInt* is
+  unsupported).
+- cityHash64 returns UInt64. Casting directly to Int64 can flip sign when the
+  high bit is set, which would make `% positive` return negative offsets and
+  place T0 before first_ts. Truncating to the lower 31 bits via bitAnd
+  guarantees a non-negative dividend without harming uniformity (we only need
+  ~24 bits anyway: max window 365d * 86400s ≈ 3.2e7).
+"""
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Literal
+
+import structlog
+
+from posthog.hogql.property import action_to_expr
+
+from products.actions.backend.models.action import Action
+
+if TYPE_CHECKING:
+    from posthog.models import Team
+
+logger = structlog.get_logger(__name__)
+
+# Number of folds for hash-based train/holdout split. fold == 0 → holdout (20%).
+NUM_FOLDS = 5
+
+# Semantic population kinds produced by templates.py. Every kind listed here must have a
+# compiler branch in _build_population_kind_conditions below — the write-time validator in
+# api/serializers.py imports this set, so an uncompilable kind is rejected at creation.
+POPULATION_KINDS = frozenset(
+    {
+        "performed_event_within_days",
+        "person_first_seen_within_days",
+        "active_not_performed_target",
+        "ever_performed_event",
+    }
+)
+
+# v1 scope: autoresearch models identified users only. Identified persons carry a
+# stable real distinct_id, so scoring-time identity resolution always succeeds and the
+# prediction event + output person property land on the right person — no phantom,
+# person-less, or v5↔v7 edge cases. Anonymous / pre-signup populations (e.g.
+# anonymous → signup) are deferred to v2. This is a hard limit baked into every
+# population query; flip to False to relax — the rest of the pipeline is
+# population-agnostic.
+IDENTIFIED_USERS_ONLY = True
+
+
+def _identified_users_and_clause() -> str:
+    """`AND person.is_identified` fragment for an events-table WHERE, or '' when the
+    v1 identified-only scope is disabled. The events table must be unaliased at the
+    call site (or aliased so that ``person`` still resolves via the lazy join)."""
+    return " AND person.is_identified" if IDENTIFIED_USERS_ONLY else ""
+
+
+def _build_population_conditions(
+    properties: list[dict[str, Any]],
+) -> tuple[list[str], dict[str, Any]]:
+    """
+    Translate a list of PostHog property filter dicts into HogQL WHERE condition
+    strings and a values dict for parameterized binding.
+
+    Property types:
+    - "person"  → person.properties[<key>]  (events table context)
+    - "event"   → properties[<key>]
+
+    Operators: exact, is_not, icontains, not_icontains, gt, gte, lt, lte,
+               is_set, is_not_set.
+
+    The property key is bound as a HogQL value (a parameterized subscript,
+    ``properties[{param}]``) rather than interpolated into the query text, so any
+    key — including PostHog system properties like ``$browser`` — is safe without
+    an allowlist. Unsupported types/operators are skipped with a warning rather
+    than raising. Lives in labeling.py (not inference.py) because labeling.py is
+    the lower-level SQL-building layer that inference.py and validation.py both
+    depend on.
+    """
+    parts: list[str] = []
+    values: dict[str, Any] = {}
+
+    for i, prop in enumerate(properties):
+        key = prop.get("key")
+        prop_type = prop.get("type", "person")
+        operator = prop.get("operator", "exact")
+        value = prop.get("value")
+
+        if not key:
+            logger.warning("autoresearch_population_missing_key", key=key)
+            continue
+
+        if prop_type == "person":
+            map_expr = "person.properties"
+        elif prop_type == "event":
+            map_expr = "properties"
+        else:
+            logger.warning("autoresearch_population_unsupported_prop_type", prop_type=prop_type)
+            continue
+
+        # Bind the key as a value (parameterized subscript) — never interpolate it into SQL text.
+        key_param = f"pop_k_{i}"
+        values[key_param] = str(key)
+        field = f"{map_expr}[{{{key_param}}}]"
+
+        param = f"pop_{i}"
+
+        if operator == "is_set":
+            parts.append(f"isNotNull({field}) AND {field} != ''")
+        elif operator == "is_not_set":
+            parts.append(f"(isNull({field}) OR {field} = '')")
+        elif operator == "exact":
+            if isinstance(value, list):
+                in_params = [f"pop_{i}_{j}" for j in range(len(value))]
+                for j, v in enumerate(value):
+                    values[f"pop_{i}_{j}"] = v
+                in_refs = ", ".join("{" + p + "}" for p in in_params)
+                parts.append(f"{field} IN ({in_refs})")
+            else:
+                values[param] = value
+                parts.append(f"{field} = {{{param}}}")
+        elif operator == "is_not":
+            if isinstance(value, list):
+                in_params = [f"pop_{i}_{j}" for j in range(len(value))]
+                for j, v in enumerate(value):
+                    values[f"pop_{i}_{j}"] = v
+                in_refs = ", ".join("{" + p + "}" for p in in_params)
+                parts.append(f"{field} NOT IN ({in_refs})")
+            else:
+                values[param] = value
+                parts.append(f"{field} != {{{param}}}")
+        elif operator == "icontains":
+            values[param] = f"%{value}%"
+            parts.append(f"{field} ILIKE {{{param}}}")
+        elif operator == "not_icontains":
+            values[param] = f"%{value}%"
+            parts.append(f"{field} NOT ILIKE {{{param}}}")
+        elif operator in ("gt", "gte", "lt", "lte"):
+            op_sql = {"gt": ">", "gte": ">=", "lt": "<", "lte": "<="}[operator]
+            values[param] = value
+            parts.append(f"toFloat64OrNull({field}) {op_sql} {{{param}}}")
+        else:
+            logger.warning("autoresearch_population_unsupported_operator", operator=operator)
+
+    return parts, values
+
+
+@dataclass(frozen=True, kw_only=True)
+class _CompiledPopulationKind:
+    where_parts: list[str] = field(default_factory=list)
+    values: dict[str, Any] = field(default_factory=dict)
+    # Training-only refinement applied per user at T0 in the labeled_users CTE:
+    # "performed_before" keeps only users who performed the target before their T0,
+    # "not_performed_before" keeps only users who had not. None = fully expressed in where_parts.
+    anchor_target_relation: Literal["performed_before", "not_performed_before"] | None = None
+
+
+def _build_population_kind_conditions(
+    population: dict[str, Any] | None,
+    *,
+    now_expr: str = "now()",
+    anchor_mode: bool = False,
+) -> _CompiledPopulationKind:
+    """
+    Compile a semantic population spec (``{"kind": ..., ...}``, produced by
+    templates.py) into row-level HogQL WHERE fragments for an events scan.
+
+    Membership subqueries are bounded to the caller's lookback window, so
+    "ever performed" and "has not performed" mean "within the lookback window" —
+    the scan cost stays proportional to the data the query already reads. The
+    emitted fragments reference the ``{lookback}`` bound value, which every
+    population-consuming builder in this module binds.
+
+    ``now_expr`` is the anchor instant — ``now()`` for live queries, or a bound
+    backfill cutoff expression for historical scoring. All time windows are
+    computed relative to it.
+
+    ``anchor_mode=True`` (training) moves the target-performed test from a
+    row-level filter to a per-user-at-T0 refinement via ``anchor_target_relation``,
+    which ``_build_labeled_users_cte`` applies against each user's T0. This matters
+    for correctness, not just fidelity: excluding "ever performed the target" users
+    with a row filter at training time would remove exactly the users whose post-T0
+    adoption provides the positive labels.
+
+    Raises ValueError on an unknown kind or a spec missing a required key — a
+    population that cannot be compiled must fail loudly rather than silently
+    widening to "all users".
+    """
+    spec = population or {}
+    kind = spec.get("kind")
+    if kind is None:
+        return _CompiledPopulationKind()
+    if kind not in POPULATION_KINDS:
+        raise ValueError(f"Unknown population kind '{kind}'. Supported: {', '.join(sorted(POPULATION_KINDS))}")
+
+    def _positive_int(key: str) -> int:
+        raw = spec.get(key)
+        if not isinstance(raw, int) or isinstance(raw, bool) or raw <= 0:
+            raise ValueError(f"Population kind '{kind}' requires a positive integer '{key}'")
+        return raw
+
+    def _event() -> str:
+        raw = spec.get("event")
+        if not raw or not isinstance(raw, str):
+            raise ValueError(f"Population kind '{kind}' requires an 'event'")
+        return raw
+
+    parts: list[str] = []
+    values: dict[str, Any] = {}
+    anchor_target_relation: Literal["performed_before", "not_performed_before"] | None = None
+
+    if kind == "performed_event_within_days":
+        values["popk_days"] = _positive_int("days")
+        event_clause = ""
+        if spec.get("event"):
+            values["popk_event"] = _event()
+            event_clause = " AND event = {popk_event}"
+        parts.append(
+            "person_id IN (SELECT DISTINCT person_id FROM events"
+            f" WHERE timestamp >= {now_expr} - toIntervalDay({{popk_days}})"
+            f" AND timestamp < {now_expr}{event_clause})"
+        )
+    elif kind == "person_first_seen_within_days":
+        values["popk_days"] = _positive_int("days")
+        parts.append(f"person.created_at >= {now_expr} - toIntervalDay({{popk_days}})")
+    elif kind == "active_not_performed_target":
+        values["popk_active_days"] = _positive_int("active_within_days")
+        parts.append(
+            "person_id IN (SELECT DISTINCT person_id FROM events"
+            f" WHERE timestamp >= {now_expr} - toIntervalDay({{popk_active_days}})"
+            f" AND timestamp < {now_expr})"
+        )
+        if anchor_mode:
+            anchor_target_relation = "not_performed_before"
+        else:
+            values["popk_event"] = _event()
+            parts.append(
+                "person_id NOT IN (SELECT DISTINCT person_id FROM events"
+                f" WHERE event = {{popk_event}} AND timestamp >= {now_expr} - toIntervalDay({{lookback}})"
+                f" AND timestamp < {now_expr})"
+            )
+    elif kind == "ever_performed_event":
+        values["popk_event"] = _event()
+        parts.append(
+            "person_id IN (SELECT DISTINCT person_id FROM events"
+            f" WHERE event = {{popk_event}} AND timestamp >= {now_expr} - toIntervalDay({{lookback}})"
+            f" AND timestamp < {now_expr})"
+        )
+        if anchor_mode:
+            # The row filter is a cheap superset (performed within lookback as of now);
+            # the anchor refinement narrows it to "performed before this user's T0".
+            anchor_target_relation = "performed_before"
+
+    return _CompiledPopulationKind(where_parts=parts, values=values, anchor_target_relation=anchor_target_relation)
+
+
+def build_target_condition(
+    *,
+    target_event: str,
+    target_definition: dict[str, Any] | None,
+    team: "Team | None",
+) -> tuple[str, dict[str, Any]]:
+    """
+    Build the HogQL boolean fragment deciding whether a single events-table row
+    matches the prediction target, plus any bound parameter values.
+
+    The target is the only place an event target and an action target differ —
+    features, scoring, and inference are all target-agnostic. Two shapes:
+      - event target  → ``event = {target}`` (one bound value).
+      - action target → the action's matcher compiled via ``action_to_expr`` and
+        printed back to a self-contained HogQL fragment. The printer inlines and
+        escapes constants, so the action path needs no extra bound values.
+
+    ``target_definition`` selects the shape: ``{"type": "action", "action_id": N}``
+    routes to the action path; anything else (empty, the default, or
+    ``{"type": "event"}``) uses ``target_event``.
+
+    The compiled fragment references events-table columns unqualified (``event``,
+    ``properties``, ``elements_chain``). Every call site embeds it where those
+    columns resolve to the events table — the labeler join (``events e`` plus a
+    person-keyed anchors table that exposes none of them) and the realized-label
+    query (``FROM events``) — so the absent table alias is intentional and safe.
+    """
+    definition = target_definition or {}
+    if definition.get("type") == "action":
+        action_id = definition.get("action_id")
+        if action_id is None:
+            raise ValueError("Action target requires 'action_id' in target_definition")
+        if team is None:
+            raise ValueError("Action target requires a team to resolve the action")
+        # Scope the lookup to the pipeline's team so a foreign action id can't leak across tenants.
+        action = Action.objects.get(id=action_id, team=team)
+        return f"({action_to_expr(action).to_hogql()})", {}
+    return "event = {target}", {"target": target_event}
+
+
+def _build_labeled_users_cte(
+    *,
+    target_event: str,
+    target_definition: dict[str, Any] | None,
+    team: "Team | None",
+    horizon_days: int,
+    lookback_days: int,
+    training_population: dict[str, Any] | None,
+    sample_limit: int | None,
+) -> tuple[str, dict[str, Any]]:
+    """
+    Build the WITH clause that materialises the labeled_users table:
+        labeled_users(person_id, t0_ts, positive)
+    Caller appends `SELECT ... FROM labeled_users` to use it.
+
+    sample_limit caps user_window for fast wizard previews; None = full
+    materialization (trainer).
+    """
+    training_properties = (training_population or {}).get("properties", []) if training_population else []
+    train_parts, train_values = _build_population_conditions(training_properties)
+    compiled_kind = _build_population_kind_conditions(training_population, anchor_mode=True)
+    all_parts = train_parts + compiled_kind.where_parts
+    training_clause = f" AND ({' AND '.join(all_parts)})" if all_parts else ""
+    identified_clause = _identified_users_and_clause()
+    # A bare LIMIT would hand back whatever ClickHouse reads first, which correlates with
+    # storage order; the sampled base rate is extrapolated to the whole population, so order
+    # by a uniform hash of the person to make the sample representative and reproducible.
+    limit_clause = (
+        f"\n              ORDER BY cityHash64(toString(person_id))\n              LIMIT {int(sample_limit)}"
+        if sample_limit is not None
+        else ""
+    )
+    target_cond, target_values = build_target_condition(
+        target_event=target_event, target_definition=target_definition, team=team
+    )
+
+    # Per-user-at-T0 population refinement for target-relative kinds (see
+    # _build_population_kind_conditions): membership is decided against each
+    # user's own T0, exactly as inference decides it against its cutoff.
+    anchor_having = ""
+    if compiled_kind.anchor_target_relation is not None:
+        wanted = 1 if compiled_kind.anchor_target_relation == "performed_before" else 0
+        anchor_having = (
+            f"\n              HAVING max(({target_cond}) AND toInt(toUnixTimestamp(e.timestamp)) < u.t0_ts) = {wanted}"
+        )
+
+    cte = f"""
+        WITH user_window AS (
+            SELECT
+                person_id,
+                toInt(toUnixTimestamp(min(timestamp))) AS first_ts,
+                toInt(toUnixTimestamp(now() - toIntervalDay({{horizon}}))) AS cutoff_ts
+            FROM events
+            WHERE timestamp >= now() - toIntervalDay({{lookback}})
+              AND timestamp < now(){training_clause}{identified_clause}
+            GROUP BY person_id
+            HAVING first_ts < cutoff_ts{limit_clause}
+        ),
+        user_t0 AS (
+            SELECT
+                person_id,
+                first_ts
+                  + (toInt(bitAnd(cityHash64(toString(person_id)), 2147483647)) % (cutoff_ts - first_ts))
+                  AS t0_ts
+            FROM user_window
+        ),
+        labeled_users AS (
+            SELECT
+                u.person_id AS person_id,
+                u.t0_ts AS t0_ts,
+                max(
+                    {target_cond}
+                    AND toInt(toUnixTimestamp(e.timestamp)) >= u.t0_ts
+                    AND toInt(toUnixTimestamp(e.timestamp)) < u.t0_ts + ({{horizon}} * 86400)
+                ) AS positive
+            FROM events e
+            INNER JOIN user_t0 u ON e.person_id = u.person_id
+            WHERE e.timestamp >= now() - toIntervalDay({{lookback}})
+              AND e.timestamp < now()
+            GROUP BY u.person_id, u.t0_ts{anchor_having}
+        )
+    """
+    values: dict[str, Any] = {
+        "horizon": horizon_days,
+        "lookback": lookback_days,
+        **target_values,
+        **train_values,
+        **compiled_kind.values,
+    }
+    return cte, values
+
+
+def build_random_t0_labeler_sql(
+    *,
+    target_event: str,
+    horizon_days: int,
+    lookback_days: int,
+    training_population: dict[str, Any] | None,
+    sample_limit: int | None = None,
+    target_definition: dict[str, Any] | None = None,
+    team: "Team | None" = None,
+) -> tuple[str, dict[str, Any]]:
+    """
+    Build a HogQL query that returns one row of (eligible, positives) for a
+    random-T0-per-user labeler. Used by the wizard for live base-rate feedback.
+
+    eligible: users in the training_population with at least one event before
+              now - horizon_days (so a horizon window fits in the data).
+    positives: of those, users who fire target_event in [T0, T0 + horizon).
+
+    With sample_limit=None this gives the trainer's actual eligible count;
+    with sample_limit=N it gives an unbiased estimator computed over N users.
+    """
+    cte, values = _build_labeled_users_cte(
+        target_event=target_event,
+        target_definition=target_definition,
+        team=team,
+        horizon_days=horizon_days,
+        lookback_days=lookback_days,
+        training_population=training_population,
+        sample_limit=sample_limit,
+    )
+    sql = f"""
+        {cte}
+        SELECT
+            count() AS eligible,
+            sum(positive) AS positives
+        FROM labeled_users
+    """
+    return sql, values
+
+
+def build_eligible_count_sql(
+    *,
+    horizon_days: int,
+    lookback_days: int,
+    training_population: dict[str, Any] | None,
+) -> tuple[str, dict[str, Any]]:
+    """
+    Build a HogQL query returning the count of users eligible to be labeled by the
+    random-T0 labeler — i.e. users in the training_population with at least one event
+    before now - horizon_days. Used as the UI headline number so the wizard reports
+    the full population size, not the sampled subset.
+
+    Returns two columns: ``eligible`` (the v1 headline — restricted to identified
+    users when IDENTIFIED_USERS_ONLY is on) and ``eligible_all`` (the same count
+    without the identified restriction). The caller divides the two to detect a
+    mostly-anonymous population and warn that v1 excludes the anonymous remainder.
+    """
+    training_properties = (training_population or {}).get("properties", []) if training_population else []
+    train_parts, train_values = _build_population_conditions(training_properties)
+    # Row mode: the target-relative kinds are evaluated as of now() here, which is an
+    # approximation of the trainer's per-user-at-T0 semantics — acceptable for an
+    # advisory headline count.
+    compiled_kind = _build_population_kind_conditions(training_population)
+    all_parts = train_parts + compiled_kind.where_parts
+    training_clause = f" AND ({' AND '.join(all_parts)})" if all_parts else ""
+
+    horizon_cond = "timestamp < now() - toIntervalDay({horizon})"
+    eligible_cond = f"{horizon_cond} AND person.is_identified" if IDENTIFIED_USERS_ONLY else horizon_cond
+
+    sql = f"""
+        SELECT
+            countDistinctIf(person_id, {eligible_cond}) AS eligible,
+            countDistinctIf(person_id, {horizon_cond}) AS eligible_all
+        FROM events
+        WHERE timestamp >= now() - toIntervalDay({{lookback}})
+          AND timestamp < now(){training_clause}
+    """
+    values: dict[str, Any] = {
+        "horizon": horizon_days,
+        "lookback": lookback_days,
+        **train_values,
+        **compiled_kind.values,
+    }
+    return sql, values
+
+
+def build_inference_anchors_sql(
+    *,
+    lookback_days: int,
+    inference_population: dict[str, Any] | None,
+    cutoff_ts: int | None = None,
+) -> tuple[str, dict[str, Any]]:
+    """
+    Build a HogQL query producing (person_id, cutoff_ts) rows for scoring.
+
+    cutoff_ts defaults to now() for every row — at inference time we score "the
+    user's state as of right now." Pass an explicit ``cutoff_ts`` (unix seconds)
+    to backfill a historical prediction date: features are then computed strictly
+    before that instant, exactly as live scoring would have on that day. Eligible
+    = users in inference_population with at least one event in the lookback_days
+    window before the cutoff (so there's signal to score on).
+
+    Substituted as the {anchors} table when running the agent's feature_sql
+    at inference time. Same SQL the trainer executed against per-user T0;
+    only the anchors table changes.
+    """
+    inference_properties = (inference_population or {}).get("properties", []) if inference_population else []
+    inf_parts, inf_values = _build_population_conditions(inference_properties)
+
+    # now() for live scoring; a bound, backdated instant for a historical backfill.
+    cutoff_expr = "fromUnixTimestamp({cutoff_ts})" if cutoff_ts is not None else "now()"
+    cutoff_select = "toInt({cutoff_ts})" if cutoff_ts is not None else "toInt(toUnixTimestamp(now()))"
+
+    # Row mode anchored at the cutoff: population membership is decided as of the
+    # scoring instant, mirroring how training decides it as of each user's T0.
+    compiled_kind = _build_population_kind_conditions(inference_population, now_expr=cutoff_expr)
+    all_parts = inf_parts + compiled_kind.where_parts
+    inf_clause = f" AND ({' AND '.join(all_parts)})" if all_parts else ""
+    identified_clause = _identified_users_and_clause()
+
+    sql = f"""
+        SELECT DISTINCT
+            person_id,
+            {cutoff_select} AS cutoff_ts
+        FROM events
+        WHERE timestamp >= {cutoff_expr} - toIntervalDay({{lookback}})
+          AND timestamp < {cutoff_expr}{inf_clause}{identified_clause}
+    """
+    values: dict[str, Any] = {
+        "lookback": lookback_days,
+        **inf_values,
+        **compiled_kind.values,
+    }
+    if cutoff_ts is not None:
+        values["cutoff_ts"] = cutoff_ts
+    return sql, values
+
+
+def strip_sql_comments(sql: str) -> str:
+    """
+    Remove ``--`` line comments and ``/* */`` block comments from HogQL, leaving
+    string/identifier literals intact.
+
+    Agent-authored feature SQL routinely carries comments. Blindly substituting
+    ``{anchors}`` with a multi-line subquery that happens to land inside a ``--``
+    comment injects newlines that escape the comment and corrupt the parse, and a
+    comment can also swallow the rest of a line it was never meant to. Stripping
+    comments before substitution sidesteps both. Single-quoted strings (with the
+    ``''`` escape), double-quoted identifiers, and backtick identifiers are
+    preserved verbatim so a literal ``--`` or ``/*`` inside them is not mistaken
+    for a comment.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(sql)
+    quote: str | None = None  # one of ' " ` when inside a literal
+    while i < n:
+        ch = sql[i]
+        if quote is not None:
+            out.append(ch)
+            if ch == quote:
+                # '' inside a single-quoted string is an escaped quote, not a close.
+                if quote == "'" and i + 1 < n and sql[i + 1] == "'":
+                    out.append("'")
+                    i += 2
+                    continue
+                quote = None
+            i += 1
+            continue
+        if ch in ("'", '"', "`"):
+            quote = ch
+            out.append(ch)
+            i += 1
+            continue
+        if ch == "-" and i + 1 < n and sql[i + 1] == "-":
+            i += 2
+            while i < n and sql[i] != "\n":
+                i += 1
+            continue  # leave the newline so adjacent tokens don't fuse
+        if ch == "/" and i + 1 < n and sql[i + 1] == "*":
+            i += 2
+            while i + 1 < n and not (sql[i] == "*" and sql[i + 1] == "/"):
+                i += 1
+            i += 2  # skip the closing */
+            out.append(" ")  # block comment may sit mid-expression; keep a separator
+            continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+def _substitute_anchors(feature_sql: str, anchors_subquery: str) -> str:
+    """
+    Substitute the agent's `{anchors}` placeholder with the actual per-user
+    cutoff subquery. The contract from Step B's static validator guarantees
+    the placeholder is present.
+
+    Comments are stripped first so a placeholder sitting in (or adjacent to) a
+    comment can't break the substituted SQL — see ``strip_sql_comments``.
+    """
+    return strip_sql_comments(feature_sql).replace("{anchors}", anchors_subquery)
+
+
+def build_training_features_sql(
+    *,
+    feature_sql: str,
+    target_event: str,
+    horizon_days: int,
+    lookback_days: int,
+    training_population: dict[str, Any] | None,
+    target_definition: dict[str, Any] | None = None,
+    team: "Team | None" = None,
+) -> tuple[str, dict[str, Any]]:
+    """
+    Build the composite training-time query:
+      labeled_users CTE  +  labeled_anchors (adds fold)
+      + agent's feature_sql (with {anchors} substituted to per-user T0)
+      + JOIN back to labels/fold so each feature row has (__label, __fold)
+
+    Caller substitutes {lookback_days} in feature_sql before calling. Returns
+    one row per eligible user with the agent's feature columns plus __label
+    and __fold for the train/holdout split.
+    """
+    cte, values = _build_labeled_users_cte(
+        target_event=target_event,
+        target_definition=target_definition,
+        team=team,
+        horizon_days=horizon_days,
+        lookback_days=lookback_days,
+        training_population=training_population,
+        sample_limit=None,
+    )
+    anchors_subquery = "(SELECT person_id, t0_ts AS cutoff_ts FROM labeled_anchors)"
+    substituted_feature_sql = _substitute_anchors(feature_sql, anchors_subquery)
+
+    sql = f"""
+        {cte},
+        labeled_anchors AS (
+            SELECT
+                person_id,
+                t0_ts,
+                positive,
+                toInt(bitAnd(cityHash64(concat('fold:', toString(person_id))), 2147483647)) % {NUM_FOLDS} AS fold
+            FROM labeled_users
+        )
+        SELECT
+            f.*,
+            la.positive AS __label,
+            la.fold AS __fold
+        FROM (
+            {substituted_feature_sql}
+        ) f
+        LEFT JOIN labeled_anchors la ON f.distinct_id = la.person_id
+    """
+    return sql, values
+
+
+def build_inference_features_sql(
+    *,
+    feature_sql: str,
+    lookback_days: int,
+    inference_population: dict[str, Any] | None,
+    cutoff_ts: int | None = None,
+) -> tuple[str, dict[str, Any]]:
+    """
+    Build the inference-time query: the agent's feature_sql with {anchors}
+    substituted with the inference anchors (cutoff_ts = now() per user, or a
+    backdated instant when ``cutoff_ts`` is given for a historical backfill).
+    Returns one row per eligible scoring user with the agent's feature
+    columns — no labels, no fold.
+
+    Caller substitutes {lookback_days} in feature_sql before calling.
+    """
+    anchors_sql, anchors_values = build_inference_anchors_sql(
+        lookback_days=lookback_days,
+        inference_population=inference_population,
+        cutoff_ts=cutoff_ts,
+    )
+    # Wrap the inference anchors query as the {anchors} subquery — agent's
+    # feature_sql references columns (person_id, cutoff_ts) just like training.
+    anchors_subquery = f"({anchors_sql.strip()})"
+    substituted_feature_sql = _substitute_anchors(feature_sql, anchors_subquery)
+    return substituted_feature_sql, anchors_values

--- a/products/autoresearch/backend/dataset/templates.py
+++ b/products/autoresearch/backend/dataset/templates.py
@@ -1,0 +1,310 @@
+"""
+Built-in autoresearch prediction templates.
+
+Each template resolves to the same pipeline config shape as a custom pipeline,
+so validation and creation work identically whether the user started from a template
+or built a fully custom definition.
+
+Population specs use a semantic format compiled to HogQL by
+labeling._build_population_kind_conditions. Supported kinds:
+  performed_event_within_days   users who did `event` (any event when omitted) in
+                                the last `days` days
+  person_first_seen_within_days users whose first-seen date is within `days` days
+  active_not_performed_target   active users (any event in `active_within_days`) who
+                                have NOT performed `event`
+  ever_performed_event          users who have performed `event` at least once
+
+"Ever" and "has not performed" are bounded to the pipeline's training lookback
+window, and the target-relative kinds are evaluated per user at T0 during
+training — see the compiler's docstring for the semantics.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import structlog
+
+from posthog.schema import HogQLQuery
+
+from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
+from posthog.dataclasses import frozen
+from posthog.models.team.team import Team
+
+from products.autoresearch.backend.query import run_hogql_rows
+
+logger = structlog.get_logger(__name__)
+
+# Checked in this order when resolving an activity event for universal templates
+_PREFERRED_ACTIVITY_EVENTS = ["$pageview", "$screen", "$autocapture"]
+
+# Internal / noisy events that should never be chosen as the activity signal
+_NOISY_EVENTS: frozenset[str] = frozenset(
+    {
+        "$feature_flag_called",
+        "$decide",
+        "$set",
+        "$identify",
+        "$rageclick",
+        "$$heatmap",
+        "$web_vitals",
+        "$exception",
+        "$pageview_autocapture",
+        "$$plugin_metrics",
+    }
+)
+
+
+@frozen
+class AutoresearchTemplate:
+    key: str
+    display_name: str
+    description: str
+    default_horizon_days: int
+    output_property_prefix: str
+    requires_user_event: bool  # user must supply target_event override
+    requires_activity_resolution: bool  # target_event resolved from schema
+    training_population_spec: dict[str, Any]
+    inference_population_spec: dict[str, Any]
+    notes: str = ""
+
+
+TEMPLATES: dict[str, AutoresearchTemplate] = {
+    "likely_active_soon": AutoresearchTemplate(
+        key="likely_active_soon",
+        display_name="Likely active soon",
+        description=(
+            "Predict which active users will be active again in the next 7 days. "
+            "Best universal starter template — works for any product with pageview or session data."
+        ),
+        default_horizon_days=7,
+        output_property_prefix="predicted_p_active_soon",
+        requires_user_event=False,
+        requires_activity_resolution=True,
+        training_population_spec={"kind": "performed_event_within_days", "days": 30},
+        inference_population_spec={"kind": "performed_event_within_days", "days": 30},
+        notes=(
+            "Activity event is resolved from your event schema — prefers $pageview, $screen, "
+            "then any high-volume identified-user event. You can override the resolved event."
+        ),
+    ),
+    "at_risk_of_inactivity": AutoresearchTemplate(
+        key="at_risk_of_inactivity",
+        display_name="At risk of inactivity",
+        description=(
+            "Identify users unlikely to be active in the next 14 days. "
+            "Models future activity probability — low-probability users are the at-risk cohort. "
+            "Good for retention campaigns."
+        ),
+        default_horizon_days=14,
+        output_property_prefix="predicted_p_active_next",
+        requires_user_event=False,
+        requires_activity_resolution=True,
+        training_population_spec={"kind": "performed_event_within_days", "days": 60},
+        inference_population_spec={"kind": "performed_event_within_days", "days": 60},
+        notes=(
+            "Predicts activity probability. Users with a low score (e.g. p < 0.2) are at risk. "
+            "Create the 'At risk of inactivity' cohort using a low threshold on the prediction score, "
+            "not by modeling the absence of an event directly."
+        ),
+    ),
+    "return_after_first_use": AutoresearchTemplate(
+        key="return_after_first_use",
+        display_name="Likely to return after first use",
+        description=(
+            "Predict which new users will have a second active session within 7 days. "
+            "Works without a custom signup event — uses first-seen date. Good for onboarding."
+        ),
+        default_horizon_days=7,
+        output_property_prefix="predicted_p_return_after_signup",
+        requires_user_event=False,
+        requires_activity_resolution=True,
+        training_population_spec={"kind": "person_first_seen_within_days", "days": 14},
+        inference_population_spec={"kind": "person_first_seen_within_days", "days": 14},
+        notes=(
+            "Population is users first seen in the last 14 days. "
+            "Target event (second-session activity) is resolved from your event schema."
+        ),
+    ),
+    "feature_adoption": AutoresearchTemplate(
+        key="feature_adoption",
+        display_name="Likely to adopt a feature",
+        description=(
+            "Predict which active users will use a selected feature for the first time within 14 days. "
+            "Requires you to choose the feature's event or action."
+        ),
+        default_horizon_days=14,
+        output_property_prefix="predicted_p_adopt",
+        requires_user_event=True,
+        requires_activity_resolution=False,
+        training_population_spec={"kind": "active_not_performed_target", "active_within_days": 30},
+        inference_population_spec={"kind": "active_not_performed_target", "active_within_days": 30},
+        notes=(
+            "Population automatically excludes users who have already performed the selected event/action — "
+            "adoption mode predicts first-time use. Circular population is caught by validation."
+        ),
+    ),
+    "repeat_key_behavior": AutoresearchTemplate(
+        key="repeat_key_behavior",
+        display_name="Likely to repeat a key behavior",
+        description=(
+            "Predict which users who have already done a key action will do it again within 7 days. "
+            "Good for feature retention, power usage, and repeat purchases."
+        ),
+        default_horizon_days=7,
+        output_property_prefix="predicted_p_repeat",
+        requires_user_event=True,
+        requires_activity_resolution=False,
+        training_population_spec={"kind": "ever_performed_event"},
+        inference_population_spec={"kind": "ever_performed_event"},
+        notes=(
+            "Population includes only users who have performed the selected event/action at least once. "
+            "Continuation mode predicts repeat occurrence."
+        ),
+    ),
+}
+
+
+def resolve_activity_event(team: Team) -> tuple[str, list[str]]:
+    """
+    Discover the best activity event for universal activity templates.
+
+    Queries the last 30 days of events, checks for preferred activity events
+    ($pageview, $screen, $autocapture) in priority order, and falls back to the
+    highest-volume non-noisy event if none of the preferred events exist.
+
+    Returns (resolved_event, alternatives) where alternatives are other viable
+    events the user can choose as an override.
+    """
+    try:
+        query = HogQLQuery(
+            query="""
+                SELECT event, count() AS c
+                FROM events
+                WHERE timestamp >= now() - toIntervalDay(30)
+                  AND timestamp < now()
+                GROUP BY event
+                ORDER BY c DESC
+                LIMIT 100
+            """,
+        )
+        tag_queries(product=Product.AUTORESEARCH, feature=Feature.QUERY)
+        rows = run_hogql_rows(team=team, query=query)
+
+        seen: dict[str, int] = {}
+        if rows:
+            for row in rows:
+                event_name = str(row[0])
+                count = int(row[1] or 0)
+                if event_name not in _NOISY_EVENTS:
+                    seen[event_name] = count
+
+        for preferred in _PREFERRED_ACTIVITY_EVENTS:
+            if preferred in seen:
+                alts = [e for e in _PREFERRED_ACTIVITY_EVENTS if e in seen and e != preferred]
+                for event, _ in sorted(seen.items(), key=lambda x: x[1], reverse=True):
+                    if event not in alts and event != preferred and len(alts) < 4:
+                        alts.append(event)
+                return preferred, alts
+
+        if seen:
+            sorted_events = sorted(seen.items(), key=lambda x: x[1], reverse=True)
+            resolved = sorted_events[0][0]
+            return resolved, [e for e, _ in sorted_events[1:4]]
+
+    except Exception:
+        logger.exception("autoresearch_activity_resolver_error", team_id=team.pk)
+
+    return "$pageview", []
+
+
+@frozen
+class ResolvedTemplate:
+    template_key: str
+    display_name: str
+    description: str
+    target_event: str
+    resolved_activity_event: Optional[str]
+    activity_event_alternatives: list[str]
+    horizon_days: int
+    training_population: dict[str, Any]
+    inference_population: dict[str, Any]
+    output_person_property: str
+    suggested_name: str
+    notes: str
+
+
+def resolve_template(
+    team: Team,
+    template_key: str,
+    target_event_override: Optional[str] = None,
+    horizon_days_override: Optional[int] = None,
+) -> ResolvedTemplate:
+    """
+    Resolve a template key + optional overrides into a concrete pipeline config.
+
+    Raises ValueError if template_key is unknown or a required override is missing.
+    The returned ResolvedTemplate can be passed directly to pipeline creation.
+    """
+    template = TEMPLATES.get(template_key)
+    if template is None:
+        raise ValueError(f"Unknown template '{template_key}'. Available: {', '.join(TEMPLATES)}")
+
+    if template.requires_user_event and not target_event_override:
+        raise ValueError(
+            f"Template '{template_key}' requires a target_event override. "
+            "Provide the event or action name you want to predict."
+        )
+
+    resolved_activity: Optional[str] = None
+    alternatives: list[str] = []
+
+    if template.requires_activity_resolution:
+        resolved_activity, alternatives = resolve_activity_event(team)
+        target_event = target_event_override or resolved_activity
+    else:
+        target_event = target_event_override or ""
+
+    horizon_days = horizon_days_override if horizon_days_override is not None else template.default_horizon_days
+
+    # Append the horizon so two pipelines on the same target but different horizons write to
+    # distinct person properties instead of clobbering one another. The horizon lives in the
+    # suffix (not the prefix) so it tracks a horizon override rather than the template default.
+    if template.requires_user_event and target_event:
+        safe_name = target_event.lstrip("$").replace(" ", "_").lower()
+        output_person_property = f"{template.output_property_prefix}_{safe_name}_{horizon_days}d"
+    else:
+        output_person_property = f"{template.output_property_prefix}_{horizon_days}d"
+
+    training_population = _fill_population(template.training_population_spec, target_event)
+    inference_population = _fill_population(template.inference_population_spec, target_event)
+
+    if template.requires_user_event and target_event:
+        safe_label = target_event.lstrip("$").replace("_", " ")
+        suggested_name = f"{template.display_name}: {safe_label}"
+    else:
+        suggested_name = template.display_name
+
+    return ResolvedTemplate(
+        template_key=template_key,
+        display_name=template.display_name,
+        description=template.description,
+        target_event=target_event,
+        resolved_activity_event=resolved_activity,
+        activity_event_alternatives=alternatives,
+        horizon_days=horizon_days,
+        training_population=training_population,
+        inference_population=inference_population,
+        output_person_property=output_person_property,
+        suggested_name=suggested_name,
+        notes=template.notes,
+    )
+
+
+def _fill_population(spec: dict[str, Any], target_event: str) -> dict[str, Any]:
+    """Substitute the resolved target_event into a population spec."""
+    result = dict(spec)
+    kind = result.get("kind", "")
+    if kind in ("active_not_performed_target", "ever_performed_event") and target_event:
+        result["event"] = target_event
+    return result

--- a/products/autoresearch/backend/dataset/test_labeling.py
+++ b/products/autoresearch/backend/dataset/test_labeling.py
@@ -1,0 +1,212 @@
+from typing import Any
+
+from posthog.test.base import BaseTest
+
+from django.test import SimpleTestCase
+
+from parameterized import parameterized
+
+from products.autoresearch.backend.dataset.labeling import (
+    _build_labeled_users_cte,
+    _substitute_anchors,
+    build_eligible_count_sql,
+    build_inference_anchors_sql,
+    build_inference_features_sql,
+    strip_sql_comments,
+)
+
+
+class TestStripSqlComments(BaseTest):
+    @parameterized.expand(
+        [
+            ("line_comment", "SELECT a -- the count\nFROM t", "SELECT a \nFROM t"),
+            ("block_comment", "SELECT a /* inline */ FROM t", "SELECT a   FROM t"),
+            ("trailing_line_comment", "SELECT a FROM t -- trailing", "SELECT a FROM t "),
+            ("no_comment", "SELECT a FROM t", "SELECT a FROM t"),
+        ]
+    )
+    def test_strips_comments(self, _name: str, sql: str, expected: str) -> None:
+        self.assertEqual(strip_sql_comments(sql), expected)
+
+    def test_preserves_double_dash_inside_string_literal(self) -> None:
+        sql = "SELECT 'a -- b' AS x FROM t"
+        self.assertEqual(strip_sql_comments(sql), sql)
+
+    def test_preserves_escaped_quote_inside_string(self) -> None:
+        sql = "SELECT 'it''s -- fine' AS x FROM t"
+        self.assertEqual(strip_sql_comments(sql), sql)
+
+    def test_preserves_block_comment_markers_inside_string(self) -> None:
+        sql = "SELECT '/* not a comment */' AS x FROM t"
+        self.assertEqual(strip_sql_comments(sql), sql)
+
+    def test_preserves_double_dash_inside_backtick_identifier(self) -> None:
+        sql = "SELECT `weird--name` FROM t"
+        self.assertEqual(strip_sql_comments(sql), sql)
+
+
+class TestSubstituteAnchors(BaseTest):
+    def test_placeholder_in_line_comment_does_not_corrupt_substitution(self) -> None:
+        # A multi-line anchors subquery substituted into a `--` comment would
+        # escape the comment and break the parse — stripping comments first avoids it.
+        feature_sql = "SELECT a.person_id AS distinct_id\n-- read FROM {anchors} a here\nFROM {anchors} a"
+        anchors = "(SELECT person_id, t0_ts AS cutoff_ts\nFROM labeled_anchors)"
+        result = _substitute_anchors(feature_sql, anchors)
+        self.assertNotIn("--", result)
+        # The real FROM {anchors} got substituted; the commented one was removed.
+        self.assertEqual(result.count("labeled_anchors"), 1)
+
+    def test_substitutes_all_real_occurrences(self) -> None:
+        feature_sql = "SELECT * FROM {anchors} a JOIN {anchors} b ON a.person_id = b.person_id"
+        result = _substitute_anchors(feature_sql, "(SELECT 1)")
+        self.assertEqual(result.count("(SELECT 1)"), 2)
+        self.assertNotIn("{anchors}", result)
+
+
+class TestBuildInferenceFeaturesSql(BaseTest):
+    def test_comment_in_feature_sql_is_stripped_before_substitution(self) -> None:
+        feature_sql = "SELECT a.person_id AS distinct_id -- {anchors}\nFROM {anchors} a"
+        sql, _values = build_inference_features_sql(
+            feature_sql=feature_sql,
+            lookback_days=30,
+            inference_population=None,
+        )
+        self.assertNotIn("{anchors}", sql)
+        self.assertNotIn("--", sql)
+
+
+class TestPopulationKindCompilation(SimpleTestCase):
+    # Guards against the regression where a semantic population spec ({"kind": ...})
+    # fell through the compiler and silently widened to "all identified users".
+
+    @parameterized.expand(
+        [
+            (
+                "performed_any_event",
+                {"kind": "performed_event_within_days", "days": 30},
+                ["person_id IN (SELECT DISTINCT person_id FROM events"],
+                {"popk_days": 30},
+            ),
+            (
+                "performed_specific_event",
+                {"kind": "performed_event_within_days", "days": 30, "event": "$pageview"},
+                ["person_id IN (SELECT DISTINCT person_id FROM events", "event = {popk_event}"],
+                {"popk_days": 30, "popk_event": "$pageview"},
+            ),
+            (
+                "first_seen",
+                {"kind": "person_first_seen_within_days", "days": 14},
+                ["person.created_at >= now() - toIntervalDay({popk_days})"],
+                {"popk_days": 14},
+            ),
+            (
+                "active_not_performed_target",
+                {"kind": "active_not_performed_target", "active_within_days": 30, "event": "feature_used"},
+                ["person_id IN (SELECT DISTINCT person_id FROM events", "person_id NOT IN", "event = {popk_event}"],
+                {"popk_active_days": 30, "popk_event": "feature_used"},
+            ),
+            (
+                "ever_performed_event",
+                {"kind": "ever_performed_event", "event": "checkout"},
+                ["person_id IN (SELECT DISTINCT person_id FROM events", "event = {popk_event}"],
+                {"popk_event": "checkout"},
+            ),
+        ]
+    )
+    def test_inference_anchors_filter_kind_population(
+        self,
+        _name: str,
+        population: dict[str, Any],
+        fragments: list[str],
+        expected_values: dict[str, Any],
+    ) -> None:
+        sql, values = build_inference_anchors_sql(lookback_days=90, inference_population=population)
+        for fragment in fragments:
+            self.assertIn(fragment, sql)
+        for key, expected in expected_values.items():
+            self.assertEqual(values[key], expected)
+
+    def test_eligible_count_filters_kind_population(self) -> None:
+        sql, values = build_eligible_count_sql(
+            horizon_days=7,
+            lookback_days=90,
+            training_population={"kind": "performed_event_within_days", "days": 30},
+        )
+        self.assertIn("person_id IN (SELECT DISTINCT person_id FROM events", sql)
+        self.assertEqual(values["popk_days"], 30)
+
+    def test_inference_backfill_anchors_kind_windows_at_cutoff(self) -> None:
+        sql, _values = build_inference_anchors_sql(
+            lookback_days=90,
+            inference_population={"kind": "performed_event_within_days", "days": 30},
+            cutoff_ts=1_700_000_000,
+        )
+        self.assertIn("timestamp >= fromUnixTimestamp({cutoff_ts}) - toIntervalDay({popk_days})", sql)
+
+    @parameterized.expand(
+        [
+            ("unknown_kind", {"kind": "bogus"}),
+            ("missing_days", {"kind": "performed_event_within_days"}),
+            ("non_int_days", {"kind": "person_first_seen_within_days", "days": "14"}),
+            ("missing_active_days", {"kind": "active_not_performed_target", "event": "x"}),
+            ("missing_event", {"kind": "ever_performed_event"}),
+        ]
+    )
+    def test_uncompilable_kind_raises_instead_of_widening(self, _name: str, population: dict[str, Any]) -> None:
+        with self.assertRaises(ValueError):
+            build_inference_anchors_sql(lookback_days=90, inference_population=population)
+
+
+class TestPopulationKindTrainingSemantics(SimpleTestCase):
+    # Training must evaluate target-relative membership per user at T0. A row-level
+    # "has not performed the target" filter would delete exactly the users whose
+    # post-T0 adoption provides the positive labels.
+
+    def test_adoption_kind_excludes_pre_t0_performers_via_having(self) -> None:
+        cte, values = _build_labeled_users_cte(
+            target_event="feature_used",
+            target_definition=None,
+            team=None,
+            horizon_days=7,
+            lookback_days=90,
+            training_population={
+                "kind": "active_not_performed_target",
+                "active_within_days": 30,
+                "event": "feature_used",
+            },
+            sample_limit=None,
+        )
+        self.assertIn("HAVING max((event = {target}) AND toInt(toUnixTimestamp(e.timestamp)) < u.t0_ts) = 0", cte)
+        self.assertNotIn("NOT IN", cte)
+        self.assertEqual(values["popk_active_days"], 30)
+
+    def test_repeat_kind_requires_pre_t0_performance_via_having(self) -> None:
+        cte, _values = _build_labeled_users_cte(
+            target_event="checkout",
+            target_definition=None,
+            team=None,
+            horizon_days=7,
+            lookback_days=90,
+            training_population={"kind": "ever_performed_event", "event": "checkout"},
+            sample_limit=None,
+        )
+        self.assertIn("HAVING max((event = {target}) AND toInt(toUnixTimestamp(e.timestamp)) < u.t0_ts) = 1", cte)
+        self.assertIn("person_id IN (SELECT DISTINCT person_id FROM events", cte)
+
+    def test_kind_and_property_filters_compose(self) -> None:
+        cte, values = _build_labeled_users_cte(
+            target_event="checkout",
+            target_definition=None,
+            team=None,
+            horizon_days=7,
+            lookback_days=90,
+            training_population={
+                "kind": "performed_event_within_days",
+                "days": 30,
+                "properties": [{"key": "email", "type": "person", "operator": "is_set"}],
+            },
+            sample_limit=None,
+        )
+        self.assertIn("person_id IN (SELECT DISTINCT person_id FROM events", cte)
+        self.assertIn("isNotNull(person.properties[{pop_k_0}])", cte)
+        self.assertEqual(values["popk_days"], 30)

--- a/products/autoresearch/backend/dataset/test_templates.py
+++ b/products/autoresearch/backend/dataset/test_templates.py
@@ -1,0 +1,175 @@
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from parameterized import parameterized
+
+from products.autoresearch.backend.dataset.labeling import _build_population_kind_conditions
+from products.autoresearch.backend.dataset.templates import (
+    TEMPLATES,
+    ResolvedTemplate,
+    _fill_population,
+    resolve_template,
+)
+
+
+class TestTemplateDefinitions(TestCase):
+    def test_all_five_templates_present(self) -> None:
+        self.assertEqual(
+            set(TEMPLATES.keys()),
+            {
+                "likely_active_soon",
+                "at_risk_of_inactivity",
+                "return_after_first_use",
+                "feature_adoption",
+                "repeat_key_behavior",
+            },
+        )
+
+    @parameterized.expand(list(TEMPLATES.keys()))
+    def test_template_has_required_fields(self, key: str) -> None:
+        t = TEMPLATES[key]
+        self.assertTrue(t.display_name)
+        self.assertTrue(t.description)
+        self.assertGreater(t.default_horizon_days, 0)
+        self.assertTrue(t.output_property_prefix)
+        self.assertIsInstance(t.training_population_spec, dict)
+        self.assertIsInstance(t.inference_population_spec, dict)
+
+    @parameterized.expand(
+        [
+            ("likely_active_soon", 7, False, True),
+            ("at_risk_of_inactivity", 14, False, True),
+            ("return_after_first_use", 7, False, True),
+            ("feature_adoption", 14, True, False),
+            ("repeat_key_behavior", 7, True, False),
+        ]
+    )
+    def test_template_config(
+        self,
+        key: str,
+        expected_horizon: int,
+        requires_user_event: bool,
+        requires_activity_resolution: bool,
+    ) -> None:
+        t = TEMPLATES[key]
+        self.assertEqual(t.default_horizon_days, expected_horizon)
+        self.assertEqual(t.requires_user_event, requires_user_event)
+        self.assertEqual(t.requires_activity_resolution, requires_activity_resolution)
+
+
+class TestTemplateSpecsCompile(TestCase):
+    # Drift guard: every template's population spec must have a compiler branch in
+    # labeling.py, in both row mode (inference/eligible count) and anchor mode (training).
+
+    @parameterized.expand(list(TEMPLATES.keys()))
+    def test_population_specs_compile_in_both_modes(self, key: str) -> None:
+        t = TEMPLATES[key]
+        for spec in (t.training_population_spec, t.inference_population_spec):
+            population = _fill_population(spec, "some_target_event")
+            row = _build_population_kind_conditions(population)
+            anchor = _build_population_kind_conditions(population, anchor_mode=True)
+            self.assertTrue(row.where_parts)
+            self.assertTrue(anchor.where_parts or anchor.anchor_target_relation)
+
+
+class TestFillPopulation(TestCase):
+    def test_ever_performed_event_gets_event_key(self) -> None:
+        spec = {"kind": "ever_performed_event"}
+        result = _fill_population(spec, "my_event")
+        self.assertEqual(result, {"kind": "ever_performed_event", "event": "my_event"})
+
+    def test_active_not_performed_target_gets_event_key(self) -> None:
+        spec = {"kind": "active_not_performed_target", "active_within_days": 30}
+        result = _fill_population(spec, "feature_clicked")
+        self.assertEqual(result["event"], "feature_clicked")
+        self.assertEqual(result["kind"], "active_not_performed_target")
+
+    def test_performed_event_within_days_unchanged(self) -> None:
+        spec = {"kind": "performed_event_within_days", "days": 30}
+        result = _fill_population(spec, "$pageview")
+        self.assertNotIn("event", result)
+
+    def test_original_spec_not_mutated(self) -> None:
+        spec = {"kind": "ever_performed_event"}
+        _fill_population(spec, "my_event")
+        self.assertNotIn("event", spec)
+
+
+class TestResolveTemplate(TestCase):
+    def _make_team(self) -> MagicMock:
+        team = MagicMock()
+        team.pk = 1
+        return team
+
+    def test_unknown_template_raises(self) -> None:
+        with self.assertRaises(ValueError, msg="Unknown template"):
+            resolve_template(self._make_team(), "nonexistent_template")
+
+    def test_feature_adoption_without_target_event_raises(self) -> None:
+        with self.assertRaises(ValueError, msg="requires a target_event override"):
+            resolve_template(self._make_team(), "feature_adoption")
+
+    def test_repeat_key_behavior_without_target_event_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            resolve_template(self._make_team(), "repeat_key_behavior")
+
+    @patch(
+        "products.autoresearch.backend.dataset.templates.resolve_activity_event",
+        return_value=("$pageview", ["$screen"]),
+    )
+    def test_likely_active_soon_resolves(self, mock_resolve: MagicMock) -> None:
+        team = self._make_team()
+        result = resolve_template(team, "likely_active_soon")
+        self.assertIsInstance(result, ResolvedTemplate)
+        self.assertEqual(result.target_event, "$pageview")
+        self.assertEqual(result.resolved_activity_event, "$pageview")
+        self.assertEqual(result.horizon_days, 7)
+        self.assertEqual(result.output_person_property, "predicted_p_active_soon_7d")
+
+    @patch("products.autoresearch.backend.dataset.templates.resolve_activity_event", return_value=("$pageview", []))
+    def test_activity_event_override_respected(self, mock_resolve: MagicMock) -> None:
+        result = resolve_template(self._make_team(), "likely_active_soon", target_event_override="$screen")
+        self.assertEqual(result.target_event, "$screen")
+        # resolved_activity_event still shows what the schema resolver found
+        self.assertEqual(result.resolved_activity_event, "$pageview")
+
+    @patch("products.autoresearch.backend.dataset.templates.resolve_activity_event", return_value=("$pageview", []))
+    def test_horizon_override_respected(self, _: MagicMock) -> None:
+        result = resolve_template(self._make_team(), "likely_active_soon", horizon_days_override=14)
+        self.assertEqual(result.horizon_days, 14)
+        # Horizon is part of the output property so the same target over a different horizon
+        # does not clobber another pipeline's score.
+        self.assertEqual(result.output_person_property, "predicted_p_active_soon_14d")
+
+    def test_feature_adoption_with_target_event(self) -> None:
+        result = resolve_template(self._make_team(), "feature_adoption", target_event_override="feature_clicked")
+        self.assertEqual(result.target_event, "feature_clicked")
+        self.assertEqual(result.horizon_days, 14)
+        self.assertIn("predicted_p_adopt_feature_clicked", result.output_person_property)
+        self.assertEqual(result.training_population["event"], "feature_clicked")
+        self.assertIsNone(result.resolved_activity_event)
+
+    def test_repeat_key_behavior_with_target_event(self) -> None:
+        result = resolve_template(self._make_team(), "repeat_key_behavior", target_event_override="$pageview")
+        self.assertEqual(result.target_event, "$pageview")
+        self.assertEqual(result.training_population["event"], "$pageview")
+        self.assertIn("pageview", result.output_person_property)
+
+    def test_feature_adoption_suggested_name_includes_event(self) -> None:
+        result = resolve_template(self._make_team(), "feature_adoption", target_event_override="my_feature")
+        self.assertIn("my feature", result.suggested_name)
+
+    @patch(
+        "products.autoresearch.backend.dataset.templates.resolve_activity_event",
+        return_value=("$pageview", ["$screen"]),
+    )
+    def test_activity_alternatives_returned(self, _: MagicMock) -> None:
+        result = resolve_template(self._make_team(), "at_risk_of_inactivity")
+        self.assertIn("$screen", result.activity_event_alternatives)
+
+    @patch("products.autoresearch.backend.dataset.templates.resolve_activity_event", return_value=("$pageview", []))
+    def test_return_after_first_use_population_is_first_seen(self, _: MagicMock) -> None:
+        result = resolve_template(self._make_team(), "return_after_first_use")
+        self.assertEqual(result.training_population["kind"], "person_first_seen_within_days")
+        self.assertEqual(result.training_population["days"], 14)

--- a/products/autoresearch/backend/dataset/test_validation.py
+++ b/products/autoresearch/backend/dataset/test_validation.py
@@ -1,0 +1,117 @@
+from posthog.test.base import BaseTest
+from unittest.mock import patch
+
+from products.autoresearch.backend.dataset.validation import _run_validation, validate_pipeline_definition
+
+
+def _mock_rows(positives: int, total: int, identified: int | None = None) -> list[list[list[int]]]:
+    """
+    Validation issues three HogQL queries in order:
+      1. eligible count            -> [[eligible_identified, eligible_all]]
+      2. random-T0 sampled labeler -> [[sampled_users, sampled_positives]]
+      3. inference population count -> [[inference_size]]
+    The inference count runs whenever an inference filter applies, including the v1
+    identified-only restriction, which is always on. For tests we assume sample size
+    == total (i.e. total <= live sample cap) so the extrapolated positives line up with
+    the input. `identified` defaults to `total` (no anonymous remainder, so no
+    mostly-anonymous warning).
+    """
+    eligible_identified = total if identified is None else identified
+    return [
+        [[eligible_identified, total]],
+        [[eligible_identified, positives]],
+        [[eligible_identified]],
+    ]
+
+
+class TestValidationWarnings(BaseTest):
+    def setUp(self):
+        super().setUp()
+
+    def _run(
+        self,
+        positives: int,
+        total: int,
+        horizon_days: int = 7,
+        training_lookback_days: int = 180,
+        identified: int | None = None,
+    ):
+        with patch("products.autoresearch.backend.dataset.validation.run_hogql_rows") as mock_run:
+            mock_run.side_effect = _mock_rows(positives, total, identified=identified)
+            return _run_validation(
+                team=self.team,
+                target_event="$pageview",
+                horizon_days=horizon_days,
+                training_lookback_days=training_lookback_days,
+                training_population={},
+                inference_population={},
+            )
+
+    def test_ok_result_has_no_warnings(self):
+        result = self._run(positives=100, total=1000)
+        assert result.can_proceed is True
+        assert result.requires_acknowledgement is False
+        assert result.warnings == []
+        assert result.base_rate == 0.1
+
+    def test_low_volume_is_error(self):
+        result = self._run(positives=10, total=50)
+        codes = [w.code for w in result.warnings]
+        assert "low_volume" in codes
+        assert result.can_proceed is False
+
+    def test_moderate_volume_is_warning(self):
+        result = self._run(positives=30, total=200)
+        codes = [w.code for w in result.warnings]
+        assert "moderate_volume" in codes
+        assert result.can_proceed is True
+        assert result.requires_acknowledgement is True
+
+    def test_low_positives_is_error(self):
+        result = self._run(positives=5, total=1000)
+        codes = [w.code for w in result.warnings]
+        assert "low_positives" in codes
+        assert result.can_proceed is False
+
+    def test_extreme_imbalance_is_warning(self):
+        result = self._run(positives=1, total=10000)
+        codes = [w.code for w in result.warnings]
+        assert "extreme_imbalance" in codes
+
+    def test_near_universal_is_warning(self):
+        result = self._run(positives=980, total=1000)
+        codes = [w.code for w in result.warnings]
+        assert "near_universal" in codes
+
+    def test_mostly_anonymous_population_is_warning(self):
+        result = self._run(positives=40, total=1000, identified=200)
+        codes = [w.code for w in result.warnings]
+        assert "mostly_anonymous_population" in codes
+        assert result.can_proceed is True
+        assert result.estimated_training_rows == 200
+
+    def test_majority_identified_population_has_no_anonymous_warning(self):
+        result = self._run(positives=100, total=1000, identified=900)
+        codes = [w.code for w in result.warnings]
+        assert "mostly_anonymous_population" not in codes
+
+    def test_error_in_query_returns_error_result(self):
+        with patch("products.autoresearch.backend.dataset.validation.run_hogql_rows") as mock_run:
+            mock_run.side_effect = RuntimeError("CH is down")
+            result = validate_pipeline_definition(
+                team=self.team,
+                target_event="$pageview",
+                horizon_days=7,
+                training_lookback_days=180,
+                training_population={},
+                inference_population={},
+            )
+        assert result.can_proceed is False
+        assert result.error is not None
+        assert "CH is down" in result.error
+
+    def test_zero_users_returns_low_volume_error(self):
+        result = self._run(positives=0, total=0)
+        assert result.can_proceed is False
+        codes = [w.code for w in result.warnings]
+        assert "low_volume" in codes

--- a/products/autoresearch/backend/dataset/validation.py
+++ b/products/autoresearch/backend/dataset/validation.py
@@ -1,0 +1,263 @@
+from dataclasses import field
+from typing import Any, Optional
+
+import structlog
+
+from posthog.schema import HogQLQuery
+
+from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
+from posthog.dataclasses import frozen
+from posthog.models.team.team import Team
+
+from products.autoresearch.backend.dataset.labeling import (
+    IDENTIFIED_USERS_ONLY,
+    _build_population_conditions,
+    _build_population_kind_conditions,
+    _identified_users_and_clause,
+    build_eligible_count_sql,
+    build_random_t0_labeler_sql,
+)
+from products.autoresearch.backend.query import run_hogql_rows
+
+logger = structlog.get_logger(__name__)
+
+# Minimum number of labeled examples needed to train a meaningful model
+MIN_TRAINING_ROWS = 100
+MIN_POSITIVE_EXAMPLES = 20
+
+# Warn when fewer than this fraction of the population is identified — under the v1
+# identified-only scope the anonymous remainder is silently excluded, so flag it.
+MIN_IDENTIFIED_FRACTION = 0.5
+
+# Cap the user_window CTE during live wizard estimates — sampled base rate is
+# unbiased for the same quantity the trainer computes unsampled.
+LIVE_ESTIMATE_SAMPLE_LIMIT = 5_000
+
+
+@frozen
+class ValidationWarning:
+    code: str
+    message: str
+    severity: str  # "info" | "warning" | "error"
+
+
+@frozen
+class ValidationResult:
+    can_proceed: bool
+    requires_acknowledgement: bool
+    estimated_training_rows: Optional[int]
+    positive_count: Optional[int]
+    negative_count: Optional[int]
+    base_rate: Optional[float]
+    inference_population_size: Optional[int]
+    warnings: list[ValidationWarning] = field(default_factory=list)
+    error: Optional[str] = None
+
+
+def validate_pipeline_definition(
+    team: Team,
+    target_event: str,
+    horizon_days: int,
+    training_lookback_days: int,
+    training_population: dict[str, Any],
+    inference_population: dict[str, Any],
+    target_definition: dict[str, Any] | None = None,
+) -> ValidationResult:
+    """
+    Validate a proposed pipeline definition against real team data.
+
+    Runs HogQL count queries to estimate volume, base rate, and catch common
+    mistakes before training is triggered.
+    """
+    try:
+        return _run_validation(
+            team=team,
+            target_event=target_event,
+            target_definition=target_definition,
+            horizon_days=horizon_days,
+            training_lookback_days=training_lookback_days,
+            training_population=training_population,
+            inference_population=inference_population,
+        )
+    except Exception as exc:
+        logger.exception("autoresearch_validation_error", team_id=team.pk, target_event=target_event)
+        return ValidationResult(
+            can_proceed=False,
+            requires_acknowledgement=False,
+            estimated_training_rows=None,
+            positive_count=None,
+            negative_count=None,
+            base_rate=None,
+            inference_population_size=None,
+            error=str(exc),
+        )
+
+
+def _run_validation(
+    *,
+    team: Team,
+    target_event: str,
+    horizon_days: int,
+    training_lookback_days: int,
+    training_population: dict[str, Any],
+    inference_population: dict[str, Any],
+    target_definition: dict[str, Any] | None = None,
+) -> ValidationResult:
+    warnings: list[ValidationWarning] = []
+
+    # Use the explicit training lookback window. Clamp to a sane minimum so very short windows
+    # still produce a meaningful estimate.
+    lookback_days = max(training_lookback_days, 7)
+
+    tag_queries(product=Product.AUTORESEARCH, feature=Feature.QUERY)
+
+    # Headline eligible count — true number of users that would be labeled by the
+    # random-T0 labeler, no sampling. Used for the UI's "Training rows" metric and
+    # volume warnings.
+    eligible_sql, eligible_values = build_eligible_count_sql(
+        horizon_days=horizon_days,
+        lookback_days=lookback_days,
+        training_population=training_population,
+    )
+    eligible_rows = run_hogql_rows(team=team, query=HogQLQuery(query=eligible_sql, values=eligible_values))
+    # eligible = identified-only headline (v1); eligible_all = same count without the
+    # identified restriction, used to detect a mostly-anonymous population.
+    total_users = 0
+    total_users_all = 0
+    if eligible_rows:
+        row = eligible_rows[0]
+        total_users = int(row[0] or 0)
+        total_users_all = int(row[1] or 0) if len(row) > 1 else total_users
+
+    # Sampled random-T0 labeler — each user is assigned a deterministic random T0 in
+    # their history and labeled by whether target_event fires in [T0, T0 + horizon).
+    # Sampled at LIVE_ESTIMATE_SAMPLE_LIMIT for fast wizard feedback; the resulting
+    # base_rate is an unbiased estimator of the trainer's unsampled rate.
+    label_sql, label_values = build_random_t0_labeler_sql(
+        target_event=target_event,
+        target_definition=target_definition,
+        team=team,
+        horizon_days=horizon_days,
+        lookback_days=lookback_days,
+        training_population=training_population,
+        sample_limit=LIVE_ESTIMATE_SAMPLE_LIMIT,
+    )
+    label_rows = run_hogql_rows(team=team, query=HogQLQuery(query=label_sql, values=label_values))
+    sampled_users = 0
+    sampled_positives = 0
+    if label_rows:
+        row = label_rows[0]
+        sampled_users = int(row[0] or 0)
+        sampled_positives = int(row[1] or 0)
+
+    base_rate = sampled_positives / sampled_users if sampled_users > 0 else 0.0
+    # Extrapolate sample-rate to the full eligible population for the headline counts.
+    positives = round(base_rate * total_users) if total_users > 0 else 0
+    negatives = total_users - positives
+
+    # Inference population — count distinct users matching the prediction filter.
+    # If no inference filter is provided we fall back to the training count.
+    inference_properties = (inference_population or {}).get("properties", []) if inference_population else []
+    identified_clause = _identified_users_and_clause()
+    # Template populations carry a `kind` rather than raw properties, so compile it through
+    # the same helper scoring uses — counting every identified user would preview a
+    # population the pipeline will never score.
+    compiled_inference_kind = _build_population_kind_conditions(inference_population)
+    if inference_properties or compiled_inference_kind.where_parts or identified_clause:
+        inf_parts, inf_values = _build_population_conditions(inference_properties)
+        inf_parts.extend(compiled_inference_kind.where_parts)
+        inf_values.update(compiled_inference_kind.values)
+        inference_clause = f" AND ({' AND '.join(inf_parts)})" if inf_parts else ""
+        inference_query = HogQLQuery(
+            query=f"""
+                SELECT countDistinct(person_id) AS users
+                FROM events
+                WHERE timestamp >= now() - toIntervalDay({{lookback}})
+                  AND timestamp < now(){inference_clause}{identified_clause}
+            """,
+            values={"lookback": lookback_days, **inf_values},
+        )
+        inf_rows = run_hogql_rows(team=team, query=inference_query)
+        inference_size = int(inf_rows[0][0] or 0) if inf_rows else 0
+    else:
+        inference_size = total_users
+
+    # Volume warnings
+    if total_users < MIN_TRAINING_ROWS:
+        warnings.append(
+            ValidationWarning(
+                code="low_volume",
+                message=f"Only {total_users} users found in the last {lookback_days} days. "
+                f"At least {MIN_TRAINING_ROWS} are recommended for reliable training.",
+                severity="error",
+            )
+        )
+    elif total_users < MIN_TRAINING_ROWS * 5:
+        warnings.append(
+            ValidationWarning(
+                code="moderate_volume",
+                message=f"{total_users} users found — model may have limited accuracy with this volume.",
+                severity="warning",
+            )
+        )
+
+    # Mostly-anonymous population — under the v1 identified-only scope the anonymous
+    # remainder is excluded from training and scoring, which can shrink the population
+    # well below what the user expects. Warn so the exclusion is visible.
+    if IDENTIFIED_USERS_ONLY and total_users_all > 0:
+        identified_fraction = total_users / total_users_all
+        if identified_fraction < MIN_IDENTIFIED_FRACTION:
+            excluded = total_users_all - total_users
+            warnings.append(
+                ValidationWarning(
+                    code="mostly_anonymous_population",
+                    message=f"Only {identified_fraction:.0%} of this population is identified. "
+                    f"Autoresearch models identified users only, so {excluded} anonymous "
+                    f"user(s) are excluded from training and scoring.",
+                    severity="warning",
+                )
+            )
+
+    if positives < MIN_POSITIVE_EXAMPLES:
+        warnings.append(
+            ValidationWarning(
+                code="low_positives",
+                message=f"Only {positives} users performed '{target_event}'. "
+                f"At least {MIN_POSITIVE_EXAMPLES} positive examples are needed.",
+                severity="error",
+            )
+        )
+
+    # Extreme imbalance
+    if total_users > 0 and base_rate < 0.01:
+        warnings.append(
+            ValidationWarning(
+                code="extreme_imbalance",
+                message=f"Base rate is {base_rate:.2%} — very rare events require special handling "
+                "and will need a larger population for reliable calibration.",
+                severity="warning",
+            )
+        )
+    elif total_users > 0 and base_rate > 0.95:
+        warnings.append(
+            ValidationWarning(
+                code="near_universal",
+                message=f"Base rate is {base_rate:.2%} — almost everyone does this event. "
+                "The model may not add much predictive value.",
+                severity="warning",
+            )
+        )
+
+    has_errors = any(w.severity == "error" for w in warnings)
+    has_hard_warnings = any(w.severity == "warning" for w in warnings)
+
+    return ValidationResult(
+        can_proceed=not has_errors,
+        requires_acknowledgement=has_hard_warnings and not has_errors,
+        estimated_training_rows=total_users,
+        positive_count=positives,
+        negative_count=negatives,
+        base_rate=base_rate,
+        inference_population_size=inference_size,
+        warnings=warnings,
+    )

--- a/products/autoresearch/backend/query.py
+++ b/products/autoresearch/backend/query.py
@@ -1,0 +1,30 @@
+from typing import Any
+
+from posthog.schema import CacheMissResponse, HogQLQuery, QueryStatusResponse
+
+from posthog.hogql_queries.hogql_query_runner import HogQLQueryRunner
+from posthog.hogql_queries.query_runner import ExecutionMode
+from posthog.models.team.team import Team
+
+
+class AutoresearchQueryError(Exception):
+    pass
+
+
+def run_hogql_rows(
+    *,
+    team: Team,
+    query: HogQLQuery,
+    execution_mode: ExecutionMode = ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE,
+) -> list[list[Any]]:
+    """Run a HogQL query under a blocking execution mode and return its rows.
+
+    The runner's return type also covers the cache-miss and async-status shapes that
+    a blocking mode never produces. Raising on those keeps every caller off the union,
+    and keeps "the query returned nothing" distinct from "the query did not run",
+    which callers here read as a real zero.
+    """
+    response = HogQLQueryRunner(query=query, team=team).run(execution_mode=execution_mode)
+    if isinstance(response, CacheMissResponse | QueryStatusResponse):
+        raise AutoresearchQueryError(f"HogQL query did not execute: got {type(response).__name__}")
+    return response.results or []

--- a/tach.toml
+++ b/tach.toml
@@ -188,6 +188,7 @@ layer = "modules"
 path = "products.autoresearch"
 depends_on = [
     "posthog",
+    "products.actions",
     "products.feature_flags",
 ]
 layer = "modules"


### PR DESCRIPTION
> [!NOTE]
> Piece 6 of 13 in the split of #60081. Pieces 1-4 land prerequisites that stand alone on master. Pieces 5-13 add the autoresearch product. The map lives in #60081.

## Problem

Autoresearch cannot answer "is this question learnable?" until something turns a pipeline definition into SQL.

A person names a target event, a population, and a horizon. Turning that into rows a model can learn from is one job with one right answer, and the trainer, the scorer, and the create form all have to agree on it. If they disagree about what a row means, the model is quietly wrong rather than loudly broken.

## Changes

- Nobody sees anything different. No route or job calls this yet.
- Adds the labeler, which is the load-bearing piece: a training example is one `(person, T0, label)` triple per person, with `T0` a deterministic hash of `person_id` so it is stable across runs and spread across the lookback.
- Adds pre-flight viability checks that return warnings rather than raising, because the create form will show them as advice.
- Adds the five built-in templates. A template resolves to the same pipeline shape as a fully custom one, so nothing downstream needs a template code path.
- Adds `run_hogql_rows`, which narrows the query runner's response union in one place. That clears the 14 `union-attr` errors this code carried, part of the mypy blocker #60081 lists.
- Mechanical: the `autoresearch` value on the ClickHouse query-tagging `Product` enum, and the `products.actions` entry in `tach.toml`.

The `TestTemplateAPIEndpoints` class moves out to the API piece, since it drives HTTP rather than this package.

## How did you test this code?

`hogli test products/autoresearch/backend/dataset` covers the labeler, the templates, and the validator. The tests came with the code from the branch; the ones I changed are the validator's, which now stub `run_hogql_rows` rather than the query runner class.

One drift guard earns its place beyond the rest: every template's population spec has to compile in both row mode and anchor mode, because a spec with no compiler branch is accepted at creation and only fails at query time.

Also run: `uv run mypy --cache-fine-grained .` repo-wide, `uv run tach check`, and `hogli product:lint autoresearch`.

Not run: anything against real ClickHouse data. The query builders are covered by their generated SQL, not by execution.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`products/autoresearch/backend/dataset/AGENTS.md` is new and in this PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5), driven by @andrewm4894. Cut by path from the `autoresearch-dev` branch (#60081) per the split plan in that PR.

Skills invoked: /writing-tests, /writing-code-comments, /writing-pr-descriptions.

`run_hogql_rows` is the one addition that is not on the branch. Four call sites here read `.results` straight off a union that includes two response shapes a blocking query never returns, and the same pattern repeats in the later layers, so it became a shared helper rather than four narrowing checks.
