### PR TITLE
feat(posthog_ai): make docs searches free on the sandbox runtime

### DIFF
--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -3913,6 +3913,120 @@ class TestAIEventsUsageReport(ClickhouseDestroyTablesMixin, TestCase, Clickhouse
         # Expected: No charges when all tools are in the excluded list
         self.assertEqual(len(result), 0)
 
+    def _analytics_team_with_gateway_spend(self, period: Any) -> Team:
+        """A team whose gateway spend bills 120 credits, with no paired $ai_trace.
+
+        This is the sandbox shape: the gateway emits $ai_generation only, so the generation bills
+        through the empty-trace fallback rather than the trace-level tool rule.
+        """
+        self._setup_teams()
+        analytics_org = Organization.objects.create(name="PostHog Analytics")
+        analytics_team = Team.objects.create(pk=2, organization=analytics_org, name="Analytics")
+        self._setup_instance_group_mapping(analytics_team)
+
+        _create_event(
+            event="$ai_generation",
+            team=analytics_team,
+            distinct_id="user_1",
+            timestamp=period.start + relativedelta(hours=1),
+            properties={
+                "team_id": self.org_1_team_1.id,
+                "$ai_trace_id": "trace_gateway",
+                "$ai_total_cost_usd": 1.0,
+                "$ai_billable": True,
+                "ai_product": "posthog_ai",
+                "$group_1": "https://us.posthog.com",
+            },
+        )
+        return analytics_team
+
+    def _create_docs_search(
+        self, analytics_team: Team, period: Any, *, source: str = "posthog_ai", mcp_region: str = "us"
+    ) -> None:
+        _create_event(
+            event="$mcp_tool_call",
+            team=analytics_team,
+            distinct_id="user_1",
+            timestamp=period.start + relativedelta(hours=2),
+            properties={
+                "$mcp_tool_name": "docs-search",
+                "source": source,
+                "$mcp_region": mcp_region,
+                "$mcp_project_id": str(self.org_1_team_1.id),
+            },
+        )
+
+    @patch("posthog.tasks.usage_report.get_instance_region")
+    def test_docs_searches_are_deducted_from_ai_credits(self, mock_region: MagicMock) -> None:
+        from posthog.tasks.usage_report import get_teams_with_ai_credits_used_in_period
+
+        mock_region.return_value = "US"
+        period = get_previous_day(at=now() + relativedelta(days=1))
+        analytics_team = self._analytics_team_with_gateway_spend(period)
+        for _ in range(3):
+            self._create_docs_search(analytics_team, period)
+
+        flush_persons_and_events()
+
+        result = get_teams_with_ai_credits_used_in_period(period.start, period.end)
+
+        # 120 gross, less 3 searches * 3 credits
+        self.assertEqual(result, [(self.org_1_team_1.id, 111)])
+
+    @parameterized.expand([("third_party_agent", "mcp"), ("desktop", "posthog_code"), ("slack", "slack")])
+    @patch("posthog.tasks.usage_report.get_instance_region")
+    def test_docs_searches_from_other_surfaces_are_not_deducted(
+        self, _name: str, source: str, mock_region: MagicMock
+    ) -> None:
+        from posthog.tasks.usage_report import get_teams_with_ai_credits_used_in_period
+
+        mock_region.return_value = "US"
+        period = get_previous_day(at=now() + relativedelta(days=1))
+        analytics_team = self._analytics_team_with_gateway_spend(period)
+        self._create_docs_search(analytics_team, period, source=source)
+
+        flush_persons_and_events()
+
+        result = get_teams_with_ai_credits_used_in_period(period.start, period.end)
+
+        # Only PostHog AI runs spend PostHog AI credits, so no other surface may take credits off them
+        self.assertEqual(result, [(self.org_1_team_1.id, 120)])
+
+    @patch("posthog.tasks.usage_report.get_instance_region")
+    def test_docs_searches_from_another_region_are_not_deducted(self, mock_region: MagicMock) -> None:
+        from posthog.tasks.usage_report import get_teams_with_ai_credits_used_in_period
+
+        mock_region.return_value = "US"
+        period = get_previous_day(at=now() + relativedelta(days=1))
+        analytics_team = self._analytics_team_with_gateway_spend(period)
+        self._create_docs_search(analytics_team, period, mcp_region="eu")
+
+        flush_persons_and_events()
+
+        result = get_teams_with_ai_credits_used_in_period(period.start, period.end)
+
+        # The MCP server captures a region's calls into both regions' projects. Without the region
+        # filter each search would be deducted once per regional report.
+        self.assertEqual(result, [(self.org_1_team_1.id, 120)])
+
+    @patch("posthog.tasks.usage_report.DOCS_SEARCH_EXEMPTION_DAILY_CAP_PER_TEAM", 2)
+    @patch("posthog.tasks.usage_report.get_instance_region")
+    def test_docs_search_deduction_is_capped_per_day(self, mock_region: MagicMock) -> None:
+        from posthog.tasks.usage_report import get_teams_with_ai_credits_used_in_period
+
+        mock_region.return_value = "US"
+        period = get_previous_day(at=now() + relativedelta(days=1))
+        analytics_team = self._analytics_team_with_gateway_spend(period)
+        for _ in range(4):
+            self._create_docs_search(analytics_team, period)
+
+        flush_persons_and_events()
+
+        result = get_teams_with_ai_credits_used_in_period(period.start, period.end)
+
+        # 4 searches, capped to 2 * 3 credits — uncapped this would deduct 12
+        self.assertEqual(result, [(self.org_1_team_1.id, 114)])
+
     @patch("posthog.tasks.usage_report.get_instance_region")
     def test_ai_credits_with_summarize_sessions_and_billable_tool(self, mock_region: MagicMock) -> None:
         """Test that traces with summarize_sessions + a billable tool ARE billed."""
@@ -4961,6 +5075,29 @@ class TestPostHogCodeComputeUsageReport(SimpleTestCase):
 
         assert mock_compute.call_count == QUERY_RETRIES
         mock_capture.assert_not_called()
+
+
+class TestAICreditExemptions(SimpleTestCase):
+    @parameterized.expand(
+        [
+            ("no_exemptions", [(1, 100)], [], [(1, 100)]),
+            ("partial_offset", [(1, 100)], [(1, 30)], [(1, 70)]),
+            ("exact_offset_drops_the_team", [(1, 30)], [(1, 30)], []),
+            ("over_offset_clamps_instead_of_going_negative", [(1, 30)], [(1, 500)], []),
+            ("exemption_for_a_team_with_no_spend_is_dropped", [(1, 40)], [(2, 25)], [(1, 40)]),
+            ("offsets_are_per_team", [(1, 40), (2, 40)], [(2, 10)], [(1, 40), (2, 30)]),
+        ]
+    )
+    def test_exemptions_net_off_gross_credits(
+        self,
+        _name: str,
+        gross: list[tuple[int, int]],
+        exemptions: list[tuple[int, int]],
+        expected: list[tuple[int, int]],
+    ) -> None:
+        from posthog.tasks.usage_report import subtract_ai_credit_exemptions
+
+        assert subtract_ai_credit_exemptions(gross, exemptions) == expected
 
 
 class TestSendUsage(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest):

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -266,8 +266,13 @@ class UsageReportCounters:
     # AI observability
     ai_event_count_in_period: int
 
-    # AI Billing Credits (PostHog AI feature usage)
+    # AI Billing Credits (PostHog AI feature usage), net of the docs-search exemption below
     ai_credits_used_in_period: int
+    # Credits docs searches earned this period, reported so the deduction taken off
+    # ai_credits_used_in_period can be reconciled against the gateway's own generation costs. This is the
+    # amount before clamping, so it reads higher than the deduction actually applied for a team whose
+    # docs searches earned more credits than its total PostHog AI spend
+    ai_credits_docs_search_exempted_in_period: int
 
     # Signals Billing Credits (flat credits per report whose implementation shipped a PR)
     signals_credits_used_in_period: int
@@ -1689,6 +1694,29 @@ POSTHOG_AI_PRODUCTS = [
 # ai_product values billed as PostHog Desktop credits.
 POSTHOG_CODE_AI_PRODUCTS = ["posthog_code"]
 
+# The MCP tool whose calls earn the docs-search exemption. The `exec` dispatcher relabels itself to the
+# tool it dispatched (`resolveExecTool` in services/mcp/src/hono/tool-executor.ts), so a docs search made
+# through the umbrella tool is recorded under this name rather than as `exec`.
+DOCS_SEARCH_MCP_TOOL = "docs-search"
+
+# The `source` value marking a call made by a PostHog AI run. Deliberately not `$mcp_consumer`, which
+# reports `posthog-code` for every sandbox agent, nor `$ai_product`, which is uniformly `mcp` on these
+# events. Neither separates PostHog AI from PostHog Desktop or from third-party agents, which make the
+# large majority of docs searches and spend no PostHog AI credits.
+DOCS_SEARCH_EXEMPT_SOURCE = "posthog_ai"
+
+# Flat credits taken off the bill per exempt docs search, at 1 credit = $0.01. This is a pricing policy
+# number, not a measurement: it should approximate what a docs answer costs on the sandbox runtime, and
+# wants a calibration pass against observed `$ai_generation` costs before it is treated as fair.
+DOCS_SEARCH_EXEMPTION_CREDITS = 3
+
+# Ceiling on exempt searches per team per UTC day. Producing a signals PR is expensive, so that billing
+# path needs no equivalent; asking a documentation question is not, so without a ceiling a loop of
+# searches would mint credits without bound. It also bounds the repeat-search case, where one turn runs
+# several searches and each earns the flat credit. `source` is stamped from a caller-supplied header,
+# which is a second reason to keep the ceiling.
+DOCS_SEARCH_EXEMPTION_DAILY_CAP_PER_TEAM = 50
+
 
 def get_ai_billing_instance_group_type_index(team_id: int) -> int | None:
     """Resolve the $group_N index that holds the customer cloud URL for the internal AI events team."""
@@ -1907,19 +1935,146 @@ def _get_teams_with_ai_credits_for_products(
     return results
 
 
+def subtract_ai_credit_exemptions(
+    gross: list[tuple[int, int]], exemptions: list[tuple[int, int]]
+) -> list[tuple[int, int]]:
+    """Net AI credits per team after exemptions, dropping any team left at or below zero.
+
+    Clamping mirrors the gross query's `HAVING ai_credits > 0`, so a team whose exemptions exceed its
+    gateway spend reports nothing rather than a negative. Exemptions for a team with no gross credits
+    have nothing to offset and fall away with it — credits are only ever taken off a bill, never handed
+    back as a balance.
+    """
+    exempted_by_team = dict(exemptions)
+    return [(team_id, net) for team_id, credits in gross if (net := credits - exempted_by_team.get(team_id, 0)) > 0]
+
+
 @timed_log()
 @retry(tries=QUERY_RETRIES, delay=QUERY_RETRY_DELAY, backoff=QUERY_RETRY_BACKOFF)
 def get_teams_with_ai_credits_used_in_period(
     begin: datetime,
     end: datetime,
 ) -> list[tuple[int, int]]:
-    """PostHog AI (Max) billing credits — events tagged with an ai_product in POSTHOG_AI_PRODUCTS."""
-    return _get_teams_with_ai_credits_for_products(
+    """PostHog AI (Max) billing credits — events tagged with an ai_product in POSTHOG_AI_PRODUCTS.
+
+    Net of the docs-search exemption, which is subtracted here at the source rather than offset later
+    so the single number reaches both the bill and the quota limiter's `todays_usage`, which is patched
+    from this same function.
+    """
+    gross = _get_teams_with_ai_credits_for_products(
         begin,
         end,
         ai_products=POSTHOG_AI_PRODUCTS,
         usage_report_tag="ai_credits",
     )
+    if not gross:
+        # Nothing to take credits off. This also keeps the exemption query from running when the gross
+        # query bailed out because it could not resolve the region it must filter on: a billing query
+        # that cannot be region-filtered must not run at all.
+        return []
+    return subtract_ai_credit_exemptions(gross, get_teams_with_ai_credits_docs_search_exempted_in_period(begin, end))
+
+
+@timed_log()
+@retry(tries=QUERY_RETRIES, delay=QUERY_RETRY_DELAY, backoff=QUERY_RETRY_BACKOFF)
+def get_teams_with_ai_credits_docs_search_exempted_in_period(
+    begin: datetime,
+    end: datetime,
+) -> list[tuple[int, int]]:
+    """Flat AI credits taken off each team's bill for documentation searches in `[begin, end)`.
+
+    Asking PostHog AI a documentation question is free. On the LangGraph runtime that fell out of the
+    trace-level rule in `_get_teams_with_ai_credits_for_products`, which reads a turn's tool calls off
+    the `$ai_trace` event and skips the turn when every call is in `AI_BILLING_EXCLUDED_TOOLS`. The
+    sandbox runtime spends through the LLM gateway, which emits `$ai_generation` and never `$ai_trace`,
+    so that rule has no turn state to read and every sandbox generation bills.
+
+    This restores the exemption from the MCP side instead. Django serves docs search itself
+    (`MCPToolsViewSet.docs_search`) and the MCP server emits a `$mcp_tool_call` per invocation, so the
+    searches are already counted in ClickHouse alongside the generations they offset.
+
+    The unit is one search rather than one turn: `$mcp_tool_call` carries no trace or conversation id,
+    so there is nothing to group a turn by, and the tool-call denominator a proportional rule would need
+    lives on `$ai_generation` with no key joining the two. A flat credit needs neither. It is also the
+    honest shape, because a docs answer on Claude Code re-sends the system prompt and tool definitions
+    on every loop iteration, so it is cheap but not free.
+    """
+    region = get_instance_region()
+
+    if region is None:
+        # Mirrors the gross-credit query: fail fast in production, degrade quietly in tests.
+        from posthog.settings import TEST
+
+        if not TEST:
+            assert region is not None, "Region must be set in production infrastructure"
+        return []
+
+    use_new = use_new_events_schema(None)
+    events_table = events_read_table(use_new)
+    tool_name_expr, _ = get_property_string_expr(
+        "events", "$mcp_tool_name", "'$mcp_tool_name'", "properties", use_new_events_schema=use_new
+    )
+    source_expr, _ = get_property_string_expr(
+        "events", "source", "'source'", "properties", use_new_events_schema=use_new
+    )
+    mcp_region_expr, _ = get_property_string_expr(
+        "events", "$mcp_region", "'$mcp_region'", "properties", use_new_events_schema=use_new
+    )
+    customer_team_id_expr, _ = get_property_string_expr(
+        "events", "$mcp_project_id", "'$mcp_project_id'", "properties", use_new_events_schema=use_new
+    )
+
+    with tags_context(
+        product=Product.MAX_AI,
+        feature=Feature.USAGE_REPORT,
+        usage_report="ai_credits_docs_search_exempted",
+        kind="usage_report",
+    ):
+        # nosemgrep: clickhouse-fstring-param-audit - property document/table expressions are internal fragments
+        return sync_execute(
+            f"""
+            SELECT
+                customer_team_id AS team,
+                toInt64(sum(least(daily_searches, %(daily_cap)s)) * %(credits_per_search)s) AS credits
+            FROM (
+                SELECT
+                    toInt64OrZero({customer_team_id_expr}) AS customer_team_id,
+                    toDate(timestamp) AS day,
+                    count() AS daily_searches
+                FROM {events_table}
+                PREWHERE
+                    -- data inside PostHog project used as ground truth for billing (depends on region)
+                    team_id = %(team_to_query)s
+                    AND timestamp >= %(begin)s
+                    AND timestamp < %(end)s
+                    AND event = '$mcp_tool_call'
+                WHERE
+                    {tool_name_expr} = %(tool_name)s
+                    AND {source_expr} = %(source)s
+                    -- The MCP server captures a region's calls into both regions' projects, so without
+                    -- this every team would be credited once per regional report.
+                    AND {mcp_region_expr} = %(mcp_region)s
+                GROUP BY customer_team_id, day
+            )
+            WHERE customer_team_id > 0
+            GROUP BY team
+            HAVING credits > 0
+            ORDER BY credits DESC
+            """,
+            {
+                "team_to_query": CLOUD_REGION_TO_TEAM_ID[region],
+                "begin": begin,
+                "end": end,
+                "tool_name": DOCS_SEARCH_MCP_TOOL,
+                "source": DOCS_SEARCH_EXEMPT_SOURCE,
+                "mcp_region": region.lower(),
+                "daily_cap": DOCS_SEARCH_EXEMPTION_DAILY_CAP_PER_TEAM,
+                "credits_per_search": DOCS_SEARCH_EXEMPTION_CREDITS,
+            },
+            workload=Workload.OFFLINE,
+            settings=CH_BILLING_SETTINGS,
+            ch_user=ClickHouseUser.BILLING,
+        )
 
 
 @timed_log()
@@ -3054,6 +3209,9 @@ def _get_all_usage_data(period_start: datetime, period_end: datetime) -> dict[st
         ),
         "teams_with_ai_event_count_in_period": get_teams_with_ai_event_count_in_period(period_start, period_end),
         "teams_with_ai_credits_used_in_period": get_teams_with_ai_credits_used_in_period(period_start, period_end),
+        "teams_with_ai_credits_docs_search_exempted_in_period": (
+            get_teams_with_ai_credits_docs_search_exempted_in_period(period_start, period_end)
+        ),
         "teams_with_signals_credits_used_in_period": get_teams_with_signals_credits_used_in_period(
             period_start, period_end
         ),
@@ -3273,6 +3431,9 @@ def _get_team_report(all_data: dict[str, Any], team: Team) -> UsageReportCounter
         rust_events_count_in_period=all_data["teams_with_rust_events_count_in_period"].get(team.id, 0),
         ai_event_count_in_period=all_data["teams_with_ai_event_count_in_period"].get(team.id, 0),
         ai_credits_used_in_period=all_data["teams_with_ai_credits_used_in_period"].get(team.id, 0),
+        ai_credits_docs_search_exempted_in_period=all_data["teams_with_ai_credits_docs_search_exempted_in_period"].get(
+            team.id, 0
+        ),
         signals_credits_used_in_period=all_data["teams_with_signals_credits_used_in_period"].get(team.id, 0),
         posthog_code_credits_used_in_period=combine_posthog_code_credits(
             all_data["teams_with_posthog_code_credits_used_in_period"].get(team.id, 0),


### PR DESCRIPTION
## Problem

Asking PostHog AI a documentation question is free on the LangGraph runtime and bills on the sandbox one. Teams whose conversations run on the sandbox runtime pay AI credits for a question that costs their peers nothing.

The exemption lives in the AI-credit usage query. It reads a turn's tool calls off the `$ai_trace` event and skips the turn when every call is in `AI_BILLING_EXCLUDED_TOOLS`. The sandbox runtime spends through the LLM gateway, which emits `$ai_generation` and never `$ai_trace`. That leaves the rule with no turn state to read, so every sandbox generation bills.

## Changes

- Docs searches made by a PostHog AI run now take a flat credit off the team's reported AI credits.
- `get_teams_with_ai_credits_docs_search_exempted_in_period` counts those searches from `$mcp_tool_call`, which the MCP server already emits per call.
- The deduction happens inside `get_teams_with_ai_credits_used_in_period`, so one number reaches both the bill and the quota limiter's `todays_usage`.
- Nothing in the product UI changes. The visible effect is a lower AI-credit figure on a bill.

Three filters carry the correctness, and each has a test:

| Filter | Without it |
| --- | --- |
| `source = 'posthog_ai'` | Third-party agents and PostHog Desktop take credits off a bill they never ran up |
| `$mcp_region` | The MCP server captures a region's calls into both regions' projects, so every team is deducted twice |
| Daily cap per team | A loop of documentation questions mints credits without bound |

`$mcp_consumer` reports `posthog-code` for every sandbox agent, and `$ai_product` is uniformly `mcp` on these events. Neither separates PostHog AI from other surfaces, so `source` is the only field that can.

### Why one credit per search, not a share of the turn

The obvious alternative exempts a turn where documentation search is most of the work. It is not computable here. `$mcp_tool_call` carries no trace or conversation id, so there is nothing to group a turn by. The tool-call denominator that rule needs lives on `$ai_generation`, with no key joining the two.

A flat credit per search needs neither. The trade is that a turn which searched the docs and then did billable work is credited too. The flat rate and the daily cap bound that.

> [!NOTE]
> The credit rate and the daily cap are pricing policy numbers, not measurements. Both want a calibration pass against observed generation costs before the deduction is treated as fair.

## How did you test this code?

Four ClickHouse-backed tests in `TestAIEventsUsageReport`, one per money bug:

- A team with gateway spend and docs searches reports credits net of the deduction.
- A docs search from another surface deducts nothing. Parameterized over the third-party, Desktop, and Slack surfaces.
- A docs search from another region deducts nothing.
- Searches past the daily cap deduct only the cap.

One parameterized `SimpleTestCase` covers the clamp in `subtract_ai_credit_exemptions`. A team whose deduction exceeds its spend reports nothing rather than a negative.

An existing test caught a real bug during development. `test_ai_credits_returns_no_rows_when_instance_group_missing` asserts that a billing query with no region to filter on runs no SQL. The exemption query broke that. Short-circuiting on an empty gross result fixes it and leaves the test unchanged.

Not checked: the deduction never ran against production data, because the query reads events the local stack does not carry.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The exemption restores documented behavior rather than changing it.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code (Opus 5), directed by @skoob13. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`. `/django-migrations` and `/improving-drf-endpoints` were invoked for an earlier design that this PR no longer contains.

The session began as an audit of whether the new sandbox runtime bills correctly. Token spend does, through the gateway's `posthog_ai` product and its `ai_credits` bucket. The docs-search exemption was the gap.

The first implementation was a Postgres ledger written from the `docs_search` endpoint, on the belief that a sandbox agent's recorded tool calls could not name documentation search. That was wrong. The `exec` dispatcher relabels itself to the tool it dispatched, so the MCP server already records the search by name. The ledger, its model, and its migration came out again in favor of counting the events that exist.

Two follow-ups this PR does not take:

- Sandbox compute for PostHog AI runs is unbilled. `is_billable_compute` admits only PostHog Desktop provenance with a user-created or loop origin, so a PostHog AI conversation's sandbox cost lands in no credit bucket.
- Exposing `docs-search` as its own MCP tool, rather than through the `exec` dispatcher, would put the tool name on `$ai_tools_called` and make a share-of-turn rule computable later.

**Public artifact:** the design drew on queries against PostHog's own analytics project. No figures, identifiers, or customer data from those queries appear in the code, comments, commit message, or this description.
