### PR TITLE
chore(alerts): strengthen alerting coverage guidance

### DIFF
--- a/.agents/skills/adding-product-alerting/SKILL.md
+++ b/.agents/skills/adding-product-alerting/SKILL.md
@@ -44,6 +44,7 @@ Both paths must preserve these rules:
 7. **Shared code has no product branches.** The lifecycle module stays pure Python. Reusable Django behavior belongs elsewhere in `products/alerts/backend/`.
 8. **Frontend data is normalized at the product boundary.** Shared editor components render normalized definitions, destinations, advanced options, schedules, and history. Product API calls, payloads, and evaluation-specific fields stay in the product adapter.
 9. **Defaults remain backward compatible.** New platform options must preserve existing adopters until they explicitly opt in.
+10. **Configuration, routing, and delivery are one contract.** A supported destination must persist, remain visible, be selected when its alert fires, and reach its delivery worker. Do not test only one of these steps.
 
 ## Review shared changes as one alert system
 
@@ -57,6 +58,8 @@ the change. Start with the reference adopters and inspect the affected dimension
 - **Authorization:** product, project, and organization boundaries at destination creation, management, and dispatch.
 - **Frontend and API contracts:** generated clients, pending-destination retries, existing-destination visibility, and
   every UI that uses the shared data.
+- **Classification and eligibility:** every producer and consumer that classifies an event, template, destination, or
+  alert type. A new restriction can block creation in one path and delivery in another.
 
 For event, destination, query, or authorization changes, map all matching products and clients by exact event IDs,
 template IDs, model types, generic APIs, UIs, and regex or prefix matches. A new product can own its destination
@@ -65,6 +68,33 @@ lifecycle while another product still intentionally uses a generic HogFunction p
 When generic access violates an ownership or authorization boundary, restrict it immediately. Preserve generic access
 only for explicitly safe, supported paths, and migrate those paths to product-owned APIs deliberately. Add
 public-interface tests for the new ownership boundary and every existing path that remains supported.
+
+## Treat alerting as an end-to-end system
+
+Alerting crosses several boundaries. A destination can be valid in the UI, rejected by an API, saved but hidden, or
+saved and never invoked. A unit test at one boundary does not prove the next boundary works.
+
+For each supported alert source and destination type, test this path through public interfaces:
+
+1. Create or update the destination through every supported management API.
+2. Read the alert back and confirm the destination is visible.
+3. Trigger the alert and confirm routing selects the destination.
+4. Confirm the delivery worker accepts the notification or records a clear failure.
+
+Use a test transport or a mock external endpoint for the final step. Do not depend on a real customer destination.
+Add a focused test whenever a shared filter, allowlist, event ID, template ID, or ownership rule changes.
+
+Keep one explicit compatibility matrix for supported source, event, destination, and management-path combinations. A
+single source of truth should drive related allowlists where practical. If separate allowlists are required, name the
+supported combinations and test them. Never treat an empty match as success without recording why it was empty.
+
+Instrument the lifecycle at each boundary: configuration accepted or rejected, destination selected, event produced,
+worker matched, delivery attempted, and delivery outcome. Include a correlation ID and stable source and destination
+dimensions. Alert on a sustained mismatch between adjacent stages. This finds silent drops even when individual
+components report no errors.
+
+Run isolated synthetic checks for high-value supported paths after deployment and at a regular interval. A synthetic
+check must prove the whole path, not only that a producer accepted an event.
 
 ## Current limits
 


### PR DESCRIPTION
## Problem

- Engineers extending alerting need clear checks that cover configuration and delivery as one system.

## Changes

- The alerting skill now requires end-to-end coverage for supported destination paths.
- The skill adds compatibility, telemetry, and synthetic-check guidance for silent routing failures.
- This change updates engineering guidance only.

## How did you test this code?

- Ran `git diff --check`.
- Not run: automated tests. This PR changes Markdown guidance only.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- No user-facing documentation change is required.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- PostHog Slack app updated the alerting skill after reviewing the existing alerting contracts.
- Skills used: `/adding-product-alerting`, `/writing-simplified-technical-english`, and `/writing-pr-descriptions`.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BPULZFS84/p1787214984594829?thread_ts=1787214984.594829&cid=C0BPULZFS84)*