### PR TITLE
fix(dashboards): evaluate density flag with user email

### DIFF
--- a/products/dashboards/backend/feature_flags.py
+++ b/products/dashboards/backend/feature_flags.py
@@ -27,6 +27,7 @@ def widget_flag_enabled(flag: str, *, team: Team, user: User | None = None) -> b
         posthoganalytics.feature_enabled(
             flag,
             distinct_id,
+            person_properties={"email": user.email} if user is not None else None,
             groups={"organization": organization_id, "project": project_id},
             group_properties={"organization": {"id": organization_id}, "project": {"id": project_id}},
             only_evaluate_locally=False,

--- a/products/dashboards/backend/test/test_feature_flags.py
+++ b/products/dashboards/backend/test/test_feature_flags.py
@@ -1,0 +1,27 @@
+from unittest.mock import MagicMock, patch
+
+from django.test import SimpleTestCase
+
+from products.dashboards.backend.feature_flags import dashboard_customization_enabled
+
+
+class TestDashboardFeatureFlags(SimpleTestCase):
+    @patch("products.dashboards.backend.feature_flags.posthoganalytics.feature_enabled", return_value=True)
+    def test_passes_user_email_to_feature_flag_evaluation(self, mock_feature_enabled) -> None:
+        team = MagicMock(id=2, organization_id="organization-id")
+        user = MagicMock(distinct_id="user-id", email="user@example.com")
+
+        dashboard_customization_enabled(team=team, user=user)
+
+        mock_feature_enabled.assert_called_once_with(
+            "dashboard-customization",
+            "user-id",
+            person_properties={"email": "user@example.com"},
+            groups={"organization": "organization-id", "project": "2"},
+            group_properties={
+                "organization": {"id": "organization-id"},
+                "project": {"id": "2"},
+            },
+            only_evaluate_locally=False,
+            send_feature_flag_events=False,
+        )


### PR DESCRIPTION
## Problem

- Dashboard owners can see tile density controls but the server can reject their save request.
- **Why:** The server omits the email property used by the rollout rule.

## Changes

- Dashboard density saves now use the same user email context as the rollout rule.
- The regression test checks the server-side flag evaluation inputs.

## How did you test this code?

- The test covers email-targeted rollout rules for authenticated dashboard updates.
- Ruff checks cover formatting and static lint rules.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- None. This fixes internal flag evaluation behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex investigated the dashboard error reports and used `/writing-pr-descriptions`.
- The committed test data is invented.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*