### PR TITLE
fix(alerts): store alert destination webhook urls as secret inputs

### DIFF
--- a/products/alerts/backend/destination_configs.py
+++ b/products/alerts/backend/destination_configs.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, NotRequired, TypedDict
+from urllib.parse import urlsplit
 
 from django.db import models
 
@@ -29,6 +30,25 @@ DESTINATION_REQUIRED_FIELDS: dict[DestinationType, tuple[str, ...]] = {
     DestinationType.WEBHOOK: ("webhook_url",),
     DestinationType.TEAMS: ("webhook_url",),
 }
+
+# A webhook URL's path is the channel credential (Slack/Discord/Teams webhook secret), and
+# alert-owned rows are readable through the generic hog function API. These inputs are
+# therefore stored secret (encrypted at rest, masked on read), unlike the same inputs on
+# user-created destinations, which stay editable in the destination form.
+DESTINATION_SECRET_INPUT_KEYS: dict[DestinationType, tuple[str, ...]] = {
+    DestinationType.SLACK: (),
+    DestinationType.DISCORD: ("webhookUrl",),
+    DestinationType.WEBHOOK: ("url",),
+    DestinationType.TEAMS: ("webhookUrl",),
+}
+
+
+def webhook_url_host(url: str) -> str:
+    # hostname, not the raw authority: it drops any user:password@ prefix.
+    try:
+        return urlsplit(url).hostname or "destination"
+    except ValueError:
+        return "destination"
 
 
 class AlertDestinationData(TypedDict):
@@ -196,7 +216,7 @@ def build_alert_destination_config(
             "channel": {"value": data["slack_channel_id"]},
         }
     elif destination_type == DestinationType.WEBHOOK:
