### PR TITLE
fix(sentry): avoid pyarrow string_view crash in warehouse-parent row filter

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_warehouse_parent.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_warehouse_parent.py
@@ -300,6 +300,15 @@ def _write_parent_table_with_ages(tmp_path: Path, physical: str) -> str:
     last_seen: pa.Array
     if physical == "string":
         last_seen = pa.array([fresh.strftime("%Y-%m-%dT%H:%M:%S.%fZ"), old.strftime("%Y-%m-%dT%H:%M:%S.%fZ"), None])
+    elif physical == "string_view":
+        # pyarrow's Parquet reader can materialize a written string_view column as
+        # string_view again on read, even though the Delta schema still declares it as a
+        # plain string — and pyarrow has no `greater_equal`/`array_filter` kernel for
+        # string_view, so a pushed-down filter on such a column crashes the scan.
+        last_seen = pa.array(
+            [fresh.strftime("%Y-%m-%dT%H:%M:%S.%fZ"), old.strftime("%Y-%m-%dT%H:%M:%S.%fZ"), None],
+            type=pa.string_view(),
+        )
     elif physical == "timestamp_tz":
         last_seen = pa.array([fresh, old, None], type=pa.timestamp("us", tz="UTC"))
     else:
@@ -312,7 +321,7 @@ def _write_parent_table_with_ages(tmp_path: Path, physical: str) -> str:
 _LAST_SEEN_FLOOR = ParentRowFilter(field="lastSeen", not_older_than=timedelta(days=90))
 
 
-@pytest.mark.parametrize("physical", ["string", "timestamp_tz", "timestamp_naive"])
+@pytest.mark.parametrize("physical", ["string", "string_view", "timestamp_tz", "timestamp_naive"])
 def test_row_filter_drops_old_rows_and_keeps_null_ones(tmp_path: Path, physical: str) -> None:
     # The floor must adapt to the column's physical type: the Delta writer stores the API's
     # ISO string either verbatim or parsed, and prod tables carry the parsed form while the

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/warehouse_parent.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/warehouse_parent.py
@@ -9,6 +9,8 @@ import deltalake
 import structlog
 import pyarrow.compute as pc
 
+from posthog.dataclasses import frozen
+
 from products.warehouse_sources.backend.models.external_data_job import ExternalDataJob
 from products.warehouse_sources.backend.models.external_data_schema import get_schema_if_exists
 from products.warehouse_sources.backend.temporal.data_imports.naming_convention import NamingConvention
@@ -75,9 +77,18 @@ def _physical_columns_by_api_name(
     return physical_by_api_name
 
 
+@frozen
+class _ResolvedRowFilter:
+    """A row filter resolved against a Delta table's actual column type."""
+
+    scan_filter: pc.Expression | None
+    row_passes: Callable[[dict[str, Any]], bool]
+    physical_column: str
+
+
 def _row_filter_scan_and_predicate(
     delta_table: "deltalake.DeltaTable", parent_name: str, row_filter: ParentRowFilter
-) -> tuple[pc.Expression | None, Callable[[dict[str, Any]], bool], str]:
+) -> _ResolvedRowFilter:
     """Resolve a row filter into an optional parquet-scan pushdown and a matching row check.
 
     The row check (applied to every materialized row regardless of whether a pushdown ran) is
@@ -91,9 +102,9 @@ def _row_filter_scan_and_predicate(
     optimization. NULLs are kept: a row without the filter field carries no recency signal, and
     the tag-values iterator's per-row cutoff (the semantics this reproduces) keeps them too.
 
-    Returns the pushdown expression (or None), the row check, and the filter field's physical
-    column name (the caller must ensure it's projected, even if not requested as output, or the
-    row check would see it as absent and keep every row).
+    `physical_column` is the filter field's physical column name; the caller must ensure it's
+    projected, even if not requested as output, or the row check would see it as absent and
+    keep every row.
     """
     physical = _physical_columns_by_api_name(delta_table, parent_name, [row_filter.field])[row_filter.field]
     field_type = pyarrow_schema_from_arrow_exportable(delta_table.schema()).field(physical).type
