### PR TITLE
feat(alerts): render the alert preview card with quill charts

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4761,9 +4761,9 @@ snapshots:
     products-alerts-alert-modal--create-wizard--light:
         hash: v1.k794b7964.494bd726adc6e478744c5418538e1e5bc6e3afdffd7ffc6ee5db7f9447736ad8.XrOtsQ190MyCOe3g_QspkQn_2iNZXZmb0QaWh1xt-t8
     products-alerts-alert-modal--edit-alert--dark:
-        hash: v1.k794b7964.1b0b3ec51cc999c02f8442559b676a2e2f352998c0f3d4a9b10da7da8fc3aac1.ZktPS8oprYMZQ-rLsncCgMlyidqF97zUzqDfKjQGo1A
+        hash: v1.k794b7964.dc79556ec532e112cf59b2a843d8ba07b7d528c464c8b365a2023a9cf4021d04.lruEjOumdYVcXtiN_Lm9JXeQF9Ur6p3MT0mCb8RTMSU
     products-alerts-alert-modal--edit-alert--light:
-        hash: v1.k794b7964.38643f06f9a727b550dfcde1c46769c13a24bcc43877362c3d6feab29fd2f581.L1ItMn6mhr4o_vWqlI3lpil3yPPBgM0BgUa-yB6TzUQ
+        hash: v1.k794b7964.bc073af8d08d8d410fc90dddd0026a49d8734761d1a42ef5e15168d1833f5f19.T1hTP1R7sz9WQklHnUTw3T5dekgQnpvsNDtHsUJ5c7U
     products-alerts-alert-modal--missing-alert--dark:
         hash: v1.k794b7964.9180de7bde4303208cc92881f51bfc618108d5e7204acef1114b80858661662d.gbwUGmvs26EJFVhIM-HqBuAIPreZL8pNqn2ZMVi992I
     products-alerts-alert-modal--missing-alert--light:
@@ -4816,6 +4816,18 @@ snapshots:
         hash: v1.k794b7964.3c027b2e0731f9738cdfe21d14b6a893375c0fe0a0f11b587580adafc09340f9.GfzW8vynGlDg1ZO7Mp1sS9oDhRiKra5Vxhtopyi31Go
     products-alerts-shared-components--notifications-multiple-slack-workspaces--light:
         hash: v1.k794b7964.63ec31eddf76c6f6544838a9b765e091bbe84325070fff837ed94d2cc1e85ba8.rPHnjzF-XA_HZd7mJ9KKN8iLGsZVXVdne4uww2vsx4w
+    products-alerts-shared-components--preview--dark:
+        hash: v1.k794b7964.028268f1e0e029b673387aa5129e5725c9e8b9b3d4f0761d75fdaa02e05eb4aa.FyzAHgkHBTbkpO0HEaRolDmhpTSPMAL_nwj1trK8p9c
+    products-alerts-shared-components--preview--light:
+        hash: v1.k794b7964.6214671b876d623ab5136a00072509ae5717321af9805328933ac6fe9d12ebf4.PsIKiMRq6_kAXnpednfI8qxDTslRsA2Q4kMJBkROzvk
+    products-alerts-shared-components--preview-log-scale--dark:
+        hash: v1.k794b7964.7a89fa3b7a27eadf43785232e12e1b897f90cfd190d2eb7986a59e453922ea78.TEN5g6Aj-X2FpwbevBCGrQkjImF8HbJs1Uaz7Q7nReQ
+    products-alerts-shared-components--preview-log-scale--light:
+        hash: v1.k794b7964.e03a3fbe21deb066a5e2f65872fcea2c8e343365b36ec060c224061961156fae.LdJmeKkeReubVvNbqMQIsQDsRG52SE1xP5MVd6kYDaI
+    products-alerts-shared-components--preview-relative--dark:
+        hash: v1.k794b7964.ce50d6022b148097d4b9c017ed47e9dd08bc302bbfade830b8fbbfe90811c68c.jvcr8IsLRpYWmbKPM-GRzmK9r8ejx1Tlq4pTtm_sYS0
+    products-alerts-shared-components--preview-relative--light:
+        hash: v1.k794b7964.cc8f6b54c41400d0103309c6d642fff4afd53eaabb48b3a7aed6cb826c4a50f1.w7YaHhDWK8usfPMFI_dC8sJwRvbqyVZEVIxehDvD6WQ
     products-alerts-shared-components--quiet-hours--dark:
         hash: v1.k794b7964.5882b745c748c44c9f3b1026e1c35953d8e2034b5f31588d2030a8502bd5afdd.k0NFXRurTVmlsO_6I1VF93n7KlCAP3ye3kztNwuaV0k
     products-alerts-shared-components--quiet-hours--light:

