### PR TITLE
feat(autoresearch): add the scheduled workflows (9/13)

### DIFF
--- a/posthog/management/commands/start_temporal_worker.py
+++ b/posthog/management/commands/start_temporal_worker.py
@@ -151,6 +151,10 @@ from posthog.temporal.weekly_digest import (
     WORKFLOWS as WEEKLY_DIGEST_WORKFLOWS,
 )
 
+from products.autoresearch.backend.temporal import (
+    ACTIVITIES as AUTORESEARCH_ACTIVITIES,
+    WORKFLOWS as AUTORESEARCH_WORKFLOWS,
+)
 from products.batch_exports.backend.temporal import (
     ACTIVITIES as BATCH_EXPORTS_ACTIVITIES,
     WORKFLOWS as BATCH_EXPORTS_WORKFLOWS,
@@ -497,6 +501,11 @@ _task_queue_specs = [
         settings.LOGS_VOLUME_TICK_TASK_QUEUE,
         LOGS_VOLUME_TICK_WORKFLOWS,
         LOGS_VOLUME_TICK_ACTIVITIES,
+    ),
+    (
+        settings.AUTORESEARCH_TASK_QUEUE,
+        AUTORESEARCH_WORKFLOWS,
+        AUTORESEARCH_ACTIVITIES,
     ),
     (
         settings.STAMPHOG_TASK_QUEUE,

--- a/posthog/settings/temporal.py
+++ b/posthog/settings/temporal.py
@@ -238,6 +238,7 @@ ERROR_TRACKING_TASK_QUEUE = _set_temporal_task_queue("error-tracking-task-queue"
 ERROR_TRACKING_LIFECYCLE_TASK_QUEUE = _set_temporal_task_queue("error-tracking-lifecycle-task-queue")
 EVENT_SCREENSHOTS_TASK_QUEUE = _set_temporal_task_queue("event-screenshots-task-queue")
 LOGS_ALERTING_TASK_QUEUE = _set_temporal_task_queue("logs-alerting-task-queue")
+AUTORESEARCH_TASK_QUEUE = _set_temporal_task_queue("autoresearch-task-queue")
 # Dedicated queue: the tick becomes the scan-heavy rollup writer, and it must not
 # share pods with the latency-sensitive alerting workers.
 LOGS_VOLUME_TICK_TASK_QUEUE = _set_temporal_task_queue(

--- a/posthog/temporal/schedule.py
+++ b/posthog/temporal/schedule.py
@@ -76,6 +76,7 @@ from posthog.temporal.warehouse_sources_queue_partition_management.schedule impo
 )
 from posthog.temporal.weekly_digest.types import WeeklyDigestInput
 
+from products.autoresearch.backend.temporal.schedule import create_autoresearch_daily_schedule
 from products.billing_alerts.backend.temporal.schedule import create_schedule_due_billing_alert_checks_schedule
 from products.business_knowledge.backend.temporal.schedule import create_business_knowledge_refresh_coordinator_schedule
 from products.conversations.backend.temporal.channel_summary.schedule import create_channel_summary_coordinator_schedule
@@ -888,6 +889,7 @@ schedules = [
     create_schedule_due_alert_checks_schedule,
     create_run_investigation_safety_net_schedule,
     create_cleanup_alert_checks_schedule,
+    create_autoresearch_daily_schedule,
     create_signals_scout_coordinator_schedule,
     create_support_reply_coordinator_schedule,
     create_channel_summary_coordinator_schedule,

--- a/products/autoresearch/backend/temporal/AGENTS.md
+++ b/products/autoresearch/backend/temporal/AGENTS.md
@@ -1,0 +1,61 @@
+# Temporal workflows
+
+The scheduled half of autoresearch. Three workflows and five activities, registered on the `autoresearch-task-queue` by `start_temporal_worker`, which imports `WORKFLOWS` and `ACTIVITIES` from `__init__.py`.
+
+Nothing here implements product logic. Every activity is a thin call into `../inference/`, `../evaluation/`, or `../training/` — the same functions the management commands and the API reach. That is deliberate: the scheduled path must not be able to drift from the headless one.
+
+The API and the management commands that also drive these paths arrive in a later piece of the split tracked in [#60081](https://github.com/PostHog/posthog/pull/60081).
+
+## What lives here
+
+- `workflows.py`
+  - `AutoresearchCoordinatorWorkflow` (`autoresearch-coordinator`) — the daily tick. Loads active pipelines (`activity_load_active_pipelines`) and fans out inference, validation, and training kickoff per pipeline.
+  - `AutoresearchInferenceWorkflow` (`autoresearch-inference`) — `activity_load_champion` then `activity_run_inference` for one pipeline.
+  - `AutoresearchValidationWorkflow` (`autoresearch-validation`) — `activity_run_validation` for one pipeline.
+  - `activity_kickoff_training` — launches a training run for a pipeline that is due.
+
+  Each workflow has a typed input/result dataclass pair (`InferenceWorkflowInput` / `InferenceWorkflowResult`, and so on). Activities are named with a `autoresearch-<workflow>.<activity>` convention.
+
+- `schedule.py`
+  `create_autoresearch_daily_schedule()` registers schedule `autoresearch-daily-coordinator` driving workflow id `autoresearch-coordinator`.
+  Overlap policy is **SKIP** — a tick that is still running causes the next one to be dropped rather than queued, so a slow day cannot pile up a backlog of duplicate scoring runs.
+- `__init__.py`
+  The registration surface. `WORKFLOWS` and `ACTIVITIES` are what the worker reads; a workflow that is not in these lists does not exist as far as production is concerned.
+
+## Mental model
+
+```text
+daily schedule
+   └─ AutoresearchCoordinatorWorkflow
+        ├─ activity_load_active_pipelines
+        └─ per pipeline:
+             ├─ AutoresearchInferenceWorkflow   → ../inference/
+             ├─ AutoresearchValidationWorkflow  → ../evaluation/
+             └─ activity_kickoff_training       → ../training/
+```
+
+The coordinator decides _whether_ each pipeline is due; the child workflows do one pipeline's work. Keep that split — per-pipeline logic in the coordinator is what makes a fan-out impossible to reason about.
+
+Note that training is launched by an _activity_, not a child workflow, because the actual agent run happens in a Tasks sandbox with its own lifecycle. Autoresearch does not own that workflow; it fires it and the `TaskRun` `post_save` signal (`../training/ingestion.py`) picks the result back up.
+
+## Payload discipline
+
+Temporal activity payloads are capped at roughly 2 MiB, and autoresearch moves genuinely large data — feature matrices, prediction sets, materialized populations.
+
+**Do all heavy work inside a single activity and return only references.** Scoring writes its events and returns counts; validation computes its metrics inside the activity and returns the summary. Never pass a materialized population or a prediction set through a workflow on its way to being persisted — it will work in dev and fail with `PayloadSizeError` the moment a real team runs it.
+
+## Where the rest of the system meets this package
+
+- **Registered by** — `posthog/management/commands/start_temporal_worker.py`, which imports `WORKFLOWS` / `ACTIVITIES` from here.
+- **Scheduled by** — `posthog/temporal/schedule.py`, which calls `create_autoresearch_daily_schedule()`.
+- **Calls into** — `../inference/scoring.py`, `../evaluation/online_validation.py`, `../training/runner.py`.
+- **Result handoff** — training results come back through the `TaskRun` `post_save` signal wired in `../apps.py`, not through this workflow.
+
+## When editing this flow
+
+- **Editing a `@workflow.defn` body breaks in-flight executions.** Adding, removing, or reordering `execute_activity` calls, child-workflow starts, or timers fails replay with a non-determinism error on every running execution.
+  Gate new commands behind `workflow.patched("...")`, or on a new field of an existing activity's output dataclass that defaults to the skip value. Activity _implementations_ and activity _input_ dataclasses are safe to edit; command sequences are not.
+- **Never gate a workflow command on something computed inside the workflow body** — a feature flag, a setting, the clock, a database read. That is itself non-deterministic.
+- Keep activities thin. If you are writing product logic here, it belongs in the package the activity calls, or the management commands will quietly behave differently from production.
+- New workflows and activities must be added to `WORKFLOWS` / `ACTIVITIES` in `__init__.py` or they are never registered — this fails silently, since nothing errors when a workflow simply never runs.
+- **If you add or rename a workflow or activity, update this file to match.**

--- a/products/autoresearch/backend/temporal/CLAUDE.md
+++ b/products/autoresearch/backend/temporal/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/products/autoresearch/backend/temporal/__init__.py
+++ b/products/autoresearch/backend/temporal/__init__.py
@@ -1,0 +1,38 @@
+"""Temporal workflows and activities for autoresearch inference, validation, and training.
+
+`start_temporal_worker` imports WORKFLOWS and ACTIVITIES from here and
+registers them on the `autoresearch-task-queue`.
+"""
+
+from .workflows import (
+    AutoresearchCoordinatorWorkflow,
+    AutoresearchInferenceWorkflow,
+    AutoresearchValidationWorkflow,
+    activity_kickoff_training,
+    activity_load_active_pipelines,
+    activity_load_champion,
+    activity_run_inference,
+    activity_run_validation,
+)
+
+WORKFLOWS = [
+    AutoresearchCoordinatorWorkflow,
+    AutoresearchInferenceWorkflow,
+    AutoresearchValidationWorkflow,
+]
+
+ACTIVITIES = [
+    activity_kickoff_training,
+    activity_load_active_pipelines,
+    activity_load_champion,
+    activity_run_inference,
+    activity_run_validation,
+]
+
+__all__ = [
+    "ACTIVITIES",
+    "WORKFLOWS",
+    "AutoresearchCoordinatorWorkflow",
+    "AutoresearchInferenceWorkflow",
+    "AutoresearchValidationWorkflow",
+]

--- a/products/autoresearch/backend/temporal/schedule.py
+++ b/products/autoresearch/backend/temporal/schedule.py
@@ -1,0 +1,54 @@
+"""Temporal schedule for the daily autoresearch coordinator workflow."""
+
+from __future__ import annotations
+
+from django.conf import settings
+
+from temporalio.client import (
+    Client,
+    Schedule,
+    ScheduleActionStartWorkflow,
+    ScheduleCalendarSpec,
+    ScheduleOverlapPolicy,
+    SchedulePolicy,
+    ScheduleRange,
+    ScheduleSpec,
+)
+
+from posthog.temporal.common.schedule import a_create_schedule, a_schedule_exists, a_update_schedule
+
+from products.autoresearch.backend.temporal.workflows import CoordinatorWorkflowInput
+
+_SCHEDULE_ID = "autoresearch-daily-coordinator"
+_WORKFLOW_ID = "autoresearch-coordinator"
+
+
+async def create_autoresearch_daily_schedule(client: Client) -> None:
+    """Create or update the daily schedule for the autoresearch coordinator workflow.
+
+    Fires once per day at 2 AM UTC. The coordinator fans out inference, validation,
+    and training-kickoff for every active pipeline. SKIP overlap prevents a new run
+    from starting if the previous day's coordinator is still executing.
+    """
+    schedule = Schedule(
+        action=ScheduleActionStartWorkflow(
+            "autoresearch-coordinator",
+            CoordinatorWorkflowInput(),
+            id=_WORKFLOW_ID,
+            task_queue=settings.AUTORESEARCH_TASK_QUEUE,
+        ),
+        spec=ScheduleSpec(
+            calendars=[
+                ScheduleCalendarSpec(
+                    comment="Daily at 2 AM UTC",
+                    hour=[ScheduleRange(start=2, end=2)],
+                )
+            ]
+        ),
+        policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.SKIP),
+    )
+
+    if await a_schedule_exists(client, _SCHEDULE_ID):
+        await a_update_schedule(client, _SCHEDULE_ID, schedule)
+    else:
+        await a_create_schedule(client, _SCHEDULE_ID, schedule, trigger_immediately=False)

--- a/products/autoresearch/backend/temporal/test_workflows.py
+++ b/products/autoresearch/backend/temporal/test_workflows.py
@@ -1,0 +1,140 @@
+from datetime import timedelta
+from typing import Any, Optional
+
+from posthog.test.base import BaseTest
+from unittest.mock import MagicMock, patch
+
+from django.test import SimpleTestCase
+from django.utils import timezone
+
+from parameterized import parameterized
+
+from products.autoresearch.backend.models import AutoresearchPipeline
+from products.autoresearch.backend.temporal.workflows import (
+    InferenceWorkflowResult,
+    KickoffTrainingInput,
+    KickoffTrainingResult,
+    LoadActivePipelinesInput,
+    ValidationWorkflowResult,
+    activity_kickoff_training,
+    activity_load_active_pipelines,
+    evaluate_pipeline_outcome,
+)
+from products.autoresearch.backend.testing import TeamScopedTestMixin
+
+
+def _inference(status: str = "completed", error: Optional[str] = None) -> InferenceWorkflowResult:
+    return InferenceWorkflowResult(run_id="run-1", rows_scored=10, status=status, error=error)
+
+
+def _validation(status: str = "completed", error: Optional[str] = None) -> ValidationWorkflowResult:
+    return ValidationWorkflowResult(dates_validated=1, total_rows=10, status=status, error=error)
+
+
+def _kickoff(reason: str = "started", error: Optional[str] = None) -> KickoffTrainingResult:
+    return KickoffTrainingResult(kicked_off=reason == "started", reason=reason, error=error)
+
+
+class TestEvaluatePipelineOutcome(SimpleTestCase):
+    @parameterized.expand(
+        [
+            ("all_steps_succeed", _inference(), _validation(), _kickoff(), True, 0),
+            ("inference_raises", RuntimeError("boom"), _validation(), _kickoff(), False, 1),
+            ("inference_soft_fails", _inference(status="failed", error="oom"), _validation(), _kickoff(), False, 1),
+            ("validation_raises", _inference(), RuntimeError("boom"), _kickoff(), False, 1),
+            ("validation_soft_fails", _inference(), _validation(status="failed", error="boom"), _kickoff(), False, 1),
+            ("kickoff_raises", _inference(), _validation(), RuntimeError("boom"), False, 1),
+            ("kickoff_errors", _inference(), _validation(), _kickoff(reason="error", error="boom"), False, 1),
+            ("kickoff_no_creator", _inference(), _validation(), _kickoff(reason="no_creator", error="boom"), False, 1),
+            ("kickoff_skip_is_not_failure", _inference(), _validation(), _kickoff(reason="budget_exhausted"), True, 0),
+            (
+                "multiple_failures_all_counted",
+                RuntimeError("boom"),
+                _validation(status="failed", error="boom"),
+                _kickoff(),
+                False,
+                2,
+            ),
+        ]
+    )
+    def test_outcome_classification(
+        self,
+        _name: str,
+        inference: Any,
+        validation: Any,
+        kickoff: Any,
+        expected_succeeded: bool,
+        expected_error_count: int,
+    ) -> None:
+        outcome = evaluate_pipeline_outcome(
+            pipeline_id="pipeline-1", inference=inference, validation=validation, kickoff=kickoff
+        )
+        assert outcome.succeeded == expected_succeeded
+        assert len(outcome.errors) == expected_error_count
+
+
+class TestCoordinatorActivities(TeamScopedTestMixin, BaseTest):
+    def _create_pipeline(self, **overrides: Any) -> AutoresearchPipeline:
+        params: dict[str, Any] = {
+            "team": self.team,
+            "created_by": self.user,
+            "name": "test pipeline",
+            "target_event": "$pageview",
+            "status": AutoresearchPipeline.Status.RUNNING,
+            "iteration_budget_remaining": 20,
+            **overrides,
+        }
+        return AutoresearchPipeline.objects.create(**params)
+
+    @parameterized.expand(
+        [
+            ("never_scored_is_due", AutoresearchPipeline.Status.RUNNING, 1, None, True),
+            ("overdue_is_due", AutoresearchPipeline.Status.RUNNING, 1, timedelta(days=2), True),
+            ("recently_scored_is_not_due", AutoresearchPipeline.Status.RUNNING, 1, timedelta(hours=1), False),
+            ("within_cadence_window_is_not_due", AutoresearchPipeline.Status.RUNNING, 7, timedelta(days=3), False),
+            ("past_cadence_window_is_due", AutoresearchPipeline.Status.RUNNING, 7, timedelta(days=8), True),
+            ("converged_overdue_is_due", AutoresearchPipeline.Status.CONVERGED, 1, timedelta(days=2), True),
+            ("paused_is_excluded", AutoresearchPipeline.Status.PAUSED, 1, None, False),
+        ]
+    )
+    def test_load_active_pipelines_honors_cadence(
+        self,
+        _name: str,
+        status: str,
+        cadence_days: int,
+        scored_ago: Optional[timedelta],
+        expected_due: bool,
+    ) -> None:
+        pipeline = self._create_pipeline(
+            status=status,
+            cadence_days=cadence_days,
+            last_scored_at=timezone.now() - scored_ago if scored_ago else None,
+        )
+        result = activity_load_active_pipelines(LoadActivePipelinesInput())
+        assert (str(pipeline.id) in [d.pipeline_id for d in result.due]) == expected_due
+
+    @patch("products.autoresearch.backend.temporal.workflows.run_training")
+    def test_kickoff_passes_pipeline_creator_to_training(self, mock_run_training: MagicMock) -> None:
+        pipeline = self._create_pipeline()
+
+        result = activity_kickoff_training(KickoffTrainingInput(pipeline_id=str(pipeline.id), team_id=self.team.id))
+
+        assert result.kicked_off
+        assert result.reason == "started"
+        mock_run_training.assert_called_once()
+        assert mock_run_training.call_args.kwargs["user_id"] == self.user.id
+        pipeline.refresh_from_db()
+        assert pipeline.iteration_budget_remaining == 10
+
+    @patch("products.autoresearch.backend.temporal.workflows.run_training")
+    def test_kickoff_without_creator_fails_loudly_and_spends_no_budget(self, mock_run_training: MagicMock) -> None:
+        pipeline = self._create_pipeline(created_by=None)
+
+        result = activity_kickoff_training(KickoffTrainingInput(pipeline_id=str(pipeline.id), team_id=self.team.id))
+
+        assert not result.kicked_off
+        assert result.reason == "no_creator"
+        assert result.error
+        mock_run_training.assert_not_called()
+        pipeline.refresh_from_db()
+        assert pipeline.iteration_budget_remaining == 20

--- a/products/autoresearch/backend/temporal/workflows.py
+++ b/products/autoresearch/backend/temporal/workflows.py
@@ -1,0 +1,551 @@
+"""
+Temporal workflows for autoresearch inference and online validation.
+
+Both workflows are regular Temporal workflows (not TaskRun/agent sandboxes) because
+scoring and validation are deterministic pipelines. Training runs through Task/TaskRun.
+
+Activities are synchronous — Temporal runs them in a thread pool, which is correct
+for Django ORM + HogQL queries. Workflows are async and only orchestrate activities.
+"""
+
+from __future__ import annotations
+
+from dataclasses import field
+from datetime import date, timedelta
+from typing import Optional
+
+import structlog
+from temporalio import activity, workflow
+from temporalio.common import RetryPolicy
+from temporalio.exceptions import ApplicationError
+
+with workflow.unsafe.imports_passed_through():
+    import asyncio as _asyncio
+
+    from django.db import transaction
+    from django.db.models import F
+    from django.utils import timezone as django_timezone
+
+    from products.autoresearch.backend.evaluation.online_validation import run_online_validation_for_pipeline
+    from products.autoresearch.backend.inference.scoring import run_inference_for_pipeline
+    from products.autoresearch.backend.models import (
+        AutoresearchModel,
+        AutoresearchPipeline,
+        AutoresearchRun,
+        AutoresearchTrainingRun,
+    )
+    from products.autoresearch.backend.training.runner import run_training
+
+from posthog.dataclasses import frozen
+from posthog.models.scoping import team_scope
+from posthog.temporal.common.base import PostHogWorkflow
+
+logger = structlog.get_logger(__name__)
+
+
+# ── I/O dataclasses ──────────────────────────────────────────────────────────
+
+
+@frozen
+class InferenceWorkflowInput:
+    pipeline_id: str
+    team_id: int
+    prediction_date: str  # ISO date string, e.g. "2026-05-26"
+
+
+@frozen
+class InferenceWorkflowResult:
+    run_id: str
+    rows_scored: int
+    status: str
+    error: Optional[str] = None
+
+
+@frozen
+class LoadChampionInput:
+    pipeline_id: str
+    team_id: int
+
+
+@frozen
+class LoadChampionResult:
+    model_id: str
+
+
+@frozen
+class RunInferenceInput:
+    pipeline_id: str
+    team_id: int
+    model_id: str
+    prediction_date: str  # ISO date string
+
+
+@frozen
+class RunInferenceResult:
+    run_id: str
+    rows_scored: int
+    status: str
+    error: Optional[str] = None
+
+
+# ── Activities ───────────────────────────────────────────────────────────────
+
+
+@activity.defn(name="autoresearch-inference.load_champion")
+def activity_load_champion(inp: LoadChampionInput) -> LoadChampionResult:
+    """Load the champion model for a pipeline. Raises if none exists."""
+    with team_scope(inp.team_id):
+        pipeline = AutoresearchPipeline.objects.get(pk=inp.pipeline_id)
+        champion = (
+            AutoresearchModel.objects.filter(pipeline=pipeline, role=AutoresearchModel.Role.CHAMPION)
+            .order_by("-created_at")
+            .first()
+        )
+    if not champion:
+        raise ValueError(f"No champion model for pipeline {inp.pipeline_id}")
+    return LoadChampionResult(model_id=str(champion.pk))
+
+
+@activity.defn(name="autoresearch-inference.run_inference")
+def activity_run_inference(inp: RunInferenceInput) -> RunInferenceResult:
+    """Score the inference population and emit autoresearch_prediction events."""
+    with team_scope(inp.team_id):
+        pipeline = AutoresearchPipeline.objects.select_related("team").get(pk=inp.pipeline_id)
+        model = AutoresearchModel.objects.get(pk=inp.model_id)
+        run = run_inference_for_pipeline(
+            pipeline=pipeline, model=model, prediction_date=date.fromisoformat(inp.prediction_date)
+        )
+    return RunInferenceResult(
+        run_id=str(run.pk),
+        rows_scored=run.rows_scored or 0,
+        status=run.status,
+        error=run.error or None,
+    )
+
+
+# ── Workflow ─────────────────────────────────────────────────────────────────
+
+# Load champion is a cheap DB read; score can take minutes for large populations.
+_LOAD_RETRY = RetryPolicy(maximum_attempts=3, initial_interval=timedelta(seconds=5))
+_SCORE_RETRY = RetryPolicy(maximum_attempts=2, initial_interval=timedelta(seconds=30))
+
+
+@workflow.defn(name="autoresearch-inference")
+class AutoresearchInferenceWorkflow(PostHogWorkflow):
+    """
+    Temporal workflow that runs daily inference for one autoresearch pipeline.
+
+    Steps:
+    1. Load the champion model for the pipeline.
+    2. Score the inference population and emit autoresearch_prediction events.
+
+    Both steps delegate to products.autoresearch.backend.inference.scoring so the same
+    code is exercised by both the Temporal workflow and the local management
+    command (autoresearch_score).
+    """
+
+    inputs_cls = InferenceWorkflowInput
+
+    @workflow.run
+    async def run(self, inp: InferenceWorkflowInput) -> InferenceWorkflowResult:
+        workflow.logger.info(
+            "autoresearch_inference_workflow_start",
+            pipeline_id=inp.pipeline_id,
+            prediction_date=inp.prediction_date,
+        )
+
+        champion = await workflow.execute_activity(
+            activity_load_champion,
+            LoadChampionInput(pipeline_id=inp.pipeline_id, team_id=inp.team_id),
+            start_to_close_timeout=timedelta(minutes=2),
+            retry_policy=_LOAD_RETRY,
+        )
+
+        result = await workflow.execute_activity(
+            activity_run_inference,
+            RunInferenceInput(
+                pipeline_id=inp.pipeline_id,
+                team_id=inp.team_id,
+                model_id=champion.model_id,
+                prediction_date=inp.prediction_date,
+            ),
+            start_to_close_timeout=timedelta(hours=2),
+            retry_policy=_SCORE_RETRY,
+        )
+
+        workflow.logger.info(
+            "autoresearch_inference_workflow_complete",
+            pipeline_id=inp.pipeline_id,
+            run_id=result.run_id,
+            rows_scored=result.rows_scored,
+            status=result.status,
+        )
+
+        return InferenceWorkflowResult(
+            run_id=result.run_id,
+            rows_scored=result.rows_scored,
+            status=result.status,
+            error=result.error,
+        )
+
+
+# ── Validation workflow I/O ───────────────────────────────────────────────────
+
+
+@frozen
+class ValidationWorkflowInput:
+    pipeline_id: str
+    team_id: int
+
+
+@frozen
+class ValidationWorkflowResult:
+    dates_validated: int
+    total_rows: int
+    status: str
+    error: Optional[str] = None
+
+
+@frozen
+class RunValidationInput:
+    pipeline_id: str
+    team_id: int
+
+
+@frozen
+class RunValidationResult:
+    dates_validated: int
+    total_rows: int
+    status: str
+    error: Optional[str] = None
+
+
+# ── Validation activities ─────────────────────────────────────────────────────
+
+# Validation does all its work (HogQL + sklearn) inside a single activity to
+# keep the Temporal payload small — we only return summary counts, not raw data.
+_VALIDATION_RETRY = RetryPolicy(maximum_attempts=2, initial_interval=timedelta(seconds=30))
+
+
+@activity.defn(name="autoresearch-validation.run_validation")
+def activity_run_validation(inp: RunValidationInput) -> RunValidationResult:
+    """Find all matured unvalidated prediction dates and validate each one."""
+    with team_scope(inp.team_id):
+        pipeline = AutoresearchPipeline.objects.select_related("team").get(pk=inp.pipeline_id)
+        runs = run_online_validation_for_pipeline(pipeline)
+    # A per-date failure is recorded on its own run rather than raised, so inspect the
+    # statuses here. Reporting completed regardless would leave the retry policy unused
+    # even when every matured date failed; the coordinator isolates the failure per
+    # pipeline (it gathers with return_exceptions=True).
+    failed = [r for r in runs if r.status == AutoresearchRun.Status.FAILED]
+    if failed:
+        raise ApplicationError(
+            f"{len(failed)} of {len(runs)} validation dates failed: "
+            + "; ".join(str(r.error or "unknown")[:200] for r in failed[:3])
+        )
+    return RunValidationResult(
+        dates_validated=len(runs),
+        total_rows=sum(r.rows_scored or 0 for r in runs),
+        status="completed",
+    )
+
+
+# ── Validation workflow ───────────────────────────────────────────────────────
+
+
+@workflow.defn(name="autoresearch-validation")
+class AutoresearchValidationWorkflow(PostHogWorkflow):
+    """
+    Temporal workflow that runs online validation for one autoresearch pipeline.
+
+    Triggered daily (same cadence as inference) after inference has emitted
+    predictions. Finds all matured, unvalidated prediction dates and computes
+    realized AUC / Brier / ECE / lift@k per model. Updates AutoresearchModel
+    realized_score, calibration_error, and is_preliminary in Postgres.
+    """
+
+    inputs_cls = ValidationWorkflowInput
+
+    @workflow.run
+    async def run(self, inp: ValidationWorkflowInput) -> ValidationWorkflowResult:
+        workflow.logger.info(
+            "autoresearch_validation_workflow_start",
+            pipeline_id=inp.pipeline_id,
+        )
+
+        result = await workflow.execute_activity(
+            activity_run_validation,
+            RunValidationInput(pipeline_id=inp.pipeline_id, team_id=inp.team_id),
+            start_to_close_timeout=timedelta(hours=1),
+            retry_policy=_VALIDATION_RETRY,
+        )
+
+        workflow.logger.info(
+            "autoresearch_validation_workflow_complete",
+            pipeline_id=inp.pipeline_id,
+            dates_validated=result.dates_validated,
+            total_rows=result.total_rows,
+            status=result.status,
+        )
+
+        return ValidationWorkflowResult(
+            dates_validated=result.dates_validated,
+            total_rows=result.total_rows,
+            status=result.status,
+            error=result.error,
+        )
+
+
+# ── Coordinator workflow I/O ──────────────────────────────────────────────────
+
+
+@frozen
+class CoordinatorWorkflowInput:
+    # ISO date string; if omitted the workflow uses workflow.now()
+    run_date: Optional[str] = None
+
+
+@frozen
+class CoordinatorWorkflowResult:
+    pipelines_processed: int
+    pipelines_errored: int
+    status: str
+
+
+@frozen
+class LoadActivePipelinesInput:
+    pass
+
+
+@frozen
+class DuePipeline:
+    pipeline_id: str
+    team_id: int
+
+
+@frozen
+class LoadActivePipelinesResult:
+    due: list[DuePipeline]
+
+
+@frozen
+class KickoffTrainingInput:
+    pipeline_id: str
+    team_id: int
+
+
+@frozen
+class PipelineRunOutcome:
+    pipeline_id: str
+    succeeded: bool
+    errors: list[str] = field(default_factory=list)
+
+
+def evaluate_pipeline_outcome(
+    pipeline_id: str,
+    inference: InferenceWorkflowResult | BaseException,
+    validation: ValidationWorkflowResult | BaseException,
+    kickoff: KickoffTrainingResult | BaseException,
+) -> PipelineRunOutcome:
+    """Classify one pipeline's step results, treating soft-failed activity results as failures too."""
+    errors: list[str] = []
+
+    if isinstance(inference, BaseException):
+        errors.append(f"inference: {inference}")
+    elif inference.status == "failed":
+        errors.append(f"inference: {inference.error or 'failed'}")
+
+    if isinstance(validation, BaseException):
+        errors.append(f"validation: {validation}")
+    elif validation.status == "failed":
+        errors.append(f"validation: {validation.error or 'failed'}")
+
+    if isinstance(kickoff, BaseException):
+        errors.append(f"training kickoff: {kickoff}")
+    elif kickoff.error:
+        errors.append(f"training kickoff ({kickoff.reason}): {kickoff.error}")
+
+    return PipelineRunOutcome(pipeline_id=pipeline_id, succeeded=not errors, errors=errors)
+
+
+@frozen
+class KickoffTrainingResult:
+    kicked_off: bool
+    reason: str  # "started" | "budget_exhausted" | "already_running" | "not_eligible" | "no_creator" | "error"
+    error: Optional[str] = None
+
+
+# ── Coordinator activities ────────────────────────────────────────────────────
+
+_COORDINATOR_RETRY = RetryPolicy(maximum_attempts=3, initial_interval=timedelta(seconds=5))
+_KICKOFF_RETRY = RetryPolicy(maximum_attempts=2, initial_interval=timedelta(seconds=10))
+
+
+@activity.defn(name="autoresearch-coordinator.load_active_pipelines")
+def activity_load_active_pipelines(inp: LoadActivePipelinesInput) -> LoadActivePipelinesResult:
+    """Return the pipelines that are due for scoring per their cadence, across every team."""
+    now = django_timezone.now()
+    # unscoped() because the coordinator's job is exactly to sweep every team. The
+    # pipelines it returns carry their team so the downstream activities can scope.
+    candidates = (
+        AutoresearchPipeline.objects.unscoped()
+        .filter(status__in=[AutoresearchPipeline.Status.RUNNING, AutoresearchPipeline.Status.CONVERGED])
+        .values("id", "team_id", "cadence_days", "last_scored_at")
+    )
+    due = [
+        DuePipeline(pipeline_id=str(row["id"]), team_id=row["team_id"])
+        for row in candidates
+        if row["last_scored_at"] is None or row["last_scored_at"] + timedelta(days=row["cadence_days"]) <= now
+    ]
+    return LoadActivePipelinesResult(due=due)
+
+
+@activity.defn(name="autoresearch-coordinator.kickoff_training")
+def activity_kickoff_training(inp: KickoffTrainingInput) -> KickoffTrainingResult:
+    """Deduct iteration budget and fire a new agent training run if eligible."""
+    daily_budget: int = 0
+    try:
+        with team_scope(inp.team_id), transaction.atomic():
+            pipeline = AutoresearchPipeline.objects.select_for_update().get(pk=inp.pipeline_id)
+
+            if pipeline.status != AutoresearchPipeline.Status.RUNNING:
+                return KickoffTrainingResult(kicked_off=False, reason="not_eligible")
+
+            if pipeline.iteration_budget_remaining <= 0:
+                return KickoffTrainingResult(kicked_off=False, reason="budget_exhausted")
+
+            if AutoresearchTrainingRun.objects.filter(
+                pipeline=pipeline,
+                status=AutoresearchTrainingRun.Status.RUNNING,
+            ).exists():
+                return KickoffTrainingResult(kicked_off=False, reason="already_running")
+
+            # Training runs in a Tasks sandbox that requires a real owning user. CLI-created
+            # pipelines have no creator, so fail before spending budget rather than launching
+            # a run that would crash in the tasks facade.
+            if pipeline.created_by_id is None:
+                error = (
+                    f"Pipeline {inp.pipeline_id} has no creator; training kickoff requires created_by to own the task"
+                )
+                logger.error(
+                    "autoresearch_kickoff_training_no_creator",
+                    pipeline_id=inp.pipeline_id,
+                )
+                return KickoffTrainingResult(kicked_off=False, reason="no_creator", error=error)
+
+            daily_budget = min(10, pipeline.iteration_budget_remaining)
+            pipeline.iteration_budget_remaining -= daily_budget
+            pipeline.save(update_fields=["iteration_budget_remaining"])
+
+        with team_scope(inp.team_id):
+            run_training(pipeline=pipeline, iteration_budget=daily_budget, user_id=pipeline.created_by_id)
+        return KickoffTrainingResult(kicked_off=True, reason="started")
+
+    except Exception as exc:
+        if daily_budget > 0:
+            # Re-add the budget since the training launch failed.
+            with team_scope(inp.team_id):
+                AutoresearchPipeline.objects.filter(pk=inp.pipeline_id).update(
+                    iteration_budget_remaining=F("iteration_budget_remaining") + daily_budget
+                )
+        return KickoffTrainingResult(kicked_off=False, reason="error", error=str(exc))
+
+
+# ── Coordinator workflow ──────────────────────────────────────────────────────
+
+
+@workflow.defn(name="autoresearch-coordinator")
+class AutoresearchCoordinatorWorkflow(PostHogWorkflow):
+    """
+    Daily coordinator that fans out inference, validation, and training kickoff
+    for every active autoresearch pipeline.
+
+    Triggered once per day by a Temporal schedule. For each pipeline whose status
+    is RUNNING or CONVERGED and whose cadence_days have elapsed since last_scored_at
+    it starts:
+      - AutoresearchInferenceWorkflow  — scores users, emits prediction events
+      - AutoresearchValidationWorkflow — validates predictions from horizon days ago
+      - activity_kickoff_training      — starts a new agent training run if eligible
+
+    All three steps run concurrently. Per-pipeline failures — raised exceptions and
+    activity results that report a soft failure — are logged and counted in
+    pipelines_errored, but do not prevent other pipelines from running.
+    """
+
+    inputs_cls = CoordinatorWorkflowInput
+
+    @workflow.run
+    async def run(self, inp: CoordinatorWorkflowInput) -> CoordinatorWorkflowResult:
+        run_date = inp.run_date or workflow.now().strftime("%Y-%m-%d")
+
+        workflow.logger.info("autoresearch_coordinator_start", run_date=run_date)
+
+        active = await workflow.execute_activity(
+            activity_load_active_pipelines,
+            LoadActivePipelinesInput(),
+            start_to_close_timeout=timedelta(minutes=2),
+            retry_policy=_COORDINATOR_RETRY,
+        )
+
+        if not active.due:
+            workflow.logger.info("autoresearch_coordinator_no_active_pipelines")
+            return CoordinatorWorkflowResult(pipelines_processed=0, pipelines_errored=0, status="completed")
+
+        outcomes = await _asyncio.gather(
+            *[self._run_pipeline(due, run_date) for due in active.due],
+            return_exceptions=True,
+        )
+
+        errored = sum(1 for o in outcomes if isinstance(o, BaseException) or not o.succeeded)
+        processed = len(outcomes) - errored
+
+        workflow.logger.info(
+            "autoresearch_coordinator_complete",
+            run_date=run_date,
+            pipelines_processed=processed,
+            pipelines_errored=errored,
+        )
+
+        return CoordinatorWorkflowResult(
+            pipelines_processed=processed,
+            pipelines_errored=errored,
+            status="completed" if errored == 0 else "partial",
+        )
+
+    async def _run_pipeline(self, due: DuePipeline, run_date: str) -> PipelineRunOutcome:
+        """Run inference, validation, and training kickoff for one pipeline."""
+        pipeline_id = due.pipeline_id
+        inference_result, validation_result, kickoff_result = await _asyncio.gather(
+            workflow.execute_child_workflow(
+                AutoresearchInferenceWorkflow.run,
+                InferenceWorkflowInput(pipeline_id=pipeline_id, team_id=due.team_id, prediction_date=run_date),
+                id=f"autoresearch-inference-{pipeline_id}-{run_date}",
+                execution_timeout=timedelta(hours=3),
+            ),
+            workflow.execute_child_workflow(
+                AutoresearchValidationWorkflow.run,
+                ValidationWorkflowInput(pipeline_id=pipeline_id, team_id=due.team_id),
+                id=f"autoresearch-validation-{pipeline_id}-{run_date}",
+                execution_timeout=timedelta(hours=2),
+            ),
+            workflow.execute_activity(
+                activity_kickoff_training,
+                KickoffTrainingInput(pipeline_id=pipeline_id, team_id=due.team_id),
+                start_to_close_timeout=timedelta(minutes=5),
+                retry_policy=_KICKOFF_RETRY,
+            ),
+            return_exceptions=True,
+        )
+        outcome = evaluate_pipeline_outcome(
+            pipeline_id=pipeline_id,
+            inference=inference_result,
+            validation=validation_result,
+            kickoff=kickoff_result,
+        )
+        for error in outcome.errors:
+            workflow.logger.warning(
+                "autoresearch_pipeline_step_failed",
+                pipeline_id=pipeline_id,
+                error=error,
+            )
+        return outcome


### PR DESCRIPTION
> [!NOTE]
> Piece 9 of 13 in the split of #60081. Pieces 1-4 land prerequisites that stand alone on master. Pieces 5-13 add the autoresearch product. The map lives in #60081.

## Problem

Scoring is only useful if it keeps happening. Pieces 7 and 8 built the work; nothing runs it on a cadence.

## Changes

- A pipeline that is running or converged now gets scored, validated, and retrained on its own cadence, without anyone asking.
- A daily coordinator at 2 AM UTC finds every pipeline whose cadence has elapsed and fans out three things per pipeline: inference, online validation, and a training kickoff.
- One pipeline's failure does not stop the others. Each is gathered separately and counted.
- A training kickoff deducts budget inside a transaction and puts it back if the launch fails, so a Temporal retry cannot spend the same budget twice.
- Runs on its own task queue, so a slow scoring run cannot crowd out another product's workers.
- Mechanical: the task queue setting, the worker registration, and the schedule registration.

Two departures from the `autoresearch-dev` branch:

- Activity payloads carry `team_id`. The activities are the entry boundary for these paths, and the models have been fail-closed since piece 5, so each one opens its team's scope. The coordinator's own sweep is the single deliberate cross-team read, and it hands each pipeline's team down with its id.
- The payload dataclasses become `@frozen`, which is the house decorator and what the ratchet in `test_dataclass_defaults.py` asks for.

## How did you test this code?

`hogli test products/autoresearch/backend/temporal` passes 19 tests, which came with the code from the branch. The ones I changed read the coordinator's new return shape and pass `team_id` into the kickoff activity.

Also run: `uv run mypy --cache-fine-grained .` repo-wide, `uv run tach check`, and `pytest posthog/test/repo_invariants/`.

Not run: the workflows against a real Temporal server. The activities are tested directly; the workflow bodies are not.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`products/autoresearch/backend/temporal/AGENTS.md` is new and in this PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5), driven by @andrewm4894. Cut by path from the `autoresearch-dev` branch (#60081) per the split plan in that PR.

Skills invoked: /writing-dataclasses, /writing-tests, /writing-code-comments, /writing-pr-descriptions.
