### PR TITLE
feat(integration): Extend AWS integration models

### DIFF
--- a/posthog/api/integration.py
+++ b/posthog/api/integration.py
@@ -854,10 +854,12 @@ class IntegrationSerializer(serializers.ModelSerializer, UserAccessControlSerial
                 redshift_integration: (
                     type[RedshiftIntegration] | type[AWSRedshiftIntegration] | type[AWSRedshiftRoleBasedIntegration]
                 ) = AWSRedshiftRoleBasedIntegration
+            elif any(required in config for required in ("aws_access_key_id", "aws_secret_access_key")):
+                # Checked before the plain-server keys: AWS-credential configs also carry
+                # 'user' (the database user to obtain temporary credentials for).
+                redshift_integration = AWSRedshiftIntegration
             elif any(required in config for required in ("host", "port", "user", "password")):
                 redshift_integration = RedshiftIntegration
-            elif any(required in config for required in ("aws_access_key_id", "aws_secret_access_key")):
-                redshift_integration = AWSRedshiftIntegration
             else:
                 raise ValidationError("Missing required inputs")
 

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -637,6 +637,11 @@ class TestAWSIntegration:
             self.organization, "test@posthog.com", "test", level=OrganizationMembership.Level.ADMIN
         )
         self.integration_kind = aws_integration_kind
+        # Redshift integrations also carry the database user to obtain temporary credentials for.
+        if aws_integration_kind == Integration.IntegrationKind.AWS_REDSHIFT:
+            self.extra_config = {"user": "awsuser"}
+        else:
+            self.extra_config = {}
 
     @patch("posthog.models.integration.aws.validate_aws_credentials", return_value="123456789012")
     def test_create_with_valid_config(self, mock_validate, client: HttpClient):
@@ -650,6 +655,7 @@ class TestAWSIntegration:
                     "name": "prod-aws",
                     "aws_access_key_id": "AKIAEXAMPLE",
                     "aws_secret_access_key": "secret",
+                    **self.extra_config,
                 },
             },
             content_type="application/json",
@@ -662,7 +668,7 @@ class TestAWSIntegration:
         assert integration.kind == self.integration_kind
         assert integration.team == self.team
         assert integration.integration_id == "prod-aws"
-        assert integration.config == {"name": "prod-aws", "aws_account_id": "123456789012"}
+        assert integration.config == {"name": "prod-aws", "aws_account_id": "123456789012", **self.extra_config}
         assert integration.sensitive_config == {
             "aws_access_key_id": "AKIAEXAMPLE",
             "aws_secret_access_key": "secret",
@@ -702,7 +708,12 @@ class TestAWSIntegration:
         client.force_login(self.user)
         payload = {
             "kind": self.integration_kind,
-            "config": {"name": "prod-aws", "aws_access_key_id": "AKIAEXAMPLE", "aws_secret_access_key": "secret"},
+            "config": {
+                "name": "prod-aws",
+                "aws_access_key_id": "AKIAEXAMPLE",
+                "aws_secret_access_key": "secret",
+                **self.extra_config,
+            },
         }
 
         first = client.post(f"/api/environments/{self.team.pk}/integrations", payload, content_type="application/json")

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -772,8 +772,14 @@ class TestAWSRoleBasedIntegration:
         )
 
         self.integration_kind = aws_integration_kind
+        # Redshift integrations also carry the database user to obtain temporary credentials for.
+        if aws_integration_kind == Integration.IntegrationKind.AWS_REDSHIFT:
+            self.extra_config = {"user": "awsuser"}
+        else:
+            self.extra_config = {}
 
-    def test_create_with_valid_config(self, client: HttpClient):
+    @patch("posthog.models.integration.aws.validate_aws_role_arn")
+    def test_create_with_valid_config(self, mock_validate, client: HttpClient):
         client.force_login(self.user)
 
         role = "arn:aws:iam::123456789012:role/my-role"
@@ -784,6 +790,7 @@ class TestAWSRoleBasedIntegration:
                 "config": {
                     "name": "prod-aws",
                     "aws_role_arn": role,
+                    **self.extra_config,
                 },
             },
             content_type="application/json",
