### PR TITLE
feat(signals): run report canvases as Signals

### DIFF
--- a/products/signals/backend/report_canvas.py
+++ b/products/signals/backend/report_canvas.py
@@ -25,11 +25,7 @@ from products.signals.backend.report_generation.resolve_reviewers import (
     normalized_github_logins_from_suggested_reviewer_artefacts,
     resolve_org_github_login_to_users,
 )
-from products.signals.backend.sandbox import (
-    SIGNALS_REPORT_CANVAS_ENV_NAME,
-    get_or_create_signals_sandbox_env,
-    resolve_acting_user_id_for_team,
-)
+from products.signals.backend.sandbox import SIGNALS_REPORT_CANVAS_ENV_NAME, get_or_create_signals_sandbox_env
 from products.tasks.backend.facade import api as tasks_facade
 
 REPORT_CANVAS_FEATURE_FLAG = "signals-report-canvases"
@@ -300,9 +296,6 @@ def ensure_and_start_report_canvas_generation(*, team_id: int, report_id: str) -
         session.generated_fingerprint = fingerprint
         session.save(update_fields=["generation_status", "failure_reason", "generated_fingerprint", "updated_at"])
 
-        user_id = resolve_acting_user_id_for_team(team_id)
-        if user_id is None:
-            raise RuntimeError("No active organization member can run the report canvas agent")
         sandbox_environment_id = get_or_create_signals_sandbox_env(
             team_id,
             SIGNALS_REPORT_CANVAS_ENV_NAME,
@@ -325,7 +318,9 @@ def ensure_and_start_report_canvas_generation(*, team_id: int, report_id: str) -
             title=f"Canvas: {report.title or 'Report'}",
             description=prompt,
             origin_product=tasks_facade.TaskOriginProduct.SIGNAL_REPORT,
-            user_id=user_id,
+            user_id=None,
+            system_principal=tasks_facade.TaskSystemPrincipal.SIGNALS,
+            system_workload=tasks_facade.TaskSystemWorkload.REPORT_CANVAS,
             create_pr=False,
             pending_user_message=prompt,
             posthog_mcp_scopes="report_canvas",

--- a/products/signals/backend/test/test_report_canvas.py
+++ b/products/signals/backend/test/test_report_canvas.py
@@ -63,7 +63,6 @@ class TestReportCanvasGeneration(APIBaseTest):
             patch("products.signals.backend.report_canvas.report_canvases_enabled", return_value=True),
             patch("products.signals.backend.report_canvas._fetch_report_signals", return_value=[]),
             patch("products.signals.backend.report_canvas.fetch_implementation_pr_urls_for_reports", return_value={}),
-            patch("products.signals.backend.report_canvas.resolve_acting_user_id_for_team", return_value=self.user.id),
             patch(
                 "products.signals.backend.report_canvas.get_or_create_signals_sandbox_env", return_value="env"
             ) as get_sandbox_environment,
@@ -103,6 +102,11 @@ class TestReportCanvasGeneration(APIBaseTest):
         assert discussion.state["activity_target"] == {"scope": "desktop_canvas", "id": str(canvas.id)}
         assert attempt.status == SignalReportCanvasGeneration.Status.GENERATING
         assert attempt.generation_task_id == generation_task_id
+        generation_kwargs = create_generation.call_args.kwargs
+        assert generation_kwargs["user_id"] is None
+        assert generation_kwargs["system_principal"] == tasks_facade.TaskSystemPrincipal.SIGNALS
+        assert generation_kwargs["system_workload"] == tasks_facade.TaskSystemWorkload.REPORT_CANVAS
+        assert generation_kwargs["description"] == generation_kwargs["pending_user_message"]
 
     def test_generation_prompt_includes_current_report_decisions_and_rejects_fake_controls(self) -> None:
         report = self._report()

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -135,6 +135,8 @@ TaskRunStatus = TaskRun.Status
 TaskRunEnvironment = TaskRun.Environment
 TaskOriginProduct = Task.OriginProduct
 TaskRuntime = Task.Runtime
+TaskSystemPrincipal = Task.SystemPrincipal
+TaskSystemWorkload = Task.SystemWorkload
 SandboxNetworkAccessLevel = SandboxEnvironment.NetworkAccessLevel
 SandboxSnapshotStatus = SandboxSnapshot.Status
 
@@ -1253,7 +1255,7 @@ def create_and_run_task(
     title: str,
     description: str,
     origin_product: "Task.OriginProduct",
-    user_id: int,
+    user_id: int | None,
     repository: str | None = None,
     create_pr: bool = True,
     mode: str = "background",
@@ -1263,6 +1265,8 @@ def create_and_run_task(
     internal: bool = False,
     sandbox_environment_id: str | None = None,
     channel_id: str | UUID | None = None,
+    system_principal: Task.SystemPrincipal | None = None,
+    system_workload: Task.SystemWorkload | None = None,
     **extra,
 ) -> contracts.CreatedTaskDTO:
     """Create a task and (optionally) kick off its processing workflow.
@@ -1300,6 +1304,8 @@ def create_and_run_task(
         signal_report_id=signal_report_id,
         internal=internal,
         sandbox_environment_id=sandbox_environment_id,
+        system_principal=system_principal,
+        system_workload=system_workload,
         **extra,
     )
     latest = task.latest_run

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -688,7 +688,7 @@ class Task(DeletedMetaFields, models.Model):
         title: str,
         description: str,
         origin_product: "Task.OriginProduct",
-        user_id: int,
+        user_id: int | None,
         repository: str | None = None,
         channel: Channel | None = None,
         slack_thread_context: Optional["SlackThreadContext"] = None,
@@ -719,6 +719,8 @@ class Task(DeletedMetaFields, models.Model):
         client_provenance: TaskClientProvenance | None = None,
         mcp_credential_owner_id: int | None = None,
         mcp_gateway_server_ids: list[str] | None = None,
+        system_principal: "Task.SystemPrincipal | None" = None,
+        system_workload: "Task.SystemWorkload | None" = None,
     ) -> tuple["Task", dict[str, Any]]:
         """Create the Task row and assemble the initial run's `extra_state`.
 
@@ -726,7 +728,11 @@ class Task(DeletedMetaFields, models.Model):
         `create_without_run` (which discards the run state). One path keeps the
         GitHub-integration resolution and authorship logic from drifting between them.
         """
-        created_by = User.objects.get(id=user_id)
+        if (user_id is None) == (system_principal is None):
+            raise ValueError("Exactly one human or system task principal is required")
+        if system_principal is not None and system_workload is None:
+            raise ValueError("System-owned tasks require an explicit workload")
+        created_by = User.objects.get(id=user_id) if user_id is not None else None
 
         from products.tasks.backend.logic.services.sandbox import is_public_sandbox_repo
         from products.tasks.backend.temporal.process_task.utils import (
@@ -753,6 +759,8 @@ class Task(DeletedMetaFields, models.Model):
             origin_product=origin_product,
             client_provenance=client_provenance,
             created_by=created_by,
+            system_principal=system_principal,
+            system_workload=system_workload,
             repository=repository,
             github_integration=github_integration,
         )
@@ -770,7 +778,7 @@ class Task(DeletedMetaFields, models.Model):
             )
             if user_github_integration_is_usable(user_github_integration):
                 github_user_integration = user_github_integration.integration if user_github_integration else None
-        elif authorship_mode == PrAuthorshipMode.BOT and github_integration is None:
+        elif authorship_mode == PrAuthorshipMode.BOT and github_integration is None and created_by is not None:
             # If BOT starts a task, provides a repo, but there's no team GitHub Integration,
             # then use the user_id BOT provided and get user's GitHub Integration instead
             user_github_integration = resolve_user_github_integration_for_task(
@@ -1000,7 +1008,7 @@ class Task(DeletedMetaFields, models.Model):
         title: str,
         description: str,
         origin_product: "Task.OriginProduct",
-        user_id: int,  # Will be used to validate the tasks feature flag and create a personal api key for interacting with PostHog.
+        user_id: int | None,
         repository: str | None = None,  # Format: "organization/repository", e.g. "posthog/posthog-js"
         channel: Channel | None = None,
         create_pr: bool = True,
@@ -1037,6 +1045,8 @@ class Task(DeletedMetaFields, models.Model):
         mcp_builtin_agent_key: MCPBuiltInAgentKey | None = None,
         mcp_credential_owner_id: int | None = None,
         mcp_gateway_server_ids: list[str] | None = None,
+        system_principal: "Task.SystemPrincipal | None" = None,
+        system_workload: "Task.SystemWorkload | None" = None,
     ) -> "Task":
         from products.tasks.backend.logic.services.workflow_dispatch import (
             WorkflowDispatchOptions,
@@ -1079,6 +1089,8 @@ class Task(DeletedMetaFields, models.Model):
             mcp_builtin_agent_key=mcp_builtin_agent_key,
             mcp_credential_owner_id=mcp_credential_owner_id,
             mcp_gateway_server_ids=mcp_gateway_server_ids,
+            system_principal=system_principal,
+            system_workload=system_workload,
         )
 
         run_extra_state = dict(extra_state or {})

--- a/products/tasks/backend/temporal/process_task/activities/start_agent_server.py
+++ b/products/tasks/backend/temporal/process_task/activities/start_agent_server.py
@@ -240,7 +240,7 @@ def _validate_system_report_canvas_context(task: Task, ctx: TaskProcessingContex
         ctx.repositories
         or ctx.github_integration_id
         or ctx.github_user_integration_id
-        or ctx.sandbox_environment_id
+        or (ctx.sandbox_environment_id and ctx.sandbox_environment_name != "SIGNALS_REPORT_CANVAS")
         or ctx.custom_image_name
         or task.mcp_credential_owner_id is not None
     ):


### PR DESCRIPTION
## Problem

Automatic report-canvas sessions appear as work started by an unrelated project member.

**Why:** Generated canvases need truthful ownership and must stop when system credentials are unavailable.

## Changes

- Automatic generation tasks persist Signals as their owner and leave `created_by` empty.
- Generation starts with the fixed system credential and restricted Signals environment.
- The generation prompt remains the task description and the message that starts the background agent.
- Manual Discuss, Create PR, chat, Slack, and onboarding tasks remain human-owned.

Before:

```mermaid
flowchart LR
  A[Report ready] --> B[Select active member]
  B --> C[Create human-owned task]
  C --> D[Generate canvas]
```

After:

```mermaid
flowchart LR
  A[Report ready] --> B[Create Signals-owned task]
  B --> C[Mint system token]
  C --> D[Generate canvas]
```

No screenshots: Desktop rendering lands in the next stack layer.


### Stack order

This PR is part of the integration stack:

1. [#86617](https://github.com/PostHog/posthog/pull/86617) moves automatic report-canvas runs onto the Signals principal.
2. [#86619](https://github.com/PostHog/posthog/pull/86619) renders that principal in Desktop.

Land the canvas provenance stack and identity foundation first. Then rebase and land these two integration layers.

## How did you test this code?

- Static checks cover the Tasks and Signals changes.
- A focused regression verifies system ownership and identical description/start prompts.
- Not run: the database-backed report test stalled during test-schema setup.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No public setup or configuration workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented this stack layer with the `/stacking-prs` and `/writing-pr-descriptions` skills.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*