### PR TITLE
fix(cli): add --preserve-sources for non-mutating sourcemap inject

### DIFF
--- a/cli/src/sourcemaps/inject.rs
+++ b/cli/src/sourcemaps/inject.rs
@@ -41,11 +41,26 @@ pub struct InjectArgs {
         default_value = "symbol-set"
     )]
     pub release_mode: ReleaseMode,
+
+    /// Do not rewrite minified JS. Stamp chunk/release ids onto sourcemaps only, leaving deploy
+    /// artifacts byte-identical so content hashes (Angular `ngsw.json`, SRI, CDN checksums) stay
+    /// valid. Incompatible with `--release-mode=event`, which embeds a runtime release id in JS.
+    /// See https://github.com/PostHog/posthog/issues/86046
+    #[arg(long, default_value_t = false)]
+    pub preserve_sources: bool,
 }
 
 impl InjectArgs {
     pub fn validate(&self) -> Result<()> {
-        self.file_selection.validate()
+        self.file_selection.validate()?;
+        if self.preserve_sources && self.release_mode == ReleaseMode::Event {
+            bail!(
+                "--preserve-sources cannot be combined with --release-mode=event \
+                 (event mode injects `_posthogReleaseId` into JS). Use symbol-set mode, \
+                 or omit --preserve-sources."
+            );
+        }
+        Ok(())
     }
 }
 
@@ -59,9 +74,21 @@ pub fn inject_impl(
         public_path_prefix,
         release,
         release_mode,
+        preserve_sources,
     } = args;
 
     info!("injecting selection: {}", file_selection);
+    if *preserve_sources {
+        info!(
+            "preserve-sources: minified JS will not be rewritten; chunk ids go on sourcemaps only"
+        );
+    } else if directory_has_service_worker_manifest(file_selection) {
+        warn!(
+            "ngsw.json detected under the inject directory. In-place inject rewrites JS and \
+             invalidates Angular service-worker hashes (see posthog/posthog#86046). Re-run with \
+             --preserve-sources, or regenerate the manifest after inject with ngsw-config."
+        );
+    }
 
     let iterator = FileSelection::try_from(file_selection.clone())?;
 
@@ -84,7 +111,7 @@ pub fn inject_impl(
                     "no release could be resolved, injecting chunk ids only — events will carry no release"
                 );
             }
-            pairs = inject_pairs(pairs, release_id.as_deref())?;
+            pairs = inject_pairs_with_options(pairs, release_id.as_deref(), *preserve_sources)?;
         }
         ReleaseMode::SymbolSet => {
             // Fetch or create a release over the API and stamp its id into the sourcemap,
@@ -97,28 +124,49 @@ pub fn inject_impl(
                     .as_ref()
                     .map(|r| r.id.to_string())
             };
-            pairs = inject_pairs_legacy(pairs, created_release_id)?;
+            pairs =
+                inject_pairs_legacy_with_options(pairs, created_release_id, *preserve_sources)?;
         }
     }
 
-    // Write the source and sourcemaps back to disk
+    // Write artifacts back to disk. With preserve-sources, JS files are left untouched.
     for pair in &pairs {
-        pair.save()?;
+        pair.save_with_options(*preserve_sources)?;
     }
     info!("injecting done");
     Ok(())
 }
 
