### PR TITLE
feat(redshift-batch-export): Support integration models 

### DIFF
--- a/posthog/api/integration.py
+++ b/posthog/api/integration.py
@@ -854,10 +854,12 @@ class IntegrationSerializer(serializers.ModelSerializer, UserAccessControlSerial
                 redshift_integration: (
                     type[RedshiftIntegration] | type[AWSRedshiftIntegration] | type[AWSRedshiftRoleBasedIntegration]
                 ) = AWSRedshiftRoleBasedIntegration
+            elif any(required in config for required in ("aws_access_key_id", "aws_secret_access_key")):
+                # Checked before the plain-server keys: AWS-credential configs also carry
+                # 'user' (the database user to obtain temporary credentials for).
+                redshift_integration = AWSRedshiftIntegration
             elif any(required in config for required in ("host", "port", "user", "password")):
                 redshift_integration = RedshiftIntegration
-            elif any(required in config for required in ("aws_access_key_id", "aws_secret_access_key")):
-                redshift_integration = AWSRedshiftIntegration
             else:
                 raise ValidationError("Missing required inputs")
 

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -637,6 +637,11 @@ class TestAWSIntegration:
             self.organization, "test@posthog.com", "test", level=OrganizationMembership.Level.ADMIN
         )
         self.integration_kind = aws_integration_kind
+        # Redshift integrations also carry the database user to obtain temporary credentials for.
+        if aws_integration_kind == Integration.IntegrationKind.AWS_REDSHIFT:
+            self.extra_config = {"user": "awsuser"}
+        else:
+            self.extra_config = {}
 
     @patch("posthog.models.integration.aws.validate_aws_credentials", return_value="123456789012")
     def test_create_with_valid_config(self, mock_validate, client: HttpClient):
@@ -650,6 +655,7 @@ class TestAWSIntegration:
                     "name": "prod-aws",
                     "aws_access_key_id": "AKIAEXAMPLE",
                     "aws_secret_access_key": "secret",
+                    **self.extra_config,
                 },
             },
             content_type="application/json",
@@ -662,7 +668,7 @@ class TestAWSIntegration:
         assert integration.kind == self.integration_kind
         assert integration.team == self.team
         assert integration.integration_id == "prod-aws"
-        assert integration.config == {"name": "prod-aws", "aws_account_id": "123456789012"}
+        assert integration.config == {"name": "prod-aws", "aws_account_id": "123456789012", **self.extra_config}
         assert integration.sensitive_config == {
             "aws_access_key_id": "AKIAEXAMPLE",
             "aws_secret_access_key": "secret",
@@ -702,7 +708,12 @@ class TestAWSIntegration:
         client.force_login(self.user)
         payload = {
             "kind": self.integration_kind,
-            "config": {"name": "prod-aws", "aws_access_key_id": "AKIAEXAMPLE", "aws_secret_access_key": "secret"},
+            "config": {
+                "name": "prod-aws",
+                "aws_access_key_id": "AKIAEXAMPLE",
+                "aws_secret_access_key": "secret",
+                **self.extra_config,
+            },
         }
 
         first = client.post(f"/api/environments/{self.team.pk}/integrations", payload, content_type="application/json")

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -772,8 +772,14 @@ class TestAWSRoleBasedIntegration:
         )
 
         self.integration_kind = aws_integration_kind
+        # Redshift integrations also carry the database user to obtain temporary credentials for.
+        if aws_integration_kind == Integration.IntegrationKind.AWS_REDSHIFT:
+            self.extra_config = {"user": "awsuser"}
+        else:
+            self.extra_config = {}
 
-    def test_create_with_valid_config(self, client: HttpClient):
+    @patch("posthog.models.integration.aws.validate_aws_role_arn")
+    def test_create_with_valid_config(self, mock_validate, client: HttpClient):
         client.force_login(self.user)
 
         role = "arn:aws:iam::123456789012:role/my-role"
@@ -784,6 +790,7 @@ class TestAWSRoleBasedIntegration:
                 "config": {
                     "name": "prod-aws",
                     "aws_role_arn": role,
+                    **self.extra_config,
                 },
             },
             content_type="application/json",
@@ -796,10 +803,35 @@ class TestAWSRoleBasedIntegration:
         assert integration.kind == self.integration_kind
         assert integration.team == self.team
         assert integration.integration_id == "prod-aws"
-        assert integration.config == {"name": "prod-aws", "aws_role_arn": role}
+        assert integration.config == {"name": "prod-aws", "aws_role_arn": role, **self.extra_config}
         assert integration.sensitive_config == {}
 