@@ -120,7 +131,7 @@ def _row_filter_scan_and_predicate(
         value = row.get(physical)
         return value is None or value >= floor
 
-    return scan_filter, _passes_floor, physical
+    return _ResolvedRowFilter(scan_filter=scan_filter, row_passes=_passes_floor, physical_column=physical)
 
 
 def resolve_parent_table_ref(
@@ -321,17 +332,16 @@ def iter_parent_pages_from_warehouse(
     delta_table = deltalake.DeltaTable(table.uri, version=table.version, storage_options=delta_storage_options())
     physical_by_api_name = _physical_columns_by_api_name(delta_table, parent_name, columns)
 
-    scan_filter: pc.Expression | None = None
-    row_passes_filter: Callable[[dict[str, Any]], bool] | None = None
+    resolved_row_filter: _ResolvedRowFilter | None = None
     projected = list(dict.fromkeys(physical_by_api_name.values()))
     if row_filter is not None:
-        scan_filter, row_passes_filter, filter_physical = _row_filter_scan_and_predicate(
-            delta_table, parent_name, row_filter
-        )
-        if filter_physical not in projected:
+        resolved_row_filter = _row_filter_scan_and_predicate(delta_table, parent_name, row_filter)
+        if resolved_row_filter.physical_column not in projected:
             # The row check below needs the value even when the caller didn't ask for it as
             # output — otherwise it reads as absent and every row would pass.
-            projected.append(filter_physical)
+            projected.append(resolved_row_filter.physical_column)
+
+    scan_filter = resolved_row_filter.scan_filter if resolved_row_filter is not None else None
 
     dataset = delta_table.to_pyarrow_dataset()
 
@@ -341,7 +351,7 @@ def iter_parent_pages_from_warehouse(
         page: list[dict[str, Any]] = []
         for batch in dataset.to_batches(columns=projected, batch_size=page_size, filter=scan_filter):
             for row in batch.to_pylist():
-                if row_passes_filter is not None and not row_passes_filter(row):
+                if resolved_row_filter is not None and not resolved_row_filter.row_passes(row):
                     continue
                 page.append({api_name: row.get(physical) for api_name, physical in physical_by_api_name.items()})
                 rows_streamed += 1

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/warehouse_parent.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/warehouse_parent.py
@@ -1,6 +1,6 @@
 import uuid
 import datetime as dt
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from dataclasses import dataclass
 from typing import Any
 
@@ -75,35 +75,52 @@ def _physical_columns_by_api_name(
     return physical_by_api_name
 
 
-def _row_filter_expression(
+def _row_filter_scan_and_predicate(
     delta_table: "deltalake.DeltaTable", parent_name: str, row_filter: ParentRowFilter
-) -> pc.Expression:
-    """Predicate pushed into the parquet scan so filtered-out parents are never read.
+) -> tuple[pc.Expression | None, Callable[[dict[str, Any]], bool], str]:
+    """Resolve a row filter into an optional parquet-scan pushdown and a matching row check.
 
-    NULLs are kept: a row without the filter field carries no recency signal, and the
-    tag-values iterator's per-row cutoff (the semantics this reproduces) keeps them too.
-    The cutoff adapts to the column's physical type because the Delta writer may store the
-    API's ISO-8601 string either parsed as a timestamp or verbatim; ISO-8601 UTC strings
-    order lexicographically, so a string floor compares correctly. Any other physical type
-    raises the fallback signal rather than guessing.
+    The row check (applied to every materialized row regardless of whether a pushdown ran) is
+    the single source of truth for the filter's semantics, not just an optimization on top of
+    it: pyarrow's `greater_equal`/`array_filter` compute kernels have no implementation for its
+    canonical `string_view` type, and pyarrow's Parquet dataset scanner can materialize a
+    string/large_string column as `string_view` internally while evaluating a pushed-down
+    filter — regardless of the column's declared schema type — crashing the scan. So a string
+    field's cutoff is only ever checked here, in Python, after the value is materialized;
+    pushdown is built only for the timestamp type that isn't affected, as a pure I/O
+    optimization. NULLs are kept: a row without the filter field carries no recency signal, and
+    the tag-values iterator's per-row cutoff (the semantics this reproduces) keeps them too.
+
+    Returns the pushdown expression (or None), the row check, and the filter field's physical
+    column name (the caller must ensure it's projected, even if not requested as output, or the
+    row check would see it as absent and keep every row).
     """
     physical = _physical_columns_by_api_name(delta_table, parent_name, [row_filter.field])[row_filter.field]
     field_type = pyarrow_schema_from_arrow_exportable(delta_table.schema()).field(physical).type
     cutoff = row_filter.floor(dt.datetime.now(dt.UTC))
 
-    cutoff_scalar: pa.Scalar
+    scan_filter: pc.Expression | None
+    floor: dt.datetime | str
     if pa.types.is_timestamp(field_type):
-        cutoff_scalar = pa.scalar(cutoff if field_type.tz is not None else cutoff.replace(tzinfo=None), type=field_type)
+        floor = cutoff if field_type.tz is not None else cutoff.replace(tzinfo=None)
+        field_ref = pc.field(physical)
+        scan_filter = field_ref.is_null() | (field_ref >= pa.scalar(floor, type=field_type))
     elif pa.types.is_string(field_type) or pa.types.is_large_string(field_type):
-        cutoff_scalar = pa.scalar(cutoff.strftime("%Y-%m-%dT%H:%M:%S"), type=field_type)
+        # ISO-8601 UTC strings order lexicographically, so a string floor compares correctly —
+        # just not through pyarrow's own kernel (see the missing-kernel note above).
+        floor = cutoff.strftime("%Y-%m-%dT%H:%M:%S")
+        scan_filter = None
     else:
         raise WarehouseParentTableNotFoundError(
             f"Parent table '{parent_name}' stores filter field '{row_filter.field}' as {field_type}, "
             f"which can't be compared against a time floor"
         )
 
-    field_ref = pc.field(physical)
-    return field_ref.is_null() | (field_ref >= cutoff_scalar)
+    def _passes_floor(row: dict[str, Any]) -> bool:
+        value = row.get(physical)
+        return value is None or value >= floor
+
+    return scan_filter, _passes_floor, physical
 
 
 def resolve_parent_table_ref(
@@ -165,9 +182,9 @@ def resolve_parent_table_ref(
             # surface deep inside the pipeline, past the caller's fall-back-to-the-API branch.
             _physical_columns_by_api_name(delta_table, parent_name, required_columns)
         if row_filter is not None:
-            # Same eagerness for the filter: the reader rebuilds this expression, but a missing
-            # or unfilterable column must surface while the API fallback is still possible.
-            _row_filter_expression(delta_table, parent_name, row_filter)
+            # Same eagerness for the filter: the reader rebuilds this, but a missing or
+            # unfilterable column must surface while the API fallback is still possible.
+            _row_filter_scan_and_predicate(delta_table, parent_name, row_filter)
         return ParentTableRef(uri=uri, version=delta_table.version())
     except WarehouseParentTableNotFoundError:
         raise
@@ -303,9 +320,19 @@ def iter_parent_pages_from_warehouse(
     page_size = max(1, min(page_size, MAX_PARENT_PAGE_SIZE))
     delta_table = deltalake.DeltaTable(table.uri, version=table.version, storage_options=delta_storage_options())
     physical_by_api_name = _physical_columns_by_api_name(delta_table, parent_name, columns)
-    scan_filter = None if row_filter is None else _row_filter_expression(delta_table, parent_name, row_filter)
 
+    scan_filter: pc.Expression | None = None
+    row_passes_filter: Callable[[dict[str, Any]], bool] | None = None
     projected = list(dict.fromkeys(physical_by_api_name.values()))
+    if row_filter is not None:
+        scan_filter, row_passes_filter, filter_physical = _row_filter_scan_and_predicate(
+            delta_table, parent_name, row_filter
+        )
+        if filter_physical not in projected:
+            # The row check below needs the value even when the caller didn't ask for it as
+            # output — otherwise it reads as absent and every row would pass.
+            projected.append(filter_physical)
+
     dataset = delta_table.to_pyarrow_dataset()
 
     rows_streamed = 0
@@ -314,6 +341,8 @@ def iter_parent_pages_from_warehouse(
         page: list[dict[str, Any]] = []
         for batch in dataset.to_batches(columns=projected, batch_size=page_size, filter=scan_filter):
             for row in batch.to_pylist():
+                if row_passes_filter is not None and not row_passes_filter(row):
+                    continue
                 page.append({api_name: row.get(physical) for api_name, physical in physical_by_api_name.items()})
                 rows_streamed += 1
                 if len(page) >= page_size:


### PR DESCRIPTION
## Problem

The Sentry data-warehouse source's `issue_tag_values` sync crashes for some
organizations with `pyarrow.lib.ArrowNotImplementedError: Function
'greater_equal' has no kernel matching input types (string_view, string_view)`,
raised from `iter_parent_pages_from_warehouse` in `warehouse_parent.py`. See
the error tracking issue: https://us.posthog.com/project/2/error_tracking/01a01f38-223b-7b23-bd79-caf520bfb2c7

pyarrow's `greater_equal` and `array_filter` compute kernels have no
implementation for its `string_view` type. pyarrow's Parquet dataset scanner
can materialize a string/large_string column as `string_view` internally
while evaluating a pushed-down filter, regardless of the column's declared
schema type, so the recency-cutoff filter this source pushes into the parquet
scan crashes the whole sync instead of just skipping stale rows.

## Changes

- `iter_parent_pages_from_warehouse` no longer pushes the row-filter
  predicate into the parquet scan for string/large_string columns. It reads
  every row and applies the recency floor in plain Python afterward instead,
  the same fallback semantics the Sentry `issue_tag_values` iterator already
  relies on for its own per-row cutoff.
- Pushdown filtering is unaffected for timestamp columns, which don't hit the
  missing kernel, so most syncs keep the I/O savings.
- Mechanical: `_row_filter_expression` is renamed to
  `_row_filter_scan_and_predicate` and returns the row-level check alongside
  the (now optional) pushdown expression.

## How did you test this code?

- Added a `string_view` case to the parametrized
  `test_row_filter_drops_old_rows_and_keeps_null_ones` test. Writing the
  fixture's recency column as `pa.string_view()` reproduces the exact
  production crash before the fix (confirmed locally) and passes after it.
- Ran the full non-Django-DB test suite in
  `test_warehouse_parent.py` and `test_fanout.py` locally: 47 passed.
- Not run locally: `TestSnapshotPinAsOf` (Django-DB-backed, unrelated to this
  change) and `test_sentry.py` — this sandbox's Postgres test-DB setup did
  not finish in a reasonable time. CI covers both.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal pipeline fix, no user-facing or documented behavior changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated and fixed via Claude Code, triggered by an error tracking
webhook for the issue linked above. Reproduced the crash locally by writing
a Delta table with a `string_view`-typed column and confirming pyarrow
23.0.1 (the pinned version) has no `greater_equal`/`array_filter` kernel for
it, before writing the fix and the regression test. No skills matched this
change's shape closely enough to invoke beyond `/writing-tests` and
`/writing-pr-descriptions`.