+fn directory_has_service_worker_manifest(file_selection: &FileSelectionArgs) -> bool {
+    file_selection.directory.iter().any(|root| {
+        root.join("ngsw.json").is_file()
+            || root.join("browser/ngsw.json").is_file()
+            || walkdir::WalkDir::new(root)
+                .max_depth(3)
+                .into_iter()
+                .filter_map(|e| e.ok())
+                .any(|e| e.file_name() == "ngsw.json")
+    })
+}
+
 /// Event-mode injection (`--release-mode=event`): content-addressed chunk ids plus an optional
 /// `_posthogReleaseId` payload.
 pub fn inject_pairs(
+    pairs: Vec<SourcePair>,
+    release_id: Option<&str>,
+) -> Result<Vec<SourcePair>> {
+    inject_pairs_with_options(pairs, release_id, false)
+}
+
+pub fn inject_pairs_with_options(
     mut pairs: Vec<SourcePair>,
     release_id: Option<&str>,
+    preserve_source: bool,
 ) -> Result<Vec<SourcePair>> {
     for pair in &mut pairs {
         let Some(chunk_id) = pair.get_chunk_id() else {
             let chunk_id = stable_chunk_id(&pair.source.inner.content);
-            pair.add_chunk_id(chunk_id, release_id)?;
+            pair.add_chunk_id_with_options(chunk_id, release_id, preserve_source)?;
             continue;
         };
 
@@ -127,14 +175,18 @@ pub fn inject_pairs(
         // or a re-run over an existing dist would keep reporting the old release on every
         // event. When no release resolves, leave the pair untouched: failing to resolve is
         // missing information (e.g. no git context), not evidence the embedded id is stale.
+        // Maps-only mode has no JS release snippet to refresh.
+        if preserve_source {
+            continue;
+        }
         let Some(release_id) = release_id else {
             continue;
         };
         if pair.get_injected_release_id().as_deref() == Some(release_id) {
             continue;
         }
-        pair.remove_chunk_id(chunk_id.clone())?;
-        pair.add_chunk_id(chunk_id, Some(release_id))?;
+        pair.remove_chunk_id_with_options(chunk_id.clone(), false)?;
+        pair.add_chunk_id_with_options(chunk_id, Some(release_id), false)?;
     }
 
     Ok(pairs)
@@ -144,8 +196,16 @@ pub fn inject_pairs(
 /// id stamped into the sourcemap. Regenerates the chunk id whenever the release id changes or is
 /// missing.
 pub fn inject_pairs_legacy(
+    pairs: Vec<SourcePair>,
+    created_release_id: Option<String>,
+) -> Result<Vec<SourcePair>> {
+    inject_pairs_legacy_with_options(pairs, created_release_id, false)
+}
+
+pub fn inject_pairs_legacy_with_options(
     mut pairs: Vec<SourcePair>,
     created_release_id: Option<String>,
+    preserve_source: bool,
 ) -> Result<Vec<SourcePair>> {
     for pair in &mut pairs {
         let current_release_id = pair.get_release_id();
@@ -155,9 +215,9 @@ pub fn inject_pairs_legacy(
 
             let chunk_id = uuid::Uuid::now_v7().to_string();
             if let Some(previous_chunk_id) = pair.get_chunk_id() {
-                pair.update_chunk_id(previous_chunk_id, chunk_id)?;
+                pair.update_chunk_id_with_options(previous_chunk_id, chunk_id, preserve_source)?;
             } else {
-                pair.add_chunk_id(chunk_id, None)?;
+                pair.add_chunk_id_with_options(chunk_id, None, preserve_source)?;
             }
         }
     }

--- a/cli/src/sourcemaps/plain/mod.rs
+++ b/cli/src/sourcemaps/plain/mod.rs
@@ -62,6 +62,10 @@ pub struct ProcessArgs {
         default_value = "symbol-set"
     )]
     pub release_mode: ReleaseMode,
+
+    /// Do not rewrite minified JS during inject (sourcemap-only chunk ids). See `inject --help`.
+    #[arg(long, default_value_t = false)]
+    pub preserve_sources: bool,
 }
 
 impl ProcessArgs {
@@ -79,6 +83,7 @@ impl From<ProcessArgs> for (InjectArgs, upload::Args) {
             release: args.release.clone(),
             public_path_prefix: args.public_path_prefix.clone(),
             release_mode: args.release_mode,
+            preserve_sources: args.preserve_sources,
         };
         let upload_args = upload::Args {
             file_selection: args.file_selection,

--- a/cli/src/sourcemaps/source_pairs.rs
+++ b/cli/src/sourcemaps/source_pairs.rs
@@ -26,7 +26,11 @@ impl SourcePair {
     }
 
     pub fn get_chunk_id(&self) -> Option<String> {
-        self.source.get_chunk_id()
+        // Prefer the minified source (runtime injection). Fall back to the sourcemap so
+        // `--preserve-sources` can stamp ids without rewriting deployable JS (#86046).
+        self.source
+            .get_chunk_id()
+            .or_else(|| self.sourcemap.get_chunk_id())
     }
 
     pub fn has_release_id(&self) -> bool {
@@ -45,8 +49,23 @@ impl SourcePair {
     }
 
     pub fn remove_chunk_id(&mut self, chunk_id: String) -> Result<()> {
+        self.remove_chunk_id_with_options(chunk_id, false)
+    }
+
+    pub fn remove_chunk_id_with_options(
+        &mut self,
+        chunk_id: String,
+        preserve_source: bool,
+    ) -> Result<()> {
         if self.get_chunk_id().as_ref() != Some(&chunk_id) {
             return Err(anyhow!("Chunk ID mismatch"));
+        }
+        if preserve_source || self.source.get_chunk_id().is_none() {
+            // Maps-only injection never rewrote the JS; clear the map field only.
+            if self.sourcemap.get_chunk_id().as_ref() == Some(&chunk_id) {
+                self.sourcemap.set_chunk_id(None);
+            }
+            return Ok(());
         }
         let adjustment = self.source.remove_chunk_id(chunk_id)?;
         self.sourcemap.apply_adjustment(adjustment)?;
@@ -59,14 +78,42 @@ impl SourcePair {
         previous_chunk_id: String,
         new_chunk_id: String,
     ) -> Result<()> {
-        self.remove_chunk_id(previous_chunk_id)?;
-        self.add_chunk_id(new_chunk_id, None)?;
+        self.update_chunk_id_with_options(previous_chunk_id, new_chunk_id, false)
+    }
+
+    pub fn update_chunk_id_with_options(
+        &mut self,
+        previous_chunk_id: String,
+        new_chunk_id: String,
+        preserve_source: bool,
+    ) -> Result<()> {
+        self.remove_chunk_id_with_options(previous_chunk_id, preserve_source)?;
+        self.add_chunk_id_with_options(new_chunk_id, None, preserve_source)?;
         Ok(())
     }
 
     pub fn add_chunk_id(&mut self, chunk_id: String, release_id: Option<&str>) -> Result<()> {
+        self.add_chunk_id_with_options(chunk_id, release_id, false)
+    }
+
+    /// When `preserve_source` is true, stamp the chunk id onto the sourcemap only and leave the
+    /// minified JS bytes untouched. Required for Angular service workers, SRI, and any pipeline
+    /// that content-hashes deploy artifacts before/without re-hashing after inject (#86046).
+    pub fn add_chunk_id_with_options(
+        &mut self,
+        chunk_id: String,
+        release_id: Option<&str>,
+        preserve_source: bool,
+    ) -> Result<()> {
         if self.has_chunk_id() {
             return Err(anyhow!("Chunk ID already set"));
+        }
+
+        if preserve_source {
+            // No IIFE / chunkId comment, no sourcemap offset adjustment — deploy hashes stay valid.
+            self.sourcemap.set_chunk_id(Some(chunk_id));
+            let _ = release_id; // event-mode release embedding requires JS mutation; rejected upstream
+            return Ok(());
         }
 
         let adjustment = self.source.set_chunk_id(&chunk_id, release_id)?;
@@ -85,7 +132,13 @@ impl SourcePair {
     }
 
     pub fn save(&self) -> Result<()> {
-        self.source.save()?;
+        self.save_with_options(false)
+    }
+
+    pub fn save_with_options(&self, preserve_source: bool) -> Result<()> {
+        if !preserve_source {
+            self.source.save()?;
+        }
         self.sourcemap.save()?;
         Ok(())
     }

--- a/cli/tests/sourcemap.rs
+++ b/cli/tests/sourcemap.rs
@@ -2,7 +2,9 @@ use posthog_cli::{
     sourcemaps::{
         args::ReleaseMode,
         content::SourceMapContent,
-        inject::{inject_pairs, inject_pairs_legacy},
+        inject::{
+            inject_pairs, inject_pairs_legacy, inject_pairs_legacy_with_options,
+        },
         plain::inject::{is_javascript_file, is_stylesheet_file},
         source_pairs::SourcePair,
     },
@@ -429,6 +431,34 @@ fn test_legacy_reinject_with_new_release() {
         first_pair.sourcemap.get_release_id().unwrap(),
         release_id.clone()
     );
+}
+
+#[test]
+fn test_preserve_sources_leaves_minified_js_bytes_unchanged() {
+    // #86046: Angular ngsw / SRI hash deploy artifacts. Inject must be able to stamp
+    // chunk ids without rewriting the minified JS that was just hashed.
+    let case_path = get_case_path("inject");
+    let pairs =
+        read_pairs(vec![case_path.clone()], vec![], vec![], &None).expect("Failed to read pairs");
+    assert_eq!(pairs.len(), 1);
+    let original_source = pairs[0].source.inner.content.clone();
+
+    let release_id = uuid::Uuid::now_v7().to_string();
+    let injected = inject_pairs_legacy_with_options(pairs, Some(release_id.clone()), true)
+        .expect("Failed to inject pairs with preserve_sources");
+    let pair = injected.first().expect("pair");
+
+    assert_eq!(
+        pair.source.inner.content, original_source,
+        "minified source must remain byte-identical"
+    );
+    assert!(
+        pair.source.get_chunk_id().is_none(),
+        "source must not gain a //# chunkId= comment"
+    );
+    assert_eq!(pair.get_chunk_id().as_deref(), pair.sourcemap.get_chunk_id().as_deref());
+    assert!(pair.sourcemap.get_chunk_id().is_some());
+    assert_eq!(pair.sourcemap.get_release_id().as_deref(), Some(release_id.as_str()));
 }
 
 #[test]


### PR DESCRIPTION
## Problem

`posthog-cli sourcemap inject` rewrites every minified JS file (chunk-id IIFE + comment). Pipelines that content-hash deploy artifacts **before** inject — notably Angular's service worker (`ngsw.json`) — then fail hash checks and stop serving updates. Same class of failure for SRI and CDN checksums.

Closes #86046

## Changes

- New `--preserve-sources` flag on `sourcemap inject` and `sourcemap process`.
- When set, chunk/release ids are written **only** to sourcemaps; minified JS is left byte-identical and is not rewritten on save.
- Warn if `ngsw.json` is found under the inject directory and `--preserve-sources` is not set.
- Reject `--preserve-sources` with `--release-mode=event` (event mode embeds `_posthogReleaseId` in JS).
- Unit test: preserve-sources keeps minified source content unchanged while stamping map ids.

## How did you test this code?

- Added `test_preserve_sources_leaves_minified_js_bytes_unchanged` in `cli/tests/sourcemap.rs`.
- Full `cargo test -p posthog-cli` not run in this environment (Windows MSVC link libs missing); CI should run CLI tests.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Angular source-map docs should recommend `sourcemap inject --preserve-sources` (or post-inject `ngsw-config`). Not updated in this PR unless docs live in-repo.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tools: OpenCode / CLI on a sparse PostHog checkout.
- Option C from issue triage: non-mutating inject for hashed deploy pipelines.
- done with midfleet
