### PR TITLE
feat(autoresearch): add the MCP tools and HogQL system table (12/13)

### DIFF
--- a/frontend/src/lib/agentScopes.generated.ts
+++ b/frontend/src/lib/agentScopes.generated.ts
@@ -18,6 +18,8 @@ export const AGENT_USE_CASE_SCOPES = [
     'annotation:write',
     'approvals:read',
     'approvals:write',
+    'autoresearch:read',
+    'autoresearch:write',
     'batch_export:read',
     'batch_export:write',
     'billing:read',

--- a/posthog/hogql/database/schema/system.py
+++ b/posthog/hogql/database/schema/system.py
@@ -1008,6 +1008,27 @@ groups: PostgresTable = PostgresTable(
     },
 )
 
+autoresearch_pipelines: PostgresTable = PostgresTable(
+    name="autoresearch_pipelines",
+    postgres_table_name="autoresearch_autoresearchpipeline",
+    access_scope="autoresearch",
+    fields={
+        "id": UUIDDatabaseField(name="id"),
+        "team_id": IntegerDatabaseField(name="team_id"),
+        "name": StringDatabaseField(name="name"),
+        "description": StringDatabaseField(name="description"),
+        "target_event": StringDatabaseField(name="target_event"),
+        "horizon_days": IntegerDatabaseField(name="horizon_days"),
+        "status": StringDatabaseField(name="status"),
+        "iteration_budget": IntegerDatabaseField(name="iteration_budget"),
+        "iteration_budget_remaining": IntegerDatabaseField(name="iteration_budget_remaining"),
+        "output_person_property": StringDatabaseField(name="output_person_property"),
+        "last_scored_at": DateTimeDatabaseField(name="last_scored_at"),
+        "created_at": DateTimeDatabaseField(name="created_at"),
+        "updated_at": DateTimeDatabaseField(name="updated_at"),
+    },
+)
+
 group_type_mappings: PostgresTable = PostgresTable(
     name="group_type_mappings",
     postgres_table_name="posthog_grouptypemapping",
@@ -2915,6 +2936,7 @@ class SystemTables(TableNode):
         "task_runs": TableNode(name="task_runs", table=task_runs),
         "tags": TableNode(name="tags", table=tags),
         "tasks": TableNode(name="tasks", table=tasks),
+        "autoresearch_pipelines": TableNode(name="autoresearch_pipelines", table=autoresearch_pipelines),
         "teams": TableNode(name="teams", table=teams),
         "trace_review_scores": TableNode(name="trace_review_scores", table=trace_review_scores),
         "trace_reviews": TableNode(name="trace_reviews", table=trace_reviews),

--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -11215,6 +11215,135 @@
           "row_count": null,
           "type": "system"
       },
+      "system.autoresearch_pipelines": {
+          "certification": null,
+          "fields": {
+              "id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "id",
+                  "id": null,
+                  "name": "id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "name": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "name",
+                  "id": null,
+                  "name": "name",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "description": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "description",
+                  "id": null,
+                  "name": "description",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "target_event": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "target_event",
+                  "id": null,
+                  "name": "target_event",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "horizon_days": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "horizon_days",
+                  "id": null,
+                  "name": "horizon_days",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "status": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "status",
+                  "id": null,
+                  "name": "status",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "iteration_budget": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "iteration_budget",
+                  "id": null,
+                  "name": "iteration_budget",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "iteration_budget_remaining": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "iteration_budget_remaining",
+                  "id": null,
+                  "name": "iteration_budget_remaining",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "output_person_property": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "output_person_property",
+                  "id": null,
+                  "name": "output_person_property",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "last_scored_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "last_scored_at",
+                  "id": null,
+                  "name": "last_scored_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "created_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "created_at",
+                  "id": null,
+                  "name": "created_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "updated_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "updated_at",
+                  "id": null,
+                  "name": "updated_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              }
+          },
+          "id": "system.autoresearch_pipelines",
+          "name": "system.autoresearch_pipelines",
+          "row_count": null,
+          "type": "system"
+      },
       "system.teams": {
           "certification": null,
           "fields": {
@@ -22025,6 +22154,135 @@
           },
           "id": "system.tasks",
           "name": "system.tasks",
+          "row_count": null,
+          "type": "system"
+      },
+      "system.autoresearch_pipelines": {
+          "certification": null,
+          "fields": {
+              "id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "id",
+                  "id": null,
+                  "name": "id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "name": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "name",
+                  "id": null,
+                  "name": "name",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "description": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "description",
+                  "id": null,
+                  "name": "description",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "target_event": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "target_event",
+                  "id": null,
+                  "name": "target_event",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "horizon_days": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "horizon_days",
+                  "id": null,
+                  "name": "horizon_days",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "status": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "status",
+                  "id": null,
+                  "name": "status",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "iteration_budget": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "iteration_budget",
+                  "id": null,
+                  "name": "iteration_budget",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "iteration_budget_remaining": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "iteration_budget_remaining",
+                  "id": null,
+                  "name": "iteration_budget_remaining",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "output_person_property": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "output_person_property",
+                  "id": null,
+                  "name": "output_person_property",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "last_scored_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "last_scored_at",
+                  "id": null,
+                  "name": "last_scored_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "created_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "created_at",
+                  "id": null,
+                  "name": "created_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "updated_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "updated_at",
+                  "id": null,
+                  "name": "updated_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              }
+          },
+          "id": "system.autoresearch_pipelines",
+          "name": "system.autoresearch_pipelines",
           "row_count": null,
           "type": "system"
       },

--- a/products/autoresearch/mcp/AGENTS.md
+++ b/products/autoresearch/mcp/AGENTS.md
@@ -1,0 +1,61 @@
+# MCP tools
+
+The `autoresearch-*` tool surface. Unusually for a PostHog product, these tools are not primarily for users or for Max — **they are how the training agent operates the product on itself.**
+
+During a run, the sandbox agent has no other write path. It records iterations, materializes features, uploads its bundle, and finalizes its run entirely through these tools. Everything a tool description does not say, the agent has to guess.
+
+## What lives here
+
+- `tools.yaml`
+  The whole surface: 29 enabled tools, `category: Autoresearch`, `feature: autoresearch`, `url_prefix: /autoresearch`.
+  Each entry names an `operation` (an operation id from the OpenAPI spec), an `enabled` flag, required `scopes` (`autoresearch:read` / `autoresearch:write`), `annotations` (`readOnly`, `destructive`, `idempotent`), and a `title` + `description`.
+
+Tool entries are scaffolded from the OpenAPI schema — `pnpm --filter=@posthog/mcp run scaffold-yaml -- --sync-all` keeps the tool list and operation ids in sync. Everything editorial (description, title, `enrich_url`, `exclude_params`) is yours to write.
+
+## The two tool families
+
+**Agent-facing** — the training loop's own control surface, backed by `AutoresearchTrainingRunViewSet`:
+
+`autoresearch-training-runs-create`, `-iterations-create`, `-materialize-features`, `-artifacts-upload-create`, `-artifacts-get-create`, `-artifacts-retrieve`, `-artifacts-delete-create`, `-complete-create`, `-history`.
+
+**User-facing** — managing pipelines: `autoresearch-create`, `-list`, `-retrieve`, `-archive-create`, `-pause-create`, `-resume-create`, `-score-create`, `-train-create`, `-models-list`, `-models-retrieve`, `-runs-list`, `-suggestions-*`, `-templates-list`, `-resolve-template-create`, `-validate-*`.
+
+The split matters when you change a description. An agent-facing description is a **contract**: `autoresearch-training-runs-iterations-create` has to tell the agent what a valid `feature_sql` looks like, because the server will reject anything that is not a read-only `SELECT` keyed on `person_id` and the agent has no other way to learn that.
+
+## Descriptions are the product
+
+The descriptions here already do real work, and that is the standard to hold. Examples of what "good" looks like in this file:
+
+- `autoresearch-create` spells out the mutual exclusion — pass `target_event` _or_ `target_definition`, exactly one — and names the next call (`autoresearch-train-create`).
+- It also tells the caller to run `autoresearch-validate-create` first _and_ warns that the endpoint does not block on validation errors, so the model knows the check is advisory.
+- `autoresearch-archive-create` says what is preserved, that it is reversible only via direct DB access, and points at `pause` as the reversible alternative.
+
+Write for a model that has read nothing else. Name the prerequisite call, the next call, and the failure mode.
+
+## Cross-run memory
+
+These tools are also how a run learns from previous ones. A training agent can call `autoresearch-models-list` and `autoresearch-training-runs-history` on _sibling_ pipelines and build on what already worked — that behavior has been observed in practice, with a run opening by reading an earlier pipeline's champion recipe and using it as its baseline.
+
+That makes the read tools load-bearing for model quality, not just for introspection. Do not disable or narrow them casually.
+
+## Where the rest of the system meets this file
+
+- **Backed by** — `../backend/api/views.py`. A tool is only as good as its serializer annotations; `help_text` and `@extend_schema` flow directly into these schemas.
+- **Generated into** — `services/mcp/src/tools/generated/autoresearch.ts` and `services/mcp/src/generated/autoresearch/api.ts`.
+- **Consumed by** — the sandbox agent during `../backend/training/` runs, plus any normal MCP client.
+
+## `enrich_url` needs a documented response schema
+
+`enrich_url: '{id}'` makes the generated handler read `result.id`, so the operation's **response** type has to actually carry that field.
+
+This broke once: `autoresearch-create` failed MCP typecheck with `Property 'id' does not exist on type 'AutoresearchPipelineCreate'`. The endpoint returned the read serializer at runtime but only declared the write one, so drf-spectacular typed the response as the request body — which has no `id`. Fixed by declaring `responses={201: AutoresearchPipelineSerializer}` on the viewset's `create`.
+
+If you add `enrich_url` to a tool, check the operation's declared response schema contains the field you interpolate. Fix it on the endpoint and regenerate; never patch the generated file.
+
+## When editing this file
+
+- **Adding an endpoint does not expose it.** A tool exists only once it has an entry here with `enabled: true`.
+- Set `scopes` and `annotations` deliberately — `readOnly` and `destructive` change how clients treat a tool.
+- Prefer improving the serializer's `help_text` over writing a longer tool description; the serializer feeds the frontend types too, so the fix lands in both places.
+- After any change run `pnpm --filter=@posthog/mcp run typecheck` and commit the regenerated files — CI checks for drift.
+- **If you add or retire a tool, update this file to match.**

