### PR TITLE
chore(review_hog): drop the gif from the clean-review comment

### DIFF
--- a/products/review_hog/backend/reviewer/status_comment.py
+++ b/products/review_hog/backend/reviewer/status_comment.py
@@ -15,7 +15,6 @@ Every entry point here is best-effort by construction: a status comment must nev
 retry a review, so all exceptions are swallowed after logging.
 """
 
-import random
 import logging
 from datetime import timedelta
 from typing import Any
@@ -88,26 +87,8 @@ _THRESHOLD_ATTRIBUTIONS = {
 # Only personal thresholds live in someone's ReviewHog settings; the default variant has no page to point at.
 _PERSONAL_THRESHOLD_SOURCES = frozenset({"author", "override"})
 
-# A clean review deserves a reward, not a bare "nothing here". We still post the comment (so "no
-# comment" can never be mistaken for "the run broke"), but swap the flat sign-off for calming media.
-# Assets are optimized and self-hosted on pr-assets (SHA-pinned, permanent) rather than hotlinked.
-_NO_ISSUES_MEDIA = (
-    (
-        "https://raw.githubusercontent.com/PostHog/pr-assets/"
-        "2cfa8ec2d6e5c88ed94a98881499a09153681886/2026/07/41e56d03-cfbe-4660-b7d5-8774d805af5c.gif",
-        "Someone relaxing in a sunny garden",
-    ),
-    (
-        "https://raw.githubusercontent.com/PostHog/pr-assets/"
-        "e58e5703b12db9127e450347a5dc7882eec1a8dd/2026/07/fb797d93-c7f5-4f67-869b-68f630e0e1a2.png",
-        "A happy dog on a sunny path",
-    ),
-    (
-        "https://raw.githubusercontent.com/PostHog/pr-assets/"
-        "3cf9366a6d40bc591284b00304cb6ecd84164343/2026/07/c755cc49-ef33-4435-87e0-51074f110b19.gif",
-        "A panda relaxing and waving",
-    ),
-)
+# A clean review still gets a comment, so "no comment" can never be mistaken for "the run broke".
+_NO_ISSUES_LINE = "Nothing worth raising this time."
 
 
 def status_marker(report_id: str) -> str:
@@ -194,14 +175,7 @@ def render_final_body(
     )
     lines = ["### \U0001f994 ReviewHog reviewed this pull request", ""]
     if found_total == 0:
-        media_url, media_alt = random.choice(_NO_ISSUES_MEDIA)
-        lines.extend(
-            [
-                "Nothing worth raising this time, so here's a calming picture instead:",
-                "",
-                f"![{media_alt}]({media_url})",
-            ]
-        )
+        lines.append(_NO_ISSUES_LINE)
     else:
         lines.append(found_line + ".")
         lines.append("")

--- a/products/review_hog/backend/tests/test_status_comment.py
+++ b/products/review_hog/backend/tests/test_status_comment.py
@@ -99,8 +99,8 @@ class TestRenderFinalBody:
                 0,
                 IssuePriority.SHOULD_FIX,
                 None,
-                ["Nothing worth raising this time, so here's a calming picture instead:", "![", "pr-assets"],
-                ["Published", "stayed below"],
+                ["Nothing worth raising this time."],
+                ["Published", "stayed below", "!["],
             ),
             # Posted on a prior crashed attempt (marker skip): published, but no link to render.
             (
@@ -157,20 +157,6 @@ class TestRenderFinalBody:
         assert f"2 findings stayed below {expected}" in body, body
         # Held-back findings are otherwise invisible to the author — the comment must not dead-end.
         assert "[View them in PostHog](https://ph.test/project/1/code-review?review=rid)" in body
-
-    @patch(f"{_MODULE}.random.choice", return_value=("https://example.test/dog.png", "A happy dog"))
-    def test_uses_the_randomly_selected_clean_review_media(self, mock_choice: MagicMock) -> None:
-        body = render_final_body(
-            "rid",
-            counts={IssuePriority.MUST_FIX: 0, IssuePriority.SHOULD_FIX: 0, IssuePriority.CONSIDER: 0},
-            published_count=0,
-            held_back_count=0,
-            threshold=IssuePriority.SHOULD_FIX,
-            review_url=None,
-        )
-
-        assert "![A happy dog](https://example.test/dog.png)" in body
-        mock_choice.assert_called_once()
 
 
 def _pr_metadata(pr_number: int = 123) -> PRMetadata:


### PR DESCRIPTION
## Problem

When ReviewHog finishes a review with no findings, it closes its PR status comment with a randomly picked animated gif or photo. PR authors get a large, low-quality image on an otherwise clean pull request, and it isn't as funny the tenth time.

## Changes

- A clean review now ends with the plain line "Nothing worth raising this time." — no image.
- The comment is still posted on a clean run, so "no comment" can never read as "the review broke".
- Mechanical: removed the media URL table, the `random` import, and the test that asserted the random pick.

## How did you test this code?

Ran `products/review_hog/backend/tests/test_status_comment.py` locally: the 15 pure-render tests pass, including the nothing-found case, which now also asserts no image markdown is emitted. The 13 DB-backed tests in that file error out on a missing local Postgres and were not run; CI covers them.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested by a PostHog employee via the linked Slack thread; the requester's GitHub handle was not verifiable from that context, so the PR is left unassigned for them to self-assign. Authored by the PostHog Slack app (Claude Code). No repo skills were invoked — the change is a single render branch in `status_comment.py`.

Only the media was dropped, not the comment: the surrounding code documents that a clean run must still leave a comment behind so it can't be confused with a failed run. The `.gif` pattern in `reviewer/tools/github_meta.py` is a diff-filter for binary files and was left alone.

Nothing in this diff carries material from the agent session that isn't already public.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8QA6740/p1787227902712139?thread_ts=1787227902.712139&cid=C09G8QA6740)*
