### PR TITLE
feat(tasks): add system-owned sandbox OAuth

### DIFF
--- a/posthog/auth.py
+++ b/posthog/auth.py
@@ -59,6 +59,7 @@ from posthog.rbac.user_access_control import UserAccessControl
 from posthog.scoped_service_jwt import ScopedServiceJwtPurpose
 from posthog.shared_link_user import SharedLinkUser
 from posthog.synthetic_user import SyntheticUser
+from posthog.temporal.oauth import SIGNALS_OAUTH_APP_CLIENT_IDS, resolve_scopes
 
 
 class WebAuthnAuthenticationResponse(TypedDict):
@@ -956,6 +957,105 @@ class OAuthAccessTokenAuthentication(authentication.BaseAuthentication):
 
     def authenticate_header(self, request):
         return self.keyword
+
+
+class OAuthMachinePrincipal:
+    """Narrow DRF principal for an explicitly bound system-owned sandbox token."""
+
+    is_authenticated = True
+    is_active = True
+    is_anonymous = False
+    pk = None
+    id = None
+
+    def __init__(self, *, team_id: int, organization_id: str, task_id: str, principal: str, workload: str) -> None:
+        self.current_team_id = team_id
+        self.current_organization_id = organization_id
+        self.task_id = task_id
+        self.system_principal = principal
+        self.system_workload = workload
+
+
+class SystemOAuthAccessTokenAuthentication(OAuthAccessTokenAuthentication):
+    """OAuth authentication for the report-canvas machine principal.
+
+    Views must opt into this authenticator. The default OAuth authenticator continues to reject
+    every user-null token.
+    """
+
+    machine_principal: OAuthMachinePrincipal | None = None
+
+    def authenticate(self, request: Union[HttpRequest, Request]) -> Optional[tuple[Any, None]]:
+        authorization_token = self._extract_token(request)
+        if not authorization_token:
+            return None
+
+        access_token = self._machine_access_token(authorization_token)
+        if access_token is None:
+            return super().authenticate(request)
+
+        self.access_token = access_token
+        team_id = access_token.scoped_teams[0]
+        task = self._bound_system_task(access_token, team_id)
+        team = Team.objects.select_related("organization").get(id=team_id)
+        principal = OAuthMachinePrincipal(
+            team_id=team_id,
+            organization_id=str(team.organization_id),
+            task_id=str(task.id),
+            principal=task.system_principal,
+            workload=task.system_workload,
+        )
+        self.machine_principal = principal
+        tag_authentication(user_id=None, team_id=team_id, access_method=AccessMethod.OAUTH)
+        structlog_logger.info(
+            "system_oauth_authenticated",
+            team_id=team_id,
+            task_id=str(task.id),
+            system_principal=task.system_principal,
+            system_workload=task.system_workload,
+        )
+        return principal, None
+
+    def _machine_access_token(self, token: str) -> OAuthAccessToken | None:
+        try:
+            access_token = OAuthAccessToken.objects.select_related("application").get(token=token)
+        except OAuthAccessToken.DoesNotExist:
+            return None
+        if access_token.user_id is not None:
+            return None
+        if access_token.is_expired():
+            raise AuthenticationFailed(detail="Access token has expired.")
+        if access_token.application_id is None:
+            raise AuthenticationFailed(detail="Access token is not associated with a valid application.")
+        return access_token
+
+    @staticmethod
+    def _bound_system_task(access_token: OAuthAccessToken, team_id: int):
+        if access_token.application.client_id not in SIGNALS_OAUTH_APP_CLIENT_IDS:
+            raise AuthenticationFailed(detail="System token uses the wrong OAuth application.")
+        if access_token.scoped_teams is None or len(access_token.scoped_teams) != 1:
+            raise AuthenticationFailed(detail="System token must be scoped to exactly one project.")
+        if access_token.sandbox_task_id is None or access_token.sandbox_workload != "report_canvas":
+            raise AuthenticationFailed(detail="System token is missing its task or workload binding.")
+        expected_scopes = set(resolve_scopes("report_canvas", include_internal_scopes=True))
+        if set((access_token.scope or "").split()) != expected_scopes:
+            raise AuthenticationFailed(detail="System token has invalid scopes.")
+
+        Task = apps.get_model("tasks", "Task")
+        try:
+            task = Task.objects.only("id", "team_id", "created_by_id", "system_principal", "system_workload").get(
+                id=access_token.sandbox_task_id,
+                team_id=team_id,
+            )
+        except Task.DoesNotExist:
+            raise AuthenticationFailed(detail="System token task binding is invalid.")
+        if (
+            task.created_by_id is not None
+            or task.system_principal != "signals"
+            or task.system_workload != "report_canvas"
+        ):
+            raise AuthenticationFailed(detail="System token principal binding is invalid.")
+        return task
 
 
 class WidgetAuthentication(authentication.BaseAuthentication):

