### PR TITLE
fix(warehouse-sources): ask Shopify for JSON oauth token errors

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/shopify.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/shopify.py
@@ -68,6 +68,16 @@ SHOPIFY_ACCESS_TOKEN_UNSUPPORTED_GRANT_ERROR = (
     "docs, then enter its client ID and secret."
 )
 
+# Raised on a 4xx whose body reports `error: shop_not_permitted`. Shopify only allows the
+# client_credentials grant when the app and the store belong to the same Shopify organization,
+# so re-entering credentials can never fix it. Surfaced separately so the message points at the
+# organization rather than the credentials.
+SHOPIFY_ACCESS_TOKEN_SHOP_NOT_PERMITTED_ERROR = (
+    "Shopify doesn't allow this app to connect to this store (shop_not_permitted). The app and "
+    "the store must be in the same Shopify organization. In the Shopify Dev Dashboard, open the "
+    "organization that contains your store and create the app there."
+)
+
 # Raised when the OAuth token endpoint returns 404 — there is no store at
 # `<store-id>.myshopify.com`, so the store id is wrong or the store no longer exists.
 # Reconnecting the app can't fix a bad store id, so this is surfaced separately from the
@@ -377,6 +387,8 @@ def _access_token_auth_error_message(error_code: str | None) -> str:
         return SHOPIFY_ACCESS_TOKEN_INVALID_CLIENT_ERROR
     if error_code == "unsupported_grant_type":
         return SHOPIFY_ACCESS_TOKEN_UNSUPPORTED_GRANT_ERROR
+    if error_code == "shop_not_permitted":
+        return SHOPIFY_ACCESS_TOKEN_SHOP_NOT_PERMITTED_ERROR
     return SHOPIFY_ACCESS_TOKEN_AUTH_ERROR
 
 
@@ -419,7 +431,9 @@ def _get_shopify_access_token(shopify_store_id: str, shopify_client_id: str, sho
         "client_secret": shopify_client_secret,
         "grant_type": SHOPIFY_ACCESS_TOKEN_GRANT,
     }
