### PR TITLE
fix(signals): stop research runs claiming other people's PRs as the report's

### DIFF
--- a/products/desktop/packages/agent/src/pr-url-detector.test.ts
+++ b/products/desktop/packages/agent/src/pr-url-detector.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   findPrUrl,
   findPrUrls,
+  parsePrRepository,
   wasCreatedByLogin,
   wasCreatedByThisRun,
   wasCreatedRecently,
@@ -99,76 +100,91 @@ describe("wasCreatedRecently", () => {
   });
 });
 
+describe("parsePrRepository", () => {
+  it.each([
+    ["https://github.com/PostHog/posthog/pull/123", "posthog/posthog"],
+    ["https://github.com/PostHog/posthog.com/pull/1", "posthog/posthog.com"],
+    ["https://example.com/PostHog/posthog/pull/1", null],
+  ])("%s -> %s", (url, expected) => {
+    expect(parsePrRepository(url)).toBe(expected);
+  });
+});
+
 describe("wasCreatedByThisRun", () => {
   const nowMs = new Date("2026-06-18T17:00:00Z").getTime();
   const fresh = "2026-06-18T16:59:00Z";
   const stale = "2026-06-18T12:00:00Z";
+  const ours = { repository: "posthog/posthog", branch: "run/branch" };
   const base = {
+    createdAt: fresh,
     nowMs,
     author: "app/posthog",
     ghLogin: null,
+    prRepository: "posthog/posthog",
+    headRefName: "run/branch",
+    isCrossRepository: false,
+    ownedBranches: [ours],
     baseBranch: "master",
   };
 
   it.each([
-    [
-      "fresh PR on the run's branch",
-      {
-        createdAt: fresh,
-        headRefName: "run/branch",
-        currentBranch: "run/branch",
-      },
-      true,
-    ],
+    ["fresh PR on a branch the run pushed", {}, true],
     [
       "fresh PR on another branch, run on master",
       {
-        createdAt: fresh,
         headRefName: "their/branch",
-        currentBranch: "master",
+        ownedBranches: [{ repository: "posthog/posthog", branch: "master" }],
       },
       false,
     ],
     [
       "fresh PR whose head is the base branch",
-      { createdAt: fresh, headRefName: "master", currentBranch: "master" },
-      false,
-    ],
-    [
-      "stale PR on the run's branch",
       {
-        createdAt: stale,
-        headRefName: "run/branch",
-        currentBranch: "run/branch",
+        headRefName: "master",
+        ownedBranches: [{ repository: "posthog/posthog", branch: "master" }],
       },
       false,
     ],
+    ["fork PR with a matching branch name", { isCrossRepository: true }, false],
     [
-      "fresh PR, branch unknown, author matches login",
-      {
-        createdAt: fresh,
-        headRefName: null,
-        currentBranch: null,
-        ghLogin: "me",
-        author: "me",
-      },
+      "same branch name in a different repository",
+      { prRepository: "posthog/posthog.com" },
+      false,
+    ],
+    [
+      "same branch name, run repository unknown",
+      { ownedBranches: [{ repository: null, branch: "run/branch" }] },
       true,
     ],
     [
-      "fresh PR, branch unknown, author unknown",
-      { createdAt: fresh, headRefName: null, currentBranch: null },
+      "branch pushed by signed commit, no checkout",
+      {
+        ownedBranches: [
+          { repository: "posthog/posthog", branch: "run/branch" },
+        ],
+      },
+      true,
+    ],
+    ["stale PR on the run's branch", { createdAt: stale }, false],
+    [
+      "fresh PR, no branches known, author matches login",
+      { headRefName: null, ownedBranches: [], ghLogin: "me", author: "me" },
+      true,
+    ],
+    [
+      "fresh PR, no branches known, author unknown",
+      { headRefName: null, ownedBranches: [] },
       false,
     ],
     [
-      "fresh PR, branch known but run branch unknown, author matches",
-      {
-        createdAt: fresh,
-        headRefName: "run/branch",
-        currentBranch: null,
-        ghLogin: "me",
-        author: "me",
-      },
+      "fresh PR from another branch, author matches login",
+      { headRefName: "other/branch", ghLogin: "me", author: "me" },
       true,
+    ],
+    [
+      "fresh fork PR, author matches login",
+      { isCrossRepository: true, ghLogin: "me", author: "me" },
+      false,
     ],
   ] as const)("%s -> %s", (_name, overrides, expected) => {
     expect(wasCreatedByThisRun({ ...base, ...overrides })).toBe(expected);

--- a/products/desktop/packages/agent/src/pr-url-detector.test.ts
+++ b/products/desktop/packages/agent/src/pr-url-detector.test.ts
@@ -179,6 +179,22 @@ describe("wasCreatedByThisRun", () => {
     [
       "fresh PR from another branch, author matches login",
       { headRefName: "other/branch", ghLogin: "me", author: "me" },
+      false,
+    ],
+    [
+      "fresh PR, head known but no branches pushed, author matches login",
+      { ownedBranches: [], ghLogin: "me", author: "me" },
+      true,
+    ],
+    [
+      "fresh PR, only branches in other repositories known, author matches login",
+      {
+        ownedBranches: [
+          { repository: "posthog/posthog.com", branch: "run/branch" },
+        ],
+        ghLogin: "me",
+        author: "me",
+      },
       true,
     ],
     [

--- a/products/desktop/packages/agent/src/pr-url-detector.test.ts
+++ b/products/desktop/packages/agent/src/pr-url-detector.test.ts
@@ -3,6 +3,7 @@ import {
   findPrUrl,
   findPrUrls,
   wasCreatedByLogin,
+  wasCreatedByThisRun,
   wasCreatedRecently,
 } from "./pr-url-detector";
 
@@ -95,5 +96,81 @@ describe("wasCreatedRecently", () => {
 
   it("fails closed on an unparseable createdAt", () => {
     expect(wasCreatedRecently("not-a-date", now, maxAge)).toBe(false);
+  });
+});
+
+describe("wasCreatedByThisRun", () => {
+  const nowMs = new Date("2026-06-18T17:00:00Z").getTime();
+  const fresh = "2026-06-18T16:59:00Z";
+  const stale = "2026-06-18T12:00:00Z";
+  const base = {
+    nowMs,
+    author: "app/posthog",
+    ghLogin: null,
+    baseBranch: "master",
+  };
+
+  it.each([
+    [
+      "fresh PR on the run's branch",
+      {
+        createdAt: fresh,
+        headRefName: "run/branch",
+        currentBranch: "run/branch",
+      },
+      true,
+    ],
+    [
+      "fresh PR on another branch, run on master",
+      {
+        createdAt: fresh,
+        headRefName: "their/branch",
+        currentBranch: "master",
+      },
+      false,
+    ],
+    [
+      "fresh PR whose head is the base branch",
+      { createdAt: fresh, headRefName: "master", currentBranch: "master" },
+      false,
+    ],
+    [
+      "stale PR on the run's branch",
+      {
+        createdAt: stale,
+        headRefName: "run/branch",
+        currentBranch: "run/branch",
+      },
+      false,
+    ],
+    [
+      "fresh PR, branch unknown, author matches login",
+      {
+        createdAt: fresh,
+        headRefName: null,
+        currentBranch: null,
+        ghLogin: "me",
+        author: "me",
+      },
+      true,
+    ],
+    [
+      "fresh PR, branch unknown, author unknown",
+      { createdAt: fresh, headRefName: null, currentBranch: null },
+      false,
+    ],
+    [
+      "fresh PR, branch known but run branch unknown, author matches",
+      {
+        createdAt: fresh,
+        headRefName: "run/branch",
+        currentBranch: null,
+        ghLogin: "me",
+        author: "me",
+      },
+      true,
+    ],
+  ] as const)("%s -> %s", (_name, overrides, expected) => {
+    expect(wasCreatedByThisRun({ ...base, ...overrides })).toBe(expected);
   });
 });

--- a/products/desktop/packages/agent/src/pr-url-detector.ts
+++ b/products/desktop/packages/agent/src/pr-url-detector.ts
@@ -32,3 +32,30 @@ export function wasCreatedRecently(
   if (Number.isNaN(createdAt.getTime())) return false;
   return createdAt.getTime() >= nowMs - maxAgeMs;
 }
+
+export interface PrOwnershipEvidence {
+  createdAt: string | null | undefined;
+  nowMs: number;
+  author: string | null | undefined;
+  ghLogin: string | null | undefined;
+  headRefName: string | null | undefined;
+  currentBranch: string | null | undefined;
+  baseBranch?: string | null;
+}
+
+// Whether a PR URL seen in the agent's output is a PR this run opened, rather than
+// one it read while checking GitHub for in-flight work. Recency is necessary but
+// never sufficient on its own: a research run listing open PRs sees every PR the
+// repo opened in the last few minutes. Ownership needs one positive signal on top,
+// either the PR's head branch is the branch this run has checked out, or the PR
+// author is the identity this run pushes as. A run sitting on the base branch
+// cannot own a same-repo PR, so a head ref equal to the base is rejected outright.
+export function wasCreatedByThisRun(evidence: PrOwnershipEvidence): boolean {
+  if (!wasCreatedRecently(evidence.createdAt, evidence.nowMs)) return false;
+  const { headRefName, currentBranch, baseBranch } = evidence;
+  if (headRefName && baseBranch && headRefName === baseBranch) return false;
+  if (headRefName && currentBranch) {
+    return headRefName === currentBranch;
+  }
+  return wasCreatedByLogin(evidence.author, evidence.ghLogin);
+}

--- a/products/desktop/packages/agent/src/pr-url-detector.ts
+++ b/products/desktop/packages/agent/src/pr-url-detector.ts
@@ -66,24 +66,28 @@ export function parsePrRepository(prUrl: string): string | null {
 // Whether a PR URL seen in the agent's output is a PR this run opened, rather than
 // one it read while checking GitHub for in-flight work. Recency is necessary but
 // never sufficient on its own: a research run listing open PRs sees every PR the
-// repo opened in the last few minutes. Ownership needs one positive signal on top,
-// either the PR's head branch is a branch this run pushed in that same repository,
-// or the PR author is the identity this run pushes as. A run sitting on the base
-// branch cannot own a same-repo PR, so a head ref equal to the base is rejected,
-// and so is any fork PR, whose head branch name is not ours to trust.
+// repo opened in the last few minutes. A fork PR never qualifies, because its head
+// branch name is chosen by the fork owner, and neither does a head ref equal to
+// the base branch, because a run sitting on the base cannot own a same-repo PR.
+//
+// With branch evidence on both sides (the PR's head, and branches this run pushed
+// in that repository) the branch decides: a match is ownership, a mismatch is a PR
+// the run only read, even when the author is this run's own login. On a desktop
+// run the login is the person's, who authors most PRs in the repo, so a fresh PR
+// of theirs from another branch would otherwise be re-attributed, which is the
+// bug this gate exists to stop. The author match is the fallback only when branch
+// evidence is missing on either side.
 export function wasCreatedByThisRun(evidence: PrOwnershipEvidence): boolean {
   if (!wasCreatedRecently(evidence.createdAt, evidence.nowMs)) return false;
   if (evidence.isCrossRepository) return false;
   const { headRefName, baseBranch, prRepository } = evidence;
   if (headRefName && baseBranch && headRefName === baseBranch) return false;
-  const branchOwned =
-    !!headRefName &&
-    evidence.ownedBranches.some(
-      (owned) =>
-        owned.branch === headRefName &&
-        (!owned.repository ||
-          !prRepository ||
-          owned.repository === prRepository),
-    );
-  return branchOwned || wasCreatedByLogin(evidence.author, evidence.ghLogin);
+  const comparable = evidence.ownedBranches.filter(
+    (owned) =>
+      !owned.repository || !prRepository || owned.repository === prRepository,
+  );
+  if (headRefName && comparable.length > 0) {
+    return comparable.some((owned) => owned.branch === headRefName);
+  }
+  return wasCreatedByLogin(evidence.author, evidence.ghLogin);
 }

--- a/products/desktop/packages/agent/src/pr-url-detector.ts
+++ b/products/desktop/packages/agent/src/pr-url-detector.ts
@@ -33,29 +33,57 @@ export function wasCreatedRecently(
   return createdAt.getTime() >= nowMs - maxAgeMs;
 }
 
+// A branch this run pushed, as `owner/name` (lowercased) plus branch. `repository`
+// is null when the run knows its branch but not which remote it points at.
+export interface OwnedBranch {
+  repository: string | null;
+  branch: string;
+}
+
 export interface PrOwnershipEvidence {
   createdAt: string | null | undefined;
   nowMs: number;
   author: string | null | undefined;
   ghLogin: string | null | undefined;
+  // `owner/name` of the repository the PR lives in, lowercased, from its URL.
+  prRepository: string | null;
   headRefName: string | null | undefined;
-  currentBranch: string | null | undefined;
+  // True when the PR head lives in a fork. A fork's branch name is chosen by the
+  // fork owner, so it can never prove this run opened the PR.
+  isCrossRepository: boolean | null | undefined;
+  ownedBranches: readonly OwnedBranch[];
   baseBranch?: string | null;
+}
+
+const PR_REPOSITORY_REGEX =
+  /^https:\/\/github\.com\/([^/\s"]+\/[^/\s"]+)\/pull\/\d+/;
+
+export function parsePrRepository(prUrl: string): string | null {
+  const match = PR_REPOSITORY_REGEX.exec(prUrl);
+  return match ? match[1].toLowerCase() : null;
 }
 
 // Whether a PR URL seen in the agent's output is a PR this run opened, rather than
 // one it read while checking GitHub for in-flight work. Recency is necessary but
 // never sufficient on its own: a research run listing open PRs sees every PR the
 // repo opened in the last few minutes. Ownership needs one positive signal on top,
-// either the PR's head branch is the branch this run has checked out, or the PR
-// author is the identity this run pushes as. A run sitting on the base branch
-// cannot own a same-repo PR, so a head ref equal to the base is rejected outright.
+// either the PR's head branch is a branch this run pushed in that same repository,
+// or the PR author is the identity this run pushes as. A run sitting on the base
+// branch cannot own a same-repo PR, so a head ref equal to the base is rejected,
+// and so is any fork PR, whose head branch name is not ours to trust.
 export function wasCreatedByThisRun(evidence: PrOwnershipEvidence): boolean {
   if (!wasCreatedRecently(evidence.createdAt, evidence.nowMs)) return false;
-  const { headRefName, currentBranch, baseBranch } = evidence;
+  if (evidence.isCrossRepository) return false;
+  const { headRefName, baseBranch, prRepository } = evidence;
   if (headRefName && baseBranch && headRefName === baseBranch) return false;
-  if (headRefName && currentBranch) {
-    return headRefName === currentBranch;
-  }
-  return wasCreatedByLogin(evidence.author, evidence.ghLogin);
+  const branchOwned =
+    !!headRefName &&
+    evidence.ownedBranches.some(
+      (owned) =>
+        owned.branch === headRefName &&
+        (!owned.repository ||
+          !prRepository ||
+          owned.repository === prRepository),
+    );
+  return branchOwned || wasCreatedByLogin(evidence.author, evidence.ghLogin);
 }

--- a/products/desktop/packages/agent/src/server/agent-server.test.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.test.ts
@@ -4118,9 +4118,13 @@ describe("AgentServer HTTP Mode", () => {
         createdAt: string | null;
         author: string | null;
         headRefName: string | null;
+        isCrossRepository: boolean | null;
       }>;
       fetchGhLogin(): Promise<string | null>;
-      getCurrentGitBranch(): Promise<string | null>;
+      getCurrentCheckout(): Promise<{
+        repository: string | null;
+        branch: string;
+      } | null>;
       detectedPrUrl: string | null;
       posthogAPI: {
         getTaskRun: ReturnType<typeof vi.fn>;
@@ -4132,20 +4136,24 @@ describe("AgentServer HTTP Mode", () => {
     const longAgo = "2020-01-01T00:00:00Z";
     const GH_LOGIN = "run-owner";
     const RUN_BRANCH = "posthog-self-driving/fix-the-thing-ab12cd";
+    const RUN_REPOSITORY = "posthog/posthog.com";
+    const RUN_CHECKOUT = { repository: RUN_REPOSITORY, branch: RUN_BRANCH };
 
     const setup = (
       prCreatedAt: string | null,
       prAuthor: string | null = GH_LOGIN,
       prHeadRefName: string | null = RUN_BRANCH,
+      isCrossRepository: boolean | null = false,
     ): PrTestServer => {
       const s = createServer() as unknown as PrTestServer;
       s.fetchPrAttribution = vi.fn(async () => ({
         createdAt: prCreatedAt,
         author: prAuthor,
         headRefName: prHeadRefName,
+        isCrossRepository,
       }));
       s.fetchGhLogin = vi.fn(async () => GH_LOGIN);
-      s.getCurrentGitBranch = vi.fn(async () => RUN_BRANCH);
+      s.getCurrentCheckout = vi.fn(async () => RUN_CHECKOUT);
       let storedOutput: Record<string, unknown> | null = null;
       s.posthogAPI = {
         getTaskRun: vi.fn(async () => ({ output: storedOutput })),
@@ -4222,6 +4230,7 @@ describe("AgentServer HTTP Mode", () => {
         createdAt: url === PR_URL ? justNow() : longAgo,
         author: GH_LOGIN,
         headRefName: RUN_BRANCH,
+        isCrossRepository: false,
       }));
       s.maybeAttachCreatedPr(payload, terminalUpdate(PR_URL));
       s.maybeAttachCreatedPr(payload, terminalUpdate(viewed));
@@ -4257,7 +4266,10 @@ describe("AgentServer HTTP Mode", () => {
       // work. Every PR opened in the last few minutes scrolls past it; none is its own.
       const s = setup(justNow(), "app/posthog", "someone/feature-branch");
       s.fetchGhLogin = vi.fn(async () => null);
-      s.getCurrentGitBranch = vi.fn(async () => "master");
+      s.getCurrentCheckout = vi.fn(async () => ({
+        repository: RUN_REPOSITORY,
+        branch: "master",
+      }));
       s.maybeAttachCreatedPr(payload, terminalUpdate(PR_URL));
       await flush();
       expect(s.posthogAPI.updateTaskRun).not.toHaveBeenCalled();
@@ -4267,10 +4279,43 @@ describe("AgentServer HTTP Mode", () => {
     it("does not attribute a fresh PR when neither the branch nor the identity can be resolved", async () => {
       const s = setup(justNow(), "app/posthog", null);
       s.fetchGhLogin = vi.fn(async () => null);
-      s.getCurrentGitBranch = vi.fn(async () => null);
+      s.getCurrentCheckout = vi.fn(async () => null);
       s.maybeAttachCreatedPr(payload, terminalUpdate(PR_URL));
       await flush();
       expect(s.posthogAPI.updateTaskRun).not.toHaveBeenCalled();
+    });
+
+    it("does not attribute a fork PR whose head branch name matches the run's branch", async () => {
+      // A fork owner picks the branch name, so a matching name proves nothing.
+      const s = setup(justNow(), "someone-else", RUN_BRANCH, true);
+      s.fetchGhLogin = vi.fn(async () => null);
+      s.maybeAttachCreatedPr(payload, terminalUpdate(PR_URL));
+      await flush();
+      expect(s.posthogAPI.updateTaskRun).not.toHaveBeenCalled();
+      expect(s.detectedPrUrl).toBeNull();
+    });
+
+    it("attributes a PR on a branch the run pushed by signed commit when it has no checkout (no-repository mode)", async () => {
+      const s = setup(justNow(), "app/posthog");
+      s.fetchGhLogin = vi.fn(async () => null);
+      s.getCurrentCheckout = vi.fn(async () => null);
+      s.posthogAPI.getTaskRun = vi.fn(async () => ({
+        output: {
+          head_branches: [{ repository: RUN_REPOSITORY, branch: RUN_BRANCH }],
+        },
+      }));
+      s.maybeAttachCreatedPr(payload, terminalUpdate(PR_URL));
+      await flush();
+      expect(s.posthogAPI.updateTaskRun).toHaveBeenCalledTimes(1);
+      expect(s.detectedPrUrl).toBe(PR_URL);
+    });
+
+    it("attributes a fresh PR the run's own identity authored from a branch it is no longer on", async () => {
+      const s = setup(justNow(), GH_LOGIN, "another-branch-of-ours");
+      s.maybeAttachCreatedPr(payload, terminalUpdate(PR_URL));
+      await flush();
+      expect(s.posthogAPI.updateTaskRun).toHaveBeenCalledTimes(1);
+      expect(s.detectedPrUrl).toBe(PR_URL);
     });
 
     it("still rejects an old PR when the identity cannot be resolved (recency guards)", async () => {

--- a/products/desktop/packages/agent/src/server/agent-server.test.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.test.ts
@@ -4114,10 +4114,13 @@ describe("AgentServer HTTP Mode", () => {
         p: JwtPayload,
         u: Record<string, unknown> | undefined,
       ): void;
-      fetchPrAttribution(
-        url: string,
-      ): Promise<{ createdAt: string | null; author: string | null }>;
+      fetchPrAttribution(url: string): Promise<{
+        createdAt: string | null;
+        author: string | null;
+        headRefName: string | null;
+      }>;
       fetchGhLogin(): Promise<string | null>;
+      getCurrentGitBranch(): Promise<string | null>;
       detectedPrUrl: string | null;
       posthogAPI: {
         getTaskRun: ReturnType<typeof vi.fn>;
@@ -4128,17 +4131,21 @@ describe("AgentServer HTTP Mode", () => {
     const justNow = () => new Date().toISOString();
     const longAgo = "2020-01-01T00:00:00Z";
     const GH_LOGIN = "run-owner";
+    const RUN_BRANCH = "posthog-self-driving/fix-the-thing-ab12cd";
 
     const setup = (
       prCreatedAt: string | null,
       prAuthor: string | null = GH_LOGIN,
+      prHeadRefName: string | null = RUN_BRANCH,
     ): PrTestServer => {
       const s = createServer() as unknown as PrTestServer;
       s.fetchPrAttribution = vi.fn(async () => ({
         createdAt: prCreatedAt,
         author: prAuthor,
+        headRefName: prHeadRefName,
       }));
       s.fetchGhLogin = vi.fn(async () => GH_LOGIN);
+      s.getCurrentGitBranch = vi.fn(async () => RUN_BRANCH);
       let storedOutput: Record<string, unknown> | null = null;
       s.posthogAPI = {
         getTaskRun: vi.fn(async () => ({ output: storedOutput })),
@@ -4214,6 +4221,7 @@ describe("AgentServer HTTP Mode", () => {
       s.fetchPrAttribution = vi.fn(async (url: string) => ({
         createdAt: url === PR_URL ? justNow() : longAgo,
         author: GH_LOGIN,
+        headRefName: RUN_BRANCH,
       }));
       s.maybeAttachCreatedPr(payload, terminalUpdate(PR_URL));
       s.maybeAttachCreatedPr(payload, terminalUpdate(viewed));
@@ -4222,18 +4230,18 @@ describe("AgentServer HTTP Mode", () => {
       expect(s.posthogAPI.updateTaskRun).toHaveBeenCalledTimes(1);
     });
 
-    it("does not attribute a fresh PR authored by someone else (merely viewed)", async () => {
-      const s = setup(justNow(), "someone-else");
+    it("does not attribute a fresh PR authored by someone else from another branch (merely viewed)", async () => {
+      const s = setup(justNow(), "someone-else", "someone-elses-branch");
       s.maybeAttachCreatedPr(payload, terminalUpdate(PR_URL));
       await flush();
       expect(s.posthogAPI.updateTaskRun).not.toHaveBeenCalled();
       expect(s.detectedPrUrl).toBeNull();
     });
 
-    it("attributes a recent PR when the identity is a GitHub App installation (gh api user unavailable)", async () => {
+    it("attributes a recent PR on the run's branch when the identity is a GitHub App installation (gh api user unavailable)", async () => {
       // Cloud runs authenticate with a GitHub App installation token, for which
       // `gh api user` returns 403 → ghLogin is null. The PR is authored by the
-      // app bot (e.g. "app/posthog"); recency alone must carry attribution.
+      // app bot (e.g. "app/posthog"); the head-branch match carries attribution.
       const s = setup(justNow(), "app/posthog");
       s.fetchGhLogin = vi.fn(async () => null);
       s.maybeAttachCreatedPr(payload, terminalUpdate(PR_URL));
@@ -4242,6 +4250,27 @@ describe("AgentServer HTTP Mode", () => {
         output: { pr_url: PR_URL, pr_urls: [PR_URL] },
       });
       expect(s.detectedPrUrl).toBe(PR_URL);
+    });
+
+    it("does not attribute a fresh PR from another branch that a run on the base branch listed", async () => {
+      // A research run sits on master and runs `gh pr list` to look for in-flight
+      // work. Every PR opened in the last few minutes scrolls past it; none is its own.
+      const s = setup(justNow(), "app/posthog", "someone/feature-branch");
+      s.fetchGhLogin = vi.fn(async () => null);
+      s.getCurrentGitBranch = vi.fn(async () => "master");
+      s.maybeAttachCreatedPr(payload, terminalUpdate(PR_URL));
+      await flush();
+      expect(s.posthogAPI.updateTaskRun).not.toHaveBeenCalled();
+      expect(s.detectedPrUrl).toBeNull();
+    });
+
+    it("does not attribute a fresh PR when neither the branch nor the identity can be resolved", async () => {
+      const s = setup(justNow(), "app/posthog", null);
+      s.fetchGhLogin = vi.fn(async () => null);
+      s.getCurrentGitBranch = vi.fn(async () => null);
+      s.maybeAttachCreatedPr(payload, terminalUpdate(PR_URL));
+      await flush();
+      expect(s.posthogAPI.updateTaskRun).not.toHaveBeenCalled();
     });
 
     it("still rejects an old PR when the identity cannot be resolved (recency guards)", async () => {

--- a/products/desktop/packages/agent/src/server/agent-server.test.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.test.ts
@@ -4310,8 +4310,19 @@ describe("AgentServer HTTP Mode", () => {
       expect(s.detectedPrUrl).toBe(PR_URL);
     });
 
-    it("attributes a fresh PR the run's own identity authored from a branch it is no longer on", async () => {
-      const s = setup(justNow(), GH_LOGIN, "another-branch-of-ours");
+    it("does not attribute a fresh PR the run's own identity opened from a branch the run never pushed", async () => {
+      // On a desktop run the login is the person's, and they author most PRs in
+      // the repo. A known branch mismatch outranks the author match.
+      const s = setup(justNow(), GH_LOGIN, "another-branch-of-theirs");
+      s.maybeAttachCreatedPr(payload, terminalUpdate(PR_URL));
+      await flush();
+      expect(s.posthogAPI.updateTaskRun).not.toHaveBeenCalled();
+      expect(s.detectedPrUrl).toBeNull();
+    });
+
+    it("falls back to the author match when the run has no branch evidence", async () => {
+      const s = setup(justNow(), GH_LOGIN, "branch-we-cannot-see");
+      s.getCurrentCheckout = vi.fn(async () => null);
       s.maybeAttachCreatedPr(payload, terminalUpdate(PR_URL));
       await flush();
       expect(s.posthogAPI.updateTaskRun).toHaveBeenCalledTimes(1);

--- a/products/desktop/packages/agent/src/server/agent-server.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.ts
@@ -4818,11 +4818,16 @@ ${commonInstructions}
       baseBranch: this.config.baseBranch ?? null,
     });
     if (!owned) {
-      this.logger.debug(
+      // Info, not debug: a wrongly rejected PR leaves the run with no PR until the
+      // webhook backstop binds it, and this line is the only trace of why.
+      this.logger.info(
         "PR seen in output is not this run's, skipping attribution",
         {
           runId: payload.run_id,
           prUrl,
+          createdAt: attribution.createdAt,
+          author: attribution.author,
+          ghLogin,
           headRefName: attribution.headRefName,
           currentBranch,
         },

--- a/products/desktop/packages/agent/src/server/agent-server.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.ts
@@ -77,11 +77,7 @@ import {
   isPostHogExecDescriptor,
   matchesPostHogExecPermission,
 } from "../posthog-exec-permission";
-import {
-  findPrUrls,
-  wasCreatedByLogin,
-  wasCreatedRecently,
-} from "../pr-url-detector";
+import { findPrUrls, wasCreatedByThisRun } from "../pr-url-detector";
 import {
   formatConversationForResume,
   type ResumeState,
@@ -440,6 +436,12 @@ export function codexAuthFromGatewayEnv(env: GatewayEnv): {
   apiKey: string;
 } {
   return { apiBaseUrl: env.openaiBaseUrl, apiKey: env.openaiApiKey };
+}
+
+interface PrAttribution {
+  createdAt: string | null;
+  author: string | null;
+  headRefName: string | null;
 }
 
 export class AgentServer {
@@ -4786,12 +4788,14 @@ ${commonInstructions}
     // Already the attributed PR (e.g. seeded from a Slack notification, or re-detected).
     if (prUrl === this.detectedPrUrl) return;
 
-    let attribution: { createdAt: string | null; author: string | null };
+    let attribution: PrAttribution;
     let ghLogin: string | null;
+    let currentBranch: string | null;
     try {
-      [attribution, ghLogin] = await Promise.all([
+      [attribution, ghLogin, currentBranch] = await Promise.all([
         this.fetchPrAttribution(prUrl),
         this.fetchGhLogin(),
+        this.getCurrentGitBranch(),
       ]);
     } catch (err) {
       this.logger.debug("PR attribution lookup failed", {
@@ -4802,13 +4806,29 @@ ${commonInstructions}
       return;
     }
 
-    // Only attribute PRs created during this run — not ones the agent merely
-    // viewed. GitHub App installation tokens (all cloud runs) can't read
-    // `gh api user`, so ghLogin is null there; enforce the author match only when
-    // we resolved our own identity, otherwise the recency gate alone scopes
-    // attribution to PRs created during this run.
-    if (!wasCreatedRecently(attribution.createdAt, Date.now())) return;
-    if (ghLogin && !wasCreatedByLogin(attribution.author, ghLogin)) return;
+    // GitHub App installation tokens (all cloud runs) can't read `gh api user`, so
+    // ghLogin is null there and the head-branch match is what proves ownership.
+    const owned = wasCreatedByThisRun({
+      createdAt: attribution.createdAt,
+      nowMs: Date.now(),
+      author: attribution.author,
+      ghLogin,
+      headRefName: attribution.headRefName,
+      currentBranch,
+      baseBranch: this.config.baseBranch ?? null,
+    });
+    if (!owned) {
+      this.logger.debug(
+        "PR seen in output is not this run's, skipping attribution",
+        {
+          runId: payload.run_id,
+          prUrl,
+          headRefName: attribution.headRefName,
+          currentBranch,
+        },
+      );
+      return;
+    }
 
     this.detectedPrUrl = prUrl;
 
@@ -4845,29 +4865,34 @@ ${commonInstructions}
     return token === undefined ? undefined : ghTokenEnv(token);
   }
 
-  private async fetchPrAttribution(
-    prUrl: string,
-  ): Promise<{ createdAt: string | null; author: string | null }> {
+  private async fetchPrAttribution(prUrl: string): Promise<PrAttribution> {
+    const unknown: PrAttribution = {
+      createdAt: null,
+      author: null,
+      headRefName: null,
+    };
     const res = await execGh(
-      ["pr", "view", prUrl, "--json", "createdAt,author"],
+      ["pr", "view", prUrl, "--json", "createdAt,author,headRefName"],
       {
         cwd: this.config.repositoryPath,
         timeoutMs: 10_000,
         env: this.ghActorEnv(),
       },
     );
-    if (res.exitCode !== 0) return { createdAt: null, author: null };
+    if (res.exitCode !== 0) return unknown;
     try {
       const data = JSON.parse(res.stdout) as {
         createdAt?: string;
         author?: { login?: string };
+        headRefName?: string;
       };
       return {
         createdAt: data.createdAt ?? null,
         author: data.author?.login ?? null,
+        headRefName: data.headRefName ?? null,
       };
     } catch {
-      return { createdAt: null, author: null };
+      return unknown;
     }
   }
 

--- a/products/desktop/packages/agent/src/server/agent-server.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.ts
@@ -15,7 +15,7 @@ import {
 } from "@agentclientprotocol/sdk";
 import { type ServerType, serve } from "@hono/node-server";
 import { execGh } from "@posthog/git/gh";
-import { getCurrentBranch } from "@posthog/git/queries";
+import { getCurrentBranch, getRemoteUrl } from "@posthog/git/queries";
 import { ghTokenEnv } from "@posthog/git/signed-commit";
 import {
   type Adapter,
@@ -77,7 +77,12 @@ import {
   isPostHogExecDescriptor,
   matchesPostHogExecPermission,
 } from "../posthog-exec-permission";
-import { findPrUrls, wasCreatedByThisRun } from "../pr-url-detector";
+import {
+  findPrUrls,
+  type OwnedBranch,
+  parsePrRepository,
+  wasCreatedByThisRun,
+} from "../pr-url-detector";
 import {
   formatConversationForResume,
   type ResumeState,
@@ -442,6 +447,50 @@ interface PrAttribution {
   createdAt: string | null;
   author: string | null;
   headRefName: string | null;
+  isCrossRepository: boolean | null;
+}
+
+const GITHUB_REMOTE_REGEX = /github\.com[:/]([^/\s]+\/[^/\s]+?)(?:\.git)?\/?$/i;
+
+export function parseGithubRemoteRepository(
+  remoteUrl: string | null | undefined,
+): string | null {
+  if (!remoteUrl) return null;
+  const match = GITHUB_REMOTE_REGEX.exec(remoteUrl.trim());
+  return match ? match[1].toLowerCase() : null;
+}
+
+// Branches the run has pushed, as recorded on its task run by signed commits
+// (`output.head_branches`, per repository) and by the branch sync
+// (`output.head_branch`, repository unknown). This is what proves ownership when
+// the agent-server has no checkout of its own, as in no-repository mode.
+export function ownedBranchesFromOutput(
+  output: Record<string, unknown> | null | undefined,
+): OwnedBranch[] {
+  if (!output) return [];
+  const owned: OwnedBranch[] = [];
+  const listed = output.head_branches;
+  if (Array.isArray(listed)) {
+    for (const entry of listed) {
+      if (!entry || typeof entry !== "object") continue;
+      const { repository, branch } = entry as {
+        repository?: unknown;
+        branch?: unknown;
+      };
+      if (typeof branch !== "string" || !branch) continue;
+      owned.push({
+        repository:
+          typeof repository === "string" && repository
+            ? repository.trim().toLowerCase()
+            : null,
+        branch,
+      });
+    }
+  }
+  if (typeof output.head_branch === "string" && output.head_branch) {
+    owned.push({ repository: null, branch: output.head_branch });
+  }
+  return owned;
 }
 
 export class AgentServer {
@@ -4098,6 +4147,25 @@ ${commonInstructions}
     }
   }
 
+  // The checked-out branch and the GitHub repository its `origin` points at, or
+  // null without a checkout (no-repository mode) or on a detached HEAD.
+  private async getCurrentCheckout(): Promise<OwnedBranch | null> {
+    const branch = await this.getCurrentGitBranch();
+    if (!branch || !this.config.repositoryPath) return null;
+    let repository: string | null = null;
+    try {
+      repository = parseGithubRemoteRepository(
+        await getRemoteUrl(this.config.repositoryPath),
+      );
+    } catch (error) {
+      this.logger.debug("Failed to determine git origin", {
+        repositoryPath: this.config.repositoryPath,
+        error,
+      });
+    }
+    return { repository, branch };
+  }
+
   private async syncCloudBranchMetadata(payload: JwtPayload): Promise<void> {
     const branchName = await this.getCurrentGitBranch();
     if (!branchName || branchName === this.lastReportedBranch) {
@@ -4790,12 +4858,17 @@ ${commonInstructions}
 
     let attribution: PrAttribution;
     let ghLogin: string | null;
-    let currentBranch: string | null;
+    let checkout: OwnedBranch | null;
+    let freshOutput: Record<string, unknown> | null;
     try {
-      [attribution, ghLogin, currentBranch] = await Promise.all([
+      [attribution, ghLogin, checkout, freshOutput] = await Promise.all([
         this.fetchPrAttribution(prUrl),
         this.fetchGhLogin(),
-        this.getCurrentGitBranch(),
+        this.getCurrentCheckout(),
+        this.posthogAPI
+          .getTaskRun(payload.task_id, payload.run_id)
+          .then((run) => run.output ?? null)
+          .catch(() => null),
       ]);
     } catch (err) {
       this.logger.debug("PR attribution lookup failed", {
@@ -4806,6 +4879,10 @@ ${commonInstructions}
       return;
     }
 
+    const ownedBranches = [
+      ...(checkout ? [checkout] : []),
+      ...ownedBranchesFromOutput(freshOutput),
+    ];
     // GitHub App installation tokens (all cloud runs) can't read `gh api user`, so
     // ghLogin is null there and the head-branch match is what proves ownership.
     const owned = wasCreatedByThisRun({
@@ -4813,8 +4890,10 @@ ${commonInstructions}
       nowMs: Date.now(),
       author: attribution.author,
       ghLogin,
+      prRepository: parsePrRepository(prUrl),
       headRefName: attribution.headRefName,
-      currentBranch,
+      isCrossRepository: attribution.isCrossRepository,
+      ownedBranches,
       baseBranch: this.config.baseBranch ?? null,
     });
     if (!owned) {
@@ -4829,7 +4908,8 @@ ${commonInstructions}
           author: attribution.author,
           ghLogin,
           headRefName: attribution.headRefName,
-          currentBranch,
+          isCrossRepository: attribution.isCrossRepository,
+          ownedBranches,
         },
       );
       return;
@@ -4838,10 +4918,6 @@ ${commonInstructions}
     this.detectedPrUrl = prUrl;
 
     try {
-      const freshOutput = await this.posthogAPI
-        .getTaskRun(payload.task_id, payload.run_id)
-        .then((run) => run.output)
-        .catch(() => null);
       const urls = mergePrUrls(readPrUrls(freshOutput), [prUrl]);
       await this.posthogAPI.updateTaskRun(payload.task_id, payload.run_id, {
         output: buildPrOutput(freshOutput, urls),
@@ -4875,9 +4951,16 @@ ${commonInstructions}
       createdAt: null,
       author: null,
       headRefName: null,
+      isCrossRepository: null,
     };
     const res = await execGh(
-      ["pr", "view", prUrl, "--json", "createdAt,author,headRefName"],
+      [
+        "pr",
+        "view",
+        prUrl,
+        "--json",
+        "createdAt,author,headRefName,isCrossRepository",
+      ],
       {
         cwd: this.config.repositoryPath,
         timeoutMs: 10_000,
@@ -4890,11 +4973,16 @@ ${commonInstructions}
         createdAt?: string;
         author?: { login?: string };
         headRefName?: string;
+        isCrossRepository?: boolean;
       };
       return {
         createdAt: data.createdAt ?? null,
         author: data.author?.login ?? null,
         headRefName: data.headRefName ?? null,
+        isCrossRepository:
+          typeof data.isCrossRepository === "boolean"
+            ? data.isCrossRepository
+            : null,
       };
     } catch {
       return unknown;

--- a/products/signals/backend/implementation_pr.py
+++ b/products/signals/backend/implementation_pr.py
@@ -3,13 +3,19 @@
 from dataclasses import dataclass
 from typing import Literal, cast
 
+from django.db.models import Q
+
 import structlog
 
 from posthog.models.github_integration_base import GitHubIntegrationBase
 from posthog.models.integration import GitHubIntegration
 
 from products.signals.backend.models import SignalReport
-from products.signals.backend.task_run_artefacts import SIGNALS_PRODUCT, TASK_RUN_TYPE_IMPLEMENTATION
+from products.signals.backend.task_run_artefacts import (
+    NON_PR_BEARING_TASK_RUN_TYPES,
+    SIGNALS_PRODUCT,
+    TASK_RUN_TYPE_IMPLEMENTATION,
+)
 from products.tasks.backend.facade import api as tasks_facade
 
 logger = structlog.get_logger(__name__)
@@ -31,11 +37,16 @@ def fetch_implementation_pr_state_for_reports(report_ids: list[str]) -> dict[str
     the facade then resolves the latest PR-bearing run for each task, so multiple runs of a task
     collapse to the newest PR.
 
-    Every signals task associated with the report is a candidate, not just the `implementation`
+    Every code-shipping signals task associated with the report is a candidate, not just the `implementation`
     ones: a task started from the inbox's "Discuss" button runs the same agent against the same
     repo, so it can push a branch and open a PR too, and that PR is the report's PR as much as an
     auto-started one is. Implementation tasks are still consulted first, so a report that has both
     surfaces exactly what it surfaced before.
+
+    Research, repo-selection, and scout runs are never candidates (`NON_PR_BEARING_TASK_RUN_TYPES`):
+    they read other people's PRs while checking for in-flight work, and a PR URL recorded on one of
+    them is a PR the agent saw, not one it opened. Surfacing it would label a stranger's PR as the
+    report's, and `close_implementation_pr_for_report` would then close it on dismissal.
 
     A report can be associated with several tasks (retries, plus any discussion), but only one PR is
     surfaced — the first candidate that has one. The merge flag is read from *that* task, so the URL
@@ -56,6 +67,7 @@ def fetch_implementation_pr_state_for_reports(report_ids: list[str]) -> dict[str
         for report_id, runs in runs_by_report.items()
         # Stable sort, so implementation tasks lead and each group keeps its oldest-first order.
         for run in sorted(runs, key=lambda run: run.type != TASK_RUN_TYPE_IMPLEMENTATION)
+        if run.type not in NON_PR_BEARING_TASK_RUN_TYPES
     ]
     if not pairs:
         return {}
@@ -70,6 +82,19 @@ def fetch_implementation_pr_state_for_reports(report_ids: list[str]) -> dict[str
         if pr_url and report_id not in result:
             result[report_id] = ImplementationPr(url=pr_url, merged=task_id in merged_task_ids)
     return result
+
+
+def pr_bearing_task_run_filter() -> Q:
+    """SQL counterpart of the `NON_PR_BEARING_TASK_RUN_TYPES` exclusion, as a `Q` on `tasks.TaskRun`.
+
+    The run type lives in artefact JSON the SQL path deliberately doesn't cast, so this keys on the
+    `state.ai_stage` stamp the pipeline writes at run creation, which carries the same names
+    (`research`, `repo_selection`, `scout:<skill>`). Runs without a stamp pass, matching the Python
+    path, where an unlabelled legacy association is a candidate.
+    """
+    return Q(state__ai_stage__isnull=True) | (
+        ~Q(state__ai_stage__in=sorted(NON_PR_BEARING_TASK_RUN_TYPES)) & ~Q(state__ai_stage__startswith="scout:")
+    )
 
 
 def fetch_implementation_pr_urls_for_reports(report_ids: list[str]) -> dict[str, str]:

--- a/products/signals/backend/task_run_artefacts.py
+++ b/products/signals/backend/task_run_artefacts.py
@@ -63,6 +63,12 @@ _PIPELINE_TASK_RUN_TYPES = frozenset(
     {TASK_RUN_TYPE_IMPLEMENTATION, TASK_RUN_TYPE_RESEARCH, TASK_RUN_TYPE_REPO_SELECTION, TASK_RUN_TYPE_SCOUT}
 )
 
+# Pipeline runs that never open a PR for the report. Research and repo-selection runs sit on the
+# base branch and read other people's PRs while checking for in-flight work, so a PR URL on one of
+# their runs is something the agent looked at, not something it shipped. Kept as a denylist so a
+# new run type that does ship code (a report is expected to grow several PRs) counts by default.
+NON_PR_BEARING_TASK_RUN_TYPES = frozenset({TASK_RUN_TYPE_RESEARCH, TASK_RUN_TYPE_REPO_SELECTION, TASK_RUN_TYPE_SCOUT})
+
 _TERMINAL_NO_PR_RUN_STATUSES = frozenset({"failed", "cancelled"})
 
 _GITHUB_PR_URL_PREFIX = "https://github.com/"

--- a/products/signals/backend/test/test_signal_report_api.py
+++ b/products/signals/backend/test/test_signal_report_api.py
@@ -39,6 +39,9 @@ from products.signals.backend.signal_metadata import ReportSignalMeta
 from products.signals.backend.task_run_artefacts import (
     TASK_RUN_TYPE_DISCUSSION,
     TASK_RUN_TYPE_IMPLEMENTATION,
+    TASK_RUN_TYPE_REPO_SELECTION,
+    TASK_RUN_TYPE_RESEARCH,
+    TASK_RUN_TYPE_SCOUT,
     append_task_run_artefact,
     record_implementation_task,
     record_report_task,
@@ -586,6 +589,7 @@ class TestSignalReportListAPI(APIBaseTest):
         pr_url: str | None = None,
         output: dict | None = None,
         relationship: str = TASK_RUN_TYPE_IMPLEMENTATION,
+        state: dict | None = None,
     ) -> "tuple[Task, TaskRun]":
         Task = apps.get_model("tasks", "Task")
         TaskRun = apps.get_model("tasks", "TaskRun")
@@ -607,6 +611,7 @@ class TestSignalReportListAPI(APIBaseTest):
             task=task,
             status=TaskRun.Status.COMPLETED,
             output=run_output,
+            state=state or {},
         )
         return task, run
 
@@ -703,6 +708,51 @@ class TestSignalReportListAPI(APIBaseTest):
         row = next(r for r in self.client.get(self._list_url()).json()["results"] if r["id"] == str(report.id))
 
         assert row["implementation_pr_url"] == expected_url
+
+    @parameterized.expand(
+        [
+            ("research", TASK_RUN_TYPE_RESEARCH, "research"),
+            ("repo_selection", TASK_RUN_TYPE_REPO_SELECTION, "repo_selection"),
+            ("scout", TASK_RUN_TYPE_SCOUT, "scout:some-skill"),
+        ]
+    )
+    def test_implementation_pr_url_ignores_pr_recorded_on_non_code_run(self, _name, relationship, ai_stage):
+        # A research run checks GitHub for in-flight work and the agent-server can record a PR it
+        # merely read as the run's own. That must never surface as the report's PR, on the list, the
+        # detail view, or the "has PR" filter the Pull requests tab counts.
+        report = self._create_report()
+        self._create_implementation_task_with_run(
+            report,
+            pr_url="https://github.com/o/r/pull/99",
+            relationship=relationship,
+            state={"ai_stage": ai_stage},
+        )
+
+        row = next(r for r in self.client.get(self._list_url()).json()["results"] if r["id"] == str(report.id))
+        detail = self.client.get(f"/api/projects/{self.team.id}/signals/reports/{report.id}/").json()
+        with_pr = self.client.get(self._list_url(has_implementation_pr="true")).json()
+
+        assert row["implementation_pr_url"] is None
+        assert detail["implementation_pr_url"] is None
+        assert with_pr["count"] == 0
+
+    def test_implementation_pr_url_prefers_real_pr_over_one_read_by_research(self):
+        report = self._create_report()
+        self._create_implementation_task_with_run(
+            report,
+            pr_url="https://github.com/o/r/pull/99",
+            relationship=TASK_RUN_TYPE_RESEARCH,
+            state={"ai_stage": "research"},
+        )
+        self._create_implementation_task_with_run(
+            report, pr_url="https://github.com/o/r/pull/100", state={"ai_stage": "implementation"}
+        )
+
+        row = next(r for r in self.client.get(self._list_url()).json()["results"] if r["id"] == str(report.id))
+        with_pr = self.client.get(self._list_url(has_implementation_pr="true")).json()
+
+        assert row["implementation_pr_url"] == "https://github.com/o/r/pull/100"
+        assert with_pr["count"] == 1
 
     @parameterized.expand(
         [

--- a/products/signals/backend/views.py
+++ b/products/signals/backend/views.py
@@ -94,6 +94,7 @@ from products.signals.backend.feedback_notes import forward_feedback_note
 from products.signals.backend.implementation_pr import (
     fetch_implementation_pr_state_for_reports,
     fetch_implementation_pr_urls_for_reports,
+    pr_bearing_task_run_filter,
 )
 from products.signals.backend.models import (
     ArtefactAttribution,
@@ -1002,7 +1003,9 @@ class SignalReportViewSet(
         # `pr_url` and maps them to reports via the indexed `task_id` columns — instead of a correlated
         # `Exists` over `tasks.TaskRun` evaluated once per candidate report (which made the inbox
         # PR-tab count scan the whole `ready` set per PR'd run).
-        return SignalReport.reports_for_task_ids_filter(tasks_facade.task_ids_with_pr_url_subquery(self.team.id))
+        return SignalReport.reports_for_task_ids_filter(
+            tasks_facade.task_ids_with_pr_url_subquery(self.team.id, pr_bearing_task_run_filter())
+        )
 
     def _apply_signal_report_implementation_pr_filter(self, queryset):
         # `has_implementation_pr=true|false` filters reports by whether a shipped
@@ -1248,10 +1251,12 @@ class SignalReportViewSet(
         # task" to the one that opened the report's PR.
         latest_impl_pr_url = tasks_facade.latest_task_run_pr_url_subquery(
             SignalReport.associated_task_runs_filter(OuterRef(OuterRef("id"))),
+            pr_bearing_task_run_filter(),
         )
         # Resolved over the same run, so the merge flag always describes the PR URL alongside it.
         latest_impl_pr_merged = tasks_facade.latest_task_run_pr_merged_subquery(
             SignalReport.associated_task_runs_filter(OuterRef(OuterRef("id"))),
+            pr_bearing_task_run_filter(),
         )
         return queryset.annotate(
             implementation_pr_url=latest_impl_pr_url,

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -886,8 +886,9 @@ def get_latest_pr_url_by_task(task_ids: Iterable[str | UUID]) -> dict[str, str]:
     return {str(row["task_id"]): row["output_pr_url_text"] for row in rows if row["output_pr_url_text"]}
 
 
-def task_ids_with_pr_url_subquery(team_id: int) -> QuerySet[TaskRun, Any]:
-    """A ``values('task_id')`` queryset of ``team_id``'s tasks that produced a non-empty ``output.pr_url``.
+def task_ids_with_pr_url_subquery(team_id: int, *conditions: Q) -> QuerySet[TaskRun, Any]:
+    """A ``values('task_id')`` queryset of ``team_id``'s tasks that produced a non-empty ``output.pr_url``,
+    narrowed by any extra ``Q`` ``conditions`` on the run.
 
     For embedding in a caller's ``task_id__in=...`` lookup so the report→PR correlation can be
     *decorrelated*: instead of a per-report ``Exists`` over runs, the caller drives off this small,
@@ -898,7 +899,7 @@ def task_ids_with_pr_url_subquery(team_id: int) -> QuerySet[TaskRun, Any]:
     team's PR-bearing runs — associated runs are always same-team, so this drops no valid matches.
     """
     return (
-        TaskRun.objects.filter(team_id=team_id, output__pr_url__isnull=False)
+        TaskRun.objects.filter(*conditions, team_id=team_id, output__pr_url__isnull=False)
         .exclude(output__pr_url="")
         .values("task_id")
     )


### PR DESCRIPTION
## Problem

- Inbox reports show other people's pull requests as their own implementation PR, and dismissing such a report would comment on and close that stranger's PR.
- The research run for a report checks GitHub for in-flight work with `gh pr list`, and every recently opened PR in the repo scrolls through its output.
- The agent-server attributes any PR URL it sees in the output to the run when the PR is under five minutes old. On cloud runs it cannot resolve its own GitHub login, so recency was the only check, and the run's branch was never compared.
- One research run on `master` recorded eleven PRs it never touched, including merge-queue bot PRs and PRs from unrelated branches.
- Since #83321 the inbox reads the PR from every signals task on a report, so the research run's recorded PR surfaces whenever the implementation run has no PR yet.

## Changes

- A report no longer shows a PR that one of its research, repo-selection, or scout runs merely read. Those run types are excluded from PR candidates in the inbox list, the detail view, the Pull requests tab count, and the close-on-dismiss path.
- The agent-server only attributes a PR to a run when the PR's head is a branch the run pushed in that same repository (its checkout, or a branch recorded by `git_signed_commit` in `output.head_branches`). A known branch mismatch is decisive; the run's GitHub login as author counts only when branch evidence is missing on either side. Recency stays required but is never sufficient on its own. Fork PRs and a head ref equal to the base branch are rejected outright.
- Rejected attributions log at info with the evidence (PR head, repository, author, the run's branches), so a wrongly refused PR is one grep away.
- The candidate set stays a list of tasks per report, so a report that grows several code-shipping tasks keeps working. Only which task types count changed.
- Mechanical: `task_ids_with_pr_url_subquery` in the tasks facade accepts extra `Q` conditions so the signals filter can narrow it.

> [!NOTE]
> Research runs that already recorded foreign PR URLs keep them in `output.pr_urls`. The inbox ignores them after this change; no data cleanup is included here.

## How did you test this code?

- `test_signal_report_api.py`: a parameterized case per excluded run type asserts the list row, the detail view, and `has_implementation_pr=true` all ignore a PR recorded on that run; a second case asserts the implementation run's PR still wins when a research run also carries one. No existing test created a PR-bearing research run.
- `agent-server.test.ts`: a run on `master` listing a fresh PR from another branch records nothing; a fork PR with a matching branch name records nothing; a run with no checkout attributes a PR on a branch its signed commit pushed; the run's own login on a branch it never pushed records nothing, and counts only when no branch evidence exists. The existing installation-token case now proves attribution through the branch match.
- `pr-url-detector.test.ts`: table over the ownership rule (branch and repository match, fork, base branch, author match, stale PR, unknown evidence).
- Ran the signals API tests above and the agent package vitest suite locally. Not run: the full frontend typecheck for `products/desktop` (stale `@posthog/shared` build locally).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code from a Slack report of a mislinked inbox PR. The diagnosis traced the report's `task_run` artefacts to the research run's `output.pr_urls`, then to the agent-server attribution gate.
- Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.
- Bot review raised fork PRs and no-repository-mode runs; both are addressed in the second commit. Codex asked for an author fallback after a branch mismatch and ReviewHog argued against it; the third commit keeps the mismatch decisive, with the reasoning in the function comment and replies inline.
- Considered fixing only the signals side. Both layers changed because the agent-server bug also mislabels runs outside signals, and the signals exclusion protects reports before sandboxes pick up the new agent build.
