### PR TITLE
fix(insights): give the insight Duplicate button loading and failure feedback

### DIFF
--- a/frontend/src/lib/components/Scenes/SceneDuplicate.tsx
+++ b/frontend/src/lib/components/Scenes/SceneDuplicate.tsx
@@ -1,22 +1,25 @@
 import { IconCopy } from '@posthog/icons'
 
+import { Spinner } from 'lib/lemon-ui/Spinner'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 
 import { SceneDataAttrKeyProps } from './utils'
 
 interface SceneDuplicateProps extends SceneDataAttrKeyProps {
     onClick: () => void
+    loading?: boolean
 }
 
-export function SceneDuplicate({ dataAttrKey, onClick }: SceneDuplicateProps): JSX.Element {
+export function SceneDuplicate({ dataAttrKey, onClick, loading }: SceneDuplicateProps): JSX.Element {
     return (
         <ButtonPrimitive
             menuItem
             onClick={onClick}
+            disabled={loading}
             data-attr={`${dataAttrKey}-duplicate-button`}
-            tooltip="Duplicate resource"
+            tooltip={loading ? 'Duplicating…' : 'Duplicate resource'}
         >
-            <IconCopy />
+            {loading ? <Spinner textColored /> : <IconCopy />}
             Duplicate
         </ButtonPrimitive>
     )

--- a/frontend/src/scenes/insights/SidePanel/InsightPanelActions.tsx
+++ b/frontend/src/scenes/insights/SidePanel/InsightPanelActions.tsx
@@ -44,7 +44,7 @@ const RESOURCE_TYPE = 'insight'
 
 export function InsightPanelActions({ insightLogicProps }: { insightLogicProps: InsightLogicProps }): JSX.Element {
     const theInsightLogic = insightLogic(insightLogicProps)
-    const { insightProps, insight, hasDashboardItemId } = useValues(theInsightLogic)
+    const { insightProps, insight, hasDashboardItemId, insightDuplicating } = useValues(theInsightLogic)
     const { duplicateInsight, setInsightMetadata } = useActions(theInsightLogic)
 
     const theInsightDataLogic = insightDataLogic(insightProps)
@@ -78,6 +78,7 @@ export function InsightPanelActions({ insightLogicProps }: { insightLogicProps: 
         <ScenePanelActionsSection>
             <SceneDuplicate
                 dataAttrKey={RESOURCE_TYPE}
+                loading={insightDuplicating}
                 onClick={() => duplicateInsight(insight as QueryBasedInsightModel, true)}
             />
             {isSavedInsight && canCopyToProject && (

--- a/frontend/src/scenes/insights/SidePanel/InsightSceneMenuBar.tsx
+++ b/frontend/src/scenes/insights/SidePanel/InsightSceneMenuBar.tsx
@@ -85,7 +85,8 @@ export function InsightSceneMenuBar({
 
 function InsightSceneMenuBarInner({ insightLogicProps }: { insightLogicProps: InsightLogicProps }): JSX.Element {
     const theInsightLogic = insightLogic(insightLogicProps)
-    const { insightProps, insight, hasDashboardItemId, canEditInsight, isSavingTags } = useValues(theInsightLogic)
+    const { insightProps, insight, hasDashboardItemId, canEditInsight, isSavingTags, insightDuplicating } =
+        useValues(theInsightLogic)
     const { duplicateInsight, deleteInsight, setInsightMetadata } = useActions(theInsightLogic)
 
     const theInsightDataLogic = insightDataLogic(insightProps)
@@ -340,6 +341,7 @@ function InsightSceneMenuBarInner({ insightLogicProps }: { insightLogicProps: In
             {showEditMenu && (
                 <SceneMenuBarMenu label="Edit" dataAttr={`${RESOURCE_TYPE}-menubar-edit`}>
                     <SceneMenuBarItem
+                        disabled={insightDuplicating}
                         onClick={() => duplicateInsight(insight as QueryBasedInsightModel, true)}
                         data-attr={`${RESOURCE_TYPE}-menubar-duplicate`}
                     >

--- a/frontend/src/scenes/insights/SidePanel/InsightSceneMenuBar.tsx
+++ b/frontend/src/scenes/insights/SidePanel/InsightSceneMenuBar.tsx
@@ -342,6 +342,7 @@ function InsightSceneMenuBarInner({ insightLogicProps }: { insightLogicProps: In
                 <SceneMenuBarMenu label="Edit" dataAttr={`${RESOURCE_TYPE}-menubar-edit`}>
                     <SceneMenuBarItem
                         disabled={insightDuplicating}
+                        tooltip={insightDuplicating ? 'Duplicating…' : undefined}
                         onClick={() => duplicateInsight(insight as QueryBasedInsightModel, true)}
                         data-attr={`${RESOURCE_TYPE}-menubar-duplicate`}
                     >

--- a/frontend/src/scenes/insights/insightLogic.test.ts
+++ b/frontend/src/scenes/insights/insightLogic.test.ts
@@ -4,6 +4,7 @@ import { router } from 'kea-router'
 import { expectLogic, partial, truth } from 'kea-test-utils'
 
 import api from 'lib/api'
+import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { objectsEqual } from 'lib/utils/objects'
 import 'lib/constants'
 import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
@@ -1042,6 +1043,33 @@ describe('insightLogic', () => {
                 logic.actions.duplicateInsight(logic.values.insight as QueryBasedInsightModel, false)
             }).toFinishAllListeners()
 
+            await expectLogic(router).toNotHaveDispatchedActions(['push'])
+        })
+
+        it('marks the insight as duplicating until the request settles', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.duplicateInsight(logic.values.insight as QueryBasedInsightModel, true)
+            })
+                .toMatchValues({ insightDuplicating: true })
+                .toFinishAllListeners()
+                .toMatchValues({ insightDuplicating: false })
+        })
+
+        it('surfaces a failure instead of silently doing nothing', async () => {
+            useMocks({
+                post: {
+                    '/api/environments/:team_id/insights/': () => [400, { detail: 'Insight limit reached' }],
+                },
+            })
+            jest.spyOn(lemonToast, 'error')
+
+            await expectLogic(logic, () => {
+                logic.actions.duplicateInsight(logic.values.insight as QueryBasedInsightModel, true)
+            })
+                .toFinishAllListeners()
+                .toMatchValues({ insightDuplicating: false })
+
+            expect(lemonToast.error).toHaveBeenCalledWith('Insight limit reached')
             await expectLogic(router).toNotHaveDispatchedActions(['push'])
         })
     })

--- a/frontend/src/scenes/insights/insightLogic.test.ts
+++ b/frontend/src/scenes/insights/insightLogic.test.ts
@@ -2,6 +2,7 @@ import { MOCK_DEFAULT_TEAM, MOCK_TEAM_ID } from 'lib/api.mock'
 
 import { router } from 'kea-router'
 import { expectLogic, partial, truth } from 'kea-test-utils'
+import posthog from 'posthog-js'
 
 import api from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
@@ -1055,23 +1056,40 @@ describe('insightLogic', () => {
                 .toMatchValues({ insightDuplicating: false })
         })
 
-        it('surfaces a failure instead of silently doing nothing', async () => {
-            useMocks({
-                post: {
-                    '/api/environments/:team_id/insights/': () => [400, { detail: 'Insight limit reached' }],
-                },
-            })
-            jest.spyOn(lemonToast, 'error')
+        // Catching the rejection skips the gate `initKea` applies to loader failures, so the
+        // listener has to reapply it: a validation error is the app's own bug and stays
+        // reportable, while an access-denied 403 the AccessDenied scene already handles would
+        // file an issue sharing its stack with every other ApiError, burying real crashes.
+        it.each([
+            ['a validation error', 400, { detail: 'Insight limit reached' }, 1],
+            [
+                'a failure the app recovers from',
+                403,
+                { detail: 'You do not have permission', code: 'permission_denied' },
+                0,
+            ],
+        ])(
+            'toasts %s rather than doing nothing, and reports it only if it is worth filing',
+            async (_, status, body, timesReported) => {
+                useMocks({
+                    post: {
+                        '/api/environments/:team_id/insights/': () => [status, body],
+                    },
+                })
+                jest.spyOn(lemonToast, 'error')
+                jest.spyOn(posthog, 'captureException')
 
-            await expectLogic(logic, () => {
-                logic.actions.duplicateInsight(logic.values.insight as QueryBasedInsightModel, true)
-            })
-                .toFinishAllListeners()
-                .toMatchValues({ insightDuplicating: false })
+                await expectLogic(logic, () => {
+                    logic.actions.duplicateInsight(logic.values.insight as QueryBasedInsightModel, true)
+                })
+                    .toFinishAllListeners()
+                    .toMatchValues({ insightDuplicating: false })
 
-            expect(lemonToast.error).toHaveBeenCalledWith('Insight limit reached')
-            await expectLogic(router).toNotHaveDispatchedActions(['push'])
-        })
+                expect(lemonToast.error).toHaveBeenCalledWith(body.detail)
+                expect(posthog.captureException).toHaveBeenCalledTimes(timesReported)
+                await expectLogic(router).toNotHaveDispatchedActions(['push'])
+            }
+        )
     })
 
     describe('hasOverrides', () => {

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -120,6 +120,7 @@ export interface insightLogicValues {
     highlightedSeries: IndexedTrendResult | null
     insight: Partial<QueryBasedInsightModel<Node<Record<string, any>>>>
     insightChanged: boolean
+    insightDuplicating: boolean
     insightFeedback: 'disliked' | 'liked' | null
     insightId: number | null
     insightLoading: boolean
@@ -154,6 +155,9 @@ export interface insightLogicActions {
     ) => {
         insight: QueryBasedInsightModel<Node<Record<string, any>>>
         redirectToInsight: any
+    }
+    duplicateInsightComplete: () => {
+        value: true
     }
     handleInsightSuggested: (suggestedInsight: Node | null) => {
         suggestedInsight: Node<Record<string, any>> | null
@@ -609,6 +613,7 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
             insight,
             redirectToInsight,
         }),
+        duplicateInsightComplete: true,
         deleteInsight: (dashboardId: number | null) => ({ dashboardId }),
         confirmDeleteInsight: (dashboardId: number | null) => ({ dashboardId }),
         setInsightFeedback: (feedback: 'liked' | 'disliked') => ({ feedback }),
@@ -735,6 +740,13 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
             null as IndexedTrendResult | null,
             {
                 highlightSeries: (_, { series }) => series,
+            },
+        ],
+        insightDuplicating: [
+            false,
+            {
+                duplicateInsight: () => true,
+                duplicateInsightComplete: () => false,
             },
         ],
         insight: {
@@ -1239,22 +1251,32 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
             }
         },
         duplicateInsight: async ({ insight, redirectToInsight }) => {
-            let insightToDuplicate = insight
-            if (insight.short_id) {
-                try {
-                    const cleanInsight = await insightsApi.getByShortId(insight.short_id)
-                    if (cleanInsight) {
-                        insightToDuplicate = cleanInsight
+            try {
+                let insightToDuplicate = insight
+                if (insight.short_id) {
+                    try {
+                        const cleanInsight = await insightsApi.getByShortId(insight.short_id)
+                        if (cleanInsight) {
+                            insightToDuplicate = cleanInsight
+                        }
+                    } catch {
+                        // Fall through to duplicate the original insight
                     }
-                } catch {
-                    // Fall through to duplicate the original insight
                 }
+                const newInsight = await insightsApi.duplicate(insightToDuplicate)
+                for (const logic of savedInsightsLogic.findAllMounted()) {
+                    logic.actions.addInsight(newInsight)
+                }
+                lemonToast.success('Insight duplicated')
+                redirectToInsight && router.actions.push(urls.insightEdit(newInsight.short_id))
+            } catch (e: any) {
+                // Nothing downstream reports this: the copy is created by a plain listener rather than
+                // a loader, so without a toast here a failure is indistinguishable from a dead button.
+                lemonToast.error(e.detail ?? 'Could not duplicate insight')
+                posthog.captureException(e)
+            } finally {
+                actions.duplicateInsightComplete()
             }
-            const newInsight = await insightsApi.duplicate(insightToDuplicate)
-            for (const logic of savedInsightsLogic.findAllMounted()) {
-                logic.actions.addInsight(newInsight)
-            }
-            redirectToInsight && router.actions.push(urls.insightEdit(newInsight.short_id))
         },
         deleteInsight: ({ dashboardId }) => {
             LemonDialog.open({

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -19,7 +19,7 @@ import posthog from 'posthog-js'
 import { LemonDialog, LemonInput } from '@posthog/lemon-ui'
 
 import { ApiError } from 'lib/api'
-import { isTransientServerError } from 'lib/api-error'
+import { isTransientServerError, shouldReportApiFailure } from 'lib/api-error'
 import { tryShowMCPHint } from 'lib/components/MCPHint/mcpHintLogic'
 import { SetupTaskId, globalSetupLogic } from 'lib/components/ProductSetup'
 import { LemonField } from 'lib/lemon-ui/LemonField'
@@ -1273,7 +1273,9 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
                 // Nothing downstream reports this: the copy is created by a plain listener rather than
                 // a loader, so without a toast here a failure is indistinguishable from a dead button.
                 lemonToast.error(e.detail ?? 'Could not duplicate insight')
-                posthog.captureException(e)
+                if (shouldReportApiFailure(e)) {
+                    posthog.captureException(e)
+                }
             } finally {
                 actions.duplicateInsightComplete()
             }

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -1273,6 +1273,9 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
                 // Nothing downstream reports this: the copy is created by a plain listener rather than
                 // a loader, so without a toast here a failure is indistinguishable from a dead button.
                 lemonToast.error(e.detail ?? 'Could not duplicate insight')
+                // Catching here also skips the gate `initKea` applies to loader failures, so reapply
+                // it: a recovered failure shares its stack with every other ApiError, so filing it
+                // buries the crashes worth seeing.
                 if (shouldReportApiFailure(e)) {
                     posthog.captureException(e)
                 }


### PR DESCRIPTION
## Problem

Duplicating an insight from the scene panel or the Edit menu looks like nothing happened. The copy is created, but the button gives no loading state, no toast, and no error, so a slow or failed request is indistinguishable from a dead button. Impatient clicking then creates one extra copy per click, which is what surfaced this.

- `duplicateInsight` in `insightLogic` awaits the create and navigates only on success.
- A rejection anywhere after the request is swallowed. Kea logs it and the user sees nothing.
- The button stays enabled for the whole request, against the repo rule that a network-triggering button must disable and show loading.

## Changes

- The scene panel's Duplicate button disables and swaps its icon for a spinner until the create settles.
- The Edit menu's Duplicate item disables and carries a "Duplicating…" tooltip, so reopening the menu says why it is greyed out.
- A successful duplicate toasts "Insight duplicated" as well as navigating to the copy, so the user still gets feedback if the redirect does not happen.
- A failed duplicate toasts the server's reason and re-enables the button, instead of doing nothing.
- A failure the app already resolves elsewhere, such as an access-denied 403, is toasted without being filed to error tracking.
- `SceneDuplicate` takes an optional `loading` prop. The dashboard, survey, and playlist call sites are unchanged.

Mechanical: the kea typegen block is regenerated for the new `insightDuplicating` value.

Nothing looks different at rest. The only new visual is the existing `Spinner` replacing `IconCopy` in the scene panel while the request is in flight, so no screenshot is attached.

## How did you test this code?

Kea logic tests were added to `insightLogic.test.ts`:

- `insightDuplicating` flips true on dispatch and back to false once the request settles. This catches the button staying clickable and firing one create per click.
- A parameterized pair drives the create to a 400 and to an access-denied 403. Both assert the server detail is toasted, the flag clears, and no navigation happens, which catches the swallowed failure and the button latching disabled. They differ on reporting: the 400 is filed, the 403 is not. That second row catches removal of the `shouldReportApiFailure` gate, which was verified by deleting the gate and watching the row fail.

Ran `jest frontend/src/scenes/insights/insightLogic.test.ts -t duplicateInsight` (7 passed) and `pnpm --filter=@posthog/frontend typescript:check` locally. Not checked: the app was not run, so there is no manual browser verification of the spinner, the tooltip, or the toasts.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude Code) from a Slack thread reporting that the side panel Duplicate button appeared to do nothing.

Diagnosis came from the project's own data before any code changed: autocapture and rageclick events on the button, `client_request_failure` events showing two aborted `POST /insights/` requests, and matching rows in `system.insights` proving every click did create a copy. Server-side latency on the create endpoint was checked through APM root spans and is not the problem, so the fix targets the missing client feedback rather than the endpoint.

Git history was checked for a regression. The redirect has been on this path since 2022 and is covered by passing tests, and no toast ever existed here, so the gap is long-standing rather than recently broken. The insight scene is the odd one out among `SceneDuplicate` call sites: survey and playlist both toast on duplicate. Whether the redirect itself also fails under some condition is still open, which is why the success toast was added rather than relying on navigation alone.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

Review round: two bots independently flagged the same two gaps. ReviewHog's auto-fix bot pushed the source fixes for both (the `shouldReportApiFailure` gate, the menu tooltip) directly to this branch. This turn's commit adds the test that was missing for the gate, so removing it is no longer silent, and records in the source why the gate exists. Where the two bots disagreed on the menu item, the tooltip was taken over swapping in a spinner: no `SceneMenuBarItem` in the repo renders one, while `ExperimentSceneMenuBar` already pairs `disabled` with an in-flight tooltip.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1787228466060889)*

