### PR TITLE
fix(cdp): emit alert delivery SLO failures

### DIFF
--- a/.agents/skills/adding-product-alerting/SKILL.md
+++ b/.agents/skills/adding-product-alerting/SKILL.md
@@ -93,6 +93,14 @@ worker matched, delivery attempted, and delivery outcome. Include a correlation 
 dimensions. Alert on a sustained mismatch between adjacent stages. This finds silent drops even when individual
 components report no errors.
 
+Name each SLO for the boundary it measures. An internal-event producer acknowledgement measures enqueue health. It
+does not measure destination delivery. Start a delivery SLO only when an alert has an eligible configured target. Mark
+it successful only after the worker accepts the target. Record external-provider acceptance as a later stage when the
+transport can report it. Treat an eligible configured target with no routing match as a delivery failure, not success.
+
+An SLO event does not create an alert by itself. Configure a PostHog alert for the delivery failure rate and the
+stage-to-stage mismatch. The alert must use the same source and destination dimensions as the SLO.
+
 Run isolated synthetic checks for high-value supported paths after deployment and at a regular interval. A synthetic
 check must prove the whole path, not only that a producer accepted an event.
 

--- a/.agents/skills/adding-product-alerting/references/extending-platform-alerting.md
+++ b/.agents/skills/adding-product-alerting/references/extending-platform-alerting.md
@@ -55,7 +55,13 @@ For an advanced option on an existing destination, decide whether it is transpor
 ### Delivery
 
 - Treat event creation, producer flush, and producer acknowledgement as separate phases.
-- Do not describe producer acknowledgement as final destination delivery. HogFunction execution and external destination delivery happen downstream.
+- Name producer acknowledgement as enqueue health. Do not call it destination delivery. HogFunction execution and
+  external destination delivery happen downstream.
+- Start a destination-delivery SLO only when an eligible target exists. Mark it successful only when the worker
+  accepts that target. Mark a configured target with no routing match as a failure.
+- Record provider acceptance as a separate final stage when the provider reports it. Do not claim external delivery
+  when the transport cannot report it.
+- Configure alerts for delivery failures and for sustained mismatches between enqueue, worker match, and delivery.
 - Keep batch flushing efficient and bounded.
 - Keep helpers non-throwing only where the caller can make an explicit rollback decision from the return value.
 - Add metrics and structured failure context for new dispatch phases.

--- a/nodejs/src/cdp/consumers/cdp-internal-event.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-internal-event.consumer.ts
@@ -5,7 +5,7 @@ import { KafkaConsumerInterface, createKafkaConsumer } from '~/common/kafka/cons
 import { instrumentFn, instrumented } from '~/common/tracing/tracing-utils'
 import { parseJSON } from '~/common/utils/json-parse'
 import { logger } from '~/common/utils/logger'
-import { captureException } from '~/common/utils/posthog'
+import { captureException, captureSloFailure } from '~/common/utils/posthog'
 
 import { HealthCheckResult, PluginsServerConfig } from '../../types'
 import { isManagedAlertInternalEvent } from '../managed-alert-events'
@@ -89,9 +89,9 @@ export class CdpInternalEventsConsumer extends CdpConsumerBase {
                         return true
                     }
                     const alertId = globals.event.properties?.alert_id