--- a/products/autoresearch/mcp/CLAUDE.md
+++ b/products/autoresearch/mcp/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/products/autoresearch/mcp/tools.yaml
+++ b/products/autoresearch/mcp/tools.yaml
@@ -1,0 +1,616 @@
+# MCP tool definition — tool entries are scaffolded from the OpenAPI schema.
+# The tool list and operation IDs are kept in sync automatically:
+#   pnpm --filter=@posthog/mcp run scaffold-yaml -- --sync-all
+#
+# To enable a tool, set enabled: true and add required scopes + annotations.
+# All other fields (title, description, enrich_url, etc.) are yours to configure.
+category: Autoresearch
+feature: autoresearch
+url_prefix: /autoresearch
+ui_apps: {}
+tools:
+    autoresearch-archive-create:
+        operation: autoresearch_archive_create
+        enabled: true
+        scopes:
+            - autoresearch:write
+        annotations:
+            readOnly: false
+            destructive: true
+            idempotent: true
+        title: Archive pipeline
+        description: >
+            Soft-delete a pipeline. Stops daily scoring and training. Prediction history and model artifacts are
+            preserved. Archived pipelines are excluded from autoresearch-list. This is reversible only via direct DB
+            access — use pause instead if you want to temporarily stop a pipeline.
+        feature_flag: autoresearch
+    autoresearch-create:
+        operation: autoresearch_create
+        enabled: true
+        scopes:
+            - autoresearch:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        enrich_url: '{id}'
+        title: Create a pipeline
+        description: >
+            Create a new autoresearch prediction pipeline. Always call autoresearch-validate-create first — this
+            endpoint does not block on validation errors. The prediction target is either an event (pass target_event,
+            e.g. '$pageview') or a PostHog action (pass target_definition = {"type": "action", "action_id": N} to predict
+            a multi-step / property / autocapture matcher; target_event is then optional and used only as a display
+            label). Provide exactly one. horizon_days defaults to 7. The output person property (e.g.
+            'predicted_p_pageview') is auto-derived from target_event if omitted, and must be unique among the
+            project's non-archived pipelines. After creating, call autoresearch-train-create to start an asynchronous
+            agent training run.
+        exclude_params:
+            - id
+            - created_by
+            - created_at
+            - updated_at
+            - last_scored_at
+            - status
+            - iteration_budget_remaining
+        feature_flag: autoresearch
+    autoresearch-destroy:
+        operation: autoresearch_destroy
+        enabled: false
+    autoresearch-list:
+        operation: autoresearch_list
+        enabled: true
+        mcp_version: 1
+        scopes:
+            - autoresearch:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        list: true
+        title: List pipelines
+        description: >
+            List autoresearch prediction pipelines for the current project. Archived pipelines are excluded. Each
+            pipeline entry includes its status (draft, bootstrapping, running, converged, paused), target event,
+            horizon, and timestamps. Use autoresearch-retrieve to get full details including population definitions.
+        response:
+            include:
+                - id
+                - name
+                - description
+                - target_event
+                - horizon_days
+                - status
+                - iteration_budget
+                - iteration_budget_remaining
+                - last_scored_at
+                - created_at
+                - updated_at
+        feature_flag: autoresearch
+    autoresearch-materialize-features:
+        operation: autoresearch_training_runs_materialize_features_create
+        enabled: true
+        scopes:
+            - autoresearch:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        title: Materialize training features to the sandbox
+        description: >
+            Run your features.sql server-side against the labeled training population and write the train/holdout
+            feature and label parquet files directly into your sandbox. Returns the local paths (train_features_path,
+            train_labels_path, holdout_features_path, holdout_labels_path), row counts, and the feature column list —
+            the feature rows never pass through your context and there is NO 500-row cap. Then pd.read_parquet the
+            returned paths and iterate in Python. Use this to pull training data instead of execute-sql, and re-call it
+            whenever you change features.sql.
+        feature_flag: autoresearch
+    autoresearch-models-list:
+        operation: autoresearch_models_list
+        enabled: true
+        mcp_version: 1
+        scopes:
+            - autoresearch:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        list: true
+        title: List models for a pipeline
+        description: >
+            List champion, challenger, and archived model versions for a pipeline. Each model includes its
+            holdout_score, role, recipe_hash, is_preliminary flag, and agent_description. The active scoring model has
+            role='champion'. Use the recipe_hash to detect when the champion has changed across training runs.
+        response:
+            include:
+                - id
+                - pipeline
+                - role
+                - recipe_hash
+                - holdout_score
+                - realized_score
+                - is_preliminary
+                - agent_description
+                - trained_on_start
+                - trained_on_end
+                - promoted_at
+                - created_at
+        feature_flag: autoresearch
+    autoresearch-models-retrieve:
+        operation: autoresearch_models_retrieve
+        enabled: true
+        mcp_version: 1
+        scopes:
+            - autoresearch:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Get model
+        description: >
+            Get full details for a specific model version, including the portable model recipe (feature SQL, transforms,
+            model class, params) and feature importance explanation.
+        feature_flag: autoresearch
+    autoresearch-partial-update:
+        operation: autoresearch_partial_update
+        enabled: false
+    autoresearch-pause-create:
+        operation: autoresearch_pause_create
+        enabled: true
+        scopes:
+            - autoresearch:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        title: Pause pipeline
+        description: >
+            Pause a running pipeline. Daily scoring and training stop until the pipeline is resumed. Use
+            autoresearch-resume-create to restart.
+        feature_flag: autoresearch
+    autoresearch-resolve-template-create:
+        operation: autoresearch_resolve_template_create
+        enabled: true
+        scopes:
+            - autoresearch:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Resolve a template
+        description: >
+            Resolve a template key and optional overrides into a ready-to-use pipeline config. For activity-based
+            templates ('likely_active_soon', 'at_risk_of_inactivity', 'return_after_first_use'), the target_event is
+            auto-resolved from your event schema — review resolved_activity_event and activity_event_alternatives, then
+            re-resolve with a target_event override if the chosen event is wrong. For 'feature_adoption' and
+            'repeat_key_behavior', supply target_event (required). After resolving: (1) call
+            autoresearch-validate-create with the resolved target_event, training_population, and inference_population
+            to check volume and warnings; (2) if can_proceed is true, call autoresearch-create with the resolved fields
+            as-is.
+        exclude_params:
+            - resolved_activity_event
+            - activity_event_alternatives
+            - display_name
+            - description
+            - notes
+        feature_flag: autoresearch
+    autoresearch-resume-create:
+        operation: autoresearch_resume_create
+        enabled: true
+        scopes:
+            - autoresearch:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        title: Resume pipeline
+        description: |
+            Resume a paused pipeline. Returns 400 if the pipeline is not currently paused.
+        feature_flag: autoresearch
+    autoresearch-retrieve:
+        operation: autoresearch_retrieve
+        enabled: true
+        mcp_version: 1
+        scopes:
+            - autoresearch:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        enrich_url: '{id}'
+        title: Get pipeline
+        description: >
+            Get full details for a specific autoresearch pipeline by ID, including population definitions, training
+            configuration, and current status.
+        feature_flag: autoresearch
+    autoresearch-runs-list:
+        operation: autoresearch_runs_list
+        enabled: true
+        mcp_version: 1
+        scopes:
+            - autoresearch:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        list: true
+        title: List inference runs
+        description: >
+            List inference and validation runs for a pipeline, ordered most recent first. Check rows_scored and status
+            to understand scoring history. run_type is 'inference' for daily scoring runs.
+        response:
+            include:
+                - id
+                - pipeline
+                - model
+                - run_type
+                - status
+                - rows_scored
+                - error
+                - started_at
+                - completed_at
+                - created_at
+        feature_flag: autoresearch
+    autoresearch-runs-retrieve:
+        operation: autoresearch_runs_retrieve
+        enabled: false
+    autoresearch-score-create:
+        operation: autoresearch_score_create
+        enabled: true
+        scopes:
+            - autoresearch:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        title: Run inference (score users)
+        description: >
+            Score the inference population using the champion model and emit 'autoresearch_prediction' events for each
+            user. Returns the inference run object with rows_scored and status. Requires a champion model — run
+            autoresearch-train-create first if the pipeline has no champion. Each scored user gets a '$autoresearch_p_y'
+            property on their prediction event and a person property update. After scoring, query predictions with
+            execute-sql: SELECT distinct_id, properties.$autoresearch_p_y FROM events WHERE event =
+            'autoresearch_prediction' AND properties.$autoresearch_pipeline_id = '<pipeline_id>' ORDER BY
+            properties.$autoresearch_p_y DESC LIMIT 50.
+        feature_flag: autoresearch
+    autoresearch-suggestions-create:
+        operation: autoresearch_suggestions_create
+        enabled: true
+        scopes:
+            - autoresearch:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        title: Submit a suggestion
+        description: >
+            Inject a free-text hypothesis or direction into a running pipeline for the sandbox agent to consider. The
+            agent reads queued suggestions at the start of each training batch and decides whether to translate the
+            suggestion into a concrete iteration ('acted_on'), apply it as a search constraint ('picked_up'), or reject
+            it with rationale ('dismissed'). Use priority='try_next' to instruct the agent to act on this before
+            autonomous iterations; 'consider' (default) is advisory. Check 'agent_response' after the next training run
+            to see how the suggestion was interpreted. Examples: 'try a gradient boosting model', 'remove recency
+            features — I suspect leakage', 'the target event has a 7-day spike on Mondays, account for day-of-week'.
+            Suggestions survive pipeline pauses and are included in the next training batch when the pipeline resumes.
+        exclude_params:
+            - source
+            - status
+            - agent_response
+            - created_by
+            - linked_iteration_ids
+        feature_flag: autoresearch
+    autoresearch-suggestions-list:
+        operation: autoresearch_suggestions_list
+        enabled: true
+        mcp_version: 1
+        scopes:
+            - autoresearch:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        list: true
+        title: List suggestions
+        description: >
+            List steering suggestions for a pipeline, ordered most recent first. Each entry shows the prompt, priority,
+            status (queued/picked_up/acted_on/dismissed), and the agent's response when available. Use
+            'linked_iteration_ids' to trace which iterations were spawned from a suggestion.
+        response:
+            include:
+                - id
+                - pipeline
+                - prompt
+                - priority
+                - status
+                - source
+                - agent_response
+                - linked_iteration_ids
+                - created_at
+        feature_flag: autoresearch
+    autoresearch-suggestions-retrieve:
+        operation: autoresearch_suggestions_retrieve
+        enabled: true
+        mcp_version: 1
+        scopes:
+            - autoresearch:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Get suggestion
+        description: |
+            Get full details for a specific suggestion including its status and agent_response.
+        feature_flag: autoresearch
+    autoresearch-suggestions-respond:
+        operation: autoresearch_suggestions_respond_create
+        enabled: true
+        scopes:
+            - autoresearch:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        title: Respond to a suggestion
+        description: >
+            Record how you handled a steering suggestion so the human who submitted it sees the outcome (it stays
+            'queued' in the UI until you do). Set status to 'picked_up' (applied as a search constraint across
+            iterations), 'acted_on' (spawned one or more iterations from it), or 'dismissed' (rejected — explain why in
+            agent_response), and write a one-line agent_response. Recording an iteration with parent_suggestion set
+            already advances a suggestion to 'acted_on'; use this tool to add the narrative or to mark a suggestion
+            picked_up/dismissed without a dedicated iteration.
+        feature_flag: autoresearch
+    autoresearch-templates-list:
+        operation: autoresearch_templates_list
+        enabled: true
+        scopes:
+            - autoresearch:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        list: true
+        title: List available templates
+        description: >
+            List all built-in autoresearch prediction templates. Each entry includes the template key, display name,
+            description, default horizon, prediction mode, and whether you need to supply a target_event. Templates:
+            'likely_active_soon' (best universal starter — predicts next-7d activity), 'at_risk_of_inactivity' (predicts
+            14d inactivity risk), 'return_after_first_use' (predicts new-user return within 7d), 'feature_adoption'
+            (predicts first use of your chosen event within 14d — requires target_event), 'repeat_key_behavior'
+            (predicts repeat use of your chosen event within 7d — requires target_event). After picking a template, call
+            autoresearch-resolve-template-create to get a resolved pipeline config.
+        response:
+            include:
+                - key
+                - display_name
+                - description
+                - default_horizon_days
+                - requires_user_event
+                - requires_activity_resolution
+                - notes
+        feature_flag: autoresearch
+    autoresearch-train-create:
+        operation: autoresearch_train_create
+        enabled: true
+        scopes:
+            - autoresearch:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        title: Start training
+        description: >
+            Start an asynchronous training run for a pipeline. Launches the autoresearch agent in a sandbox and returns
+            the training run immediately with status 'running'. Poll autoresearch-training-runs-list until the run
+            reaches 'completed' or 'failed'; no champion model exists until the run completes and server-side promotion
+            runs. Returns 400 if a training run is already in progress for the pipeline. After a run completes and
+            promotes a champion, call autoresearch-score-create to run inference and emit prediction events. You can
+            optionally override the iteration_budget for this run.
+        feature_flag: autoresearch
+    autoresearch-training-runs-artifacts-delete-create:
+        operation: autoresearch_training_runs_artifacts_delete_create
+        enabled: true
+        scopes:
+            - autoresearch:write
+        annotations:
+            readOnly: false
+            destructive: true
+            idempotent: true
+        title: Delete an artifact bundle file
+        description: >
+            Remove one file from a training run's artifact bundle. Idempotent — deleting a missing file is a no-op.
+            Only allowed while the run is still running; the bundle is frozen once the run completes or fails.
+        feature_flag: autoresearch
+    autoresearch-training-runs-artifacts-get-create:
+        operation: autoresearch_training_runs_artifacts_get_create
+        enabled: true
+        scopes:
+            - autoresearch:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Get an artifact bundle file
+        description: >
+            Fetch one file from a training run's artifact bundle, base64-encoded. Use this to read the prior champion's
+            train.py / features.sql as a starting point before iterating (look up the champion's source_training_run via
+            autoresearch-models-retrieve).
+        feature_flag: autoresearch
+    autoresearch-training-runs-artifacts-retrieve:
+        operation: autoresearch_training_runs_artifacts_retrieve
+        enabled: true
+        scopes:
+            - autoresearch:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: List artifact bundle files
+        description: >
+            List the files uploaded for a training run's artifact bundle (train.py, predict.py, features.sql, and any
+            eda/ notebooks). Use to confirm a complete bundle is present before finalizing the run.
+        feature_flag: autoresearch
+    autoresearch-training-runs-artifacts-upload-create:
+        operation: autoresearch_training_runs_artifacts_upload_create
+        enabled: true
+        scopes:
+            - autoresearch:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        title: Upload an artifact bundle file
+        description: >
+            Upload one file of a training run's runnable model bundle. Send the file contents base64-encoded in
+            content_base64; path is the relative path within the bundle (train.py, predict.py, features.sql, or an eda/
+            notebook). Re-uploading the same path overwrites it. This is how you author the model — author train.py and
+            predict.py (standalone sklearn scripts) and features.sql (HogQL with the {anchors}/{lookback_days}
+            contract), then upload each here. Do NOT use set_output or curl — the bundle you upload is what inference
+            runs in a sandbox. Only allowed while the run is still running; the bundle is frozen once the run completes
+            or fails.
+        feature_flag: autoresearch
+    autoresearch-training-runs-complete-create:
+        operation: autoresearch_training_runs_complete_create
+        enabled: true
+        scopes:
+            - autoresearch:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        title: Complete a training run
+        description: >
+            Finalize a training run. The backend selects the best iteration (highest holdout_score, or the
+            best_iteration_id you name), decides champion vs challenger via the promotion ladder (cold-start
+            preliminary, anti-thrash margin for an existing champion), and persists the model. Agents cannot set the
+            champion directly — promotion is server-only. Call autoresearch-models-list afterwards to see the resulting
+            champion/challenger. Optionally pass model_explanation (top features and directionality) for the model card.
+            Also pass distillation (1–2 sentences on what this run learned) and recommended_next (what a future run
+            should try next) — these are stored in the run summary and read back by the next run during orientation; the
+            backend derives the rest of the summary (kept ladder, dead-ends) from your recorded iterations.
+        feature_flag: autoresearch
+    autoresearch-training-runs-create:
+        operation: autoresearch_training_runs_create
+        enabled: true
+        scopes:
+            - autoresearch:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        title: Open a training run
+        description: >
+            Open a new training run for a pipeline and return its id. An agent (your own, the in-house sandbox, or a
+            scheduled job) then records iterations against this run with autoresearch-training-runs-iterations-create
+            and finalizes it with autoresearch-training-runs-complete-create. The run starts in 'running'. Optionally
+            override the iteration_budget for this run.
+        feature_flag: autoresearch
+    autoresearch-training-runs-history:
+        operation: autoresearch_training_runs_history_retrieve
+        enabled: true
+        scopes:
+            - autoresearch:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Read prior training-run history
+        description: >
+            Cross-run learning memory. Returns recent completed training runs — this pipeline first, then same-target
+            sibling pipelines on the team. Each run has a distilled `summary` (read this first: distillation,
+            recommended_next, the kept_ladder of winning approaches, and dead_ends to avoid) plus the full `iterations`
+            trail (every recipe tried, its agent_description rationale, holdout_score, kept/discarded status,
+            model_spec) to drill into when a summary points somewhere worth it. Call this before iterating to reuse the
+            features and transforms that won and avoid repeating approaches already discarded. Optional `limit` (default
+            5, max 20) caps how many prior runs are returned.
+        feature_flag: autoresearch
+    autoresearch-training-runs-iterations-create:
+        operation: autoresearch_training_runs_iterations_create
+        enabled: true
+        scopes:
+            - autoresearch:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        title: Record a training iteration
+        description: >
+            Record one iteration of an open training run. Idempotent on iteration_number — re-sending the same number
+            updates that iteration in place. The recipe is validated server-side: model_class in model_spec must be in
+            the sklearn/xgboost allowlist, and feature_sql in recipe_snapshot must be a read-only SELECT keyed on
+            person_id. Use status='kept' if the iteration improved on the best score, 'discarded' otherwise, 'crashed'
+            on failure. Iterations are picked up at completion time to choose the champion. If this iteration was
+            spawned from a pending steering suggestion, pass parent_suggestion = the suggestion's ID — that links the
+            iteration to the suggestion for attribution and marks the suggestion 'acted_on'.
+        feature_flag: autoresearch
+    autoresearch-training-runs-list:
+        operation: autoresearch_training_runs_list
+        enabled: true
+        mcp_version: 1
+        scopes:
+            - autoresearch:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        list: true
+        title: List training runs
+        description: >
+            List training runs for a pipeline, ordered most recent first. Check status (completed/failed),
+            iteration_count, and best_holdout_score to understand training history.
+        response:
+            include:
+                - id
+                - pipeline
+                - status
+                - iteration_budget
+                - iteration_count
+                - best_holdout_score
+                - error
+                - started_at
+                - completed_at
+                - created_at
+        feature_flag: autoresearch
+    autoresearch-training-runs-retrieve:
+        operation: autoresearch_training_runs_retrieve
+        enabled: false
+    autoresearch-update:
+        operation: autoresearch_update
+        enabled: false
+    autoresearch-validate-create:
+        operation: autoresearch_validate_create
+        enabled: true
+        scopes:
+            - autoresearch:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Validate a pipeline definition
+        description: >
+            Validate a proposed autoresearch pipeline before creating it. The target is either an event (pass
+            target_event) or a PostHog action (pass target_definition = {"type": "action", "action_id": N}); base-rate
+            and volume estimates are computed against whichever you provide. Returns volume estimates, base rate, positive
+            and negative example counts, and a list of warnings. Check 'can_proceed' before calling autoresearch-create:
+            if false, resolve errors first. 'requires_acknowledgement' means there are non-blocking warnings worth
+            noting. Typical errors: low_volume (fewer than 100 users), low_positives (fewer than 20 positive examples),
+            or extreme_imbalance (base rate below 0.001). Always validate before creating.
+        feature_flag: autoresearch
+    autoresearch-validate-online-create:
+        operation: autoresearch_validate_online_create
+        enabled: true
+        scopes:
+            - autoresearch:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        title: Run online validation
+        description: >
+            Validate predictions against realized outcomes for all matured prediction dates. A prediction date is
+            matured when today >= prediction_date + horizon_days — meaning the outcome window has closed and
+            ground-truth labels can be fetched. Computes per-model realized AUC, Brier score, expected calibration error
+            (ECE), and lift@10/20. Updates the model's realized_score and calibration_error in Postgres, and clears the
+            is_preliminary flag after the first successful validation cycle. Already-validated dates are skipped
+            automatically. Returns one run object per prediction date processed; an empty list means no dates have
+            matured yet. In production this is triggered by the daily Temporal validation workflow after inference runs.
+            Call autoresearch-models-list after this to see updated realized_score values on champion/challenger models.
+        feature_flag: autoresearch

--- a/products/posthog_ai/skills/querying-posthog-data/SKILL.md
+++ b/products/posthog_ai/skills/querying-posthog-data/SKILL.md
@@ -57,6 +57,7 @@ Schema reference for PostHog's core system models, organized by domain:
 - [Actions](./references/models-actions.md)
 - [Alerts](./references/models-alerts.md)
 - [Annotations](./references/models-annotations.md)
+- [Autoresearch](./references/models-autoresearch.md)
 - [APM / tracing (`posthog.trace_spans`)](./references/models-apm-spans.md)
 - [Batch exports](./references/models-batch-exports.md)
 - [Early Access Features](./references/models-early-access-features.md)

--- a/products/posthog_ai/skills/querying-posthog-data/references/models-autoresearch.md
+++ b/products/posthog_ai/skills/querying-posthog-data/references/models-autoresearch.md
@@ -1,0 +1,31 @@
+# Autoresearch
+
+## AutoresearchPipeline (`system.autoresearch_pipelines`)
+
+A standing prediction question: a target event, a population, and a horizon ("who will download a file in the next 30 days?"). An agent searches for a model that answers it, and the product scores the population on a cadence, emitting one `autoresearch_prediction` event per person.
+
+### Columns
+
+Column | Type | Nullable | Description
+`id` | uuid | NOT NULL | Primary key
+`team_id` | integer | NOT NULL | Team this pipeline belongs to
+`name` | varchar(255) | NOT NULL | Human-readable name
+`description` | text | NOT NULL | Free-text description (can be blank)
+`target_event` | varchar(255) | NOT NULL | Event being predicted, for example `$pageview`
+`horizon_days` | integer | NOT NULL | Predict whether the target occurs within N days
+`status` | varchar(20) | NOT NULL | `draft`, `bootstrapping`, `running`, `converged`, `paused`, or `archived`
+`iteration_budget` | integer | NOT NULL | Maximum training iterations allowed
+`iteration_budget_remaining` | integer | NOT NULL | Iterations still available to spend
+`output_person_property` | varchar(255) | NOT NULL | Person property the champion's score is written to
+`last_scored_at` | timestamp with tz | NULL | When inference last ran
+`created_at` | timestamp with tz | NOT NULL | Creation timestamp
+`updated_at` | timestamp with tz | NOT NULL | Last modification timestamp
+
+### Key Relationships
+
+- Pipelines belong to a **Team** (`team_id`)
+- A pipeline owns its training runs, iterations, trained models, operational runs, and suggestions. Those are not exposed as system tables; read them through the `autoresearch-*` API.
+
+### Prediction events
+
+Scoring emits `autoresearch_prediction` events. Each carries `$autoresearch_pipeline_id`, `$autoresearch_model_id`, `$autoresearch_p_y` (the predicted probability), `$autoresearch_prediction_date`, and `$autoresearch_person_id`, so predictions can be joined back to outcomes in `events`.

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -821,6 +821,441 @@
             "readOnlyHint": true
         }
     },
