### PR TITLE
feat(desktop): let the spaces layout hide and reorder sidebar nav items

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelNav.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelNav.test.tsx
@@ -26,6 +26,7 @@ vi.mock("@posthog/ui/router/navigationBridge", () => ({
   navigateToActivity: vi.fn(),
   navigateToHome: vi.fn(),
   navigateToInbox: vi.fn(),
+  navigateToLoops: vi.fn(),
   navigateToWebsiteCommandCenter: vi.fn(),
 }));
 vi.mock("@posthog/ui/shell/analytics", () => ({ track: vi.fn() }));
@@ -33,11 +34,47 @@ vi.mock("./ActivityHoverCard", () => ({
   ActivityHoverCard: () => <div>Recent activity card</div>,
 }));
 
+import { useSidebarStore } from "@posthog/ui/features/sidebar/sidebarStore";
 import { ChannelNav } from "./ChannelNav";
+
+const navLabels = (container: HTMLElement) =>
+  [...container.querySelectorAll("button")].map((button) =>
+    button.getAttribute("aria-label"),
+  );
 
 describe("ChannelNav", () => {
   beforeEach(() => {
     mocks.view = { type: "task-input" };
+    useSidebarStore.setState({ navItemOverrides: {}, navItemOrder: [] });
+  });
+
+  it("keeps Inbox available in the channels navigation", () => {
+    render(<ChannelNav />);
+
+    expect(screen.getByLabelText("Inbox")).toBeEnabled();
+  });
+
+  it("drops an item hidden in the sidebar settings", () => {
+    useSidebarStore.setState({ navItemOverrides: { "command-center": false } });
+
+    render(<ChannelNav />);
+
+    expect(screen.queryByLabelText("Command Center")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Inbox")).toBeInTheDocument();
+  });
+
+  it("follows the order stored by the sidebar settings, after Home", () => {
+    useSidebarStore.setState({ navItemOrder: ["configure", "inbox"] });
+
+    const { container } = render(<ChannelNav />);
+
+    expect(navLabels(container)).toEqual([
+      "Home",
+      "Settings",
+      "Inbox",
+      "Activity",
+      "Command Center",
+    ]);
   });
 
   it("opens recent activity from the bell after the hover delay", async () => {

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelNav.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelNav.tsx
@@ -230,7 +230,9 @@ export function ChannelNav() {
   const renderNavItem: Record<CustomizableNavItemId, () => ReactNode> = {
     inbox: () => (
       <NavIcon
-        icon={<EnvelopeSimple size={16} weight={isInbox ? "fill" : "regular"} />}
+        icon={
+          <EnvelopeSimple size={16} weight={isInbox ? "fill" : "regular"} />
+        }
         label="Inbox"
         shortcut={formatHotkey(SHORTCUTS.INBOX)}
         isActive={isInbox}

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelNav.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelNav.tsx
@@ -30,6 +30,12 @@ import { useCommandCenterActiveCount } from "@posthog/ui/features/command-center
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import { useInboxAllReports } from "@posthog/ui/features/inbox/hooks/useInboxAllReports";
 import { openSettings } from "@posthog/ui/features/settings/hooks/useOpenSettings";
+import {
+  type CustomizableNavItemId,
+  isNavItemVisible,
+  orderedNavItems,
+} from "@posthog/ui/features/sidebar/constants";
+import { useSidebarStore } from "@posthog/ui/features/sidebar/sidebarStore";
 import { CountBadge } from "@posthog/ui/primitives/CountBadge";
 import { LoopIcon } from "@posthog/ui/primitives/LoopIcon";
 import {
@@ -43,6 +49,7 @@ import { useAppView } from "@posthog/ui/router/useAppView";
 import { track } from "@posthog/ui/shell/analytics";
 import {
   type ComponentPropsWithRef,
+  Fragment,
   type ReactElement,
   type ReactNode,
   useState,
@@ -192,6 +199,8 @@ export function ChannelNav() {
   });
   const { unreadCount: unseenActivity } = useTaskActivity();
   const commandCenterCount = useCommandCenterActiveCount();
+  const navItemOverrides = useSidebarStore((s) => s.navItemOverrides);
+  const navItemOrder = useSidebarStore((s) => s.navItemOrder);
 
   const withTrack = (item: SidebarNavItem, action: () => void) => () => {
     track(ANALYTICS_EVENTS.SIDEBAR_NAV_ITEM_CLICKED, {
@@ -206,6 +215,74 @@ export function ChannelNav() {
   const isInbox = view.type === "inbox";
   const isActivity = view.type === "activity";
   const isCommandCenter = view.type === "command-center";
+  const isLoops = view.type === "loops";
+
+  // Bluebird is already on wherever this nav renders, so Activity needs no
+  // second gate here — unlike the code layout's SidebarNavSection.
+  const navItemAvailable: Record<CustomizableNavItemId, boolean> = {
+    inbox: true,
+    activity: true,
+    "command-center": true,
+    loops: loopsEnabled,
+    configure: true,
+  };
+
+  const renderNavItem: Record<CustomizableNavItemId, () => ReactNode> = {
+    inbox: () => (
+      <NavIcon
+        icon={<EnvelopeSimple size={16} weight={isInbox ? "fill" : "regular"} />}
+        label="Inbox"
+        shortcut={formatHotkey(SHORTCUTS.INBOX)}
+        isActive={isInbox}
+        onClick={withTrack("inbox", navigateToInbox)}
+        badge={<CountBadge count={counts.pulls} className={ICON_BADGE_CLASS} />}
+      />
+    ),
+    activity: () => (
+      <ActivityNavItem
+        isActive={isActivity}
+        unreadCount={unseenActivity}
+        onNavigate={withTrack("activity", navigateToActivity)}
+      />
+    ),
+    "command-center": () => (
+      <NavIcon
+        icon={
+          <Lightning size={16} weight={isCommandCenter ? "fill" : "regular"} />
+        }
+        label="Command Center"
+        isActive={isCommandCenter}
+        onClick={withTrack("command_center", navigateToWebsiteCommandCenter)}
+        badge={
+          <CountBadge
+            count={commandCenterCount}
+            tone="neutral"
+            className={ICON_BADGE_CLASS}
+          />
+        }
+      />
+    ),
+    loops: () => (
+      <NavIcon
+        icon={<LoopIcon size={16} weight={isLoops ? "fill" : "regular"} />}
+        label="Loops"
+        isActive={isLoops}
+        onClick={withTrack("loops", navigateToLoops)}
+      />
+    ),
+    configure: () => (
+      <NavIcon
+        icon={<GearSix size={16} />}
+        label="Settings"
+        isActive={false}
+        onClick={withTrack("configure", () => openSettings())}
+      />
+    ),
+  };
+
+  const items = orderedNavItems(navItemOrder).filter(
+    ({ id }) => navItemAvailable[id] && isNavItemVisible(navItemOverrides, id),
+  );
 
   return (
     // One provider for the row: once any tooltip is up, moving to its
@@ -215,66 +292,17 @@ export function ChannelNav() {
     // providers never share it.
     <TooltipProvider delay={400}>
       <div className="flex shrink-0 gap-2 p-2">
+        {/* Home is the space's own root rather than one of the customizable
+            destinations, so it stays first and is never hidden. */}
         <NavIcon
           icon={<HouseSimple size={16} weight={isHome ? "fill" : "regular"} />}
           label="Home"
           isActive={isHome}
           onClick={withTrack("home", navigateToHome)}
         />
-        <NavIcon
-          icon={
-            <EnvelopeSimple size={16} weight={isInbox ? "fill" : "regular"} />
-          }
-          label="Inbox"
-          shortcut={formatHotkey(SHORTCUTS.INBOX)}
-          isActive={isInbox}
-          onClick={withTrack("inbox", navigateToInbox)}
-          badge={
-            <CountBadge count={counts.pulls} className={ICON_BADGE_CLASS} />
-          }
-        />
-        <ActivityNavItem
-          isActive={isActivity}
-          unreadCount={unseenActivity}
-          onNavigate={withTrack("activity", navigateToActivity)}
-        />
-        <NavIcon
-          icon={
-            <Lightning
-              size={16}
-              weight={isCommandCenter ? "fill" : "regular"}
-            />
-          }
-          label="Command Center"
-          isActive={isCommandCenter}
-          onClick={withTrack("command_center", navigateToWebsiteCommandCenter)}
-          badge={
-            <CountBadge
-              count={commandCenterCount}
-              tone="neutral"
-              className={ICON_BADGE_CLASS}
-            />
-          }
-        />
-        {loopsEnabled ? (
-          <NavIcon
-            icon={
-              <LoopIcon
-                size={16}
-                weight={view.type === "loops" ? "fill" : "regular"}
-              />
-            }
-            label="Loops"
-            isActive={view.type === "loops"}
-            onClick={withTrack("loops", navigateToLoops)}
-          />
-        ) : null}
-        <NavIcon
-          icon={<GearSix size={16} />}
-          label="Settings"
-          isActive={false}
-          onClick={withTrack("configure", () => openSettings())}
-        />
+        {items.map(({ id }) => (
+          <Fragment key={id}>{renderNavItem[id]()}</Fragment>
+        ))}
       </div>
     </TooltipProvider>
   );

--- a/products/desktop/packages/ui/src/features/settings/components/SettingsPanel.tsx
+++ b/products/desktop/packages/ui/src/features/settings/components/SettingsPanel.tsx
@@ -31,7 +31,6 @@ import { useAuthStateValue } from "@posthog/ui/features/auth/store";
 import { UserAvatar } from "@posthog/ui/features/auth/UserAvatar";
 import { useLogoutMutation } from "@posthog/ui/features/auth/useAuthMutations";
 import { useCurrentUser } from "@posthog/ui/features/auth/useCurrentUser";
-import { useChannelsLayout } from "@posthog/ui/features/canvas/hooks/useChannelsLayout";
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import { useQuickAskAvailable } from "@posthog/ui/features/quick-ask/useQuickAskAvailable";
 import { SettingsPageContent } from "@posthog/ui/features/settings/components/SettingsPageContent";
@@ -148,8 +147,6 @@ export function SettingsPanel({
   const client = useOptionalAuthenticatedClient();
   const { data: user } = useCurrentUser({ client });
   const billingEnabled = useFeatureFlag(BILLING_FLAG);
-  // The channels layout's nav is fixed, so the Sidebar page can't do anything.
-  const channelsLayout = useChannelsLayout();
   const { localWorkspaces } = useHostCapabilities();
   const logoutMutation = useLogoutMutation();
   const quickAskAvailable = useQuickAskAvailable();
@@ -159,7 +156,6 @@ export function SettingsPanel({
     billingEnabled,
     spendAnalysisEnabled,
     localWorkspaces,
-    channelsLayout,
     quickAskAvailable,
   });
   const sidebarGroups = SIDEBAR_GROUPS.map((group) => ({

--- a/products/desktop/packages/ui/src/features/settings/settingsVisibility.test.ts
+++ b/products/desktop/packages/ui/src/features/settings/settingsVisibility.test.ts
@@ -34,19 +34,6 @@ describe("getHiddenSettingsCategories", () => {
       expected: ["workspaces", "worktrees", "terminal", "harness", "discord"],
     },
     {
-      // The channels layout uses a fixed nav, so the Sidebar page's
-      // reorder/hide controls would have nothing to act on.
-      name: "hides the sidebar page under the channels layout",
-      input: {
-        billingEnabled: true,
-        spendAnalysisEnabled: true,
-        localWorkspaces: true,
-        channelsLayout: true,
-        quickAskAvailable: true,
-      },
-      expected: ["sidebar"],
-    },
-    {
       // The page's only content when the panel is unavailable is a dead-end
       // "not available in this build" message, so hide it (web hosts and
       // packaged desktop without the prototype gate).

--- a/products/desktop/packages/ui/src/features/settings/settingsVisibility.ts
+++ b/products/desktop/packages/ui/src/features/settings/settingsVisibility.ts
@@ -29,6 +29,8 @@ export function getHiddenSettingsCategories({
   localWorkspaces,
   quickAskAvailable = false,
 }: SettingsVisibility): ReadonlySet<SettingsCategory> {
+  // SettingsPanel drops these from its nav and its search, and redirects
+  // direct navigation to one, so a deep link can't reach them either.
   const hiddenCategories = new Set<SettingsCategory>();
 
   if (!billingEnabled && !spendAnalysisEnabled) {
@@ -39,9 +41,6 @@ export function getHiddenSettingsCategories({
       hiddenCategories.add(category);
     }
   }
-  // Better to hide the page than to leave one whose controls silently do
-  // nothing. SettingsPanel also redirects direct navigation to a hidden
-  // category, so a deep link can't reach it either.
   if (!quickAskAvailable) {
     hiddenCategories.add("quick-ask");
   }

--- a/products/desktop/packages/ui/src/features/settings/settingsVisibility.ts
+++ b/products/desktop/packages/ui/src/features/settings/settingsVisibility.ts
@@ -16,11 +16,6 @@ interface SettingsVisibility {
   spendAnalysisEnabled: boolean;
   localWorkspaces: boolean;
   /**
-   * The channels layout replaces the customizable nav with a fixed one, so the
-   * Sidebar page's controls have nothing to act on there.
-   */
-  channelsLayout?: boolean;
-  /**
    * The quick-ask panel exists on this host and build. Off (web, and packaged
    * desktop without the prototype gate) hides its settings page, whose only
    * content otherwise is an "unavailable" message.
@@ -32,7 +27,6 @@ export function getHiddenSettingsCategories({
   billingEnabled,
   spendAnalysisEnabled,
   localWorkspaces,
-  channelsLayout = false,
   quickAskAvailable = false,
 }: SettingsVisibility): ReadonlySet<SettingsCategory> {
   const hiddenCategories = new Set<SettingsCategory>();
@@ -48,9 +42,6 @@ export function getHiddenSettingsCategories({
   // Better to hide the page than to leave one whose controls silently do
   // nothing. SettingsPanel also redirects direct navigation to a hidden
   // category, so a deep link can't reach it either.
-  if (channelsLayout) {
-    hiddenCategories.add("sidebar");
-  }
   if (!quickAskAvailable) {
     hiddenCategories.add("quick-ask");
   }


### PR DESCRIPTION
## TL;DR

The app has a settings page for hiding sidebar items. If you use the spaces layout, that page is invisible, so you cannot hide anything. This makes the page work in that layout and stops hiding it.

## Problem

Anyone on the spaces layout cannot hide Inbox, Command Center, or Loops from their sidebar. The Sidebar settings page does not appear for them at all, and a deep link to it redirects to General.

- That layout renders `ChannelNav`, which hardcoded its icon row and read no user preference.
- `settingsVisibility.ts` therefore hid the Sidebar page, rather than shipping checkboxes that do nothing.
- The two layouts diverged by accident. `SidebarNavSection`, the code layout's nav, has honored these preferences all along.

## Changes

- Unchecking an item in settings now removes it from the spaces layout's icon row, and dragging one reorders that row.
- The Sidebar settings page appears under the spaces layout, in settings search and by deep link.
- `ChannelNav` reads `navItemOverrides` and `navItemOrder` from `sidebarStore`, the same state `SidebarNavSection` reads.
- Home stays fixed and first. It is the space's own root, not one of the customizable destinations.

> [!NOTE]
> Loops and Command Center swap places for anyone with the `loops` flag on. The two navs held different default orders, and this adopts the shared one. Loops is off by default, so most users see no move.

Mechanical: `ChannelNav`'s row became a per-item renderer map, mirroring `SidebarNavSection`. No icon, label, badge, shortcut or analytics call changed.

No screenshot: this needs a packaged Electron build, which this sandbox cannot run. The visible result is items disappearing from the icon row and a "Sidebar" row appearing in settings.

## How did you test this code?

Automated only. Manual verification in the running app did not happen.

- Two new cases in `ChannelNav.test.tsx`. They catch a regression that nothing covered: someone re-hardcoding the icon row, which silently breaks the settings page again. That is the exact state of the code before this PR.
- One case deleted from `settingsVisibility.test.ts`, for the branch this PR removes.
- Not run: `apps/code` E2E, which needs `pnpm --filter code package`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code in a PostHog Code cloud task. Skills invoked: `/writing-tests` before the test cases, `/writing-pr-descriptions` before this body.

The task started as a question about whether a setting existed, not a request for code. It does exist, and the answer to why it was invisible turned into this fix.

One decision worth flagging. Honoring visibility alone was the smaller diff, but it would have left the settings page's drag handles dead in this layout, which is the same defect the original author avoided by hiding the page. Wiring order too is what makes unhiding the page honest. That forced a choice between the two navs' default orders, resolved in the note above.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
