### PR TITLE
fix(flags): drop per-flag-id bind parameters from bulk delete queries

### DIFF
--- a/products/feature_flags/backend/api/feature_flag.py
+++ b/products/feature_flags/backend/api/feature_flag.py
@@ -114,7 +114,11 @@ from products.feature_flags.backend.flag_status import (
 from products.feature_flags.backend.local_evaluation import _get_flag_properties_from_filters
 from products.feature_flags.backend.models.evaluation_context import normalize_context_name
 from products.feature_flags.backend.models.feature_flag import FeatureFlag, FeatureFlagDashboards
-from products.feature_flags.backend.session_recording_links import teams_linking_flag
+from products.feature_flags.backend.session_recording_links import (
+    REPLAY_LINKED_FLAG_DELETE_ERROR,
+    replay_linked_flag_ids,
+    teams_linking_flag,
+)
 from products.feature_flags.backend.types import PropertyFilterType
 from products.feature_flags.backend.user_blast_radius import get_user_blast_radius
 from products.feature_flags.backend.version_history import (
@@ -2057,9 +2061,7 @@ class FeatureFlagSerializer(
 
             # Check if flag is used in session replay settings
             if teams_linking_flag(instance).exists():
-                raise exceptions.ValidationError(
-                    "This feature flag is used in session replay settings. Please remove it from replay settings before deleting."
-                )
+                raise exceptions.ValidationError(REPLAY_LINKED_FLAG_DELETE_ERROR)
 
             # If the flag is linked to any experiment, rename the key to free it up.
             # Append ID to the key when soft-deleting to prevent key conflicts.
@@ -3752,6 +3754,8 @@ class FeatureFlagViewSet(
         # Batch query for dependent flags
         dependent_flags_map = find_dependent_flags_batch(flags_list)
 
+        replay_linked_ids = replay_linked_flag_ids(self.project_id, [flag.id for flag in flags_list])
+
         deleted = []
         errors = []
 
@@ -3816,6 +3820,18 @@ class FeatureFlagViewSet(
                         "id": flag_id,
                         "key": flag.key,
                         "reason": f"Cannot delete because other flags depend on it: {', '.join(dependent_flag_names)}",
+                    }
+                )
+                continue
+
+            # Deleting a flag a team gates recording on stops that team recording, and the
+            # tombstone rename below fires no signal to relink them.
+            if flag_id in replay_linked_ids:
+                errors.append(
+                    {
+                        "id": flag_id,
+                        "key": flag.key,
+                        "reason": REPLAY_LINKED_FLAG_DELETE_ERROR,
                     }
                 )
                 continue

--- a/products/feature_flags/backend/api/feature_flag.py
+++ b/products/feature_flags/backend/api/feature_flag.py
@@ -508,26 +508,24 @@ def find_dependent_flags_batch(
     team = flags_to_check[0].team
     flag_ids = [f.id for f in flags_to_check]
 
-    # Build OR conditions for each flag ID we're checking
-    # We need to find any flag that depends on ANY of these flags
-    or_conditions = " OR ".join(["prop->>'key' = %s" for _ in flag_ids])
-
+    # One array parameter, not one per flag ID: an OR of per-ID parameters would hit Postgres's
+    # ~65,535 parameter cap once a caller passes a large explicit ids list.
     dependent_flags = list(
         # nosemgrep: python.django.security.audit.query-set-extra.avoid-query-set-extra (parameterized via params)
         FeatureFlag.objects.filter(team=team, active=True)
         .exclude(id__in=flag_ids)
         .extra(
             where=[
-                f"""
+                """
                     EXISTS (
                         SELECT 1 FROM jsonb_array_elements(filters->'groups') AS grp
                         CROSS JOIN jsonb_array_elements(grp->'properties') AS prop
                         WHERE prop->>'type' = 'flag'
-                        AND ({or_conditions})
+                        AND prop->>'key' = ANY(%s)
                     )
                     """
             ],
-            params=[str(fid) for fid in flag_ids],
+            params=[[str(fid) for fid in flag_ids]],
         )
         .order_by("key")
     )

--- a/products/feature_flags/backend/api/test/test_feature_flag.py
+++ b/products/feature_flags/backend/api/test/test_feature_flag.py
@@ -12733,16 +12733,21 @@ class TestFeatureFlagBulkDelete(APIBaseTest):
 
     @parameterized.expand(
         [
-            ("bool_id", {"id": True, "key": "replay_gate"}),
-            ("string_id", {"id": "abc", "key": "replay_gate"}),
-            ("missing_id", {"key": "replay_gate"}),
+            ("bool_id", lambda flag_id: {"id": True, "key": "replay_gate"}),
+            ("string_id", lambda flag_id: {"id": "abc", "key": "replay_gate"}),
+            ("missing_id", lambda flag_id: {"key": "replay_gate"}),
+            # A text id matching the flag's number is malformed, not linked: the team API
+            # normalizes numeric-string ids to ints at write time (see
+            # validate_session_recording_linked_flag), so jsonb's type-sensitive equality
+            # can safely ignore it, same as the single-flag guard's containment check.
+            ("numeric_string_id", lambda flag_id: {"id": str(flag_id), "key": "replay_gate"}),
         ]
     )
-    def test_bulk_delete_ignores_a_malformed_replay_link(self, _case, stored_link):
+    def test_bulk_delete_ignores_a_malformed_replay_link(self, _case, stored_link_factory):
         # One team's malformed stored link must not block or 500 the project's bulk deletes:
         # the guard's jsonb filter matches no flag for these shapes, so it ignores them.
         flag = FeatureFlag.objects.create(team=self.team, created_by=self.user, key="unrelated")
-        self.team.session_recording_linked_flag = stored_link
+        self.team.session_recording_linked_flag = stored_link_factory(flag.id)
         self.team.save()
 
         response = self.client.post(

--- a/products/feature_flags/backend/api/test/test_feature_flag.py
+++ b/products/feature_flags/backend/api/test/test_feature_flag.py
@@ -58,6 +58,7 @@ from products.feature_flags.backend.api.feature_flag import (
     FLAG_FILTERS_VIOLATION_COUNTER,
     FLAG_FILTERS_WRITE_COUNTER,
     FeatureFlagSerializer,
+    find_dependent_flags_batch,
     parse_created_by_ids,
 )
 from products.feature_flags.backend.encrypted_flag_payloads import (
@@ -12989,6 +12990,43 @@ class TestFeatureFlagBulkDelete(APIBaseTest):
         # Verify flag is not deleted
         base_flag.refresh_from_db()
         assert base_flag.deleted is False
+
+    def test_find_dependent_flags_batch_matches_any_of_several_flag_ids(self):
+        # Two base flags distinguish the array bind (`params=[[...]]`) from a flattened scalar
+        # (`params=[...]`): with one flag both forms coincide and the test would be blind.
+        base_a = FeatureFlag.objects.create(team=self.team, created_by=self.user, key="base_a")
+        base_b = FeatureFlag.objects.create(team=self.team, created_by=self.user, key="base_b")
+        FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            key="depends_on_a",
+            filters={
+                "groups": [
+                    {
+                        "rollout_percentage": 100,
+                        "properties": [{"key": str(base_a.id), "type": "flag", "value": "true"}],
+                    }
+                ]
+            },
+        )
+        FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            key="depends_on_b",
+            filters={
+                "groups": [
+                    {
+                        "rollout_percentage": 100,
+                        "properties": [{"key": str(base_b.id), "type": "flag", "value": "true"}],
+                    }
+                ]
+            },
+        )
+
+        result = find_dependent_flags_batch([base_a, base_b])
+
+        result_by_key = {flag_id: {f.key for f in flags} for flag_id, flags in result.items()}
+        assert result_by_key == {base_a.id: {"depends_on_a"}, base_b.id: {"depends_on_b"}}
 
     def test_bulk_delete_renames_key_with_soft_deleted_experiment(self):
         """Test that deleting a flag with a soft-deleted experiment renames the key."""

--- a/products/feature_flags/backend/api/test/test_feature_flag.py
+++ b/products/feature_flags/backend/api/test/test_feature_flag.py
@@ -12685,6 +12685,78 @@ class TestFeatureFlagBulkDelete(APIBaseTest):
         # Key is freed up for reuse
         assert flag.key == f"stopped_experiment_flag:deleted:{flag.id}"
 
+    def test_bulk_delete_blocks_a_flag_used_in_session_replay(self):
+        # bulk_delete bypasses the serializer, so it needs its own replay guard; without one,
+        # this delete would silently stop the linking team's recording.
+        linked_flag = FeatureFlag.objects.create(team=self.team, created_by=self.user, key="replay_gate")
+        unlinked_flag = FeatureFlag.objects.create(team=self.team, created_by=self.user, key="unrelated")
+        self.team.session_recording_linked_flag = {"id": linked_flag.id, "key": "replay_gate"}
+        self.team.save()
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/feature_flags/bulk_delete/",
+            {"ids": [linked_flag.id, unlinked_flag.id]},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        # The rest of the batch still deletes, so one linked flag does not block the whole call.
+        assert {d["id"] for d in data["deleted"]} == {unlinked_flag.id}
+        assert len(data["errors"]) == 1
+        assert data["errors"][0]["id"] == linked_flag.id
+        assert "session replay settings" in data["errors"][0]["reason"]
+
+        linked_flag.refresh_from_db()
+        unlinked_flag.refresh_from_db()
+        assert linked_flag.deleted is False
+        assert unlinked_flag.deleted is True
+
+    def test_bulk_delete_blocks_a_flag_a_sibling_team_links(self):
+        # Replay links are project-scoped: a team can gate recording on a flag owned by a sibling
+        # team, so a team-scoped lookup would let this delete through.
+        flag = FeatureFlag.objects.create(team=self.team, created_by=self.user, key="replay_gate")
+        sibling_team = Team.objects.create(organization=self.organization, project=self.team.project)
+        sibling_team.session_recording_linked_flag = {"id": flag.id, "key": "replay_gate"}
+        sibling_team.save()
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/feature_flags/bulk_delete/",
+            {"ids": [flag.id]},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["deleted"]) == 0
+        assert len(data["errors"]) == 1
+        flag.refresh_from_db()
+        assert flag.deleted is False
+
+    @parameterized.expand(
+        [
+            ("bool_id", {"id": True, "key": "replay_gate"}),
+            ("string_id", {"id": "abc", "key": "replay_gate"}),
+            ("missing_id", {"key": "replay_gate"}),
+        ]
+    )
+    def test_bulk_delete_ignores_a_malformed_replay_link(self, _case, stored_link):
+        # One team's malformed stored link must not block or 500 the project's bulk deletes:
+        # the guard's jsonb filter matches no flag for these shapes, so it ignores them.
+        flag = FeatureFlag.objects.create(team=self.team, created_by=self.user, key="unrelated")
+        self.team.session_recording_linked_flag = stored_link
+        self.team.save()
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/feature_flags/bulk_delete/",
+            {"ids": [flag.id]},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert {d["id"] for d in data["deleted"]} == {flag.id}
+        assert data["errors"] == []
+        flag.refresh_from_db()
+        assert flag.deleted is True
+
     def test_bulk_delete_requires_filters_or_ids(self):
         """Test validation error when neither filters nor ids provided."""
         response = self.client.post(

--- a/products/feature_flags/backend/session_recording_links.py
+++ b/products/feature_flags/backend/session_recording_links.py
@@ -6,6 +6,7 @@ browser and React Native SDKs treat a linked flag they can't resolve as "do not 
 stale key silently turns replay off for the team rather than surfacing an error anywhere.
 """
 
+from collections.abc import Collection
 from typing import Any
 
 from django.db import transaction
@@ -21,6 +22,10 @@ from products.feature_flags.backend.models.feature_flag import FeatureFlag
 
 logger = structlog.get_logger(__name__)
 
+REPLAY_LINKED_FLAG_DELETE_ERROR = (
+    "This feature flag is used in session replay settings. Please remove it from replay settings before deleting."
+)
+
 
 def teams_linking_flag(feature_flag: FeatureFlag) -> QuerySet[Team]:
     """Every team gating session recording on this flag."""
@@ -30,6 +35,25 @@ def teams_linking_flag(feature_flag: FeatureFlag) -> QuerySet[Team]:
         project_id=feature_flag.team.project_id,
         session_recording_linked_flag__contains={"id": feature_flag.id},
     )
+
+
+def replay_linked_flag_ids(project_id: int, flag_ids: Collection[int]) -> set[int]:
+    """Which of the given flags a team in this project gates session recording on.
+
+    The batch equivalent of `teams_linking_flag`, in one query. Matching ids inside jsonb keeps
+    that check's comparison semantics, so the single-flag and bulk delete guards agree on what
+    counts as linked; a malformed value like `{"id": true}` matches no flag, because jsonb never
+    equates booleans with numbers.
+    """
+    if not flag_ids:
+        return set()
+    stored_ids = Team.objects.filter(
+        project_id=project_id,
+        session_recording_linked_flag__id__in=flag_ids,
+    ).values_list("session_recording_linked_flag__id", flat=True)
+    # jsonb also equates numbers regardless of representation, so a stored float id can match an
+    # int flag id; normalize for the int membership checks callers do.
+    return {int(stored_id) for stored_id in stored_ids}
 
 
 def update_linked_flag_key(team: Team, expected_flag_id: int, new_key: str) -> None:

--- a/products/feature_flags/backend/session_recording_links.py
+++ b/products/feature_flags/backend/session_recording_links.py
@@ -37,23 +37,40 @@ def teams_linking_flag(feature_flag: FeatureFlag) -> QuerySet[Team]:
     )
 
 
+def jsonb_number_counts_as_flag_id(stored: Any, flag_ids: Collection[int]) -> bool:
+    """Whether a stored `session_recording_linked_flag.id` jsonb value equals one of the flag ids.
+
+    Python stand-in for the jsonb equality `teams_linking_flag`'s containment filter applies:
+    numbers match only numbers, so a bool or a numeric string never counts. The bool check must
+    come first — Python's `True == 1` would otherwise let a stored `true` collide with flag id 1.
+    """
+    if isinstance(stored, bool):
+        return False
+    if isinstance(stored, (int, float)):
+        return stored in flag_ids
+    return False
+
+
 def replay_linked_flag_ids(project_id: int, flag_ids: Collection[int]) -> set[int]:
     """Which of the given flags a team in this project gates session recording on.
 
-    The batch equivalent of `teams_linking_flag`, in one query. Matching ids inside jsonb keeps
-    that check's comparison semantics, so the single-flag and bulk delete guards agree on what
-    counts as linked; a malformed value like `{"id": true}` matches no flag, because jsonb never
-    equates booleans with numbers.
+    The batch equivalent of `teams_linking_flag`, in one query. Filtering in python rather than
+    in jsonb reproduces that check's comparison semantics (see `jsonb_number_counts_as_flag_id`),
+    so the single-flag and bulk delete guards agree on what counts as linked. Fetching every
+    linked id in the project keeps the statement's bind-parameter count constant however many
+    flags the caller passes, so a large `ids` list can't exceed Postgres's parameter limit.
     """
     if not flag_ids:
         return set()
+    # Callers pass a list; a set turns the membership check in jsonb_number_counts_as_flag_id O(1).
+    flag_id_set = set(flag_ids)
     stored_ids = Team.objects.filter(
         project_id=project_id,
-        session_recording_linked_flag__id__in=flag_ids,
+        session_recording_linked_flag__id__isnull=False,
     ).values_list("session_recording_linked_flag__id", flat=True)
     # jsonb also equates numbers regardless of representation, so a stored float id can match an
     # int flag id; normalize for the int membership checks callers do.
-    return {int(stored_id) for stored_id in stored_ids}
+    return {int(stored_id) for stored_id in stored_ids if jsonb_number_counts_as_flag_id(stored_id, flag_id_set)}
 
 
 def update_linked_flag_key(team: Team, expected_flag_id: int, new_key: str) -> None:

--- a/products/feature_flags/backend/test/test_session_recording_links.py
+++ b/products/feature_flags/backend/test/test_session_recording_links.py
@@ -1,9 +1,34 @@
+from typing import Any
+
 from posthog.test.base import BaseTest
+
+from parameterized import parameterized
 
 from posthog.models import Team
 
 from products.feature_flags.backend.models.feature_flag import FeatureFlag
-from products.feature_flags.backend.session_recording_links import relink_teams, update_linked_flag_key
+from products.feature_flags.backend.session_recording_links import (
+    jsonb_number_counts_as_flag_id,
+    relink_teams,
+    update_linked_flag_key,
+)
+
+
+class TestJsonbNumberCountsAsFlagId:
+    @parameterized.expand(
+        [
+            ("int", 5, {5}, True),
+            ("float_matching", 5.0, {5}, True),
+            ("numeric_string", "5", {5}, False),
+            ("string", "abc", {5}, False),
+            ("none", None, {5}, False),
+            ("different_number", 6, {5}, False),
+            ("bool_true", True, {1}, False),
+            ("bool_false", False, {0}, False),
+        ]
+    )
+    def test_membership_semantics(self, _name: str, stored: Any, flag_ids: set[int], expected: bool) -> None:
+        assert jsonb_number_counts_as_flag_id(stored, flag_ids) is expected
 
 
 class TestUpdateLinkedFlagKey(BaseTest):


### PR DESCRIPTION
## Problem

Bulk-deleting feature flags by explicit `ids` breaks above roughly 65,000 ids: two of the batch queries place one bind parameter per id, and Postgres caps a statement at 65,535 parameters. Stacked on [#80998](https://github.com/PostHog/posthog/pull/80998), which added the replay-link guard.

## Changes

- Batch replay-link lookup no longer places one bind parameter per flag id. It fetches the project's linked ids and intersects in python, so the statement holds a constant number of parameters however large the explicit ids list grows.
- The python intersection lives in a new pure helper that reproduces jsonb equality for the shapes the single-flag guard accepts: numbers match numbers of any representation, while bools and numeric strings never match. The bool check runs first because Python's `True == 1` would collide with flag id 1.
- Dependent-flag lookup collapses its OR of per-id `%s` slots into a single `ANY(%s)` array parameter.

This is a small internal change. Nothing user-visible beyond the failure mode going away.

## How did you test this code?

- Added `TestJsonbNumberCountsAsFlagId` in `test_session_recording_links.py` covering the pure helper directly. The DB-backed bool test case cannot catch a missing bool guard because `True` only collides with flag id 1 and fixture ids never are; the pure-function case pins `True` against `{1}`.
- Existing bulk-delete suite covers the dependent-flag rewrite end to end, including `test_bulk_delete_ignores_a_malformed_replay_link`'s four cases that pin the replay-link semantics the rewrite must preserve.
- Did not run the full feature-flag suite or any frontend checks; this sandbox shares a ClickHouse test DB with other worktrees, and CI covers it.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tools: Claude Code (`code-reviewer`, `splitting-oversized-modules` agent skill runs), `writing-tests` and `writing-pr-descriptions` skills.
- The base branch for this stack is `haacked/bulk-delete-replay-guard` (PR [#80998](https://github.com/PostHog/posthog/pull/80998)), which is open but not merged.
- Stacked-branch trade-off: the replay-link lookup now issues one statement regardless of `len(ids)`, but scans every team in the project holding a linked flag, not just the passed ids. That keeps per-statement parameters constant at the cost of a per-project read, which is small in practice.