--- a/posthog/migrations/1311_oauthaccesstoken_sandbox_workload.py
+++ b/posthog/migrations/1311_oauthaccesstoken_sandbox_workload.py
@@ -1,0 +1,13 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [("posthog", "1310_provisioning_rate_limit_overrides")]
+
+    operations = [
+        migrations.AddField(
+            model_name="oauthaccesstoken",
+            name="sandbox_workload",
+            field=models.CharField(blank=True, max_length=32, null=True),
+        )
+    ]

--- a/posthog/migrations/max_migration.txt
+++ b/posthog/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-1310_provisioning_rate_limit_overrides
+1311_oauthaccesstoken_sandbox_workload

--- a/posthog/models/oauth.py
+++ b/posthog/models/oauth.py
@@ -540,6 +540,7 @@ class OAuthAccessToken(AbstractAccessToken):
     scoped_organizations: ArrayField = ArrayField(models.CharField(max_length=100), null=True, blank=True)
     # Server-minted sandbox binding: task-scoped APIs must not trust a caller-supplied task header alone.
     sandbox_task_id: models.UUIDField = models.UUIDField(null=True, blank=True)
+    sandbox_workload: models.CharField = models.CharField(max_length=32, null=True, blank=True)
 
     # When set, this token was minted by a staff user impersonating `user`. Used to revoke
     # tokens at impersonation end. SET_NULL so the customer's tokens survive admin deactivation.

--- a/posthog/permissions.py
+++ b/posthog/permissions.py
@@ -332,7 +332,15 @@ def is_authenticated_via_project_secret_api_key(request: Request) -> bool:
 
 
 def is_service_auth(request: Request) -> bool:
-    return is_authenticated_via_team_secret_token(request) or is_authenticated_via_project_secret_api_key(request)
+    authenticator = request.successful_authenticator
+    is_machine_oauth = isinstance(authenticator, OAuthAccessTokenAuthentication) and bool(
+        getattr(authenticator, "machine_principal", None)
+    )
+    return (
+        is_authenticated_via_team_secret_token(request)
+        or is_authenticated_via_project_secret_api_key(request)
+        or is_machine_oauth
+    )
 
 
 def _is_request_for_team_secret_token_secured_endpoint(request: Request) -> bool:

--- a/posthog/temporal/oauth.py
+++ b/posthog/temporal/oauth.py
@@ -311,7 +311,13 @@ def get_sandbox_oauth_app(application: SandboxOAuthApplication = "array") -> OAu
 
 
 def _mint_oauth_access_token(
-    user, team_id: int, *, app: OAuthApplication, scopes: list[str], sandbox_task_id: UUID | None = None
+    user,
+    team_id: int,
+    *,
+    app: OAuthApplication,
+    scopes: list[str],
+    sandbox_task_id: UUID | None = None,
+    sandbox_workload: str | None = None,
 ) -> str:
     token_value = generate_random_oauth_access_token(None)
 
@@ -323,9 +329,26 @@ def _mint_oauth_access_token(
         scope=" ".join(dict.fromkeys(scopes)),
         scoped_teams=[team_id],
         sandbox_task_id=sandbox_task_id,
+        sandbox_workload=sandbox_workload,
     )
 
     return token_value
