### PR TITLE
fix(postgres): decode inet/cidr columns to strings

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
@@ -1700,6 +1700,21 @@ class RangeAsStringLoader(Loader):
         return bytes(data).decode("utf-8")
 
 
+class NetworkAsStringLoader(Loader):
+    """Load PostgreSQL inet/cidr values as their string representation.
+
+    psycopg's default loaders convert these to `ipaddress.IPv4Address`/`IPv4Network`
+    (and IPv6 counterparts) objects. `PostgreSQLColumn.to_arrow_field` maps `inet`/`cidr`
+    to `pa.string()` via the default case, so pyarrow rejects those objects with
+    "Expected bytes, got a '...' object" when building the column array.
+    """
+
+    def load(self, data):
+        if data is None:
+            return None
+        return bytes(data).decode("utf-8")
+
+
 class SafeDateLoader(Loader):
     """Load PostgreSQL dates, handling edge cases beyond Python's date range.
 
@@ -3359,6 +3374,8 @@ def postgres_source(
                 connection.adapters.register_loader("timestamptz", SafeTimestamptzLoader)
                 connection.adapters.register_loader("time", SafeTimeLoader)
                 connection.adapters.register_loader("timetz", SafeTimetzLoader)
+                connection.adapters.register_loader("inet", NetworkAsStringLoader)
+                connection.adapters.register_loader("cidr", NetworkAsStringLoader)
                 # Bump statement_timeout for the streaming connection. A server
                 # cursor FETCH inherits the session statement_timeout, and on
                 # wide/partitioned scans the source's default (often 30-60s)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -66,6 +66,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.p
     SSL_REQUIRED_AFTER_DATE,
     XMIN_PROJECTED_COLUMN,
     JsonAsStringLoader,
+    NetworkAsStringLoader,
     PostgresDiscoveredSchema,
     PostgresImplementation,
     PostgreSQLColumn,
@@ -5925,6 +5926,24 @@ class TestRangeAsStringLoader:
 
     def test_loads_unbounded_range(self, loader):
         assert loader.load(b"[,10)") == "[,10)"
+
+
+class TestNetworkAsStringLoader:
+    @pytest.fixture
+    def loader(self):
+        return NetworkAsStringLoader(oid=869)
+
+    def test_loads_inet_address(self, loader):
+        assert loader.load(b"192.168.1.1") == "192.168.1.1"
+
+    def test_loads_cidr_network(self, loader):
+        assert loader.load(b"192.168.1.0/24") == "192.168.1.0/24"
+
+    def test_loads_ipv6(self, loader):
+        assert loader.load(b"::1") == "::1"
+
+    def test_none_returns_none(self, loader):
+        assert loader.load(None) is None
 
 
 class TestSSLRequiredAfterDate:


### PR DESCRIPTION
## Problem

Syncing a Postgres table with an `inet` or `cidr` column crashes the whole import, surfaced by error tracking as `ArrowTypeError: Expected bytes, got a 'IPv4Network' object` ([issue](https://us.posthog.com/project/2/error_tracking/01a01fe9-7f6f-7583-9551-7744132866a3)).

## Changes

- Registers a text loader for `inet`/`cidr` columns that decodes them to plain strings, mirroring the existing loaders for `json`/`jsonb` and range types.
- Root cause: psycopg's default loaders decode `inet`/`cidr` values into `ipaddress.IPv4Address`/`IPv4Network` (and IPv6 counterparts) objects, but `PostgreSQLColumn.to_arrow_field` maps both column types to `pa.string()`. pyarrow then rejects the object when building the column array.
- Classified as a fixable bug, not a user/upstream error: our type mapping is incomplete for a valid, common Postgres column type.

## How did you test this code?

- Added `TestNetworkAsStringLoader`, covering an IPv4 address, an IPv4 network with a prefix, an IPv6 address, and `None` — guards the exact "expected bytes" crash, which no existing test caught since `inet`/`cidr` had no loader override.
- Ran the new tests plus the neighboring `TestJsonAsStringLoader`/`TestRangeAsStringLoader` suites locally: all pass.
- Not run: a live sync against a real Postgres database with `inet`/`cidr` columns (no such source available in this environment).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog error tracking MCP tools (issue details, sampled exception event with full stack trace) to confirm the failure originates in `products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py`. Traced the stack through `arrow_utils.table_from_iterator`/`_process_batch` into pyarrow's `from_pydict`, then read `psycopg`'s `types/net.py` to confirm it converts `inet`/`cidr` values to `ipaddress` objects by default. Fixed by adding a loader override following the existing `JsonAsStringLoader`/`RangeAsStringLoader` pattern in the same file, and added a matching unit test. No skills beyond `/writing-tests` and `/writing-pr-descriptions` were invoked, since the change didn't touch DRF, migrations, or frontend code.