### PR TITLE
feat(desktop): mark canvas generation sessions by source

### DIFF
--- a/products/desktop/packages/core/src/canvas/canvasApplicationService.test.ts
+++ b/products/desktop/packages/core/src/canvas/canvasApplicationService.test.ts
@@ -84,6 +84,7 @@ describe("CanvasApplicationService", () => {
       adapter: "claude",
       model: "model-1",
       allowNoRepo: true,
+      originProduct: "canvas",
     });
     expect(gateway.fileTask).toHaveBeenCalledWith("chan-1", "task-1");
     expect(gateway.setGenerationTask).toHaveBeenCalledWith("dash-1", "task-1");

--- a/products/desktop/packages/core/src/canvas/canvasApplicationService.ts
+++ b/products/desktop/packages/core/src/canvas/canvasApplicationService.ts
@@ -227,6 +227,7 @@ export class CanvasApplicationService {
             ? CANVAS_PREFERRED_REASONING
             : undefined),
         allowNoRepo: true,
+        originProduct: "canvas",
         channelContext: input.channelContext,
         channelName: input.channelName,
         channelId: input.channelId,

--- a/products/desktop/packages/core/src/task-detail/taskCreationSaga.test.ts
+++ b/products/desktop/packages/core/src/task-detail/taskCreationSaga.test.ts
@@ -897,6 +897,23 @@ describe("TaskCreationSaga", () => {
     expect(createTaskRunMock).not.toHaveBeenCalled();
   });
 
