### PR TITLE
fix(desktop): unwedge a session after an aborted compaction

### DIFF
--- a/products/desktop/packages/core/src/sessions/sessionService.ts
+++ b/products/desktop/packages/core/src/sessions/sessionService.ts
@@ -3676,6 +3676,13 @@ export class SessionService {
         this.d.store.updateSession(taskRunId, {
           isCompacting: !params.isComplete,
         });
+      } else if (params?.status === "compacting_failed") {
+        // A failed or interrupted compaction emits no compact boundary, so this
+        // is the only signal that clears the flag. Left set, `sendPrompt` queues
+        // every later message and nothing is left to drain the queue.
+        this.d.store.updateSession(taskRunId, {
+          isCompacting: false,
+        });
       }
     }
 
@@ -4498,6 +4505,10 @@ export class SessionService {
     this.d.store.updateSession(session.taskRunId, {
       isPromptPending: false,
       promptStartedAt: null,
+      // A compaction cannot outlive the turn it ran in, and the adapter's
+      // failure status may never arrive, so don't leave the session wedged
+      // waiting for one.
+      isCompacting: false,
     });
 
     if (session.isCloud) {

--- a/products/desktop/packages/core/src/sessions/sessionServiceCompaction.test.ts
+++ b/products/desktop/packages/core/src/sessions/sessionServiceCompaction.test.ts
@@ -1,0 +1,156 @@
+import type { AcpMessage, AgentSession } from "@posthog/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { POSTHOG_NOTIFICATIONS } from "./acpNotifications";
+import { SessionService, type SessionServiceDeps } from "./sessionService";
+
+const TASK_ID = "task-1";
+const RUN_ID = "run-1";
+const SESSION_EVENT_FLUSH_MS = 16;
+
+function compactionStatus(status: string): AcpMessage {
+  return {
+    ts: 1,
+    message: {
+      jsonrpc: "2.0",
+      method: POSTHOG_NOTIFICATIONS.STATUS,
+      params: { sessionId: RUN_ID, status },
+    },
+  } as unknown as AcpMessage;
+}
+
+function createHarness() {
+  const sessions: Record<string, AgentSession> = {
+    [RUN_ID]: {
+      taskRunId: RUN_ID,
+      taskId: TASK_ID,
+      taskTitle: "Local Task",
+      events: [],
+      messageQueue: [],
+      pendingPermissions: new Map(),
+      status: "connected",
+      startedAt: 0,
+      currentPromptId: null,
+      adapter: "claude",
+      isCloud: false,
+      isPromptPending: false,
+      isCompacting: false,
+    } as unknown as AgentSession,
+  };
+
+  const store = {
+    getSessions: () => sessions,
+    getSessionByTaskId: (taskId: string) =>
+      Object.values(sessions).find((s) => s.taskId === taskId),
+    setSession: (session: AgentSession) => {
+      sessions[session.taskRunId] = session;
+    },
+    updateSession: (taskRunId: string, updates: Partial<AgentSession>) => {
+      const session = sessions[taskRunId];
+      if (session) sessions[taskRunId] = { ...session, ...updates };
+    },
+    enqueueMessage: (taskId: string, text: string) => {
+      const session = Object.values(sessions).find((s) => s.taskId === taskId);
+      if (!session) return;
+      sessions[session.taskRunId] = {
+        ...session,
+        messageQueue: [...session.messageQueue, { id: text, text }],
+      } as unknown as AgentSession;
+    },
+    appendEvents: vi.fn(),
+    replaceOptimisticWithEvent: vi.fn(),
+    setPendingPermissions: vi.fn(),
+    clearMessageQueue: vi.fn(),
+    clearTailOptimisticItems: vi.fn(),
+    clearOptimisticItems: vi.fn(),
+    appendOptimisticItem: vi.fn(),
+  };
+
+  const cancelPrompt = vi.fn(async () => true);
+  const prompt = vi.fn(async () => ({ stopReason: "end_turn" }));
+  let onEvent: ((payload: unknown) => void) | undefined;
+
+  const deps = {
+    store,
+    log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    track: vi.fn(),
+    getIsOnline: () => true,
+    addDirectoryDialog: { open: false },
+    notifyPromptComplete: vi.fn(),
+    notifyPermissionRequest: vi.fn(),
+    enqueueSpeech: vi.fn(),
+    toast: { error: vi.fn(), success: vi.fn() },
+    usageLimit: { show: vi.fn() },
+    taskViewedApi: { markActivity: vi.fn() },
+    h: { extractSkillButtonId: () => undefined },
+    getPersistedConfigOptions: () => undefined,
+    setPersistedConfigOptions: vi.fn(),
+    trpc: {
+      agent: {
+        prompt: { mutate: prompt },
+        cancelPrompt: { mutate: cancelPrompt },
+        onSessionEvent: {
+          subscribe: (
+            _input: unknown,
+            handlers: { onData: (payload: unknown) => void },
+          ) => {
+            onEvent = handlers.onData;
+            return { unsubscribe: vi.fn() };
+          },
+        },
+        onPermissionRequest: { subscribe: () => ({ unsubscribe: vi.fn() }) },
+        onSessionIdleKilled: { subscribe: () => ({ unsubscribe: vi.fn() }) },
+      },
+    },
+  } as unknown as SessionServiceDeps;
+
+  const service = new SessionService(deps);
+  (
+    service as unknown as { subscribeToChannel(id: string): void }
+  ).subscribeToChannel(RUN_ID);
+  if (!onEvent) throw new Error("subscribeToChannel did not subscribe");
+
+  return {
+    service,
+    prompt,
+    // Session events land in a batch the service flushes on a short timer.
+    emit: async (event: AcpMessage) => {
+      onEvent?.(event);
+      await vi.advanceTimersByTimeAsync(SESSION_EVENT_FLUSH_MS);
+    },
+    isCompacting: () => sessions[RUN_ID].isCompacting,
+  };
+}
+
+describe("compaction busy state", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("clears the busy flag when the compaction fails", async () => {
+    const h = createHarness();
+    await h.emit(compactionStatus("compacting"));
+    expect(h.isCompacting()).toBe(true);
+
+    await h.emit(compactionStatus("compacting_failed"));
+
+    expect(h.isCompacting()).toBe(false);
+    await h.service.sendPrompt(TASK_ID, "carry on");
+    expect(h.prompt).toHaveBeenCalledTimes(1);
+  });
+
+  // Interrupting the turn can leave the adapter's failure status unsent, so the
+  // cancel itself has to clear the flag or the session queues forever.
+  it("clears the busy flag when the user cancels mid-compaction", async () => {
+    const h = createHarness();
+    await h.emit(compactionStatus("compacting"));
+
+    await h.service.cancelPrompt(TASK_ID);
+
+    expect(h.isCompacting()).toBe(false);
+    await h.service.sendPrompt(TASK_ID, "carry on");
+    expect(h.prompt).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Problem

- Cancelling a compaction leaves the session unusable: every message the user types is queued and never sent, and the only way out is a new session.
- The thread shows "Interrupted by user" then "Compacting failed: aborted", so the session looks idle while the composer keeps queueing.
- The adapter reports that outcome as a `compacting_failed` status, which the desktop session state never handled.
- `isCompacting` stays true. `sendPrompt` takes its queue branch for every later message, and nothing is left to drain the queue.

## Changes

- A failed or interrupted compaction now leaves the session usable. The next message sends instead of queuing.
- Clearing `isCompacting` on `compacting_failed` gives the local session path the branch the pi runtime already has for the same status.
- Cancelling a prompt clears the flag too, so an interrupt that never produces a failure status cannot wedge the session either.
- No UI code changed. The status row and the queue dock render as before.

## How did you test this code?

- New `sessionServiceCompaction.test.ts` covers the two ways the flag gets stuck: a `compacting_failed` status, and a cancel that arrives with no status behind it. Both tests fail on master and pass here.
- Ran the `@posthog/core` sessions suite and the package typecheck locally.
- Not done: no manual run of the desktop app, so the interrupt was not reproduced end to end against a real adapter.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Reported from a Slack thread with a screenshot of the wedged composer. The investigation traced the stuck state to the one status the local session path does not handle, and confirmed `piSessionController` already handles it, which set the shape of the fix.

The cancel-path reset is deliberate belt and braces: the reported case does emit `compacting_failed`, but an interrupt that kills the stream before the adapter reports would leave the session stuck in exactly the same way.

Skills invoked: `/writing-pr-descriptions`. Tools: Read, Grep, Bash, Edit, Write, and an Explore subagent to trace the compaction and queue lifecycle.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1787231626916969)*
