### PR TITLE
feat(desktop): keep notification payloads in activity

### DIFF
--- a/products/desktop/packages/agent/src/adapters/claude/conversion/sdk-to-acp.test.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/conversion/sdk-to-acp.test.ts
@@ -6,6 +6,7 @@ import type {
   SDKAssistantMessage,
   SDKModelRefusalFallbackMessage,
   SDKPartialAssistantMessage,
+  SDKTaskNotificationMessage,
   SDKUserMessage,
 } from "@anthropic-ai/claude-agent-sdk";
 import { describe, expect, it } from "vitest";
@@ -434,6 +435,41 @@ describe("import replay (no client-side history)", () => {
       context,
     );
     expect(chunkTexts(updates, "agent_message_chunk")).toEqual([]);
+  });
+});
+
+describe("handleSystemMessage task_notification", () => {
+  it("forwards the complete SDK payload for activity details", async () => {
+    const { context, notifications } = createHandlerContext();
+    const message: SDKTaskNotificationMessage = {
+      type: "system",
+      subtype: "task_notification",
+      task_id: "background-1",
+      tool_use_id: "tool-1",
+      status: "failed",
+      output_file: "/tmp/background-1.output",
+      summary: "Background check failed",
+      usage: { total_tokens: 120, tool_uses: 3, duration_ms: 4_000 },
+      skip_transcript: true,
+      uuid: "00000000-0000-0000-0000-000000000010",
+      session_id: "test-session",
+    };
+
+    await handleSystemMessage(message, context);
+
+    expect(notifications).toEqual([
+      {
+        method: "_posthog/task_notification",
+        params: {
+          sessionId: "test-session",
+          taskId: "background-1",
+          status: "failed",
+          summary: "Background check failed",
+          outputFile: "/tmp/background-1.output",
+          payload: message,
+        },
+      },
+    ]);
   });
 });
 

--- a/products/desktop/packages/agent/src/adapters/claude/conversion/sdk-to-acp.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/conversion/sdk-to-acp.ts
@@ -760,6 +760,9 @@ export async function handleSystemMessage(
         status: message.status,
         summary: message.summary,
         outputFile: message.output_file,
+        // Keep the original SDK message so activity can show fields this
+        // adapter does not interpret, including future SDK additions.
+        payload: message,
       });
       break;
     }

--- a/products/desktop/packages/core/src/canvas/activityTimeline.test.ts
+++ b/products/desktop/packages/core/src/canvas/activityTimeline.test.ts
@@ -3,6 +3,7 @@ import {
   parseActivityEvent,
 } from "@posthog/core/canvas/activityEvents";
 import {
+  type ActivityNotificationLike,
   type ActivityTaskLike,
   buildActivityTimeline,
   type CommentThreadLike,
@@ -47,11 +48,13 @@ function build(input: {
   messages?: ThreadMessageLike[];
   commentThreads?: CommentThreadLike[];
   taskOverrides?: Partial<ActivityTaskLike>;
+  notifications?: ActivityNotificationLike[];
 }) {
   return buildActivityTimeline({
     task: { ...task, ...input.taskOverrides },
     messages: input.messages ?? [],
     commentThreads: input.commentThreads ?? [],
+    notifications: input.notifications ?? [],
   });
 }
 
@@ -85,6 +88,32 @@ describe("activity timeline", () => {
       "message-m1",
       "event-m2",
       "comment-thread-1",
+    ]);
+  });
+
+  it("keeps background notifications in chronological order", () => {
+    const rows = build({
+      notifications: [
+        {
+          kind: "task_notification",
+          id: "notification-1",
+          timestamp: Date.parse("2026-08-01T10:20:00Z"),
+          status: "failed",
+          summary: "Background check failed",
+          payload: { task_id: "background-1", output_file: "/tmp/output" },
+        },
+      ],
+    });
+
+    expect(rows).toEqual([
+      expect.objectContaining({ kind: "task_created" }),
+      expect.objectContaining({
+        kind: "notification",
+        item: expect.objectContaining({
+          status: "failed",
+          payload: expect.objectContaining({ task_id: "background-1" }),
+        }),
+      }),
     ]);
   });
 

--- a/products/desktop/packages/core/src/canvas/activityTimeline.ts
+++ b/products/desktop/packages/core/src/canvas/activityTimeline.ts
@@ -36,6 +36,23 @@ export interface UserMessageLike {
   timestamp: number;
 }
 
+export type ActivityNotificationLike =
+  | {
+      kind: "task_notification";
+      id: string;
+      timestamp: number;
+      status: "completed" | "failed" | "stopped";
+      summary: string;
+      payload?: Record<string, unknown>;
+    }
+  | {
+      kind: "error";
+      id: string;
+      timestamp: number;
+      message: string;
+      payload?: Record<string, unknown>;
+    };
+
 export type ActivityRow<
   TMessage extends ThreadMessageLike = ThreadMessageLike,
   TComment extends CommentThreadLike = CommentThreadLike,
@@ -53,6 +70,12 @@ export type ActivityRow<
     }
   | { kind: "human_message"; key: string; ts: number; message: TMessage }
   | { kind: "user_message"; key: string; ts: number; item: UserMessageLike }