+  it("forwards the origin product for task creation", async () => {
+    const createTaskMock = vi.fn().mockResolvedValue(createTask());
+    const saga = makeSaga({ createTask: createTaskMock });
+
+    const result = await saga.run({
+      content: "Build a canvas",
+      workspaceMode: "local",
+      allowNoRepo: true,
+      originProduct: "canvas",
+    });
+
+    expect(result.success).toBe(true);
+    expect(createTaskMock).toHaveBeenCalledWith(
+      expect.objectContaining({ origin_product: "canvas" }),
+    );
+  });
+
   it("uses the selected user GitHub integration for cloud task creation", async () => {
     const createdTask = createTask({
       github_user_integration: "user-integration-123",

--- a/products/desktop/packages/core/src/task-detail/taskCreationSaga.ts
+++ b/products/desktop/packages/core/src/task-detail/taskCreationSaga.ts
@@ -817,7 +817,7 @@ export class TaskCreationSaga extends Saga<
               : undefined,
           origin_product: input.signalReportId
             ? "signal_report"
-            : "user_created",
+            : (input.originProduct ?? "user_created"),
           // The server associates the task with the report and records the implementation
           // task_run artefact — no relationship label is sent (associations are unlabelled).
           branch:

--- a/products/desktop/packages/shared/src/task-creation-domain.ts
+++ b/products/desktop/packages/shared/src/task-creation-domain.ts
@@ -47,6 +47,7 @@ export interface TaskCreationInput {
   customImageId?: string;
   cloudPrAuthorshipMode?: PrAuthorshipMode;
   cloudRunSource?: CloudRunSource;
+  originProduct?: Task["origin_product"];
   /**
    * When true, the cloud run agent pushes its work and opens a draft PR on
    * completion without waiting for an explicit ask (Settings → Advanced).

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelSidebar.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelSidebar.test.tsx
@@ -181,14 +181,14 @@ describe("ChannelSidebar", () => {
     expect(screen.queryByText("No sessions yet")).not.toBeInTheDocument();
   });
 
-  it("gives up a source filter the space you moved to has none of", async () => {
+  it("filters canvas generation sessions and gives up the filter in a space with none", async () => {
     const user = userEvent.setup({ pointerEventsCheck: 0 });
     mocks.items = [
       item({
-        key: "task:slack",
-        id: "slack",
-        title: "Filed from Slack",
-        source: "slack",
+        key: "task:canvas",
+        id: "canvas",
+        title: "Generate signup canvas",
+        source: "canvas",
       }),
       item({ key: "task:local", id: "local", title: "Started here" }),
     ];
@@ -197,11 +197,12 @@ describe("ChannelSidebar", () => {
     await user.click(screen.getByRole("button", { name: "Filter" }));
     await user.click(await screen.findByRole("menuitem", { name: /Source/ }));
     fireEvent.click(
-      await screen.findByRole("menuitemradio", { name: "Slack" }),
+      await screen.findByRole("menuitemradio", { name: "Canvas" }),
     );
+    expect(screen.getByText("Generate signup canvas")).toBeInTheDocument();
     expect(screen.queryByText("Started here")).not.toBeInTheDocument();
 
-    // A space with no Slack sessions: the option that narrowed the list is no
+    // A space with no canvas sessions: the option that narrowed the list is no
     // longer in the menu, so the filter must not be what empties it.
     mocks.items = [
       item({ key: "task:other", id: "other", title: "Somewhere else" }),

--- a/products/desktop/packages/ui/src/features/sidebar/components/items/TaskIcon.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/items/TaskIcon.tsx
@@ -13,6 +13,7 @@ import {
   Lifebuoy,
   Pause,
   PushPin,
+  ShapesIcon,
   SlackLogo,
   WarningCircle,
 } from "@phosphor-icons/react";
@@ -42,6 +43,7 @@ export const ICON_SIZE = 12;
 // the default status icon. Extend this when a new origin needs its own badge.
 type OriginProductMeta = { Icon: typeof SlackLogo; label: string };
 const ORIGIN_PRODUCT_META: Record<string, OriginProductMeta> = {
+  canvas: { Icon: ShapesIcon, label: "Canvas" },
   slack: { Icon: SlackLogo, label: "Slack" },
   signal_report: { Icon: Broadcast, label: "Signals" },
   signals_scout: { Icon: Binoculars, label: "Signals scout" },

--- a/products/tasks/backend/logic/services/compute_quota.py
+++ b/products/tasks/backend/logic/services/compute_quota.py
@@ -10,6 +10,7 @@ from products.tasks.backend.models import Task, TaskClientProvenance
 
 COMPUTE_QUOTA_DENIAL_CODE = "posthog_code_billing_limit_exceeded"
 ORGANIZATION_DEACTIVATED_DENIAL_CODE = "organization_deactivated"
+DIRECT_BILLABLE_ORIGIN_PRODUCTS = frozenset({Task.OriginProduct.USER_CREATED, Task.OriginProduct.CANVAS})
 
 
 class ComputeQuotaDenialReason(StrEnum):
@@ -47,7 +48,7 @@ def is_billable_compute(
 ) -> bool:
     if client_provenance != TaskClientProvenance.POSTHOG_DESKTOP:
         return False
-    if origin_product == Task.OriginProduct.USER_CREATED:
+    if origin_product in DIRECT_BILLABLE_ORIGIN_PRODUCTS:
         return True
     return bool(
         origin_product == Task.OriginProduct.LOOP and source_loop_id is not None and source_loop_internal is False

--- a/products/tasks/backend/logic/services/sandbox_usage.py
+++ b/products/tasks/backend/logic/services/sandbox_usage.py
@@ -27,7 +27,7 @@ import structlog
 
 from posthog.dataclasses import frozen
 
-from products.tasks.backend.logic.services.compute_quota import is_billable_compute
+from products.tasks.backend.logic.services.compute_quota import DIRECT_BILLABLE_ORIGIN_PRODUCTS, is_billable_compute
 from products.tasks.backend.logic.services.sandbox import Sandbox, SandboxBase, SandboxConfig
 from products.tasks.backend.logic.services.sandbox_pricing import (
     COMPUTE_RATE_CARDS,
@@ -310,7 +310,7 @@ def get_billable_sandbox_compute_usage_by_team(
             user_attributed_at__isnull=False,
             user_attributed_at__lt=end,
         )
-        .filter(Q(origin_product=Task.OriginProduct.USER_CREATED) | Q(origin_product=Task.OriginProduct.LOOP))
+        .filter(Q(origin_product__in=DIRECT_BILLABLE_ORIGIN_PRODUCTS) | Q(origin_product=Task.OriginProduct.LOOP))
         .filter(Q(ended_at__isnull=True, ttl_expires_at__gt=begin) | Q(ended_at__gt=begin))
     )
 

--- a/products/tasks/backend/logic/services/task_usage.py
+++ b/products/tasks/backend/logic/services/task_usage.py
@@ -23,6 +23,7 @@ from posthog.clickhouse.query_tagging import Feature, Product, tags_context
 from posthog.dataclasses import frozen
 from posthog.models import Team
 
+from products.tasks.backend.logic.services.compute_quota import DIRECT_BILLABLE_ORIGIN_PRODUCTS
 from products.tasks.backend.logic.services.sandbox_pricing import (
     COMPUTE_RATE_CARDS,
     calculate_sandbox_compute_cost,
@@ -171,7 +172,7 @@ def _get_task_compute_cost(*, team_id: int, task_id: UUID) -> Decimal:
             user_attributed_at__isnull=False,
         )
         .filter(
-            Q(origin_product=Task.OriginProduct.USER_CREATED)
+            Q(origin_product__in=DIRECT_BILLABLE_ORIGIN_PRODUCTS)
             | Q(
                 origin_product=Task.OriginProduct.LOOP,
                 task_run__task__loop__isnull=False,

--- a/products/tasks/backend/logic/services/tests/test_compute_quota.py
+++ b/products/tasks/backend/logic/services/tests/test_compute_quota.py
@@ -15,6 +15,16 @@ from products.tasks.backend.logic.services.compute_quota import (
 from products.tasks.backend.models import Loop, Task, TaskClientProvenance
 
 
+class TestBillableCompute:
+    def test_canvas_is_billable_desktop_compute(self):
+        assert is_billable_compute(
+            origin_product=Task.OriginProduct.CANVAS,
+            client_provenance=TaskClientProvenance.POSTHOG_DESKTOP,
+            source_loop_id=None,
+            source_loop_internal=None,
+        )
+
+
 @pytest.mark.django_db
 class TestComputeQuota:
     @pytest.fixture(autouse=True)

--- a/products/tasks/backend/logic/services/tests/test_sandbox_usage.py
+++ b/products/tasks/backend/logic/services/tests/test_sandbox_usage.py
@@ -365,17 +365,21 @@ class TestSandboxUsageAggregation(SandboxUsageBase):
             memory_gib_second_usd=memory_gib_second_usd,
         )
 
-    def test_billable_compute_requires_trusted_desktop_user_created_snapshot(self):
+    def test_billable_compute_requires_trusted_desktop_user_driven_snapshot(self):
         self._session(client_provenance=TaskClientProvenance.POSTHOG_DESKTOP)
+        self._session(
+            client_provenance=TaskClientProvenance.POSTHOG_DESKTOP,
+            origin_product=Task.OriginProduct.CANVAS,
+        )
         for origin in (Task.OriginProduct.SLACK, Task.OriginProduct.SIGNAL_REPORT, Task.OriginProduct.LOOP, None):
             self._session(client_provenance=TaskClientProvenance.POSTHOG_DESKTOP, origin_product=origin)
         self._session(client_provenance=None)
 
         usage = get_billable_sandbox_compute_usage_by_team(self.BEGIN, self.END, rate_cards=(self._rate(),))
 
-        assert usage.cpu_millicore_seconds == [(self.team.id, 14_400_000)]
-        assert usage.memory_mib_seconds == [(self.team.id, 58_982_400)]
-        assert usage.credits == [(self.team.id, 2016)]
+        assert usage.cpu_millicore_seconds == [(self.team.id, 28_800_000)]
+        assert usage.memory_mib_seconds == [(self.team.id, 117_964_800)]
+        assert usage.credits == [(self.team.id, 4032)]
 
     def test_billable_compute_includes_user_loops_and_excludes_internal_loops(self):
         self._loop_session(internal=False)

--- a/products/tasks/backend/logic/services/tests/test_task_usage.py
+++ b/products/tasks/backend/logic/services/tests/test_task_usage.py
@@ -95,13 +95,17 @@ class TestTaskUsage(ClickhouseTestMixin, APIBaseTest):
             cpu_core_second_usd=Decimal("0.01"),
             memory_gib_second_usd=Decimal("0.01"),
         )
-        for provenance in (TaskClientProvenance.POSTHOG_DESKTOP, None):
+        for provenance, origin_product in (
+            (TaskClientProvenance.POSTHOG_DESKTOP, Task.OriginProduct.USER_CREATED),
+            (TaskClientProvenance.POSTHOG_DESKTOP, Task.OriginProduct.CANVAS),
+            (None, Task.OriginProduct.USER_CREATED),
+        ):
             run = TaskRun.objects.create(task=self.task, team=self.team)
             SandboxSession.objects.unscoped().create(
                 team=self.team,
                 task_run=run,
-                sandbox_id=f"sandbox-{provenance or 'untrusted'}",
-                origin_product=Task.OriginProduct.USER_CREATED,
+                sandbox_id=f"sandbox-{origin_product}-{provenance or 'untrusted'}",
+                origin_product=origin_product,
                 client_provenance=provenance,
                 cpu_cores=1,
                 memory_gb=1,
@@ -124,7 +128,7 @@ class TestTaskUsage(ClickhouseTestMixin, APIBaseTest):
                 task_created_at=self.task.created_at,
             )
 
-        assert usage.compute_cost_usd == Decimal("0.20")
+        assert usage.compute_cost_usd == Decimal("0.40")
 
     def test_usage_is_reported_before_the_first_rate_card_takes_effect(self) -> None:
         rate_start = datetime(2026, 8, 1, tzinfo=UTC)

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -219,6 +219,7 @@ class Task(DeletedMetaFields, models.Model):
         ERROR_TRACKING = "error_tracking", "Error Tracking"
         EVAL_CLUSTERS = "eval_clusters", "Eval Clusters"
         USER_CREATED = "user_created", "User Created"
+        CANVAS = "canvas", "Canvas"
         SLACK = "slack", "Slack"
         SUPPORT_QUEUE = "support_queue", "Support Queue"
         SESSION_SUMMARIES = "session_summaries", "Session Summaries"
@@ -861,7 +862,11 @@ class Task(DeletedMetaFields, models.Model):
         if origin_product == Task.OriginProduct.SIGNAL_REPORT:
             extra_state["run_source"] = RunSource.SIGNAL_REPORT.value
             extra_state["pr_authorship_mode"] = PrAuthorshipMode.BOT.value
-        elif origin_product in (Task.OriginProduct.USER_CREATED, Task.OriginProduct.SLACK):
+        elif origin_product in (
+            Task.OriginProduct.USER_CREATED,
+            Task.OriginProduct.CANVAS,
+            Task.OriginProduct.SLACK,
+        ):
             extra_state["pr_authorship_mode"] = (
                 PrAuthorshipMode.USER.value if github_user_integration is not None else PrAuthorshipMode.BOT.value
             )

--- a/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
@@ -56,7 +56,9 @@ from products.tasks.backend.temporal.process_task.utils import (
     get_pr_authorship_mode,
     get_task_run_credential_user,
     is_slack_interaction_state,
+    is_user_driven_origin_product,
     resolve_user_github_integration_for_task,
+    sandbox_policy_origin_product,
 )
 
 
@@ -240,9 +242,9 @@ class TaskProcessingContext:
         )
 
     def _is_user_origin(self) -> bool:
-        return not self.origin_product or self.origin_product in (
-            Task.OriginProduct.USER_CREATED.value,
-            Task.OriginProduct.IMAGE_BUILDER.value,
+        return (
+            is_user_driven_origin_product(self.origin_product)
+            or self.origin_product == Task.OriginProduct.IMAGE_BUILDER.value
         )
 
     def max_run_duration(self) -> timedelta | None:
@@ -562,8 +564,11 @@ def _resolve_modal_vm_sandbox(
         origin_rollout_percentages = vm_sandbox_origin_rollout_percentages(payload)
         default_custom_image = vm_sandbox_default_custom_image(payload)
 
-    origin_in_percentage_rollout = vm_sandbox_origin_in_rollout(origin_product, run_id, origin_rollout_percentages)
-    origin_allows_default_base = origin_product in default_base_origins or origin_in_percentage_rollout
+    policy_origin_product = sandbox_policy_origin_product(origin_product)
+    origin_in_percentage_rollout = vm_sandbox_origin_in_rollout(
+        policy_origin_product, run_id, origin_rollout_percentages
+    )
+    origin_allows_default_base = policy_origin_product in default_base_origins or origin_in_percentage_rollout
 
     # Custom images are VM-only, so VM historically required one. image_builder always
     # runs on VM (it builds images on that base); origins in the default-base allowlist
@@ -588,7 +593,7 @@ def _resolve_modal_vm_sandbox(
         )
         return VmSandboxDecision(use_vm_sandbox=state_override)
 
-    result = origin_product in allowed_origins or origin_allows_default_base
+    result = policy_origin_product in allowed_origins or origin_allows_default_base
     log_with_activity_context(
         "modal_vm_sandbox_flag_checked",
         run_id=run_id,

--- a/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
@@ -599,6 +599,7 @@ def _resolve_modal_vm_sandbox(
         run_id=run_id,
         flag_enabled=bool(allowed_origins or default_base_origins or origin_rollout_percentages),
         origin_product=origin_product,
+        policy_origin_product=policy_origin_product,
         allowed_origin_products=sorted(allowed_origins),
         default_base_origin_products=sorted(default_base_origins),
         origin_product_rollout_percentages=origin_rollout_percentages,

--- a/products/tasks/backend/temporal/process_task/activities/relay_sandbox_events.py
+++ b/products/tasks/backend/temporal/process_task/activities/relay_sandbox_events.py
@@ -26,16 +26,14 @@ from products.tasks.backend.logic.services.permission_broker import (
     try_auto_respond_permission_request,
 )
 from products.tasks.backend.logic.stream.redis_stream import TaskRunRedisStream, get_task_run_stream_key
-from products.tasks.backend.models import (
-    Task as TaskModel,
-    TaskRun as TaskRunModel,
-)
+from products.tasks.backend.models import TaskRun as TaskRunModel
 from products.tasks.backend.redis import run_uses_dedicated_stream
 from products.tasks.backend.temporal.constants import INACTIVITY_TIMEOUT_DEFAULT_SECONDS, resolve_inactivity_timeout
 from products.tasks.backend.temporal.process_task.utils import (
     get_actor_distinct_id,
     get_task_run_credential_user,
     is_slack_interaction_state,
+    is_user_driven_origin_product,
 )
 
 from ee.hogai.sandbox import is_turn_complete
@@ -124,7 +122,7 @@ async def _relay_sandbox_events(input: RelaySandboxEventsInput, *, finalize_stre
     # flight; see _background_heartbeat), so the relay never resets a timer for
     # a run that is genuinely idle.
     origin_product = task_run.task.origin_product
-    is_user_origin = not origin_product or origin_product == TaskModel.OriginProduct.USER_CREATED.value
+    is_user_origin = is_user_driven_origin_product(origin_product)
     inactivity_timeout_seconds = resolve_inactivity_timeout(
         is_user_origin=is_user_origin, origin_product=origin_product, state=task_run.state
     ).total_seconds()

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
@@ -1084,6 +1084,12 @@ class TestGetTaskProcessingContextActivity:
                 False,
                 True,
             ),
+            (
+                "canvas",
+                {"origin_products": ["user_created"], "default_base_origin_products": ["user_created"]},
+                False,
+                True,
+            ),
             # default-base alone (no origin_products) is enough for a no-custom-image run.
             ("user_created", {"default_base_origin_products": ["user_created"]}, False, True),
             # the waiver is scoped per origin — an unlisted origin still gets gVisor.

--- a/products/tasks/backend/temporal/process_task/tests/test_inactivity_timeout.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_inactivity_timeout.py
@@ -33,10 +33,16 @@ class TestResolveInactivityTimeout(SimpleTestCase):
     def test_posthog_ai_origin_constant_matches_model_enum(self):
         self.assertEqual(POSTHOG_AI_ORIGIN_PRODUCT, Task.OriginProduct.POSTHOG_AI.value)
 
+    @parameterized.expand(
+        [
+            ("posthog_ai", POSTHOG_AI_ORIGIN_PRODUCT, POSTHOG_AI_IDLE_TIMEOUT_SECONDS),
+            ("canvas", Task.OriginProduct.CANVAS, INACTIVITY_TIMEOUT_USER_SECONDS),
+        ]
+    )
     @override_settings(TEST=False, TASKS_INACTIVITY_TIMEOUT_SECONDS=0)
-    def test_context_forwards_its_origin_to_the_resolver(self):
-        # Guards the wiring, not the resolver: dropping `origin_product=` at this call site
-        # would leave every resolver case green while PostHog AI silently fell back to 30 minutes.
+    def test_context_applies_the_origin_timeout(self, _name, origin_product, expected_seconds):
+        # Guards the context wiring because resolver-only cases cannot catch a dropped origin
+        # or a wrong user-origin classification.
         context = TaskProcessingContext(
             task_id="task-id",
             run_id="run-id",
@@ -46,9 +52,9 @@ class TestResolveInactivityTimeout(SimpleTestCase):
             github_integration_id=123,
             repository="explore-science/paper-wizard-frontend",
             distinct_id="distinct",
-            origin_product=POSTHOG_AI_ORIGIN_PRODUCT,
+            origin_product=origin_product,
         )
-        self.assertEqual(context.inactivity_timeout(), timedelta(seconds=POSTHOG_AI_IDLE_TIMEOUT_SECONDS))
+        self.assertEqual(context.inactivity_timeout(), timedelta(seconds=expected_seconds))
 
     @override_settings(TEST=True, TASKS_INACTIVITY_TIMEOUT_SECONDS=0)
     def test_test_default_is_short_regardless_of_origin(self):

--- a/products/tasks/backend/temporal/process_task/utils.py
+++ b/products/tasks/backend/temporal/process_task/utils.py
@@ -73,7 +73,16 @@ class RunSource(StrEnum):
 
 
 # Origins whose runs are meant to carry a human git identity; everything else is bot-authored.
-USER_AUTHORABLE_ORIGIN_PRODUCTS: tuple[str, ...] = ("user_created", "slack")
+USER_AUTHORABLE_ORIGIN_PRODUCTS: tuple[str, ...] = ("user_created", "canvas", "slack")
+USER_DRIVEN_ORIGIN_PRODUCTS: tuple[str, ...] = ("user_created", "canvas")
+
+
+def is_user_driven_origin_product(origin_product: str | None) -> bool:
+    return not origin_product or origin_product in USER_DRIVEN_ORIGIN_PRODUCTS
+
+
+def sandbox_policy_origin_product(origin_product: str | None) -> str | None:
+    return "user_created" if origin_product == "canvas" else origin_product
 
 
 class RuntimeAdapter(StrEnum):

--- a/products/tasks/backend/tests/test_presentation_serializers.py
+++ b/products/tasks/backend/tests/test_presentation_serializers.py
@@ -59,6 +59,7 @@ class TestTaskWriteSerializerOriginProduct(SimpleTestCase):
             ("image_builder", True),
             ("signals_scout", True),
             ("user_created", False),
+            ("canvas", False),
         ]
     )
     def test_internal_only_origins_are_rejected(self, origin_product: str, expected_rejected: bool) -> None:

--- a/products/tasks/docs/CHANNELS.md
+++ b/products/tasks/docs/CHANNELS.md
@@ -118,6 +118,7 @@ membership without adding permissions to Task.
   also clears the stored GitHub user-integration preference and any borrowed MCP
   credential owner, posts a system `task_handed_off` announcement into the task's
   thread, and notifies the recipient.
+- Canvas generation tasks use `origin_product: "canvas"`. The Spaces session list exposes this as the Canvas source filter.
 
 ### Canvas endpoints
 

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -1653,6 +1653,7 @@ export interface PaginatedTaskDetailDTOListApi {
  * * `error_tracking` - Error Tracking
  * * `eval_clusters` - Eval Clusters
  * * `user_created` - User Created
+ * * `canvas` - Canvas
  * * `slack` - Slack
  * * `support_queue` - Support Queue
  * * `session_summaries` - Session Summaries
@@ -1676,6 +1677,7 @@ export const OriginProductEnumApi = {
     ErrorTracking: 'error_tracking',
     EvalClusters: 'eval_clusters',
     UserCreated: 'user_created',
+    Canvas: 'canvas',
     Slack: 'slack',
     SupportQueue: 'support_queue',
     SessionSummaries: 'session_summaries',
@@ -1716,6 +1718,7 @@ export interface TaskCreateApi {
      * * `error_tracking` - Error Tracking
      * * `eval_clusters` - Eval Clusters
      * * `user_created` - User Created
+     * * `canvas` - Canvas
      * * `slack` - Slack
      * * `support_queue` - Support Queue
      * * `session_summaries` - Session Summaries
@@ -1858,6 +1861,7 @@ export interface TaskWriteApi {
      * * `error_tracking` - Error Tracking
      * * `eval_clusters` - Eval Clusters
      * * `user_created` - User Created
+     * * `canvas` - Canvas
      * * `slack` - Slack
      * * `support_queue` - Support Queue
      * * `session_summaries` - Session Summaries
@@ -1985,6 +1989,7 @@ export interface PatchedTaskWriteApi {
      * * `error_tracking` - Error Tracking
      * * `eval_clusters` - Eval Clusters
      * * `user_created` - User Created
+     * * `canvas` - Canvas
      * * `slack` - Slack
      * * `support_queue` - Support Queue
      * * `session_summaries` - Session Summaries

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -4491,6 +4491,7 @@ export type TasksListParams = {
      * * `error_tracking` - Error Tracking
      * * `eval_clusters` - Eval Clusters
      * * `user_created` - User Created
+     * * `canvas` - Canvas
      * * `slack` - Slack
      * * `support_queue` - Support Queue
      * * `session_summaries` - Session Summaries
@@ -4618,6 +4619,7 @@ export const TasksListExcludeOriginProduct = {
     ErrorTracking: 'error_tracking',
     EvalClusters: 'eval_clusters',
     UserCreated: 'user_created',
+    Canvas: 'canvas',
     Slack: 'slack',
     SupportQueue: 'support_queue',
     SessionSummaries: 'session_summaries',

--- a/products/tasks/frontend/generated/api.zod.ts
+++ b/products/tasks/frontend/generated/api.zod.ts
@@ -1093,6 +1093,7 @@ export const TasksCreateBody = /* @__PURE__ */ zod
                 'error_tracking',
                 'eval_clusters',
                 'user_created',
+                'canvas',
                 'slack',
                 'support_queue',
                 'session_summaries',
@@ -1110,11 +1111,11 @@ export const TasksCreateBody = /* @__PURE__ */ zod
                 'workflow',
             ])
             .describe(
-                '\* `onboarding` - Onboarding\n\* `error_tracking` - Error Tracking\n\* `eval_clusters` - Eval Clusters\n\* `user_created` - User Created\n\* `slack` - Slack\n\* `support_queue` - Support Queue\n\* `session_summaries` - Session Summaries\n\* `posthog_ai` - PostHog AI\n\* `experiments` - Experiments\n\* `signal_report` - Signal Report\n\* `signals_scout` - Signals Scout\n\* `support_reply` - Support Reply\n\* `hogdesk` - HogDesk\n\* `review_hog` - ReviewHog\n\* `image_builder` - Image Builder\n\* `loop` - Loop\n\* `mcp_analytics` - MCP Analytics\n\* `signals_chat` - Signals Chat\n\* `workflow` - Workflow'
+                '\* `onboarding` - Onboarding\n\* `error_tracking` - Error Tracking\n\* `eval_clusters` - Eval Clusters\n\* `user_created` - User Created\n\* `canvas` - Canvas\n\* `slack` - Slack\n\* `support_queue` - Support Queue\n\* `session_summaries` - Session Summaries\n\* `posthog_ai` - PostHog AI\n\* `experiments` - Experiments\n\* `signal_report` - Signal Report\n\* `signals_scout` - Signals Scout\n\* `support_reply` - Support Reply\n\* `hogdesk` - HogDesk\n\* `review_hog` - ReviewHog\n\* `image_builder` - Image Builder\n\* `loop` - Loop\n\* `mcp_analytics` - MCP Analytics\n\* `signals_chat` - Signals Chat\n\* `workflow` - Workflow'
             )
             .optional()
             .describe(
-                'PostHog product or surface that created this task (e.g. error_tracking, slack, user_created). Origins reserved for server-created agents cannot be set through this API.\n\n\* `onboarding` - Onboarding\n\* `error_tracking` - Error Tracking\n\* `eval_clusters` - Eval Clusters\n\* `user_created` - User Created\n\* `slack` - Slack\n\* `support_queue` - Support Queue\n\* `session_summaries` - Session Summaries\n\* `posthog_ai` - PostHog AI\n\* `experiments` - Experiments\n\* `signal_report` - Signal Report\n\* `signals_scout` - Signals Scout\n\* `support_reply` - Support Reply\n\* `hogdesk` - HogDesk\n\* `review_hog` - ReviewHog\n\* `image_builder` - Image Builder\n\* `loop` - Loop\n\* `mcp_analytics` - MCP Analytics\n\* `signals_chat` - Signals Chat\n\* `workflow` - Workflow'
+                'PostHog product or surface that created this task (e.g. error_tracking, slack, user_created). Origins reserved for server-created agents cannot be set through this API.\n\n\* `onboarding` - Onboarding\n\* `error_tracking` - Error Tracking\n\* `eval_clusters` - Eval Clusters\n\* `user_created` - User Created\n\* `canvas` - Canvas\n\* `slack` - Slack\n\* `support_queue` - Support Queue\n\* `session_summaries` - Session Summaries\n\* `posthog_ai` - PostHog AI\n\* `experiments` - Experiments\n\* `signal_report` - Signal Report\n\* `signals_scout` - Signals Scout\n\* `support_reply` - Support Reply\n\* `hogdesk` - HogDesk\n\* `review_hog` - ReviewHog\n\* `image_builder` - Image Builder\n\* `loop` - Loop\n\* `mcp_analytics` - MCP Analytics\n\* `signals_chat` - Signals Chat\n\* `workflow` - Workflow'
             ),
         repository: zod
             .string()
@@ -1254,6 +1255,7 @@ export const TasksUpdateBody = /* @__PURE__ */ zod
                 'error_tracking',
                 'eval_clusters',
                 'user_created',
+                'canvas',
                 'slack',
                 'support_queue',
                 'session_summaries',
@@ -1271,11 +1273,11 @@ export const TasksUpdateBody = /* @__PURE__ */ zod
                 'workflow',
             ])
             .describe(
-                '\* `onboarding` - Onboarding\n\* `error_tracking` - Error Tracking\n\* `eval_clusters` - Eval Clusters\n\* `user_created` - User Created\n\* `slack` - Slack\n\* `support_queue` - Support Queue\n\* `session_summaries` - Session Summaries\n\* `posthog_ai` - PostHog AI\n\* `experiments` - Experiments\n\* `signal_report` - Signal Report\n\* `signals_scout` - Signals Scout\n\* `support_reply` - Support Reply\n\* `hogdesk` - HogDesk\n\* `review_hog` - ReviewHog\n\* `image_builder` - Image Builder\n\* `loop` - Loop\n\* `mcp_analytics` - MCP Analytics\n\* `signals_chat` - Signals Chat\n\* `workflow` - Workflow'
+                '\* `onboarding` - Onboarding\n\* `error_tracking` - Error Tracking\n\* `eval_clusters` - Eval Clusters\n\* `user_created` - User Created\n\* `canvas` - Canvas\n\* `slack` - Slack\n\* `support_queue` - Support Queue\n\* `session_summaries` - Session Summaries\n\* `posthog_ai` - PostHog AI\n\* `experiments` - Experiments\n\* `signal_report` - Signal Report\n\* `signals_scout` - Signals Scout\n\* `support_reply` - Support Reply\n\* `hogdesk` - HogDesk\n\* `review_hog` - ReviewHog\n\* `image_builder` - Image Builder\n\* `loop` - Loop\n\* `mcp_analytics` - MCP Analytics\n\* `signals_chat` - Signals Chat\n\* `workflow` - Workflow'
             )
             .optional()
             .describe(
-                'PostHog product or surface that created this task (e.g. error_tracking, slack, user_created). Origins reserved for server-created agents cannot be set through this API.\n\n\* `onboarding` - Onboarding\n\* `error_tracking` - Error Tracking\n\* `eval_clusters` - Eval Clusters\n\* `user_created` - User Created\n\* `slack` - Slack\n\* `support_queue` - Support Queue\n\* `session_summaries` - Session Summaries\n\* `posthog_ai` - PostHog AI\n\* `experiments` - Experiments\n\* `signal_report` - Signal Report\n\* `signals_scout` - Signals Scout\n\* `support_reply` - Support Reply\n\* `hogdesk` - HogDesk\n\* `review_hog` - ReviewHog\n\* `image_builder` - Image Builder\n\* `loop` - Loop\n\* `mcp_analytics` - MCP Analytics\n\* `signals_chat` - Signals Chat\n\* `workflow` - Workflow'
+                'PostHog product or surface that created this task (e.g. error_tracking, slack, user_created). Origins reserved for server-created agents cannot be set through this API.\n\n\* `onboarding` - Onboarding\n\* `error_tracking` - Error Tracking\n\* `eval_clusters` - Eval Clusters\n\* `user_created` - User Created\n\* `canvas` - Canvas\n\* `slack` - Slack\n\* `support_queue` - Support Queue\n\* `session_summaries` - Session Summaries\n\* `posthog_ai` - PostHog AI\n\* `experiments` - Experiments\n\* `signal_report` - Signal Report\n\* `signals_scout` - Signals Scout\n\* `support_reply` - Support Reply\n\* `hogdesk` - HogDesk\n\* `review_hog` - ReviewHog\n\* `image_builder` - Image Builder\n\* `loop` - Loop\n\* `mcp_analytics` - MCP Analytics\n\* `signals_chat` - Signals Chat\n\* `workflow` - Workflow'
             ),
         repository: zod
             .string()
@@ -1400,6 +1402,7 @@ export const TasksPartialUpdateBody = /* @__PURE__ */ zod
                 'error_tracking',
                 'eval_clusters',
                 'user_created',
+                'canvas',
                 'slack',
                 'support_queue',
                 'session_summaries',
@@ -1417,11 +1420,11 @@ export const TasksPartialUpdateBody = /* @__PURE__ */ zod
                 'workflow',
             ])
             .describe(
-                '\* `onboarding` - Onboarding\n\* `error_tracking` - Error Tracking\n\* `eval_clusters` - Eval Clusters\n\* `user_created` - User Created\n\* `slack` - Slack\n\* `support_queue` - Support Queue\n\* `session_summaries` - Session Summaries\n\* `posthog_ai` - PostHog AI\n\* `experiments` - Experiments\n\* `signal_report` - Signal Report\n\* `signals_scout` - Signals Scout\n\* `support_reply` - Support Reply\n\* `hogdesk` - HogDesk\n\* `review_hog` - ReviewHog\n\* `image_builder` - Image Builder\n\* `loop` - Loop\n\* `mcp_analytics` - MCP Analytics\n\* `signals_chat` - Signals Chat\n\* `workflow` - Workflow'
+                '\* `onboarding` - Onboarding\n\* `error_tracking` - Error Tracking\n\* `eval_clusters` - Eval Clusters\n\* `user_created` - User Created\n\* `canvas` - Canvas\n\* `slack` - Slack\n\* `support_queue` - Support Queue\n\* `session_summaries` - Session Summaries\n\* `posthog_ai` - PostHog AI\n\* `experiments` - Experiments\n\* `signal_report` - Signal Report\n\* `signals_scout` - Signals Scout\n\* `support_reply` - Support Reply\n\* `hogdesk` - HogDesk\n\* `review_hog` - ReviewHog\n\* `image_builder` - Image Builder\n\* `loop` - Loop\n\* `mcp_analytics` - MCP Analytics\n\* `signals_chat` - Signals Chat\n\* `workflow` - Workflow'
             )
             .optional()
             .describe(
-                'PostHog product or surface that created this task (e.g. error_tracking, slack, user_created). Origins reserved for server-created agents cannot be set through this API.\n\n\* `onboarding` - Onboarding\n\* `error_tracking` - Error Tracking\n\* `eval_clusters` - Eval Clusters\n\* `user_created` - User Created\n\* `slack` - Slack\n\* `support_queue` - Support Queue\n\* `session_summaries` - Session Summaries\n\* `posthog_ai` - PostHog AI\n\* `experiments` - Experiments\n\* `signal_report` - Signal Report\n\* `signals_scout` - Signals Scout\n\* `support_reply` - Support Reply\n\* `hogdesk` - HogDesk\n\* `review_hog` - ReviewHog\n\* `image_builder` - Image Builder\n\* `loop` - Loop\n\* `mcp_analytics` - MCP Analytics\n\* `signals_chat` - Signals Chat\n\* `workflow` - Workflow'
+                'PostHog product or surface that created this task (e.g. error_tracking, slack, user_created). Origins reserved for server-created agents cannot be set through this API.\n\n\* `onboarding` - Onboarding\n\* `error_tracking` - Error Tracking\n\* `eval_clusters` - Eval Clusters\n\* `user_created` - User Created\n\* `canvas` - Canvas\n\* `slack` - Slack\n\* `support_queue` - Support Queue\n\* `session_summaries` - Session Summaries\n\* `posthog_ai` - PostHog AI\n\* `experiments` - Experiments\n\* `signal_report` - Signal Report\n\* `signals_scout` - Signals Scout\n\* `support_reply` - Support Reply\n\* `hogdesk` - HogDesk\n\* `review_hog` - ReviewHog\n\* `image_builder` - Image Builder\n\* `loop` - Loop\n\* `mcp_analytics` - MCP Analytics\n\* `signals_chat` - Signals Chat\n\* `workflow` - Workflow'
             ),
         repository: zod
             .string()

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -94100,6 +94100,7 @@ export namespace Schemas {
      * * `error_tracking` - Error Tracking
      * * `eval_clusters` - Eval Clusters
      * * `user_created` - User Created
+     * * `canvas` - Canvas
      * * `slack` - Slack
      * * `support_queue` - Support Queue
      * * `session_summaries` - Session Summaries
@@ -94229,6 +94230,7 @@ export namespace Schemas {
       ErrorTracking: 'error_tracking',
       EvalClusters: 'eval_clusters',
       UserCreated: 'user_created',
+      Canvas: 'canvas',
       Slack: 'slack',
       SupportQueue: 'support_queue',
       SessionSummaries: 'session_summaries',

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -50423,6 +50423,7 @@ export namespace Schemas {
      * * `error_tracking` - Error Tracking
      * * `eval_clusters` - Eval Clusters
      * * `user_created` - User Created
+     * * `canvas` - Canvas
      * * `slack` - Slack
      * * `support_queue` - Support Queue
      * * `session_summaries` - Session Summaries
@@ -50447,6 +50448,7 @@ export namespace Schemas {
       ErrorTracking: 'error_tracking',
       EvalClusters: 'eval_clusters',
       UserCreated: 'user_created',
+      Canvas: 'canvas',
       Slack: 'slack',
       SupportQueue: 'support_queue',
       SessionSummaries: 'session_summaries',
@@ -64045,6 +64047,7 @@ export namespace Schemas {
        * * `error_tracking` - Error Tracking
        * * `eval_clusters` - Eval Clusters
        * * `user_created` - User Created
+       * * `canvas` - Canvas
        * * `slack` - Slack
        * * `support_queue` - Support Queue
        * * `session_summaries` - Session Summaries
@@ -79901,6 +79904,7 @@ export namespace Schemas {
        * * `error_tracking` - Error Tracking
        * * `eval_clusters` - Eval Clusters
        * * `user_created` - User Created
+       * * `canvas` - Canvas
        * * `slack` - Slack
        * * `support_queue` - Support Queue
        * * `session_summaries` - Session Summaries
@@ -81201,6 +81205,7 @@ export namespace Schemas {
        * * `error_tracking` - Error Tracking
        * * `eval_clusters` - Eval Clusters
        * * `user_created` - User Created
+       * * `canvas` - Canvas
        * * `slack` - Slack
        * * `support_queue` - Support Queue
        * * `session_summaries` - Session Summaries

--- a/services/mcp/src/generated/tasks/api.ts
+++ b/services/mcp/src/generated/tasks/api.ts
@@ -894,6 +894,7 @@ export const TasksListQueryParams = /* @__PURE__ */ zod.object({
             'error_tracking',
             'eval_clusters',
             'user_created',
+            'canvas',
             'slack',
             'support_queue',
             'session_summaries',
@@ -912,7 +913,7 @@ export const TasksListQueryParams = /* @__PURE__ */ zod.object({
         ])
         .optional()
         .describe(
-            'Exclude tasks with this origin product from the results\n\n\* `onboarding` - Onboarding\n\* `error_tracking` - Error Tracking\n\* `eval_clusters` - Eval Clusters\n\* `user_created` - User Created\n\* `slack` - Slack\n\* `support_queue` - Support Queue\n\* `session_summaries` - Session Summaries\n\* `posthog_ai` - PostHog AI\n\* `experiments` - Experiments\n\* `signal_report` - Signal Report\n\* `signals_scout` - Signals Scout\n\* `support_reply` - Support Reply\n\* `hogdesk` - HogDesk\n\* `review_hog` - ReviewHog\n\* `image_builder` - Image Builder\n\* `loop` - Loop\n\* `mcp_analytics` - MCP Analytics\n\* `signals_chat` - Signals Chat\n\* `workflow` - Workflow'
+            'Exclude tasks with this origin product from the results\n\n\* `onboarding` - Onboarding\n\* `error_tracking` - Error Tracking\n\* `eval_clusters` - Eval Clusters\n\* `user_created` - User Created\n\* `canvas` - Canvas\n\* `slack` - Slack\n\* `support_queue` - Support Queue\n\* `session_summaries` - Session Summaries\n\* `posthog_ai` - PostHog AI\n\* `experiments` - Experiments\n\* `signal_report` - Signal Report\n\* `signals_scout` - Signals Scout\n\* `support_reply` - Support Reply\n\* `hogdesk` - HogDesk\n\* `review_hog` - ReviewHog\n\* `image_builder` - Image Builder\n\* `loop` - Loop\n\* `mcp_analytics` - MCP Analytics\n\* `signals_chat` - Signals Chat\n\* `workflow` - Workflow'
         ),
     internal: zod
         .enum(['true', 'false', 'all'])

--- a/services/mcp/src/generated/tasks/api.ts
+++ b/services/mcp/src/generated/tasks/api.ts
@@ -1009,6 +1009,7 @@ export const TasksCreateBody = /* @__PURE__ */ zod
                 'error_tracking',
                 'eval_clusters',
                 'user_created',
+                'canvas',
                 'slack',
                 'support_queue',
                 'session_summaries',
@@ -1026,11 +1027,11 @@ export const TasksCreateBody = /* @__PURE__ */ zod
                 'workflow',
             ])
             .describe(
-                '\* `onboarding` - Onboarding\n\* `error_tracking` - Error Tracking\n\* `eval_clusters` - Eval Clusters\n\* `user_created` - User Created\n\* `slack` - Slack\n\* `support_queue` - Support Queue\n\* `session_summaries` - Session Summaries\n\* `posthog_ai` - PostHog AI\n\* `experiments` - Experiments\n\* `signal_report` - Signal Report\n\* `signals_scout` - Signals Scout\n\* `support_reply` - Support Reply\n\* `hogdesk` - HogDesk\n\* `review_hog` - ReviewHog\n\* `image_builder` - Image Builder\n\* `loop` - Loop\n\* `mcp_analytics` - MCP Analytics\n\* `signals_chat` - Signals Chat\n\* `workflow` - Workflow'
+                '\* `onboarding` - Onboarding\n\* `error_tracking` - Error Tracking\n\* `eval_clusters` - Eval Clusters\n\* `user_created` - User Created\n\* `canvas` - Canvas\n\* `slack` - Slack\n\* `support_queue` - Support Queue\n\* `session_summaries` - Session Summaries\n\* `posthog_ai` - PostHog AI\n\* `experiments` - Experiments\n\* `signal_report` - Signal Report\n\* `signals_scout` - Signals Scout\n\* `support_reply` - Support Reply\n\* `hogdesk` - HogDesk\n\* `review_hog` - ReviewHog\n\* `image_builder` - Image Builder\n\* `loop` - Loop\n\* `mcp_analytics` - MCP Analytics\n\* `signals_chat` - Signals Chat\n\* `workflow` - Workflow'
             )
             .optional()
             .describe(
-                'PostHog product or surface that created this task (e.g. error_tracking, slack, user_created). Origins reserved for server-created agents cannot be set through this API.\n\n\* `onboarding` - Onboarding\n\* `error_tracking` - Error Tracking\n\* `eval_clusters` - Eval Clusters\n\* `user_created` - User Created\n\* `slack` - Slack\n\* `support_queue` - Support Queue\n\* `session_summaries` - Session Summaries\n\* `posthog_ai` - PostHog AI\n\* `experiments` - Experiments\n\* `signal_report` - Signal Report\n\* `signals_scout` - Signals Scout\n\* `support_reply` - Support Reply\n\* `hogdesk` - HogDesk\n\* `review_hog` - ReviewHog\n\* `image_builder` - Image Builder\n\* `loop` - Loop\n\* `mcp_analytics` - MCP Analytics\n\* `signals_chat` - Signals Chat\n\* `workflow` - Workflow'
+                'PostHog product or surface that created this task (e.g. error_tracking, slack, user_created). Origins reserved for server-created agents cannot be set through this API.\n\n\* `onboarding` - Onboarding\n\* `error_tracking` - Error Tracking\n\* `eval_clusters` - Eval Clusters\n\* `user_created` - User Created\n\* `canvas` - Canvas\n\* `slack` - Slack\n\* `support_queue` - Support Queue\n\* `session_summaries` - Session Summaries\n\* `posthog_ai` - PostHog AI\n\* `experiments` - Experiments\n\* `signal_report` - Signal Report\n\* `signals_scout` - Signals Scout\n\* `support_reply` - Support Reply\n\* `hogdesk` - HogDesk\n\* `review_hog` - ReviewHog\n\* `image_builder` - Image Builder\n\* `loop` - Loop\n\* `mcp_analytics` - MCP Analytics\n\* `signals_chat` - Signals Chat\n\* `workflow` - Workflow'
             ),
         repository: zod
             .string()


### PR DESCRIPTION
## Problem

People using Spaces cannot distinguish canvas generation runs from sessions they started directly, so the Source filter cannot isolate them.

## Changes

- Canvas generation sessions now appear as **Canvas** in the Source filter and use the Canvas badge.
- The Tasks API accepts `canvas` as an origin and publishes the updated generated API types.
- Canvas sessions keep the same user-driven timeout, sandbox rollout, authorship, and compute billing behavior.
- The migration updates Django choices only and produces no SQL.

Before:

```mermaid
flowchart LR
    A[Generate canvas] --> B[user_created task] --> C[No source option]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A phYellow;
    class B,C phBlue;
```

After:

```mermaid
flowchart LR
    A[Generate canvas] --> B[canvas task] --> C[Canvas source option]
    B --> D[User-driven runtime policies]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A phYellow;
    class B,C,D phBlue;
```

No screenshot: the filter menu layout is unchanged. The existing dynamic Source menu gains the Canvas option when a space contains canvas runs.

## How did you test this code?

- Targeted desktop service, task creation, and Spaces sidebar tests cover source propagation and filtering.
- Desktop core and UI type checks, Biome, and host-boundary checks pass.
- Backend serializer, compute classification, timeout, and sandbox policy tests cover the new origin.
- OpenAPI generation and migration checks pass. `sqlmigrate` confirms the migration is a no-op.
- Not run: database-backed usage aggregation tests. Local schema setup did not finish within the available runtime.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated `products/tasks/docs/CHANNELS.md` with the Canvas origin contract.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

An OpenAI coding agent in pi authored this change with repository, shell, GitHub, and signed-commit tools. No public session link is available.

Skills invoked: `/improving-drf-endpoints`, `/django-migrations`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-code-comments`, and `/writing-pr-descriptions`.