-        destination_name = f"Webhook {data['webhook_url']}"
+        destination_name = f"Webhook {webhook_url_host(data['webhook_url'])}"
         inputs = {
             "body": {"value": spec.webhook_body},
             "url": {"value": data["webhook_url"]},

--- a/products/alerts/backend/destinations.py
+++ b/products/alerts/backend/destinations.py
@@ -22,8 +22,14 @@ from posthog.exceptions_capture import capture_exception
 from posthog.kafka_client.client import ProduceResult
 from posthog.plugins.plugin_server_api import reload_hog_functions_on_workers
 
-from products.alerts.backend.destination_configs import DESTINATION_TEMPLATE_IDS, AlertDestinationConfig
+from products.alerts.backend.destination_configs import (
+    DESTINATION_SECRET_INPUT_KEYS,
+    DESTINATION_TEMPLATE_IDS,
+    AlertDestinationConfig,
+    DestinationType,
+)
 from products.cdp.backend.api.hog_function import HogFunctionSerializer
+from products.cdp.backend.models.hog_function_template import HogFunctionTemplate
 from products.cdp.backend.models.hog_functions.hog_function import HogFunction
 
 logger = structlog.get_logger(__name__)
@@ -79,14 +85,39 @@ def _active_alert_destinations_qs(
     )
 
 
+def _secret_inputs_schema(template_id: str | None) -> list[dict[str, Any]] | None:
+    """The template's inputs schema with credential-bearing inputs flipped to secret, or None
+    when the template has none. Passing this on the create payload overrides the template
+    default, so the URL lands in encrypted inputs instead of the readable inputs field."""
+    if not template_id:
+        return None
+    destination_type_value = _TEMPLATE_ID_TO_DESTINATION_TYPE.get(template_id)
+    if destination_type_value is None:
+        return None
+    secret_keys = DESTINATION_SECRET_INPUT_KEYS.get(DestinationType(destination_type_value), ())
+    if not secret_keys:
+        return None
+    template = HogFunctionTemplate.get_template(template_id)
+    if template is None or not template.inputs_schema:
+        return None
+    return [
+        {**schema, "secret": True} if schema.get("key") in secret_keys else dict(schema)
+        for schema in template.inputs_schema
+    ]
+
+
 def create_alert_destination_hog_functions(configs: list[AlertDestinationConfig], *, request: Any) -> list[HogFunction]:
     created: list[HogFunction] = []
     hog_function_ids_by_team: dict[int, list[UUID]] = {}
     with transaction.atomic():
         for config in configs:
             team = config.team
+            payload = config.payload
+            inputs_schema = _secret_inputs_schema(payload.get("template_id"))
+            if inputs_schema is not None:
+                payload = {**payload, "inputs_schema": inputs_schema}
             serializer = HogFunctionSerializer(
-                data=config.payload,
+                data=payload,
                 context={
                     "request": request,
                     "get_team": lambda team=team: team,

--- a/products/alerts/backend/management/commands/harden_alert_destination_secrets.py
+++ b/products/alerts/backend/management/commands/harden_alert_destination_secrets.py
@@ -11,8 +11,10 @@ Dry run by default; pass --live to apply.
 """
 
 from typing import Any
+from uuid import UUID
 
 from django.core.management.base import BaseCommand
+from django.db import transaction
 
 import structlog
 
@@ -46,6 +48,22 @@ def _is_alert_owned(hog_function: HogFunction) -> bool:
     return any(is_managed_alert_internal_event(event.get("id")) for event in events if isinstance(event, dict))
 
 
+def _plan_hardening(hog_function: HogFunction) -> tuple[list[dict], str, bool, bool]:
+    """Compute the hardened inputs_schema and name for a row, and whether either changed."""
+    secret_keys = _TEMPLATE_ID_TO_SECRET_KEYS.get(hog_function.template_id or "", ())
+    new_schema = []
+    schema_changed = False
+    for schema in hog_function.inputs_schema or []:
+        if schema.get("key") in secret_keys and not schema.get("secret"):
+            schema = {**schema, "secret": True}
+            schema_changed = True
+        new_schema.append(schema)
+
+    new_name = _host_only_destination_segment(hog_function.name or "")
+    name_changed = new_name != (hog_function.name or "")
+    return new_schema, new_name, schema_changed, name_changed
+
+
 class Command(BaseCommand):
     help = "Move alert-owned webhook URLs into encrypted inputs and strip them from function names"
 
@@ -55,9 +73,11 @@ class Command(BaseCommand):
     def handle(self, *args: Any, **options: Any) -> None:
         live: bool = options["live"]
         scanned = 0
-        changed = 0
+        to_harden: list[UUID] = []
 
         # Cross-team by design: a one-off backfill over every alert-owned destination row.
+        # Scan without a lock first so the read cursor never spans a write transaction, then
+        # apply each change under its own row lock below.
         candidates = HogFunction.objects.filter(
             type="internal_destination",
             deleted=False,
@@ -69,21 +89,10 @@ class Command(BaseCommand):
                 continue
             scanned += 1
 
-            secret_keys = _TEMPLATE_ID_TO_SECRET_KEYS.get(hog_function.template_id or "", ())
-            new_schema = []
-            schema_changed = False
-            for schema in hog_function.inputs_schema or []:
-                if schema.get("key") in secret_keys and not schema.get("secret"):
-                    schema = {**schema, "secret": True}
-                    schema_changed = True
-                new_schema.append(schema)
-
-            new_name = _host_only_destination_segment(hog_function.name or "")
-            name_changed = new_name != (hog_function.name or "")
-
+            _, _, schema_changed, name_changed = _plan_hardening(hog_function)
             if not schema_changed and not name_changed:
                 continue
-            changed += 1
+            to_harden.append(hog_function.id)
 
             if not live:
                 logger.info(
@@ -93,7 +102,38 @@ class Command(BaseCommand):
                     rename=name_changed,
                     secret_inputs=schema_changed,
                 )
-                continue
+
+        hardened = 0
+        if live:
+            for hog_function_id in to_harden:
+                if self._harden_locked(hog_function_id):
+                    hardened += 1
+
+        if live:
+            self.stdout.write(
+                f"Scanned {scanned} alert-owned destinations, hardened {hardened} of {len(to_harden)} candidates (applied)"
+            )
+        else:
+            self.stdout.write(
+                f"Scanned {scanned} alert-owned destinations, {len(to_harden)} need hardening "
+                "(dry run - re-run with --live to apply)"
+            )
+
+    def _harden_locked(self, hog_function_id: UUID) -> bool:
+        """Lock the row, re-check it after the lock, and save the hardened fields from the
+        locked copy. Locking closes the window in which a concurrent soft-delete could be
+        reverted by a stale full-row save, and recomputing from the locked row preserves any
+        edit that landed between the scan and now."""
+        with transaction.atomic():
+            hog_function = HogFunction.objects.select_for_update().filter(id=hog_function_id, deleted=False).first()
+            if hog_function is None:
+                # Deleted (or already hardened away) since the scan; do not resurrect it.
+                logger.info("skipped alert destination gone since scan", hog_function_id=str(hog_function_id))
+                return False
+
+            new_schema, new_name, schema_changed, name_changed = _plan_hardening(hog_function)
+            if not schema_changed and not name_changed:
+                return False
 
             hog_function.inputs_schema = new_schema
             hog_function.name = new_name
@@ -105,6 +145,4 @@ class Command(BaseCommand):
                 hog_function_id=str(hog_function.id),
                 team_id=hog_function.team_id,
             )
-
-        mode = "applied" if live else "dry run - re-run with --live to apply"
-        self.stdout.write(f"Scanned {scanned} alert-owned destinations, {changed} needed hardening ({mode})")
+            return True

--- a/products/alerts/backend/management/commands/harden_alert_destination_secrets.py
+++ b/products/alerts/backend/management/commands/harden_alert_destination_secrets.py
@@ -19,6 +19,7 @@ from django.db import transaction
 import structlog
 
 from posthog.cdp.internal_events import is_managed_alert_internal_event
+from posthog.dataclasses import frozen
 
 from products.alerts.backend.destination_configs import DESTINATION_SECRET_INPUT_KEYS, DESTINATION_TEMPLATE_IDS
 from products.alerts.backend.destinations import _DESTINATION_NAME_SEPARATOR, _receipt_safe_name
@@ -48,8 +49,19 @@ def _is_alert_owned(hog_function: HogFunction) -> bool:
     return any(is_managed_alert_internal_event(event.get("id")) for event in events if isinstance(event, dict))
 
 
-def _plan_hardening(hog_function: HogFunction) -> tuple[list[dict], str, bool, bool]:
-    """Compute the hardened inputs_schema and name for a row, and whether either changed."""
+@frozen
+class _HardeningPlan:
+    inputs_schema: list[dict]
+    name: str
+    schema_changed: bool
+    name_changed: bool
+
+    @property
+    def has_changes(self) -> bool:
+        return self.schema_changed or self.name_changed
+
+
+def _plan_hardening(hog_function: HogFunction) -> _HardeningPlan:
     secret_keys = _TEMPLATE_ID_TO_SECRET_KEYS.get(hog_function.template_id or "", ())
     new_schema = []
     schema_changed = False
@@ -60,8 +72,12 @@ def _plan_hardening(hog_function: HogFunction) -> tuple[list[dict], str, bool, b
         new_schema.append(schema)
 
     new_name = _host_only_destination_segment(hog_function.name or "")
-    name_changed = new_name != (hog_function.name or "")
-    return new_schema, new_name, schema_changed, name_changed
+    return _HardeningPlan(
+        inputs_schema=new_schema,
+        name=new_name,
+        schema_changed=schema_changed,
+        name_changed=new_name != (hog_function.name or ""),
+    )
 
 
 class Command(BaseCommand):
@@ -89,8 +105,8 @@ class Command(BaseCommand):
                 continue
             scanned += 1
 
-            _, _, schema_changed, name_changed = _plan_hardening(hog_function)
-            if not schema_changed and not name_changed:
+            plan = _plan_hardening(hog_function)
+            if not plan.has_changes:
                 continue
             to_harden.append(hog_function.id)
 
@@ -99,8 +115,8 @@ class Command(BaseCommand):
                     "would harden alert destination",
                     hog_function_id=str(hog_function.id),
                     team_id=hog_function.team_id,
-                    rename=name_changed,
-                    secret_inputs=schema_changed,
+                    rename=plan.name_changed,
+                    secret_inputs=plan.schema_changed,
                 )
 
         hardened = 0
@@ -131,12 +147,12 @@ class Command(BaseCommand):
                 logger.info("skipped alert destination gone since scan", hog_function_id=str(hog_function_id))
                 return False
 
-            new_schema, new_name, schema_changed, name_changed = _plan_hardening(hog_function)
-            if not schema_changed and not name_changed:
+            plan = _plan_hardening(hog_function)
+            if not plan.has_changes:
                 return False
 
-            hog_function.inputs_schema = new_schema
-            hog_function.name = new_name
+            hog_function.inputs_schema = plan.inputs_schema
+            hog_function.name = plan.name
             # A full save so move_secret_inputs relocates the credential and the post_save
             # signal reloads the function on workers.
             hog_function.save()

--- a/products/alerts/backend/management/commands/harden_alert_destination_secrets.py
+++ b/products/alerts/backend/management/commands/harden_alert_destination_secrets.py
@@ -1,0 +1,100 @@
+"""Move alert-owned webhook URLs out of readable hog function fields.
+
+Alert-owned destination rows created before webhook inputs were stored secret carry the
+full webhook URL (a channel credential) in the function name and in the readable inputs
+field. This command renames those rows to keep only the URL host and flips the
+credential-bearing schema entries to secret, so saving relocates the value into
+encrypted inputs. User-created destinations, including legacy insight-alert ones, are
+not touched.
+
+Dry run by default; pass --live to apply.
+"""
+
+from typing import Any
+
+from django.core.management.base import BaseCommand
+
+import structlog
+
+from posthog.cdp.internal_events import is_managed_alert_internal_event
+
+from products.alerts.backend.destination_configs import DESTINATION_SECRET_INPUT_KEYS, DESTINATION_TEMPLATE_IDS
+from products.alerts.backend.destinations import _receipt_safe_name
+from products.cdp.backend.models.hog_functions.hog_function import HogFunction
+
+logger = structlog.get_logger(__name__)
+
+_TEMPLATE_ID_TO_SECRET_KEYS: dict[str, tuple[str, ...]] = {
+    template_id: DESTINATION_SECRET_INPUT_KEYS[destination_type]
+    for destination_type, template_id in DESTINATION_TEMPLATE_IDS.items()
+    if DESTINATION_SECRET_INPUT_KEYS[destination_type]
+}
+
+
+def _is_alert_owned(hog_function: HogFunction) -> bool:
+    events = (hog_function.filters or {}).get("events") or []
+    return any(is_managed_alert_internal_event(event.get("id")) for event in events if isinstance(event, dict))
+
+
+class Command(BaseCommand):
+    help = "Move alert-owned webhook URLs into encrypted inputs and strip them from function names"
+
+    def add_arguments(self, parser: Any) -> None:
+        parser.add_argument("--live", action="store_true", help="Apply changes; without it the command only reports")
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        live: bool = options["live"]
+        scanned = 0
+        changed = 0
+
+        # Cross-team by design: a one-off backfill over every alert-owned destination row.
+        candidates = HogFunction.objects.filter(
+            type="internal_destination",
+            deleted=False,
+            template_id__in=_TEMPLATE_ID_TO_SECRET_KEYS.keys(),
+        ).iterator()
+
+        for hog_function in candidates:
+            if not _is_alert_owned(hog_function):
+                continue
+            scanned += 1
+
+            secret_keys = _TEMPLATE_ID_TO_SECRET_KEYS.get(hog_function.template_id or "", ())
+            new_schema = []
+            schema_changed = False
+            for schema in hog_function.inputs_schema or []:
+                if schema.get("key") in secret_keys and not schema.get("secret"):
+                    schema = {**schema, "secret": True}
+                    schema_changed = True
+                new_schema.append(schema)
+
+            new_name = _receipt_safe_name(hog_function.name or "")
+            name_changed = new_name != (hog_function.name or "")
+
+            if not schema_changed and not name_changed:
+                continue
+            changed += 1
+
+            if not live:
+                logger.info(
+                    "would harden alert destination",
+                    hog_function_id=str(hog_function.id),
+                    team_id=hog_function.team_id,
+                    rename=name_changed,
+                    secret_inputs=schema_changed,
+                )
+                continue
+
+            hog_function.inputs_schema = new_schema
+            hog_function.name = new_name
+            # A full save so move_secret_inputs relocates the credential and the post_save
+            # signal reloads the function on workers.
+            hog_function.save()
+            logger.info(
+                "hardened alert destination",
+                hog_function_id=str(hog_function.id),
+                team_id=hog_function.team_id,
+            )
+
+        mode = "applied" if live else "dry run - re-run with --live to apply"
+        self.stdout.write(f"Scanned {scanned} alert-owned destinations, {changed} needed hardening ({mode})")

--- a/products/alerts/backend/management/commands/harden_alert_destination_secrets.py
+++ b/products/alerts/backend/management/commands/harden_alert_destination_secrets.py
@@ -19,7 +19,7 @@ import structlog
 from posthog.cdp.internal_events import is_managed_alert_internal_event
 
 from products.alerts.backend.destination_configs import DESTINATION_SECRET_INPUT_KEYS, DESTINATION_TEMPLATE_IDS
-from products.alerts.backend.destinations import _receipt_safe_name
+from products.alerts.backend.destinations import _DESTINATION_NAME_SEPARATOR, _receipt_safe_name
 from products.cdp.backend.models.hog_functions.hog_function import HogFunction
 
 logger = structlog.get_logger(__name__)
@@ -29,6 +29,16 @@ _TEMPLATE_ID_TO_SECRET_KEYS: dict[str, tuple[str, ...]] = {
     for destination_type, template_id in DESTINATION_TEMPLATE_IDS.items()
     if DESTINATION_SECRET_INPUT_KEYS[destination_type]
 }
+
+
+def _host_only_destination_segment(name: str) -> str:
+    """Names read "<product> — <alert> (<kind>) → <destination>". Only the destination segment
+    carries the webhook URL, and an alert name may legitimately contain a URL of its own, so
+    rewrite the trailing segment and leave the prefix as the user wrote it."""
+    prefix, separator, destination = name.rpartition(_DESTINATION_NAME_SEPARATOR)
+    if not separator:
+        return _receipt_safe_name(name)
+    return f"{prefix}{separator}{_receipt_safe_name(destination)}"
 
 
 def _is_alert_owned(hog_function: HogFunction) -> bool:
@@ -68,7 +78,7 @@ class Command(BaseCommand):
                     schema_changed = True
                 new_schema.append(schema)
 
-            new_name = _receipt_safe_name(hog_function.name or "")
+            new_name = _host_only_destination_segment(hog_function.name or "")
             name_changed = new_name != (hog_function.name or "")
 
             if not schema_changed and not name_changed:

--- a/products/alerts/backend/test/test_destinations.py
+++ b/products/alerts/backend/test/test_destinations.py
@@ -404,8 +404,8 @@ class TestCreateAlertDestinationSecretInputs(APIBaseTest):
         hog_function = created[0]
         assert url_key not in (hog_function.inputs or {})
         assert (hog_function.encrypted_inputs or {})[url_key]["value"] == webhook_url
-        assert "secret" not in hog_function.name
-        schema_by_key = {schema["key"]: schema for schema in hog_function.inputs_schema}
+        assert "secret" not in (hog_function.name or "")
+        schema_by_key = {schema["key"]: schema for schema in hog_function.inputs_schema or []}
         assert schema_by_key[url_key]["secret"] is True
 
 
@@ -439,7 +439,7 @@ class TestHardenAlertDestinationSecrets(APIBaseTest):
         call_command("harden_alert_destination_secrets")
         managed.refresh_from_db()
         assert (managed.inputs or {})["url"]["value"] == "https://hooks.example.com/T123/secret"
-        assert managed.name.endswith("Webhook https://hooks.example.com/T123/secret")
+        assert (managed.name or "").endswith("Webhook https://hooks.example.com/T123/secret")
 
         call_command("harden_alert_destination_secrets", "--live")
 
@@ -453,3 +453,14 @@ class TestHardenAlertDestinationSecrets(APIBaseTest):
         legacy_insight.refresh_from_db()
         assert (legacy_insight.inputs or {})["url"]["value"] == "https://hooks.example.com/T123/secret"
         assert legacy_insight.name == "Webhook https://hooks.example.com/T123/secret"
+
+    def test_backfill_keeps_a_url_the_user_put_in_the_alert_name(self) -> None:
+        row = self._legacy_row(
+            event_id="$logs_alert_firing",
+            name="Logs alert on https://api.example.com/checkout (firing) → Webhook https://hooks.example.com/T123/secret",
+        )
+
+        call_command("harden_alert_destination_secrets", "--live")
+
+        row.refresh_from_db()
+        assert row.name == "Logs alert on https://api.example.com/checkout (firing) → Webhook hooks.example.com"

--- a/products/alerts/backend/test/test_destinations.py
+++ b/products/alerts/backend/test/test_destinations.py
@@ -1,6 +1,8 @@
 from posthog.test.base import APIBaseTest
 from unittest.mock import MagicMock, patch
 
+from django.core.management import call_command
+
 from parameterized import parameterized
 from rest_framework.exceptions import ValidationError
 
@@ -319,3 +321,49 @@ class TestSerializeDeliveries(APIBaseTest):
                 "at": "2026-08-11T01:00:00+00:00",
             }
         ]
+
+
+class TestHardenAlertDestinationSecrets(APIBaseTest):
+    def _legacy_row(self, *, event_id: str, name: str) -> HogFunction:
+        return HogFunction.objects.create(
+            team=self.team,
+            name=name,
+            type="internal_destination",
+            template_id="template-webhook",
+            enabled=True,
+            hog="return event",
+            inputs_schema=[{"key": "url", "type": "string"}, {"key": "body", "type": "json"}],
+            inputs={"url": {"value": "https://hooks.example.com/T123/secret"}, "body": {"value": {}}},
+            filters={
+                "events": [{"id": event_id, "type": "events"}],
+                "properties": [{"key": "alert_id", "value": "alert-1"}],
+            },
+        )
+
+    def test_backfill_moves_url_to_encrypted_inputs_and_strips_names(self) -> None:
+        managed = self._legacy_row(
+            event_id="$billing_alert_firing",
+            name="Billing alert (firing) → Webhook https://hooks.example.com/T123/secret",
+        )
+        legacy_insight = self._legacy_row(
+            event_id="$insight_alert_firing",
+            name="Webhook https://hooks.example.com/T123/secret",
+        )
+
+        call_command("harden_alert_destination_secrets")
+        managed.refresh_from_db()
+        assert (managed.inputs or {})["url"]["value"] == "https://hooks.example.com/T123/secret"
+        assert managed.name.endswith("Webhook https://hooks.example.com/T123/secret")
+
+        call_command("harden_alert_destination_secrets", "--live")
+
+        managed.refresh_from_db()
+        assert managed.name == "Billing alert (firing) → Webhook hooks.example.com"
+        assert "url" not in (managed.inputs or {})
+        assert (managed.encrypted_inputs or {})["url"]["value"] == "https://hooks.example.com/T123/secret"
+        assert (managed.inputs or {})["body"] == {"value": {}}
+        assert managed.enabled is True
+
+        legacy_insight.refresh_from_db()
+        assert (legacy_insight.inputs or {})["url"]["value"] == "https://hooks.example.com/T123/secret"
+        assert legacy_insight.name == "Webhook https://hooks.example.com/T123/secret"

--- a/products/alerts/backend/test/test_destinations.py
+++ b/products/alerts/backend/test/test_destinations.py
@@ -6,14 +6,22 @@ from django.core.management import call_command
 from parameterized import parameterized
 from rest_framework.exceptions import ValidationError
 
+from products.alerts.backend.destination_configs import (
+    DESTINATION_TEMPLATE_IDS,
+    DestinationType,
+    EventKindSpec,
+    build_alert_destination_config,
+)
 from products.alerts.backend.destinations import (
     AlertDelivery,
     alert_internal_event_delivered,
+    create_alert_destination_hog_functions,
     list_active_alert_destinations,
     serialize_deliveries,
     soft_delete_alert_destinations,
     soft_delete_all_alert_destinations,
 )
+from products.cdp.backend.models.hog_function_template import HogFunctionTemplate
 from products.cdp.backend.models.hog_functions.hog_function import HogFunction
 
 ALLOWED_EVENT_IDS = ("$logs_alert_firing", "$logs_alert_resolved")
@@ -321,6 +329,84 @@ class TestSerializeDeliveries(APIBaseTest):
                 "at": "2026-08-11T01:00:00+00:00",
             }
         ]
+
+
+class TestCreateAlertDestinationSecretInputs(APIBaseTest):
+    @parameterized.expand(
+        [
+            (
+                "webhook",
+                DestinationType.WEBHOOK,
+                "url",
+                [{"key": "url", "type": "string"}, {"key": "body", "type": "json"}],
+                "https://hooks.example.com/T123/secret-path",
+            ),
+            (
+                "discord",
+                DestinationType.DISCORD,
+                "webhookUrl",
+                [{"key": "webhookUrl", "type": "string"}, {"key": "content", "type": "string"}],
+                "https://discord.com/api/webhooks/123/secret-token",
+            ),
+            (
+                "teams",
+                DestinationType.TEAMS,
+                "webhookUrl",
+                [{"key": "webhookUrl", "type": "string"}, {"key": "text", "type": "string"}],
+                "https://example.webhook.office.com/webhookb2/secret-path/IncomingWebhook/abc/def",
+            ),
+        ]
+    )
+    def test_created_destination_stores_webhook_url_as_secret_input(
+        self,
+        _name: str,
+        destination_type: DestinationType,
+        url_key: str,
+        inputs_schema: list[dict],
+        webhook_url: str,
+    ) -> None:
+        HogFunctionTemplate.objects.get_or_create(
+            template_id=DESTINATION_TEMPLATE_IDS[destination_type],
+            defaults={
+                "sha": "1.0.0",
+                "name": destination_type.label,
+                "description": "Test template",
+                "code": "return event",
+                "code_language": "hog",
+                "inputs_schema": inputs_schema,
+                "type": "destination",
+                "status": "stable",
+                "category": ["Integrations"],
+                "free": True,
+            },
+        )
+        spec = EventKindSpec(
+            event_id="$logs_alert_firing",
+            display_kind="firing",
+            header="Alert firing",
+            details=(),
+            primary_action_url="https://example.com/alerts",
+            primary_action_label="View alert",
+            webhook_body={},
+        )
+        config = build_alert_destination_config(
+            team=self.team,
+            spec=spec,
+            alert_id="alert-1",
+            alert_name="Test alert",
+            data={"type": destination_type, "webhook_url": webhook_url},
+            slack_context_elements=(),
+        )
+
+        created = create_alert_destination_hog_functions([config], request=MagicMock(user=self.user))
+
+        assert len(created) == 1
+        hog_function = created[0]
+        assert url_key not in (hog_function.inputs or {})
+        assert (hog_function.encrypted_inputs or {})[url_key]["value"] == webhook_url
+        assert "secret" not in hog_function.name
+        schema_by_key = {schema["key"]: schema for schema in hog_function.inputs_schema}
+        assert schema_by_key[url_key]["secret"] is True
 
 
 class TestHardenAlertDestinationSecrets(APIBaseTest):

--- a/products/billing_alerts/backend/test/test_alert_destinations.py
+++ b/products/billing_alerts/backend/test/test_alert_destinations.py
@@ -135,7 +135,7 @@ class TestBillingAlertDestinations(APIBaseTest):
         for hog_function in HogFunction.objects.filter(id__in=response.json()["hog_function_ids"]):
             assert "url" not in (hog_function.inputs or {})
             assert (hog_function.encrypted_inputs or {})["url"]["value"] == webhook_url
-            assert "secret-path" not in hog_function.name
+            assert "secret-path" not in (hog_function.name or "")
 
     def test_configuration_and_destination_changes_commit_atomically(self) -> None:
         self._sync_webhook_template()

--- a/products/billing_alerts/backend/test/test_alert_destinations.py
+++ b/products/billing_alerts/backend/test/test_alert_destinations.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 from posthog.test.base import APIBaseTest
 from unittest.mock import patch
 
+from parameterized import parameterized
 from rest_framework import status
 
 from posthog.models.organization import OrganizationMembership
@@ -65,15 +66,18 @@ class TestBillingAlertDestinations(APIBaseTest):
         )
 
     def _sync_webhook_template(self) -> None:
+        self._sync_template("template-webhook", [{"key": "url", "type": "string"}, {"key": "body", "type": "json"}])
+
+    def _sync_template(self, template_id: str, inputs_schema: list[dict]) -> None:
         HogFunctionTemplate.objects.get_or_create(
-            template_id="template-webhook",
+            template_id=template_id,
             defaults={
                 "sha": "1.0.0",
                 "name": "Webhook",
                 "description": "Generic webhook template",
                 "code": "return event",
                 "code_language": "hog",
-                "inputs_schema": [{"key": "url", "type": "string"}, {"key": "body", "type": "json"}],
+                "inputs_schema": inputs_schema,
                 "type": "destination",
                 "status": "stable",
                 "category": ["Integrations"],
@@ -114,6 +118,44 @@ class TestBillingAlertDestinations(APIBaseTest):
         assert alert_response.json()["destinations"] == [
             {"type": "webhook", "hog_function_ids": sorted(hog_function_ids)}
         ]
+
+    @parameterized.expand(
+        [
+            (
+                "webhook",
+                "template-webhook",
+                "url",
+                [{"key": "url", "type": "string"}, {"key": "body", "type": "json"}],
+                "https://hooks.example.com/T123/secret-path",
+            ),
+            (
+                "teams",
+                "template-microsoft-teams",
+                "webhookUrl",
+                [{"key": "webhookUrl", "type": "string"}, {"key": "text", "type": "string"}],
+                "https://example.webhook.office.com/webhookb2/secret-path/IncomingWebhook/abc/def",
+            ),
+        ]
+    )
+    def test_created_destination_stores_webhook_url_as_secret_input(
+        self, destination_type: str, template_id: str, url_key: str, inputs_schema: list[dict], webhook_url: str
+    ) -> None:
+        self._sync_template(template_id, inputs_schema)
+        alert = self._alert()
+
+        response = self.client.post(
+            f"{self.url}{alert.id}/destinations/",
+            {"type": destination_type, "webhook_url": webhook_url},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED, response.json()
+        for hog_function in HogFunction.objects.filter(id__in=response.json()["hog_function_ids"]):
+            assert url_key not in (hog_function.inputs or {})
+            assert (hog_function.encrypted_inputs or {})[url_key]["value"] == webhook_url
+            assert "secret-path" not in hog_function.name
+            schema_by_key = {schema["key"]: schema for schema in hog_function.inputs_schema}
+            assert schema_by_key[url_key]["secret"] is True
 
     def test_configuration_and_destination_changes_commit_atomically(self) -> None:
         self._sync_webhook_template()

--- a/products/billing_alerts/backend/test/test_alert_destinations.py
+++ b/products/billing_alerts/backend/test/test_alert_destinations.py
@@ -3,7 +3,6 @@ from decimal import Decimal
 from posthog.test.base import APIBaseTest
 from unittest.mock import patch
 
-from parameterized import parameterized
 from rest_framework import status
 
 from posthog.models.organization import OrganizationMembership
@@ -119,43 +118,24 @@ class TestBillingAlertDestinations(APIBaseTest):
             {"type": "webhook", "hog_function_ids": sorted(hog_function_ids)}
         ]
 
-    @parameterized.expand(
-        [
-            (
-                "webhook",
-                "template-webhook",
-                "url",
-                [{"key": "url", "type": "string"}, {"key": "body", "type": "json"}],
-                "https://hooks.example.com/T123/secret-path",
-            ),
-            (
-                "teams",
-                "template-microsoft-teams",
-                "webhookUrl",
-                [{"key": "webhookUrl", "type": "string"}, {"key": "text", "type": "string"}],
-                "https://example.webhook.office.com/webhookb2/secret-path/IncomingWebhook/abc/def",
-            ),
-        ]
-    )
-    def test_created_destination_stores_webhook_url_as_secret_input(
-        self, destination_type: str, template_id: str, url_key: str, inputs_schema: list[dict], webhook_url: str
-    ) -> None:
-        self._sync_template(template_id, inputs_schema)
+    def test_created_destination_stores_webhook_url_as_secret_input(self) -> None:
+        # Wiring guard for the endpoint; the per-type matrix lives in
+        # products/alerts/backend/test/test_destinations.py.
+        self._sync_webhook_template()
         alert = self._alert()
+        webhook_url = "https://hooks.example.com/T123/secret-path"
 
         response = self.client.post(
             f"{self.url}{alert.id}/destinations/",
-            {"type": destination_type, "webhook_url": webhook_url},
+            {"type": "webhook", "webhook_url": webhook_url},
             format="json",
         )
 
         assert response.status_code == status.HTTP_201_CREATED, response.json()
         for hog_function in HogFunction.objects.filter(id__in=response.json()["hog_function_ids"]):
-            assert url_key not in (hog_function.inputs or {})
-            assert (hog_function.encrypted_inputs or {})[url_key]["value"] == webhook_url
+            assert "url" not in (hog_function.inputs or {})
+            assert (hog_function.encrypted_inputs or {})["url"]["value"] == webhook_url
             assert "secret-path" not in hog_function.name
-            schema_by_key = {schema["key"]: schema for schema in hog_function.inputs_schema}
-            assert schema_by_key[url_key]["secret"] is True
 
     def test_configuration_and_destination_changes_commit_atomically(self) -> None:
         self._sync_webhook_template()

--- a/products/logs/backend/test/test_alerts_api.py
+++ b/products/logs/backend/test/test_alerts_api.py
@@ -894,7 +894,7 @@ class TestLogsAlertAPI(APIBaseTest):
         for hf in hog_functions:
             assert hf.template_id == "template-webhook"
             inputs = hf.inputs or {}
-            assert inputs["url"]["value"] == "https://example.com/hook"
+            assert (hf.encrypted_inputs or {})["url"]["value"] == "https://example.com/hook"
             body = inputs["body"]["value"]
             assert body["type"] in (
                 "logs_alert.firing",
@@ -920,7 +920,7 @@ class TestLogsAlertAPI(APIBaseTest):
         for hf in hog_functions:
             assert hf.template_id == "template-microsoft-teams"
             inputs = hf.inputs or {}
-            assert inputs["webhookUrl"]["value"] == teams_url
+            assert (hf.encrypted_inputs or {})["webhookUrl"]["value"] == teams_url
             text_value = inputs["text"]["value"]
             # Adaptive Card markdown: bold label and an inline action link, not Slack-style single asterisks.
             assert text_value.startswith("**")


### PR DESCRIPTION
## Problem

- Alert-owned notification destinations store the webhook URL in fields any `hog_function:read` token can read: embedded in the function name ("Webhook {url}") and as a non-secret input.
- A webhook URL's path is the channel credential (Slack, Discord, Teams, custom webhooks), so read access alone recovers the credential and lets a caller send forged notifications.
- #86614 made these rows visible through the generic hog function API, which turned the stored plaintext into an exposure. Both review bots on that PR flagged it.
- The alerts product already treats the URL as sensitive at read time: `list_active_alert_destinations` strips names down to the host. The credential just should not enter the row at all.

## Changes

- New alert destinations name webhook destinations by host only ("Webhook hooks.example.com"). Display output is unchanged, because the receipts path already stripped names to the host.
- New alert destinations store the URL input (`url` for webhook, `webhookUrl` for Discord and Teams) as a secret input. The value moves to encrypted inputs on save and reads back masked.
- The creation path passes the destination template's schema with those inputs flipped to secret. The templates themselves are unchanged, so user-created destinations keep editable URLs.
- A backfill command, `harden_alert_destination_secrets`, renames existing alert-owned rows to host-only and relocates their URL values into encrypted inputs. Dry run by default, `--live` to apply. Legacy insight-alert destinations are user-created and are not touched.

Run after deploy, per region:

```bash
python manage.py harden_alert_destination_secrets          # report only
python manage.py harden_alert_destination_secrets --live   # apply
```

## How did you test this code?

- `test_created_destination_stores_webhook_url_as_secret_input` (new): a parameterized matrix over every masked type (webhook, Discord, Teams) against the shared creator, plus a billing endpoint wiring guard. Fails if the creation path leaves the URL in readable inputs or names, which is exactly the flagged exposure. No existing test asserted where the URL is stored.
- `test_backfill_moves_url_to_encrypted_inputs_and_strips_names` (new): pins the backfill contract, including that a dry run changes nothing and that legacy insight-alert rows are left alone.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code as the follow-up promised on #86614's bot findings ([veria](https://github.com/PostHog/posthog/pull/86614#discussion_r3822907959), [parameter.ai](https://github.com/PostHog/posthog/pull/86614#discussion_r3822923907)). Skills invoked: /writing-tests, /writing-code-comments, /writing-pr-descriptions. The alternative of re-hiding the rows in the generic API was rejected in the team thread; this removes the credential from every read path instead.