-                    return Boolean(
+                    const matchesEvent = fn.filters?.events?.some((event) => event.id === globals.event.event)
+                    const matchesAlert = Boolean(
                         typeof alertId === 'string' &&
-                            fn.filters?.events?.some((event) => event.id === globals.event.event) &&
                             fn.filters?.properties?.some(
                                 (property) =>
                                     property.type === 'event' &&
@@ -100,6 +100,17 @@ export class CdpInternalEventsConsumer extends CdpConsumerBase {
                                     property.value === alertId
                             )
                     )
+                    if (matchesEvent && !matchesAlert && !fn.filters?.properties?.some((property) => property.key === 'alert_id')) {
+                        captureSloFailure({
+                            distinctId: typeof alertId === 'string' ? alertId : String(fn.id),
+                            teamId: globals.project.id,
+                            resourceId: typeof alertId === 'string' ? alertId : String(fn.id),
+                            operation: 'alert_delivery',
+                            failurePhase: 'destination_ownership_filter',
+                            properties: { alert_event: globals.event.event },
+                        })
+                    }
+                    return Boolean(matchesEvent && matchesAlert)
                 },
             }),
             this.hogFlowPipeline.buildInvocations(invocationGlobals, {

--- a/nodejs/src/cdp/consumers/cdp-internal-events-consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-internal-events-consumer.test.ts
@@ -2,6 +2,7 @@ import { createMockJobQueue } from '../../../tests/helpers/mocks/job-queue.mock'
 import '../../../tests/helpers/mocks/producer.mock'
 
 import { HogFlow } from '~/cdp/schema/hogflow'
+import { captureSloFailure } from '~/common/utils/posthog'
 import { closeHub, createHub } from '~/common/utils/db/hub'
 
 import { createCdpConsumerDeps } from '../../../tests/helpers/cdp'
@@ -19,6 +20,8 @@ import { insertHogFlow as _insertHogFlow } from '../_tests/fixtures-hogflows'
 import { HogWatcherState } from '../services/monitoring/hog-watcher.service'
 import { HogFunctionType } from '../types'
 import { CdpInternalEventsConsumer } from './cdp-internal-event.consumer'
+
+jest.mock('~/common/utils/posthog', () => ({ captureSloFailure: jest.fn() }))
 
 describe('CDP Internal Events Consumer', () => {
     let processor: CdpInternalEventsConsumer
@@ -298,6 +301,33 @@ describe('CDP Internal Events Consumer', () => {
             const { invocations } = await processor.processBatch(globals)
 
             expect(invocations.map((invocation) => invocation.functionId)).toEqual([fn.id])
+        })
+
+        it('records a delivery SLO failure when the ownership filter rejects an unscoped destination', async () => {
+            await insertHogFunction({
+                ...HOG_EXAMPLES.simple_fetch,
+                ...HOG_INPUTS_EXAMPLES.simple_fetch,
+                filters: {
+                    ...HOG_FILTERS_EXAMPLES.no_filters.filters,
+                    events: [{ id: '$billing_alert_firing', type: 'events' as const }],
+                },
+            })
+            const event = createInternalEvent(team.id, {})
+            event.event.event = '$billing_alert_firing'
+            event.event.properties = { alert_id: 'alert-1' }
+
+            const globals = await processor._parseKafkaBatch([createKafkaMessage(event)])
+            const { invocations } = await processor.processBatch(globals)
+
+            expect(invocations).toHaveLength(0)
+            expect(captureSloFailure).toHaveBeenCalledWith({
+                distinctId: 'alert-1',
+                teamId: team.id,
+                resourceId: 'alert-1',
+                operation: 'alert_delivery',
+                failurePhase: 'destination_ownership_filter',
+                properties: { alert_event: '$billing_alert_firing' },
+            })
         })
     })
 

--- a/nodejs/src/common/utils/posthog.ts
+++ b/nodejs/src/common/utils/posthog.ts
@@ -65,6 +65,39 @@ export function captureTeamEvent(
     }
 }
 
+export function captureSloFailure({
+    distinctId,
+    teamId,
+    resourceId,
+    operation,
+    failurePhase,
+    properties = {},
+}: {
+    distinctId: string
+    teamId: number
+    resourceId: string
+    operation: string
+    failurePhase: string
+    properties?: Record<string, string | number | boolean | null>
+}): void {
+    if (posthog) {
+        posthog.capture({
+            distinctId,
+            event: 'slo_operation_completed',
+            properties: {
+                area: 'analytic-platform',
+                operation,
+                team_id: teamId,
+                resource_id: resourceId,
+                outcome: 'failure',
+                duration_ms: 0,
+                failure_phase: failurePhase,
+                ...properties,
+            },
+        })
+    }
+}
+
 export async function isFeatureFlagEnabled(
     key: string,
     distinctId: string,


### PR DESCRIPTION
## Problem

- Alert owners could lose a destination in CDP while the delivery SLO still reported success.

## Changes

- CDP now emits a failed `alert_delivery` SLO completion when its ownership filter rejects an unscoped destination.
- The existing PostHog delivery failure alert now evaluates this consumer-side failure.
- The alerting skill defines the same delivery boundary for future changes.

## How did you test this code?

- Added a CDP consumer test for an unscoped destination rejected by the ownership filter.
- Ran `git diff --check`.
- Not run: the focused Node test needs the local Redis and HogVM test dependencies.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- No user-facing documentation change is required.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- PostHog Slack app added consumer-side SLO failure reporting after tracing the delivery alert and CDP ownership filter.
- Skills used: `/adding-product-alerting`, `/instrumenting-first-party-metrics`, `/writing-tests`, `/writing-simplified-technical-english`, and `/writing-pr-descriptions`.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BPULZFS84/p1787214984594829?thread_ts=1787214984.594829&cid=C0BPULZFS84)*