+    "autoresearch-archive-create": {
+        "description": "Soft-delete a pipeline. Stops daily scoring and training. Prediction history and model artifacts are preserved. Archived pipelines are excluded from autoresearch-list. This is reversible only via direct DB access — use pause instead if you want to temporarily stop a pipeline.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "Archive pipeline",
+        "title": "Archive pipeline",
+        "required_scopes": ["autoresearch:write"],
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-create": {
+        "description": "Create a new autoresearch prediction pipeline. Always call autoresearch-validate-create first — this endpoint does not block on validation errors. The prediction target is either an event (pass target_event, e.g. '$pageview') or a PostHog action (pass target_definition = {\"type\": \"action\", \"action_id\": N} to predict a multi-step / property / autocapture matcher; target_event is then optional and used only as a display label). Provide exactly one. horizon_days defaults to 7. The output person property (e.g. 'predicted_p_pageview') is auto-derived from target_event if omitted, and must be unique among the project's non-archived pipelines. After creating, call autoresearch-train-create to start an asynchronous agent training run.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "Create a pipeline",
+        "title": "Create a pipeline",
+        "required_scopes": ["autoresearch:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-list": {
+        "description": "List autoresearch prediction pipelines for the current project. Archived pipelines are excluded. Each pipeline entry includes its status (draft, bootstrapping, running, converged, paused), target event, horizon, and timestamps. Use autoresearch-retrieve to get full details including population definitions.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "List pipelines",
+        "title": "List pipelines",
+        "required_scopes": ["autoresearch:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-materialize-features": {
+        "description": "Run your features.sql server-side against the labeled training population and write the train/holdout feature and label parquet files directly into your sandbox. Returns the local paths (train_features_path, train_labels_path, holdout_features_path, holdout_labels_path), row counts, and the feature column list — the feature rows never pass through your context and there is NO 500-row cap. Then pd.read_parquet the returned paths and iterate in Python. Use this to pull training data instead of execute-sql, and re-call it whenever you change features.sql.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "Materialize training features to the sandbox",
+        "title": "Materialize training features to the sandbox",
+        "required_scopes": ["autoresearch:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-models-list": {
+        "description": "List champion, challenger, and archived model versions for a pipeline. Each model includes its holdout_score, role, recipe_hash, is_preliminary flag, and agent_description. The active scoring model has role='champion'. Use the recipe_hash to detect when the champion has changed across training runs.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "List models for a pipeline",
+        "title": "List models for a pipeline",
+        "required_scopes": ["autoresearch:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-models-retrieve": {
+        "description": "Get full details for a specific model version, including the portable model recipe (feature SQL, transforms, model class, params) and feature importance explanation.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "Get model",
+        "title": "Get model",
+        "required_scopes": ["autoresearch:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-pause-create": {
+        "description": "Pause a running pipeline. Daily scoring and training stop until the pipeline is resumed. Use autoresearch-resume-create to restart.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "Pause pipeline",
+        "title": "Pause pipeline",
+        "required_scopes": ["autoresearch:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-resolve-template-create": {
+        "description": "Resolve a template key and optional overrides into a ready-to-use pipeline config. For activity-based templates ('likely_active_soon', 'at_risk_of_inactivity', 'return_after_first_use'), the target_event is auto-resolved from your event schema — review resolved_activity_event and activity_event_alternatives, then re-resolve with a target_event override if the chosen event is wrong. For 'feature_adoption' and 'repeat_key_behavior', supply target_event (required). After resolving: (1) call autoresearch-validate-create with the resolved target_event, training_population, and inference_population to check volume and warnings; (2) if can_proceed is true, call autoresearch-create with the resolved fields as-is.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "Resolve a template",
+        "title": "Resolve a template",
+        "required_scopes": ["autoresearch:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-resume-create": {
+        "description": "Resume a paused pipeline. Returns 400 if the pipeline is not currently paused.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "Resume pipeline",
+        "title": "Resume pipeline",
+        "required_scopes": ["autoresearch:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-retrieve": {
+        "description": "Get full details for a specific autoresearch pipeline by ID, including population definitions, training configuration, and current status.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "Get pipeline",
+        "title": "Get pipeline",
+        "required_scopes": ["autoresearch:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-runs-list": {
+        "description": "List inference and validation runs for a pipeline, ordered most recent first. Check rows_scored and status to understand scoring history. run_type is 'inference' for daily scoring runs.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "List inference runs",
+        "title": "List inference runs",
+        "required_scopes": ["autoresearch:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-score-create": {
+        "description": "Score the inference population using the champion model and emit 'autoresearch_prediction' events for each user. Returns the inference run object with rows_scored and status. Requires a champion model — run autoresearch-train-create first if the pipeline has no champion. Each scored user gets a '$autoresearch_p_y' property on their prediction event and a person property update. After scoring, query predictions with execute-sql: SELECT distinct_id, properties.$autoresearch_p_y FROM events WHERE event = 'autoresearch_prediction' AND properties.$autoresearch_pipeline_id = '<pipeline_id>' ORDER BY properties.$autoresearch_p_y DESC LIMIT 50.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "Run inference (score users)",
+        "title": "Run inference (score users)",
+        "required_scopes": ["autoresearch:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-suggestions-create": {
+        "description": "Inject a free-text hypothesis or direction into a running pipeline for the sandbox agent to consider. The agent reads queued suggestions at the start of each training batch and decides whether to translate the suggestion into a concrete iteration ('acted_on'), apply it as a search constraint ('picked_up'), or reject it with rationale ('dismissed'). Use priority='try_next' to instruct the agent to act on this before autonomous iterations; 'consider' (default) is advisory. Check 'agent_response' after the next training run to see how the suggestion was interpreted. Examples: 'try a gradient boosting model', 'remove recency features — I suspect leakage', 'the target event has a 7-day spike on Mondays, account for day-of-week'. Suggestions survive pipeline pauses and are included in the next training batch when the pipeline resumes.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "Submit a suggestion",
+        "title": "Submit a suggestion",
+        "required_scopes": ["autoresearch:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-suggestions-list": {
+        "description": "List steering suggestions for a pipeline, ordered most recent first. Each entry shows the prompt, priority, status (queued/picked_up/acted_on/dismissed), and the agent's response when available. Use 'linked_iteration_ids' to trace which iterations were spawned from a suggestion.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "List suggestions",
+        "title": "List suggestions",
+        "required_scopes": ["autoresearch:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-suggestions-respond": {
+        "description": "Record how you handled a steering suggestion so the human who submitted it sees the outcome (it stays 'queued' in the UI until you do). Set status to 'picked_up' (applied as a search constraint across iterations), 'acted_on' (spawned one or more iterations from it), or 'dismissed' (rejected — explain why in agent_response), and write a one-line agent_response. Recording an iteration with parent_suggestion set already advances a suggestion to 'acted_on'; use this tool to add the narrative or to mark a suggestion picked_up/dismissed without a dedicated iteration.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "Respond to a suggestion",
+        "title": "Respond to a suggestion",
+        "required_scopes": ["autoresearch:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-suggestions-retrieve": {
+        "description": "Get full details for a specific suggestion including its status and agent_response.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "Get suggestion",
+        "title": "Get suggestion",
+        "required_scopes": ["autoresearch:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-templates-list": {
+        "description": "List all built-in autoresearch prediction templates. Each entry includes the template key, display name, description, default horizon, prediction mode, and whether you need to supply a target_event. Templates: 'likely_active_soon' (best universal starter — predicts next-7d activity), 'at_risk_of_inactivity' (predicts 14d inactivity risk), 'return_after_first_use' (predicts new-user return within 7d), 'feature_adoption' (predicts first use of your chosen event within 14d — requires target_event), 'repeat_key_behavior' (predicts repeat use of your chosen event within 7d — requires target_event). After picking a template, call autoresearch-resolve-template-create to get a resolved pipeline config.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "List available templates",
+        "title": "List available templates",
+        "required_scopes": ["autoresearch:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-train-create": {
+        "description": "Start an asynchronous training run for a pipeline. Launches the autoresearch agent in a sandbox and returns the training run immediately with status 'running'. Poll autoresearch-training-runs-list until the run reaches 'completed' or 'failed'; no champion model exists until the run completes and server-side promotion runs. Returns 400 if a training run is already in progress for the pipeline. After a run completes and promotes a champion, call autoresearch-score-create to run inference and emit prediction events. You can optionally override the iteration_budget for this run.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "Start training",
+        "title": "Start training",
+        "required_scopes": ["autoresearch:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-training-runs-artifacts-delete-create": {
+        "description": "Remove one file from a training run's artifact bundle. Idempotent — deleting a missing file is a no-op. Only allowed while the run is still running; the bundle is frozen once the run completes or fails.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "Delete an artifact bundle file",
+        "title": "Delete an artifact bundle file",
+        "required_scopes": ["autoresearch:write"],
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-training-runs-artifacts-get-create": {
+        "description": "Fetch one file from a training run's artifact bundle, base64-encoded. Use this to read the prior champion's train.py / features.sql as a starting point before iterating (look up the champion's source_training_run via autoresearch-models-retrieve).",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "Get an artifact bundle file",
+        "title": "Get an artifact bundle file",
+        "required_scopes": ["autoresearch:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-training-runs-artifacts-retrieve": {
+        "description": "List the files uploaded for a training run's artifact bundle (train.py, predict.py, features.sql, and any eda/ notebooks). Use to confirm a complete bundle is present before finalizing the run.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "List artifact bundle files",
+        "title": "List artifact bundle files",
+        "required_scopes": ["autoresearch:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-training-runs-artifacts-upload-create": {
+        "description": "Upload one file of a training run's runnable model bundle. Send the file contents base64-encoded in content_base64; path is the relative path within the bundle (train.py, predict.py, features.sql, or an eda/ notebook). Re-uploading the same path overwrites it. This is how you author the model — author train.py and predict.py (standalone sklearn scripts) and features.sql (HogQL with the {anchors}/{lookback_days} contract), then upload each here. Do NOT use set_output or curl — the bundle you upload is what inference runs in a sandbox. Only allowed while the run is still running; the bundle is frozen once the run completes or fails.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "Upload an artifact bundle file",
+        "title": "Upload an artifact bundle file",
+        "required_scopes": ["autoresearch:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-training-runs-complete-create": {
+        "description": "Finalize a training run. The backend selects the best iteration (highest holdout_score, or the best_iteration_id you name), decides champion vs challenger via the promotion ladder (cold-start preliminary, anti-thrash margin for an existing champion), and persists the model. Agents cannot set the champion directly — promotion is server-only. Call autoresearch-models-list afterwards to see the resulting champion/challenger. Optionally pass model_explanation (top features and directionality) for the model card. Also pass distillation (1–2 sentences on what this run learned) and recommended_next (what a future run should try next) — these are stored in the run summary and read back by the next run during orientation; the backend derives the rest of the summary (kept ladder, dead-ends) from your recorded iterations.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "Complete a training run",
+        "title": "Complete a training run",
+        "required_scopes": ["autoresearch:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-training-runs-create": {
+        "description": "Open a new training run for a pipeline and return its id. An agent (your own, the in-house sandbox, or a scheduled job) then records iterations against this run with autoresearch-training-runs-iterations-create and finalizes it with autoresearch-training-runs-complete-create. The run starts in 'running'. Optionally override the iteration_budget for this run.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "Open a training run",
+        "title": "Open a training run",
+        "required_scopes": ["autoresearch:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-training-runs-history": {
+        "description": "Cross-run learning memory. Returns recent completed training runs — this pipeline first, then same-target sibling pipelines on the team. Each run has a distilled `summary` (read this first: distillation, recommended_next, the kept_ladder of winning approaches, and dead_ends to avoid) plus the full `iterations` trail (every recipe tried, its agent_description rationale, holdout_score, kept/discarded status, model_spec) to drill into when a summary points somewhere worth it. Call this before iterating to reuse the features and transforms that won and avoid repeating approaches already discarded. Optional `limit` (default 5, max 20) caps how many prior runs are returned.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "Read prior training-run history",
+        "title": "Read prior training-run history",
+        "required_scopes": ["autoresearch:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-training-runs-iterations-create": {
+        "description": "Record one iteration of an open training run. Idempotent on iteration_number — re-sending the same number updates that iteration in place. The recipe is validated server-side: model_class in model_spec must be in the sklearn/xgboost allowlist, and feature_sql in recipe_snapshot must be a read-only SELECT keyed on person_id. Use status='kept' if the iteration improved on the best score, 'discarded' otherwise, 'crashed' on failure. Iterations are picked up at completion time to choose the champion. If this iteration was spawned from a pending steering suggestion, pass parent_suggestion = the suggestion's ID — that links the iteration to the suggestion for attribution and marks the suggestion 'acted_on'.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "Record a training iteration",
+        "title": "Record a training iteration",
+        "required_scopes": ["autoresearch:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-training-runs-list": {
+        "description": "List training runs for a pipeline, ordered most recent first. Check status (completed/failed), iteration_count, and best_holdout_score to understand training history.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "List training runs",
+        "title": "List training runs",
+        "required_scopes": ["autoresearch:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-validate-create": {
+        "description": "Validate a proposed autoresearch pipeline before creating it. The target is either an event (pass target_event) or a PostHog action (pass target_definition = {\"type\": \"action\", \"action_id\": N}); base-rate and volume estimates are computed against whichever you provide. Returns volume estimates, base rate, positive and negative example counts, and a list of warnings. Check 'can_proceed' before calling autoresearch-create: if false, resolve errors first. 'requires_acknowledgement' means there are non-blocking warnings worth noting. Typical errors: low_volume (fewer than 100 users), low_positives (fewer than 20 positive examples), or extreme_imbalance (base rate below 0.001). Always validate before creating.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "Validate a pipeline definition",
+        "title": "Validate a pipeline definition",
+        "required_scopes": ["autoresearch:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-validate-online-create": {
+        "description": "Validate predictions against realized outcomes for all matured prediction dates. A prediction date is matured when today >= prediction_date + horizon_days — meaning the outcome window has closed and ground-truth labels can be fetched. Computes per-model realized AUC, Brier score, expected calibration error (ECE), and lift@10/20. Updates the model's realized_score and calibration_error in Postgres, and clears the is_preliminary flag after the first successful validation cycle. Already-validated dates are skipped automatically. Returns one run object per prediction date processed; an empty list means no dates have matured yet. In production this is triggered by the daily Temporal validation workflow after inference runs. Call autoresearch-models-list after this to see updated realized_score values on champion/challenger models.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "Run online validation",
+        "title": "Run online validation",
+        "required_scopes": ["autoresearch:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "autoresearch"
+    },
     "batch-export-create": {
         "description": "Create a new batch export. Typed destination config schemas are available for Databricks, AzureBlob, BigQuery, Postgres, AwsS3, S3Compatible and Snowflake destinations. All of those except Snowflake require a team-scoped Integration for credentials (use integrations-list to find one). Other destination types are permitted by the API but typically must be created via the PostHog UI because their credentials are stored in the destination config. Always specify the model field (events, persons, or sessions) — omitting it defaults to events but the field should be set explicitly.",
         "category": "Data pipelines",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -836,6 +836,441 @@
             "readOnlyHint": true
         }
     },
+    "autoresearch-archive-create": {
+        "description": "Soft-delete a pipeline. Stops daily scoring and training. Prediction history and model artifacts are preserved. Archived pipelines are excluded from autoresearch-list. This is reversible only via direct DB access — use pause instead if you want to temporarily stop a pipeline.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "Archive pipeline",
+        "title": "Archive pipeline",
+        "required_scopes": ["autoresearch:write"],
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-create": {
+        "description": "Create a new autoresearch prediction pipeline. Always call autoresearch-validate-create first — this endpoint does not block on validation errors. The prediction target is either an event (pass target_event, e.g. '$pageview') or a PostHog action (pass target_definition = {\"type\": \"action\", \"action_id\": N} to predict a multi-step / property / autocapture matcher; target_event is then optional and used only as a display label). Provide exactly one. horizon_days defaults to 7. The output person property (e.g. 'predicted_p_pageview') is auto-derived from target_event if omitted, and must be unique among the project's non-archived pipelines. After creating, call autoresearch-train-create to start an asynchronous agent training run.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "Create a pipeline",
+        "title": "Create a pipeline",
+        "required_scopes": ["autoresearch:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-list": {
+        "description": "List autoresearch prediction pipelines for the current project. Archived pipelines are excluded. Each pipeline entry includes its status (draft, bootstrapping, running, converged, paused), target event, horizon, and timestamps. Use autoresearch-retrieve to get full details including population definitions.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "List pipelines",
+        "title": "List pipelines",
+        "required_scopes": ["autoresearch:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-materialize-features": {
+        "description": "Run your features.sql server-side against the labeled training population and write the train/holdout feature and label parquet files directly into your sandbox. Returns the local paths (train_features_path, train_labels_path, holdout_features_path, holdout_labels_path), row counts, and the feature column list — the feature rows never pass through your context and there is NO 500-row cap. Then pd.read_parquet the returned paths and iterate in Python. Use this to pull training data instead of execute-sql, and re-call it whenever you change features.sql.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "Materialize training features to the sandbox",
+        "title": "Materialize training features to the sandbox",
+        "required_scopes": ["autoresearch:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-models-list": {
+        "description": "List champion, challenger, and archived model versions for a pipeline. Each model includes its holdout_score, role, recipe_hash, is_preliminary flag, and agent_description. The active scoring model has role='champion'. Use the recipe_hash to detect when the champion has changed across training runs.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "List models for a pipeline",
+        "title": "List models for a pipeline",
+        "required_scopes": ["autoresearch:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-models-retrieve": {
+        "description": "Get full details for a specific model version, including the portable model recipe (feature SQL, transforms, model class, params) and feature importance explanation.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "Get model",
+        "title": "Get model",
+        "required_scopes": ["autoresearch:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-pause-create": {
+        "description": "Pause a running pipeline. Daily scoring and training stop until the pipeline is resumed. Use autoresearch-resume-create to restart.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "Pause pipeline",
+        "title": "Pause pipeline",
+        "required_scopes": ["autoresearch:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-resolve-template-create": {
+        "description": "Resolve a template key and optional overrides into a ready-to-use pipeline config. For activity-based templates ('likely_active_soon', 'at_risk_of_inactivity', 'return_after_first_use'), the target_event is auto-resolved from your event schema — review resolved_activity_event and activity_event_alternatives, then re-resolve with a target_event override if the chosen event is wrong. For 'feature_adoption' and 'repeat_key_behavior', supply target_event (required). After resolving: (1) call autoresearch-validate-create with the resolved target_event, training_population, and inference_population to check volume and warnings; (2) if can_proceed is true, call autoresearch-create with the resolved fields as-is.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "Resolve a template",
+        "title": "Resolve a template",
+        "required_scopes": ["autoresearch:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-resume-create": {
+        "description": "Resume a paused pipeline. Returns 400 if the pipeline is not currently paused.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "Resume pipeline",
+        "title": "Resume pipeline",
+        "required_scopes": ["autoresearch:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-retrieve": {
+        "description": "Get full details for a specific autoresearch pipeline by ID, including population definitions, training configuration, and current status.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "Get pipeline",
+        "title": "Get pipeline",
+        "required_scopes": ["autoresearch:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-runs-list": {
+        "description": "List inference and validation runs for a pipeline, ordered most recent first. Check rows_scored and status to understand scoring history. run_type is 'inference' for daily scoring runs.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "List inference runs",
+        "title": "List inference runs",
+        "required_scopes": ["autoresearch:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-score-create": {
+        "description": "Score the inference population using the champion model and emit 'autoresearch_prediction' events for each user. Returns the inference run object with rows_scored and status. Requires a champion model — run autoresearch-train-create first if the pipeline has no champion. Each scored user gets a '$autoresearch_p_y' property on their prediction event and a person property update. After scoring, query predictions with execute-sql: SELECT distinct_id, properties.$autoresearch_p_y FROM events WHERE event = 'autoresearch_prediction' AND properties.$autoresearch_pipeline_id = '<pipeline_id>' ORDER BY properties.$autoresearch_p_y DESC LIMIT 50.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "Run inference (score users)",
+        "title": "Run inference (score users)",
+        "required_scopes": ["autoresearch:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-suggestions-create": {
+        "description": "Inject a free-text hypothesis or direction into a running pipeline for the sandbox agent to consider. The agent reads queued suggestions at the start of each training batch and decides whether to translate the suggestion into a concrete iteration ('acted_on'), apply it as a search constraint ('picked_up'), or reject it with rationale ('dismissed'). Use priority='try_next' to instruct the agent to act on this before autonomous iterations; 'consider' (default) is advisory. Check 'agent_response' after the next training run to see how the suggestion was interpreted. Examples: 'try a gradient boosting model', 'remove recency features — I suspect leakage', 'the target event has a 7-day spike on Mondays, account for day-of-week'. Suggestions survive pipeline pauses and are included in the next training batch when the pipeline resumes.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "Submit a suggestion",
+        "title": "Submit a suggestion",
+        "required_scopes": ["autoresearch:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-suggestions-list": {
+        "description": "List steering suggestions for a pipeline, ordered most recent first. Each entry shows the prompt, priority, status (queued/picked_up/acted_on/dismissed), and the agent's response when available. Use 'linked_iteration_ids' to trace which iterations were spawned from a suggestion.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "List suggestions",
+        "title": "List suggestions",
+        "required_scopes": ["autoresearch:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-suggestions-respond": {
+        "description": "Record how you handled a steering suggestion so the human who submitted it sees the outcome (it stays 'queued' in the UI until you do). Set status to 'picked_up' (applied as a search constraint across iterations), 'acted_on' (spawned one or more iterations from it), or 'dismissed' (rejected — explain why in agent_response), and write a one-line agent_response. Recording an iteration with parent_suggestion set already advances a suggestion to 'acted_on'; use this tool to add the narrative or to mark a suggestion picked_up/dismissed without a dedicated iteration.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "Respond to a suggestion",
+        "title": "Respond to a suggestion",
+        "required_scopes": ["autoresearch:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-suggestions-retrieve": {
+        "description": "Get full details for a specific suggestion including its status and agent_response.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "Get suggestion",
+        "title": "Get suggestion",
+        "required_scopes": ["autoresearch:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-templates-list": {
+        "description": "List all built-in autoresearch prediction templates. Each entry includes the template key, display name, description, default horizon, prediction mode, and whether you need to supply a target_event. Templates: 'likely_active_soon' (best universal starter — predicts next-7d activity), 'at_risk_of_inactivity' (predicts 14d inactivity risk), 'return_after_first_use' (predicts new-user return within 7d), 'feature_adoption' (predicts first use of your chosen event within 14d — requires target_event), 'repeat_key_behavior' (predicts repeat use of your chosen event within 7d — requires target_event). After picking a template, call autoresearch-resolve-template-create to get a resolved pipeline config.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "List available templates",
+        "title": "List available templates",
+        "required_scopes": ["autoresearch:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-train-create": {
+        "description": "Start an asynchronous training run for a pipeline. Launches the autoresearch agent in a sandbox and returns the training run immediately with status 'running'. Poll autoresearch-training-runs-list until the run reaches 'completed' or 'failed'; no champion model exists until the run completes and server-side promotion runs. Returns 400 if a training run is already in progress for the pipeline. After a run completes and promotes a champion, call autoresearch-score-create to run inference and emit prediction events. You can optionally override the iteration_budget for this run.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "Start training",
+        "title": "Start training",
+        "required_scopes": ["autoresearch:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-training-runs-artifacts-delete-create": {
+        "description": "Remove one file from a training run's artifact bundle. Idempotent — deleting a missing file is a no-op. Only allowed while the run is still running; the bundle is frozen once the run completes or fails.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "Delete an artifact bundle file",
+        "title": "Delete an artifact bundle file",
+        "required_scopes": ["autoresearch:write"],
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-training-runs-artifacts-get-create": {
+        "description": "Fetch one file from a training run's artifact bundle, base64-encoded. Use this to read the prior champion's train.py / features.sql as a starting point before iterating (look up the champion's source_training_run via autoresearch-models-retrieve).",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "Get an artifact bundle file",
+        "title": "Get an artifact bundle file",
+        "required_scopes": ["autoresearch:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-training-runs-artifacts-retrieve": {
+        "description": "List the files uploaded for a training run's artifact bundle (train.py, predict.py, features.sql, and any eda/ notebooks). Use to confirm a complete bundle is present before finalizing the run.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "List artifact bundle files",
+        "title": "List artifact bundle files",
+        "required_scopes": ["autoresearch:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-training-runs-artifacts-upload-create": {
+        "description": "Upload one file of a training run's runnable model bundle. Send the file contents base64-encoded in content_base64; path is the relative path within the bundle (train.py, predict.py, features.sql, or an eda/ notebook). Re-uploading the same path overwrites it. This is how you author the model — author train.py and predict.py (standalone sklearn scripts) and features.sql (HogQL with the {anchors}/{lookback_days} contract), then upload each here. Do NOT use set_output or curl — the bundle you upload is what inference runs in a sandbox. Only allowed while the run is still running; the bundle is frozen once the run completes or fails.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "Upload an artifact bundle file",
+        "title": "Upload an artifact bundle file",
+        "required_scopes": ["autoresearch:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-training-runs-complete-create": {
+        "description": "Finalize a training run. The backend selects the best iteration (highest holdout_score, or the best_iteration_id you name), decides champion vs challenger via the promotion ladder (cold-start preliminary, anti-thrash margin for an existing champion), and persists the model. Agents cannot set the champion directly — promotion is server-only. Call autoresearch-models-list afterwards to see the resulting champion/challenger. Optionally pass model_explanation (top features and directionality) for the model card. Also pass distillation (1–2 sentences on what this run learned) and recommended_next (what a future run should try next) — these are stored in the run summary and read back by the next run during orientation; the backend derives the rest of the summary (kept ladder, dead-ends) from your recorded iterations.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "Complete a training run",
+        "title": "Complete a training run",
+        "required_scopes": ["autoresearch:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-training-runs-create": {
+        "description": "Open a new training run for a pipeline and return its id. An agent (your own, the in-house sandbox, or a scheduled job) then records iterations against this run with autoresearch-training-runs-iterations-create and finalizes it with autoresearch-training-runs-complete-create. The run starts in 'running'. Optionally override the iteration_budget for this run.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "Open a training run",
+        "title": "Open a training run",
+        "required_scopes": ["autoresearch:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-training-runs-history": {
+        "description": "Cross-run learning memory. Returns recent completed training runs — this pipeline first, then same-target sibling pipelines on the team. Each run has a distilled `summary` (read this first: distillation, recommended_next, the kept_ladder of winning approaches, and dead_ends to avoid) plus the full `iterations` trail (every recipe tried, its agent_description rationale, holdout_score, kept/discarded status, model_spec) to drill into when a summary points somewhere worth it. Call this before iterating to reuse the features and transforms that won and avoid repeating approaches already discarded. Optional `limit` (default 5, max 20) caps how many prior runs are returned.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "Read prior training-run history",
+        "title": "Read prior training-run history",
+        "required_scopes": ["autoresearch:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-training-runs-iterations-create": {
+        "description": "Record one iteration of an open training run. Idempotent on iteration_number — re-sending the same number updates that iteration in place. The recipe is validated server-side: model_class in model_spec must be in the sklearn/xgboost allowlist, and feature_sql in recipe_snapshot must be a read-only SELECT keyed on person_id. Use status='kept' if the iteration improved on the best score, 'discarded' otherwise, 'crashed' on failure. Iterations are picked up at completion time to choose the champion. If this iteration was spawned from a pending steering suggestion, pass parent_suggestion = the suggestion's ID — that links the iteration to the suggestion for attribution and marks the suggestion 'acted_on'.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "Record a training iteration",
+        "title": "Record a training iteration",
+        "required_scopes": ["autoresearch:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-training-runs-list": {
+        "description": "List training runs for a pipeline, ordered most recent first. Check status (completed/failed), iteration_count, and best_holdout_score to understand training history.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "List training runs",
+        "title": "List training runs",
+        "required_scopes": ["autoresearch:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-validate-create": {
+        "description": "Validate a proposed autoresearch pipeline before creating it. The target is either an event (pass target_event) or a PostHog action (pass target_definition = {\"type\": \"action\", \"action_id\": N}); base-rate and volume estimates are computed against whichever you provide. Returns volume estimates, base rate, positive and negative example counts, and a list of warnings. Check 'can_proceed' before calling autoresearch-create: if false, resolve errors first. 'requires_acknowledgement' means there are non-blocking warnings worth noting. Typical errors: low_volume (fewer than 100 users), low_positives (fewer than 20 positive examples), or extreme_imbalance (base rate below 0.001). Always validate before creating.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "Validate a pipeline definition",
+        "title": "Validate a pipeline definition",
+        "required_scopes": ["autoresearch:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "autoresearch"
+    },
+    "autoresearch-validate-online-create": {
+        "description": "Validate predictions against realized outcomes for all matured prediction dates. A prediction date is matured when today >= prediction_date + horizon_days — meaning the outcome window has closed and ground-truth labels can be fetched. Computes per-model realized AUC, Brier score, expected calibration error (ECE), and lift@10/20. Updates the model's realized_score and calibration_error in Postgres, and clears the is_preliminary flag after the first successful validation cycle. Already-validated dates are skipped automatically. Returns one run object per prediction date processed; an empty list means no dates have matured yet. In production this is triggered by the daily Temporal validation workflow after inference runs. Call autoresearch-models-list after this to see updated realized_score values on champion/challenger models.",
+        "category": "Autoresearch",
+        "feature": "autoresearch",
+        "summary": "Run online validation",
+        "title": "Run online validation",
+        "required_scopes": ["autoresearch:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "autoresearch"
+    },
     "batch-export-create": {
         "description": "Create a new batch export. Typed destination config schemas are available for Databricks, AzureBlob, BigQuery, Postgres, AwsS3, S3Compatible and Snowflake destinations. All of those except Snowflake require a team-scoped Integration for credentials (use integrations-list to find one). Other destination types are permitted by the API but typically must be created via the PostHog UI because their credentials are stored in the destination config. Always specify the model field (events, persons, or sessions) — omitting it defaults to events but the field should be set explicitly.",
         "category": "Data pipelines",

--- a/services/mcp/src/generated/autoresearch/api.ts
+++ b/services/mcp/src/generated/autoresearch/api.ts
@@ -1,0 +1,820 @@
+/**
+ * Auto-generated from the Django backend OpenAPI schema.
+ * MCP service uses these Zod schemas for generated tool handlers.
+ * To regenerate: hogli build:openapi
+ *
+ * PostHog API - MCP 29 enabled ops
+ * OpenAPI spec version: 1.0.0
+ */
+import * as zod from 'zod'
+
+/**
+ * Manage autoresearch prediction pipelines.
+ *
+ * A pipeline defines a target event, population, and horizon. The autoresearch
+ * training loop finds the best predictive recipe; the inference workflow scores
+ * users daily and emits autoresearch_prediction events.
+ */
+export const AutoresearchListParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const AutoresearchListQueryParams = /* @__PURE__ */ zod.object({
+    limit: zod.number().optional().describe('Number of results to return per page.'),
+    offset: zod.number().optional().describe('The initial index from which to return the results.'),
+})
+
+/**
+ * Manage autoresearch prediction pipelines.
+ *
+ * A pipeline defines a target event, population, and horizon. The autoresearch
+ * training loop finds the best predictive recipe; the inference workflow scores
+ * users daily and emits autoresearch_prediction events.
+ */
+export const AutoresearchCreateParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const autoresearchCreateBodyNameMax = 255
+
+export const autoresearchCreateBodyTargetEventMax = 255
+
+export const autoresearchCreateBodyHorizonDaysMax = 365
+
+export const autoresearchCreateBodyTrainingLookbackDaysMin = 7
+export const autoresearchCreateBodyTrainingLookbackDaysMax = 730
+
+export const autoresearchCreateBodyCadenceDaysMax = 365
+
+export const autoresearchCreateBodyIterationBudgetMax = 500
+
+export const autoresearchCreateBodyPlateauIterationsMin = -2147483648
+export const autoresearchCreateBodyPlateauIterationsMax = 2147483647
+
+export const autoresearchCreateBodyOutputPersonPropertyMax = 255
+
+export const AutoresearchCreateBody = /* @__PURE__ */ zod.object({
+    name: zod.string().max(autoresearchCreateBodyNameMax).describe('Display name for the pipeline.'),
+    description: zod.string().optional().describe('Optional free-text description.'),
+    target_event: zod
+        .string()
+        .max(autoresearchCreateBodyTargetEventMax)
+        .optional()
+        .describe(
+            "PostHog event name to predict, e.g. '$pageview' or 'signed_up'. Omit when predicting an action target (pass target_definition instead)."
+        ),
+    target_definition: zod
+        .looseObject({})
+        .optional()
+        .describe(
+            'Omit (or pass {\"type\": \"event\"}) to predict target_event; pass {\"type\": \"action\", \"action_id\": N} to predict a PostHog action. No other shapes are accepted.'
+        ),
+    horizon_days: zod
+        .number()
+        .min(1)
+        .max(autoresearchCreateBodyHorizonDaysMax)
+        .optional()
+        .describe(
+            'Prediction horizon in days (1-365). The model predicts whether the target event occurs within this window.'
+        ),
+    training_lookback_days: zod
+        .number()
+        .min(autoresearchCreateBodyTrainingLookbackDaysMin)
+        .max(autoresearchCreateBodyTrainingLookbackDaysMax)
+        .optional()
+        .describe(
+            'How far back to look for training examples (7-730 days). Larger windows give more data but may include stale behavior. Default: 180.'
+        ),
+    training_population: zod
+        .looseObject({})
+        .optional()
+        .describe('Training population filter. Use {} for all identified users.'),
+    inference_population: zod
+        .looseObject({})
+        .optional()
+        .describe('Inference population filter. Defaults to training_population if not set.'),
+    cadence_days: zod
+        .number()
+        .min(1)
+        .max(autoresearchCreateBodyCadenceDaysMax)
+        .optional()
+        .describe('Re-score the inference population every N days (1-365). Default: 1.'),
+    iteration_budget: zod
+        .number()
+        .min(1)
+        .max(autoresearchCreateBodyIterationBudgetMax)
+        .optional()
+        .describe('Total training iterations allowed for the autoresearch loop (1-500). Default: 50.'),
+    success_auc: zod
+        .number()
+        .nullish()
+        .describe('Target AUC threshold. Training stops early if reached. Default: 0.75.'),
+    plateau_iterations: zod
+        .number()
+        .min(autoresearchCreateBodyPlateauIterationsMin)
+        .max(autoresearchCreateBodyPlateauIterationsMax)
+        .optional()
+        .describe('Stop training if no improvement in this many consecutive iterations. Default: 10.'),
+    output_person_property: zod
+        .string()
+        .max(autoresearchCreateBodyOutputPersonPropertyMax)
+        .optional()
+        .describe(
+            "Person property name for the prediction score, e.g. 'predicted_p_pageview'. Auto-derived from target_event if omitted. Letters, digits, and _ $ . - only; must be unique among this project's non-archived pipelines."
+        ),
+})
+
+/**
+ * List and retrieve champion/challenger models for a pipeline.
+ *
+ * Models are the persisted artifacts produced by training runs. Each model
+ * holds a portable recipe (feature SQL, transforms, model class, params) that
+ * the daily inference workflow compiles to score users.
+ */
+export const AutoresearchModelsListParams = /* @__PURE__ */ zod.object({
+    pipeline_id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const AutoresearchModelsListQueryParams = /* @__PURE__ */ zod.object({
+    limit: zod.number().optional().describe('Number of results to return per page.'),
+    offset: zod.number().optional().describe('The initial index from which to return the results.'),
+})
+
+/**
+ * List and retrieve champion/challenger models for a pipeline.
+ *
+ * Models are the persisted artifacts produced by training runs. Each model
+ * holds a portable recipe (feature SQL, transforms, model class, params) that
+ * the daily inference workflow compiles to score users.
+ */
+export const AutoresearchModelsRetrieveParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this autoresearch model.'),
+    pipeline_id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+/**
+ * List and retrieve inference and validation runs for a pipeline.
+ */
+export const AutoresearchRunsListParams = /* @__PURE__ */ zod.object({
+    pipeline_id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const AutoresearchRunsListQueryParams = /* @__PURE__ */ zod.object({
+    limit: zod.number().optional().describe('Number of results to return per page.'),
+    offset: zod.number().optional().describe('The initial index from which to return the results.'),
+})
+
+/**
+ * List steering suggestions for a pipeline, ordered most recent first. Check 'status' to see which have been picked up or acted on by the agent.
+ * @summary List suggestions
+ */
+export const AutoresearchSuggestionsListParams = /* @__PURE__ */ zod.object({
+    pipeline_id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const AutoresearchSuggestionsListQueryParams = /* @__PURE__ */ zod.object({
+    limit: zod.number().optional().describe('Number of results to return per page.'),
+    offset: zod.number().optional().describe('The initial index from which to return the results.'),
+})
+
+/**
+ * Inject a free-text hypothesis or direction into a running pipeline. The sandbox agent reads queued suggestions at the start of each iteration batch and decides: translate into a concrete iteration ('acted_on'), apply as a search constraint ('picked_up'), or reject with rationale ('dismissed'). Use priority='try_next' to instruct the agent to act on this before autonomous iterations; 'consider' is advisory. Check 'agent_response' after the next training run to see how the suggestion was interpreted.
+ * @summary Submit a suggestion
+ */
+export const AutoresearchSuggestionsCreateParams = /* @__PURE__ */ zod.object({
+    pipeline_id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const autoresearchSuggestionsCreateBodyPromptMax = 2000
+
+export const autoresearchSuggestionsCreateBodyPriorityDefault = `consider`
+
+export const AutoresearchSuggestionsCreateBody = /* @__PURE__ */ zod.object({
+    prompt: zod
+        .string()
+        .max(autoresearchSuggestionsCreateBodyPromptMax)
+        .describe(
+            "Free-text hypothesis or direction for the agent to explore, e.g. 'try a tree-based model' or 'remove recency features, I suspect leakage'."
+        ),
+    priority: zod
+        .enum(['try_next', 'consider'])
+        .describe('\* `try_next` - try_next\n\* `consider` - consider')
+        .default(autoresearchSuggestionsCreateBodyPriorityDefault)
+        .describe(
+            "'try_next' asks the agent to act on this before other autonomous iterations; 'consider' is advisory context.\n\n\* `try_next` - try_next\n\* `consider` - consider"
+        ),
+})
+
+/**
+ * Get details for a specific suggestion including its status and agent_response.
+ * @summary Get suggestion
+ */
+export const AutoresearchSuggestionsRetrieveParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this autoresearch suggestion.'),
+    pipeline_id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+/**
+ * Record how the agent handled a steering suggestion: set status to 'picked_up' (applied as a search constraint), 'acted_on' (spawned iterations), or 'dismissed' (rejected — explain in agent_response), and write the agent_response note the human will read. Call this from the training loop after deciding what to do with a pending suggestion. Recording an iteration with parent_suggestion set already advances a suggestion to 'acted_on'; use this to add the narrative or to mark a suggestion picked_up/dismissed without spawning an iteration.
+ * @summary Respond to a suggestion
+ */
+export const AutoresearchSuggestionsRespondCreateParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this autoresearch suggestion.'),
+    pipeline_id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const autoresearchSuggestionsRespondCreateBodyAgentResponseDefault = ``
+export const autoresearchSuggestionsRespondCreateBodyAgentResponseMax = 2000
+
+export const AutoresearchSuggestionsRespondCreateBody = /* @__PURE__ */ zod
+    .object({
+        status: zod
+            .enum(['picked_up', 'acted_on', 'dismissed'])
+            .describe('\* `picked_up` - picked_up\n\* `acted_on` - acted_on\n\* `dismissed` - dismissed')
+            .describe(
+                "How the agent handled the suggestion: 'picked_up' (applied as a search constraint), 'acted_on' (spawned one or more iterations), or 'dismissed' (rejected — explain why in agent_response).\n\n\* `picked_up` - picked_up\n\* `acted_on` - acted_on\n\* `dismissed` - dismissed"
+            ),
+        agent_response: zod
+            .string()
+            .max(autoresearchSuggestionsRespondCreateBodyAgentResponseMax)
+            .default(autoresearchSuggestionsRespondCreateBodyAgentResponseDefault)
+            .describe(
+                'Plain-English note on how the suggestion was interpreted and acted upon (or why it was dismissed).'
+            ),
+    })
+    .describe('Input for the agent to record how it interpreted a steering suggestion.')
+
+/**
+ * List, retrieve, open, record iterations into, and complete training runs for a pipeline.
+ *
+ * The write endpoints let an external (bring-your-own) agent or a scheduled job drive a
+ * training run directly — recording each iteration as it completes rather than via a single
+ * terminal sandbox output. Recipe validation and champion promotion stay server-side.
+ */
+export const AutoresearchTrainingRunsListParams = /* @__PURE__ */ zod.object({
+    pipeline_id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const AutoresearchTrainingRunsListQueryParams = /* @__PURE__ */ zod.object({
+    limit: zod.number().optional().describe('Number of results to return per page.'),
+    offset: zod.number().optional().describe('The initial index from which to return the results.'),
+})
+
+/**
+ * Open a new training run for a pipeline and return its id. An agent — the in-house sandbox, an external bring-your-own agent, or a scheduled job — then records iterations against this run and finalizes it with the complete endpoint. The run starts in 'running'.
+ * @summary Open a training run
+ */
+export const AutoresearchTrainingRunsCreateParams = /* @__PURE__ */ zod.object({
+    pipeline_id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const autoresearchTrainingRunsCreateBodyIterationBudgetMax = 500
+
+export const AutoresearchTrainingRunsCreateBody = /* @__PURE__ */ zod
+    .object({
+        iteration_budget: zod
+            .number()
+            .min(1)
+            .max(autoresearchTrainingRunsCreateBodyIterationBudgetMax)
+            .optional()
+            .describe("Iteration budget for this run. Defaults to the pipeline's iteration_budget if omitted."),
+    })
+    .describe('Input for opening an agent-driven training run.')
+
+/**
+ * List the files an agent has uploaded for this training run's artifact bundle (train.py, predict.py, features.sql, and any eda/ notebooks).
+ * @summary List artifact bundle files
+ */
+export const AutoresearchTrainingRunsArtifactsRetrieveParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this autoresearch training run.'),
+    pipeline_id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+/**
+ * Remove one file from this training run's artifact bundle. Idempotent — deleting a missing file is a no-op. The bundle is frozen once the run completes or fails.
+ * @summary Delete an artifact bundle file
+ */
+export const AutoresearchTrainingRunsArtifactsDeleteCreateParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this autoresearch training run.'),
+    pipeline_id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const autoresearchTrainingRunsArtifactsDeleteCreateBodyPathMax = 500
+
+export const AutoresearchTrainingRunsArtifactsDeleteCreateBody = /* @__PURE__ */ zod
+    .object({
+        path: zod
+            .string()
+            .max(autoresearchTrainingRunsArtifactsDeleteCreateBodyPathMax)
+            .describe("Relative path of the file within the bundle, e.g. 'train.py'."),
+    })
+    .describe('Input for fetching or deleting one bundle file by path.')
+
+/**
+ * Fetch one file from this training run's artifact bundle, base64-encoded.
+ * @summary Get an artifact bundle file
+ */
+export const AutoresearchTrainingRunsArtifactsGetCreateParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this autoresearch training run.'),
+    pipeline_id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const autoresearchTrainingRunsArtifactsGetCreateBodyPathMax = 500
+
+export const AutoresearchTrainingRunsArtifactsGetCreateBody = /* @__PURE__ */ zod
+    .object({
+        path: zod
+            .string()
+            .max(autoresearchTrainingRunsArtifactsGetCreateBodyPathMax)
+            .describe("Relative path of the file within the bundle, e.g. 'train.py'."),
+    })
+    .describe('Input for fetching or deleting one bundle file by path.')
+
+/**
+ * Upload one file of this training run's artifact bundle. Send the file contents base64-encoded in content_base64. Re-uploading the same path overwrites it. Use this — not curl/set_output — to author train.py, predict.py, and features.sql. The bundle is frozen once the run completes or fails.
+ * @summary Upload an artifact bundle file
+ */
+export const AutoresearchTrainingRunsArtifactsUploadCreateParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this autoresearch training run.'),
+    pipeline_id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const autoresearchTrainingRunsArtifactsUploadCreateBodyPathMax = 500
+
+export const AutoresearchTrainingRunsArtifactsUploadCreateBody = /* @__PURE__ */ zod
+    .object({
+        path: zod
+            .string()
+            .max(autoresearchTrainingRunsArtifactsUploadCreateBodyPathMax)
+            .describe(
+                "Relative path within the bundle, e.g. 'train.py', 'predict.py', 'features.sql', or 'eda\/iter-3-gbm.ipynb'. Segments are limited to [A-Za-z0-9_.-]; absolute paths and '..' traversal are rejected."
+            ),
+        content_base64: zod
+            .string()
+            .describe(
+                'File contents, base64-encoded. Decoded server-side and written to object storage. Max 10 MB decoded.'
+            ),
+    })
+    .describe("Input for uploading one file of a training run's artifact bundle.")
+
+/**
+ * Finalize a training run. The backend selects the best iteration (highest holdout score, or the one you name), decides champion vs challenger via the promotion ladder, and persists the model. Agents cannot set the champion directly — promotion is server-side.
+ * @summary Complete a training run
+ */
+export const AutoresearchTrainingRunsCompleteCreateParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this autoresearch training run.'),
+    pipeline_id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const autoresearchTrainingRunsCompleteCreateBodyRecommendedNextDefault = ``
+export const autoresearchTrainingRunsCompleteCreateBodyRecommendedNextMax = 2000
+
+export const autoresearchTrainingRunsCompleteCreateBodyDistillationDefault = ``
+export const autoresearchTrainingRunsCompleteCreateBodyDistillationMax = 2000
+
+export const AutoresearchTrainingRunsCompleteCreateBody = /* @__PURE__ */ zod
+    .object({
+        best_iteration_id: zod
+            .string()
+            .nullish()
+            .describe(
+                'Iteration to promote as champion candidate. If omitted, the kept iteration with the highest holdout_score is used.'
+            ),
+        model_explanation: zod
+            .looseObject({})
+            .optional()
+            .describe('Global feature importance \/ directionality bundle for the champion model card.'),
+        recommended_next: zod
+            .string()
+            .max(autoresearchTrainingRunsCompleteCreateBodyRecommendedNextMax)
+            .default(autoresearchTrainingRunsCompleteCreateBodyRecommendedNextDefault)
+            .describe(
+                'What a future run should try next, given what this run learned. Stored in the run summary so the next run reads it during orientation. Keep it short and concrete; max 2000 characters.'
+            ),
+        distillation: zod
+            .string()
+            .max(autoresearchTrainingRunsCompleteCreateBodyDistillationMax)
+            .default(autoresearchTrainingRunsCompleteCreateBodyDistillationDefault)
+            .describe(
+                'A 1–2 sentence distillation of what this run learned — the winning signal, the key transform, the dead-ends. Stored in the run summary as the cheapest thing the next run reads. Max 2000 characters.'
+            ),
+    })
+    .describe('Input for finalizing a training run. The backend selects\/promotes the champion.')
+
+/**
+ * Record one iteration of an open training run. Idempotent on iteration_number — re-sending the same number updates that iteration. The recipe is validated server-side: model_class must be in the allowlist and feature_sql must be a read-only SELECT keyed on person_id.
+ * @summary Record a training iteration
+ */
+export const AutoresearchTrainingRunsIterationsCreateParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this autoresearch training run.'),
+    pipeline_id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const autoresearchTrainingRunsIterationsCreateBodyIterationNumberMin = 0
+
+export const autoresearchTrainingRunsIterationsCreateBodyTrainScoreMin = 0
+export const autoresearchTrainingRunsIterationsCreateBodyTrainScoreMax = 1
+
+export const autoresearchTrainingRunsIterationsCreateBodyHoldoutScoreMin = 0
+export const autoresearchTrainingRunsIterationsCreateBodyHoldoutScoreMax = 1
+
+export const autoresearchTrainingRunsIterationsCreateBodyAgentDescriptionDefault = ``
+export const autoresearchTrainingRunsIterationsCreateBodyAgentConfidenceMin = 0
+export const autoresearchTrainingRunsIterationsCreateBodyAgentConfidenceMax = 1
+
+export const AutoresearchTrainingRunsIterationsCreateBody = /* @__PURE__ */ zod
+    .object({
+        iteration_number: zod
+            .number()
+            .min(autoresearchTrainingRunsIterationsCreateBodyIterationNumberMin)
+            .describe(
+                'Zero-based index of this iteration within the run. Re-sending the same number updates that iteration (idempotent).'
+            ),
+        recipe_snapshot: zod
+            .looseObject({})
+            .describe(
+                'Compact recipe for this iteration: feature_sql (HogQL SELECT keyed on person_id) and transforms.'
+            ),
+        model_spec: zod
+            .looseObject({})
+            .describe('model_class (must be allowlisted) and model_params tried this iteration.'),
+        status: zod
+            .enum(['kept', 'discarded', 'crashed'])
+            .describe('\* `kept` - kept\n\* `discarded` - discarded\n\* `crashed` - crashed')
+            .describe(
+                "'kept' if this iteration improved on the best score, 'discarded' otherwise, 'crashed' on failure.\n\n\* `kept` - kept\n\* `discarded` - discarded\n\* `crashed` - crashed"
+            ),
+        train_score: zod
+            .number()
+            .min(autoresearchTrainingRunsIterationsCreateBodyTrainScoreMin)
+            .max(autoresearchTrainingRunsIterationsCreateBodyTrainScoreMax)
+            .nullish()
+            .describe('Training-set AUC for this iteration (0-1).'),
+        holdout_score: zod
+            .number()
+            .min(autoresearchTrainingRunsIterationsCreateBodyHoldoutScoreMin)
+            .max(autoresearchTrainingRunsIterationsCreateBodyHoldoutScoreMax)
+            .nullish()
+            .describe('Held-out AUC for this iteration (0-1). Used to pick the champion at completion.'),
+        agent_description: zod
+            .string()
+            .default(autoresearchTrainingRunsIterationsCreateBodyAgentDescriptionDefault)
+            .describe("Agent's plain-English rationale for this iteration."),
+        agent_confidence: zod
+            .number()
+            .min(autoresearchTrainingRunsIterationsCreateBodyAgentConfidenceMin)
+            .max(autoresearchTrainingRunsIterationsCreateBodyAgentConfidenceMax)
+            .nullish()
+            .describe("Agent's self-assessed confidence (0–1) that this iteration helps."),
+        parent_suggestion: zod
+            .string()
+            .nullish()
+            .describe(
+                "UUID of the steering suggestion this iteration was spawned from, if any. Set it whenever the iteration acts on a pending suggestion — it links the iteration back to the suggestion for attribution and advances the suggestion to 'acted_on'."
+            ),
+    })
+    .describe('Input for recording one training iteration. Validated against the recipe allowlist.')
+
+/**
+ * Run features_sql server-side against the labeled training population and write the resulting train/holdout feature and label parquet files directly into this run's sandbox. Returns the local sandbox paths, row counts, and feature columns. The rows never pass through the agent's context and there is no 500-row cap. Read the returned paths with pd.read_parquet and iterate in Python.
+ * @summary Materialize training features to the sandbox
+ */
+export const AutoresearchTrainingRunsMaterializeFeaturesCreateParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this autoresearch training run.'),
+    pipeline_id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const AutoresearchTrainingRunsMaterializeFeaturesCreateBody = /* @__PURE__ */ zod
+    .object({
+        features_sql: zod
+            .string()
+            .describe(
+                'Your HogQL feature query, using the {anchors}\/{lookback_days} contract. Must be a read-only SELECT keyed on person_id (aliased to distinct_id), one row per user. The backend runs it server-side against the labeled training population — no 500-row cap — and writes the resulting train\/holdout feature and label parquet files into your sandbox.'
+            ),
+    })
+    .describe("Input for materializing the labeled training feature matrix into the run's sandbox.")
+
+/**
+ * Return recent completed training runs and their iteration trails so a new run can learn from what was already tried. Scoped to this pipeline first, then same-target sibling pipelines on the team. Read this before iterating to reuse winning features and avoid repeating discarded approaches.
+ * @summary Read prior training-run history
+ */
+export const AutoresearchTrainingRunsHistoryRetrieveParams = /* @__PURE__ */ zod.object({
+    pipeline_id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const AutoresearchTrainingRunsHistoryRetrieveQueryParams = /* @__PURE__ */ zod.object({
+    limit: zod.number().optional().describe('Maximum number of prior runs to return (default 5, capped at 20).'),
+})
+
+/**
+ * Manage autoresearch prediction pipelines.
+ *
+ * A pipeline defines a target event, population, and horizon. The autoresearch
+ * training loop finds the best predictive recipe; the inference workflow scores
+ * users daily and emits autoresearch_prediction events.
+ */
+export const AutoresearchRetrieveParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this autoresearch pipeline.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+/**
+ * Soft-delete a pipeline. Stops daily scoring and training. Predictions and metrics are preserved.
+ * @summary Archive a pipeline
+ */
+export const AutoresearchArchiveCreateParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this autoresearch pipeline.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+/**
+ * Pause daily scoring and training. The pipeline can be resumed later.
+ * @summary Pause a pipeline
+ */
+export const AutoresearchPauseCreateParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this autoresearch pipeline.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+/**
+ * Resume a paused pipeline. Daily scoring and training will restart on the next cadence tick.
+ * @summary Resume a pipeline
+ */
+export const AutoresearchResumeCreateParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this autoresearch pipeline.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+/**
+ * Score the inference population using the champion model and emit autoresearch_prediction events for each scored user. Updates the predicted_p_<target> person property. In production this is triggered by the daily Temporal inference workflow.
+ * @summary Run inference (score users)
+ */
+export const AutoresearchScoreCreateParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this autoresearch pipeline.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+/**
+ * Start an asynchronous training run for this pipeline. Creates a Task/TaskRun sandbox where the autoresearch agent iterates on features and models, and returns the run immediately with status 'running'. Poll the training run until it reaches a terminal status (completed or failed); no champion model exists until the run completes and server-side promotion runs.
+ * @summary Start a training run
+ */
+export const AutoresearchTrainCreateParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this autoresearch pipeline.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const autoresearchTrainCreateBodyIterationBudgetMax = 500
+
+export const AutoresearchTrainCreateBody = /* @__PURE__ */ zod.object({
+    iteration_budget: zod
+        .number()
+        .min(1)
+        .max(autoresearchTrainCreateBodyIterationBudgetMax)
+        .optional()
+        .describe('Override the pipeline iteration budget for this training run.'),
+})
+
+/**
+ * Validate predictions against realized outcomes for all matured prediction dates. A prediction date is matured when today >= prediction_date + horizon_days. Computes realized AUC, Brier score, calibration error (ECE), and lift@10/20 per model. Updates the model's realized_score, calibration_error, and clears the is_preliminary flag. Already-validated dates are skipped. In production this is triggered by the daily Temporal validation workflow after inference runs.
+ * @summary Run online validation
+ */
+export const AutoresearchValidateOnlineCreateParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this autoresearch pipeline.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+/**
+ * Resolve a template key and optional overrides into a concrete pipeline config. For activity-based templates ('likely_active_soon', 'at_risk_of_inactivity', 'return_after_first_use'), the target event is auto-resolved from your event schema — check resolved_activity_event and activity_event_alternatives, then override if needed. For 'feature_adoption' and 'repeat_key_behavior', supply target_event. After resolving, call autoresearch-validate-create to check volume and warnings, then autoresearch-create to create the pipeline.
+ * @summary Resolve a template
+ */
+export const AutoresearchResolveTemplateCreateParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const autoresearchResolveTemplateCreateBodyHorizonDaysMax = 365
+
+export const AutoresearchResolveTemplateCreateBody = /* @__PURE__ */ zod.object({
+    template_key: zod
+        .enum([
+            'likely_active_soon',
+            'at_risk_of_inactivity',
+            'return_after_first_use',
+            'feature_adoption',
+            'repeat_key_behavior',
+        ])
+        .describe(
+            '\* `likely_active_soon` - likely_active_soon\n\* `at_risk_of_inactivity` - at_risk_of_inactivity\n\* `return_after_first_use` - return_after_first_use\n\* `feature_adoption` - feature_adoption\n\* `repeat_key_behavior` - repeat_key_behavior'
+        )
+        .describe(
+            'Template to resolve. Use autoresearch-templates-list to see all available templates with descriptions. Required.\n\n\* `likely_active_soon` - likely_active_soon\n\* `at_risk_of_inactivity` - at_risk_of_inactivity\n\* `return_after_first_use` - return_after_first_use\n\* `feature_adoption` - feature_adoption\n\* `repeat_key_behavior` - repeat_key_behavior'
+        ),
+    target_event: zod
+        .string()
+        .optional()
+        .describe(
+            "Event or action name to use as the prediction target. Required for 'feature_adoption' and 'repeat_key_behavior'. Optional override for activity-based templates ('likely_active_soon', 'at_risk_of_inactivity', 'return_after_first_use') — omit to use the auto-resolved event."
+        ),
+    horizon_days: zod
+        .number()
+        .min(1)
+        .max(autoresearchResolveTemplateCreateBodyHorizonDaysMax)
+        .optional()
+        .describe("Override the template's default prediction horizon in days."),
+})
+
+/**
+ * Return all built-in autoresearch prediction templates. Each entry describes what the template predicts, its default horizon and prediction mode, and whether it requires you to supply a target_event. After choosing a template, call autoresearch-resolve-template-create to get a fully resolved pipeline config ready to pass to autoresearch-create.
+ * @summary List available templates
+ */
+export const AutoresearchTemplatesListParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const AutoresearchTemplatesListQueryParams = /* @__PURE__ */ zod.object({
+    limit: zod.number().optional().describe('Number of results to return per page.'),
+    offset: zod.number().optional().describe('The initial index from which to return the results.'),
+})
+
+/**
+ * Validate a proposed pipeline's target event and population before creating it. Returns volume estimates, base rate, and any warnings. Warnings with severity='error' must be resolved before creation can proceed. Call this before autoresearch-create.
+ * @summary Validate a pipeline definition
+ */
+export const AutoresearchValidateCreateParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const autoresearchValidateCreateBodyTargetEventDefault = ``
+export const autoresearchValidateCreateBodyHorizonDaysDefault = 7
+export const autoresearchValidateCreateBodyHorizonDaysMax = 365
+
+export const autoresearchValidateCreateBodyTrainingLookbackDaysDefault = 180
+export const autoresearchValidateCreateBodyTrainingLookbackDaysMin = 7
+export const autoresearchValidateCreateBodyTrainingLookbackDaysMax = 730
+
+export const AutoresearchValidateCreateBody = /* @__PURE__ */ zod.object({
+    target_event: zod
+        .string()
+        .default(autoresearchValidateCreateBodyTargetEventDefault)
+        .describe(
+            "Event name to predict, e.g. '$pageview'. Must exist in the team's event schema. Omit when predicting an action target (pass target_definition instead)."
+        ),
+    target_definition: zod
+        .unknown()
+        .optional()
+        .describe(
+            'Optional target definition. Pass {\"type\": \"action\", \"action_id\": N} to predict a PostHog action (multi-step \/ property \/ autocapture matcher) instead of a single event.'
+        ),
+    horizon_days: zod
+        .number()
+        .min(1)
+        .max(autoresearchValidateCreateBodyHorizonDaysMax)
+        .default(autoresearchValidateCreateBodyHorizonDaysDefault)
+        .describe('Predict whether the target event occurs within this many days.'),
+    training_lookback_days: zod
+        .number()
+        .min(autoresearchValidateCreateBodyTrainingLookbackDaysMin)
+        .max(autoresearchValidateCreateBodyTrainingLookbackDaysMax)
+        .default(autoresearchValidateCreateBodyTrainingLookbackDaysDefault)
+        .describe('How far back to look for training examples. Default: 180.'),
+    training_population: zod
+        .looseObject({})
+        .optional()
+        .describe('Population filter for training examples. Use {} for all identified users.'),
+    inference_population: zod
+        .looseObject({})
+        .optional()
+        .describe('Population filter for daily scoring. Defaults to training_population if not provided.'),
+})

--- a/services/mcp/src/tools/generated/autoresearch.ts
+++ b/services/mcp/src/tools/generated/autoresearch.ts
@@ -1,0 +1,921 @@
+// AUTO-GENERATED from products/autoresearch/mcp/tools.yaml + OpenAPI — do not edit
+import { z } from 'zod'
+
+import type { Schemas } from '@/api/generated'
+import {
+    AutoresearchArchiveCreateParams,
+    AutoresearchCreateBody,
+    AutoresearchListQueryParams,
+    AutoresearchModelsListParams,
+    AutoresearchModelsListQueryParams,
+    AutoresearchModelsRetrieveParams,
+    AutoresearchPauseCreateParams,
+    AutoresearchResolveTemplateCreateBody,
+    AutoresearchResumeCreateParams,
+    AutoresearchRetrieveParams,
+    AutoresearchRunsListParams,
+    AutoresearchRunsListQueryParams,
+    AutoresearchScoreCreateParams,
+    AutoresearchSuggestionsCreateBody,
+    AutoresearchSuggestionsCreateParams,
+    AutoresearchSuggestionsListParams,
+    AutoresearchSuggestionsListQueryParams,
+    AutoresearchSuggestionsRespondCreateBody,
+    AutoresearchSuggestionsRespondCreateParams,
+    AutoresearchSuggestionsRetrieveParams,
+    AutoresearchTemplatesListQueryParams,
+    AutoresearchTrainCreateBody,
+    AutoresearchTrainCreateParams,
+    AutoresearchTrainingRunsArtifactsDeleteCreateBody,
+    AutoresearchTrainingRunsArtifactsDeleteCreateParams,
+    AutoresearchTrainingRunsArtifactsGetCreateBody,
+    AutoresearchTrainingRunsArtifactsGetCreateParams,
+    AutoresearchTrainingRunsArtifactsRetrieveParams,
+    AutoresearchTrainingRunsArtifactsUploadCreateBody,
+    AutoresearchTrainingRunsArtifactsUploadCreateParams,
+    AutoresearchTrainingRunsCompleteCreateBody,
+    AutoresearchTrainingRunsCompleteCreateParams,
+    AutoresearchTrainingRunsCreateBody,
+    AutoresearchTrainingRunsCreateParams,
+    AutoresearchTrainingRunsHistoryRetrieveParams,
+    AutoresearchTrainingRunsHistoryRetrieveQueryParams,
+    AutoresearchTrainingRunsIterationsCreateBody,
+    AutoresearchTrainingRunsIterationsCreateParams,
+    AutoresearchTrainingRunsListParams,
+    AutoresearchTrainingRunsListQueryParams,
+    AutoresearchTrainingRunsMaterializeFeaturesCreateBody,
+    AutoresearchTrainingRunsMaterializeFeaturesCreateParams,
+    AutoresearchValidateCreateBody,
+    AutoresearchValidateOnlineCreateParams,
+} from '@/generated/autoresearch/api'
+import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
+
+const AutoresearchArchiveCreateSchema = AutoresearchArchiveCreateParams.omit({ project_id: true })
+
+const autoresearchArchiveCreate = (): ToolBase<
+    typeof AutoresearchArchiveCreateSchema,
+    Schemas.AutoresearchPipeline
+> => ({
+    name: 'autoresearch-archive-create',
+    schema: AutoresearchArchiveCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof AutoresearchArchiveCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.AutoresearchPipeline>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/autoresearch/${encodeURIComponent(String(params.id))}/archive/`,
+        })
+        return result
+    },
+})
+
+const AutoresearchCreateSchema = AutoresearchCreateBody
+
+const autoresearchCreate = (): ToolBase<
+    typeof AutoresearchCreateSchema,
+    WithPostHogUrl<Schemas.AutoresearchPipeline>
+> => ({
+    name: 'autoresearch-create',
+    schema: AutoresearchCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof AutoresearchCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.name !== undefined) {
+            body['name'] = params.name
+        }
+        if (params.description !== undefined) {
+            body['description'] = params.description
+        }
+        if (params.target_event !== undefined) {
+            body['target_event'] = params.target_event
+        }
+        if (params.target_definition !== undefined) {
+            body['target_definition'] = params.target_definition
+        }
+        if (params.horizon_days !== undefined) {
+            body['horizon_days'] = params.horizon_days
+        }
+        if (params.training_lookback_days !== undefined) {
+            body['training_lookback_days'] = params.training_lookback_days
+        }
+        if (params.training_population !== undefined) {
+            body['training_population'] = params.training_population
+        }
+        if (params.inference_population !== undefined) {
+            body['inference_population'] = params.inference_population
+        }
+        if (params.cadence_days !== undefined) {
+            body['cadence_days'] = params.cadence_days
+        }
+        if (params.iteration_budget !== undefined) {
+            body['iteration_budget'] = params.iteration_budget
+        }
+        if (params.success_auc !== undefined) {
+            body['success_auc'] = params.success_auc
+        }
+        if (params.plateau_iterations !== undefined) {
+            body['plateau_iterations'] = params.plateau_iterations
+        }
+        if (params.output_person_property !== undefined) {
+            body['output_person_property'] = params.output_person_property
+        }
+        const result = await context.api.request<Schemas.AutoresearchPipeline>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/autoresearch/`,
+            body,
+        })
+        return await withPostHogUrl(context, result, `/autoresearch/${result.id}`)
+    },
+})
+
+const AutoresearchListSchema = AutoresearchListQueryParams
+
+const autoresearchList = (): ToolBase<
+    typeof AutoresearchListSchema,
+    WithPostHogUrl<Schemas.PaginatedAutoresearchPipelineList>
+> => ({
+    name: 'autoresearch-list',
+    schema: AutoresearchListSchema,
+    handler: async (context: Context, params: z.infer<typeof AutoresearchListSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.PaginatedAutoresearchPipelineList>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/autoresearch/`,
+            query: {
+                limit: params.limit,
+                offset: params.offset,
+            },
+        })
+        const filtered = {
+            ...result,
+            results: (result.results ?? []).map((item: any) =>
+                pickResponseFields(item, [
+                    'id',
+                    'name',
+                    'description',
+                    'target_event',
+                    'horizon_days',
+                    'status',
+                    'iteration_budget',
+                    'iteration_budget_remaining',
+                    'last_scored_at',
+                    'created_at',
+                    'updated_at',
+                ])
+            ),
+        } as typeof result
+        return await withPostHogUrl(context, filtered, '/autoresearch')
+    },
+})
+
+const AutoresearchMaterializeFeaturesSchema = AutoresearchTrainingRunsMaterializeFeaturesCreateParams.omit({
+    project_id: true,
+}).extend(AutoresearchTrainingRunsMaterializeFeaturesCreateBody.shape)
+
+const autoresearchMaterializeFeatures = (): ToolBase<
+    typeof AutoresearchMaterializeFeaturesSchema,
+    Schemas.MaterializeFeaturesResponse
+> => ({
+    name: 'autoresearch-materialize-features',
+    schema: AutoresearchMaterializeFeaturesSchema,
+    handler: async (context: Context, params: z.infer<typeof AutoresearchMaterializeFeaturesSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.features_sql !== undefined) {
+            body['features_sql'] = params.features_sql
+        }
+        const result = await context.api.request<Schemas.MaterializeFeaturesResponse>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/autoresearch/${encodeURIComponent(String(params.pipeline_id))}/training_runs/${encodeURIComponent(String(params.id))}/materialize-features/`,
+            body,
+        })
+        return result
+    },
+})
+
+const AutoresearchModelsListSchema = AutoresearchModelsListParams.omit({ project_id: true }).extend(
+    AutoresearchModelsListQueryParams.shape
+)
+
+const autoresearchModelsList = (): ToolBase<
+    typeof AutoresearchModelsListSchema,
+    WithPostHogUrl<Schemas.PaginatedAutoresearchModelList>
+> => ({
+    name: 'autoresearch-models-list',
+    schema: AutoresearchModelsListSchema,
+    handler: async (context: Context, params: z.infer<typeof AutoresearchModelsListSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.PaginatedAutoresearchModelList>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/autoresearch/${encodeURIComponent(String(params.pipeline_id))}/models/`,
+            query: {
+                limit: params.limit,
+                offset: params.offset,
+            },
+        })
+        const filtered = {
+            ...result,
+            results: (result.results ?? []).map((item: any) =>
+                pickResponseFields(item, [
+                    'id',
+                    'pipeline',
+                    'role',
+                    'recipe_hash',
+                    'holdout_score',
+                    'realized_score',
+                    'is_preliminary',
+                    'agent_description',
+                    'trained_on_start',
+                    'trained_on_end',
+                    'promoted_at',
+                    'created_at',
+                ])
+            ),
+        } as typeof result
+        return await withPostHogUrl(context, filtered, '/autoresearch')
+    },
+})
+
+const AutoresearchModelsRetrieveSchema = AutoresearchModelsRetrieveParams.omit({ project_id: true })
+
+const autoresearchModelsRetrieve = (): ToolBase<
+    typeof AutoresearchModelsRetrieveSchema,
+    Schemas.AutoresearchModel
+> => ({
+    name: 'autoresearch-models-retrieve',
+    schema: AutoresearchModelsRetrieveSchema,
+    handler: async (context: Context, params: z.infer<typeof AutoresearchModelsRetrieveSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.AutoresearchModel>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/autoresearch/${encodeURIComponent(String(params.pipeline_id))}/models/${encodeURIComponent(String(params.id))}/`,
+        })
+        return result
+    },
+})
+
+const AutoresearchPauseCreateSchema = AutoresearchPauseCreateParams.omit({ project_id: true })
+
+const autoresearchPauseCreate = (): ToolBase<typeof AutoresearchPauseCreateSchema, Schemas.AutoresearchPipeline> => ({
+    name: 'autoresearch-pause-create',
+    schema: AutoresearchPauseCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof AutoresearchPauseCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.AutoresearchPipeline>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/autoresearch/${encodeURIComponent(String(params.id))}/pause/`,
+        })
+        return result
+    },
+})
+
+const AutoresearchResolveTemplateCreateSchema = AutoresearchResolveTemplateCreateBody
+
+const autoresearchResolveTemplateCreate = (): ToolBase<
+    typeof AutoresearchResolveTemplateCreateSchema,
+    Schemas.ResolvedTemplate
+> => ({
+    name: 'autoresearch-resolve-template-create',
+    schema: AutoresearchResolveTemplateCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof AutoresearchResolveTemplateCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.template_key !== undefined) {
+            body['template_key'] = params.template_key
+        }
+        if (params.target_event !== undefined) {
+            body['target_event'] = params.target_event
+        }
+        if (params.horizon_days !== undefined) {
+            body['horizon_days'] = params.horizon_days
+        }
+        const result = await context.api.request<Schemas.ResolvedTemplate>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/autoresearch/resolve-template/`,
+            body,
+        })
+        return result
+    },
+})
+
+const AutoresearchResumeCreateSchema = AutoresearchResumeCreateParams.omit({ project_id: true })
+
+const autoresearchResumeCreate = (): ToolBase<typeof AutoresearchResumeCreateSchema, Schemas.AutoresearchPipeline> => ({
+    name: 'autoresearch-resume-create',
+    schema: AutoresearchResumeCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof AutoresearchResumeCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.AutoresearchPipeline>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/autoresearch/${encodeURIComponent(String(params.id))}/resume/`,
+        })
+        return result
+    },
+})
+
+const AutoresearchRetrieveSchema = AutoresearchRetrieveParams.omit({ project_id: true })
+
+const autoresearchRetrieve = (): ToolBase<
+    typeof AutoresearchRetrieveSchema,
+    WithPostHogUrl<Schemas.AutoresearchPipeline>
+> => ({
+    name: 'autoresearch-retrieve',
+    schema: AutoresearchRetrieveSchema,
+    handler: async (context: Context, params: z.infer<typeof AutoresearchRetrieveSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.AutoresearchPipeline>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/autoresearch/${encodeURIComponent(String(params.id))}/`,
+        })
+        return await withPostHogUrl(context, result, `/autoresearch/${result.id}`)
+    },
+})
+
+const AutoresearchRunsListSchema = AutoresearchRunsListParams.omit({ project_id: true }).extend(
+    AutoresearchRunsListQueryParams.shape
+)
+
+const autoresearchRunsList = (): ToolBase<
+    typeof AutoresearchRunsListSchema,
+    WithPostHogUrl<Schemas.PaginatedAutoresearchRunList>
+> => ({
+    name: 'autoresearch-runs-list',
+    schema: AutoresearchRunsListSchema,
+    handler: async (context: Context, params: z.infer<typeof AutoresearchRunsListSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.PaginatedAutoresearchRunList>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/autoresearch/${encodeURIComponent(String(params.pipeline_id))}/runs/`,
+            query: {
+                limit: params.limit,
+                offset: params.offset,
+            },
+        })
+        const filtered = {
+            ...result,
+            results: (result.results ?? []).map((item: any) =>
+                pickResponseFields(item, [
+                    'id',
+                    'pipeline',
+                    'model',
+                    'run_type',
+                    'status',
+                    'rows_scored',
+                    'error',
+                    'started_at',
+                    'completed_at',
+                    'created_at',
+                ])
+            ),
+        } as typeof result
+        return await withPostHogUrl(context, filtered, '/autoresearch')
+    },
+})
+
+const AutoresearchScoreCreateSchema = AutoresearchScoreCreateParams.omit({ project_id: true })
+
+const autoresearchScoreCreate = (): ToolBase<typeof AutoresearchScoreCreateSchema, Schemas.AutoresearchRun> => ({
+    name: 'autoresearch-score-create',
+    schema: AutoresearchScoreCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof AutoresearchScoreCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.AutoresearchRun>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/autoresearch/${encodeURIComponent(String(params.id))}/score/`,
+        })
+        return result
+    },
+})
+
+const AutoresearchSuggestionsCreateSchema = AutoresearchSuggestionsCreateParams.omit({ project_id: true }).extend(
+    AutoresearchSuggestionsCreateBody.shape
+)
+
+const autoresearchSuggestionsCreate = (): ToolBase<
+    typeof AutoresearchSuggestionsCreateSchema,
+    Schemas.AutoresearchSuggestion
+> => ({
+    name: 'autoresearch-suggestions-create',
+    schema: AutoresearchSuggestionsCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof AutoresearchSuggestionsCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.prompt !== undefined) {
+            body['prompt'] = params.prompt
+        }
+        if (params.priority !== undefined) {
+            body['priority'] = params.priority
+        }
+        const result = await context.api.request<Schemas.AutoresearchSuggestion>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/autoresearch/${encodeURIComponent(String(params.pipeline_id))}/suggestions/`,
+            body,
+        })
+        return result
+    },
+})
+
+const AutoresearchSuggestionsListSchema = AutoresearchSuggestionsListParams.omit({ project_id: true }).extend(
+    AutoresearchSuggestionsListQueryParams.shape
+)
+
+const autoresearchSuggestionsList = (): ToolBase<
+    typeof AutoresearchSuggestionsListSchema,
+    WithPostHogUrl<Schemas.PaginatedAutoresearchSuggestionList>
+> => ({
+    name: 'autoresearch-suggestions-list',
+    schema: AutoresearchSuggestionsListSchema,
+    handler: async (context: Context, params: z.infer<typeof AutoresearchSuggestionsListSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.PaginatedAutoresearchSuggestionList>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/autoresearch/${encodeURIComponent(String(params.pipeline_id))}/suggestions/`,
+            query: {
+                limit: params.limit,
+                offset: params.offset,
+            },
+        })
+        const filtered = {
+            ...result,
+            results: (result.results ?? []).map((item: any) =>
+                pickResponseFields(item, [
+                    'id',
+                    'pipeline',
+                    'prompt',
+                    'priority',
+                    'status',
+                    'source',
+                    'agent_response',
+                    'linked_iteration_ids',
+                    'created_at',
+                ])
+            ),
+        } as typeof result
+        return await withPostHogUrl(context, filtered, '/autoresearch')
+    },
+})
+
+const AutoresearchSuggestionsRetrieveSchema = AutoresearchSuggestionsRetrieveParams.omit({ project_id: true })
+
+const autoresearchSuggestionsRetrieve = (): ToolBase<
+    typeof AutoresearchSuggestionsRetrieveSchema,
+    Schemas.AutoresearchSuggestion
+> => ({
+    name: 'autoresearch-suggestions-retrieve',
+    schema: AutoresearchSuggestionsRetrieveSchema,
+    handler: async (context: Context, params: z.infer<typeof AutoresearchSuggestionsRetrieveSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.AutoresearchSuggestion>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/autoresearch/${encodeURIComponent(String(params.pipeline_id))}/suggestions/${encodeURIComponent(String(params.id))}/`,
+        })
+        return result
+    },
+})
+
+const AutoresearchSuggestionsRespondSchema = AutoresearchSuggestionsRespondCreateParams.omit({
+    project_id: true,
+}).extend(AutoresearchSuggestionsRespondCreateBody.shape)
+
+const autoresearchSuggestionsRespond = (): ToolBase<
+    typeof AutoresearchSuggestionsRespondSchema,
+    Schemas.AutoresearchSuggestion
+> => ({
+    name: 'autoresearch-suggestions-respond',
+    schema: AutoresearchSuggestionsRespondSchema,
+    handler: async (context: Context, params: z.infer<typeof AutoresearchSuggestionsRespondSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.status !== undefined) {
+            body['status'] = params.status
+        }
+        if (params.agent_response !== undefined) {
+            body['agent_response'] = params.agent_response
+        }
+        const result = await context.api.request<Schemas.AutoresearchSuggestion>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/autoresearch/${encodeURIComponent(String(params.pipeline_id))}/suggestions/${encodeURIComponent(String(params.id))}/respond/`,
+            body,
+        })
+        return result
+    },
+})
+
+const AutoresearchTemplatesListSchema = AutoresearchTemplatesListQueryParams
+
+const autoresearchTemplatesList = (): ToolBase<
+    typeof AutoresearchTemplatesListSchema,
+    WithPostHogUrl<Schemas.PaginatedTemplateInfoList>
+> => ({
+    name: 'autoresearch-templates-list',
+    schema: AutoresearchTemplatesListSchema,
+    handler: async (context: Context, params: z.infer<typeof AutoresearchTemplatesListSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.PaginatedTemplateInfoList>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/autoresearch/templates/`,
+            query: {
+                limit: params.limit,
+                offset: params.offset,
+            },
+        })
+        const filtered = {
+            ...result,
+            results: (result.results ?? []).map((item: any) =>
+                pickResponseFields(item, [
+                    'key',
+                    'display_name',
+                    'description',
+                    'default_horizon_days',
+                    'requires_user_event',
+                    'requires_activity_resolution',
+                    'notes',
+                ])
+            ),
+        } as typeof result
+        return await withPostHogUrl(context, filtered, '/autoresearch')
+    },
+})
+
+const AutoresearchTrainCreateSchema = AutoresearchTrainCreateParams.omit({ project_id: true }).extend(
+    AutoresearchTrainCreateBody.shape
+)
+
+const autoresearchTrainCreate = (): ToolBase<
+    typeof AutoresearchTrainCreateSchema,
+    Schemas.AutoresearchTrainingRun
+> => ({
+    name: 'autoresearch-train-create',
+    schema: AutoresearchTrainCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof AutoresearchTrainCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.iteration_budget !== undefined) {
+            body['iteration_budget'] = params.iteration_budget
+        }
+        const result = await context.api.request<Schemas.AutoresearchTrainingRun>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/autoresearch/${encodeURIComponent(String(params.id))}/train/`,
+            body,
+        })
+        return result
+    },
+})
+
+const AutoresearchTrainingRunsArtifactsDeleteCreateSchema = AutoresearchTrainingRunsArtifactsDeleteCreateParams.omit({
+    project_id: true,
+}).extend(AutoresearchTrainingRunsArtifactsDeleteCreateBody.shape)
+
+const autoresearchTrainingRunsArtifactsDeleteCreate = (): ToolBase<
+    typeof AutoresearchTrainingRunsArtifactsDeleteCreateSchema,
+    Schemas.ArtifactDeleteResult
+> => ({
+    name: 'autoresearch-training-runs-artifacts-delete-create',
+    schema: AutoresearchTrainingRunsArtifactsDeleteCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof AutoresearchTrainingRunsArtifactsDeleteCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.path !== undefined) {
+            body['path'] = params.path
+        }
+        const result = await context.api.request<Schemas.ArtifactDeleteResult>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/autoresearch/${encodeURIComponent(String(params.pipeline_id))}/training_runs/${encodeURIComponent(String(params.id))}/artifacts/delete/`,
+            body,
+        })
+        return result
+    },
+})
+
+const AutoresearchTrainingRunsArtifactsGetCreateSchema = AutoresearchTrainingRunsArtifactsGetCreateParams.omit({
+    project_id: true,
+}).extend(AutoresearchTrainingRunsArtifactsGetCreateBody.shape)
+
+const autoresearchTrainingRunsArtifactsGetCreate = (): ToolBase<
+    typeof AutoresearchTrainingRunsArtifactsGetCreateSchema,
+    Schemas.ArtifactContent
+> => ({
+    name: 'autoresearch-training-runs-artifacts-get-create',
+    schema: AutoresearchTrainingRunsArtifactsGetCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof AutoresearchTrainingRunsArtifactsGetCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.path !== undefined) {
+            body['path'] = params.path
+        }
+        const result = await context.api.request<Schemas.ArtifactContent>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/autoresearch/${encodeURIComponent(String(params.pipeline_id))}/training_runs/${encodeURIComponent(String(params.id))}/artifacts/get/`,
+            body,
+        })
+        return result
+    },
+})
+
+const AutoresearchTrainingRunsArtifactsRetrieveSchema = AutoresearchTrainingRunsArtifactsRetrieveParams.omit({
+    project_id: true,
+})
+
+const autoresearchTrainingRunsArtifactsRetrieve = (): ToolBase<
+    typeof AutoresearchTrainingRunsArtifactsRetrieveSchema,
+    Schemas.ArtifactList
+> => ({
+    name: 'autoresearch-training-runs-artifacts-retrieve',
+    schema: AutoresearchTrainingRunsArtifactsRetrieveSchema,
+    handler: async (context: Context, params: z.infer<typeof AutoresearchTrainingRunsArtifactsRetrieveSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.ArtifactList>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/autoresearch/${encodeURIComponent(String(params.pipeline_id))}/training_runs/${encodeURIComponent(String(params.id))}/artifacts/`,
+        })
+        return result
+    },
+})
+
+const AutoresearchTrainingRunsArtifactsUploadCreateSchema = AutoresearchTrainingRunsArtifactsUploadCreateParams.omit({
+    project_id: true,
+}).extend(AutoresearchTrainingRunsArtifactsUploadCreateBody.shape)
+
+const autoresearchTrainingRunsArtifactsUploadCreate = (): ToolBase<
+    typeof AutoresearchTrainingRunsArtifactsUploadCreateSchema,
+    Schemas.StoredArtifact
+> => ({
+    name: 'autoresearch-training-runs-artifacts-upload-create',
+    schema: AutoresearchTrainingRunsArtifactsUploadCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof AutoresearchTrainingRunsArtifactsUploadCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.path !== undefined) {
+            body['path'] = params.path
+        }
+        if (params.content_base64 !== undefined) {
+            body['content_base64'] = params.content_base64
+        }
+        const result = await context.api.request<Schemas.StoredArtifact>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/autoresearch/${encodeURIComponent(String(params.pipeline_id))}/training_runs/${encodeURIComponent(String(params.id))}/artifacts/upload/`,
+            body,
+        })
+        return result
+    },
+})
+
+const AutoresearchTrainingRunsCompleteCreateSchema = AutoresearchTrainingRunsCompleteCreateParams.omit({
+    project_id: true,
+}).extend(AutoresearchTrainingRunsCompleteCreateBody.shape)
+
+const autoresearchTrainingRunsCompleteCreate = (): ToolBase<
+    typeof AutoresearchTrainingRunsCompleteCreateSchema,
+    Schemas.AutoresearchTrainingRun
+> => ({
+    name: 'autoresearch-training-runs-complete-create',
+    schema: AutoresearchTrainingRunsCompleteCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof AutoresearchTrainingRunsCompleteCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.best_iteration_id !== undefined) {
+            body['best_iteration_id'] = params.best_iteration_id
+        }
+        if (params.model_explanation !== undefined) {
+            body['model_explanation'] = params.model_explanation
+        }
+        if (params.recommended_next !== undefined) {
+            body['recommended_next'] = params.recommended_next
+        }
+        if (params.distillation !== undefined) {
+            body['distillation'] = params.distillation
+        }
+        const result = await context.api.request<Schemas.AutoresearchTrainingRun>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/autoresearch/${encodeURIComponent(String(params.pipeline_id))}/training_runs/${encodeURIComponent(String(params.id))}/complete/`,
+            body,
+        })
+        return result
+    },
+})
+
+const AutoresearchTrainingRunsCreateSchema = AutoresearchTrainingRunsCreateParams.omit({ project_id: true }).extend(
+    AutoresearchTrainingRunsCreateBody.shape
+)
+
+const autoresearchTrainingRunsCreate = (): ToolBase<
+    typeof AutoresearchTrainingRunsCreateSchema,
+    Schemas.AutoresearchTrainingRun
+> => ({
+    name: 'autoresearch-training-runs-create',
+    schema: AutoresearchTrainingRunsCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof AutoresearchTrainingRunsCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.iteration_budget !== undefined) {
+            body['iteration_budget'] = params.iteration_budget
+        }
+        const result = await context.api.request<Schemas.AutoresearchTrainingRun>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/autoresearch/${encodeURIComponent(String(params.pipeline_id))}/training_runs/`,
+            body,
+        })
+        return result
+    },
+})
+
+const AutoresearchTrainingRunsHistorySchema = AutoresearchTrainingRunsHistoryRetrieveParams.omit({
+    project_id: true,
+}).extend(AutoresearchTrainingRunsHistoryRetrieveQueryParams.shape)
+
+const autoresearchTrainingRunsHistory = (): ToolBase<
+    typeof AutoresearchTrainingRunsHistorySchema,
+    Schemas.TrainingRunHistory
+> => ({
+    name: 'autoresearch-training-runs-history',
+    schema: AutoresearchTrainingRunsHistorySchema,
+    handler: async (context: Context, params: z.infer<typeof AutoresearchTrainingRunsHistorySchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.TrainingRunHistory>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/autoresearch/${encodeURIComponent(String(params.pipeline_id))}/training_runs/history/`,
+            query: {
+                limit: params.limit,
+            },
+        })
+        return result
+    },
+})
+
+const AutoresearchTrainingRunsIterationsCreateSchema = AutoresearchTrainingRunsIterationsCreateParams.omit({
+    project_id: true,
+}).extend(AutoresearchTrainingRunsIterationsCreateBody.shape)
+
+const autoresearchTrainingRunsIterationsCreate = (): ToolBase<
+    typeof AutoresearchTrainingRunsIterationsCreateSchema,
+    Schemas.AutoresearchIteration
+> => ({
+    name: 'autoresearch-training-runs-iterations-create',
+    schema: AutoresearchTrainingRunsIterationsCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof AutoresearchTrainingRunsIterationsCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.iteration_number !== undefined) {
+            body['iteration_number'] = params.iteration_number
+        }
+        if (params.recipe_snapshot !== undefined) {
+            body['recipe_snapshot'] = params.recipe_snapshot
+        }
+        if (params.model_spec !== undefined) {
+            body['model_spec'] = params.model_spec
+        }
+        if (params.status !== undefined) {
+            body['status'] = params.status
+        }
+        if (params.train_score !== undefined) {
+            body['train_score'] = params.train_score
+        }
+        if (params.holdout_score !== undefined) {
+            body['holdout_score'] = params.holdout_score
+        }
+        if (params.agent_description !== undefined) {
+            body['agent_description'] = params.agent_description
+        }
+        if (params.agent_confidence !== undefined) {
+            body['agent_confidence'] = params.agent_confidence
+        }
+        if (params.parent_suggestion !== undefined) {
+            body['parent_suggestion'] = params.parent_suggestion
+        }
+        const result = await context.api.request<Schemas.AutoresearchIteration>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/autoresearch/${encodeURIComponent(String(params.pipeline_id))}/training_runs/${encodeURIComponent(String(params.id))}/iterations/`,
+            body,
+        })
+        return result
+    },
+})
+
+const AutoresearchTrainingRunsListSchema = AutoresearchTrainingRunsListParams.omit({ project_id: true }).extend(
+    AutoresearchTrainingRunsListQueryParams.shape
+)
+
+const autoresearchTrainingRunsList = (): ToolBase<
+    typeof AutoresearchTrainingRunsListSchema,
+    WithPostHogUrl<Schemas.PaginatedAutoresearchTrainingRunList>
+> => ({
+    name: 'autoresearch-training-runs-list',
+    schema: AutoresearchTrainingRunsListSchema,
+    handler: async (context: Context, params: z.infer<typeof AutoresearchTrainingRunsListSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.PaginatedAutoresearchTrainingRunList>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/autoresearch/${encodeURIComponent(String(params.pipeline_id))}/training_runs/`,
+            query: {
+                limit: params.limit,
+                offset: params.offset,
+            },
+        })
+        const filtered = {
+            ...result,
+            results: (result.results ?? []).map((item: any) =>
+                pickResponseFields(item, [
+                    'id',
+                    'pipeline',
+                    'status',
+                    'iteration_budget',
+                    'iteration_count',
+                    'best_holdout_score',
+                    'error',
+                    'started_at',
+                    'completed_at',
+                    'created_at',
+                ])
+            ),
+        } as typeof result
+        return await withPostHogUrl(context, filtered, '/autoresearch')
+    },
+})
+
+const AutoresearchValidateCreateSchema = AutoresearchValidateCreateBody
+
+const autoresearchValidateCreate = (): ToolBase<
+    typeof AutoresearchValidateCreateSchema,
+    Schemas.ValidatePipelineResponse
+> => ({
+    name: 'autoresearch-validate-create',
+    schema: AutoresearchValidateCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof AutoresearchValidateCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.target_event !== undefined) {
+            body['target_event'] = params.target_event
+        }
+        if (params.target_definition !== undefined) {
+            body['target_definition'] = params.target_definition
+        }
+        if (params.horizon_days !== undefined) {
+            body['horizon_days'] = params.horizon_days
+        }
+        if (params.training_lookback_days !== undefined) {
+            body['training_lookback_days'] = params.training_lookback_days
+        }
+        if (params.training_population !== undefined) {
+            body['training_population'] = params.training_population
+        }
+        if (params.inference_population !== undefined) {
+            body['inference_population'] = params.inference_population
+        }
+        const result = await context.api.request<Schemas.ValidatePipelineResponse>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/autoresearch/validate/`,
+            body,
+        })
+        return result
+    },
+})
+
+const AutoresearchValidateOnlineCreateSchema = AutoresearchValidateOnlineCreateParams.omit({ project_id: true })
+
+const autoresearchValidateOnlineCreate = (): ToolBase<
+    typeof AutoresearchValidateOnlineCreateSchema,
+    Schemas.AutoresearchRun[]
+> => ({
+    name: 'autoresearch-validate-online-create',
+    schema: AutoresearchValidateOnlineCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof AutoresearchValidateOnlineCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.AutoresearchRun[]>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/autoresearch/${encodeURIComponent(String(params.id))}/validate-online/`,
+        })
+        return result
+    },
+})
+
+export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
+    'autoresearch-archive-create': autoresearchArchiveCreate,
+    'autoresearch-create': autoresearchCreate,
+    'autoresearch-list': autoresearchList,
+    'autoresearch-materialize-features': autoresearchMaterializeFeatures,
+    'autoresearch-models-list': autoresearchModelsList,
+    'autoresearch-models-retrieve': autoresearchModelsRetrieve,
+    'autoresearch-pause-create': autoresearchPauseCreate,
+    'autoresearch-resolve-template-create': autoresearchResolveTemplateCreate,
+    'autoresearch-resume-create': autoresearchResumeCreate,
+    'autoresearch-retrieve': autoresearchRetrieve,
+    'autoresearch-runs-list': autoresearchRunsList,
+    'autoresearch-score-create': autoresearchScoreCreate,
+    'autoresearch-suggestions-create': autoresearchSuggestionsCreate,
+    'autoresearch-suggestions-list': autoresearchSuggestionsList,
+    'autoresearch-suggestions-retrieve': autoresearchSuggestionsRetrieve,
+    'autoresearch-suggestions-respond': autoresearchSuggestionsRespond,
+    'autoresearch-templates-list': autoresearchTemplatesList,
+    'autoresearch-train-create': autoresearchTrainCreate,
+    'autoresearch-training-runs-artifacts-delete-create': autoresearchTrainingRunsArtifactsDeleteCreate,
+    'autoresearch-training-runs-artifacts-get-create': autoresearchTrainingRunsArtifactsGetCreate,
+    'autoresearch-training-runs-artifacts-retrieve': autoresearchTrainingRunsArtifactsRetrieve,
+    'autoresearch-training-runs-artifacts-upload-create': autoresearchTrainingRunsArtifactsUploadCreate,
+    'autoresearch-training-runs-complete-create': autoresearchTrainingRunsCompleteCreate,
+    'autoresearch-training-runs-create': autoresearchTrainingRunsCreate,
+    'autoresearch-training-runs-history': autoresearchTrainingRunsHistory,
+    'autoresearch-training-runs-iterations-create': autoresearchTrainingRunsIterationsCreate,
+    'autoresearch-training-runs-list': autoresearchTrainingRunsList,
+    'autoresearch-validate-create': autoresearchValidateCreate,
+    'autoresearch-validate-online-create': autoresearchValidateOnlineCreate,
+}

--- a/services/mcp/src/tools/generated/index.ts
+++ b/services/mcp/src/tools/generated/index.ts
@@ -5,6 +5,7 @@ import { GENERATED_TOOLS as actions } from './actions'
 import { GENERATED_TOOLS as ai_observability } from './ai_observability'
 import { GENERATED_TOOLS as alerts } from './alerts'
 import { GENERATED_TOOLS as annotations } from './annotations'
+import { GENERATED_TOOLS as autoresearch } from './autoresearch'
 import { GENERATED_TOOLS as batch_exports } from './batch_exports'
 import { GENERATED_TOOLS as billing } from './billing'
 import { GENERATED_TOOLS as billing_alerts } from './billing_alerts'
@@ -68,6 +69,7 @@ export const GENERATED_TOOL_MAP: Record<string, () => ToolBase<ZodObjectAny>> = 
     ...ai_observability,
     ...alerts,
     ...annotations,
+    ...autoresearch,
     ...batch_exports,
     ...billing,
     ...billing_alerts,

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-archive-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-archive-create.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "id": {
+            "description": "A UUID string identifying this autoresearch pipeline.",
+            "type": "string"
+        }
+    },
+    "required": ["id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-create.json
@@ -1,0 +1,85 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "cadence_days": {
+            "description": "Re-score the inference population every N days (1-365). Default: 1.",
+            "maximum": 365,
+            "minimum": 1,
+            "type": "number"
+        },
+        "description": {
+            "description": "Optional free-text description.",
+            "type": "string"
+        },
+        "horizon_days": {
+            "description": "Prediction horizon in days (1-365). The model predicts whether the target event occurs within this window.",
+            "maximum": 365,
+            "minimum": 1,
+            "type": "number"
+        },
+        "inference_population": {
+            "additionalProperties": {},
+            "description": "Inference population filter. Defaults to training_population if not set.",
+            "properties": {},
+            "type": "object"
+        },
+        "iteration_budget": {
+            "description": "Total training iterations allowed for the autoresearch loop (1-500). Default: 50.",
+            "maximum": 500,
+            "minimum": 1,
+            "type": "number"
+        },
+        "name": {
+            "description": "Display name for the pipeline.",
+            "maxLength": 255,
+            "type": "string"
+        },
+        "output_person_property": {
+            "description": "Person property name for the prediction score, e.g. 'predicted_p_pageview'. Auto-derived from target_event if omitted. Letters, digits, and _ $ . - only; must be unique among this project's non-archived pipelines.",
+            "maxLength": 255,
+            "type": "string"
+        },
+        "plateau_iterations": {
+            "description": "Stop training if no improvement in this many consecutive iterations. Default: 10.",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "number"
+        },
+        "success_auc": {
+            "anyOf": [
+                {
+                    "type": "number"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Target AUC threshold. Training stops early if reached. Default: 0.75."
+        },
+        "target_definition": {
+            "additionalProperties": {},
+            "description": "Omit (or pass {\"type\": \"event\"}) to predict target_event; pass {\"type\": \"action\", \"action_id\": N} to predict a PostHog action. No other shapes are accepted.",
+            "properties": {},
+            "type": "object"
+        },
+        "target_event": {
+            "description": "PostHog event name to predict, e.g. '$pageview' or 'signed_up'. Omit when predicting an action target (pass target_definition instead).",
+            "maxLength": 255,
+            "type": "string"
+        },
+        "training_lookback_days": {
+            "description": "How far back to look for training examples (7-730 days). Larger windows give more data but may include stale behavior. Default: 180.",
+            "maximum": 730,
+            "minimum": 7,
+            "type": "number"
+        },
+        "training_population": {
+            "additionalProperties": {},
+            "description": "Training population filter. Use {} for all identified users.",
+            "properties": {},
+            "type": "object"
+        }
+    },
+    "required": ["name"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-list.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "limit": {
+            "description": "Number of results to return per page.",
+            "type": "number"
+        },
+        "offset": {
+            "description": "The initial index from which to return the results.",
+            "type": "number"
+        }
+    },
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-materialize-features.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-materialize-features.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "features_sql": {
+            "description": "Your HogQL feature query, using the {anchors}/{lookback_days} contract. Must be a read-only SELECT keyed on person_id (aliased to distinct_id), one row per user. The backend runs it server-side against the labeled training population — no 500-row cap — and writes the resulting train/holdout feature and label parquet files into your sandbox.",
+            "type": "string"
+        },
+        "id": {
+            "description": "A UUID string identifying this autoresearch training run.",
+            "type": "string"
+        },
+        "pipeline_id": {
+            "type": "string"
+        }
+    },
+    "required": ["id", "pipeline_id", "features_sql"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-models-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-models-list.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "limit": {
+            "description": "Number of results to return per page.",
+            "type": "number"
+        },
+        "offset": {
+            "description": "The initial index from which to return the results.",
+            "type": "number"
+        },
+        "pipeline_id": {
+            "type": "string"
+        }
+    },
+    "required": ["pipeline_id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-models-retrieve.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-models-retrieve.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "id": {
+            "description": "A UUID string identifying this autoresearch model.",
+            "type": "string"
+        },
+        "pipeline_id": {
+            "type": "string"
+        }
+    },
+    "required": ["id", "pipeline_id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-pause-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-pause-create.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "id": {
+            "description": "A UUID string identifying this autoresearch pipeline.",
+            "type": "string"
+        }
+    },
+    "required": ["id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-resolve-template-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-resolve-template-create.json
@@ -1,0 +1,28 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "horizon_days": {
+            "description": "Override the template's default prediction horizon in days.",
+            "maximum": 365,
+            "minimum": 1,
+            "type": "number"
+        },
+        "target_event": {
+            "description": "Event or action name to use as the prediction target. Required for 'feature_adoption' and 'repeat_key_behavior'. Optional override for activity-based templates ('likely_active_soon', 'at_risk_of_inactivity', 'return_after_first_use') — omit to use the auto-resolved event.",
+            "type": "string"
+        },
+        "template_key": {
+            "description": "Template to resolve. Use autoresearch-templates-list to see all available templates with descriptions. Required.\n\n* `likely_active_soon` - likely_active_soon\n* `at_risk_of_inactivity` - at_risk_of_inactivity\n* `return_after_first_use` - return_after_first_use\n* `feature_adoption` - feature_adoption\n* `repeat_key_behavior` - repeat_key_behavior",
+            "enum": [
+                "likely_active_soon",
+                "at_risk_of_inactivity",
+                "return_after_first_use",
+                "feature_adoption",
+                "repeat_key_behavior"
+            ],
+            "type": "string"
+        }
+    },
+    "required": ["template_key"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-resume-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-resume-create.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "id": {
+            "description": "A UUID string identifying this autoresearch pipeline.",
+            "type": "string"
+        }
+    },
+    "required": ["id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-retrieve.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-retrieve.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "id": {
+            "description": "A UUID string identifying this autoresearch pipeline.",
+            "type": "string"
+        }
+    },
+    "required": ["id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-runs-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-runs-list.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "limit": {
+            "description": "Number of results to return per page.",
+            "type": "number"
+        },
+        "offset": {
+            "description": "The initial index from which to return the results.",
+            "type": "number"
+        },
+        "pipeline_id": {
+            "type": "string"
+        }
+    },
+    "required": ["pipeline_id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-score-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-score-create.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "id": {
+            "description": "A UUID string identifying this autoresearch pipeline.",
+            "type": "string"
+        }
+    },
+    "required": ["id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-suggestions-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-suggestions-create.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "pipeline_id": {
+            "type": "string"
+        },
+        "priority": {
+            "default": "consider",
+            "description": "'try_next' asks the agent to act on this before other autonomous iterations; 'consider' is advisory context.\n\n* `try_next` - try_next\n* `consider` - consider",
+            "enum": ["try_next", "consider"],
+            "type": "string"
+        },
+        "prompt": {
+            "description": "Free-text hypothesis or direction for the agent to explore, e.g. 'try a tree-based model' or 'remove recency features, I suspect leakage'.",
+            "maxLength": 2000,
+            "type": "string"
+        }
+    },
+    "required": ["pipeline_id", "prompt"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-suggestions-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-suggestions-list.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "limit": {
+            "description": "Number of results to return per page.",
+            "type": "number"
+        },
+        "offset": {
+            "description": "The initial index from which to return the results.",
+            "type": "number"
+        },
+        "pipeline_id": {
+            "type": "string"
+        }
+    },
+    "required": ["pipeline_id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-suggestions-respond.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-suggestions-respond.json
@@ -1,0 +1,25 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "agent_response": {
+            "default": "",
+            "description": "Plain-English note on how the suggestion was interpreted and acted upon (or why it was dismissed).",
+            "maxLength": 2000,
+            "type": "string"
+        },
+        "id": {
+            "description": "A UUID string identifying this autoresearch suggestion.",
+            "type": "string"
+        },
+        "pipeline_id": {
+            "type": "string"
+        },
+        "status": {
+            "description": "How the agent handled the suggestion: 'picked_up' (applied as a search constraint), 'acted_on' (spawned one or more iterations), or 'dismissed' (rejected — explain why in agent_response).\n\n* `picked_up` - picked_up\n* `acted_on` - acted_on\n* `dismissed` - dismissed",
+            "enum": ["picked_up", "acted_on", "dismissed"],
+            "type": "string"
+        }
+    },
+    "required": ["id", "pipeline_id", "status"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-suggestions-retrieve.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-suggestions-retrieve.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "id": {
+            "description": "A UUID string identifying this autoresearch suggestion.",
+            "type": "string"
+        },
+        "pipeline_id": {
+            "type": "string"
+        }
+    },
+    "required": ["id", "pipeline_id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-templates-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-templates-list.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "limit": {
+            "description": "Number of results to return per page.",
+            "type": "number"
+        },
+        "offset": {
+            "description": "The initial index from which to return the results.",
+            "type": "number"
+        }
+    },
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-train-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-train-create.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "id": {
+            "description": "A UUID string identifying this autoresearch pipeline.",
+            "type": "string"
+        },
+        "iteration_budget": {
+            "description": "Override the pipeline iteration budget for this training run.",
+            "maximum": 500,
+            "minimum": 1,
+            "type": "number"
+        }
+    },
+    "required": ["id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-training-runs-artifacts-delete-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-training-runs-artifacts-delete-create.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "id": {
+            "description": "A UUID string identifying this autoresearch training run.",
+            "type": "string"
+        },
+        "path": {
+            "description": "Relative path of the file within the bundle, e.g. 'train.py'.",
+            "maxLength": 500,
+            "type": "string"
+        },
+        "pipeline_id": {
+            "type": "string"
+        }
+    },
+    "required": ["id", "pipeline_id", "path"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-training-runs-artifacts-get-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-training-runs-artifacts-get-create.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "id": {
+            "description": "A UUID string identifying this autoresearch training run.",
+            "type": "string"
+        },
+        "path": {
+            "description": "Relative path of the file within the bundle, e.g. 'train.py'.",
+            "maxLength": 500,
+            "type": "string"
+        },
+        "pipeline_id": {
+            "type": "string"
+        }
+    },
+    "required": ["id", "pipeline_id", "path"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-training-runs-artifacts-retrieve.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-training-runs-artifacts-retrieve.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "id": {
+            "description": "A UUID string identifying this autoresearch training run.",
+            "type": "string"
+        },
+        "pipeline_id": {
+            "type": "string"
+        }
+    },
+    "required": ["id", "pipeline_id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-training-runs-artifacts-upload-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-training-runs-artifacts-upload-create.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "content_base64": {
+            "description": "File contents, base64-encoded. Decoded server-side and written to object storage. Max 10 MB decoded.",
+            "type": "string"
+        },
+        "id": {
+            "description": "A UUID string identifying this autoresearch training run.",
+            "type": "string"
+        },
+        "path": {
+            "description": "Relative path within the bundle, e.g. 'train.py', 'predict.py', 'features.sql', or 'eda/iter-3-gbm.ipynb'. Segments are limited to [A-Za-z0-9_.-]; absolute paths and '..' traversal are rejected.",
+            "maxLength": 500,
+            "type": "string"
+        },
+        "pipeline_id": {
+            "type": "string"
+        }
+    },
+    "required": ["id", "pipeline_id", "path", "content_base64"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-training-runs-complete-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-training-runs-complete-create.json
@@ -1,0 +1,43 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "best_iteration_id": {
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Iteration to promote as champion candidate. If omitted, the kept iteration with the highest holdout_score is used."
+        },
+        "distillation": {
+            "default": "",
+            "description": "A 1–2 sentence distillation of what this run learned — the winning signal, the key transform, the dead-ends. Stored in the run summary as the cheapest thing the next run reads. Max 2000 characters.",
+            "maxLength": 2000,
+            "type": "string"
+        },
+        "id": {
+            "description": "A UUID string identifying this autoresearch training run.",
+            "type": "string"
+        },
+        "model_explanation": {
+            "additionalProperties": {},
+            "description": "Global feature importance / directionality bundle for the champion model card.",
+            "properties": {},
+            "type": "object"
+        },
+        "pipeline_id": {
+            "type": "string"
+        },
+        "recommended_next": {
+            "default": "",
+            "description": "What a future run should try next, given what this run learned. Stored in the run summary so the next run reads it during orientation. Keep it short and concrete; max 2000 characters.",
+            "maxLength": 2000,
+            "type": "string"
+        }
+    },
+    "required": ["id", "pipeline_id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-training-runs-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-training-runs-create.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "iteration_budget": {
+            "description": "Iteration budget for this run. Defaults to the pipeline's iteration_budget if omitted.",
+            "maximum": 500,
+            "minimum": 1,
+            "type": "number"
+        },
+        "pipeline_id": {
+            "type": "string"
+        }
+    },
+    "required": ["pipeline_id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-training-runs-history.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-training-runs-history.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "limit": {
+            "description": "Maximum number of prior runs to return (default 5, capped at 20).",
+            "type": "number"
+        },
+        "pipeline_id": {
+            "type": "string"
+        }
+    },
+    "required": ["pipeline_id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-training-runs-iterations-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-training-runs-iterations-create.json
@@ -1,0 +1,91 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "agent_confidence": {
+            "anyOf": [
+                {
+                    "maximum": 1,
+                    "minimum": 0,
+                    "type": "number"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Agent's self-assessed confidence (0–1) that this iteration helps."
+        },
+        "agent_description": {
+            "default": "",
+            "description": "Agent's plain-English rationale for this iteration.",
+            "type": "string"
+        },
+        "holdout_score": {
+            "anyOf": [
+                {
+                    "maximum": 1,
+                    "minimum": 0,
+                    "type": "number"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Held-out AUC for this iteration (0-1). Used to pick the champion at completion."
+        },
+        "id": {
+            "description": "A UUID string identifying this autoresearch training run.",
+            "type": "string"
+        },
+        "iteration_number": {
+            "description": "Zero-based index of this iteration within the run. Re-sending the same number updates that iteration (idempotent).",
+            "minimum": 0,
+            "type": "number"
+        },
+        "model_spec": {
+            "additionalProperties": {},
+            "description": "model_class (must be allowlisted) and model_params tried this iteration.",
+            "properties": {},
+            "type": "object"
+        },
+        "parent_suggestion": {
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "UUID of the steering suggestion this iteration was spawned from, if any. Set it whenever the iteration acts on a pending suggestion — it links the iteration back to the suggestion for attribution and advances the suggestion to 'acted_on'."
+        },
+        "pipeline_id": {
+            "type": "string"
+        },
+        "recipe_snapshot": {
+            "additionalProperties": {},
+            "description": "Compact recipe for this iteration: feature_sql (HogQL SELECT keyed on person_id) and transforms.",
+            "properties": {},
+            "type": "object"
+        },
+        "status": {
+            "description": "'kept' if this iteration improved on the best score, 'discarded' otherwise, 'crashed' on failure.\n\n* `kept` - kept\n* `discarded` - discarded\n* `crashed` - crashed",
+            "enum": ["kept", "discarded", "crashed"],
+            "type": "string"
+        },
+        "train_score": {
+            "anyOf": [
+                {
+                    "maximum": 1,
+                    "minimum": 0,
+                    "type": "number"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Training-set AUC for this iteration (0-1)."
+        }
+    },
+    "required": ["id", "pipeline_id", "iteration_number", "recipe_snapshot", "model_spec", "status"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-training-runs-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-training-runs-list.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "limit": {
+            "description": "Number of results to return per page.",
+            "type": "number"
+        },
+        "offset": {
+            "description": "The initial index from which to return the results.",
+            "type": "number"
+        },
+        "pipeline_id": {
+            "type": "string"
+        }
+    },
+    "required": ["pipeline_id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-validate-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-validate-create.json
@@ -1,0 +1,40 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "horizon_days": {
+            "default": 7,
+            "description": "Predict whether the target event occurs within this many days.",
+            "maximum": 365,
+            "minimum": 1,
+            "type": "number"
+        },
+        "inference_population": {
+            "additionalProperties": {},
+            "description": "Population filter for daily scoring. Defaults to training_population if not provided.",
+            "properties": {},
+            "type": "object"
+        },
+        "target_definition": {
+            "description": "Optional target definition. Pass {\"type\": \"action\", \"action_id\": N} to predict a PostHog action (multi-step / property / autocapture matcher) instead of a single event."
+        },
+        "target_event": {
+            "default": "",
+            "description": "Event name to predict, e.g. '$pageview'. Must exist in the team's event schema. Omit when predicting an action target (pass target_definition instead).",
+            "type": "string"
+        },
+        "training_lookback_days": {
+            "default": 180,
+            "description": "How far back to look for training examples. Default: 180.",
+            "maximum": 730,
+            "minimum": 7,
+            "type": "number"
+        },
+        "training_population": {
+            "additionalProperties": {},
+            "description": "Population filter for training examples. Use {} for all identified users.",
+            "properties": {},
+            "type": "object"
+        }
+    },
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-validate-online-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/autoresearch-validate-online-create.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "id": {
+            "description": "A UUID string identifying this autoresearch pipeline.",
+            "type": "string"
+        }
+    },
+    "required": ["id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/tool-filtering.test.ts
+++ b/services/mcp/tests/unit/tool-filtering.test.ts
@@ -881,9 +881,10 @@ describe('Tool Filtering - Feature Flags', () => {
                 'experiment-behavior-comparison',
                 'data-warehouse-scene',
                 'data-quality-checks',
+                'autoresearch',
             ])
         )
-        expect(flags).toHaveLength(32)
+        expect(flags).toHaveLength(33)
     })
 
     it('every loops tool is gated on the loops flag', () => {

--- a/services/mcp/tests/unit/tool-schema-snapshots.test.ts
+++ b/services/mcp/tests/unit/tool-schema-snapshots.test.ts
@@ -101,6 +101,7 @@ describe('Tool schema snapshots', () => {
             'agent-platform': true,
             'billing-alerts': true,
             'billing-mcp-read-tools': true,
+            autoresearch: true,
         }
         const tools = [...(await getToolsFromContext(context, { featureFlags }))].sort((a, b) =>
             a.name.localeCompare(b.name)


### PR DESCRIPTION
> [!NOTE]
> Piece 12 of 13 in the split of #60081. Pieces 1-4 land prerequisites that stand alone on master. Pieces 5-13 add the autoresearch product. The map lives in #60081.

## Problem

The training agent runs inside a sandbox and has to record its own work: log each experiment, upload the model bundle it authored, and read what a sibling pipeline already learned. Without an MCP surface it has no way to do any of that.

## Changes

- The sandbox agent can drive its own research loop, and a person with the flag can reach autoresearch from an MCP client.
- Adds 29 generated `autoresearch-*` tools, all gated on the `autoresearch` flag.
- Adds `system.autoresearch_pipelines`, so pipelines are queryable in SQL. That is why the list and retrieve tools are marked v1-only: v2 agents answer those from the table instead.
- Mechanical: the generated tool schemas, the agent scopes, and the data-schema reference for the new table.

> [!WARNING]
> **The `exec` schema cap test fails on this PR, and the cause is not this product.**
> `instructions-formatter-snapshot.test.ts` asserts the serialized `exec` inputSchema stays under claude.ai's 16384-char registry limit. Master already measures 16363, leaving 21 characters. Autoresearch's tools take it to 16650.
> The budget is shared across every product with no per-product allocation, so whatever ships next fails this test regardless of its size. Trimming autoresearch to fit would buy the next team 21 characters and would mean cutting the tools the training agent depends on.
> Reported to the devex and MCP teams. This needs an owner for the `exec` schema budget, not a change here.

## How did you test this code?

`vitest tests/unit` in `services/mcp` passes 2673 of 2674, the exception being the cap test above.

Tests that changed: the feature-flag inventory test gains `autoresearch` and its count, and the tool-schema snapshot test enables the flag so the 29 generated schemas are covered.

`hogli test posthog/hogql/database/test/test_database.py` passes 132 with the regenerated snapshot for the new system table.

Also run: `pnpm --filter=@posthog/mcp lint-tool-names`.

Not run: the tools against a live MCP client.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`products/autoresearch/mcp/AGENTS.md` is new. `products/posthog_ai/skills/querying-posthog-data/` gains the model reference for the new system table, registered in its SKILL.md.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5), driven by @andrewm4894. Cut by path from the `autoresearch-dev` branch (#60081) per the split plan in that PR.

Skills invoked: /implementing-mcp-tools, /writing-tests, /writing-pr-descriptions.

This piece was originally planned before the frontend and swapped after it. The tool config links to a scene path, and a placeholder would have had to be corrected a piece later.

The branch did not add the HogQL system table or the data-schema reference; both are required by the MCP tool guide for a product exposing list and get endpoints.
