### PR TITLE
chore(ci): validate dagster test selection

### DIFF
--- a/posthog/dags/deletes.py
+++ b/posthog/dags/deletes.py
@@ -1,3 +1,5 @@
+"""Dagster jobs for deleting expired and requested data."""
+
 import abc
 import time
 import uuid

--- a/posthog/dags/tests/test_deletes.py
+++ b/posthog/dags/tests/test_deletes.py
@@ -623,7 +623,7 @@ def test_cleanup_old_events_delete_query_format(cluster: ClickhouseCluster, snap
 
 
 @pytest.mark.django_db
-def test_monthly_old_events_cleanup_job(cluster: ClickhouseCluster):
+def test_monthly_old_events_cleanup_job_is_registered(cluster: ClickhouseCluster):
     now = datetime.now()
     old_timestamp = now - timedelta(days=400)
     recent_timestamp = now - timedelta(days=30)


### PR DESCRIPTION
🤖 Robot-authored validation PR.

## Problem

The selector PR cannot exercise selected mode because its own workflow change forces the full Dagster suite.

## Changes

- Renames one Dagster test without changing its behavior.
- Uses `posthog/dagster-pr-test-selection` as the base, so CI sees only this test-file change.
- This PR will close after it proves the narrow workflow path.

Nothing user-visible changes.

## How did you test this code?

- Pytest collection finds the renamed test.
- The parent PR's selector unit tests, repository-wide mypy, workflow lint, and actionlint pass.
- This PR exists to validate the selected-mode workflow in GitHub Actions.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This PR is temporary CI validation and will not merge.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi created this temporary stacked PR to validate the selected Dagster path before merging the parent PR. Skills invoked: `authoring-ci-workflows`, `writing-tests`, and `writing-pr-descriptions`.