--- a/products/alerts/frontend/components/AlertComponents.stories.tsx
+++ b/products/alerts/frontend/components/AlertComponents.stories.tsx
@@ -9,9 +9,10 @@ import { LemonCheckbox, LemonInput, LemonSegmentedButton } from '@posthog/lemon-
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 
 import { useStorybookMocks } from '~/mocks/browser'
-import { AlertCalculationInterval } from '~/queries/schema/schema-general'
+import { AlertCalculationInterval, AlertConditionType, InsightThresholdType } from '~/queries/schema/schema-general'
 import { IntegrationType } from '~/types'
 
+import type { AlertFormType } from 'products/alerts/frontend/logic/alertFormLogic'
 import { alertCadenceMinutes } from 'products/alerts/frontend/logic/alertIntervalHelpers'
 import { alertNotificationLogic } from 'products/alerts/frontend/logic/alertNotificationLogic'
 import type { ScheduleRestriction } from 'products/alerts/frontend/types'
@@ -30,6 +31,7 @@ import {
     AlertNotificationDestinationView,
     PendingAlertNotificationDestinationView,
 } from './AlertNotificationDestinationEditor'
+import { AlertPreviewCard } from './AlertPreviewCard'
 import { QuietHoursFields } from './QuietHoursFields'
 
 const alertEditorStoryLogic = kea([
@@ -386,6 +388,67 @@ function EvaluationHistoryStory(): JSX.Element {
     )
 }
 
+const PREVIEW_LABELS = ['Jun 1', 'Jun 2', 'Jun 3', 'Jun 4', 'Jun 5', 'Jun 6', 'Jun 7']
+
+function buildTrendsAlertForm(overrides: Partial<AlertFormType> = {}): AlertFormType {
+    return {
+        name: 'Preview alert',
+        enabled: true,
+        config: { type: 'TrendsAlertConfig', series_index: 0 },
+        condition: { type: AlertConditionType.ABSOLUTE_VALUE },
+        threshold: { configuration: { type: InsightThresholdType.ABSOLUTE, bounds: { upper: 60, lower: 20 } } },
+        ...overrides,
+    } as AlertFormType
+}
+
+function PreviewStory(): JSX.Element {
+    return (
+        <div className="max-w-md border rounded bg-surface-primary p-4">
+            <AlertPreviewCard
+                alertForm={buildTrendsAlertForm()}
+                trendsValues={[42, 48, 71, 64, 53, 68, 76]}
+                trendsLabels={PREVIEW_LABELS}
+                funnelPreview={null}
+                hogqlPreview={null}
+            />
+        </div>
+    )
+}
+
+function PreviewRelativeStory(): JSX.Element {
+    return (
+        <div className="max-w-md border rounded bg-surface-primary p-4">
+            <AlertPreviewCard
+                alertForm={buildTrendsAlertForm({
+                    condition: { type: AlertConditionType.RELATIVE_INCREASE },
+                    threshold: { configuration: { type: InsightThresholdType.PERCENTAGE, bounds: { upper: 0.25 } } },
+                })}
+                trendsValues={[100, 90, 130, 120, 160, 140, 175]}
+                trendsLabels={PREVIEW_LABELS}
+                funnelPreview={null}
+                hogqlPreview={null}
+            />
+        </div>
+    )
+}
+
+// Values span three orders of magnitude over a small threshold, so the card switches to a log scale.
+function PreviewLogScaleStory(): JSX.Element {
+    return (
+        <div className="max-w-md border rounded bg-surface-primary p-4">
+            <AlertPreviewCard
+                alertForm={buildTrendsAlertForm({
+                    threshold: { configuration: { type: InsightThresholdType.ABSOLUTE, bounds: { upper: 5 } } },
+                })}
+                trendsValues={[3, 5200, 8, 6100, 12, 4800, 6]}
+                trendsLabels={PREVIEW_LABELS}
+                funnelPreview={null}
+                hogqlPreview={null}
+            />
+        </div>
+    )
+}
+
 const meta: Meta = {
     title: 'Products/Alerts/Shared components',
     parameters: {
@@ -415,3 +478,6 @@ export const Notifications: Story = { render: () => <NotificationsStory /> }
 export const NotificationsMultipleSlackWorkspaces: Story = { render: () => <MultipleSlackWorkspacesStory /> }
 export const QuietHours: Story = { render: () => <QuietHoursStory /> }
 export const EvaluationHistory: Story = { render: () => <EvaluationHistoryStory /> }
+export const Preview: Story = { render: () => <PreviewStory /> }
+export const PreviewRelative: Story = { render: () => <PreviewRelativeStory /> }
+export const PreviewLogScale: Story = { render: () => <PreviewLogScaleStory /> }

--- a/products/alerts/frontend/components/AlertPreviewCard.tsx
+++ b/products/alerts/frontend/components/AlertPreviewCard.tsx
@@ -1,8 +1,7 @@
 import { IconInfo } from '@posthog/icons'
 import { LemonSkeleton, LemonTag, Tooltip } from '@posthog/lemon-ui'
+import { LineChart, ReferenceLines, useChartTheme } from '@posthog/quill-charts'
 
-import { Sparkline, SparklineReferenceLine } from 'lib/components/Sparkline'
-import type { AnyScaleOptions } from 'lib/components/Sparkline'
 import { humanFriendlyNumber } from 'lib/utils/numbers'
 
 import { AlertConditionType, InsightThresholdType } from '~/queries/schema/schema-general'
@@ -15,39 +14,55 @@ import {
     TrendsAlertPreviewSeries,
 } from 'products/alerts/frontend/logic/trendsAlertPreview'
 import { isFunnelsAlertConfig, isHogQLAlertConfig, isTrendsAlertConfig } from 'products/alerts/frontend/types'
+import { makeChartErrorHandler } from 'products/product_analytics/frontend/insights/trends/shared/chartErrorHandler'
 
 import { FunnelAlertPreviewBanner } from './AlertDefinitionFields'
-import { fromLogScale, shouldUseLogScale, thresholdReferenceLines, toLogScale } from './AlertPreviewCard.utils'
+import { AlertThresholdLine, shouldUseLogScale, thresholdReferenceLines } from './AlertPreviewCard.utils'
 import { HogQLAlertPreviewBanner } from './HogQLAlertPreview'
 
-function allowNegativeYScale(scale: AnyScaleOptions): AnyScaleOptions {
-    return { ...scale, min: undefined }
-}
+const handleChartError = makeChartErrorHandler('alerts-preview-chart')
 
-function AlertPreviewSparkline({
+function AlertPreviewChart({
     values,
     labels,
     referenceLines,
     relative,
-    renderTooltipValue,
+    useLogScale,
 }: {
     values: number[]
     labels?: string[]
-    referenceLines: SparklineReferenceLine[]
+    referenceLines: AlertThresholdLine[]
     relative: boolean
-    renderTooltipValue?: (value: number) => string
+    useLogScale: boolean
 }): JSX.Element {
+    const theme = useChartTheme()
     return (
-        <Sparkline
-            type="line"
-            data={values}
-            labels={labels}
-            maximumIndicator={false}
-            referenceLines={referenceLines}
-            renderTooltipValue={renderTooltipValue}
-            withYScale={relative ? allowNegativeYScale : undefined}
-            className="w-full h-24 flex flex-col"
-        />
+        <div className="w-full h-24 flex flex-col">
+            <LineChart
+                series={[{ key: 'preview', label: 'Value', data: values }]}
+                labels={labels ?? values.map((_, index) => String(index))}
+                theme={theme}
+                config={{
+                    hideXAxis: true,
+                    // The value axis only appears in relative mode, where it can dip below zero;
+                    // absolute previews stay axis-less and compact like the old sparkline.
+                    hideYAxis: !relative,
+                    floatBaseline: relative,
+                    yScaleType: useLogScale ? 'log' : 'linear',
+                    tooltip: { valueFormatter: (value) => humanFriendlyNumber(value) },
+                }}
+                onError={handleChartError}
+            >
+                <ReferenceLines
+                    lines={referenceLines.map((line) => ({
+                        value: line.value,
+                        label: line.label,
+                        labelPosition: line.labelPosition,
+                        variant: 'alert' as const,
+                    }))}
+                />
+            </LineChart>
+        </div>
     )
 }
 
@@ -82,10 +97,6 @@ export function AlertPreviewCard({
         : null
     const referenceLines = thresholdReferenceLines(alertForm)
     const useLogScale = Boolean(trendsPreview && shouldUseLogScale(trendsPreview.values, referenceLines))
-    const previewValues = useLogScale ? trendsPreview?.values.map(toLogScale) : trendsPreview?.values
-    const previewReferenceLines = useLogScale
-        ? referenceLines.map((line) => ({ ...line, value: toLogScale(line.value) }))
-        : referenceLines
     const checkPreviewValues = checkPreview?.values
     const isUnconfiguredAbsoluteThreshold =
         !alertForm.detector_config &&
@@ -107,11 +118,12 @@ export function AlertPreviewCard({
         )
     } else if (checkPreviewValues && checkPreviewValues.length > 0) {
         body = (
-            <AlertPreviewSparkline
+            <AlertPreviewChart
                 values={checkPreviewValues}
                 labels={checkPreview.labels}
                 referenceLines={referenceLines}
                 relative={checkPreview.relative}
+                useLogScale={false}
             />
         )
     } else if (checkPreview !== undefined) {
@@ -126,14 +138,14 @@ export function AlertPreviewCard({
                 No activity to preview for this series.
             </div>
         )
-    } else if (isTrendsAlertConfig(config) && previewValues && previewValues.length > 0) {
+    } else if (isTrendsAlertConfig(config) && trendsPreview && trendsPreview.values.length > 0) {
         body = (
-            <AlertPreviewSparkline
-                values={previewValues}
-                labels={trendsPreview?.labels}
-                referenceLines={previewReferenceLines}
-                renderTooltipValue={useLogScale ? fromLogScale : undefined}
-                relative={!!trendsPreview?.relative}
+            <AlertPreviewChart
+                values={trendsPreview.values}
+                labels={trendsPreview.labels}
+                referenceLines={referenceLines}
+                relative={trendsPreview.relative}
+                useLogScale={useLogScale}
             />
         )
     } else if (isFunnelsAlertConfig(config) && funnelPreview) {

--- a/products/alerts/frontend/components/AlertPreviewCard.tsx
+++ b/products/alerts/frontend/components/AlertPreviewCard.tsx
@@ -53,14 +53,7 @@ function AlertPreviewChart({
                 }}
                 onError={handleChartError}
             >
-                <ReferenceLines
-                    lines={referenceLines.map((line) => ({
-                        value: line.value,
-                        label: line.label,
-                        labelPosition: line.labelPosition,
-                        variant: 'alert' as const,
-                    }))}
-                />
+                <ReferenceLines lines={referenceLines.map((line) => ({ ...line, variant: 'alert' as const }))} />
             </LineChart>
         </div>
     )

--- a/products/alerts/frontend/components/AlertPreviewCard.utils.ts
+++ b/products/alerts/frontend/components/AlertPreviewCard.utils.ts
@@ -1,11 +1,16 @@
-import type { SparklineReferenceLine } from 'lib/components/Sparkline'
 import { humanFriendlyNumber } from 'lib/utils/numbers'
 
 import { AlertConditionType, InsightThresholdType } from '~/queries/schema/schema-general'
 
 import type { AlertFormType } from 'products/alerts/frontend/logic/alertFormLogic'
 
-export function thresholdReferenceLines(alertForm: AlertFormType): SparklineReferenceLine[] {
+export interface AlertThresholdLine {
+    value: number
+    label: string
+    labelPosition: 'start' | 'end'
+}
+
+export function thresholdReferenceLines(alertForm: AlertFormType): AlertThresholdLine[] {
     if (alertForm.detector_config) {
         return []
     }
@@ -15,12 +20,11 @@ export function thresholdReferenceLines(alertForm: AlertFormType): SparklineRefe
         alertForm.condition?.type !== AlertConditionType.ABSOLUTE_VALUE &&
         configuration?.type === InsightThresholdType.PERCENTAGE
     const displayValue = (value: number): number => (relativePercentage ? value * 100 : value)
-    const lines: SparklineReferenceLine[] = []
+    const lines: AlertThresholdLine[] = []
     if (bounds?.upper != null && !Number.isNaN(bounds.upper)) {
         const value = displayValue(bounds.upper)
         lines.push({
             value,
-            color: 'danger',
             label: `above ${humanFriendlyNumber(value)}`,
             labelPosition: 'end',
         })
@@ -29,7 +33,6 @@ export function thresholdReferenceLines(alertForm: AlertFormType): SparklineRefe
         const value = displayValue(bounds.lower)
         lines.push({
             value,
-            color: 'danger',
             label: `below ${humanFriendlyNumber(value)}`,
             labelPosition: 'start',
         })
@@ -37,15 +40,7 @@ export function thresholdReferenceLines(alertForm: AlertFormType): SparklineRefe
     return lines
 }
 
-export function toLogScale(value: number): number {
-    return Math.log10(value + 1)
-}
-
-export function fromLogScale(value: number): string {
-    return humanFriendlyNumber(10 ** value - 1)
-}
-
-export function shouldUseLogScale(values: number[], referenceLines: SparklineReferenceLine[]): boolean {
+export function shouldUseLogScale(values: number[], referenceLines: AlertThresholdLine[]): boolean {
     if (
         referenceLines.length === 0 ||
         values.some((value) => value < 0 || !Number.isFinite(value)) ||

--- a/products/alerts/frontend/components/AlertPreviewCard.utils.ts
+++ b/products/alerts/frontend/components/AlertPreviewCard.utils.ts
@@ -1,3 +1,5 @@
+import type { ReferenceLineLabelPosition } from '@posthog/quill-charts'
+
 import { humanFriendlyNumber } from 'lib/utils/numbers'
 
 import { AlertConditionType, InsightThresholdType } from '~/queries/schema/schema-general'
@@ -7,7 +9,7 @@ import type { AlertFormType } from 'products/alerts/frontend/logic/alertFormLogi
 export interface AlertThresholdLine {
     value: number
     label: string
-    labelPosition: 'start' | 'end'
+    labelPosition: ReferenceLineLabelPosition
 }
 
 export function thresholdReferenceLines(alertForm: AlertFormType): AlertThresholdLine[] {


### PR DESCRIPTION
## Problem

Migrating off chart-js, and these charts still use it

## Changes
<img width="923" height="734" alt="Screenshot 2026-08-20 at 17 48 31" src="https://github.com/user-attachments/assets/82adc826-4da8-4f49-944f-93ac8d7a93cb" />

- The preview card renders through the quill `LineChart` instead of the legacy `Sparkline`, so it no longer pins that consumer to Chart.js. Thresholds become quill `ReferenceLines` (dashed red).
- The value axis uses quill's native log scale for wide-spread absolute previews. This deletes the app-side `toLogScale`/`fromLogScale` helpers that faked a log scale by transforming the data and the tooltip.
- Relative previews keep the signed y-axis so negative changes stay visible; absolute previews stay axis-less and compact, as before.
- Added `Preview`, `PreviewRelative`, and `PreviewLogScale` stories for visual-regression cover.
- Mechanical: the private `AlertPreviewSparkline` helper is renamed `AlertPreviewChart`.

## How did you test this code?

- Ran the alerts frontend jest suite and the frontend TypeScript check locally; both pass.
- Booted Storybook and rendered the three new stories to confirm the thresholds, the relative signed axis, and the log scale render correctly (screenshots above).
- Not run: the live alert editor end-to-end against a real insight.

The new stories catch a rendering regression in the preview card — a broken threshold line, a collapsed axis, or a log scale that stops engaging — which no existing test covered.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (Opus 4.8) under direction to migrate the alerts charts to quill. Skills invoked: `/writing-ui-components`, `/writing-pr-descriptions`.

The log-scale simplification was a deliberate call: quill's `yScaleType: 'log'` replaces the hand-rolled `log10(v+1)` transform, its inverse, and the transformed reference lines, and it is more correct (the tooltip now shows raw values without a formatter). The compact `h-24` sizing and the axis-less-except-in-relative-mode behavior were kept to match the old sparkline exactly.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
