### PR TITLE
fix(cdp): stop hiding hog functions filtered on all events

### DIFF
--- a/products/cdp/backend/api/hog_function.py
+++ b/products/cdp/backend/api/hog_function.py
@@ -26,11 +26,7 @@ from posthog.api.log_entries import LogEntryMixin
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import SearchMatchTypeSerializerMixin, UserBasicSerializer
 from posthog.api.utils import action, log_activity_from_viewset
-from posthog.cdp.internal_events import (
-    LEGACY_INSIGHT_ALERT_EVENT,
-    MANAGED_ALERT_EVENT_PATTERN,
-    is_managed_alert_internal_event,
-)
+from posthog.cdp.internal_events import is_managed_alert_internal_event
 from posthog.cdp.services.icons import CDPIconsService
 from posthog.cdp.site_functions import get_transpiled_function
 from posthog.cdp.validation import (
@@ -951,12 +947,6 @@ class HogFunctionViewSet(
 
     def safely_get_queryset(self, queryset: QuerySet) -> QuerySet:
         queryset = queryset.exclude(type=HogFunctionType.WAREHOUSE_SOURCE_WEBHOOK.value)
-        # Managed alert destinations are single-event by construction, so events[0] is sufficient here.
-        queryset = queryset.filter(
-            Q(filters__events__0__id__isnull=True)
-            | Q(filters__events__0__id=LEGACY_INSIGHT_ALERT_EVENT)
-            | ~Q(filters__events__0__id__regex=MANAGED_ALERT_EVENT_PATTERN)
-        )
 
         if not (self.action == "partial_update" and self.request.data.get("deleted") is False):
             # We only want to include deleted functions if we are un-deleting them

--- a/products/cdp/backend/api/test/test_hog_function.py
+++ b/products/cdp/backend/api/test/test_hog_function.py
@@ -234,6 +234,8 @@ class TestHogFunctionAPIWithoutAvailableFeature(ClickhouseTestMixin, APIBaseTest
             hog="return event",
             type="internal_destination",
             enabled=True,
+            inputs_schema=[],
+            inputs={},
             filters={
                 "events": [{"id": "$billing_alert_firing", "type": "events"}],
                 "properties": [{"key": "alert_id", "value": "alert-1"}],
@@ -244,7 +246,7 @@ class TestHogFunctionAPIWithoutAvailableFeature(ClickhouseTestMixin, APIBaseTest
         retrieve_response = self.client.get(f"/api/projects/{self.team.id}/hog_functions/{managed.id}/")
         patch_response = self.client.patch(
             f"/api/projects/{self.team.id}/hog_functions/{managed.id}/",
-            data={"inputs": {"url": {"value": "https://attacker.example"}}},
+            data={"name": "Renamed alert destination"},
         )
 
         self.assertEqual(list_response.status_code, status.HTTP_200_OK)

--- a/products/cdp/backend/api/test/test_hog_function.py
+++ b/products/cdp/backend/api/test/test_hog_function.py
@@ -227,15 +227,7 @@ class TestHogFunctionAPIWithoutAvailableFeature(ClickhouseTestMixin, APIBaseTest
         listed_ids = {item["id"] for item in list_response.json()["results"]}
         self.assertIn(function_id, listed_ids)
 
-    def test_generic_api_hides_and_cannot_patch_managed_alert_destinations(self):
-        ordinary = HogFunction.objects.create(
-            team=self.team,
-            name="Ordinary destination",
-            hog="return event",
-            type="destination",
-            enabled=False,
-            filters={},
-        )
+    def test_generic_api_lists_but_cannot_patch_managed_alert_destinations(self):
         managed = HogFunction.objects.create(
             team=self.team,
             name="Billing alert destination",
@@ -249,7 +241,6 @@ class TestHogFunctionAPIWithoutAvailableFeature(ClickhouseTestMixin, APIBaseTest
         )
 
         list_response = self.client.get(f"/api/projects/{self.team.id}/hog_functions/?full=true")
-        ordinary_response = self.client.get(f"/api/projects/{self.team.id}/hog_functions/{ordinary.id}/")
         retrieve_response = self.client.get(f"/api/projects/{self.team.id}/hog_functions/{managed.id}/")
         patch_response = self.client.patch(
             f"/api/projects/{self.team.id}/hog_functions/{managed.id}/",
@@ -258,11 +249,30 @@ class TestHogFunctionAPIWithoutAvailableFeature(ClickhouseTestMixin, APIBaseTest
 
         self.assertEqual(list_response.status_code, status.HTTP_200_OK)
         listed_ids = {item["id"] for item in list_response.json()["results"]}
-        self.assertEqual(ordinary_response.status_code, status.HTTP_200_OK, ordinary_response.json())
-        self.assertIn(str(ordinary.id), listed_ids)
-        self.assertNotIn(str(managed.id), listed_ids)
-        self.assertEqual(retrieve_response.status_code, status.HTTP_404_NOT_FOUND)
-        self.assertEqual(patch_response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertIn(str(managed.id), listed_ids)
+        self.assertEqual(retrieve_response.status_code, status.HTTP_200_OK, retrieve_response.json())
+        self.assertEqual(patch_response.status_code, status.HTTP_400_BAD_REQUEST, patch_response.json())
+        self.assertIn("managed through the alert API", patch_response.json()["detail"])
+
+    def test_functions_filtered_on_all_events_are_listed_and_retrievable(self):
+        # An explicit "All events" filter persists as a JSON-null event id, which queryset-level
+        # JSON lookups (isnull, regex) silently miss, dropping the row from every read path.
+        function = HogFunction.objects.create(
+            team=self.team,
+            name="Drop events",
+            hog="return null",
+            type="transformation",
+            enabled=True,
+            filters={"events": [{"id": None, "name": "All events", "type": "events"}]},
+        )
+
+        list_response = self.client.get(f"/api/projects/{self.team.id}/hog_functions/?type=transformation")
+        retrieve_response = self.client.get(f"/api/projects/{self.team.id}/hog_functions/{function.id}/")
+
+        self.assertEqual(list_response.status_code, status.HTTP_200_OK)
+        listed_ids = {item["id"] for item in list_response.json()["results"]}
+        self.assertIn(str(function.id), listed_ids)
+        self.assertEqual(retrieve_response.status_code, status.HTTP_200_OK, retrieve_response.json())
 
 
 class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):


### PR DESCRIPTION
## Problem

- Saving a function filtered on "All events" shows a success toast, then opens the "Hog function not found" page. The function never appears in the list.
- The function still runs. Users are left with enabled functions, including Drop events transformations, that they cannot see, edit, or disable.
- `safely_get_queryset` hides alert-owned destinations by only keeping rows that look like "not an alert". A row survives when its first event id is absent, or is the legacy insight-alert event, or does not match the managed-alert regex.
- An "All events" filter stores the event id as JSON null. JSON null is not a missing key. The regex lookup on JSON null yields SQL NULL. All three branches miss, so the row drops from list, retrieve, and update.
- The bug affects every hog function with an explicit all-events filter since #66355 shipped on 2026-08-17.

## Changes

- The PR removes the queryset filter that hid managed alert destinations. Functions filtered on all events list, retrieve, and update again.
- Managed alert destinations (billing, logs) now appear in generic API reads. The serializer validation still rejects generic-API writes to them, so they stay read-only.
- The PR removes the filter instead of adding a JSON-null branch. The serializer guard already blocks writes, and the queryset filter broke twice (#83993, and this bug).

## How did you test this code?

- `test_generic_api_lists_but_cannot_patch_managed_alert_destinations` (updated) pins the new contract. Managed alert destinations list and retrieve. A generic-API patch fails with the serializer's 400.
- `test_functions_filtered_on_all_events_are_listed_and_retrievable` (new) catches any queryset change that drops rows whose first event filter has a JSON-null id. No existing test used a JSON-null event id.
- Both tests fail against the previous queryset and pass with it removed. The check ran locally by swapping the master file in and out.
- The full `products/cdp/backend/api/test/test_hog_function.py` file passes locally (116 tests).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code from a support escalation ([Slack thread](https://posthog.slack.com/archives/C06GG249PR6/p1787236171205069)). Root cause verified by compiling the queryset's SQL and checking Postgres JSON-null semantics. The team thread chose removing the filter over patching its null branch. Skills invoked: /improving-drf-endpoints, /writing-tests, /writing-code-comments, /writing-pr-descriptions.


