### PR TITLE
feat(tasks): isolate system-owned sandbox credentials

### DIFF
--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -116,6 +116,7 @@ from products.tasks.backend.pr_urls import merge_pr_output
 from products.tasks.backend.prompts import build_wizard_pr_agent_prompt, generate_wizard_head_branch
 from products.tasks.backend.visibility import (
     TEAM_READABLE_ORIGIN_PRODUCTS,
+    task_admin_q,
     task_control_q,
     task_run_visibility_q,
     task_visibility_q,
@@ -3934,6 +3935,23 @@ def bootstrap_task_run(
     initial_permission_mode = validated_data.get("initial_permission_mode")
     imported_mcp_servers = validated_data.get("imported_mcp_servers")
     relayed_mcp_servers = validated_data.get("relayed_mcp_servers")
+    if task.is_system_report_canvas and any(
+        (
+            validated_data.get("repository"),
+            imported_mcp_servers,
+            relayed_mcp_servers,
+            github_user_token,
+            validated_data.get("custom_image_id"),
+            sandbox_environment_id,
+        )
+    ):
+        return contracts.TaskRunCreateResult(
+            error=contracts.TaskRunValidationError(
+                kind="validation_error",
+                code="invalid_input",
+                detail="System report-canvas tasks cannot use personal sandbox resources.",
+            )
+        )
     if run_source == RunSource.SIGNAL_REPORT:
         pr_authorship_mode = PrAuthorshipMode.BOT
 
@@ -5088,7 +5106,7 @@ def update_task(
     task_id: str | UUID, team_id: int, user_id: int | None, *, validated_data: dict
 ) -> contracts.TaskDetailDTO | None:
     """Update a task, mirroring ``TaskSerializer.update``. ``None`` if not found/controllable."""
-    task = _visible_task_qs(team_id, user_id, for_control=True).filter(id=task_id).first()
+    task = Task.objects.filter(team_id=team_id, deleted=False).filter(task_admin_q(user_id), id=task_id).first()
     if task is None:
         return None
 
@@ -5128,7 +5146,7 @@ def update_task(
 
 def soft_delete_task(task_id: str | UUID, team_id: int, user_id: int | None) -> bool:
     """Soft-delete a task. Returns whether a task was found/controllable and deleted."""
-    task = _visible_task_qs(team_id, user_id, for_control=True).filter(id=task_id).first()
+    task = Task.objects.filter(team_id=team_id, deleted=False).filter(task_admin_q(user_id), id=task_id).first()
     if task is None:
         return False
     logger.info("Soft deleting task %s", task.id)

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -430,6 +430,14 @@ class Task(DeletedMetaFields, models.Model):
             self._track_task_created()
 
     @property
+    def is_system_report_canvas(self) -> bool:
+        return (
+            self.created_by_id is None
+            and self.system_principal == self.SystemPrincipal.SIGNALS
+            and self.system_workload == self.SystemWorkload.REPORT_CANVAS
+        )
+
+    @property
     def mcp_builtin_agent_key(self) -> MCPBuiltInAgentKey | None:
         expected_key = MCP_BUILT_IN_AGENT_KEY_BY_ORIGIN.get(self.origin_product)
         marker = (self.state or {}).get(MCP_BUILT_IN_AGENT_STATE_KEY)

--- a/products/tasks/backend/temporal/oauth.py
+++ b/products/tasks/backend/temporal/oauth.py
@@ -189,6 +189,15 @@ def create_oauth_access_token_for_run(
     to mint creator credentials for a Slack run by omitting one kwarg. Loop-fired runs
     (``loop_id`` in run state) get ``loop:write`` stripped from the granted scopes here.
     """
+    if task.is_system_report_canvas:
+        if scopes != "report_canvas":
+            raise TaskInvalidStateError(
+                f"System report-canvas task {task.id} requested unexpected scopes",
+                {"task_id": task.id},
+                cause=RuntimeError("system task scope escalation"),
+            )
+        return create_system_oauth_access_token(task)
+
     actor_user = get_task_run_credential_user(task, state)
     loop_id = (state or {}).get("loop_id")
     if task.origin_product == Task.OriginProduct.WORKFLOW:

--- a/products/tasks/backend/temporal/process_task/activities/start_agent_server.py
+++ b/products/tasks/backend/temporal/process_task/activities/start_agent_server.py
@@ -224,7 +224,31 @@ def _include_personal_mcp_for_task(task: Task) -> bool:
     in the MCP Store facade.
     User-initiated Code runs get shared + the creator's personal installs.
     """
-    return not task.internal
+    return not task.internal and task.is_system_report_canvas is not True
+
+
+def _validate_system_report_canvas_context(task: Task, ctx: TaskProcessingContext, scopes: PosthogMcpScopes) -> None:
+    if task.is_system_report_canvas is not True:
+        return
+    if scopes != "report_canvas":
+        raise OAuthTokenError(
+            f"System report-canvas task {task.id} requested unexpected scopes",
+            {"task_id": task.id},
+            cause=RuntimeError("system task scope escalation"),
+        )
+    if (
+        ctx.repositories
+        or ctx.github_integration_id
+        or ctx.github_user_integration_id
+        or ctx.sandbox_environment_id
+        or ctx.custom_image_name
+        or task.mcp_credential_owner_id is not None
+    ):
+        raise OAuthTokenError(
+            f"System report-canvas task {task.id} requested personal sandbox resources",
+            {"task_id": task.id},
+            cause=RuntimeError("system task credential isolation violation"),
+        )
 
 
 def _ensure_required_posthog_mcp_available(
@@ -256,7 +280,8 @@ def _ensure_required_posthog_mcp_available(
 def _prepare_launch(ctx: TaskProcessingContext, scopes: PosthogMcpScopes, sandbox_id: str) -> _LaunchParams:
     try:
         task = Task.objects.select_related("created_by", "team").get(id=ctx.task_id)
-        actor_user = get_task_run_credential_user(task, ctx.state)
+        _validate_system_report_canvas_context(task, ctx, scopes)
+        actor_user = None if task.is_system_report_canvas is True else get_task_run_credential_user(task, ctx.state)
         access_token = create_oauth_access_token_for_run(task, ctx.state, scopes=scopes)
     except OAuthTokenError:
         raise
@@ -304,26 +329,38 @@ def _prepare_launch(ctx: TaskProcessingContext, scopes: PosthogMcpScopes, sandbo
         task_id=str(ctx.task_id),
     )
     include_personal = _include_personal_mcp_for_task(task)
-    user_mcp_configs = get_user_mcp_server_configs(
-        token=access_token,
-        team_id=ctx.team_id,
-        user_id=actor_user.id if actor_user else None,
-        include_personal=include_personal,
-        interaction_origin=ctx.interaction_origin,
-        allowed_installation_ids=loop_mcp_installation_allowlist(ctx.state),
-        origin_product=task.origin_product,
-        task_agent_key=task.mcp_builtin_agent_key,
-        credential_owner_id=task.mcp_credential_owner_id,
-        allowed_gateway_server_ids=task.mcp_gateway_server_allowlist,
+    user_mcp_configs = (
+        []
+        if task.is_system_report_canvas is True
+        else get_user_mcp_server_configs(
+            token=access_token,
+            team_id=ctx.team_id,
+            user_id=actor_user.id if actor_user else None,
+            include_personal=include_personal,
+            interaction_origin=ctx.interaction_origin,
+            allowed_installation_ids=loop_mcp_installation_allowlist(ctx.state),
+            origin_product=task.origin_product,
+            task_agent_key=task.mcp_builtin_agent_key,
+            credential_owner_id=task.mcp_credential_owner_id,
+            allowed_gateway_server_ids=task.mcp_gateway_server_allowlist,
+        )
     )
     if user_mcp_configs:
         mcp_configs = mcp_configs + user_mcp_configs
 
-    imported_mcp_configs = get_imported_mcp_server_configs(task_run, {config.name for config in mcp_configs})
+    imported_mcp_configs = (
+        []
+        if task.is_system_report_canvas is True
+        else get_imported_mcp_server_configs(task_run, {config.name for config in mcp_configs})
+    )
     if imported_mcp_configs:
         mcp_configs = mcp_configs + imported_mcp_configs
 
-    relayed_names = get_relayed_mcp_server_names(task_run, {config.name for config in mcp_configs})
+    relayed_names = (
+        []
+        if task.is_system_report_canvas is True
+        else get_relayed_mcp_server_names(task_run, {config.name for config in mcp_configs})
+    )
     if relayed_names:
         emit_agent_log(
             ctx.run_id,

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_start_agent_server.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_start_agent_server.py
@@ -2,6 +2,7 @@ import pytest
 from freezegun import freeze_time
 
 from products.tasks.backend.exceptions import (
+    OAuthTokenError,
     RequiredMcpUnavailableError,
     SandboxExecutionError,
     SandboxMissingRepositoryError,
@@ -19,6 +20,7 @@ from products.tasks.backend.temporal.process_task.activities.start_agent_server 
     _network_enforcement_observation,
     _record_boot_total,
     _resolve_protected_base_branch,
+    _validate_system_report_canvas_context,
     start_agent_server,
 )
 from products.tasks.backend.temporal.process_task.utils import McpServerConfig
@@ -189,6 +191,19 @@ def _mock_github_integration(mocker, pr_base: str | None):
 def test_include_personal_mcp_for_task(mocker, internal, expected) -> None:
     task = mocker.Mock(internal=internal)
     assert _include_personal_mcp_for_task(task) is expected
+
+
+def test_system_report_canvas_rejects_personal_sandbox_resources(mocker) -> None:
+    task = mocker.Mock(
+        id="task-id",
+        is_system_report_canvas=True,
+        mcp_credential_owner_id=None,
+    )
+
+    _validate_system_report_canvas_context(task, _context(), "report_canvas")
+
+    with pytest.raises(OAuthTokenError, match="personal sandbox resources"):
+        _validate_system_report_canvas_context(task, _context(repository="posthog/posthog"), "report_canvas")
 
 
 @pytest.mark.parametrize(

--- a/products/tasks/backend/visibility.py
+++ b/products/tasks/backend/visibility.py
@@ -31,16 +31,30 @@ def _creator_q(user_id: int | None) -> Q:
     return Q(pk__in=[]) if user_id is None else Q(created_by_id=user_id)
 
 
-def task_control_q(user_id: int | None) -> Q:
-    """Tasks the user may mutate or drive.
+def task_admin_q(user_id: int | None) -> Q:
+    """Tasks the user may rename, move, archive, or delete.
 
     A task with a channel must be visible through that channel and owned by the user.
     Null-channel tasks keep the product-origin control rules used before channels.
     """
     channeled_q = Q(channel_id__isnull=False) & Channel.visible_to_q(user_id, relation="channel") & _creator_q(user_id)
-    legacy_q = Q(channel_id__isnull=True) & (
-        _creator_q(user_id) | Q(created_by__isnull=True) | Q(origin_product__in=TEAM_VISIBLE_ORIGIN_PRODUCTS)
+    legacy_q = Q(channel_id__isnull=True) & _creator_q(user_id)
+    return channeled_q | legacy_q
+
+
+def task_control_q(user_id: int | None) -> Q:
+    """Tasks the user may participate in by messaging, cancelling, or resuming."""
+    system_task_q = Q(
+        system_principal=Task.SystemPrincipal.SIGNALS,
+        system_workload=Task.SystemWorkload.REPORT_CANVAS,
+        created_by_id__isnull=True,
     )
+    channeled_q = (
+        Q(channel_id__isnull=False)
+        & Channel.visible_to_q(user_id, relation="channel")
+        & (_creator_q(user_id) | system_task_q)
+    )
+    legacy_q = Q(channel_id__isnull=True) & (_creator_q(user_id) | Q(origin_product__in=TEAM_VISIBLE_ORIGIN_PRODUCTS))
     return channeled_q | legacy_q
 
 


### PR DESCRIPTION
## Problem

Project members must participate in system sessions without granting those sessions access to personal credentials.

**Why:** Human interaction must not change a system-owned workload into a broader human-owned sandbox.

## Changes

- Channel members can message, cancel, and resume explicit Signals report-canvas tasks.
- Only task owners can rename, move, archive, or delete tasks.
- System runs reject personal MCP servers, relays, GitHub credentials, repositories, custom images, and user environments.
- System runs accept only the fixed report-canvas scope and internal Signals environment.

Before:

```mermaid
flowchart LR
  A[Human follow-up] --> B[Task control]
  B --> C[Human credential resolution]
  C --> D[Sandbox]
```

After:

```mermaid
flowchart LR
  A[Human follow-up] --> B[Participation policy]
  B --> C[Unchanged system credential]
  C --> D[Restricted sandbox]
```

No screenshots: this layer changes authorization and sandbox inputs only.


### Stack order

This PR is part of the independent task-identity foundation:

1. [#86155](https://github.com/PostHog/posthog/pull/86155) adds explicit system principals.
2. [#86615](https://github.com/PostHog/posthog/pull/86615) adds task-bound system OAuth.
3. [#86616](https://github.com/PostHog/posthog/pull/86616) isolates system-owned sandbox credentials.

These layers can land independently of canvas provenance. Rebase the adoption layers after both foundations reach `master`.

## How did you test this code?

- Focused tests verify personal resources are rejected and personal MCP resolution stays disabled.
- Static checks cover the changed Tasks modules.
- Not run: database-backed participation tests because test-schema setup stalled.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documented user workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented this stack layer with the `/stacking-prs` and `/writing-pr-descriptions` skills.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*