-    def test_create_rejects_duplicate_role_in_different_org(self, client: HttpClient):
+    @patch("posthog.models.integration.aws.validate_aws_role_arn")
+    def test_create_rejects_invalid_role_arn(self, mock_validate, client: HttpClient):
+        from posthog.models.integration import IntegrationError
+
+        mock_validate.side_effect = IntegrationError("AWS role ARN is not valid")
+        client.force_login(self.user)
+
+        response = client.post(
+            f"/api/environments/{self.team.pk}/integrations",
+            {
+                "kind": self.integration_kind,
+                "config": {
+                    "name": "prod-aws",
+                    "aws_role_arn": "arn:aws:iam::123456789012:role/not-assumable",
+                    **self.extra_config,
+                },
+            },
+            content_type="application/json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "AWS role ARN is not valid" in response.json()["detail"]
+        assert not Integration.objects.filter(team=self.team, kind=self.integration_kind).exists()
+
+    @patch("posthog.models.integration.aws.validate_aws_role_arn")
+    def test_create_rejects_duplicate_role_in_different_org(self, mock_validate, client: HttpClient):
         another_org = Organization.objects.create(name="Test Org 2")
         another_team = Team.objects.create(organization=another_org, name="Test Team")
         another_user = User.objects.create_and_join(
@@ -808,7 +840,11 @@ class TestAWSRoleBasedIntegration:
         client.force_login(another_user)
         payload = {
             "kind": self.integration_kind,
-            "config": {"name": "prod-aws", "aws_role_arn": "something"},
+            "config": {
+                "name": "prod-aws",
+                "aws_role_arn": "arn:aws:iam::123456789012:role/my-role",
+                **self.extra_config,
+            },
         }
 
         first = client.post(
@@ -821,11 +857,16 @@ class TestAWSRoleBasedIntegration:
         assert second.status_code == status.HTTP_400_BAD_REQUEST
         assert "Cannot create AWS integration: Invalid role" in second.json()["detail"]
 
-    def test_create_rejects_duplicate_name(self, client: HttpClient):
+    @patch("posthog.models.integration.aws.validate_aws_role_arn")
+    def test_create_rejects_duplicate_name(self, mock_validate, client: HttpClient):
         client.force_login(self.user)
         payload = {
             "kind": self.integration_kind,
-            "config": {"name": "prod-aws", "aws_role_arn": "something"},
+            "config": {
+                "name": "prod-aws",
+                "aws_role_arn": "arn:aws:iam::123456789012:role/my-role",
+                **self.extra_config,
+            },
         }
 
         first = client.post(f"/api/environments/{self.team.pk}/integrations", payload, content_type="application/json")

--- a/posthog/models/integration/aws.py
+++ b/posthog/models/integration/aws.py
@@ -9,6 +9,7 @@ from typing import Any, ClassVar, Literal
 from django.conf import settings
 from django.db import transaction
 
+import structlog
 from rest_framework.exceptions import ValidationError
 
 from posthog.credentials import AWSKeyPair
@@ -19,6 +20,8 @@ from posthog.security.url_validation import is_url_allowed
 from . import common, model
 
 _AWSKindType = Literal[model.Integration.IntegrationKind.AWS_REDSHIFT, model.Integration.IntegrationKind.AWS_S3]
+
+LOGGER = structlog.get_logger(__name__)
 
 
 def _read_aws_credentials(integration: model.Integration) -> AWSKeyPair:
@@ -164,8 +167,9 @@ def validate_aws_role_arn(aws_role_arn: str, our_aws_role_arn: str, external_id:
                 }
             ),
         )
-    except (ClientError, BotoCoreError) as e:
-        raise common.IntegrationError(f"Could not validate AWS role ARN: {e}")
+    except (ClientError, BotoCoreError):
+        LOGGER.exception("Assume role failed")
+        raise common.IntegrationError("Could not validate AWS role ARN due to an internal error. Try again later.")
 
     external_session = boto3.Session(
         aws_access_key_id=first_response["Credentials"]["AccessKeyId"],

--- a/posthog/models/integration/aws.py
+++ b/posthog/models/integration/aws.py
@@ -1,8 +1,12 @@
 """AWS role/credential-based integrations (S3, Redshift, S3-compatible endpoints)."""
 
+import re
+import json
+import secrets
 from collections.abc import Mapping
-from typing import ClassVar, Literal
+from typing import Any, ClassVar, Literal
 
+from django.conf import settings
 from django.db import transaction
 
 from rest_framework.exceptions import ValidationError
@@ -36,13 +40,14 @@ def _create_unique_aws_integration(
     account_id: str,
     credentials: AWSKeyPair,
     created_by: "User | None",
+    **extra,
 ) -> model.Integration:
     """Create an AWS integration from credentials and an account."""
     return _create_unique_named_integration(
         team_id=team_id,
         kind=kind,
         name=name,
-        config={"name": name, "aws_account_id": account_id},
+        config={"name": name, "aws_account_id": account_id, **extra},
         sensitive_config={
             "aws_access_key_id": credentials.access_key_id,
             "aws_secret_access_key": credentials.secret_access_key,
@@ -116,6 +121,91 @@ def _return_non_empty_str_from_config_for_aws(config: Mapping, key: str, friendl
     return common._return_non_empty_str_from_config(config, key, friendly_name=friendly_name, kind="AWS")
 
 
+AWS_ROLE_ARN_RE = re.compile(r"^arn:aws(-[a-z-]+)?:iam::\d{12}:role/.+")
+
+
+def validate_aws_role_arn(aws_role_arn: str, our_aws_role_arn: str, external_id: str) -> None:
+    """Validate we can assume an AWS role ARN.
+
+    Users who have configured role based authentication must grant one of our
+    AWS roles permissions to assume their role. So, here we validate that
+    our_aws_role_arn can assume their aws_role_arn.
+
+    This requires two steps: A first step to assume our own AWS role (as the
+    current session's role may not necessarilly be the one we have given our
+    users), and a second step to actually test whether we can assume our user's
+    role.
+    """
+    import boto3  # noqa: PLC0415 — keeps botocore off the module import path (startup time)
+    from botocore.config import Config  # noqa: PLC0415
+    from botocore.exceptions import BotoCoreError, ClientError  # noqa: PLC0415
+
+    if not AWS_ROLE_ARN_RE.match(aws_role_arn):
+        raise common.IntegrationError("AWS role ARN is not valid")
+
+    config = Config(connect_timeout=5, read_timeout=5, retries={"max_attempts": 1})
+    sts = boto3.client("sts", config=config)
+    try:
+        first_response = sts.assume_role(
+            RoleArn=our_aws_role_arn,
+            RoleSessionName="PostHog-validate-aws-role-arn",
+            Policy=json.dumps(
+                # Narrow permissions to only allow assuming provided role with this
+                # session.
+                {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Action": ["sts:AssumeRole"],
+                            "Resource": aws_role_arn,
+                        },
+                    ],
+                }
+            ),
+        )
+    except (ClientError, BotoCoreError) as e:
+        raise common.IntegrationError(f"Could not validate AWS role ARN: {e}")
+
+    external_session = boto3.Session(
+        aws_access_key_id=first_response["Credentials"]["AccessKeyId"],
+        aws_secret_access_key=first_response["Credentials"]["SecretAccessKey"],
+        aws_session_token=first_response["Credentials"]["SessionToken"],
+    )
+    external_sts = external_session.client("sts", config=config)
+
+    try:
+        # These two calls are required to test both that an external id is
+        # required and that it's not set to wildcard.
+        _ = sts.assume_role(
+            RoleArn=aws_role_arn,
+            RoleSessionName="PostHog-validate-aws-role-arn",
+            ExternalId=secrets.token_hex(67),
+        )
+        _ = sts.assume_role(
+            RoleArn=aws_role_arn,
+            RoleSessionName="PostHog-validate-aws-role-arn",
+        )
+    except Exception:
+        # We expect this to fail if external id is configured correctly
+        pass
+    else:
+        raise common.IntegrationError(
+            f"The provided role '{aws_role_arn}' allows access without a required external id condition. Update the role's policy with a condition to match '{external_id}' as a external id."
+        )
+
+    try:
+        _ = external_sts.assume_role(
+            RoleArn=aws_role_arn,
+            RoleSessionName="PostHog-validate-aws-role-arn",
+            ExternalId=external_id,
+        )
+    except ClientError:
+        raise common.IntegrationError("AWS role ARN is not valid")
+    except BotoCoreError:
+        raise common.IntegrationError("Could not validate AWS role ARN")
+
+
 def validate_aws_credentials(aws_access_key_id: str, aws_secret_access_key: str) -> str:
     """Validate AWS credentials via STS GetCallerIdentity, returning the AWS account id.
 
@@ -168,6 +258,11 @@ class AWSRoleBasedIntegration:
         except KeyError:
             raise common.IntegrationError("AWS integration is not valid: 'aws_role_arn' missing")
 
+    @property
+    def aws_account_id(self) -> str:
+        """The AWS account id parsed from the role ARN."""
+        return self.aws_role_arn.split(":")[4]
+
     @classmethod
     def integration_from_config(
         cls,
@@ -182,14 +277,30 @@ class AWSRoleBasedIntegration:
         if not is_unique_aws_role_by_organization_id(aws_role_arn, organization_id):
             raise ValidationError("Cannot create AWS integration: Invalid role")
 
+        extra = cls.read_extra_configuration_parameters(**config)
+
+        # Currently, only batch exports uses this integration.
+        # If you are using this integration outside batch exports, then you should make the our_aws_role_arn and external_id configurable.
+        # TODO: Make our_aws_role_arn external_id configurable.
+        validate_aws_role_arn(
+            aws_role_arn=aws_role_arn,
+            our_aws_role_arn=settings.BATCH_EXPORT_S3_EXTERNAL_ROLE_ARN,
+            external_id=f"posthog-{organization_id}",
+        )
+
         return _create_unique_named_integration(
             team_id=team_id,
             kind=cls.integration_kind,
             name=name,
-            config={"name": name, "aws_role_arn": aws_role_arn},
+            config={"name": name, "aws_role_arn": aws_role_arn, **extra},
             sensitive_config={},
             created_by=created_by,
         )
+
+    @staticmethod
+    def read_extra_configuration_parameters(**config) -> dict[str, Any]:
+        """Subclasses can override this to do further processing on the configuration."""
+        return {}
 
 
 class AWSS3RoleBasedIntegration(AWSRoleBasedIntegration):
@@ -200,12 +311,82 @@ class AWSS3RoleBasedIntegration(AWSRoleBasedIntegration):
     )
 
 
+def _return_redshift_groups(**config) -> list[str] | None:
+    if (groups := config.get("groups")) is not None:
+        if not isinstance(groups, list) or any(not isinstance(group, str) for group in groups) or len(groups) < 1:
+            raise common.IntegrationError("Groups must be a list of at least one string")
+
+        return groups
+    return None
+
+
+def _return_redshift_auto_create(**config) -> bool | None:
+    if (auto_create := config.get("auto_create")) is not None:
+        if not isinstance(auto_create, bool):
+            raise common.IntegrationError("Auto create can only be True or False")
+
+        return auto_create
+    return None
+
+
+AWS_REDSHIFT_SERVERLESS_WORKGROUP_ARN_RE = re.compile(
+    r"^arn:aws(-[a-z-]+)?:redshift-serverless:[a-z0-9-]+:\d{12}:workgroup/.+"
+)
+
+
+def _return_redshift_workgroup_arn(**config) -> str | None:
+    if (workgroup_arn := config.get("workgroup_arn")) is not None:
+        if not isinstance(workgroup_arn, str) or not AWS_REDSHIFT_SERVERLESS_WORKGROUP_ARN_RE.match(workgroup_arn):
+            raise common.IntegrationError("Workgroup ARN must be a valid Redshift Serverless workgroup ARN")
+
+        return workgroup_arn
+    return None
+
+
+def _return_extra_redshift_configuration(**config) -> dict[str, Any]:
+    user = _return_non_empty_str_from_config_for_aws(config, "user", "Username")
+
+    extra: dict[str, Any] = {"user": user}
+
+    if (groups := _return_redshift_groups(**config)) is not None:
+        extra["groups"] = groups
+
+    if (auto_create := _return_redshift_auto_create(**config)) is not None:
+        extra["auto_create"] = auto_create
+
+    if (workgroup_arn := _return_redshift_workgroup_arn(**config)) is not None:
+        extra["workgroup_arn"] = workgroup_arn
+
+    return extra
+
+
 class AWSRedshiftRoleBasedIntegration(AWSRoleBasedIntegration):
     """An AWS Redshift integration storing a customer's AWS role."""
 
     integration_kind: ClassVar[Literal[model.Integration.IntegrationKind.AWS_REDSHIFT]] = (
         model.Integration.IntegrationKind.AWS_REDSHIFT
     )
+
+    @property
+    def user(self) -> str:
+        return self.integration.config["user"]
+
+    @property
+    def groups(self) -> list[str] | None:
+        return self.integration.config.get("groups")
+
+    @property
+    def auto_create(self) -> bool | None:
+        return self.integration.config.get("auto_create")
+
+    @property
+    def workgroup_arn(self) -> str | None:
+        """ARN of a Redshift Serverless workgroup, required when the cluster is Serverless."""
+        return self.integration.config.get("workgroup_arn")
+
+    @staticmethod
+    def read_extra_configuration_parameters(**config) -> dict[str, Any]:
+        return _return_extra_redshift_configuration(**config)
 
 
 class AWSCredentialsIntegration:
@@ -267,6 +448,8 @@ class AWSCredentialsIntegration:
         # values is what they say they are. This call is safe.
         credentials = AWSKeyPair.unsafe_from_strings(aws_access_key_id, aws_secret_access_key)
 
+        extra = cls.read_extra_configuration_parameters(**config)
+
         # `name` is the unencrypted, frontend-visible identifier — never an AWS credential, which is
         # treated as a secret. The account id is non-sensitive and kept for display/debugging.
         return _create_unique_aws_integration(
@@ -276,7 +459,13 @@ class AWSCredentialsIntegration:
             account_id=account_id,
             credentials=credentials,
             created_by=created_by,
+            **extra,
         )
+
+    @staticmethod
+    def read_extra_configuration_parameters(**config) -> dict[str, Any]:
+        """Subclasses can override this to do further processing on the configuration."""
+        return {}
 
 
 class AWSS3Integration(AWSCredentialsIntegration):
@@ -297,6 +486,27 @@ class AWSRedshiftIntegration(AWSCredentialsIntegration):
     integration_kind: ClassVar[Literal[model.Integration.IntegrationKind.AWS_REDSHIFT]] = (
         model.Integration.IntegrationKind.AWS_REDSHIFT
     )
+
+    @property
+    def user(self) -> str:
+        return self.integration.config["user"]
+
+    @property
+    def groups(self) -> list[str] | None:
+        return self.integration.config.get("groups")
+
+    @property
+    def auto_create(self) -> bool | None:
+        return self.integration.config.get("auto_create")
+
+    @property
+    def workgroup_arn(self) -> str | None:
+        """ARN of a Redshift Serverless workgroup, required when the cluster is Serverless."""
+        return self.integration.config.get("workgroup_arn")
+
+    @staticmethod
+    def read_extra_configuration_parameters(**config) -> dict[str, Any]:
+        return _return_extra_redshift_configuration(**config)
 
 
 def _return_non_empty_str_from_config_for_s3_compatible(config: Mapping, key: str, friendly_name: str) -> str:

--- a/posthog/models/integration/aws.py
+++ b/posthog/models/integration/aws.py
@@ -178,20 +178,27 @@ def validate_aws_role_arn(aws_role_arn: str, our_aws_role_arn: str, external_id:
     )
     external_sts = external_session.client("sts", config=config)
 
+    # These two tests are required to test both that an external id is
+    # required and that it's not set to wildcard.
     try:
-        # These two calls are required to test both that an external id is
-        # required and that it's not set to wildcard.
-        _ = sts.assume_role(
+        _ = external_sts.assume_role(
             RoleArn=aws_role_arn,
             RoleSessionName="PostHog-validate-aws-role-arn",
-            ExternalId=secrets.token_hex(67),
+            ExternalId=f"posthog-{secrets.token_hex(67)}",
         )
-        _ = sts.assume_role(
+    except Exception:
+        pass
+    else:
+        raise common.IntegrationError(
+            f"The provided role '{aws_role_arn}' allows access without a required external id condition. Update the role's policy with a condition to match '{external_id}' as a external id."
+        )
+
+    try:
+        _ = external_sts.assume_role(
             RoleArn=aws_role_arn,
             RoleSessionName="PostHog-validate-aws-role-arn",
         )
     except Exception:
-        # We expect this to fail if external id is configured correctly
         pass
     else:
         raise common.IntegrationError(

--- a/products/batch_exports/backend/service.py
+++ b/products/batch_exports/backend/service.py
@@ -29,6 +29,7 @@ from temporalio.client import (
 from posthog.hogql.database.database import Database
 from posthog.hogql.hogql import HogQLContext
 
+from posthog.dataclasses import frozen
 from posthog.temporal.common.client import sync_connect
 from posthog.temporal.common.schedule import (
     a_pause_schedule,
@@ -400,6 +401,7 @@ class PostgresBatchExportInputs(BaseBatchExportInputs):
 
 
 IAMRole = str
+IntegrationID = int
 
 
 @dataclass(frozen=False)
@@ -417,27 +419,27 @@ class AWSCredentials:
         return self.expiration.isoformat()
 
 
-@dataclass
+@frozen
 class RedshiftCopyInputs:
     s3_bucket: str
     region_name: str
     s3_key_prefix: str
-    # Authorization role or credentials for Redshift to COPY data from bucket.
-    authorization: IAMRole | AWSCredentials
-    # S3 batch export credentials.
-    # TODO: Also support RBAC for S3 batch export, then we could take
-    # `IAMRole | AWSCredentials` here too.
-    bucket_credentials: AWSCredentials
+    # Authorization for Redshift to COPY data from the bucket: an IAM role ARN,
+    # inline credentials, or the id of a team-scoped aws-s3 integration.
+    authorization: IAMRole | AWSCredentials | IntegrationID
+    # Credentials used to stage files in the S3 bucket: inline credentials or
+    # the id of a team-scoped aws-s3 integration.
+    bucket_credentials: AWSCredentials | IntegrationID
 
 
 @dataclass(frozen=False, kw_only=True)
 class RedshiftBatchExportInputs(BaseBatchExportInputs):
     """Inputs for Redshift export workflow."""
 
-    user: str
-    password: str = field(repr=False)
-    host: str
     database: str
+    user: str | None = None
+    password: str | None = field(default=None, repr=False)
+    host: str | None = None
     schema: str = "public"
     table_name: str = "events"
     port: int = 5439
@@ -459,17 +461,31 @@ class RedshiftBatchExportInputs(BaseBatchExportInputs):
             else:
                 raise TypeError(f"Invalid type for copy inputs: '{type(self.copy_inputs)}'")
 
-            bucket_credentials = AWSCredentials(
-                aws_access_key_id=raw_inputs["bucket_credentials"]["aws_access_key_id"],
-                aws_secret_access_key=raw_inputs["bucket_credentials"]["aws_secret_access_key"],
-            )
+            # `BatchExportDestination.config` is an `EncryptedJSONField`, which stringifies scalar
+            # leaves on the decrypt round trip: an integration id saved as an int reads back as a
+            # numeric string, so both forms must be accepted here.
+            raw_bucket_credentials = raw_inputs["bucket_credentials"]
+            bucket_credentials: AWSCredentials | IntegrationID
+            if isinstance(raw_bucket_credentials, IntegrationID):
+                bucket_credentials = raw_bucket_credentials
+            elif isinstance(raw_bucket_credentials, str) and raw_bucket_credentials.isdigit():
+                bucket_credentials = IntegrationID(raw_bucket_credentials)
+            else:
+                bucket_credentials = AWSCredentials(
+                    aws_access_key_id=raw_bucket_credentials["aws_access_key_id"],
+                    aws_secret_access_key=raw_bucket_credentials["aws_secret_access_key"],
+                )
 
-            if isinstance(raw_inputs["authorization"], str):
-                authorization: IAMRole | AWSCredentials = raw_inputs["authorization"]
+            raw_authorization = raw_inputs["authorization"]
+            authorization: IAMRole | AWSCredentials | IntegrationID
+            if isinstance(raw_authorization, IntegrationID):
+                authorization = raw_authorization
+            elif isinstance(raw_authorization, str):
+                authorization = IntegrationID(raw_authorization) if raw_authorization.isdigit() else raw_authorization
             else:
                 authorization = AWSCredentials(
-                    aws_access_key_id=raw_inputs["authorization"]["aws_access_key_id"],
-                    aws_secret_access_key=raw_inputs["authorization"]["aws_secret_access_key"],
+                    aws_access_key_id=raw_authorization["aws_access_key_id"],
+                    aws_secret_access_key=raw_authorization["aws_secret_access_key"],
                 )
 
             self.copy_inputs = RedshiftCopyInputs(

--- a/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
@@ -523,6 +523,13 @@ class RedshiftClient(PostgreSQLClient):
                 secret_access_key=sql.Literal(authorization.aws_secret_access_key),
             )
 
+            if authorization.aws_session_token is not None:
+                credentials += sql.SQL(
+                    """
+                    SESSION_TOKEN {session_token}
+                    """
+                ).format(session_token=sql.Literal(authorization.aws_session_token))
+
         else:
             if authorization == "default":
                 credentials = sql.SQL("IAM_ROLE default")

--- a/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
@@ -950,7 +950,7 @@ async def _get_aws_s3_integration(integration_id: int, team_id: int) -> AWSS3Rol
 @frozen
 class RedshiftCredentials:
     user: str
-    password: str
+    password: str = dataclasses.field(repr=False)
 
 
 @frozen

--- a/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
@@ -12,6 +12,7 @@ from django.conf import settings
 
 import psycopg
 import pyarrow as pa
+import aioboto3
 import botocore.exceptions
 from psycopg import sql
 from structlog.contextvars import bind_contextvars
@@ -20,7 +21,18 @@ from temporalio.common import RetryPolicy
 
 from posthog.dataclasses import frozen
 from posthog.models import Team
-from posthog.models.integration import TLS, Authority, Credentials
+from posthog.models.integration import (
+    TLS,
+    Authority,
+    AWSRedshiftIntegration,
+    AWSRedshiftRoleBasedIntegration,
+    AWSS3Integration,
+    AWSS3RoleBasedIntegration,
+    Credentials,
+    Integration,
+    IntegrationError,
+    RedshiftIntegration,
+)
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.common.logger import get_logger, get_write_only_logger
@@ -32,6 +44,7 @@ from products.batch_exports.backend.service import (
     BatchExportModel,
     BatchExportSchema,
     IAMRole,
+    IntegrationID,
     RedshiftBatchExportInputs,
 )
 from products.batch_exports.backend.temporal.batch_exports import (
@@ -45,6 +58,7 @@ from products.batch_exports.backend.temporal.destinations.postgres_batch_export 
     Fields,
     PostgreSQLClient,
     PostgreSQLField,
+    _PostgreSQLClientInputsProtocol,
 )
 from products.batch_exports.backend.temporal.destinations.s3_batch_export import (
     ConcurrentS3Consumer,
@@ -71,8 +85,10 @@ from products.batch_exports.backend.temporal.utils import (
 LOGGER = get_write_only_logger(__name__)
 EXTERNAL_LOGGER = get_logger()
 
-
 NON_RETRYABLE_ERROR_TYPES = (
+    # The integration backing this export is missing, of the wrong kind, or
+    # misconfigured. Retrying can never recover it.
+    "IntegrationError",
     # Raised on errors that are related to database operation.
     # For example: unexpected disconnect, database or other object not found.
     "OperationalError",
@@ -632,18 +648,18 @@ def get_redshift_fields_from_record_schema(
     return pg_schema
 
 
-@dataclasses.dataclass
+@frozen
 class S3StageBucketParameters:
     name: str
     region_name: str
-    credentials: IAMRole | AWSCredentials
+    credentials: IAMRole | AWSCredentials | IntegrationID
 
 
-@dataclasses.dataclass
+@frozen
 class CopyParameters:
     s3_bucket: S3StageBucketParameters
     s3_key_prefix: str
-    authorization: IAMRole | AWSCredentials
+    authorization: IAMRole | AWSCredentials | IntegrationID
 
 
 @frozen
@@ -669,6 +685,18 @@ class ConnectionParameters:
         return TLS(ssl_mode="prefer" if settings.TEST else "require")
 
 
+@frozen
+class ServerConnectionParameters:
+    """Location of a Redshift server for exports whose credentials live in an integration.
+
+    `host` is None when a plain Redshift integration carries the host itself.
+    """
+
+    database: str
+    port: int
+    host: str | None = None
+
+
 @dataclasses.dataclass
 class TableParameters:
     schema_name: str
@@ -676,23 +704,25 @@ class TableParameters:
     properties_data_type: str = "varchar"
 
 
-@dataclasses.dataclass
+@frozen
 class RedshiftCopyActivityInputs:
     """Inputs for Redshift copy activity."""
 
     batch_export: BatchExportInsertInputs
-    connection: ConnectionParameters
+    connection: ConnectionParameters | ServerConnectionParameters
     table: TableParameters
     copy: CopyParameters
+    integration_id: IntegrationID | None = None
 
 
-@dataclasses.dataclass
+@frozen
 class RedshiftInsertInputs:
     """Inputs for Redshift insert activity."""
 
     batch_export: BatchExportInsertInputs
-    connection: ConnectionParameters
+    connection: ConnectionParameters | ServerConnectionParameters
     table: TableParameters
+    integration_id: IntegrationID | None = None
 
 
 class RedshiftConsumer(Consumer):
@@ -877,6 +907,318 @@ def _get_merge_settings(
         return NotRequiredMergeSettings(requires_merge=False)
 
 
+async def _get_redshift_integration(
+    integration_id: int, team_id: int
+) -> AWSRedshiftRoleBasedIntegration | AWSRedshiftIntegration | RedshiftIntegration:
+    """Fetch a Redshift integration from the database."""
+    try:
+        integration = await Integration.objects.aget(id=integration_id, team_id=team_id)
+    except Integration.DoesNotExist:
+        raise IntegrationError(f"Redshift integration with ID '{integration_id}' not found for team '{team_id}'")
+
+    if integration.kind != Integration.IntegrationKind.AWS_REDSHIFT:
+        raise IntegrationError(
+            f"Integration with ID '{integration_id}' for team '{team_id}' is not a Redshift integration "
+            f"(kind='{integration.kind}')"
+        )
+    if "aws_role_arn" in integration.config:
+        return AWSRedshiftRoleBasedIntegration(integration)
+    elif "aws_access_key_id" in integration.sensitive_config:
+        return AWSRedshiftIntegration(integration)
+    else:
+        return RedshiftIntegration(integration)
+
+
+async def _get_aws_s3_integration(integration_id: int, team_id: int) -> AWSS3RoleBasedIntegration | AWSS3Integration:
+    """Fetch an AWS S3 integration from the database."""
+    try:
+        integration = await Integration.objects.aget(id=integration_id, team_id=team_id)
+    except Integration.DoesNotExist:
+        raise IntegrationError(f"AWS S3 integration with ID '{integration_id}' not found for team '{team_id}'")
+
+    if integration.kind != Integration.IntegrationKind.AWS_S3:
+        raise IntegrationError(
+            f"Integration with ID '{integration_id}' for team '{team_id}' is not an S3 integration "
+            f"(kind='{integration.kind}')"
+        )
+    if "aws_role_arn" in integration.config:
+        return AWSS3RoleBasedIntegration(integration)
+    else:
+        return AWSS3Integration(integration)
+
+
+@frozen
+class RedshiftCredentials:
+    user: str
+    password: str
+
+
+@frozen
+class ProvisionedCluster:
+    """A provisioned Redshift cluster parsed from its endpoint hostname."""
+
+    cluster_identifier: str
+    region: str
+
+
+@frozen
+class ServerlessWorkgroup:
+    """A Redshift Serverless workgroup parsed from its endpoint hostname."""
+
+    workgroup: str
+    account_id: str
+    region: str
+
+
+def _parse_redshift_host(host: str) -> ProvisionedCluster | ServerlessWorkgroup:
+    """Parse a Redshift endpoint hostname into its cluster or workgroup location."""
+    match host.split("."):
+        case [cluster_identifier, _, region, "redshift", "amazonaws", *_]:
+            return ProvisionedCluster(cluster_identifier=cluster_identifier, region=region)
+        case [workgroup, account_id, region, "redshift-serverless", "amazonaws", *_]:
+            return ServerlessWorkgroup(workgroup=workgroup, account_id=account_id, region=region)
+        case _:
+            raise IntegrationError(
+                f"Redshift host '{host}' is not a recognized AWS Redshift endpoint. Expected "
+                "'<cluster>.<id>.<region>.redshift.amazonaws.com' or "
+                "'<workgroup>.<account>.<region>.redshift-serverless.amazonaws.com'"
+            )
+
+
+def _get_host_from_connection(connection: ConnectionParameters | ServerConnectionParameters) -> str:
+    if connection.host is None:
+        raise IntegrationError(
+            "An AWS Redshift integration requires the cluster endpoint to be set as 'host' in the "
+            "batch export configuration"
+        )
+    return connection.host
+
+
+async def _get_temporary_redshift_credentials(
+    aws_credentials: AWSCredentials,
+    *,
+    server: ProvisionedCluster | ServerlessWorkgroup,
+    user: str,
+    database: str,
+    auto_create: bool | None = None,
+    groups: list[str] | None = None,
+) -> RedshiftCredentials:
+    """Use AWS APIs to obtain temporary Redshift credentials.
+
+    This will return a username and password to be used to authenticate to
+    Redshift. Note that the returned user will be the same as user but it will
+    include the prefix IAM: or IAMA: (depending on the value of `auto_create`).
+    This prefix must be preserved when authenticating.
+
+    If auto_create is True, then the user or role given by aws_credentials must
+    also be allowed to redshift:CreateClusterUser on the dbuser resource. If the
+    user already exists then no new users will be created, even if
+    auto_create=True.
+
+    Automatically created users do not have any permissions. Thus, usually
+    groups should be set when auto_create=True. This parameter indicates which
+    groups is the user meant to join on creation, which is usually needed when
+    the user is automatically created. However, this is not a strict
+    requirement.
+
+    The AWS role or user requires redshift:JoinGroup on each dbgroup resource
+    whenever groups is set.
+
+    Serverless workgroups use `redshift-serverless:GetCredentials` instead of
+    `redshift:GetClusterCredentials`. There, the database user is derived from
+    the IAM identity, so `user`, `auto_create`, and `groups` do not apply.
+    """
+    session = aioboto3.Session(
+        aws_access_key_id=aws_credentials.aws_access_key_id,
+        aws_secret_access_key=aws_credentials.aws_secret_access_key,
+        aws_session_token=aws_credentials.aws_session_token,
+    )
+
+    match server:
+        case ProvisionedCluster():
+            optional: dict[str, typing.Any] = {}
+            if auto_create is not None:
+                optional["AutoCreate"] = auto_create
+            if groups is not None:
+                optional["DbGroups"] = groups
+
+            async with session.client("redshift", region_name=server.region) as redshift:
+                response = await redshift.get_cluster_credentials(
+                    DbUser=user,
+                    DbName=database,
+                    ClusterIdentifier=server.cluster_identifier,
+                    # TODO: Refreshable credentials
+                    DurationSeconds=3600,
+                    **optional,
+                )
+
+            return RedshiftCredentials(user=response["DbUser"], password=response["DbPassword"])
+
+        case ServerlessWorkgroup():
+            async with session.client("redshift-serverless", region_name=server.region) as redshift_serverless:
+                response = await redshift_serverless.get_credentials(
+                    workgroupName=server.workgroup,
+                    dbName=database,
+                    durationSeconds=3600,
+                )
+
+            return RedshiftCredentials(user=response["dbUser"], password=response["dbPassword"])
+
+        case _:
+            typing.assert_never(server)
+
+
+async def _get_redshift_client_inputs(
+    inputs: RedshiftInsertInputs | RedshiftCopyActivityInputs,
+) -> _PostgreSQLClientInputsProtocol:
+    if inputs.integration_id is not None:
+        integration = await _get_redshift_integration(inputs.integration_id, inputs.batch_export.team_id)
+        return await _get_redshift_client_inputs_from_integration(integration, inputs)
+
+    if not isinstance(inputs.connection, ConnectionParameters):
+        raise IntegrationError(
+            "Redshift connection credentials are missing: the batch export has no linked integration "
+            "and no inline user and password configured"
+        )
+
+    return inputs.connection
+
+
+def _get_redshift_credentials_policy_statements(
+    integration: AWSRedshiftRoleBasedIntegration,
+    server: ProvisionedCluster | ServerlessWorkgroup,
+    database: str,
+) -> list[PolicyStatement]:
+    """Build policy statements scoping an assumed role to obtaining Redshift credentials."""
+    match server:
+        case ProvisionedCluster():
+            account_id = integration.aws_account_id
+            get_cluster_credentials_policy = PolicyStatement(
+                Effect="Allow",
+                Action=["redshift:GetClusterCredentials"],
+                Resource=[
+                    f"arn:aws:redshift:{server.region}:{account_id}:dbuser:{server.cluster_identifier}/{integration.user}",
+                    f"arn:aws:redshift:{server.region}:{account_id}:dbname:{server.cluster_identifier}/{database}",
+                ],
+            )
+            if integration.auto_create is True:
+                get_cluster_credentials_policy["Action"].append("redshift:CreateClusterUser")
+
+            policy_statements = [get_cluster_credentials_policy]
+            if integration.groups is not None:
+                policy_statements.append(
+                    PolicyStatement(
+                        Effect="Allow",
+                        Action=["redshift:JoinGroup"],
+                        Resource=[
+                            f"arn:aws:redshift:{server.region}:{account_id}:dbgroup:{server.cluster_identifier}/{group}"
+                            for group in integration.groups
+                        ],
+                    )
+                )
+            return policy_statements
+
+        case ServerlessWorkgroup():
+            # Workgroup ARNs contain a UUID that cannot be derived from the endpoint hostname,
+            # so Serverless requires the ARN on the integration to scope the policy exactly.
+            workgroup_arn = integration.workgroup_arn
+            if workgroup_arn is None:
+                raise IntegrationError(
+                    "A Redshift Serverless workgroup requires 'workgroup_arn' to be set on the integration"
+                )
+
+            _, _, _, arn_region, arn_account_id, _ = workgroup_arn.split(":", maxsplit=5)
+            if arn_region != server.region or arn_account_id != server.account_id:
+                raise IntegrationError(
+                    f"The integration's workgroup ARN '{workgroup_arn}' does not match the region or account "
+                    f"of the Redshift Serverless host (region '{server.region}', account '{server.account_id}')"
+                )
+
+            return [
+                PolicyStatement(
+                    Effect="Allow",
+                    Action=["redshift-serverless:GetCredentials"],
+                    Resource=[workgroup_arn],
+                )
+            ]
+
+        case _:
+            typing.assert_never(server)
+
+
+async def _get_redshift_client_inputs_from_integration(
+    integration: AWSRedshiftRoleBasedIntegration | AWSRedshiftIntegration | RedshiftIntegration,
+    inputs: RedshiftInsertInputs | RedshiftCopyActivityInputs,
+) -> _PostgreSQLClientInputsProtocol:
+    client_inputs: _PostgreSQLClientInputsProtocol
+
+    match integration:
+        case AWSRedshiftRoleBasedIntegration():
+            host = _get_host_from_connection(inputs.connection)
+            server = _parse_redshift_host(host)
+
+            team = await Team.objects.aget(id=inputs.batch_export.team_id)
+            external_id = f"posthog-{team.organization_id}"
+
+            policy_statements = _get_redshift_credentials_policy_statements(
+                integration, server, inputs.connection.database
+            )
+
+            credentials = await get_credentials_using_user_aws_role(
+                integration.aws_role_arn,
+                external_id,
+                session_name=f"PostHog-batch-exports-{inputs.batch_export.batch_export_id}",
+                policy_statements=policy_statements,
+            )
+
+            redshift_credentials = await _get_temporary_redshift_credentials(
+                credentials,
+                server=server,
+                user=integration.user,
+                database=inputs.connection.database,
+                groups=integration.groups,
+                auto_create=integration.auto_create,
+            )
+            client_inputs = ConnectionParameters(
+                user=redshift_credentials.user,
+                password=redshift_credentials.password,
+                host=host,
+                port=inputs.connection.port,
+                database=inputs.connection.database,
+            )
+
+        case AWSRedshiftIntegration():
+            host = _get_host_from_connection(inputs.connection)
+            server = _parse_redshift_host(host)
+
+            redshift_credentials = await _get_temporary_redshift_credentials(
+                AWSCredentials(
+                    aws_access_key_id=integration.aws_access_key_id,
+                    aws_secret_access_key=integration.aws_secret_access_key,
+                ),
+                server=server,
+                user=integration.user,
+                database=inputs.connection.database,
+                groups=integration.groups,
+                auto_create=integration.auto_create,
+            )
+            client_inputs = ConnectionParameters(
+                user=redshift_credentials.user,
+                password=redshift_credentials.password,
+                host=host,
+                port=inputs.connection.port,
+                database=inputs.connection.database,
+            )
+
+        case RedshiftIntegration():
+            client_inputs = integration
+
+        case _:
+            typing.assert_never(integration)
+
+    return client_inputs
+
+
 @activity.defn
 @handle_non_retryable_errors(NON_RETRYABLE_ERROR_TYPES)
 async def insert_into_redshift_activity_from_stage(inputs: RedshiftInsertInputs) -> BatchExportResult:
@@ -906,6 +1248,7 @@ async def insert_into_redshift_activity_from_stage(inputs: RedshiftInsertInputs)
     bind_contextvars(
         team_id=inputs.batch_export.team_id,
         destination="Redshift",
+        integration_id=inputs.integration_id,
         data_interval_start=inputs.batch_export.data_interval_start,
         data_interval_end=inputs.batch_export.data_interval_end,
         database=inputs.connection.database,
@@ -969,8 +1312,10 @@ async def insert_into_redshift_activity_from_stage(inputs: RedshiftInsertInputs)
             else inputs.table.name
         )
 
+        client_inputs = await _get_redshift_client_inputs(inputs)
+
         async with RedshiftClient.from_inputs(
-            inputs.connection, database=inputs.connection.database
+            client_inputs, database=inputs.connection.database
         ).connect() as redshift_client:
             remove_duplicates = True
             # filter out fields that are not in the destination table
@@ -1243,6 +1588,104 @@ async def check_and_raise_redshift_copy_error(
         raise RedshiftS3CopyError(bucket) from err
 
 
+async def _resolve_aws_s3_integration(integration_id: IntegrationID, team_id: int) -> IAMRole | AWSCredentials:
+    """Resolve an AWS S3 integration into its role ARN or stored credentials."""
+    integration = await _get_aws_s3_integration(integration_id, team_id=team_id)
+
+    match integration:
+        case AWSS3RoleBasedIntegration():
+            return integration.aws_role_arn
+        case AWSS3Integration():
+            return AWSCredentials(
+                aws_access_key_id=integration.aws_access_key_id,
+                aws_secret_access_key=integration.aws_secret_access_key,
+            )
+        case _:
+            typing.assert_never(integration)
+
+
+async def _assume_role_for_stage_bucket(
+    aws_role_arn: IAMRole, inputs: RedshiftCopyActivityInputs, policy_statements: list[PolicyStatement]
+) -> AWSCredentials:
+    team = await Team.objects.aget(id=inputs.batch_export.team_id)
+    external_id = f"posthog-{team.organization_id}"
+
+    return await get_credentials_using_user_aws_role(
+        aws_role_arn,
+        external_id,
+        session_name=f"PostHog-batch-exports-{inputs.batch_export.batch_export_id}",
+        policy_statements=policy_statements,
+    )
+
+
+async def _get_s3_bucket_aws_credentials(inputs: RedshiftCopyActivityInputs) -> AWSCredentials:
+    """Resolve the credentials used to stage files in the user's S3 bucket."""
+    credentials = inputs.copy.s3_bucket.credentials
+    if isinstance(credentials, IntegrationID):
+        credentials = await _resolve_aws_s3_integration(credentials, inputs.batch_export.team_id)
+
+    if isinstance(credentials, AWSCredentials):
+        return credentials
+
+    bucket_name = inputs.copy.s3_bucket.name
+    key_prefix = get_absolute_key_prefix(
+        inputs.copy.s3_key_prefix,
+        inputs.batch_export.data_interval_start,
+        inputs.batch_export.data_interval_end,
+        inputs.batch_export.batch_export_model,
+    )
+    policy_statements = [
+        PolicyStatement(
+            Effect="Allow",
+            Action=["s3:PutObject", "s3:GetObject", "s3:DeleteObject", "s3:AbortMultipartUpload"],
+            Resource=f"arn:aws:s3:::{bucket_name}{key_prefix}*",
+        ),
+        PolicyStatement(
+            Effect="Allow",
+            Action=["s3:ListBucket"],
+            Resource=f"arn:aws:s3:::{bucket_name}",
+        ),
+    ]
+    return await _assume_role_for_stage_bucket(credentials, inputs, policy_statements)
+
+
+async def _resolve_copy_authorization(inputs: RedshiftCopyActivityInputs) -> IAMRole | AWSCredentials:
+    """Resolve the authorization Redshift uses to read staged files during COPY.
+
+    An integration id resolves to temporary AWS credentials scoped to reading the
+    staged files: a customer role ARN from an integration cannot be passed as
+    `IAM_ROLE` in the COPY statement, since it is not attached to the cluster.
+    """
+    authorization = inputs.copy.authorization
+    if not isinstance(authorization, IntegrationID):
+        return authorization
+
+    resolved = await _resolve_aws_s3_integration(authorization, inputs.batch_export.team_id)
+    if isinstance(resolved, AWSCredentials):
+        return resolved
+
+    bucket_name = inputs.copy.s3_bucket.name
+    key_prefix = get_absolute_key_prefix(
+        inputs.copy.s3_key_prefix,
+        inputs.batch_export.data_interval_start,
+        inputs.batch_export.data_interval_end,
+        inputs.batch_export.batch_export_model,
+    )
+    policy_statements = [
+        PolicyStatement(
+            Effect="Allow",
+            Action=["s3:GetObject"],
+            Resource=f"arn:aws:s3:::{bucket_name}{key_prefix}*",
+        ),
+        PolicyStatement(
+            Effect="Allow",
+            Action=["s3:ListBucket", "s3:GetBucketLocation"],
+            Resource=f"arn:aws:s3:::{bucket_name}",
+        ),
+    ]
+    return await _assume_role_for_stage_bucket(resolved, inputs, policy_statements)
+
+
 @activity.defn
 @handle_non_retryable_errors(NON_RETRYABLE_ERROR_TYPES)
 async def copy_into_redshift_activity_from_stage(inputs: RedshiftCopyActivityInputs) -> BatchExportResult:
@@ -1282,6 +1725,7 @@ async def copy_into_redshift_activity_from_stage(inputs: RedshiftCopyActivityInp
     bind_contextvars(
         team_id=inputs.batch_export.team_id,
         destination="Redshift",
+        integration_id=inputs.integration_id,
         data_interval_start=inputs.batch_export.data_interval_start,
         data_interval_end=inputs.batch_export.data_interval_end,
         database=inputs.connection.database,
@@ -1338,39 +1782,6 @@ async def copy_into_redshift_activity_from_stage(inputs: RedshiftCopyActivityInp
         # TODO: Maybe derive this from user's input?
         max_file_size_mb = 100
 
-        if isinstance(inputs.copy.s3_bucket.credentials, IAMRole):
-            team = await Team.objects.aget(id=inputs.batch_export.team_id)
-            organization_id = str(team.organization_id)
-
-            bucket_name = inputs.copy.s3_bucket.name
-            key_prefix = get_absolute_key_prefix(
-                inputs.copy.s3_key_prefix,
-                inputs.batch_export.data_interval_start,
-                inputs.batch_export.data_interval_end,
-                inputs.batch_export.batch_export_model,
-            )
-            policy_statements = [
-                PolicyStatement(
-                    Effect="Allow",
-                    Action=["s3:PutObject", "s3:GetObject", "s3:DeleteObject", "s3:AbortMultipartUpload"],
-                    Resource=f"arn:aws:s3:::{bucket_name}{key_prefix}*",
-                ),
-                PolicyStatement(
-                    Effect="Allow",
-                    Action=["s3:ListBucket"],
-                    Resource=f"arn:aws:s3:::{bucket_name}",
-                ),
-            ]
-
-            credentials = await get_credentials_using_user_aws_role(
-                inputs.copy.s3_bucket.credentials,
-                organization_id,
-                session_name=f"PostHog-batch-exports-{inputs.batch_export.batch_export_id}",
-                policy_statements=policy_statements,
-            )
-        else:
-            credentials = inputs.copy.s3_bucket.credentials
-
         table_schemas = _get_table_schemas(
             model=model,
             record_batch_schema=record_batch_schema,
@@ -1395,6 +1806,8 @@ async def copy_into_redshift_activity_from_stage(inputs: RedshiftCopyActivityInp
             else inputs.table.name
         )
 
+        client_inputs = await _get_redshift_client_inputs(inputs)
+
         if not merge_settings.requires_merge:
             # Without a stage table, Parquet files are copied directly into the final
             # table, and the COPY column list names every column in the files. Pre-set
@@ -1402,7 +1815,7 @@ async def copy_into_redshift_activity_from_stage(inputs: RedshiftCopyActivityInp
             # as COPY would otherwise fail on them.
             try:
                 async with RedshiftClient.from_inputs(
-                    inputs.connection, database=inputs.connection.database
+                    client_inputs, database=inputs.connection.database
                 ).connect() as redshift_client:
                     existing_columns = set(
                         await redshift_client.aget_table_columns(inputs.table.schema_name, inputs.table.name)
@@ -1416,6 +1829,8 @@ async def copy_into_redshift_activity_from_stage(inputs: RedshiftCopyActivityInp
                     transformer.schema = cast_record_batch_schema_json_columns(
                         pa.schema(filtered_fields), json_columns=table_schemas.super_columns
                     )
+
+        credentials = await _get_s3_bucket_aws_credentials(inputs)
 
         async with s3_client(
             credentials,
@@ -1450,8 +1865,12 @@ async def copy_into_redshift_activity_from_stage(inputs: RedshiftCopyActivityInp
         if result.error is not None:
             return result
 
+        # Re-resolved after uploads finish: temporary credentials from an integration
+        # are valid for one hour, which a long upload could outlive.
+        client_inputs = await _get_redshift_client_inputs(inputs)
+
         async with RedshiftClient.from_inputs(
-            inputs.connection, database=inputs.connection.database
+            client_inputs, database=inputs.connection.database
         ).connect() as redshift_client:
             remove_duplicates = True
 
@@ -1509,6 +1928,10 @@ async def copy_into_redshift_activity_from_stage(inputs: RedshiftCopyActivityInp
                     manifest_key=manifest_key,
                 )
 
+                # Resolved after uploads finish: temporary credentials from an assumed
+                # role last one hour, which a long upload could outlive.
+                copy_authorization = await _resolve_copy_authorization(inputs)
+
                 try:
                     external_logger.info(f"Copying {len(consumer.files_uploaded)} file/s into Redshift")
 
@@ -1519,12 +1942,12 @@ async def copy_into_redshift_activity_from_stage(inputs: RedshiftCopyActivityInp
                             schema_name=inputs.table.schema_name,
                             s3_bucket=inputs.copy.s3_bucket.name,
                             manifest_key=manifest_key,
-                            authorization=inputs.copy.authorization,
+                            authorization=copy_authorization,
                         )
                     except psycopg.errors.InternalError_ as err:
                         await check_and_raise_redshift_copy_error(
                             err,
-                            authorization=inputs.copy.authorization,
+                            authorization=copy_authorization,
                             bucket=inputs.copy.s3_bucket.name,
                             region_name=inputs.copy.s3_bucket.region_name,
                             manifest_key=manifest_key,
@@ -1625,13 +2048,24 @@ class RedshiftBatchExportWorkflow(PostHogWorkflow):
             batch_export_id=inputs.batch_export_id,
             destination_default_fields=redshift_default_fields(),
         )
-        connection_parameters = ConnectionParameters(
-            user=inputs.user,
-            password=inputs.password,
-            host=inputs.host,
-            port=inputs.port,
-            database=inputs.database,
-        )
+        connection_parameters: ConnectionParameters | ServerConnectionParameters
+        if inputs.user is not None and inputs.password is not None and inputs.host is not None:
+            connection_parameters = ConnectionParameters(
+                user=inputs.user,
+                password=inputs.password,
+                host=inputs.host,
+                port=inputs.port,
+                database=inputs.database,
+            )
+        else:
+            # Credentials live in the linked integration. The activity raises a clear,
+            # non-retryable error if there is no integration either; raising here would
+            # retry the workflow task forever.
+            connection_parameters = ServerConnectionParameters(
+                database=inputs.database,
+                port=inputs.port,
+                host=inputs.host,
+            )
         table_parameters = TableParameters(
             schema_name=inputs.schema,
             name=inputs.table_name,
@@ -1654,6 +2088,7 @@ class RedshiftBatchExportWorkflow(PostHogWorkflow):
                         s3_key_prefix=inputs.copy_inputs.s3_key_prefix,
                         authorization=inputs.copy_inputs.authorization,
                     ),
+                    integration_id=inputs.integration_id,
                 ),
                 interval=inputs.interval,
                 maximum_retry_interval_seconds=240,
@@ -1665,6 +2100,7 @@ class RedshiftBatchExportWorkflow(PostHogWorkflow):
                     batch_export=batch_export_inputs,
                     connection=connection_parameters,
                     table=table_parameters,
+                    integration_id=inputs.integration_id,
                 ),
                 interval=inputs.interval,
                 # TODO: Temporarily bump start to close timeout until we speed up

--- a/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
@@ -1071,6 +1071,12 @@ async def _get_temporary_redshift_credentials(
 async def _get_redshift_client_inputs(
     inputs: RedshiftInsertInputs | RedshiftCopyActivityInputs,
 ) -> _PostgreSQLClientInputsProtocol:
+    """Return PostgreSQL client inputs to establish a connection from Redshift.
+
+    The inputs will be obtained from an integration when integration_id is set,
+    and otherwise we will assert they are present in the activity inputs to be
+    read directly.
+    """
     if inputs.integration_id is not None:
         integration = await _get_redshift_integration(inputs.integration_id, inputs.batch_export.team_id)
         return await _get_redshift_client_inputs_from_integration(integration, inputs)
@@ -1150,6 +1156,17 @@ async def _get_redshift_client_inputs_from_integration(
     integration: AWSRedshiftRoleBasedIntegration | AWSRedshiftIntegration | RedshiftIntegration,
     inputs: RedshiftInsertInputs | RedshiftCopyActivityInputs,
 ) -> _PostgreSQLClientInputsProtocol:
+    """Return PostgreSQL client inputs to establish a connection from Redshift.
+
+    These inputs can be obtained from an integration by:
+    * Generating temporary credentials using a short-lived session via assuming
+      a role configured in an integration.
+    * Generating temporary credentials using long-lived AWS credentials stored
+      in the integration.
+    * Directly reading inputs stored in the integration.
+
+    Depending on the type of integration, is which one we'll use.
+    """
     client_inputs: _PostgreSQLClientInputsProtocol
 
     match integration:
@@ -1806,13 +1823,12 @@ async def copy_into_redshift_activity_from_stage(inputs: RedshiftCopyActivityInp
             else inputs.table.name
         )
 
-        client_inputs = await _get_redshift_client_inputs(inputs)
-
         if not merge_settings.requires_merge:
             # Without a stage table, Parquet files are copied directly into the final
             # table, and the COPY column list names every column in the files. Pre-set
             # the transformer's schema to drop columns missing from an existing table,
             # as COPY would otherwise fail on them.
+            client_inputs = await _get_redshift_client_inputs(inputs)
             try:
                 async with RedshiftClient.from_inputs(
                     client_inputs, database=inputs.connection.database
@@ -1865,10 +1881,7 @@ async def copy_into_redshift_activity_from_stage(inputs: RedshiftCopyActivityInp
         if result.error is not None:
             return result
 
-        # Re-resolved after uploads finish: temporary credentials from an integration
-        # are valid for one hour, which a long upload could outlive.
         client_inputs = await _get_redshift_client_inputs(inputs)
-
         async with RedshiftClient.from_inputs(
             client_inputs, database=inputs.connection.database
         ).connect() as redshift_client:

--- a/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
@@ -3,6 +3,7 @@ import json
 import typing
 import asyncio
 import datetime as dt
+import functools
 import posixpath
 import contextlib
 import dataclasses
@@ -63,6 +64,7 @@ from products.batch_exports.backend.temporal.destinations.postgres_batch_export 
 from products.batch_exports.backend.temporal.destinations.s3_batch_export import (
     ConcurrentS3Consumer,
     PolicyStatement,
+    RefreshCoroutine,
     get_credentials_using_user_aws_role,
     s3_client,
 )
@@ -1417,6 +1419,7 @@ async def upload_manifest_file(
     credentials: AWSCredentials,
     files_uploaded: list[str],
     manifest_key: str,
+    refresh_using: RefreshCoroutine | None = None,
 ):
     """Upload manifest file used by Redshift COPY.
 
@@ -1432,6 +1435,7 @@ async def upload_manifest_file(
         region=region_name,
         # Required for unit tests which run against a local bucket, otherwise always None.
         endpoint_url=settings.OBJECT_STORAGE_ENDPOINT if settings.TEST else None,
+        refresh_using=refresh_using,
     ) as client:
         entries = []
 
@@ -1505,6 +1509,7 @@ async def delete_uploaded_files(
     credentials: AWSCredentials,
     files_uploaded: list[str],
     manifest_key: str,
+    refresh_using: RefreshCoroutine | None = None,
 ):
     """Delete files uploaded to S3 bucket during 'COPY' activity.
 
@@ -1516,6 +1521,7 @@ async def delete_uploaded_files(
     async with s3_client(
         credentials,
         region=region_name,
+        refresh_using=refresh_using,
     ) as client:
 
         async def delete_key(f: str):
@@ -1536,6 +1542,7 @@ async def is_s3_read_access_denied(
     region_name: str,
     credentials: AWSCredentials,
     keys: collections.abc.Sequence[str],
+    refresh_using: RefreshCoroutine | None = None,
 ) -> bool:
     """Return True only if a HEAD positively confirms read access is denied for any of `keys`.
 
@@ -1550,6 +1557,7 @@ async def is_s3_read_access_denied(
         async with s3_client(
             credentials,
             region=region_name,
+            refresh_using=refresh_using,
         ) as client:
             for key in keys:
                 try:
@@ -1572,6 +1580,7 @@ async def check_and_raise_redshift_copy_error(
     region_name: str,
     manifest_key: str,
     files_uploaded: collections.abc.Sequence[str],
+    refresh_using: RefreshCoroutine | None = None,
 ) -> None:
     """Translate a failed Redshift COPY into an actionable error.
 
@@ -1589,7 +1598,11 @@ async def check_and_raise_redshift_copy_error(
     if isinstance(authorization, AWSCredentials):
         probe_keys = [manifest_key, *files_uploaded[:1]]
         if await is_s3_read_access_denied(
-            bucket=bucket, region_name=region_name, credentials=authorization, keys=probe_keys
+            bucket=bucket,
+            region_name=region_name,
+            credentials=authorization,
+            keys=probe_keys,
+            refresh_using=refresh_using,
         ):
             raise InsufficientS3PermissionsError(bucket) from err
         return
@@ -1635,14 +1648,22 @@ async def _assume_role_for_stage_bucket(
     )
 
 
-async def _get_s3_bucket_aws_credentials(inputs: RedshiftCopyActivityInputs) -> AWSCredentials:
-    """Resolve the credentials used to stage files in the user's S3 bucket."""
+async def _get_s3_bucket_aws_credentials(
+    inputs: RedshiftCopyActivityInputs,
+) -> tuple[AWSCredentials, RefreshCoroutine | None]:
+    """Resolve the credentials used to stage files in the user's S3 bucket.
+
+    If the credentials are refreshable (i.e. via role assumption), then
+    additionally return a function that may be used to refresh the crednetials.
+    Otherwise, credentials are long lived and the second returned parameter is
+    None.
+    """
     credentials = inputs.copy.s3_bucket.credentials
     if isinstance(credentials, IntegrationID):
         credentials = await _resolve_aws_s3_integration(credentials, inputs.batch_export.team_id)
 
     if isinstance(credentials, AWSCredentials):
-        return credentials
+        return credentials, None
 
     bucket_name = inputs.copy.s3_bucket.name
     key_prefix = get_absolute_key_prefix(
@@ -1663,10 +1684,14 @@ async def _get_s3_bucket_aws_credentials(inputs: RedshiftCopyActivityInputs) -> 
             Resource=f"arn:aws:s3:::{bucket_name}",
         ),
     ]
-    return await _assume_role_for_stage_bucket(credentials, inputs, policy_statements)
+    refresh_credentials = functools.partial(_assume_role_for_stage_bucket, credentials, inputs, policy_statements)
+
+    return await refresh_credentials(), refresh_credentials
 
 
-async def _resolve_copy_authorization(inputs: RedshiftCopyActivityInputs) -> IAMRole | AWSCredentials:
+async def _resolve_copy_authorization(
+    inputs: RedshiftCopyActivityInputs,
+) -> tuple[IAMRole | AWSCredentials, RefreshCoroutine | None]:
     """Resolve the authorization Redshift uses to read staged files during COPY.
 
     An integration id resolves to temporary AWS credentials scoped to reading the
@@ -1675,11 +1700,11 @@ async def _resolve_copy_authorization(inputs: RedshiftCopyActivityInputs) -> IAM
     """
     authorization = inputs.copy.authorization
     if not isinstance(authorization, IntegrationID):
-        return authorization
+        return authorization, None
 
     resolved = await _resolve_aws_s3_integration(authorization, inputs.batch_export.team_id)
     if isinstance(resolved, AWSCredentials):
-        return resolved
+        return resolved, None
 
     bucket_name = inputs.copy.s3_bucket.name
     key_prefix = get_absolute_key_prefix(
@@ -1700,7 +1725,10 @@ async def _resolve_copy_authorization(inputs: RedshiftCopyActivityInputs) -> IAM
             Resource=f"arn:aws:s3:::{bucket_name}",
         ),
     ]
-    return await _assume_role_for_stage_bucket(resolved, inputs, policy_statements)
+
+    refresh_credentials = functools.partial(_assume_role_for_stage_bucket, resolved, inputs, policy_statements)
+    credentials = await refresh_credentials()
+    return credentials, refresh_credentials
 
 
 @activity.defn
@@ -1846,11 +1874,12 @@ async def copy_into_redshift_activity_from_stage(inputs: RedshiftCopyActivityInp
                         pa.schema(filtered_fields), json_columns=table_schemas.super_columns
                     )
 
-        credentials = await _get_s3_bucket_aws_credentials(inputs)
+        credentials, refresh_credentials = await _get_s3_bucket_aws_credentials(inputs)
 
         async with s3_client(
             credentials,
             region=inputs.copy.s3_bucket.region_name,
+            refresh_using=refresh_credentials,
         ) as client:
             consumer = ConcurrentS3Consumer(
                 bucket=inputs.copy.s3_bucket.name,
@@ -1939,11 +1968,12 @@ async def copy_into_redshift_activity_from_stage(inputs: RedshiftCopyActivityInp
                     credentials=credentials,
                     files_uploaded=consumer.files_uploaded,
                     manifest_key=manifest_key,
+                    refresh_using=refresh_credentials,
                 )
 
                 # Resolved after uploads finish: temporary credentials from an assumed
                 # role last one hour, which a long upload could outlive.
-                copy_authorization = await _resolve_copy_authorization(inputs)
+                copy_authorization, refresh_copy_authorization = await _resolve_copy_authorization(inputs)
 
                 try:
                     external_logger.info(f"Copying {len(consumer.files_uploaded)} file/s into Redshift")
@@ -1965,6 +1995,7 @@ async def copy_into_redshift_activity_from_stage(inputs: RedshiftCopyActivityInp
                             region_name=inputs.copy.s3_bucket.region_name,
                             manifest_key=manifest_key,
                             files_uploaded=consumer.files_uploaded,
+                            refresh_using=refresh_copy_authorization,
                         )
                         raise
 
@@ -1992,6 +2023,7 @@ async def copy_into_redshift_activity_from_stage(inputs: RedshiftCopyActivityInp
                         credentials=credentials,
                         files_uploaded=consumer.files_uploaded,
                         manifest_key=manifest_key,
+                        refresh_using=refresh_credentials,
                     )
 
         return result

--- a/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
@@ -972,10 +972,10 @@ class ServerlessWorkgroup:
 
 def _parse_redshift_host(host: str) -> ProvisionedCluster | ServerlessWorkgroup:
     """Parse a Redshift endpoint hostname into its cluster or workgroup location."""
-    match host.split("."):
-        case [cluster_identifier, _, region, "redshift", "amazonaws", *_]:
+    match host.split(".", maxsplit=3):
+        case [cluster_identifier, _, region, "redshift.amazonaws.com"]:
             return ProvisionedCluster(cluster_identifier=cluster_identifier, region=region)
-        case [workgroup, account_id, region, "redshift-serverless", "amazonaws", *_]:
+        case [workgroup, account_id, region, "redshift-serverless.amazonaws.com"]:
             return ServerlessWorkgroup(workgroup=workgroup, account_id=account_id, region=region)
         case _:
             raise IntegrationError(

--- a/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
@@ -375,7 +375,7 @@ class S3BatchExportResult(BatchExportResult):
 class PolicyStatement(typing.TypedDict):
     Effect: typing.Literal["Allow", "Deny"]
     Action: list[str]
-    Resource: str
+    Resource: list[str] | str
 
 
 async def get_credentials_using_user_aws_role(

--- a/products/batch_exports/backend/tests/temporal/destinations/redshift/test_redshift_utils.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/redshift/test_redshift_utils.py
@@ -12,11 +12,17 @@ import aioboto3
 import pytest_asyncio
 import botocore.exceptions
 
+from posthog.models.integration import AWSRedshiftRoleBasedIntegration, Integration, IntegrationError
+
 from products.batch_exports.backend.service import AWSCredentials
 from products.batch_exports.backend.temporal.destinations.redshift_batch_export import (
     ClientErrorGroup,
     InsufficientS3PermissionsError,
+    ProvisionedCluster,
     RedshiftS3CopyError,
+    ServerlessWorkgroup,
+    _get_redshift_credentials_policy_statements,
+    _parse_redshift_host,
     check_and_raise_redshift_copy_error,
     is_s3_read_access_denied,
     upload_manifest_file,
@@ -289,3 +295,99 @@ async def test_check_and_raise_redshift_copy_error_iam_role(error, should_raise)
             await call
     else:
         await call  # should not raise
+
+
+@pytest.mark.parametrize(
+    "host,expected",
+    [
+        (
+            "examplecluster.abc123xyz789.us-west-2.redshift.amazonaws.com",
+            ProvisionedCluster(cluster_identifier="examplecluster", region="us-west-2"),
+        ),
+        (
+            "default-wg.123456789012.us-east-1.redshift-serverless.amazonaws.com",
+            ServerlessWorkgroup(workgroup="default-wg", account_id="123456789012", region="us-east-1"),
+        ),
+    ],
+)
+def test_parse_redshift_host(host, expected):
+    assert _parse_redshift_host(host) == expected
+
+
+@pytest.mark.parametrize("host", ["localhost", "my-redshift.example.com", "8.8.8.8", ""])
+def test_parse_redshift_host_rejects_unrecognized_endpoints(host):
+    with pytest.raises(IntegrationError):
+        _parse_redshift_host(host)
+
+
+def _aws_redshift_role_integration(**extra_config) -> AWSRedshiftRoleBasedIntegration:
+    integration = Integration(
+        kind=Integration.IntegrationKind.AWS_REDSHIFT,
+        config={
+            "aws_role_arn": "arn:aws:iam::123456789012:role/posthog-batch-exports",
+            "user": "awsuser",
+            **extra_config,
+        },
+    )
+    return AWSRedshiftRoleBasedIntegration(integration)
+
+
+def test_provisioned_cluster_credentials_policy_scopes_to_exact_resources():
+    integration = _aws_redshift_role_integration(groups=["exporters"], auto_create=True)
+    server = ProvisionedCluster(cluster_identifier="examplecluster", region="us-west-2")
+
+    statements = _get_redshift_credentials_policy_statements(integration, server, "posthog")
+
+    assert statements[0]["Action"] == ["redshift:GetClusterCredentials", "redshift:CreateClusterUser"]
+    assert statements[0]["Resource"] == [
+        "arn:aws:redshift:us-west-2:123456789012:dbuser:examplecluster/awsuser",
+        "arn:aws:redshift:us-west-2:123456789012:dbname:examplecluster/posthog",
+    ]
+    assert statements[1]["Action"] == ["redshift:JoinGroup"]
+    assert statements[1]["Resource"] == [
+        "arn:aws:redshift:us-west-2:123456789012:dbgroup:examplecluster/exporters",
+    ]
+    assert all("*" not in resource for statement in statements for resource in statement["Resource"])
+
+
+def test_serverless_workgroup_credentials_policy_scopes_to_workgroup_arn():
+    workgroup_arn = "arn:aws:redshift-serverless:us-east-1:123456789012:workgroup/abc-123"
+    integration = _aws_redshift_role_integration(workgroup_arn=workgroup_arn)
+    server = ServerlessWorkgroup(workgroup="default-wg", account_id="123456789012", region="us-east-1")
+
+    statements = _get_redshift_credentials_policy_statements(integration, server, "posthog")
+
+    assert statements == [
+        {
+            "Effect": "Allow",
+            "Action": ["redshift-serverless:GetCredentials"],
+            "Resource": [workgroup_arn],
+        }
+    ]
+
+
+def test_serverless_workgroup_credentials_policy_requires_workgroup_arn():
+    # There must never be a wildcard fallback here: without the exact workgroup ARN
+    # the policy cannot be scoped, so credentials must not be requested at all.
+    integration = _aws_redshift_role_integration()
+    server = ServerlessWorkgroup(workgroup="default-wg", account_id="123456789012", region="us-east-1")
+
+    with pytest.raises(IntegrationError):
+        _get_redshift_credentials_policy_statements(integration, server, "posthog")
+
+
+@pytest.mark.parametrize(
+    "workgroup_arn",
+    [
+        # Region mismatch.
+        "arn:aws:redshift-serverless:us-west-2:123456789012:workgroup/abc-123",
+        # Account mismatch.
+        "arn:aws:redshift-serverless:us-east-1:999999999999:workgroup/abc-123",
+    ],
+)
+def test_serverless_workgroup_credentials_policy_rejects_mismatched_arn(workgroup_arn):
+    integration = _aws_redshift_role_integration(workgroup_arn=workgroup_arn)
+    server = ServerlessWorkgroup(workgroup="default-wg", account_id="123456789012", region="us-east-1")
+
+    with pytest.raises(IntegrationError):
+        _get_redshift_credentials_policy_statements(integration, server, "posthog")

--- a/products/batch_exports/backend/tests/test_service.py
+++ b/products/batch_exports/backend/tests/test_service.py
@@ -10,11 +10,13 @@ from products.batch_exports.backend.models.batch_export import (
     BatchExportRun,
 )
 from products.batch_exports.backend.service import (
+    AWSCredentials,
     AzureBlobBatchExportInputs,
     BigQueryBatchExportInputs,
     DatabricksBatchExportInputs,
     PostgresBatchExportInputs,
     RedshiftBatchExportInputs,
+    RedshiftCopyInputs,
     S3BatchExportInputs,
     aget_or_create_batch_export_backfill,
     align_timestamp_to_interval,
@@ -282,3 +284,41 @@ async def test_creates_backfill_without_id_does_not_deduplicate(ateam, batch_exp
 def test_align_timestamp_to_interval(timestamp, interval, interval_offset, timezone, expected):
     batch_export = BatchExport(interval=interval, interval_offset=interval_offset, timezone=timezone)
     assert align_timestamp_to_interval(timestamp, batch_export) == expected
+
+
+class TestRedshiftCopyInputsCredentials:
+    # EncryptedJSONField stringifies scalar leaves on the decrypt round trip, so an
+    # integration id saved as an int can read back as a numeric string.
+    @pytest.mark.parametrize(
+        "authorization,bucket_credentials,expected_authorization,expected_bucket_credentials",
+        [
+            (123, 456, 123, 456),
+            ("123", "456", 123, 456),
+            (
+                "arn:aws:iam::123456789012:role/my-role",
+                {"aws_access_key_id": "key", "aws_secret_access_key": "secret"},
+                "arn:aws:iam::123456789012:role/my-role",
+                AWSCredentials(aws_access_key_id="key", aws_secret_access_key="secret"),
+            ),
+        ],
+    )
+    def test_copy_credentials_are_parsed(
+        self, authorization, bucket_credentials, expected_authorization, expected_bucket_credentials
+    ):
+        inputs = RedshiftBatchExportInputs(
+            batch_export_id="test",
+            team_id=1,
+            database="db",
+            mode="COPY",
+            copy_inputs={  # type: ignore
+                "s3_bucket": "bucket",
+                "region_name": "us-east-1",
+                "s3_key_prefix": "prefix/",
+                "authorization": authorization,
+                "bucket_credentials": bucket_credentials,
+            },
+        )
+
+        assert isinstance(inputs.copy_inputs, RedshiftCopyInputs)
+        assert inputs.copy_inputs.authorization == expected_authorization
+        assert inputs.copy_inputs.bucket_credentials == expected_bucket_credentials


### PR DESCRIPTION
<!-- This has to stand on its own: a reader who opens no files should still know why the PR is necessary and what it does. Length tracks the change, so a small diff gets a few bullets rather than a full-length body, and a section you have nothing for gets one line or "None". -->

## Problem

Redshift does not currently support integrations, like all other batch export destinations, and additionally users are still having to provide us plain text credentials. So, we should add support for integrations + role based authentication in Redshift.

This is PR 2/3 in the stack.

<!-- Who are we building for, what are their needs, why is this important? -->
<!-- First line: what is different for a person, and who they are. A fix says what breaks; a feature says what someone can now do; a chore says who is blocked. The code path goes underneath. -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

There is a lot going on in `redshift_batch_export.py`: The gist of it is that we need to do a `GetCredentials` or a `GetClusterCredentials` request (depending if Redshift is serverless or not) after assuming the role provided by the user. Assuming the role provided by the user follows the same pattern as for S3.

Additionally, we also support integrations for the S3 temporary credentials used in the COPY export. We do the same as what we do in `s3_batch_export.py`.

One small note: I am re-using the external role we use in S3. The external role is meant to be shared with users, and otherwise not used for anything else, so I thought it would be easier to use the same here. I will later rename the setting to be `BATCH_EXPORTS_AWS_EXTERNAL_ROLE_ARN`, swapping AWS for S3.

<!-- For each change a person can notice, say what they will now see or do differently, not only the code path that does it. Mark the rest as mechanical so a reviewer knows nothing user-visible is hiding in it. -->

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Ran existing tests, added new ones.

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->
<!-- Don't recite pass counts for suites CI runs; the checks report those with more authority. Link the evidence instead (run, permalink, error tracking issue), and say what you did not check. Long transcripts go in a <details> block. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

Not yet


## Docs update

Not yet

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

Similar to the first PR on the stack: I wrote the initial implementation myself. Had the robot review, which ended up fixing a lot of issues here and there, but none that required substantial changes to the code I had already written.

I did have the robot contribute the new tests.


<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
     - Public artifact: nothing in this PR — code, fixtures and sample data, comments, commit messages, or this description — carries material from the agent session that isn't already public. If the work drew on a customer conversation, ticket, or log, say so here and state that the committed data is invented. Renaming people, hosts, and identifiers does not clear real material; see AGENTS.md "Public open source repo guidance".
-->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way: what changed across the session. The reason the shipped design beats the obvious alternative goes in Changes instead, where a reviewer will actually see it.
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session — that applies to every part of this PR, not just this section.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Voice: the subject of every sentence is the change, never its author. No "I", "me" or "my" anywhere in the body. "I (actually Claude)" is worse than either half: it hands the assignee an account of work they did not do. Authorship is one stated fact in the Agent context section below.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Flow and topology changes: include separate before-and-after Mermaid `flowchart` blocks with PostHog colors. This includes CI wiring, pipelines, state machines, and request paths. Use `/writing-pr-descriptions` for the palette and role mapping.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Stack instead of stuffing: if the diff holds two or more separable steps (migration then behavior, rename then rewrite), open a stack rather than one big PR. See AGENTS.md, "Stacked PRs" and /stacking-prs.
- Simplify before opening: if your agent has a behavior-preserving cleanup pass (Claude Code: `/simplify`), run it on a non-trivial diff before final tests and preflight, since it edits the tree. Skip it for small mechanical changes.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- Shape and style: invoke the `/writing-pr-descriptions` skill before writing this body. In short: lead with the effect a person sees rather than the code path behind it, make the body stand alone for a reader who opens no files, size it to the change, link evidence rather than asserting what CI already reports, then hold what's left to one fact per bullet in under 25 words. A body that got longer as bullets was not cut.
-->