### PR TITLE
perf(ci): sparse-checkout paths-filter in change-detection jobs

### DIFF
--- a/.agents/skills/authoring-ci-workflows/SKILL.md
+++ b/.agents/skills/authoring-ci-workflows/SKILL.md
@@ -121,19 +121,49 @@ Four rules for the gate body:
 `WF007` enforces 1, 4, and the `always()` condition, and it takes the dependency list from `needs:` as well as the step body, so a job you wired into `needs:` and then forgot to test is reported rather than silently trusted.
 The half of rule 2 it cannot check is whether you named the right jobs in `needs:` to begin with: "reporting job" and "coverage job" look identical to a linter, so that one is on you and the reviewer.
 
-## Checkout / clone — shallow by default
+## Checkout / clone — sparse first, then shallow
 
-Full clones are slow and hang on degraded runners; blobs dominate clone size and are lazily fetchable.
-Default to shallow; go deep only for real merge-base or version math, and even then bound the depth and filter blobs.
+This repo is 45k tracked files and 4.6 GiB of packed objects, so **what you materialize costs more than how much history you fetch**.
+Measured checkout-step durations, from the GitHub API on real runs:
+
+| Pattern                                         | depot-ubuntu-24.04 | GitHub-hosted ubuntu |
+| ----------------------------------------------- | ------------------ | -------------------- |
+| `sparse-checkout` of a few paths, cone mode off | 0–7s               | 0–7s                 |
+| plain checkout (depth 1)                        | 11–13s             | 22–44s               |
+| `fetch-depth: 1000` + `filter: blob:none`       | 53–59s             | —                    |
+
+- **Biggest lever: check out only the paths the job reads.**
+  Sparse-checkout is not just for single files — a job that runs a local composite action, reads a JSON config, or lints one directory should name those paths and nothing else.
+
+  ```yaml
+  - uses: actions/checkout@<sha> # v6
+    with:
+      sparse-checkout: |
+        .github/actions/paths-filter
+        .github/clickhouse-versions.json
+      sparse-checkout-cone-mode: false
+  ```
+
+- **Always set `sparse-checkout-cone-mode: false`.**
+  Cone mode additionally materializes every file in the repo root — here 70 files and 21.5 MB, `.test_durations` alone 18.5 MB — which is most of what you were trying to avoid.
+  Cone mode also only takes whole directories, so it drags in all of `bin/` when you wanted one script.
+
+- **`filter: blob:none` is counterproductive if the job then materializes the tree.**
+  It removes blobs from the fetch, but `git checkout` immediately lazy-fetches every blob in HEAD in a second round trip, which is slower than having fetched them in the pack.
+  That lazy fetch also intermittently fails its per-blob credential lookup with `could not read Username for github.com` (#59779, blocked a merge until retried).
+  Pair `blob:none` with `sparse-checkout` so the lazy fetch is a handful of blobs, or drop it and take the plain depth-1 checkout.
 
 - **Default:** plain `actions/checkout` (depth 1). Add nothing.
-- **Diffing against the PR base:** bounded depth + blobless, then an explicit, scoped fetch (the sanctioned pattern, from `ci-backend.yml`):
+
+- **Diffing against the PR base:** you need real history, so bound the depth, filter blobs, **and** sparse-checkout the files the job reads:
 
   ```yaml
   - uses: actions/checkout@<sha> # v6
     with:
       fetch-depth: 1000
       filter: blob:none
+      sparse-checkout: .github/actions/paths-filter
+      sparse-checkout-cone-mode: false
   - name: Fetch PR base for affected diff
     if: github.event_name == 'pull_request'
     env:
@@ -141,13 +171,19 @@ Default to shallow; go deep only for real merge-base or version math, and even t
     run: git fetch --no-tags --depth=1000 --filter=blob:none origin "$BASE_REF:refs/remotes/origin/$BASE_REF"
   ```
 
-- **One file (e.g. `.nvmrc` before `setup-node`):** `sparse-checkout` it instead of cloning the repo.
+  A sparse working tree does not affect `git merge-base`, `git diff <a>...<b>`, `git log --name-status`, `git ls-tree`, `git ls-files`, or `git show <rev>:<path>` — those read the object database or the index.
+  Only commands that compare against the worktree (`git diff HEAD`, `git status`) see the skip-worktree entries.
+
+- **`changes` / paths-filter gating jobs:** on `pull_request` the vendored `.github/actions/paths-filter` diffs via the GitHub API and never touches the tree.
+  The only reason to check out is that a local action must exist on disk, so sparse-checkout `.github/actions/paths-filter` plus any file the job's own steps read.
+  **Never pass `base: HEAD` to paths-filter from a sparse job** — that routes it to `git diff HEAD`, which a sparse worktree makes return nothing, so every downstream job silently skips green.
+
 - **Foot-gun:** `git fetch --deepen=N` with **no refspec** falls back to the wildcard `refs/heads/*` and pulls _every branch_.
   Always pass an explicit, `--no-tags`, `--filter=blob:none` refspec scoped to the base ref.
   (Bumping `actions/checkout`'s own `fetch-depth` is safe — it uses a scoped `refs/pull/N/merge` refspec.)
 - The linter rejects `fetch-depth: 0` unless you add `filter: blob:none`, use `sparse-checkout`, or justify it with `# hogli-lint: allow-full-depth-checkout -- <reason>`.
-  Genuinely full-history jobs: repo mirroring (`foss-sync.yml`), tag/submodule version math (`release-cli.yml`).
-  Most base-diff jobs should use bounded `1000 + blob:none`.
+  Genuinely full-history jobs: repo mirroring (`foss-sync.yml`), tag/submodule version math (`release-cli.yml`, `desktop-tag.yml`).
+  Most base-diff jobs should use bounded `1000 + blob:none` **plus** a sparse set.
 
 ## Pinning and tool versions
 
@@ -250,7 +286,7 @@ Roll out a new blocking lint the same way: ship `continue-on-error`, clear the i
 - [ ] Triggers scoped: trigger `paths:` where the whole workflow is skippable; a required check must still fire on every PR (never paths-gate it into never dispatching).
 - [ ] Canonical `concurrency:` block (per-SHA push arm if it publishes on push).
 - [ ] `timeout-minutes` on every job (except reusable-caller jobs).
-- [ ] Checkout is shallow, or bounded `1000 + blob:none` for base diffing.
+- [ ] Checkout names only the paths the job reads (`sparse-checkout` + cone mode off), or is shallow; bounded `1000 + blob:none` only for base diffing.
 - [ ] Third-party actions SHA-pinned; Node from `.nvmrc`; `setup-uv` version pinned.
 - [ ] External fetches retry (`--retry-all-errors`), except where a repeat has a side effect.
 - [ ] High-volume API calls on a dedicated App token with `|| github.token` fork fallback.

--- a/.agents/skills/authoring-ci-workflows/SKILL.md
+++ b/.agents/skills/authoring-ci-workflows/SKILL.md
@@ -173,6 +173,8 @@ Measured checkout-step durations, from the GitHub API on real runs:
 
   A sparse working tree does not affect `git merge-base`, `git diff <a>...<b>`, `git log --name-status`, `git ls-tree`, `git ls-files`, or `git show <rev>:<path>` — those read the object database or the index.
   Only commands that compare against the worktree (`git diff HEAD`, `git status`) see the skip-worktree entries.
+  One caveat when `blob:none` is also set: `git show <rev>:<path>` still needs that blob, and a sparse checkout never downloaded it, so the read becomes a lazy fetch that can fail.
+  Name any file a step reads that way in the sparse set — `ci-dagster.yml` does this for `docker-compose.base.yml`, whose contents feed a cache key.
 
 - **`changes` / paths-filter gating jobs:** on `pull_request` the vendored `.github/actions/paths-filter` diffs via the GitHub API and never touches the tree.
   The only reason to check out is that a local action must exist on disk, so sparse-checkout `.github/actions/paths-filter` plus any file the job's own steps read.

--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -249,6 +249,8 @@ jobs:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   clean: false
+                  sparse-checkout: .depot/actions/paths-filter
+                  sparse-checkout-cone-mode: false
             - name: Clean up data directories with container permissions
               run: |
                   # Use docker to clean up files created by containers

--- a/.github/workflows/cd-sandbox-base-image.yml
+++ b/.github/workflows/cd-sandbox-base-image.yml
@@ -76,7 +76,10 @@ jobs:
                 contains(github.event.pull_request.labels.*.name, 'build-tasks-sandbox-image')
             )
         runs-on: ubuntu-latest
-        timeout-minutes: 30
+        # `Run migrations` builds the schema from scratch on ubuntu-latest with no schema cache and
+        # takes 22-29 minutes, so a 30-minute budget left no headroom and cut the job off mid-migrate
+        # on two of three recent runs. `Build skills`, the step this job exists for, takes 10 seconds.
+        timeout-minutes: 45
         permissions:
             contents: read
 

--- a/.github/workflows/cd-sandbox-base-image.yml
+++ b/.github/workflows/cd-sandbox-base-image.yml
@@ -39,6 +39,9 @@ jobs:
             sandbox_image: ${{ steps.filter.outputs.sandbox_image }}
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  sparse-checkout: .github/actions/paths-filter
+                  sparse-checkout-cone-mode: false
 
             - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
               id: app-token

--- a/.github/workflows/ci-agent-proxy.yml
+++ b/.github/workflows/ci-agent-proxy.yml
@@ -23,6 +23,9 @@ jobs:
             agent_proxy: ${{ steps.filter.outputs.agent_proxy || 'true' }}
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  sparse-checkout: .github/actions/paths-filter
+                  sparse-checkout-cone-mode: false
 
             - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
               id: app-token

--- a/.github/workflows/ci-agent-skills.yml
+++ b/.github/workflows/ci-agent-skills.yml
@@ -26,6 +26,9 @@ jobs:
             skills: ${{ steps.filter.outputs.skills || 'true' }}
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  sparse-checkout: .github/actions/paths-filter
+                  sparse-checkout-cone-mode: false
 
             - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
               id: app-token

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -116,6 +116,8 @@ jobs:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   clean: false
+                  sparse-checkout: .github/actions/paths-filter
+                  sparse-checkout-cone-mode: false
             - name: Clean up data directories with container permissions
               run: |
                   # Use docker to clean up files created by containers

--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -88,6 +88,10 @@ jobs:
                   fetch-depth: 1000
                   filter: blob:none
                   clean: false
+                  sparse-checkout: |
+                      .github/actions/paths-filter
+                      .github/clickhouse-versions.json
+                  sparse-checkout-cone-mode: false
 
             - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
               id: app-token

--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -83,6 +83,10 @@ jobs:
             # fetch-depth=1000 + blob:none mirrors ci-backend's turbo-discover so
             # HEAD^2 (PR branch tip) is reachable for the merge-base step below
             # without the cost of fetching blobs.
+            # docker-compose.base.yml is in the sparse set for the schema-key step, which
+            # reads it at the merge base. Checking it out puts the blob on disk, so that
+            # `git show` resolves locally rather than through a lazy fetch that could fail
+            # quietly and leave the migration cache key wrong.
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   fetch-depth: 1000
@@ -91,6 +95,7 @@ jobs:
                   sparse-checkout: |
                       .github/actions/paths-filter
                       .github/clickhouse-versions.json
+                      docker-compose.base.yml
                   sparse-checkout-cone-mode: false
 
             - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -65,6 +65,12 @@ jobs:
             # For pull requests it's not necessary to check out the code, but we
             # also want this to run on master, so we need to check out
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  sparse-checkout: |
+                      .github/actions/paths-filter
+                      bin/frontend-exclude-filter
+                      pnpm-workspace.yaml
+                  sparse-checkout-cone-mode: false
 
             - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
               id: app-token

--- a/.github/workflows/ci-hobby.yml
+++ b/.github/workflows/ci-hobby.yml
@@ -42,6 +42,9 @@ jobs:
             label_removed: ${{ steps.check-label.outputs.label_removed }}
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  sparse-checkout: .github/actions/paths-filter
+                  sparse-checkout-cone-mode: false
 
             - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
               id: app-token

--- a/.github/workflows/ci-hog.yml
+++ b/.github/workflows/ci-hog.yml
@@ -33,6 +33,9 @@ jobs:
             # For pull requests it's not necessary to checkout the code, but we
             # also want this to run on master so we need to checkout
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  sparse-checkout: .github/actions/paths-filter
+                  sparse-checkout-cone-mode: false
 
             - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
               id: app-token

--- a/.github/workflows/ci-llm-gateway.yml
+++ b/.github/workflows/ci-llm-gateway.yml
@@ -34,6 +34,9 @@ jobs:
             llm_gateway: ${{ steps.filter.outputs.llm_gateway || 'true' }}
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  sparse-checkout: .github/actions/paths-filter
+                  sparse-checkout-cone-mode: false
 
             - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
               id: app-token

--- a/.github/workflows/ci-mcp-ui-apps.yml
+++ b/.github/workflows/ci-mcp-ui-apps.yml
@@ -22,6 +22,9 @@ jobs:
             ui-apps: ${{ steps.filter.outputs.ui-apps || 'true' }}
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  sparse-checkout: .github/actions/paths-filter
+                  sparse-checkout-cone-mode: false
 
             - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
               id: app-token

--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -41,6 +41,9 @@ jobs:
             mcp: ${{ steps.filter.outputs.mcp || 'true' }}
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  sparse-checkout: .github/actions/paths-filter
+                  sparse-checkout-cone-mode: false
 
             # MCP integration tests boot the full PostHog backend (Django web server,
             # Celery worker, migrations, demo data), so the filter stays broad: any

--- a/.github/workflows/ci-migrations-service-separation-check.yml
+++ b/.github/workflows/ci-migrations-service-separation-check.yml
@@ -21,6 +21,9 @@ jobs:
         timeout-minutes: 5
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  sparse-checkout: .github/actions/paths-filter
+                  sparse-checkout-cone-mode: false
 
             # Author-attested escape hatch for DB-noop migrations (e.g. SeparateDatabaseAndState
             # state-only renames) that ship safely alongside service code. The check is path-only

--- a/.github/workflows/ci-ml-mirror-image-scrub-container.yml
+++ b/.github/workflows/ci-ml-mirror-image-scrub-container.yml
@@ -25,6 +25,9 @@ jobs:
         steps:
             - name: Check out
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  sparse-checkout: .github/actions/paths-filter
+                  sparse-checkout-cone-mode: false
 
             - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
               id: app-token

--- a/.github/workflows/ci-nodejs-container.yml
+++ b/.github/workflows/ci-nodejs-container.yml
@@ -44,6 +44,9 @@ jobs:
         steps:
             - name: Check out
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  sparse-checkout: .github/actions/paths-filter
+                  sparse-checkout-cone-mode: false
 
             - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
               id: app-token

--- a/.github/workflows/ci-oauth-proxy.yml
+++ b/.github/workflows/ci-oauth-proxy.yml
@@ -22,6 +22,9 @@ jobs:
             oauth-proxy: ${{ steps.filter.outputs.oauth-proxy || 'true' }}
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  sparse-checkout: .github/actions/paths-filter
+                  sparse-checkout-cone-mode: false
 
             - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
               id: app-token

--- a/.github/workflows/ci-proto.yml
+++ b/.github/workflows/ci-proto.yml
@@ -25,6 +25,8 @@ jobs:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   clean: false
+                  sparse-checkout: .github/actions/paths-filter
+                  sparse-checkout-cone-mode: false
             - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
               id: app-token
               if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -31,6 +31,9 @@ jobs:
             # For pull requests it's not necessary to checkout the code, but we
             # also want this to run on master so we need to checkout
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  sparse-checkout: .github/actions/paths-filter
+                  sparse-checkout-cone-mode: false
 
             - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
               id: app-token

--- a/.github/workflows/ci-recording-rasterizer-container.yml
+++ b/.github/workflows/ci-recording-rasterizer-container.yml
@@ -46,6 +46,9 @@ jobs:
         steps:
             - name: Check out
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  sparse-checkout: .github/actions/paths-filter
+                  sparse-checkout-cone-mode: false
 
             - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
               id: app-token

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -34,6 +34,8 @@ jobs:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   clean: false
+                  sparse-checkout: .github/actions/paths-filter
+                  sparse-checkout-cone-mode: false
             - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
               id: app-token
               if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/ci-security.yaml
+++ b/.github/workflows/ci-security.yaml
@@ -40,6 +40,8 @@ jobs:
               with:
                   clean: false
                   persist-credentials: false
+                  sparse-checkout: .github/actions/paths-filter
+                  sparse-checkout-cone-mode: false
             - name: Force all scans for oversized pull requests
               id: oversized
               if: github.event_name == 'pull_request' && github.event.pull_request.changed_files > 3000

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -75,6 +75,12 @@ jobs:
             # ./.github/actions/paths-filter steps, which must exist on disk (on
             # pull_request events they still diff via the API, not the checkout).
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  sparse-checkout: |
+                      .github/actions/paths-filter
+                      bin/frontend-exclude-filter
+                      pnpm-workspace.yaml
+                  sparse-checkout-cone-mode: false
 
             - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
               id: app-token

--- a/.github/workflows/container-images-ci.yml
+++ b/.github/workflows/container-images-ci.yml
@@ -38,6 +38,9 @@ jobs:
             dockerfiles_files: ${{ steps.filter.outputs.dockerfiles_files }}
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  sparse-checkout: .github/actions/paths-filter
+                  sparse-checkout-cone-mode: false
             - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
               id: app-token
               if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository


### PR DESCRIPTION
## Problem

Every PR waits about 30 seconds on gating jobs that check out 45,000 files to run a change detector that never reads them.

The 22 "Determine need to run X checks" jobs check out the whole repo, then run `./.github/actions/paths-filter`. On `pull_request` events that action diffs through the GitHub API and touches neither the working tree nor git history. The only reason to check out is that a local action must exist on disk.

These jobs gate every downstream job in their workflow, so their checkout sits on the critical path of every CI run.

Measured on real runs, via the GitHub API:

| Pattern | depot-ubuntu-24.04 | GitHub-hosted ubuntu |
| --- | --- | --- |
| `sparse-checkout`, cone mode off | 0-7s | 0-7s |
| plain checkout (depth 1) | 11-13s | 22-44s |
| `fetch-depth: 1000` + `filter: blob:none` | 53-59s | not sampled |

`ci-e2e-playwright.yml` already fixed this for itself in #59779, after the `blob:none` lazy blob fetch intermittently failed its credential lookup. That fix stayed local to one workflow.

## Problem this does not solve

Fetch depth. 202 of 263 `actions/checkout` occurrences already run at depth 1. Shallower checkouts were the obvious lever and they are already pulled.

## Changes

- Gating jobs now check out 23 files instead of 45,097, so CI starts its real work about 30 seconds sooner on every PR.
- 22 `changes` jobs across 21 workflows get `sparse-checkout` scoped to the paths their steps read.
- `ci-frontend.yml` and `ci-storybook.yml` also take `bin/frontend-exclude-filter` and `pnpm-workspace.yaml`, which their exclusion step reads.
- `ci-dagster.yml` also takes `.github/clickhouse-versions.json` and `docker-compose.base.yml`, and keeps `fetch-depth: 1000` for its merge-base math. The compose file feeds a `git show` at the merge base; because this job also filters blobs, leaving it out would turn that read into a lazy fetch that can fail quietly and skew the migration cache key.
- `.depot/workflows/ci-backend.yml` mirrors the change, scoped to `.depot/actions/paths-filter`.
- Every sparse checkout sets `sparse-checkout-cone-mode: false`. Cone mode also materializes all 70 repo-root files, 21.5 MB of them, `.test_durations` alone 18.5 MB. That is most of the saving.
- The five `AlertHistoryChart` stories now render a fixed timestamp instead of the clock, so their visual-regression snapshots stop drifting on every run. Unrelated to the checkout work, but this PR is the one that renders them: editing `.github/workflows/**` forces a full storybook render, and the identifiers were already drifting unreviewed on master.
- `cd-sandbox-base-image.yml`'s skills build gets 45 minutes instead of 30. Its migrations step takes 22-29 minutes from a cold schema, so the old budget cut the job off mid-migrate on two of three recent runs. Also unrelated to the checkout work, and also surfaced because this PR triggers that job.
- `.agents/skills/authoring-ci-workflows/SKILL.md` now ranks sparse-checkout above bounded depth, and records that `blob:none` is counterproductive when the job materializes the tree anyway.

Two paths-filter jobs keep a full checkout on purpose. `ci-nodejs.yml` builds a Rust crate through `rust-compute-affected`, and `container-images-cd.yml` is the master-push Docker build over the whole tree.

The workflow edits are mechanical and identical apart from the three sparse sets named above. The doc rewrite is the only judgment call.

> [!NOTE]
> Never pass `base: HEAD` to paths-filter from a sparse job. That routes it to `git diff HEAD`, which skip-worktree entries hide, so downstream jobs would skip green. No call site does this today, and the skill now says so.

## How did you test this code?

All 22 gating jobs ran on this PR and passed, with no failing checks anywhere. This PR edits `.github/workflows/*.yml`, which every one of these filters lists as a trigger path, so the change tests itself: a missing path would throw `ENOENT` or fail paths-filter on a missing `dist/index.js`.

Checkout seconds for the same jobs, before from a sweep of 88 recent runs, after from this PR:

| Gating job | Before | After |
| --- | --- | --- |
| UI Apps | 44, 26 | 1 |
| Rust | 30, 29 | 11 |
| MCP | 29 | 3 |
| Agent skills | 29, 27 | 3 |
| Hog | 28, 27 | 2 |
| Docker (container images) | 27, 27 | 2 |
| Hobby | 27, 9 | 3 |
| Proto | 26, 25 | 2 |
| OAuth proxy | 26 | 3 |
| Agent proxy | 22, 14 | 2 |
| Python | 9 | 3 |
| LLM services | 9 | 3 |

Median checkout across the sparse gating jobs is now 2 seconds.

`Determine need to run Node.js checks` is the one gating job left on `fetch-depth: 0` plus `blob:none`, and it now takes 61 seconds of checkout, 5 times the next slowest. That is the pattern the skill rewrite warns about, measured on this PR.

Checks run locally:

- `bin/hogli lint:workflows`: 8 checks pass across 127 workflows.
- `bin/hogli ci:preflight`: 0 failures, and shadow-drift confirms both `ci-backend.yml` copies moved together.
- Every sparse pattern applied to a real clone of master, confirming each job's files land.

<details>
<summary>Sparse patterns resolved against a clone of master</summary>

```
BASELINE full tree: 45097 files
GroupA -> 23 files   action present: YES   root files leaked: 0
GroupB -> 27 files   action present: YES   exclude-filter: YES  pnpm-workspace: YES
GroupC -> 24 files   action present: YES   ch-versions: YES
cone   -> 108 files, root files: 70
```

</details>

Not checked: whether downstream matrices keep their usual width after merge. That needs merged PRs to observe, and it is the failure mode worth watching for 48 hours.

No tests added. The change removes files from a checkout; the gating jobs themselves are the regression detector.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`.agents/skills/authoring-ci-workflows/SKILL.md` updated in this PR. No user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5). Skills invoked: `/writing-pr-descriptions`.

The request was to scope out adding `fetch-depth: 1` broadly. Measurement rejected that premise: most checkouts already run at depth 1. Pulling step durations from the GitHub API instead showed the cost was tree materialization, and pointed at the gating jobs.

Scope was deliberately held to the gating jobs. Two adjacent wins were left out because they fail differently. The `fetch-depth: 1000 + blob:none` discovery jobs are slower per job, but several are `continue-on-error` and `trunk-impacted-targets.yml` widens to `"ALL"` on diff failure, so a wrong sparse set there yields a green PR that ran fewer tests. The 8 desktop `fetch-depth: 0` workflows have no git-history dependency, but all are dispatch, tag, or nightly triggered, so they carry no normal-PR payoff.

One latent bug surfaced and is not fixed here: `publish-replay-anonymizer-crate.yml:32` runs `step-security/changed-files` on a depth-1 checkout, while all five sibling call sites set `fetch-depth: 0`.

The `.depot` shadow mirror was not in the original plan. `ci:preflight`'s drift check caught it.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*




