### PR TITLE
fix(cdp): fall back to the schema default for an omitted required input

### DIFF
--- a/posthog/cdp/test/test_validation.py
+++ b/posthog/cdp/test/test_validation.py
@@ -220,6 +220,24 @@ class TestHogFunctionValidation(ClickhouseTestMixin, APIBaseTest, QueryMatchingT
             },
         }
 
+    def test_omitted_required_input_falls_back_to_the_schema_default(self):
+        schema = [
+            {"key": "url", "type": "string", "label": "Webhook URL", "required": True},
+            {"key": "method", "type": "string", "label": "HTTP Method", "required": True, "default": "POST"},
+        ]
+
+        inputs = validate_inputs(schema, {"url": {"value": "https://example.com"}})
+
+        assert inputs["method"]["value"] == "POST"
+
+    def test_explicitly_emptied_required_input_is_still_rejected(self):
+        schema = [{"key": "method", "type": "string", "label": "HTTP Method", "required": True, "default": "POST"}]
+
+        with pytest.raises(ValidationError) as e:
+            validate_inputs(schema, {"method": {"value": ""}})
+
+        assert "This field is required." in str(e.value)
+
     def test_validate_inputs_creates_bytecode_for_html(self):
         # NOTE: CSS block curly brackets must be escaped beforehand
         html_with_css = '<html>\n<head>\n<style type="text/css">\n  .css \\{\n    width: 500px !important;\n  }</style>\n</head>\n\n<body>\n    <p>Hi {person.properties.email}</p>\n</body>\n</html>'

--- a/posthog/cdp/validation.py
+++ b/posthog/cdp/validation.py
@@ -716,11 +716,8 @@ class InputsSerializer(serializers.DictField):
                         continue
 
             if value == {} and schema.get("required") and schema.get("default") is not None:
-                # A required input the caller left out falls back to the schema's default rather than
-                # failing validation. Callers that assemble inputs by hand - the alert wizard, the API,
-                # Terraform - can't know about a default the destination editor would have pre-filled,
-                # so adding one to an existing template would otherwise break them. An explicitly empty
-                # value still fails below: only an absent key takes the default.
+                # The destination editor pre-fills defaults from the template schema, but callers that
+                # build inputs by hand cannot, so a required input with a default would reject them.
                 value = {"value": schema["default"]}
 
             self.context["schema"] = schema

--- a/posthog/cdp/validation.py
+++ b/posthog/cdp/validation.py
@@ -715,6 +715,14 @@ class InputsSerializer(serializers.DictField):
                         errors[key] = "No value is saved for this secret input. Enter the value again."
                         continue
 
+            if value == {} and schema.get("required") and schema.get("default") is not None:
+                # A required input the caller left out falls back to the schema's default rather than
+                # failing validation. Callers that assemble inputs by hand - the alert wizard, the API,
+                # Terraform - can't know about a default the destination editor would have pre-filled,
+                # so adding one to an existing template would otherwise break them. An explicitly empty
+                # value still fails below: only an absent key takes the default.
+                value = {"value": schema["default"]}
+
             self.context["schema"] = schema
 
             # Propagate templating from schema to input item, if set


### PR DESCRIPTION
## Problem

Adding a Discord destination to an insight alert always fails. The alert saves, a toast says "Alert saved, but failed to create: Discord", and no destination is created, so the alert never notifies anyone. Hit by more than one project.

The create call is rejected with `inputs__allowedMentions: This field is required.` #72486 made `allowedMentions` required with a default. The destination editor reads the template schema and pre-fills defaults, so it works. The alert wizard builds inputs by hand, has no schema to read, and omits the field. Same break for the API and Terraform.

## Changes

- Discord alert destinations save again, on the template's own `allowedMentions: "none"` default, which renders mentions as text and pings nobody.
- `InputsSerializer` fills a required input from its schema `default` when the caller omits the key. That is the whole fix.

Fixing validation instead of the wizard means the next required-with-default input added to any template does not break hand-built callers again.

Narrow on purpose: an explicitly empty value is still rejected, an optional input is still omitted when absent, a required input with no default still errors, and an explicit value still wins.

## How did you test this code?

Two tests in `posthog/cdp/test/test_validation.py`: an omitted required input takes its default, and an explicitly emptied value is still rejected so this cannot quietly become "required means optional". No existing test covered either, because they all supply a value.

Also reproduced the reported failure directly against the real Discord template schema, which now validates instead of returning a 400. Suite and ruff pass locally. Not done: no manual run of the alert UI.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude (Claude Code) from a HAR of the failing save. Skills: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

The first attempt hardcoded `allowedMentions` into the wizard's sub-template, and was dropped once the omission turned out to affect every hand-built caller. The guard was then narrowed from any input with a default to required inputs only, so clearing an optional value keeps working.

The source report included a live webhook URL and project identifiers. None of it appears in the diff, the tests, or this description.
