### PR TITLE
fix(demo): mark simulated persons that fired $identify as identified (13/13)

### DIFF
--- a/products/demo/backend/logic/matrix/manager.py
+++ b/products/demo/backend/logic/matrix/manager.py
@@ -22,7 +22,7 @@ from products.demo.backend.logic.matrix.persons_db_sync import (
 from products.demo.backend.logic.matrix.taxonomy_inference import infer_taxonomy_for_team
 
 from .matrix import Matrix
-from .models import SimEvent, SimPerson
+from .models import EVENT_IDENTIFY, SimEvent, SimPerson
 
 
 class MatrixManager:
@@ -263,10 +263,15 @@ class MatrixManager:
             if not hasattr(subject, "properties_at_now"):
                 subject.take_snapshot_at_now()
 
+            # A person that fired an $identify event during the simulation is identified,
+            # matching real ingestion, which flips is_identified on $identify. Without this the
+            # demo generator leaves every person anonymous (is_identified=False).
+            is_identified = any(event.event == EVENT_IDENTIFY for event in subject.past_events)
             create_person(
                 uuid=str(subject.in_posthog_id),
                 team_id=team.pk,
                 properties=subject.properties_at_now,
+                is_identified=is_identified,
                 version=0,
             )
             self._persons_created += 1


### PR DESCRIPTION
> [!NOTE]
> Piece 13 of 13 in the split of #60081. Pieces 1-4 land prerequisites that stand alone on master. Pieces 5-13 add the autoresearch product. The map lives in #60081.

## Problem

Every person the demo data generator creates is anonymous. It never sets `is_identified`, while real ingestion flips it the moment a person fires `$identify`.

Anything that filters on identified users sees a fraction of the population the event counts imply. Autoresearch trains on identified users only, so on demo data a target with thousands of events yields a few dozen usable training rows, and the run looks like a modelling failure rather than a data one.

## Changes

- A simulated person who fired `$identify` is now stored as identified, matching what ingestion would have done.
- Nothing changes for real data. This is the demo generator only.

## How did you test this code?

`hogli test products/demo/backend` passes 27 tests. No new test: the generator's existing tests cover person creation, and asserting that a simulated `$identify` sets a flag the same expression just computed would test the line rather than the behavior.

Not run: a regenerated demo project, which needs a populated dev stack. #60081 records the end-to-end run this fix was found from.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5), driven by @andrewm4894. Cut by path from the `autoresearch-dev` branch (#60081) per the split plan in that PR.

Skills invoked: /writing-tests, /writing-code-comments, /writing-pr-descriptions.

The branch also carried a blanket `PLC0415` ruff exemption for `autoresearch/**`. It is deliberately not here: the imports that needed it were hoisted in the earlier pieces, and the three that stay deferred carry their own justification.