+
+
+def create_signals_report_canvas_oauth_access_token(*, team_id: int, task_id: UUID) -> str:
+    """Mint the fixed, userless credential for one Signals report-canvas task."""
+    app = get_signals_app()
+    if app is None:
+        raise RuntimeError("The Signals OAuth application is not configured")
+    scopes = resolve_scopes("report_canvas", include_internal_scopes=True)
+    return _mint_oauth_access_token(
+        None,
+        team_id,
+        app=app,
+        scopes=list(scopes),
+        sandbox_task_id=task_id,
+        sandbox_workload="report_canvas",
+    )
 
 
 def create_oauth_access_token_for_user(

--- a/products/canvas/backend/presentation/views.py
+++ b/products/canvas/backend/presentation/views.py
@@ -18,7 +18,7 @@ from rest_framework.response import Response
 from rest_framework.throttling import BaseThrottle, SimpleRateThrottle
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
-from posthog.auth import OAuthAccessTokenAuthentication
+from posthog.auth import OAuthAccessTokenAuthentication, SystemOAuthAccessTokenAuthentication
 from posthog.event_usage import report_user_action
 from posthog.helpers.impersonation import is_impersonated
 from posthog.models.activity_logging.activity_log import Change, Detail, Trigger, log_activity
@@ -197,6 +197,7 @@ class CanvasViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     # current_source_version feeds the component_meta field on every row.
     queryset = Canvas.objects.unscoped().select_related("created_by", "current_source_version")
     serializer_class = CanvasSerializer
+    authentication_classes = [SystemOAuthAccessTokenAuthentication]
     http_method_names = ["get", "post", "patch", "delete", "head", "options"]
     scope_object_read_actions = [
         "list",

--- a/products/canvas/backend/tests/test_canvas_oauth.py
+++ b/products/canvas/backend/tests/test_canvas_oauth.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 
 from posthog.models.oauth import OAuthAccessToken, OAuthApplication
 from posthog.models.scoping import team_scope
-from posthog.temporal.oauth import ARRAY_APP_CLIENT_ID_DEV
+from posthog.temporal.oauth import ARRAY_APP_CLIENT_ID_DEV, SIGNALS_APP_CLIENT_ID_DEV, resolve_scopes
 
 from products.canvas.backend.models import Canvas
 from products.tasks.backend.models import Channel, Task
@@ -85,6 +85,57 @@ class TestCanvasOAuthAccess(APIBaseTest):
 
         assert response.status_code == 200
         assert response.json()["results"] == []
+
+    def test_system_report_canvas_token_authenticates_only_with_exact_provenance(self):
+        with team_scope(self.team.id):
+            channel = Channel.objects.create(team=self.team, name="general")
+            task = Task.objects.create(
+                team=self.team,
+                channel=channel,
+                title="Generate report canvas",
+                origin_product=Task.OriginProduct.SIGNAL_REPORT,
+                system_principal=Task.SystemPrincipal.SIGNALS,
+                system_workload=Task.SystemWorkload.REPORT_CANVAS,
+            )
+        app = OAuthApplication.objects.create(
+            name="Signals",
+            client_id=SIGNALS_APP_CLIENT_ID_DEV,
+            client_type=OAuthApplication.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
+            redirect_uris="https://example.com/callback",
+            algorithm="RS256",
+            skip_authorization=False,
+            organization=self.organization,
+            user=self.user,
+        )
+        token = OAuthAccessToken.objects.create(
+            user=None,
+            application=app,
+            token="pha_system_report_canvas",
+            scope=" ".join(resolve_scopes("report_canvas", include_internal_scopes=True)),
+            expires=timezone.now() + timedelta(hours=1),
+            scoped_teams=[self.team.id],
+            sandbox_task_id=task.id,
+            sandbox_workload="report_canvas",
+        )
+        self.client.logout()
+
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/canvases/?channel={channel.id}&limit=200",
+            HTTP_AUTHORIZATION=f"Bearer {token.token}",
+            HTTP_X_POSTHOG_TASK_ID=str(task.id),
+        )
+
+        assert response.status_code == 200
+
+        token.scope = f"{token.scope} task:delete"
+        token.save(update_fields=["scope"])
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/canvases/?channel={channel.id}&limit=200",
+            HTTP_AUTHORIZATION=f"Bearer {token.token}",
+            HTTP_X_POSTHOG_TASK_ID=str(task.id),
+        )
+        assert response.status_code == 401
 
     def _create_canvas(
         self,

--- a/products/tasks/backend/migrations/0104_task_system_workload.py
+++ b/products/tasks/backend/migrations/0104_task_system_workload.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [("tasks", "0103_validate_task_single_principal")]
+
+    operations = [
+        migrations.AddField(
+            model_name="task",
+            name="system_workload",
+            field=models.CharField(
+                blank=True,
+                choices=[("report_canvas", "Report canvas")],
+                editable=False,
+                help_text="Trusted workload executed by a system-owned task.",
+                max_length=32,
+                null=True,
+            ),
+        )
+    ]

--- a/products/tasks/backend/migrations/max_migration.txt
+++ b/products/tasks/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0103_validate_task_single_principal
+0104_task_system_workload

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -181,6 +181,9 @@ class Task(DeletedMetaFields, models.Model):
     class SystemPrincipal(models.TextChoices):
         SIGNALS = "signals", "Signals"
 
+    class SystemWorkload(models.TextChoices):
+        REPORT_CANVAS = "report_canvas", "Report canvas"
+
     class Runtime(models.TextChoices):
         ACP = "acp", "ACP"
         PI = "pi", "Pi"
@@ -233,6 +236,14 @@ class Task(DeletedMetaFields, models.Model):
         blank=True,
         editable=False,
         help_text="Trusted system principal that owns this task. Mutually exclusive with created_by.",
+    )
+    system_workload = models.CharField(
+        max_length=32,
+        choices=SystemWorkload,
+        null=True,
+        blank=True,
+        editable=False,
+        help_text="Trusted workload executed by a system-owned task.",
     )
     task_number = models.IntegerField(null=True, blank=True)
     title = models.CharField(max_length=255)

