### PR TITLE
fix(frontend): classify dropped body reads as NetworkError

### DIFF
--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -320,11 +320,35 @@ describe('API helper', () => {
             expect(error.message).toContain('[POST /api/environments/2/insights]')
         })
 
-        it('surfaces a body stream that fails mid-read as an ApiError instead of null', async () => {
-            fakeFetch.mockResolvedValue(fakeResponse({ text: () => Promise.reject(new TypeError('network error')) }))
+        it('classifies a body stream that fails mid-read as a NetworkError', async () => {
+            // Headers already arrived (2xx); body read rejects with TypeError — same connectivity
+            // class as a fetch rejection, not a per-endpoint ApiError (#86304).
+            const cause = new TypeError('network error')
+            fakeFetch.mockResolvedValue(fakeResponse({ text: () => Promise.reject(cause) }))
+
+            const error = await api.get('api/environments/2/insights').catch((e) => e)
+
+            expect(error).toBeInstanceOf(NetworkError)
+            expect(error.reason).toBe('network')
+            expect(error.status).toBeUndefined()
+            expect(error.cause).toBe(cause)
+            expect(posthog.capture).toHaveBeenCalledWith(
+                'client_request_failure',
+                expect.objectContaining({
+                    pathname: '/api/environments/2/insights/',
+                    method: 'GET',
+                    status: 0,
+                    failure_reason: 'network',
+                })
+            )
+        })
+
+        it('still surfaces a non-TypeError body-read failure as ApiError', async () => {
+            fakeFetch.mockResolvedValue(fakeResponse({ text: () => Promise.reject(new Error('stream broke')) }))
             const error = await api.get('api/environments/2/insights').catch((e) => e)
             expect(error).toBeInstanceOf(ApiError)
-            expect(error.status).toBeUndefined()
+            expect(error).not.toBeInstanceOf(NetworkError)
+            expect(error.message).toContain('Failed to read response body')
         })
 
         it.each([

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -403,8 +403,22 @@ async function getJSONFromSuccessResponse(response: Response, method: string, ur
         if (isAbortError(error)) {
             throw error
         }
-        // The body stream failed mid-read (e.g. a network drop truncating a chunked response) —
-        // the response is unusable, so surface it instead of handing callers a null.
+        // Headers already arrived (2xx) but the body stream died mid-read — same class of
+        // browser TypeError as a fetch that never connected. Route through the same
+        // classification as handleFetch so we emit client_request_failure / NetworkError
+        // instead of a per-endpoint ApiError fingerprint (see #86304).
+        if (error instanceof TypeError) {
+            const reason = classifyNetworkFailure()
+            captureClientRequestFailure({
+                pathname: requestPathname(url),
+                method,
+                duration: 0,
+                status: 0,
+                is_shared_view: isSharedView(),
+                failure_reason: reason,
+            })
+            throw new NetworkError(reason, error)
+        }
         throw new ApiError(`Failed to read response body ${requestContext()}`)
     }
     if (!text.trim()) {


### PR DESCRIPTION
## Problem

When a browser drops a connection after HTTP headers arrive but before the body finishes reading, `getJSONFromSuccessResponse` threw a bare `ApiError` embedding the request path. That created a permanent family of per-endpoint error-tracking issues (`Failed to read response body [METHOD path]`), while the same `TypeError` on the fetch itself was already classified as `NetworkError` and often dropped when offline/navigating.

Closes #86304

## Changes

- Body-read `TypeError` uses `classifyNetworkFailure()`, emits `client_request_failure` with `status: 0`, and throws `NetworkError` with the original error as `cause` (same path as `handleFetch`).
- Malformed JSON after a successful body read stays an `ApiError`.
- Non-`TypeError` body-read failures still surface as `ApiError`.
- Aborts still propagate unchanged.
- Unit coverage for the headers-ok / body-rejects case and the non-TypeError branch.

## How did you test this code?

- Updated `frontend/src/lib/api.test.ts` for body-stream `TypeError` → `NetworkError` + `client_request_failure`, and non-TypeError → `ApiError`.
- Python/ClickHouse not involved.
- Full frontend Jest suite not run in this environment (no installed frontend deps); CI should run `frontend` unit tests.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tools: OpenCode / CLI (`gh`, git) on a sparse PostHog checkout.
- Implemented the fix described in #86304 to align body-read failures with existing network classification.
- done with midfleet
