### PR TITLE
fix(desktop): rename login analytics event

### DIFF
--- a/products/desktop/packages/shared/src/analytics-events.ts
+++ b/products/desktop/packages/shared/src/analytics-events.ts
@@ -1345,7 +1345,7 @@ export const ANALYTICS_EVENTS = {
   APP_QUIT: "App quit",
 
   // Authentication
-  USER_LOGGED_IN: "User logged in",
+  USER_LOGGED_IN: "Desktop user logged in",
   USER_LOGGED_OUT: "User logged out",
 
   // Task management


### PR DESCRIPTION
## Problem

cloud uses `user logged in`, we use `User logged in`, what could go wrong?

## Changes

swap our event to `Desktop user logged in`

--- ai gen below ---

## How did you test this code?

- Ran `pnpm --dir products/desktop --filter @posthog/shared typecheck`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Agent: pi coding agent.
- Tools: GitHub CLI and signed-commit tool.
- Skill: `/writing-pr-descriptions`.