### PR TITLE
feat(autoresearch): add online validation (8/13)

### DIFF
--- a/products/autoresearch/backend/evaluation/AGENTS.md
+++ b/products/autoresearch/backend/evaluation/AGENTS.md
@@ -1,0 +1,64 @@
+# Evaluation
+
+Did the predictions actually come true?
+
+Training measures a model against a holdout slice of history. This package measures it against reality: once a prediction's horizon has elapsed, it joins the emitted `autoresearch_prediction` events back to what the person actually did and computes realized performance.
+
+It is the only honest number in the product. A holdout AUC of 0.93 says the model separates history well; the realized AUC says whether it predicted the future.
+
+This package landed ahead of its callers. `../api/`, `../temporal/`, and `../management/` arrive in later pieces of the split tracked in [#60081](https://github.com/PostHog/posthog/pull/60081), so the references to them below describe where they will sit.
+
+## What lives here
+
+- `online_validation.py`
+  `run_online_validation_for_pipeline()` is the entry point, called by the Temporal validation activity and by the `autoresearch_validate_online` command.
+
+  Per matured prediction date, per model, it computes:
+  - **realized AUC** — ranking quality against actual outcomes
+  - **Brier score** — squared error of the probabilities
+  - **expected calibration error** (`_expected_calibration_error`, 10 bins) — whether "0.8" really means 80%
+  - **lift@k** (`_lift_at_k`) — how much better than random the top slice is
+
+  Champions and challengers are both scored, which is what makes challenger promotion decidable on evidence rather than on holdout alone.
+  Results land on `AutoresearchModel.realized_score` / `.calibration_error` / `.metrics` via `_update_model_realized_metrics()`, and each validated date records an `AutoresearchRun`.
+
+## Mental model
+
+```text
+predictions emitted on day D
+        │
+        │  ... wait horizon_days ...
+        │
+ D + horizon <= today  →  the label is now knowable
+        │
+ _find_mature_unvalidated_dates  →  dates with predictions but no validation run
+        │
+ _fetch_predictions_by_model  ×  _fetch_realized_labels  →  metrics per model
+```
+
+`_find_mature_unvalidated_dates()` is what keeps this idempotent: it only picks up dates whose horizon has passed _and_ which have not already been validated, so the workflow can run daily without recomputing history.
+
+All the heavy work — the HogQL queries and the sklearn metrics — happens inside a single Temporal activity. Nothing large crosses a workflow boundary, which is deliberate: activity payloads are capped, and prediction sets are big.
+
+## Things that bite
+
+- **Nothing to validate on day one.** Predictions written today mature in `horizon_days`. A fresh pipeline returns zero validated dates and that is correct, not a bug.
+  To get a populated view locally, backdate: `autoresearch_score --prediction-date <past>` or `--backfill-days N` emits already-matured predictions.
+- **Backdated events are silently dropped when the team sets `drop_events_older_than_seconds`.** Ingestion discards them as too old, so validation finds nothing and nothing errors anywhere.
+- **A contiguous gap in prediction dates means the backfill lost a chunk**, not that validation skipped it — a large backfill can overwhelm the local ingestion consumer.
+
+## Where the rest of the system meets this package
+
+- **Scheduled by** — `AutoresearchValidationWorkflow` / `activity_run_validation` in `../temporal/workflows.py`.
+- **Run headlessly by** — `autoresearch_validate_online` (see `../management/AGENTS.md`), which supports `--dry-run`.
+- **Reads** — `autoresearch_prediction` events emitted by `../inference/`, and the target condition from `../dataset/labeling.py` (`build_target_condition`) so "did it happen?" is defined identically to how it was labeled at training time.
+- **Writes** — realized metrics onto `AutoresearchModel`, plus an `AutoresearchRun` per validated date.
+- **Not to be confused with** `../dataset/validation.py`, which is pre-flight target viability. Same word, opposite ends of the lifecycle.
+
+## When editing this flow
+
+- **Reuse `build_target_condition()` from `../dataset/labeling.py`.** If realized outcomes were defined differently from training labels, every realized metric would be measuring a different question than the model was trained on.
+- Keep `_find_mature_unvalidated_dates()` the only date selector, so validation stays idempotent and safe to run on a schedule.
+- Keep the heavy work inside one activity. Returning prediction sets through the workflow would hit the Temporal payload limit as soon as a pipeline scores a real population.
+- Score challengers as well as the champion — challenger realized performance is the evidence promotion should eventually rest on.
+- **If you add a metric or change the maturity rule, update this file to match.**

--- a/products/autoresearch/backend/evaluation/CLAUDE.md
+++ b/products/autoresearch/backend/evaluation/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/products/autoresearch/backend/evaluation/online_validation.py
+++ b/products/autoresearch/backend/evaluation/online_validation.py
@@ -1,0 +1,442 @@
+"""
+Online validation: join autoresearch_prediction events to realized target outcomes
+after the prediction horizon has elapsed.
+
+Computes per-model: realized AUC, Brier score, expected calibration error (ECE),
+and lift@k for both champion and challengers.
+
+Architecture:
+- Pure activity functions called by AutoresearchValidationWorkflow (Temporal)
+  and the autoresearch_validate_online management command.
+- All heavy work (HogQL queries + sklearn metrics) happens inside a single activity;
+  nothing large passes through Temporal payloads.
+"""
+
+import math
+from datetime import date, timedelta
+from typing import Any
+
+from django.utils import timezone as django_timezone
+
+import numpy as np
+import structlog
+
+from posthog.schema import HogQLQuery
+
+from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
+from posthog.models.team.team import Team
+
+from products.autoresearch.backend.dataset.labeling import build_target_condition
+from products.autoresearch.backend.models import AutoresearchModel, AutoresearchPipeline, AutoresearchRun
+from products.autoresearch.backend.query import run_hogql_rows
+
+logger = structlog.get_logger(__name__)
+
+PREDICTION_EVENT_NAME = "autoresearch_prediction"
+VALIDATION_QUERY_LIMIT = 50_000
+
+
+class ValidationDataTruncatedError(Exception):
+    """The predictions query hit VALIDATION_QUERY_LIMIT, so the fetched set may be incomplete."""
+
+
+def run_online_validation_for_pipeline(pipeline: AutoresearchPipeline) -> list[AutoresearchRun]:
+    """
+    Find all matured, unvalidated prediction dates and validate each one.
+
+    A prediction date is "matured" when today >= prediction_date + horizon_days —
+    meaning the outcome window has closed and realized labels can be fetched.
+
+    Returns one AutoresearchRun per prediction_date processed and updates
+    realized_score / calibration_error on each AutoresearchModel.
+    """
+    team = pipeline.team
+    mature_dates = _find_mature_unvalidated_dates(team, pipeline)
+
+    if not mature_dates:
+        logger.info("autoresearch_validation_no_mature_dates", pipeline_id=str(pipeline.pk))
+        return []
+
+    results = []
+    for prediction_date in sorted(mature_dates):
+        run = _validate_one_date(team, pipeline, prediction_date)
+        results.append(run)
+    return results
+
+
+def _find_mature_unvalidated_dates(team: Team, pipeline: AutoresearchPipeline) -> list[date]:
+    """
+    Return prediction dates that have matured but haven't been successfully validated.
+    Already-validated dates are tracked as COMPLETED validation AutoresearchRuns with
+    metrics['prediction_date'] set.
+    """
+    matured = _fetch_matured_prediction_dates(team, pipeline)
+    if not matured:
+        return []
+
+    already_validated = {
+        r.metrics.get("prediction_date")
+        for r in AutoresearchRun.objects.filter(
+            pipeline=pipeline,
+            run_type=AutoresearchRun.RunType.VALIDATION,
+            status=AutoresearchRun.Status.COMPLETED,
+        )
+        if r.metrics.get("prediction_date")
+    }
+
+    return [d for d in matured if d.isoformat() not in already_validated]
+
+
+def _fetch_matured_prediction_dates(team: Team, pipeline: AutoresearchPipeline) -> list[date]:
+    """
+    Query ClickHouse for distinct prediction dates where the horizon has elapsed:
+    prediction_date + horizon_days <= today.
+    """
+    sql = (
+        "SELECT DISTINCT toDate(properties['$autoresearch_prediction_date']) AS prediction_date"
+        " FROM events"
+        " WHERE event = {event_name}"
+        " AND properties['$autoresearch_pipeline_id'] = {pipeline_id}"
+        " AND addDays(toDate(properties['$autoresearch_prediction_date']), {horizon_days}) <= today()"
+        " ORDER BY prediction_date ASC"
+    )
+    values: dict[str, Any] = {
+        "event_name": PREDICTION_EVENT_NAME,
+        "pipeline_id": str(pipeline.pk),
+        "horizon_days": pipeline.horizon_days,
+    }
+
+    try:
+        tag_queries(product=Product.AUTORESEARCH, feature=Feature.QUERY)
+        rows = run_hogql_rows(team=team, query=HogQLQuery(query=sql, values=values))
+        return [date.fromisoformat(str(row[0])) for row in rows if row[0]]
+    except Exception:
+        logger.exception("autoresearch_matured_dates_query_failed", pipeline_id=str(pipeline.pk))
+        return []
+
+
+def _validate_one_date(
+    team: Team,
+    pipeline: AutoresearchPipeline,
+    prediction_date: date,
+) -> AutoresearchRun:
+    """
+    Validate predictions made on prediction_date for all models (champion + challengers).
+    Creates an AutoresearchRun record, computes metrics, and updates model records.
+
+    On any error the run is returned as FAILED (no metrics written), leaving the
+    date eligible for the next pass and other dates in the same pass unaffected.
+    """
+    now = django_timezone.now()
+    run = AutoresearchRun.objects.create(
+        pipeline=pipeline,
+        run_type=AutoresearchRun.RunType.VALIDATION,
+        status=AutoresearchRun.Status.RUNNING,
+        started_at=now,
+        metrics={"prediction_date": prediction_date.isoformat()},
+    )
+
+    try:
+        model_predictions = _fetch_predictions_by_model(team, pipeline, prediction_date)
+        realized_labels = _fetch_realized_labels(team, pipeline, prediction_date)
+
+        if not model_predictions:
+            logger.warning(
+                "autoresearch_validation_no_predictions",
+                pipeline_id=str(pipeline.pk),
+                prediction_date=prediction_date.isoformat(),
+            )
+            run.status = AutoresearchRun.Status.COMPLETED
+            run.rows_scored = 0
+            run.completed_at = django_timezone.now()
+            run.metrics["warning"] = "no_predictions_found"
+            run.save(update_fields=["status", "rows_scored", "completed_at", "metrics"])
+            return run
+
+        per_model_metrics: dict[str, Any] = {}
+        total_rows = 0
+
+        for model_id, predictions in model_predictions.items():
+            model = AutoresearchModel.objects.filter(pk=model_id, pipeline=pipeline).first()
+            if not model:
+                continue
+
+            metrics = _compute_validation_metrics(predictions, realized_labels)
+            per_model_metrics[model_id] = {
+                "model_role": model.role,
+                "n_scored": len(predictions),
+                **metrics,
+            }
+            total_rows += len(predictions)
+            _update_model_realized_metrics(model, metrics)
+
+        run.status = AutoresearchRun.Status.COMPLETED
+        run.rows_scored = total_rows
+        run.completed_at = django_timezone.now()
+        run.metrics.update(
+            {
+                "prediction_date": prediction_date.isoformat(),
+                "realized_labels_count": len(realized_labels),
+                "per_model": per_model_metrics,
+            }
+        )
+        run.save(update_fields=["status", "rows_scored", "completed_at", "metrics"])
+
+        logger.info(
+            "autoresearch_validation_complete",
+            pipeline_id=str(pipeline.pk),
+            prediction_date=prediction_date.isoformat(),
+            models_validated=len(per_model_metrics),
+            total_rows=total_rows,
+        )
+        return run
+
+    except Exception as exc:
+        # A FAILED run is not counted by _find_mature_unvalidated_dates, so the date
+        # stays eligible and the next validation pass retries it.
+        run.status = AutoresearchRun.Status.FAILED
+        run.completed_at = django_timezone.now()
+        run.metrics["error"] = str(exc)
+        run.save(update_fields=["status", "completed_at", "metrics"])
+        logger.exception(
+            "autoresearch_validation_failed",
+            pipeline_id=str(pipeline.pk),
+            prediction_date=prediction_date.isoformat(),
+        )
+        return run
+
+
+def _fetch_predictions_by_model(
+    team: Team,
+    pipeline: AutoresearchPipeline,
+    prediction_date: date,
+) -> dict[str, dict[str, float]]:
+    """
+    Return {model_id: {person_id: p_y}} for all predictions emitted on prediction_date.
+
+    Keyed on person_id to match realized labels (also keyed on person_id). Predictions
+    carry it as the $autoresearch_person_id property; we fall back to distinct_id for
+    events emitted before that property existed (when distinct_id was str(person_id)).
+
+    Raises ValidationDataTruncatedError when the row count hits VALIDATION_QUERY_LIMIT:
+    an arbitrary subset would bias every realized metric, and the COMPLETED run would
+    permanently exclude the date from revalidation.
+    """
+    # argMax picks the latest emission per (model, person), so a manual re-score of an
+    # already-scored date is validated deterministically instead of in ClickHouse
+    # return order. Backfills stamp every event of a date at the same instant, so the
+    # event UUID breaks those ties rather than leaving them to merge order.
+    sql = (
+        "SELECT"
+        " coalesce(nullIf(properties['$autoresearch_person_id'], ''), distinct_id) AS person_id,"
+        " properties['$autoresearch_model_id'] AS model_id,"
+        " argMax(toFloat(properties['$autoresearch_p_y']), (timestamp, uuid)) AS p_y"
+        " FROM events"
+        " WHERE event = {event_name}"
+        " AND properties['$autoresearch_pipeline_id'] = {pipeline_id}"
+        " AND properties['$autoresearch_prediction_date'] = {prediction_date}"
+        " GROUP BY person_id, model_id"
+        " LIMIT {limit}"
+    )
+    values: dict[str, Any] = {
+        "event_name": PREDICTION_EVENT_NAME,
+        "pipeline_id": str(pipeline.pk),
+        "prediction_date": prediction_date.isoformat(),
+        "limit": VALIDATION_QUERY_LIMIT,
+    }
+
+    try:
+        tag_queries(product=Product.AUTORESEARCH, feature=Feature.QUERY)
+        rows = run_hogql_rows(team=team, query=HogQLQuery(query=sql, values=values))
+        if not rows:
+            return {}
+    except Exception:
+        logger.exception(
+            "autoresearch_predictions_query_failed",
+            pipeline_id=str(pipeline.pk),
+            prediction_date=prediction_date.isoformat(),
+        )
+        # A swallowed failure would complete the run as no_predictions_found, and the
+        # maturity selector would then never revisit the date. Fail so it retries.
+        raise
+
+    if len(rows) >= VALIDATION_QUERY_LIMIT:
+        raise ValidationDataTruncatedError(
+            f"Predictions for {prediction_date.isoformat()} hit the {VALIDATION_QUERY_LIMIT} row limit; "
+            "refusing to compute metrics from a truncated subset"
+        )
+
+    model_predictions: dict[str, dict[str, float]] = {}
+    for row in rows:
+        person_id, model_id, p_y = row[0], row[1], row[2]
+        if not person_id or not model_id or p_y is None:
+            continue
+        mid = str(model_id)
+        if mid not in model_predictions:
+            model_predictions[mid] = {}
+        model_predictions[mid][str(person_id)] = float(p_y)
+
+    return model_predictions
+
+
+def _fetch_realized_labels(
+    team: Team,
+    pipeline: AutoresearchPipeline,
+    prediction_date: date,
+) -> frozenset[str]:
+    """
+    Return person_ids that performed the pipeline's target (event or action) in the
+    window [prediction_date, prediction_date + horizon_days).
+
+    Keyed on person_id (not distinct_id) to match the prediction events, which
+    are emitted with distinct_id = str(person_id) — the feature/score SQL keys
+    every scored row on person_id (see labeling.py, sandbox_inference.py).
+    Joining on the raw event distinct_id would compare two disjoint key spaces
+    and yield all-negative labels (AUC ≈ 0.5 / single-class).
+    """
+    end_date = prediction_date + timedelta(days=pipeline.horizon_days)
+    target_cond, target_values = build_target_condition(
+        target_event=pipeline.target_event, target_definition=pipeline.target_definition, team=team
+    )
+    sql = (
+        "SELECT DISTINCT person_id"
+        " FROM events"
+        f" WHERE {target_cond}"
+        " AND toDate(timestamp) >= {start_date}"
+        " AND toDate(timestamp) < {end_date}"
+    )
+    values: dict[str, Any] = {
+        "start_date": prediction_date.isoformat(),
+        "end_date": end_date.isoformat(),
+        **target_values,
+    }
+
+    # A query failure must propagate: returning an empty set here would make every
+    # prediction look negative, and the resulting COMPLETED run would permanently
+    # exclude this date from revalidation.
+    tag_queries(product=Product.AUTORESEARCH, feature=Feature.QUERY)
+    rows = run_hogql_rows(team=team, query=HogQLQuery(query=sql, values=values))
+    return frozenset(str(row[0]) for row in rows if row[0])
+
+
+def _compute_validation_metrics(
+    predictions: dict[str, float],
+    realized_labels: frozenset[str],
+) -> dict[str, Any]:
+    """
+    Compute AUC, Brier score, ECE, and lift@k from scored predictions vs realized labels.
+
+    predictions: {distinct_id: p_y}
+    realized_labels: distinct_ids that performed the target event in the horizon window
+    """
+    distinct_ids = list(predictions.keys())
+    y_score = np.array([predictions[did] for did in distinct_ids], dtype=np.float64)
+    y_true = np.array([1 if did in realized_labels else 0 for did in distinct_ids], dtype=np.int32)
+
+    n = len(y_true)
+    n_pos = int(y_true.sum())
+    n_neg = n - n_pos
+    base_rate = n_pos / n if n > 0 else 0.0
+
+    metrics: dict[str, Any] = {
+        "n_scored": n,
+        "n_positive": n_pos,
+        "n_negative": n_neg,
+        "base_rate": round(base_rate, 4),
+    }
+
+    if n_pos == 0 or n_neg == 0:
+        metrics["warning"] = "single_class_no_auc"
+        return metrics
+
+    # Deferred to keep the heavy dependency off the import path.
+    from sklearn.metrics import brier_score_loss, roc_auc_score  # noqa: PLC0415
+
+    metrics["realized_auc"] = round(float(roc_auc_score(y_true, y_score)), 4)
+    metrics["brier_score"] = round(float(brier_score_loss(y_true, y_score)), 4)
+    metrics["calibration_error"] = round(_expected_calibration_error(y_true, y_score), 4)
+    metrics["lift_at_10"] = round(_lift_at_k(y_true, y_score, k=0.10), 4)
+    metrics["lift_at_20"] = round(_lift_at_k(y_true, y_score, k=0.20), 4)
+
+    return metrics
+
+
+def _expected_calibration_error(y_true: np.ndarray, y_score: np.ndarray, n_bins: int = 10) -> float:
+    """
+    Expected Calibration Error (ECE): fraction-weighted mean absolute difference
+    between mean predicted probability and actual positive rate within each decile bin.
+    """
+    n = len(y_true)
+    bin_boundaries = np.linspace(0.0, 1.0, n_bins + 1)
+    ece = 0.0
+    for i in range(n_bins):
+        lo, hi = bin_boundaries[i], bin_boundaries[i + 1]
+        mask = (y_score >= lo) & (y_score <= hi) if i == n_bins - 1 else (y_score >= lo) & (y_score < hi)
+        if not mask.any():
+            continue
+        bin_n = int(mask.sum())
+        avg_pred = float(y_score[mask].mean())
+        actual_rate = float(y_true[mask].mean())
+        ece += (bin_n / n) * abs(avg_pred - actual_rate)
+    return ece
+
+
+def _lift_at_k(y_true: np.ndarray, y_score: np.ndarray, k: float) -> float:
+    """
+    Lift@k: ratio of positives captured in the top-k% of scored users vs random.
+
+    lift@k = (positives in top k%) / (k × total positives)
+
+    A lift of 2.0 at k=10% means the top 10% by score contains 2× as many positives
+    as a random 10% sample would.
+    """
+    n_pos_total = int(y_true.sum())
+    if n_pos_total == 0 or k <= 0:
+        return 0.0
+    n = len(y_true)
+    cutoff = max(1, math.ceil(n * k))
+    top_k_idx = np.argsort(y_score)[::-1][:cutoff]
+    positives_captured = int(y_true[top_k_idx].sum())
+    # Normalize by the fraction actually selected, not the requested k — rounding up to
+    # a whole user would otherwise overstate lift on small validation sets.
+    random_expected = (cutoff / n) * n_pos_total
+    return positives_captured / random_expected
+
+
+def _update_model_realized_metrics(model: AutoresearchModel, metrics: dict[str, Any]) -> None:
+    """
+    Persist validation metrics to the model record.
+
+    On first realized validation (is_preliminary=True), clears the preliminary flag
+    and sets realized_score. Subsequent validations update realized_score to the latest.
+    """
+    auc = metrics.get("realized_auc")
+    cal_error = metrics.get("calibration_error")
+
+    existing = model.metrics or {}
+    existing["realized"] = metrics
+
+    update_fields = ["metrics", "updated_at"]
+
+    if auc is not None:
+        model.realized_score = auc
+        update_fields.append("realized_score")
+        if model.is_preliminary:
+            model.is_preliminary = False
+            update_fields.append("is_preliminary")
+
+    if cal_error is not None:
+        model.calibration_error = cal_error
+        update_fields.append("calibration_error")
+
+    model.metrics = existing
+    model.save(update_fields=update_fields)
+
+    logger.info(
+        "autoresearch_model_realized_metrics_updated",
+        model_id=str(model.pk),
+        role=model.role,
+        realized_auc=auc,
+        calibration_error=cal_error,
+        is_preliminary=model.is_preliminary,
+    )

--- a/products/autoresearch/backend/evaluation/test_online_validation.py
+++ b/products/autoresearch/backend/evaluation/test_online_validation.py
@@ -1,0 +1,374 @@
+from datetime import date, timedelta
+
+from posthog.test.base import BaseTest
+from unittest.mock import patch
+
+import numpy as np
+from parameterized import parameterized
+
+from products.autoresearch.backend.evaluation.online_validation import (
+    ValidationDataTruncatedError,
+    _compute_validation_metrics,
+    _expected_calibration_error,
+    _fetch_predictions_by_model,
+    _find_mature_unvalidated_dates,
+    _lift_at_k,
+    _update_model_realized_metrics,
+    run_online_validation_for_pipeline,
+)
+from products.autoresearch.backend.models import AutoresearchModel, AutoresearchPipeline, AutoresearchRun
+from products.autoresearch.backend.testing import TeamScopedTestMixin
+
+
+class TestComputeValidationMetrics(TeamScopedTestMixin, BaseTest):
+    def _predictions(self) -> dict[str, float]:
+        return {
+            "user-1": 0.9,
+            "user-2": 0.8,
+            "user-3": 0.4,
+            "user-4": 0.3,
+            "user-5": 0.1,
+        }
+
+    def test_returns_base_counts(self):
+        preds = self._predictions()
+        labels = frozenset(["user-1", "user-2"])
+        metrics = _compute_validation_metrics(preds, labels)
+        assert metrics["n_scored"] == 5
+        assert metrics["n_positive"] == 2
+        assert metrics["n_negative"] == 3
+        assert metrics["base_rate"] == 0.4
+
+    def test_computes_auc_and_brier(self):
+        preds = self._predictions()
+        labels = frozenset(["user-1", "user-2"])
+        metrics = _compute_validation_metrics(preds, labels)
+        assert "realized_auc" in metrics
+        assert "brier_score" in metrics
+        assert 0.0 <= metrics["realized_auc"] <= 1.0
+        assert 0.0 <= metrics["brier_score"] <= 1.0
+
+    def test_perfect_separation_gives_high_auc(self):
+        preds = {"high-1": 0.95, "high-2": 0.90, "low-1": 0.05, "low-2": 0.10}
+        labels = frozenset(["high-1", "high-2"])
+        metrics = _compute_validation_metrics(preds, labels)
+        assert metrics["realized_auc"] == 1.0
+
+    def test_reversed_scores_give_low_auc(self):
+        preds = {"high-1": 0.05, "high-2": 0.10, "low-1": 0.95, "low-2": 0.90}
+        labels = frozenset(["high-1", "high-2"])
+        metrics = _compute_validation_metrics(preds, labels)
+        assert metrics["realized_auc"] == 0.0
+
+    def test_no_positives_returns_warning(self):
+        preds = {"user-1": 0.5, "user-2": 0.6}
+        metrics = _compute_validation_metrics(preds, frozenset())
+        assert metrics.get("warning") == "single_class_no_auc"
+        assert "realized_auc" not in metrics
+
+    def test_no_negatives_returns_warning(self):
+        preds = {"user-1": 0.5, "user-2": 0.6}
+        labels = frozenset(["user-1", "user-2"])
+        metrics = _compute_validation_metrics(preds, labels)
+        assert metrics.get("warning") == "single_class_no_auc"
+
+    def test_lift_at_k(self):
+        preds = self._predictions()
+        labels = frozenset(["user-1", "user-2"])
+        metrics = _compute_validation_metrics(preds, labels)
+        assert metrics["lift_at_10"] > 0.0
+        assert metrics["lift_at_20"] > 0.0
+
+    def test_calibration_error_range(self):
+        preds = self._predictions()
+        labels = frozenset(["user-1", "user-2"])
+        metrics = _compute_validation_metrics(preds, labels)
+        assert 0.0 <= metrics["calibration_error"] <= 1.0
+
+
+class TestExpectedCalibrationError(TeamScopedTestMixin, BaseTest):
+    def test_perfect_calibration_zero_ece(self):
+        # One bin where predicted = actual rate
+        y_true = np.array([1, 0, 1, 0])
+        y_score = np.array([0.5, 0.5, 0.5, 0.5])
+        ece = _expected_calibration_error(y_true, y_score)
+        assert abs(ece) < 1e-6
+
+    def test_overconfident_model_high_ece(self):
+        y_true = np.array([0, 0, 0, 0])
+        y_score = np.array([0.9, 0.9, 0.9, 0.9])
+        ece = _expected_calibration_error(y_true, y_score)
+        assert ece > 0.5
+
+
+class TestLiftAtK(TeamScopedTestMixin, BaseTest):
+    def test_perfect_ranking_lift_at_50_is_2(self):
+        y_true = np.array([1, 1, 0, 0])
+        y_score = np.array([0.9, 0.8, 0.2, 0.1])
+        lift = _lift_at_k(y_true, y_score, k=0.5)
+        assert abs(lift - 2.0) < 1e-6
+
+    def test_no_positives_returns_zero(self):
+        y_true = np.array([0, 0, 0])
+        y_score = np.array([0.9, 0.5, 0.1])
+        assert _lift_at_k(y_true, y_score, k=0.5) == 0.0
+
+    def test_lift_normalizes_by_the_rows_actually_selected(self):
+        # 11 users at k=0.1 selects 2 rows (ceil), so the random baseline is 2/11 of the
+        # positives, not 1.1 — normalizing by the requested k overstates lift.
+        y_true = np.array([1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+        y_score = np.array([0.99, 0.98, 0.5, 0.4, 0.3, 0.2, 0.1, 0.09, 0.08, 0.07, 0.06])
+        lift = _lift_at_k(y_true, y_score, k=0.1)
+        assert abs(lift - 5.5) < 1e-6
+
+    def test_random_ranking_lift_near_one(self):
+        rng = np.random.default_rng(42)
+        n = 1000
+        y_true = rng.integers(0, 2, n)
+        y_score = rng.uniform(0, 1, n)
+        lift = _lift_at_k(y_true, y_score, k=0.5)
+        assert 0.8 <= lift <= 1.2
+
+
+class TestUpdateModelRealizedMetrics(TeamScopedTestMixin, BaseTest):
+    def _make_model(self) -> AutoresearchModel:
+        pipeline = AutoresearchPipeline.objects.create(
+            team=self.team,
+            name="Test",
+            target_event="$pageview",
+            horizon_days=7,
+            iteration_budget=50,
+            iteration_budget_remaining=50,
+        )
+        return AutoresearchModel.objects.create(
+            pipeline=pipeline,
+            role=AutoresearchModel.Role.CHAMPION,
+            model_recipe={"stub": True},
+            recipe_hash="abc123",
+            holdout_score=0.75,
+        )
+
+    def test_clears_preliminary_on_first_validation(self):
+        model = self._make_model()
+        assert model.is_preliminary is True
+        _update_model_realized_metrics(model, {"realized_auc": 0.82, "calibration_error": 0.05})
+        updated = AutoresearchModel.objects.get(pk=model.pk)
+        assert updated.is_preliminary is False
+        assert updated.realized_score == 0.82
+        assert updated.calibration_error == 0.05
+
+    def test_updates_realized_score_on_subsequent_validation(self):
+        model = self._make_model()
+        _update_model_realized_metrics(model, {"realized_auc": 0.80})
+        _update_model_realized_metrics(model, {"realized_auc": 0.85})
+        model.refresh_from_db()
+        assert model.realized_score == 0.85
+        assert model.is_preliminary is False
+
+    def test_no_auc_leaves_preliminary_unchanged(self):
+        model = self._make_model()
+        _update_model_realized_metrics(model, {"warning": "single_class_no_auc"})
+        model.refresh_from_db()
+        assert model.is_preliminary is True
+        assert model.realized_score is None
+
+
+class TestRunOnlineValidationForPipeline(TeamScopedTestMixin, BaseTest):
+    def _make_pipeline(self) -> AutoresearchPipeline:
+        return AutoresearchPipeline.objects.create(
+            team=self.team,
+            name="Test pipeline",
+            target_event="$pageview",
+            horizon_days=7,
+            iteration_budget=50,
+            iteration_budget_remaining=50,
+        )
+
+    def _make_champion(self, pipeline: AutoresearchPipeline) -> AutoresearchModel:
+        return AutoresearchModel.objects.create(
+            pipeline=pipeline,
+            role=AutoresearchModel.Role.CHAMPION,
+            model_recipe={"stub": True},
+            recipe_hash="abc123",
+            holdout_score=0.75,
+        )
+
+    @patch("products.autoresearch.backend.evaluation.online_validation._fetch_matured_prediction_dates")
+    def test_no_mature_dates_returns_empty(self, mock_dates):
+        mock_dates.return_value = []
+        pipeline = self._make_pipeline()
+        runs = run_online_validation_for_pipeline(pipeline)
+        assert runs == []
+
+    @patch("products.autoresearch.backend.evaluation.online_validation._fetch_realized_labels")
+    @patch("products.autoresearch.backend.evaluation.online_validation._fetch_predictions_by_model")
+    @patch("products.autoresearch.backend.evaluation.online_validation._fetch_matured_prediction_dates")
+    def test_validates_one_mature_date(self, mock_dates, mock_preds, mock_labels):
+        pipeline = self._make_pipeline()
+        champion = self._make_champion(pipeline)
+        prediction_date = date.today() - timedelta(days=10)
+
+        mock_dates.return_value = [prediction_date]
+        mock_preds.return_value = {
+            str(champion.pk): {
+                "user-a": 0.9,
+                "user-b": 0.8,
+                "user-c": 0.2,
+                "user-d": 0.1,
+            }
+        }
+        mock_labels.return_value = frozenset(["user-a", "user-b"])
+
+        runs = run_online_validation_for_pipeline(pipeline)
+
+        assert len(runs) == 1
+        run = runs[0]
+        assert run.status == AutoresearchRun.Status.COMPLETED
+        assert run.run_type == AutoresearchRun.RunType.VALIDATION
+        assert run.metrics["prediction_date"] == prediction_date.isoformat()
+        assert run.metrics["realized_labels_count"] == 2
+        assert str(champion.pk) in run.metrics["per_model"]
+
+        champion.refresh_from_db()
+        assert champion.realized_score is not None
+        assert champion.is_preliminary is False
+
+    @patch("products.autoresearch.backend.evaluation.online_validation._fetch_realized_labels")
+    @patch("products.autoresearch.backend.evaluation.online_validation._fetch_predictions_by_model")
+    @patch("products.autoresearch.backend.evaluation.online_validation._fetch_matured_prediction_dates")
+    def test_skips_already_validated_dates(self, mock_dates, mock_preds, mock_labels):
+        pipeline = self._make_pipeline()
+        self._make_champion(pipeline)
+        prediction_date = date.today() - timedelta(days=10)
+
+        # Pre-create a completed validation run for that date
+        AutoresearchRun.objects.create(
+            pipeline=pipeline,
+            run_type=AutoresearchRun.RunType.VALIDATION,
+            status=AutoresearchRun.Status.COMPLETED,
+            metrics={"prediction_date": prediction_date.isoformat()},
+        )
+
+        mock_dates.return_value = [prediction_date]
+        runs = run_online_validation_for_pipeline(pipeline)
+
+        assert runs == []
+        mock_preds.assert_not_called()
+        mock_labels.assert_not_called()
+
+    @patch("products.autoresearch.backend.evaluation.online_validation._fetch_realized_labels")
+    @patch("products.autoresearch.backend.evaluation.online_validation._fetch_predictions_by_model")
+    @patch("products.autoresearch.backend.evaluation.online_validation._fetch_matured_prediction_dates")
+    def test_empty_predictions_marks_run_completed_with_warning(self, mock_dates, mock_preds, mock_labels):
+        pipeline = self._make_pipeline()
+        prediction_date = date.today() - timedelta(days=10)
+
+        mock_dates.return_value = [prediction_date]
+        mock_preds.return_value = {}  # no predictions found
+        mock_labels.return_value = frozenset(["user-a"])
+
+        runs = run_online_validation_for_pipeline(pipeline)
+
+        assert len(runs) == 1
+        assert runs[0].status == AutoresearchRun.Status.COMPLETED
+        assert runs[0].rows_scored == 0
+        assert runs[0].metrics.get("warning") == "no_predictions_found"
+
+    @patch("products.autoresearch.backend.evaluation.online_validation._fetch_realized_labels")
+    @patch("products.autoresearch.backend.evaluation.online_validation._fetch_predictions_by_model")
+    @patch("products.autoresearch.backend.evaluation.online_validation._fetch_matured_prediction_dates")
+    def test_label_fetch_failure_marks_run_failed_and_continues(self, mock_dates, mock_preds, mock_labels):
+        pipeline = self._make_pipeline()
+        champion = self._make_champion(pipeline)
+        d1 = date.today() - timedelta(days=11)
+        d2 = date.today() - timedelta(days=10)
+
+        mock_dates.return_value = [d1, d2]
+        mock_preds.return_value = {str(champion.pk): {"user-a": 0.9, "user-b": 0.2}}
+        mock_labels.side_effect = [RuntimeError("clickhouse unavailable"), frozenset(["user-a"])]
+
+        runs = run_online_validation_for_pipeline(pipeline)
+
+        assert [r.status for r in runs] == [AutoresearchRun.Status.FAILED, AutoresearchRun.Status.COMPLETED]
+        failed_run = runs[0]
+        assert failed_run.metrics["prediction_date"] == d1.isoformat()
+        assert "per_model" not in failed_run.metrics
+        assert "clickhouse unavailable" in failed_run.metrics["error"]
+
+
+class TestFetchPredictionsByModel(TeamScopedTestMixin, BaseTest):
+    def _make_pipeline(self) -> AutoresearchPipeline:
+        return AutoresearchPipeline.objects.create(
+            team=self.team,
+            name="Test",
+            target_event="$pageview",
+            horizon_days=7,
+            iteration_budget=50,
+            iteration_budget_remaining=50,
+        )
+
+    @parameterized.expand(
+        [
+            ("at_limit_raises", 3, True),
+            ("under_limit_returns", 2, False),
+        ]
+    )
+    @patch("products.autoresearch.backend.evaluation.online_validation.VALIDATION_QUERY_LIMIT", 3)
+    @patch("products.autoresearch.backend.evaluation.online_validation.run_hogql_rows")
+    def test_truncation_guard(self, _name, n_rows, expect_raise, mock_rows):
+        pipeline = self._make_pipeline()
+        mock_rows.return_value = [[f"user-{i}", "model-1", 0.5] for i in range(n_rows)]
+
+        if expect_raise:
+            with self.assertRaises(ValidationDataTruncatedError):
+                _fetch_predictions_by_model(self.team, pipeline, date(2026, 5, 1))
+        else:
+            predictions = _fetch_predictions_by_model(self.team, pipeline, date(2026, 5, 1))
+            assert predictions == {"model-1": {f"user-{i}": 0.5 for i in range(n_rows)}}
+
+
+class TestFindMatureUnvalidatedDates(TeamScopedTestMixin, BaseTest):
+    def _make_pipeline(self) -> AutoresearchPipeline:
+        return AutoresearchPipeline.objects.create(
+            team=self.team,
+            name="Test",
+            target_event="$pageview",
+            horizon_days=7,
+            iteration_budget=50,
+            iteration_budget_remaining=50,
+        )
+
+    @patch("products.autoresearch.backend.evaluation.online_validation._fetch_matured_prediction_dates")
+    def test_excludes_already_validated(self, mock_dates):
+        pipeline = self._make_pipeline()
+        d1 = date(2026, 5, 1)
+        d2 = date(2026, 5, 2)
+        mock_dates.return_value = [d1, d2]
+
+        # d1 already validated
+        AutoresearchRun.objects.create(
+            pipeline=pipeline,
+            run_type=AutoresearchRun.RunType.VALIDATION,
+            status=AutoresearchRun.Status.COMPLETED,
+            metrics={"prediction_date": d1.isoformat()},
+        )
+
+        unvalidated = _find_mature_unvalidated_dates(team=self.team, pipeline=pipeline)
+        assert unvalidated == [d2]
+
+    @patch("products.autoresearch.backend.evaluation.online_validation._fetch_matured_prediction_dates")
+    def test_failed_validation_run_is_retried(self, mock_dates):
+        pipeline = self._make_pipeline()
+        d1 = date(2026, 5, 1)
+        mock_dates.return_value = [d1]
+
+        # FAILED run does not count as validated
+        AutoresearchRun.objects.create(
+            pipeline=pipeline,
+            run_type=AutoresearchRun.RunType.VALIDATION,
+            status=AutoresearchRun.Status.FAILED,
+            metrics={"prediction_date": d1.isoformat()},
+        )
+
+        unvalidated = _find_mature_unvalidated_dates(team=self.team, pipeline=pipeline)
+        assert d1 in unvalidated


### PR DESCRIPTION
> [!NOTE]
> Piece 8 of 13 in the split of #60081. Pieces 1-4 land prerequisites that stand alone on master. Pieces 5-13 add the autoresearch product. The map lives in #60081.

## Problem

A holdout score says a model fit its training data. It does not say the model was right about the future.

Autoresearch emits a prediction per person per day. Once a prediction's horizon has elapsed, the answer is knowable, and nothing yet goes back to look.

## Changes

- Nobody sees anything different. Nothing schedules this yet.
- Finds every prediction date whose horizon has elapsed and that has not been validated, then scores each one: realized AUC, Brier, calibration error, and lift@k.
- Writes the result back onto the model, which is what clears `is_preliminary` and gives the champion a realized score next to its holdout score.
- A truncated prediction query raises rather than computing metrics from a partial set, because a metric from a subset would be recorded as if it were the whole.
- A failed query propagates. Swallowing it would complete the run as "no predictions found", and the maturity selector would then never revisit that date.
- Mechanical: the query call sites use the shared `run_hogql_rows` helper.

## How did you test this code?

`hogli test products/autoresearch/backend/evaluation` passes 26 tests, which came with the code from the branch.

Changed there: the truncation-guard test stubs the query helper rather than the runner class, and the fixture-building classes use the team-scoped mixin.

Also run: `uv run mypy --cache-fine-grained .` repo-wide and `uv run tach check`.

Not run: validation against real emitted events, which needs a scored population and an elapsed horizon.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`products/autoresearch/backend/evaluation/AGENTS.md` is new and in this PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5), driven by @andrewm4894. Cut by path from the `autoresearch-dev` branch (#60081) per the split plan in that PR.

Skills invoked: /writing-tests, /writing-code-comments, /writing-pr-descriptions.