--- a/products/tasks/backend/temporal/oauth.py
+++ b/products/tasks/backend/temporal/oauth.py
@@ -171,7 +171,11 @@ def create_system_oauth_access_token(task: Task) -> str:
     try:
         return create_signals_report_canvas_oauth_access_token(team_id=task.team_id, task_id=task.id)
     except RuntimeError as error:
-        raise OAuthTokenError(f"Unable to mint system OAuth for task {task.id}") from error
+        raise OAuthTokenError(
+            f"Unable to mint system OAuth for task {task.id}",
+            {"task_id": task.id, "team_id": task.team_id},
+            cause=error,
+        ) from error
 
 
 def create_oauth_access_token_for_run(

--- a/products/tasks/backend/temporal/oauth.py
+++ b/products/tasks/backend/temporal/oauth.py
@@ -13,6 +13,7 @@ from posthog.temporal.oauth import (
     PosthogMcpScopes,
     SandboxOAuthApplication,
     create_oauth_access_token_for_user as _create_oauth_access_token_for_user,
+    create_signals_report_canvas_oauth_access_token,
     create_wizard_oauth_access_token_for_user as _create_wizard_oauth_access_token_for_user,
     resolve_scopes,
 )
@@ -145,6 +146,32 @@ def create_oauth_access_token(
     if is_interactive_signals_task(task):
         token_options["include_interactive_run_scope"] = True
     return create_oauth_access_token_for_user(actor, task.team_id, **token_options)
+
+
+def create_system_oauth_access_token(task: Task) -> str:
+    """Mint the credential for a trusted system-owned report-canvas task."""
+    if task.system_principal != Task.SystemPrincipal.SIGNALS:
+        raise TaskInvalidStateError(
+            f"Task {task.id} is not owned by Signals",
+            {"task_id": task.id},
+            cause=RuntimeError("unexpected system principal"),
+        )
+    if task.system_workload != Task.SystemWorkload.REPORT_CANVAS:
+        raise TaskInvalidStateError(
+            f"Task {task.id} is not a report-canvas workload",
+            {"task_id": task.id},
+            cause=RuntimeError("unexpected system workload"),
+        )
+    if task.created_by_id is not None or task.team_id is None:
+        raise TaskInvalidStateError(
+            f"Task {task.id} has invalid system ownership",
+            {"task_id": task.id},
+            cause=RuntimeError("system task has a human owner or no team"),
+        )
+    try:
+        return create_signals_report_canvas_oauth_access_token(team_id=task.team_id, task_id=task.id)
+    except RuntimeError as error:
+        raise OAuthTokenError(f"Unable to mint system OAuth for task {task.id}") from error
 
 
 def create_oauth_access_token_for_run(

--- a/products/tasks/backend/temporal/tests/test_oauth.py
+++ b/products/tasks/backend/temporal/tests/test_oauth.py
@@ -7,7 +7,11 @@ from posthog.temporal.oauth import PosthogMcpScopes
 
 from products.tasks.backend.exceptions import TaskInvalidStateError
 from products.tasks.backend.models import MCPBuiltInAgentKey, Task
-from products.tasks.backend.temporal.oauth import create_oauth_access_token, create_oauth_access_token_for_run
+from products.tasks.backend.temporal.oauth import (
+    create_oauth_access_token,
+    create_oauth_access_token_for_run,
+    create_system_oauth_access_token,
+)
 
 
 @pytest.mark.parametrize(
@@ -162,6 +166,27 @@ def test_oauth_token_can_disable_task_creator_fallback() -> None:
 
     with pytest.raises(TaskInvalidStateError):
         create_oauth_access_token(task, user=None, allow_task_creator_fallback=False)
+
+
+@pytest.mark.django_db
+@patch("products.tasks.backend.temporal.oauth.create_signals_report_canvas_oauth_access_token", return_value="token")
+def test_system_oauth_requires_explicit_signals_report_canvas_task(mock_create: MagicMock) -> None:
+    organization = Organization.objects.create(name="system-oauth-org")
+    team = Team.objects.create(organization=organization, name="system-oauth-team")
+    task = Task.objects.create(
+        team=team,
+        title="Generate report canvas",
+        origin_product=Task.OriginProduct.SIGNAL_REPORT,
+        system_principal=Task.SystemPrincipal.SIGNALS,
+        system_workload=Task.SystemWorkload.REPORT_CANVAS,
+    )
+
+    assert create_system_oauth_access_token(task) == "token"
+    mock_create.assert_called_once_with(team_id=team.id, task_id=task.id)
+
+    task.system_workload = None
+    with pytest.raises(TaskInvalidStateError):
+        create_system_oauth_access_token(task)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Problem

Automatic report-canvas sessions cannot authenticate without borrowing a project member identity.

**Why:** Signals needs narrow credentials that cannot impersonate a person or expand beyond one task.

## Changes

- System-owned report-canvas tasks can authenticate without a Django user.
- Tokens bind to one Signals application, project, task, workload, scope set, and expiry.
- Canvas endpoints opt into machine authentication; every other endpoint still rejects userless OAuth.
- Nullable workload fields keep this layer additive and inactive until adoption.

Before:

```mermaid
flowchart LR
  A[Automatic task] --> B[Selected member]
  B --> C[Human OAuth token]
  C --> D[Canvas API]
```

After:

```mermaid
flowchart LR
  A[System task] --> B[Signals task-bound token]
  B --> C[Validated machine principal]
  C --> D[Canvas API]
```

No screenshots: this layer has no visible UI change.


### Stack order

This PR is part of the independent task-identity foundation:

1. [#86155](https://github.com/PostHog/posthog/pull/86155) adds explicit system principals.
2. [#86615](https://github.com/PostHog/posthog/pull/86615) adds task-bound system OAuth.
3. [#86616](https://github.com/PostHog/posthog/pull/86616) isolates system-owned sandbox credentials.

These layers can land independently of canvas provenance. Rebase the adoption layers after both foundations reach `master`.

## How did you test this code?

- Static checks cover lint, formatting, compilation, migration drift, and migration SQL.
- New regressions cover provenance validation and scope escalation.
- Not run: database-backed tests stalled while building the full test schema.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No user-facing workflow changes in this infrastructure layer.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented this stack layer with the `/stacking-prs`, `/django-migrations`, and `/writing-pr-descriptions` skills.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*