+  | {
+      kind: "notification";
+      key: string;
+      ts: number;
+      item: ActivityNotificationLike;
+    }
   | { kind: "comment"; key: string; ts: number; thread: TComment }
   | {
       kind: "comment_state";
@@ -71,6 +94,7 @@ const KIND_RANK: Record<ActivityRow["kind"], number> = {
   event: 1,
   human_message: 1,
   user_message: 1,
+  notification: 1,
   comment: 1,
   comment_state: 2,
   run_output_pr: 2,
@@ -90,11 +114,13 @@ export function buildActivityTimeline<
   messages,
   commentThreads,
   userMessages = [],
+  notifications = [],
 }: {
   task: ActivityTaskLike;
   messages: TMessage[];
   commentThreads: TComment[];
   userMessages?: UserMessageLike[];
+  notifications?: ActivityNotificationLike[];
 }): ActivityRow<TMessage, TComment>[] {
   const rows: ActivityRow<TMessage, TComment>[] = [
     {
@@ -153,6 +179,15 @@ export function buildActivityTimeline<
     rows.push({
       kind: "user_message",
       key: `user-message-${item.id}`,
+      ts: item.timestamp,
+      item,
+    });
+  }
+
+  for (const item of notifications) {
+    rows.push({
+      kind: "notification",
+      key: `notification-${item.id}`,
       ts: item.timestamp,
       item,
     });

--- a/products/desktop/packages/core/src/notification/agentSessionNotifications.ts
+++ b/products/desktop/packages/core/src/notification/agentSessionNotifications.ts
@@ -1,3 +1,5 @@
+import type { TaskNotificationParams } from "../sessions/schemas";
+
 export type AgentSessionNotification =
   | {
       kind: "turn_completed";
@@ -14,6 +16,20 @@ export type AgentSessionNotification =
       taskTitle: string;
       isTaskAuthor?: boolean;
       agentSpoke?: boolean;
+    }
+  | {
+      kind: "background_task_settled";
+      taskId: string;
+      taskTitle: string;
+      notification: TaskNotificationParams;
+      isTaskAuthor?: boolean;
+    }
+  | {
+      kind: "session_error";
+      taskId: string;
+      taskTitle: string;
+      error: unknown;
+      isTaskAuthor?: boolean;
     };
 
 export interface AgentSessionNotifier {

--- a/products/desktop/packages/core/src/sessions/cloudTaskUpdateNotifications.test.ts
+++ b/products/desktop/packages/core/src/sessions/cloudTaskUpdateNotifications.test.ts
@@ -158,7 +158,10 @@ function createHarness(isTaskAuthor = true) {
       }
       return;
     }
-    if (notification.stopReason !== "end_turn") {
+    if (
+      notification.kind !== "turn_completed" ||
+      notification.stopReason !== "end_turn"
+    ) {
       return;
     }
     notifyPromptComplete(

--- a/products/desktop/packages/core/src/sessions/schemas.test.ts
+++ b/products/desktop/packages/core/src/sessions/schemas.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { parseTaskNotificationParams } from "./schemas";
+
+describe("parseTaskNotificationParams", () => {
+  it("keeps the raw SDK payload and falls back to legacy params", () => {
+    const rawPayload = {
+      type: "system",
+      subtype: "task_notification",
+      task_id: "background-1",
+      usage: { total_tokens: 120 },
+    };
+
+    expect(
+      parseTaskNotificationParams({
+        taskId: "background-1",
+        status: "completed",
+        summary: "Done",
+        payload: rawPayload,
+      }),
+    ).toMatchObject({ payload: rawPayload });
+    expect(
+      parseTaskNotificationParams({
+        taskId: "background-2",
+        status: "failed",
+        summary: "Failed",
+        outputFile: "/tmp/output",
+      }),
+    ).toMatchObject({
+      payload: {
+        taskId: "background-2",
+        status: "failed",
+        summary: "Failed",
+        outputFile: "/tmp/output",
+      },
+    });
+  });
+
+  it("rejects malformed notifications", () => {
+    expect(
+      parseTaskNotificationParams({ status: "unknown", summary: "No task" }),
+    ).toBeNull();
+  });
+});

--- a/products/desktop/packages/core/src/sessions/schemas.ts
+++ b/products/desktop/packages/core/src/sessions/schemas.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+
+/** The Claude SDK payload sent when a background task settles. */
+export const taskNotificationParamsSchema = z
+  .object({
+    sessionId: z.string().optional(),
+    taskId: z.string(),
+    status: z.enum(["completed", "failed", "stopped"]),
+    summary: z.string(),
+    outputFile: z.string().optional(),
+    payload: z.record(z.string(), z.unknown()).optional(),
+  })
+  .passthrough();
+
+export type TaskNotificationParams = z.infer<
+  typeof taskNotificationParamsSchema
+>;
+
+export function parseTaskNotificationParams(
+  value: unknown,
+): TaskNotificationParams | null {
+  const result = taskNotificationParamsSchema.safeParse(value);
+  if (!result.success) return null;
+
+  return {
+    ...result.data,
+    // Older logs have no nested raw payload. Their params are the complete data
+    // available for that notification, so keep those params inspectable.
+    payload:
+      result.data.payload ??
+      (typeof value === "object" && value !== null
+        ? (value as Record<string, unknown>)
+        : undefined),
+  };
+}

--- a/products/desktop/packages/core/src/sessions/sessionEventBatching.test.ts
+++ b/products/desktop/packages/core/src/sessions/sessionEventBatching.test.ts
@@ -110,6 +110,7 @@ function createHarness() {
   };
 
   const notifyPromptComplete = vi.fn();
+  const notifyAgentSession = vi.fn();
   const deps = {
     store,
     log: noopLog,
@@ -120,6 +121,7 @@ function createHarness() {
       stopReason?: string;
       durationMs?: number;
     }) => {
+      notifyAgentSession(notification);
       if (notification.kind === "turn_completed") {
         notifyPromptComplete(
           notification.taskTitle,
@@ -166,10 +168,21 @@ function createHarness() {
     service,
     appendEvents,
     notifyPromptComplete,
+    notifyAgentSession,
     updateSession: store.updateSession,
     emit: (event: AcpMessage) => onEvent?.(event),
     events: () => sessions[RUN_ID].events,
   };
+}
+
+function extensionNotification(
+  method: string,
+  params: Record<string, unknown>,
+): AcpMessage {
+  return {
+    ts: 1_000,
+    message: { jsonrpc: "2.0", method, params },
+  } as unknown as AcpMessage;
 }
 
 function promptEcho(id: number, ts: number): AcpMessage {
@@ -258,6 +271,43 @@ describe("streamed event batching", () => {
     // The flush timer was cleared, so advancing does not re-apply anything.
     vi.advanceTimersByTime(FLUSH_MS);
     expect(h.events()).toHaveLength(2);
+  });
+
+  it("routes live background updates to the notification service", () => {
+    const h = createHarness();
+
+    h.emit(
+      extensionNotification("_posthog/task_notification", {
+        taskId: "background-1",
+        status: "failed",
+        summary: "Background check failed",
+        payload: { task_id: "background-1", output_file: "/tmp/output" },
+      }),
+    );
+    h.emit(
+      extensionNotification("_posthog/error", {
+        source: "agent_server",
+        error: "Connection refused",
+        requestId: "req-1",
+      }),
+    );
+    vi.advanceTimersByTime(FLUSH_MS);
+
+    expect(h.notifyAgentSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "background_task_settled",
+        notification: expect.objectContaining({
+          taskId: "background-1",
+          payload: expect.objectContaining({ task_id: "background-1" }),
+        }),
+      }),
+    );
+    expect(h.notifyAgentSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "session_error",
+        error: expect.objectContaining({ requestId: "req-1" }),
+      }),
+    );
   });
 
   it("keeps the turn duration when the prompt mutation clears state before the response flushes", () => {

--- a/products/desktop/packages/core/src/sessions/sessionService.ts
+++ b/products/desktop/packages/core/src/sessions/sessionService.ts
@@ -102,6 +102,7 @@ import {
   planPermissionResponse,
   resolveAllowAlwaysUpgradeMode,
 } from "./permissionResponse";
+import { parseTaskNotificationParams } from "./schemas";
 import {
   collapseSupersededToolCallUpdates,
   convertStoredEntriesToEvents,
@@ -3304,6 +3305,41 @@ export class SessionService {
         });
         if (isLive) {
           this.finalizeTurnContent(taskRunId, "stop_reason", acpMsg.ts);
+        }
+      }
+      if (
+        isLive &&
+        "method" in msg &&
+        isNotification(msg.method, POSTHOG_NOTIFICATIONS.TASK_NOTIFICATION)
+      ) {
+        const session = this.getSessionByRunId(taskRunId);
+        const notification = parseTaskNotificationParams(
+          (msg as { params?: unknown }).params,
+        );
+        if (session && notification) {
+          this.d.notifyAgentSession({
+            kind: "background_task_settled",
+            taskTitle: session.taskTitle,
+            taskId: session.taskId,
+            notification,
+            isTaskAuthor: session.isTaskAuthor,
+          });
+        }
+      }
+      if (
+        isLive &&
+        "method" in msg &&
+        isNotification(msg.method, POSTHOG_NOTIFICATIONS.ERROR)
+      ) {
+        const session = this.getSessionByRunId(taskRunId);
+        if (session) {
+          this.d.notifyAgentSession({
+            kind: "session_error",
+            taskTitle: session.taskTitle,
+            taskId: session.taskId,
+            error: (msg as { params?: unknown }).params ?? "Agent error",
+            isTaskAuthor: session.isTaskAuthor,
+          });
         }
       }
       if (isTurnCompleteEvent(acpMsg)) {

--- a/products/desktop/packages/shared/src/analytics-events.ts
+++ b/products/desktop/packages/shared/src/analytics-events.ts
@@ -998,7 +998,8 @@ export type ChannelActionType =
   | "mention_member"
   | "view_activity"
   | "open_mention"
-  | "activity_tab_change";
+  | "activity_tab_change"
+  | "expand_notification_payload";
 
 export type TaskFeedActionType = "create" | "update" | "delete" | "open";
 
@@ -1027,6 +1028,10 @@ export interface ChannelActionProperties {
   suggestion_label?: string;
   /** For activity_tab_change: the tab landed on. */
   tab?: string;
+  /** For expand_notification_payload: which notification the user opened. */
+  notification_kind?: "task_notification" | "error";
+  /** For task notifications: the terminal status. */
+  notification_status?: "completed" | "failed" | "stopped";
   /** Whether the underlying mutation resolved successfully. */
   success?: boolean;
 }

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.stories.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.stories.tsx
@@ -233,6 +233,29 @@ export const FullTimeline: Story = {
         content: "Add the events that belong on the activity panel.",
         timestamp: Date.parse("2026-08-04T09:05:00Z"),
       },
+      {
+        type: "session_update",
+        id: "notification-1",
+        timestamp: Date.parse("2026-08-04T10:20:00Z"),
+        update: {
+          sessionUpdate: "task_notification",
+          taskId: "background-1",
+          status: "failed",
+          summary: "Background validation failed",
+          payload: {
+            task_id: "background-1",
+            status: "failed",
+            output_file: "/tmp/background-1.output",
+            usage: { total_tokens: 120, tool_uses: 3 },
+          },
+        },
+        turnContext: {
+          toolCalls: new Map(),
+          childItems: new Map(),
+          turnCancelled: false,
+          turnComplete: true,
+        },
+      },
       // biome-ignore lint/suspicious/noExplicitAny: story fixture for the row under test
     ] as any,
     commentThreads,

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.test.tsx
@@ -3,6 +3,9 @@ import type { Task, TaskThreadMessage } from "@posthog/shared/domain-types";
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const track = vi.hoisted(() => vi.fn());
+vi.mock("@posthog/ui/shell/analytics", () => ({ track }));
+
 vi.mock("@posthog/ui/features/git-interaction/usePrDetails", () => ({
   usePrDetails: () => ({
     meta: { state: "open", merged: false, draft: false },
@@ -120,6 +123,53 @@ describe("ActivityTimeline", () => {
       expect.stringContaining("initial request"),
       expect.stringContaining("later follow-up"),
     ]);
+  });
+
+  it("shows notification summaries and expands their full payloads", () => {
+    renderTimeline(false, [
+      {
+        type: "session_update",
+        id: "notification-1",
+        timestamp: Date.parse("2026-07-17T09:05:00Z"),
+        update: {
+          sessionUpdate: "task_notification",
+          taskId: "background-1",
+          status: "failed",
+          summary: "Background check failed",
+          payload: {
+            error: { message: "Connection reset", code: "ECONNRESET" },
+          },
+        },
+        turnContext: {
+          toolCalls: new Map(),
+          childItems: new Map(),
+          turnCancelled: false,
+          turnComplete: true,
+        },
+      },
+    ]);
+
+    expect(screen.getByText("Background task failed")).toBeInTheDocument();
+    expect(screen.getByText(/Background check failed/)).toBeInTheDocument();
+    expect(screen.queryByText(/ECONNRESET/)).toBeNull();
+
+    const toggle = document.querySelector(
+      '[data-attr="activity-notification-payload-toggle"]',
+    );
+    expect(toggle).not.toBeNull();
+    fireEvent.click(toggle as HTMLElement);
+
+    expect(screen.getByText(/ECONNRESET/)).toBeVisible();
+    expect(track).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        action_type: "expand_notification_payload",
+        surface: "activity_panel",
+        task_id: "task-1",
+        notification_kind: "task_notification",
+        notification_status: "failed",
+      }),
+    );
   });
 
   it("renders structured references natively in conversation previews", () => {

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.tsx
@@ -1,9 +1,17 @@
-import { FileTextIcon, ScrollIcon } from "@phosphor-icons/react";
+import {
+  CheckIcon,
+  FileTextIcon,
+  ScrollIcon,
+  StopIcon,
+  WarningIcon,
+  XIcon,
+} from "@phosphor-icons/react";
 import type {
   ArtifactPayload,
   CommentEventPayload,
 } from "@posthog/core/canvas/activityEvents";
 import {
+  type ActivityNotificationLike,
   type ActivityRow,
   buildActivityTimeline,
   type UserMessageLike,
@@ -18,6 +26,7 @@ import {
   CollapsibleTrigger,
   ThreadItemGroup,
 } from "@posthog/quill";
+import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import type {
   Task,
   TaskCommentThreadSummary,
@@ -31,6 +40,8 @@ import {
   CommentRow,
   CommentStateRow,
   CREATED_BADGE,
+  DetailBlock,
+  EventBead,
   MESSAGE_BADGE,
   MessageBubble,
   PersonBead,
@@ -41,6 +52,7 @@ import {
 import { MentionText } from "@posthog/ui/features/canvas/components/MentionText";
 import { ThreadArtifactCard } from "@posthog/ui/features/canvas/components/ThreadPanel";
 import { userDisplayName } from "@posthog/ui/features/canvas/utils/userDisplay";
+import { serializeError } from "@posthog/ui/features/notifications/errorDetails";
 import { usePanelLayoutStore } from "@posthog/ui/features/panels/panelLayoutStore";
 import { useCommentNavigationStore } from "@posthog/ui/features/sessions/commentNavigationStore";
 import type { buildConversationItems } from "@posthog/ui/features/sessions/components/buildConversationItems";
@@ -52,6 +64,8 @@ import {
   useHasTranscriptListener,
   useThreadNavigationStore,
 } from "@posthog/ui/features/sessions/threadNavigationStore";
+import { CodeBlock } from "@posthog/ui/primitives/CodeBlock";
+import { track } from "@posthog/ui/shell/analytics";
 import { Fragment, useMemo } from "react";
 
 type ConversationItem = ReturnType<
@@ -146,6 +160,75 @@ function UserMessageRow({
   );
 }
 
+function ActivityNotificationRow({
+  item,
+  connectedAbove,
+  connectedBelow,
+  taskId,
+}: {
+  item: ActivityNotificationLike;
+  connectedAbove: boolean;
+  connectedBelow: boolean;
+  taskId: string;
+}) {
+  const isError = item.kind === "error" || item.status === "failed";
+  const isStopped =
+    item.kind === "task_notification" && item.status === "stopped";
+  const label =
+    item.kind === "error" ? "Agent error" : `Background task ${item.status}`;
+  const summary = item.kind === "error" ? item.message : item.summary;
+  const serializedPayload = useMemo(
+    () => (item.payload ? serializeError(item.payload) : null),
+    [item.payload],
+  );
+  const icon = isError ? (
+    item.kind === "error" ? (
+      <WarningIcon size={11} weight="fill" />
+    ) : (
+      <XIcon size={10} weight="bold" />
+    )
+  ) : isStopped ? (
+    <StopIcon size={10} weight="fill" />
+  ) : (
+    <CheckIcon size={10} weight="bold" />
+  );
+
+  return (
+    <TimelineRow
+      connectedAbove={connectedAbove}
+      connectedBelow={connectedBelow}
+      gutter={
+        <EventBead tone={isError ? "red" : isStopped ? "amber" : "green"}>
+          {icon}
+        </EventBead>
+      }
+      timestamp={new Date(item.timestamp).toISOString()}
+      dataAttr="activity-notification-payload-toggle"
+      onExpand={() =>
+        track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+          action_type: "expand_notification_payload",
+          surface: "activity_panel",
+          task_id: taskId,
+          notification_kind: item.kind,
+          ...(item.kind === "task_notification"
+            ? { notification_status: item.status }
+            : {}),
+        })
+      }
+      detail={
+        serializedPayload ? (
+          <DetailBlock className="max-h-80 overflow-auto">
+            <CodeBlock size="1">{serializedPayload}</CodeBlock>
+          </DetailBlock>
+        ) : undefined
+      }
+    >
+      <span className="font-medium">{label}</span>
+      {summary && <span className="text-muted-foreground"> · {summary}</span>}
+    </TimelineRow>
+  );
+}
+
 /** An inline `= []` default is a new array on every render, which would rebuild the timeline
  *  through the memo's dependency list. */
 const NO_COMMENT_THREADS: TaskCommentThreadSummary[] = [];
@@ -218,6 +301,34 @@ export function ActivityTimeline({
                 item.pinToTop === true && Number.isFinite(taskCreatedTimestamp)
                   ? taskCreatedTimestamp
                   : item.timestamp,
+            });
+          }
+          return items;
+        },
+        [],
+      ),
+      notifications: conversationItems.reduce<ActivityNotificationLike[]>(
+        (items, item) => {
+          if (item.type !== "session_update") return items;
+          const timestamp =
+            item.timestamp ??
+            (Number.isFinite(taskCreatedTimestamp) ? taskCreatedTimestamp : 0);
+          if (item.update.sessionUpdate === "task_notification") {
+            items.push({
+              kind: "task_notification",
+              id: item.id,
+              timestamp,
+              status: item.update.status,
+              summary: item.update.summary,
+              payload: item.update.payload,
+            });
+          } else if (item.update.sessionUpdate === "error") {
+            items.push({
+              kind: "error",
+              id: item.id,
+              timestamp,
+              message: item.update.message,
+              payload: item.update.payload,
             });
           }
           return items;
@@ -350,6 +461,15 @@ export function ActivityTimeline({
             content={row.item.content}
             timestamp={new Date(row.item.timestamp).toISOString()}
             onShowInChat={showPromptInChat(row.item.id)}
+          />
+        );
+      case "notification":
+        return (
+          <ActivityNotificationRow
+            item={row.item}
+            connectedAbove={connectedAbove}
+            connectedBelow={connectedBelow}
+            taskId={task.id}
           />
         );
       case "human_message":

--- a/products/desktop/packages/ui/src/features/canvas/components/activityRows.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/activityRows.tsx
@@ -65,6 +65,8 @@ export function TimelineRow({
   connectedBelow = true,
   onShowInChat,
   ariaLabel,
+  dataAttr,
+  onExpand,
 }: {
   gutter: ReactNode;
   children: ReactNode;
@@ -77,6 +79,8 @@ export function TimelineRow({
   connectedAbove?: boolean;
   connectedBelow?: boolean;
   ariaLabel?: string;
+  dataAttr?: string;
+  onExpand?: () => void;
 }) {
   const [open, setOpen] = useState(defaultOpen);
   // The jump counts as detail, so a row whose only content is the action still opens.
@@ -147,8 +151,15 @@ export function TimelineRow({
               type="button"
               aria-expanded={open}
               aria-label={ariaLabel}
+              data-attr={dataAttr}
               className="flex w-full text-left focus-visible:outline-none"
-              onClick={() => setOpen((current) => !current)}
+              onClick={() =>
+                setOpen((current) => {
+                  const next = !current;
+                  if (next) onExpand?.();
+                  return next;
+                })
+              }
             >
               {header}
             </button>

--- a/products/desktop/packages/ui/src/features/canvas/task-activity/taskActivity.contribution.test.ts
+++ b/products/desktop/packages/ui/src/features/canvas/task-activity/taskActivity.contribution.test.ts
@@ -59,8 +59,9 @@ describe("TaskActivityContribution", () => {
     activityListener?.({
       taskId: "task-1",
       taskTitle: "Channel task",
-      activityKind: "awaiting_input",
+      activityKind: "message",
       activityAt: "2026-07-27T10:00:00Z",
+      snippet: "Background check failed",
     });
 
     const cached = queryClient.getQueryData<InfiniteData<TaskActivityPage>>([
@@ -73,7 +74,8 @@ describe("TaskActivityContribution", () => {
           task_id: "task-1",
           task_title: "Channel task",
           channel_id: null,
-          activity_kind: "awaiting_input",
+          activity_kind: "message",
+          snippet: "Background check failed",
           is_unread: true,
         },
       ],

--- a/products/desktop/packages/ui/src/features/canvas/task-activity/taskActivity.contribution.ts
+++ b/products/desktop/packages/ui/src/features/canvas/task-activity/taskActivity.contribution.ts
@@ -57,7 +57,7 @@ export class TaskActivityContribution implements Contribution {
           channel_name: previous?.channel_name ?? null,
           activity_at: signal.activityAt,
           activity_kind: signal.activityKind,
-          snippet: "",
+          snippet: signal.snippet ?? "",
           latest_author: null,
           latest_message_id: null,
           is_unread: true,

--- a/products/desktop/packages/ui/src/features/notifications/agentSessionNotifications.test.ts
+++ b/products/desktop/packages/ui/src/features/notifications/agentSessionNotifications.test.ts
@@ -7,6 +7,8 @@ function createService() {
   const notifications = {
     notifyPermissionRequest: vi.fn(),
     notifyPromptComplete: vi.fn(),
+    notifyTaskNotification: vi.fn(),
+    notifyTaskError: vi.fn(),
   } as unknown as NotificationBus;
   const speech = { speak: vi.fn() } as unknown as SpeechNotifier;
   const service = new AgentSessionNotificationService(notifications, speech);
@@ -57,6 +59,43 @@ describe("AgentSessionNotificationService", () => {
       "task-1",
     );
     expect(speech.speak).not.toHaveBeenCalled();
+  });
+
+  it("routes background task results and session errors", () => {
+    const { notifications, service } = createService();
+    const notification = {
+      taskId: "background-1",
+      status: "failed" as const,
+      summary: "Background check failed",
+      payload: { task_id: "background-1" },
+    };
+    const error = { error: "Connection refused", requestId: "req-1" };
+
+    service.notify({
+      kind: "background_task_settled",
+      taskId: "task-1",
+      taskTitle: "Fix notifications",
+      notification,
+      isTaskAuthor: true,
+    });
+    service.notify({
+      kind: "session_error",
+      taskId: "task-1",
+      taskTitle: "Fix notifications",
+      error,
+      isTaskAuthor: true,
+    });
+
+    expect(notifications.notifyTaskNotification).toHaveBeenCalledWith(
+      "Fix notifications",
+      notification,
+      "task-1",
+    );
+    expect(notifications.notifyTaskError).toHaveBeenCalledWith(
+      "Fix notifications",
+      error,
+      "task-1",
+    );
   });
 
   it.each([false, undefined])(

--- a/products/desktop/packages/ui/src/features/notifications/agentSessionNotifications.ts
+++ b/products/desktop/packages/ui/src/features/notifications/agentSessionNotifications.ts
@@ -20,6 +20,24 @@ export class AgentSessionNotificationService implements AgentSessionNotifier {
       return;
     }
 
+    if (notification.kind === "background_task_settled") {
+      this.notifications.notifyTaskNotification(
+        notification.taskTitle,
+        notification.notification,
+        notification.taskId,
+      );
+      return;
+    }
+
+    if (notification.kind === "session_error") {
+      this.notifications.notifyTaskError(
+        notification.taskTitle,
+        notification.error,
+        notification.taskId,
+      );
+      return;
+    }
+
     if (notification.kind === "needs_input") {
       this.notifications.notifyPermissionRequest(
         notification.taskTitle,

--- a/products/desktop/packages/ui/src/features/notifications/notifications.test.ts
+++ b/products/desktop/packages/ui/src/features/notifications/notifications.test.ts
@@ -223,6 +223,63 @@ describe("native tier settings gating (app unfocused)", () => {
   });
 });
 
+describe("task background notifications", () => {
+  it("shows failures as inspectable toasts and adds them to activity", () => {
+    const { bus } = makeBus({ hasFocus: true });
+    const listener = vi.fn();
+    bus.subscribeToTaskActivity(listener);
+    const payload = {
+      task_id: "background-1",
+      status: "failed",
+      error: { message: "Connection refused", code: "ECONNREFUSED" },
+    };
+
+    bus.notifyTaskNotification(
+      "Parent task",
+      {
+        taskId: "background-1",
+        status: "failed",
+        summary: "Background check failed",
+        payload,
+      },
+      TASK_ID,
+    );
+
+    expect(toastMock.error).toHaveBeenCalledWith(
+      "Background task failed",
+      expect.objectContaining({
+        description: "Background check failed",
+        action: expect.objectContaining({ label: "Details" }),
+      }),
+    );
+    expect(listener).toHaveBeenCalledWith(
+      expect.objectContaining({
+        activityKind: "message",
+        snippet: "Background check failed",
+      }),
+    );
+  });
+
+  it("keeps the full session error behind its toast", () => {
+    const { bus } = makeBus({ hasFocus: true });
+    const error = {
+      source: "agent_server",
+      error: "Connection refused",
+      requestId: "req-1",
+    };
+
+    bus.notifyTaskError("Parent task", error, TASK_ID);
+
+    expect(toastMock.error).toHaveBeenCalledWith(
+      '"Parent task" failed',
+      expect.objectContaining({
+        description: expect.stringContaining("Connection refused"),
+        action: expect.objectContaining({ label: "Details" }),
+      }),
+    );
+  });
+});
+
 describe("notifyError", () => {
   const payload = { status: 500, message: "upstream exploded", body: { x: 1 } };
 

--- a/products/desktop/packages/ui/src/features/notifications/notifications.ts
+++ b/products/desktop/packages/ui/src/features/notifications/notifications.ts
@@ -1,3 +1,4 @@
+import type { TaskNotificationParams } from "@posthog/core/sessions/schemas";
 import {
   type INotifications,
   NOTIFICATIONS_SERVICE,
@@ -55,8 +56,12 @@ export interface NotificationDescriptor {
 export interface TaskActivitySignal {
   taskId: string;
   taskTitle: string;
-  activityKind: Extract<TaskActivityKind, "awaiting_input" | "completed">;
+  activityKind: Extract<
+    TaskActivityKind,
+    "awaiting_input" | "completed" | "message"
+  >;
   activityAt: string;
+  snippet?: string;
 }
 
 // The single channel every app notification flows through. Reads focus + the
@@ -161,6 +166,45 @@ export class NotificationBus {
     this.emitTaskActivity(taskId, taskTitle, "awaiting_input");
   }
 
+  notifyTaskNotification(
+    taskTitle: string,
+    notification: TaskNotificationParams,
+    taskId?: string,
+  ): void {
+    const title = `Background task ${notification.status}`;
+    const error =
+      notification.status === "failed"
+        ? (notification.payload ?? notification)
+        : undefined;
+    this.notify({
+      title,
+      body:
+        notification.summary || `Update for "${this.truncateTitle(taskTitle)}"`,
+      target: taskId ? { kind: "task", taskId } : undefined,
+      toast: {
+        level:
+          notification.status === "completed"
+            ? "success"
+            : notification.status === "failed"
+              ? "error"
+              : "warning",
+        description: notification.summary || undefined,
+      },
+      error,
+    });
+    this.emitTaskActivity(taskId, taskTitle, "message", notification.summary);
+  }
+
+  notifyTaskError(taskTitle: string, error: unknown, taskId?: string): void {
+    const summary = summarizeError(error);
+    this.notifyError(
+      `"${this.truncateTitle(taskTitle)}" failed`,
+      error,
+      taskId ? { kind: "task", taskId } : undefined,
+    );
+    this.emitTaskActivity(taskId, taskTitle, "message", summary);
+  }
+
   // Error entry point: the toast carries a one-line summary; the raw payload
   // rides along on `error` and stays inspectable behind the Details action.
   notifyError(
@@ -218,6 +262,7 @@ export class NotificationBus {
     taskId: string | undefined,
     taskTitle: string,
     activityKind: TaskActivitySignal["activityKind"],
+    snippet?: string,
   ): void {
     if (!taskId) return;
     const signal: TaskActivitySignal = {
@@ -225,6 +270,7 @@ export class NotificationBus {
       taskTitle,
       activityKind,
       activityAt: new Date().toISOString(),
+      snippet,
     };
     for (const listener of this.taskActivityListeners) {
       try {

--- a/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.test.ts
@@ -164,6 +164,34 @@ function statusMsg(
   };
 }
 
+function taskNotificationMsg(ts: number): AcpMessage {
+  const payload = {
+    type: "system",
+    subtype: "task_notification",
+    task_id: "background-1",
+    tool_use_id: "tool-1",
+    status: "failed",
+    output_file: "/tmp/background-1.output",
+    summary: "Background check failed",
+    usage: { total_tokens: 120, tool_uses: 3, duration_ms: 4_000 },
+  };
+  return {
+    type: "acp_message",
+    ts,
+    message: {
+      jsonrpc: "2.0",
+      method: "_posthog/task_notification",
+      params: {
+        taskId: "background-1",
+        status: "failed",
+        summary: "Background check failed",
+        outputFile: "/tmp/background-1.output",
+        payload,
+      },
+    },
+  };
+}
+
 function refusalStatusMsg(
   ts: number,
   status: "refusal" | "refusal_fallback",
@@ -181,6 +209,52 @@ function refusalStatusMsg(
 }
 
 describe("buildConversationItems", () => {
+  it("keeps background task and error payloads as conversation items", () => {
+    const result = buildConversationItems(
+      [
+        taskNotificationMsg(10),
+        {
+          type: "acp_message",
+          ts: 11,
+          message: {
+            jsonrpc: "2.0",
+            method: "_posthog/error",
+            params: {
+              message: "Request failed",
+              errorType: "upstream_error",
+              error: { status: 502, requestId: "req-1" },
+            },
+          },
+        },
+      ],
+      null,
+    );
+
+    expect(result.items).toEqual([
+      expect.objectContaining({
+        type: "session_update",
+        timestamp: 10,
+        update: expect.objectContaining({
+          sessionUpdate: "task_notification",
+          payload: expect.objectContaining({
+            tool_use_id: "tool-1",
+            output_file: "/tmp/background-1.output",
+          }),
+        }),
+      }),
+      expect.objectContaining({
+        type: "session_update",
+        timestamp: 11,
+        update: expect.objectContaining({
+          sessionUpdate: "error",
+          payload: expect.objectContaining({
+            error: { status: 502, requestId: "req-1" },
+          }),
+        }),
+      }),
+    ]);
+  });
+
   it("extracts cloud prompt attachments into user messages", () => {
     const uri = makeAttachmentUri("/tmp/hello world.txt");
 

--- a/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.ts
@@ -7,6 +7,7 @@ import {
   POSTHOG_NOTIFICATIONS,
 } from "@posthog/agent/acp-extensions";
 import { extractPromptDisplayContent } from "@posthog/core/sessions/promptContent";
+import { parseTaskNotificationParams } from "@posthog/core/sessions/schemas";
 import {
   type AcpMessage,
   type AgentConversationEvent,
@@ -757,6 +758,57 @@ function handleNotification(
       preTokens: params.preTokens,
       contextSize: params.contextSize,
     });
+    return;
+  }
+
+  if (isNotification(msg.method, POSTHOG_NOTIFICATIONS.TASK_NOTIFICATION)) {
+    const params = parseTaskNotificationParams(msg.params);
+    if (!params) return;
+    ensureImplicitTurn(b, ts);
+    pushItem(
+      b,
+      {
+        sessionUpdate: "task_notification",
+        taskId: params.taskId,
+        status: params.status,
+        summary: params.summary,
+        outputFile: params.outputFile,
+        payload: params.payload,
+      },
+      ts,
+    );
+    return;
+  }
+
+  if (isNotification(msg.method, POSTHOG_NOTIFICATIONS.ERROR)) {
+    const params =
+      typeof msg.params === "object" && msg.params !== null
+        ? (msg.params as Record<string, unknown>)
+        : {};
+    const error = params.error;
+    const message =
+      typeof params.message === "string"
+        ? params.message
+        : typeof error === "string"
+          ? error
+          : "The agent encountered an error";
+    const errorType =
+      typeof params.errorType === "string"
+        ? params.errorType
+        : typeof params.type === "string"
+          ? params.type
+          : "agent_error";
+    ensureImplicitTurn(b, ts);
+    pushItem(
+      b,
+      {
+        sessionUpdate: "error",
+        errorType,
+        message,
+        payload: params,
+      },
+      ts,
+    );
     return;
   }
 

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/ErrorNotificationView.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/ErrorNotificationView.tsx
@@ -1,36 +1,68 @@
-import { Warning } from "@phosphor-icons/react";
-import { Box, Callout, Flex, Text } from "@radix-ui/themes";
+import { CaretRightIcon, Warning } from "@phosphor-icons/react";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+  cn,
+} from "@posthog/quill";
+import { serializeError } from "@posthog/ui/features/notifications/errorDetails";
+import { CodeBlock } from "@posthog/ui/primitives/CodeBlock";
+import { useMemo } from "react";
 
 interface ErrorNotificationViewProps {
   errorType: string;
   message: string;
+  payload?: unknown;
 }
 
 export function ErrorNotificationView({
   errorType,
   message,
+  payload,
 }: ErrorNotificationViewProps) {
-  // Special styling for context-related errors
   const isContextError = errorType === "invalid_request";
+  const serializedPayload = useMemo(
+    () => (payload === undefined ? null : serializeError(payload)),
+    [payload],
+  );
 
   return (
-    <Box className="my-2">
-      <Callout.Root color={isContextError ? "orange" : "red"} size="1">
-        <Callout.Icon>
-          <Warning weight="fill" />
-        </Callout.Icon>
-        <Callout.Text>
-          <Flex direction="column" gap="1">
-            <Text className="font-medium text-sm">{message}</Text>
-            {isContextError && (
-              <Text className="text-[13px] text-gray-11">
-                Tip: Type <code>/compact</code> to manually compress the
-                conversation history.
-              </Text>
-            )}
-          </Flex>
-        </Callout.Text>
-      </Callout.Root>
-    </Box>
+    <div
+      role="alert"
+      className={cn(
+        "my-2 flex gap-2 rounded-md border p-2",
+        isContextError
+          ? "border-orange-6 bg-orange-2 text-orange-11"
+          : "border-red-6 bg-red-2 text-red-11",
+      )}
+    >
+      <Warning weight="fill" className="mt-0.5 shrink-0" />
+      <div className="min-w-0 flex-1">
+        <div className="font-medium text-sm">{message}</div>
+        {isContextError && (
+          <div className="mt-1 text-[13px]">
+            Tip: Type <code>/compact</code> to compress the conversation
+            history.
+          </div>
+        )}
+        {serializedPayload !== null && (
+          <Collapsible className="mt-1 min-w-0 bg-transparent hover:bg-transparent data-open:bg-transparent">
+            <CollapsibleTrigger
+              data-attr="agent-error-payload-toggle"
+              className="group min-h-0 bg-transparent px-0 py-1 text-left text-xs hover:bg-transparent aria-expanded:bg-transparent"
+            >
+              <CaretRightIcon
+                size={12}
+                className="transition-transform group-aria-expanded:rotate-90"
+              />
+              Full error
+            </CollapsibleTrigger>
+            <CollapsibleContent className="mt-1 max-h-80 overflow-auto rounded-md border border-border bg-muted p-2 text-default">
+              <CodeBlock size="1">{serializedPayload}</CodeBlock>
+            </CollapsibleContent>
+          </Collapsible>
+        )}
+      </div>
+    </div>
   );
 }

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/SessionUpdateView.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/SessionUpdateView.tsx
@@ -52,13 +52,15 @@ export type RenderItem =
       sessionUpdate: "error";
       errorType: string;
       message: string;
+      payload?: Record<string, unknown>;
     }
   | {
       sessionUpdate: "task_notification";
       taskId: string;
       status: "completed" | "failed" | "stopped";
       summary: string;
-      outputFile: string;
+      outputFile?: string;
+      payload?: Record<string, unknown>;
     }
   | {
       sessionUpdate: "progress_group";
@@ -154,11 +156,16 @@ export const SessionUpdateView = memo(function SessionUpdateView({
         <ErrorNotificationView
           errorType={item.errorType}
           message={item.message}
+          payload={item.payload}
         />
       );
     case "task_notification":
       return (
-        <TaskNotificationView status={item.status} summary={item.summary} />
+        <TaskNotificationView
+          status={item.status}
+          summary={item.summary}
+          payload={item.payload}
+        />
       );
     case "progress_group":
       return (

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/TaskNotificationView.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/TaskNotificationView.tsx
@@ -1,25 +1,38 @@
-import { CheckCircle, StopCircle, XCircle } from "@phosphor-icons/react";
-import { Box, Flex, Text } from "@radix-ui/themes";
+import {
+  CaretRightIcon,
+  CheckCircle,
+  StopCircle,
+  XCircle,
+} from "@phosphor-icons/react";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@posthog/quill";
+import { serializeError } from "@posthog/ui/features/notifications/errorDetails";
+import { CodeBlock } from "@posthog/ui/primitives/CodeBlock";
+import { useMemo } from "react";
 
 interface TaskNotificationViewProps {
   status: "completed" | "failed" | "stopped";
   summary: string;
+  payload?: unknown;
 }
 
 const statusConfig = {
   completed: {
     icon: <CheckCircle size={14} weight="fill" className="text-green-9" />,
-    label: "Task completed",
+    label: "Background task completed",
     borderColor: "border-green-6 dark:border-green-8",
   },
   failed: {
     icon: <XCircle size={14} weight="fill" className="text-red-9" />,
-    label: "Task failed",
+    label: "Background task failed",
     borderColor: "border-red-6 dark:border-red-8",
   },
   stopped: {
     icon: <StopCircle size={14} weight="fill" className="text-orange-9" />,
-    label: "Task stopped",
+    label: "Background task stopped",
     borderColor: "border-orange-6 dark:border-orange-8",
   },
 };
@@ -27,20 +40,42 @@ const statusConfig = {
 export function TaskNotificationView({
   status,
   summary,
+  payload,
 }: TaskNotificationViewProps) {
   const config = statusConfig[status];
+  const serializedPayload = useMemo(
+    () => (payload === undefined ? null : serializeError(payload)),
+    [payload],
+  );
 
   return (
-    <Box className={`my-1 border-l-2 py-1 pl-3 ${config.borderColor}`}>
-      <Flex direction="column" gap="1">
-        <Flex align="center" gap="2">
+    <div className={`my-1 border-l-2 py-1 pl-3 ${config.borderColor}`}>
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center gap-2">
           {config.icon}
-          <Text className="font-medium text-[13px] text-gray-12">
+          <span className="font-medium text-[13px] text-gray-12">
             {config.label}
-          </Text>
-        </Flex>
-        {summary && <Text className="text-[13px] text-gray-11">{summary}</Text>}
-      </Flex>
-    </Box>
+          </span>
+        </div>
+        {summary && <span className="text-[13px] text-gray-11">{summary}</span>}
+        {serializedPayload !== null && (
+          <Collapsible className="min-w-0 bg-transparent hover:bg-transparent data-open:bg-transparent">
+            <CollapsibleTrigger
+              data-attr="background-task-payload-toggle"
+              className="group min-h-0 bg-transparent px-0 py-1 text-left text-xs hover:bg-transparent aria-expanded:bg-transparent"
+            >
+              <CaretRightIcon
+                size={12}
+                className="transition-transform group-aria-expanded:rotate-90"
+              />
+              {status === "failed" ? "Full error" : "Full payload"}
+            </CollapsibleTrigger>
+            <CollapsibleContent className="mt-1 max-h-80 overflow-auto rounded-md border border-border bg-muted p-2">
+              <CodeBlock size="1">{serializedPayload}</CodeBlock>
+            </CollapsibleContent>
+          </Collapsible>
+        )}
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## Problem

Background task results and agent errors disappear after their notification closes, so people cannot inspect the original payload later.

The Activity page only receives task-level summaries. The Activity panel drops background task and error events from the run log.

## Changes

- Activity now lists background task results and agent errors in chronological order.
- Expanding a row shows the complete payload. Failed notifications label this detail as the full error.
- Live results also update the Activity page and use the existing toast routing.
- The run log stores the raw payload, so this change does not create a duplicate artifact.
- Payload expansion emits a typed `channel action` event without recording payload content.

**Before**

```mermaid
flowchart LR
    A{{Background task}} --> B[ACP run log]
    B --> C[Ignored notification]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phBlue;
    class B phGray;
    class C phRed;
```

**After**

```mermaid
flowchart LR
    A{{Background task}} --> B[ACP run log]
    B --> C[Toast]
    B --> D[Activity page]
    B --> E[Activity panel]
    E --> F[Expandable payload]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phBlue;
    class B phGray;
    class C,D,E phYellow;
    class F phBlue;
```

| Before | After |
| --- | --- |
| ![Activity timeline before](https://raw.githubusercontent.com/PostHog/pr-assets/1843c7acc288477ba2f27b1c7a007e8faf441300/2026/08/ba1df6d4-6043-4be5-8e08-9e12b31759e7.png) | ![Activity timeline after](https://raw.githubusercontent.com/PostHog/pr-assets/b25287abfb3ed93227f5449b616bae367e6f6dab/2026/08/e54369ff-0a80-441f-ae07-bc698ee454fd.png) |

## How did you test this code?

- Full core and UI suites guard timeline ordering, payload expansion, live routing, and activity cache updates.
- The targeted agent test guards raw SDK payload preservation across the ACP boundary.
- The desktop typecheck covers desktop, web, and mobile hosts.
- Web and Storybook production builds completed.
- `hogli ci:preflight --fix` completed with no failures.
- Not checked with a live background task session.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This changes existing Activity behavior and adds no configuration or public API.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

OpenAI's coding agent implemented this change in PostHog Desktop. It used the writing tests, user-facing copy, UI components, PR descriptions, product analytics, Simplified Technical English, and ReviewHog perspective skills.

The change keeps payloads in the existing run log instead of uploading a second artifact. Test fixtures and screenshots use invented data.