@@ -796,10 +803,35 @@ class TestAWSRoleBasedIntegration:
         assert integration.kind == self.integration_kind
         assert integration.team == self.team
         assert integration.integration_id == "prod-aws"
-        assert integration.config == {"name": "prod-aws", "aws_role_arn": role}
+        assert integration.config == {"name": "prod-aws", "aws_role_arn": role, **self.extra_config}
         assert integration.sensitive_config == {}
 
-    def test_create_rejects_duplicate_role_in_different_org(self, client: HttpClient):
+    @patch("posthog.models.integration.aws.validate_aws_role_arn")
+    def test_create_rejects_invalid_role_arn(self, mock_validate, client: HttpClient):
+        from posthog.models.integration import IntegrationError
+
+        mock_validate.side_effect = IntegrationError("AWS role ARN is not valid")
+        client.force_login(self.user)
+
+        response = client.post(
+            f"/api/environments/{self.team.pk}/integrations",
+            {
+                "kind": self.integration_kind,
+                "config": {
+                    "name": "prod-aws",
+                    "aws_role_arn": "arn:aws:iam::123456789012:role/not-assumable",
+                    **self.extra_config,
+                },
+            },
+            content_type="application/json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "AWS role ARN is not valid" in response.json()["detail"]
+        assert not Integration.objects.filter(team=self.team, kind=self.integration_kind).exists()
+
+    @patch("posthog.models.integration.aws.validate_aws_role_arn")
+    def test_create_rejects_duplicate_role_in_different_org(self, mock_validate, client: HttpClient):
         another_org = Organization.objects.create(name="Test Org 2")
         another_team = Team.objects.create(organization=another_org, name="Test Team")
         another_user = User.objects.create_and_join(
@@ -808,7 +840,11 @@ class TestAWSRoleBasedIntegration:
         client.force_login(another_user)
         payload = {
             "kind": self.integration_kind,
-            "config": {"name": "prod-aws", "aws_role_arn": "something"},
+            "config": {
+                "name": "prod-aws",
+                "aws_role_arn": "arn:aws:iam::123456789012:role/my-role",
+                **self.extra_config,
+            },
         }
 
         first = client.post(
@@ -821,11 +857,16 @@ class TestAWSRoleBasedIntegration:
         assert second.status_code == status.HTTP_400_BAD_REQUEST
         assert "Cannot create AWS integration: Invalid role" in second.json()["detail"]
 
-    def test_create_rejects_duplicate_name(self, client: HttpClient):
+    @patch("posthog.models.integration.aws.validate_aws_role_arn")
+    def test_create_rejects_duplicate_name(self, mock_validate, client: HttpClient):
         client.force_login(self.user)
         payload = {
             "kind": self.integration_kind,
-            "config": {"name": "prod-aws", "aws_role_arn": "something"},
+            "config": {
+                "name": "prod-aws",
+                "aws_role_arn": "arn:aws:iam::123456789012:role/my-role",
+                **self.extra_config,
+            },
         }
 
         first = client.post(f"/api/environments/{self.team.pk}/integrations", payload, content_type="application/json")

--- a/posthog/models/integration/aws.py
+++ b/posthog/models/integration/aws.py
@@ -9,6 +9,7 @@ from typing import Any, ClassVar, Literal
 from django.conf import settings
 from django.db import transaction
 
+import structlog
 from rest_framework.exceptions import ValidationError
 
 from posthog.credentials import AWSKeyPair
@@ -19,6 +20,8 @@ from posthog.security.url_validation import is_url_allowed
 from . import common, model
 
 _AWSKindType = Literal[model.Integration.IntegrationKind.AWS_REDSHIFT, model.Integration.IntegrationKind.AWS_S3]
+
+LOGGER = structlog.get_logger(__name__)
 
 
 def _read_aws_credentials(integration: model.Integration) -> AWSKeyPair:
@@ -164,8 +167,9 @@ def validate_aws_role_arn(aws_role_arn: str, our_aws_role_arn: str, external_id:
                 }
             ),
         )
-    except (ClientError, BotoCoreError) as e:
-        raise common.IntegrationError(f"Could not validate AWS role ARN: {e}")
+    except (ClientError, BotoCoreError):
+        LOGGER.exception("Assume role failed")
+        raise common.IntegrationError("Could not validate AWS role ARN due to an internal error. Try again later.")
 
     external_session = boto3.Session(
         aws_access_key_id=first_response["Credentials"]["AccessKeyId"],

--- a/posthog/models/integration/aws.py
+++ b/posthog/models/integration/aws.py
@@ -1,8 +1,12 @@
 """AWS role/credential-based integrations (S3, Redshift, S3-compatible endpoints)."""
 
+import re
+import json
+import secrets
 from collections.abc import Mapping
-from typing import ClassVar, Literal
+from typing import Any, ClassVar, Literal
 
+from django.conf import settings
 from django.db import transaction
 
 from rest_framework.exceptions import ValidationError
@@ -36,13 +40,14 @@ def _create_unique_aws_integration(
     account_id: str,
     credentials: AWSKeyPair,
     created_by: "User | None",
+    **extra,
 ) -> model.Integration:
     """Create an AWS integration from credentials and an account."""
     return _create_unique_named_integration(
         team_id=team_id,
         kind=kind,
         name=name,
-        config={"name": name, "aws_account_id": account_id},
+        config={"name": name, "aws_account_id": account_id, **extra},
         sensitive_config={
             "aws_access_key_id": credentials.access_key_id,
             "aws_secret_access_key": credentials.secret_access_key,
@@ -116,6 +121,91 @@ def _return_non_empty_str_from_config_for_aws(config: Mapping, key: str, friendl
     return common._return_non_empty_str_from_config(config, key, friendly_name=friendly_name, kind="AWS")
 
 
+AWS_ROLE_ARN_RE = re.compile(r"^arn:aws(-[a-z-]+)?:iam::\d{12}:role/.+")
+
+
+def validate_aws_role_arn(aws_role_arn: str, our_aws_role_arn: str, external_id: str) -> None:
+    """Validate we can assume an AWS role ARN.
+
+    Users who have configured role based authentication must grant one of our
+    AWS roles permissions to assume their role. So, here we validate that
+    our_aws_role_arn can assume their aws_role_arn.
+
+    This requires two steps: A first step to assume our own AWS role (as the
+    current session's role may not necessarilly be the one we have given our
+    users), and a second step to actually test whether we can assume our user's
+    role.
+    """
+    import boto3  # noqa: PLC0415 — keeps botocore off the module import path (startup time)
+    from botocore.config import Config  # noqa: PLC0415
+    from botocore.exceptions import BotoCoreError, ClientError  # noqa: PLC0415
+
+    if not AWS_ROLE_ARN_RE.match(aws_role_arn):
+        raise common.IntegrationError("AWS role ARN is not valid")
+
+    config = Config(connect_timeout=5, read_timeout=5, retries={"max_attempts": 1})
+    sts = boto3.client("sts", config=config)
+    try:
+        first_response = sts.assume_role(
+            RoleArn=our_aws_role_arn,
+            RoleSessionName="PostHog-validate-aws-role-arn",
+            Policy=json.dumps(
+                # Narrow permissions to only allow assuming provided role with this
+                # session.
+                {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Action": ["sts:AssumeRole"],
+                            "Resource": aws_role_arn,
+                        },
+                    ],
+                }
+            ),
+        )
+    except (ClientError, BotoCoreError) as e:
+        raise common.IntegrationError(f"Could not validate AWS role ARN: {e}")
+
+    external_session = boto3.Session(
+        aws_access_key_id=first_response["Credentials"]["AccessKeyId"],
+        aws_secret_access_key=first_response["Credentials"]["SecretAccessKey"],
+        aws_session_token=first_response["Credentials"]["SessionToken"],
+    )
+    external_sts = external_session.client("sts", config=config)
+
+    try:
+        # These two calls are required to test both that an external id is
+        # required and that it's not set to wildcard.
+        _ = sts.assume_role(
+            RoleArn=aws_role_arn,
+            RoleSessionName="PostHog-validate-aws-role-arn",
+            ExternalId=secrets.token_hex(67),
+        )
+        _ = sts.assume_role(
+            RoleArn=aws_role_arn,
+            RoleSessionName="PostHog-validate-aws-role-arn",
+        )
+    except Exception:
+        # We expect this to fail if external id is configured correctly
+        pass
+    else:
+        raise common.IntegrationError(
+            f"The provided role '{aws_role_arn}' allows access without a required external id condition. Update the role's policy with a condition to match '{external_id}' as a external id."
+        )
+
+    try:
+        _ = external_sts.assume_role(
+            RoleArn=aws_role_arn,
+            RoleSessionName="PostHog-validate-aws-role-arn",
+            ExternalId=external_id,
+        )
+    except ClientError:
+        raise common.IntegrationError("AWS role ARN is not valid")
+    except BotoCoreError:
+        raise common.IntegrationError("Could not validate AWS role ARN")
+
+
 def validate_aws_credentials(aws_access_key_id: str, aws_secret_access_key: str) -> str:
     """Validate AWS credentials via STS GetCallerIdentity, returning the AWS account id.
 
@@ -168,6 +258,11 @@ class AWSRoleBasedIntegration:
         except KeyError:
             raise common.IntegrationError("AWS integration is not valid: 'aws_role_arn' missing")
 
+    @property
+    def aws_account_id(self) -> str:
+        """The AWS account id parsed from the role ARN."""
+        return self.aws_role_arn.split(":")[4]
+
     @classmethod
     def integration_from_config(
         cls,
@@ -182,14 +277,30 @@ class AWSRoleBasedIntegration:
         if not is_unique_aws_role_by_organization_id(aws_role_arn, organization_id):
             raise ValidationError("Cannot create AWS integration: Invalid role")
 
+        extra = cls.read_extra_configuration_parameters(**config)
+
+        # Currently, only batch exports uses this integration.
+        # If you are using this integration outside batch exports, then you should make the our_aws_role_arn and external_id configurable.
+        # TODO: Make our_aws_role_arn external_id configurable.
+        validate_aws_role_arn(
+            aws_role_arn=aws_role_arn,
+            our_aws_role_arn=settings.BATCH_EXPORT_S3_EXTERNAL_ROLE_ARN,
+            external_id=f"posthog-{organization_id}",
+        )
+
         return _create_unique_named_integration(
             team_id=team_id,
             kind=cls.integration_kind,
             name=name,
-            config={"name": name, "aws_role_arn": aws_role_arn},
+            config={"name": name, "aws_role_arn": aws_role_arn, **extra},
             sensitive_config={},
             created_by=created_by,
         )
+
+    @staticmethod
+    def read_extra_configuration_parameters(**config) -> dict[str, Any]:
+        """Subclasses can override this to do further processing on the configuration."""
+        return {}
 
 
 class AWSS3RoleBasedIntegration(AWSRoleBasedIntegration):
@@ -200,12 +311,82 @@ class AWSS3RoleBasedIntegration(AWSRoleBasedIntegration):
     )
 
 
+def _return_redshift_groups(**config) -> list[str] | None:
+    if (groups := config.get("groups")) is not None:
+        if not isinstance(groups, list) or any(not isinstance(group, str) for group in groups) or len(groups) < 1:
+            raise common.IntegrationError("Groups must be a list of at least one string")
+
+        return groups
+    return None
+
+
+def _return_redshift_auto_create(**config) -> bool | None:
+    if (auto_create := config.get("auto_create")) is not None:
+        if not isinstance(auto_create, bool):
+            raise common.IntegrationError("Auto create can only be True or False")
+
+        return auto_create
+    return None
+
+
+AWS_REDSHIFT_SERVERLESS_WORKGROUP_ARN_RE = re.compile(
+    r"^arn:aws(-[a-z-]+)?:redshift-serverless:[a-z0-9-]+:\d{12}:workgroup/.+"
+)
+
+
+def _return_redshift_workgroup_arn(**config) -> str | None:
+    if (workgroup_arn := config.get("workgroup_arn")) is not None:
+        if not isinstance(workgroup_arn, str) or not AWS_REDSHIFT_SERVERLESS_WORKGROUP_ARN_RE.match(workgroup_arn):
+            raise common.IntegrationError("Workgroup ARN must be a valid Redshift Serverless workgroup ARN")
+
+        return workgroup_arn
+    return None
+
+
+def _return_extra_redshift_configuration(**config) -> dict[str, Any]:
+    user = _return_non_empty_str_from_config_for_aws(config, "user", "Username")
+
+    extra: dict[str, Any] = {"user": user}
+
+    if (groups := _return_redshift_groups(**config)) is not None:
+        extra["groups"] = groups
+
+    if (auto_create := _return_redshift_auto_create(**config)) is not None:
+        extra["auto_create"] = auto_create
+
+    if (workgroup_arn := _return_redshift_workgroup_arn(**config)) is not None:
+        extra["workgroup_arn"] = workgroup_arn
+
+    return extra
+
+
 class AWSRedshiftRoleBasedIntegration(AWSRoleBasedIntegration):
     """An AWS Redshift integration storing a customer's AWS role."""
 
     integration_kind: ClassVar[Literal[model.Integration.IntegrationKind.AWS_REDSHIFT]] = (
         model.Integration.IntegrationKind.AWS_REDSHIFT
     )
+
+    @property
+    def user(self) -> str:
+        return self.integration.config["user"]
+
+    @property
+    def groups(self) -> list[str] | None:
+        return self.integration.config.get("groups")
+
+    @property
+    def auto_create(self) -> bool | None:
+        return self.integration.config.get("auto_create")
+
+    @property
+    def workgroup_arn(self) -> str | None:
+        """ARN of a Redshift Serverless workgroup, required when the cluster is Serverless."""
+        return self.integration.config.get("workgroup_arn")
+
+    @staticmethod
+    def read_extra_configuration_parameters(**config) -> dict[str, Any]:
+        return _return_extra_redshift_configuration(**config)
 
 
 class AWSCredentialsIntegration:
@@ -267,6 +448,8 @@ class AWSCredentialsIntegration:
         # values is what they say they are. This call is safe.
         credentials = AWSKeyPair.unsafe_from_strings(aws_access_key_id, aws_secret_access_key)
 
+        extra = cls.read_extra_configuration_parameters(**config)
+
         # `name` is the unencrypted, frontend-visible identifier — never an AWS credential, which is
         # treated as a secret. The account id is non-sensitive and kept for display/debugging.
         return _create_unique_aws_integration(
@@ -276,7 +459,13 @@ class AWSCredentialsIntegration:
             account_id=account_id,
             credentials=credentials,
             created_by=created_by,
+            **extra,
         )
+
+    @staticmethod
+    def read_extra_configuration_parameters(**config) -> dict[str, Any]:
+        """Subclasses can override this to do further processing on the configuration."""
+        return {}
 
 
 class AWSS3Integration(AWSCredentialsIntegration):
@@ -297,6 +486,27 @@ class AWSRedshiftIntegration(AWSCredentialsIntegration):
     integration_kind: ClassVar[Literal[model.Integration.IntegrationKind.AWS_REDSHIFT]] = (
         model.Integration.IntegrationKind.AWS_REDSHIFT
     )
+
+    @property
+    def user(self) -> str:
+        return self.integration.config["user"]
+
+    @property
+    def groups(self) -> list[str] | None:
+        return self.integration.config.get("groups")
+
+    @property
+    def auto_create(self) -> bool | None:
+        return self.integration.config.get("auto_create")
+
+    @property
+    def workgroup_arn(self) -> str | None:
+        """ARN of a Redshift Serverless workgroup, required when the cluster is Serverless."""
+        return self.integration.config.get("workgroup_arn")
+
+    @staticmethod
+    def read_extra_configuration_parameters(**config) -> dict[str, Any]:
+        return _return_extra_redshift_configuration(**config)
 
 
 def _return_non_empty_str_from_config_for_s3_compatible(config: Mapping, key: str, friendly_name: str) -> str:

--- a/posthog/models/integration/aws.py
+++ b/posthog/models/integration/aws.py
@@ -178,20 +178,27 @@ def validate_aws_role_arn(aws_role_arn: str, our_aws_role_arn: str, external_id:
     )
     external_sts = external_session.client("sts", config=config)
 
+    # These two tests are required to test both that an external id is
+    # required and that it's not set to wildcard.
     try:
-        # These two calls are required to test both that an external id is
-        # required and that it's not set to wildcard.
-        _ = sts.assume_role(
+        _ = external_sts.assume_role(
             RoleArn=aws_role_arn,
             RoleSessionName="PostHog-validate-aws-role-arn",
-            ExternalId=secrets.token_hex(67),
+            ExternalId=f"posthog-{secrets.token_hex(67)}",
         )
-        _ = sts.assume_role(
+    except Exception:
+        pass
+    else:
+        raise common.IntegrationError(
+            f"The provided role '{aws_role_arn}' allows access without a required external id condition. Update the role's policy with a condition to match '{external_id}' as a external id."
+        )
+
+    try:
+        _ = external_sts.assume_role(
             RoleArn=aws_role_arn,
             RoleSessionName="PostHog-validate-aws-role-arn",
         )
     except Exception:
-        # We expect this to fail if external id is configured correctly
         pass
     else:
         raise common.IntegrationError(


### PR DESCRIPTION
<!-- This has to stand on its own: a reader who opens no files should still know why the PR is necessary and what it does. Length tracks the change, so a small diff gets a few bullets rather than a full-length body, and a section you have nothing for gets one line or "None". -->

## Problem

Redshift does not currently support integrations, like all other batch export destinations, and additionally users are still having to provide us plain text credentials. So, we should add support for integrations + role based authentication in Redshift.

This is PR 1/3 in the stack.

<!-- Who are we building for, what are their needs, why is this important? -->
<!-- First line: what is different for a person, and who they are. A fix says what breaks; a feature says what someone can now do; a chore says who is blocked. The code path goes underneath. -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

As setup for the Redshift work, I had to update the role-based integration models introduced in https://github.com/PostHog/posthog/pull/76745. I should have probably tried to use the classes then to avoid this small refactor here. But regardless, the role-based integration classes now support an extra set of parameters, and can return an aws account id. Redshift uses a bunch of parameters (like groups, user and auto_create) and the account id in AWS API requests to obtain credentials (see the PRs in the rest of the stack).

We also now validate the AWS role ARN when creating the integration, so that we can later rely on it (e.g. to parse the account id). This matches the work done by regular AWS integrations, so I think it's nice to be consistent.

<!-- For each change a person can notice, say what they will now see or do differently, not only the code path that does it. Mark the rest as mechanical so a reviewer knows nothing user-visible is hiding in it. -->

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Ran existing tests, added new ones.
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->
<!-- Don't recite pass counts for suites CI runs; the checks report those with more authority. Link the evidence instead (run, permalink, error tracking issue), and say what you did not check. Long transcripts go in a <details> block. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

Not yet

## Docs update

Not yet

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

I wrote the initial implementation myself. Had the robot review, which ended up fixing a lot of issues here and there, but none that required substantial changes to the code I had already written.

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
     - Public artifact: nothing in this PR — code, fixtures and sample data, comments, commit messages, or this description — carries material from the agent session that isn't already public. If the work drew on a customer conversation, ticket, or log, say so here and state that the committed data is invented. Renaming people, hosts, and identifiers does not clear real material; see AGENTS.md "Public open source repo guidance".
-->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way: what changed across the session. The reason the shipped design beats the obvious alternative goes in Changes instead, where a reviewer will actually see it.
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session — that applies to every part of this PR, not just this section.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Voice: the subject of every sentence is the change, never its author. No "I", "me" or "my" anywhere in the body. "I (actually Claude)" is worse than either half: it hands the assignee an account of work they did not do. Authorship is one stated fact in the Agent context section below.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Flow and topology changes: include separate before-and-after Mermaid `flowchart` blocks with PostHog colors. This includes CI wiring, pipelines, state machines, and request paths. Use `/writing-pr-descriptions` for the palette and role mapping.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Stack instead of stuffing: if the diff holds two or more separable steps (migration then behavior, rename then rewrite), open a stack rather than one big PR. See AGENTS.md, "Stacked PRs" and /stacking-prs.
- Simplify before opening: if your agent has a behavior-preserving cleanup pass (Claude Code: `/simplify`), run it on a non-trivial diff before final tests and preflight, since it edits the tree. Skip it for small mechanical changes.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- Shape and style: invoke the `/writing-pr-descriptions` skill before writing this body. In short: lead with the effect a person sees rather than the code path behind it, make the body stand alone for a reader who opens no files, size it to the change, link evidence rather than asserting what CI already reports, then hold what's left to one fact per bullet in under 25 words. A body that got longer as bullets was not cut.
-->