-    access_res = make_tracked_session().post(access_token_url, data=access_data)
+    # The Accept header is load-bearing: without it Shopify renders 4xx OAuth errors as an HTML
+    # page instead of JSON, which leaves `_parse_oauth_error` with no error code to read.
+    access_res = make_tracked_session(headers={"Accept": "application/json"}).post(access_token_url, data=access_data)
     if not access_res.ok:
         # A 404 means there's no store at this subdomain — the store id is wrong or the store
         # is gone. Reconnecting the app can't fix that, so point the user at the store id

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/source.py
@@ -29,6 +29,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.shopify.se
 from products.warehouse_sources.backend.temporal.data_imports.sources.shopify.shopify import (
     SHOPIFY_ACCESS_TOKEN_AUTH_ERROR,
     SHOPIFY_ACCESS_TOKEN_INVALID_CLIENT_ERROR,
+    SHOPIFY_ACCESS_TOKEN_SHOP_NOT_PERMITTED_ERROR,
     SHOPIFY_ACCESS_TOKEN_UNSUPPORTED_GRANT_ERROR,
     SHOPIFY_GRAPHQL_ACCESS_DENIED_ERROR,
     SHOPIFY_GRAPHQL_UNAUTHORIZED_ERROR_MATCH,
@@ -75,6 +76,9 @@ class ShopifySource(ResumableSource[ShopifySourceConfig, ShopifyResumeConfig]):
             # 4xx `unsupported_grant_type` — the app can't use the client_credentials grant, so
             # the user needs a Dev Dashboard app instead of a legacy custom app.
             SHOPIFY_ACCESS_TOKEN_UNSUPPORTED_GRANT_ERROR: SHOPIFY_ACCESS_TOKEN_UNSUPPORTED_GRANT_ERROR,
+            # 4xx `shop_not_permitted`: the store is not in the app's Shopify organization, so
+            # minting a token fails regardless of the credentials entered.
+            SHOPIFY_ACCESS_TOKEN_SHOP_NOT_PERMITTED_ERROR: SHOPIFY_ACCESS_TOKEN_SHOP_NOT_PERMITTED_ERROR,
             # 404 from the same endpoint — no store at this subdomain. Retrying cannot
             # recover; the user must correct the store id.
             SHOPIFY_STORE_NOT_FOUND_ERROR: SHOPIFY_STORE_NOT_FOUND_ERROR,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/tests/test_access_token.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/tests/test_access_token.py
@@ -6,6 +6,7 @@ from requests.exceptions import ChunkedEncodingError, SSLError
 from products.warehouse_sources.backend.temporal.data_imports.sources.shopify.shopify import (
     SHOPIFY_ACCESS_TOKEN_AUTH_ERROR,
     SHOPIFY_ACCESS_TOKEN_INVALID_CLIENT_ERROR,
+    SHOPIFY_ACCESS_TOKEN_SHOP_NOT_PERMITTED_ERROR,
     SHOPIFY_ACCESS_TOKEN_UNSUPPORTED_GRANT_ERROR,
     SHOPIFY_STORE_NOT_FOUND_ERROR,
     ShopifyRetryableError,
@@ -53,6 +54,7 @@ def test_get_access_token_4xx_is_non_retryable(status_code):
     [
         ("invalid_client", SHOPIFY_ACCESS_TOKEN_INVALID_CLIENT_ERROR),
         ("unsupported_grant_type", SHOPIFY_ACCESS_TOKEN_UNSUPPORTED_GRANT_ERROR),
+        ("shop_not_permitted", SHOPIFY_ACCESS_TOKEN_SHOP_NOT_PERMITTED_ERROR),
     ],
 )
 def test_get_access_token_4xx_maps_shopify_error_code(error_code, expected_message):
@@ -71,6 +73,37 @@ def test_get_access_token_4xx_maps_shopify_error_code(error_code, expected_messa
     assert any(pattern in error_message for pattern in patterns), (
         f"4xx token error '{error_message}' should match a non-retryable pattern"
     )
+
+
+def test_get_access_token_asks_shopify_for_json_errors():
+    # Without an explicit JSON Accept header Shopify renders 4xx OAuth errors as an HTML page,
+    # so _parse_oauth_error never sees the error code and every failure collapses to the
+    # generic message.
+    session_factory = mock.MagicMock(
+        return_value=mock.MagicMock(
+            post=mock.MagicMock(return_value=_mock_response(200, ok=True, json_data={"access_token": "tok"}))
+        )
+    )
+    with mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.shopify.shopify.make_tracked_session",
+        session_factory,
+    ):
+        _get_shopify_access_token("store", "client-id", "client-secret")
+    assert session_factory.call_args.kwargs["headers"] == {"Accept": "application/json"}
+
+
+def test_get_access_token_4xx_html_body_falls_back_to_generic_message():
+    # Shopify (or an intermediary) can still answer a 4xx with a non-JSON body; the parse must
+    # degrade to the generic credentials message instead of raising a decode error.
+    response = _mock_response(400, ok=False)
+    response.json.side_effect = ValueError("Expecting value: line 1 column 1 (char 0)")
+    with _patched_token_call(response):
+        with pytest.raises(Exception) as exc_info:
+            _get_shopify_access_token("store", "client-id", "client-secret")
+
+    error_message = str(exc_info.value)
+    assert SHOPIFY_ACCESS_TOKEN_AUTH_ERROR in error_message
+    assert "HTTP 400" in error_message
 
 
 def test_get_access_token_404_reports_missing_store():


### PR DESCRIPTION
## Problem

- A user connecting a Shopify store gets "Shopify rejected your app credentials" with a bare HTTP 400 and no reason, so they re-enter credentials that were never the problem.
- Shopify's token endpoint answers a 4xx with an HTML page unless the request sends `Accept: application/json`. The error-body parsing added in #83007 gets nothing from HTML, so Shopify's error code never reaches the message or the structured log.
- `shop_not_permitted` has no mapped message. Shopify returns it when the app and the store are in different Shopify organizations, where re-entering credentials can never help.

## Changes

- The token request asks for JSON, so a 4xx now carries Shopify's `error` and `error_description` into the user-facing message and the `Shopify OAuth token request failed` log line.
- A `shop_not_permitted` 4xx now tells the user the app and the store must be in the same Shopify organization, per [Shopify's troubleshooting docs](https://shopify.dev/docs/apps/build/dev-dashboard/get-api-access-tokens).
- Mechanical: the new message is registered in `get_non_retryable_errors`, so sync jobs fail fast like the other credential errors.
- Nothing changes visually; only the error message text differs.

## How did you test this code?

- The header behavior reproduces with curl against any store: a form POST to `https://<store>.myshopify.com/admin/oauth/access_token` with invalid credentials returns an HTML 400, and the same request with `Accept: application/json` returns `{"error": ..., "error_description": ...}`.
- New tests in `test_access_token.py`, run locally: losing the Accept header fails `test_get_access_token_asks_shopify_for_json_errors`; removing the defensive JSON parse fails the HTML-body fallback test; the `shop_not_permitted` mapping is a new row in the existing parameterized error-code test.
- Not run: repo-wide mypy (CI covers it); the change adds no signatures or types beyond a string constant and a header dict.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The Shopify source doc on posthog.com already points users at Dev Dashboard apps; a note on the same-organization requirement belongs there (separate repo).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with PostHog Desktop from a support investigation. No customer material is included; test bodies are invented.
- The HTML-vs-JSON behavior was established by probing the token endpoint directly, after production structured logs showed the parsed error fields empty on every 4xx.
- Skills applied: writing-user-facing-copy, writing-code-comments, writing-tests, writing-pr-descriptions.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
