### PR TITLE
feat(ingestion): split a worker's share of a batch into sub-batch chunks

### DIFF
--- a/rust/ingestion-consumer/src/config.rs
+++ b/rust/ingestion-consumer/src/config.rs
@@ -244,6 +244,32 @@ pub struct Config {
     #[envconfig(from = "INGESTION_TRANSPORT_MAX_BODY_BYTES", default = "10485760")]
     pub transport_max_body_bytes: usize,
 
+    /// Cap on the number of events in one sub-batch. A worker's share of a
+    /// Kafka batch is split into requests of at most this many events, so a
+    /// batch that lands concentrated on few workers is worked in parallel
+    /// rather than as one large request each. A key-group is never split, so a
+    /// single group larger than this stays whole (the transport's byte cap
+    /// still bounds the wire size).
+    ///
+    /// A worker whose share is already under the cap still gets one request, so
+    /// this only splits where a batch is actually concentrated.
+    ///
+    /// `0` (the default) disables chunking: each worker receives exactly one
+    /// sub-batch per Kafka batch. Enabling is a charts-side, per-lane opt-in.
+    #[envconfig(from = "INGESTION_SUB_BATCH_MAX_EVENTS", default = "0")]
+    pub sub_batch_max_events: usize,
+
+    /// Soft target that suppresses runt requests: a sub-batch still under this
+    /// many events is not closed just because the next key-group doesn't fit —
+    /// that group gets a sub-batch of its own and the under-filled one keeps
+    /// taking later groups. It is not a lower bound and never holds messages
+    /// back: sub-batches below it still ship (a worker's tail, a share smaller
+    /// than this, or the group shipped on its own). Only the max is a real cap.
+    /// `0` (the default) means no target; values above
+    /// `INGESTION_SUB_BATCH_MAX_EVENTS` are clamped to it.
+    #[envconfig(from = "INGESTION_SUB_BATCH_MIN_EVENTS", default = "0")]
+    pub sub_batch_min_events: usize,
+
     /// Shared secret for authenticating with Node.js workers (X-Internal-Api-Secret header)
     #[envconfig(default = "")]
     pub internal_api_secret: String,

--- a/rust/ingestion-consumer/src/config.rs
+++ b/rust/ingestion-consumer/src/config.rs
@@ -248,8 +248,7 @@ pub struct Config {
     /// Kafka batch is split into requests of at most this many events, so a
     /// batch that lands concentrated on few workers is worked in parallel
     /// rather than as one large request each. A key-group is never split, so a
-    /// single group larger than this stays whole (the transport's byte cap
-    /// still bounds the wire size).
+    /// single group larger than this stays whole.
     ///
     /// A worker whose share is already under the cap still gets one request, so
     /// this only splits where a batch is actually concentrated.
@@ -258,6 +257,20 @@ pub struct Config {
     /// sub-batch per Kafka batch. Enabling is a charts-side, per-lane opt-in.
     #[envconfig(from = "INGESTION_SUB_BATCH_MAX_EVENTS", default = "0")]
     pub sub_batch_max_events: usize,
+
+    /// Cap on the estimated serialized size of one sub-batch (bytes), applied
+    /// alongside `INGESTION_SUB_BATCH_MAX_EVENTS`: a sub-batch closes as soon
+    /// as the next key-group would push it past either cap. Sizes are estimated
+    /// the same way `INGESTION_TRANSPORT_MAX_BODY_BYTES` estimates a request
+    /// body.
+    ///
+    /// `0` (the default) tracks `INGESTION_TRANSPORT_MAX_BODY_BYTES`, so the
+    /// dispatcher bounds every chunk it builds and the transport's serial split
+    /// is left as the fallback for the one case the dispatcher cannot bound: a
+    /// single key-group larger than the cap, which stays whole to keep per-key
+    /// ordering.
+    #[envconfig(from = "INGESTION_SUB_BATCH_MAX_BYTES", default = "0")]
+    pub sub_batch_max_bytes: usize,
 
     /// Shared secret for authenticating with Node.js workers (X-Internal-Api-Secret header)
     #[envconfig(default = "")]

--- a/rust/ingestion-consumer/src/config.rs
+++ b/rust/ingestion-consumer/src/config.rs
@@ -259,17 +259,6 @@ pub struct Config {
     #[envconfig(from = "INGESTION_SUB_BATCH_MAX_EVENTS", default = "0")]
     pub sub_batch_max_events: usize,
 
-    /// Soft target that suppresses runt requests: a sub-batch still under this
-    /// many events is not closed just because the next key-group doesn't fit —
-    /// that group gets a sub-batch of its own and the under-filled one keeps
-    /// taking later groups. It is not a lower bound and never holds messages
-    /// back: sub-batches below it still ship (a worker's tail, a share smaller
-    /// than this, or the group shipped on its own). Only the max is a real cap.
-    /// `0` (the default) means no target; values above
-    /// `INGESTION_SUB_BATCH_MAX_EVENTS` are clamped to it.
-    #[envconfig(from = "INGESTION_SUB_BATCH_MIN_EVENTS", default = "0")]
-    pub sub_batch_min_events: usize,
-
     /// Shared secret for authenticating with Node.js workers (X-Internal-Api-Secret header)
     #[envconfig(default = "")]
     pub internal_api_secret: String,

--- a/rust/ingestion-consumer/src/dispatcher.rs
+++ b/rust/ingestion-consumer/src/dispatcher.rs
@@ -90,34 +90,25 @@ pub struct EagerFlush {
     pub sub_batch: SubBatch,
 }
 
-/// Event-count bands for splitting a worker's share of a batch into several
-/// sub-batches ("chunks") rather than one. A key-group is never split across
-/// chunks — that is what keeps per-key ordering intact — so a group larger than
-/// `max_events` becomes an over-sized chunk of its own.
+/// Cap for splitting a worker's share of a batch into several sub-batches
+/// ("chunks") rather than one. A key-group is never split across chunks — that
+/// is what keeps per-key ordering intact — so a group larger than `max_events`
+/// becomes an over-sized chunk of its own.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct ChunkConfig {
     /// Cap on events per chunk, honored except by a single over-sized
     /// key-group. `0` disables chunking, giving each worker exactly one
     /// sub-batch per batch.
     max_events: usize,
-    /// Soft target, not a lower bound: an under-filled chunk stays open instead
-    /// of closing early because the next key-group doesn't fit. Chunks below it
-    /// still ship — nothing is ever held back to reach it.
-    min_events: usize,
 }
 
 impl ChunkConfig {
-    /// A `min_events` above `max_events` is clamped — a target above the cap
-    /// could never be met.
-    pub fn new(max_events: usize, min_events: usize) -> Self {
-        Self {
-            max_events,
-            min_events: min_events.min(max_events),
-        }
+    pub fn new(max_events: usize) -> Self {
+        Self { max_events }
     }
 
     pub fn disabled() -> Self {
-        Self::new(0, 0)
+        Self::new(0)
     }
 
     pub fn enabled(&self) -> bool {
@@ -226,29 +217,21 @@ impl WorkerAssignments {
                 self.close_if_full(&worker, idx);
                 return;
             }
-            if open_events < self.chunking.min_events {
-                // Keep the under-filled sub-batch open for later groups and
-                // give this one its own, rather than splitting early.
-                self.push_sub_batch(worker, group, false);
-                return;
-            }
             self.open.remove(&worker);
         }
 
-        self.push_sub_batch(worker, group, true);
+        self.push_sub_batch(worker, group);
     }
 
-    /// Start a sub-batch for `worker` holding `group`. `keep_open` decides
-    /// whether later groups may still be added to it.
-    fn push_sub_batch(&mut self, worker: WorkerId, group: MessageGroup, keep_open: bool) {
+    /// Start a sub-batch for `worker` holding `group`, and leave it open for
+    /// later groups unless it already fills the cap.
+    fn push_sub_batch(&mut self, worker: WorkerId, group: MessageGroup) {
         let mut builder = WorkerSubBatchBuilder::new();
         builder.push(group);
         self.sub_batches.push((worker.clone(), builder));
-        if keep_open {
-            let idx = self.sub_batches.len() - 1;
-            self.open.insert(worker.clone(), idx);
-            self.close_if_full(&worker, idx);
-        }
+        let idx = self.sub_batches.len() - 1;
+        self.open.insert(worker.clone(), idx);
+        self.close_if_full(&worker, idx);
     }
 
     /// Stop filling a sub-batch that has reached the cap, so the next group
@@ -1502,9 +1485,9 @@ mod tests {
             .collect()
     }
 
-    fn chunked_dispatcher(workers: usize, max_events: usize, min_events: usize) -> Dispatcher {
+    fn chunked_dispatcher(workers: usize, max_events: usize) -> Dispatcher {
         let mut dispatcher = Dispatcher::new(healthy_registry(workers));
-        dispatcher.set_chunking(ChunkConfig::new(max_events, min_events));
+        dispatcher.set_chunking(ChunkConfig::new(max_events));
         dispatcher
     }
 
@@ -1522,72 +1505,53 @@ mod tests {
         /// Event count of each key-group, in the order they reach the worker.
         group_events: &'static [usize],
         max_events: usize,
-        min_events: usize,
         /// Expected event count of each sub-batch the worker ends up with.
         expected_sub_batches: &'static [usize],
     }
 
     #[test]
-    fn test_sub_batch_packing_bands() {
+    fn test_sub_batch_packing() {
         let cases = [
             PackCase {
                 name: "no cap merges everything into one sub-batch",
                 group_events: &[2, 2, 2],
                 max_events: 0,
-                min_events: 0,
                 expected_sub_batches: &[6],
             },
             PackCase {
                 name: "fills to the cap",
                 group_events: &[2, 2, 2, 2],
                 max_events: 4,
-                min_events: 0,
                 expected_sub_batches: &[4, 4],
             },
             PackCase {
-                name: "remainder under the target still ships",
+                name: "the tail ships as a smaller sub-batch",
                 group_events: &[4, 1],
                 max_events: 4,
-                min_events: 3,
                 expected_sub_batches: &[4, 1],
             },
             PackCase {
-                name: "whole batch under the target is one sub-batch",
+                name: "a whole share under the cap is one sub-batch",
                 group_events: &[1, 1, 1],
                 max_events: 100,
-                min_events: 50,
                 expected_sub_batches: &[3],
             },
             PackCase {
                 name: "a group over the cap stays whole",
                 group_events: &[9, 1],
                 max_events: 4,
-                min_events: 0,
                 expected_sub_batches: &[9, 1],
             },
             PackCase {
-                name: "target keeps an under-filled sub-batch open past a heavy group",
-                // Without the target the 90-event group would close the
-                // 30-event sub-batch early, emitting a runt request.
+                name: "a group that doesn't fit closes the open sub-batch",
                 group_events: &[30, 90, 30, 30],
                 max_events: 100,
-                min_events: 80,
-                expected_sub_batches: &[90, 90],
-            },
-            PackCase {
-                name: "a target above the cap is clamped, not stalled",
-                group_events: &[2, 2, 2],
-                max_events: 4,
-                min_events: 100,
-                expected_sub_batches: &[4, 2],
+                expected_sub_batches: &[30, 90, 60],
             },
         ];
 
         for case in cases {
-            let sizes = packed_sizes(
-                case.group_events,
-                ChunkConfig::new(case.max_events, case.min_events),
-            );
+            let sizes = packed_sizes(case.group_events, ChunkConfig::new(case.max_events));
 
             assert_eq!(sizes, case.expected_sub_batches, "{}", case.name);
         }
@@ -1598,7 +1562,7 @@ mod tests {
         // The reason routing is per group: a worker keeps one open sub-batch,
         // so a small pinned remainder is topped up by fresh keys routed to the
         // same worker instead of going out as a request of its own.
-        let dispatcher = chunked_dispatcher(1, 10, 0);
+        let dispatcher = chunked_dispatcher(1, 10);
 
         // Pin "a" and leave it in flight so the next batch honors the pin.
         dispatcher.assign("batch-1", make_msgs(&[("t", "a")]));
@@ -1617,7 +1581,7 @@ mod tests {
     fn test_chunking_splits_a_batch_into_capped_sub_batches() {
         // One worker, so every chunk lands on it: the split is the dispatcher's,
         // not the router's.
-        let dispatcher = chunked_dispatcher(1, 3, 0);
+        let dispatcher = chunked_dispatcher(1, 3);
         let specs: Vec<(&str, &str)> = vec![
             ("t", "a"),
             ("t", "b"),
@@ -1668,7 +1632,7 @@ mod tests {
     fn test_chunking_keeps_each_key_in_exactly_one_sub_batch() {
         // The ordering invariant: a key-group is never split, so all of a
         // distinct_id's messages ride one chunk to one worker.
-        let dispatcher = chunked_dispatcher(3, 4, 0);
+        let dispatcher = chunked_dispatcher(3, 4);
         let specs: Vec<(&str, &str)> = ["a", "b", "c", "d", "e"]
             .iter()
             .flat_map(|d| std::iter::repeat_n(("t", *d), 3))
@@ -1696,7 +1660,7 @@ mod tests {
 
     #[test]
     fn test_chunked_pinned_groups_stay_on_their_pinned_worker() {
-        let dispatcher = chunked_dispatcher(2, 2, 0);
+        let dispatcher = chunked_dispatcher(2, 2);
         let specs: Vec<(&str, &str)> = vec![("t", "a"), ("t", "b"), ("t", "c"), ("t", "d")];
 
         // First batch pins the four keys; leave it in flight so the pins live.
@@ -1727,7 +1691,7 @@ mod tests {
     fn test_chunk_resolution_drains_load_and_pins() {
         // Commit accounting is per chunk: the batch's messages are spread over
         // several sub-batches, and resolving each must leave nothing behind.
-        let dispatcher = chunked_dispatcher(1, 3, 0);
+        let dispatcher = chunked_dispatcher(1, 3);
         let specs: Vec<(String, String)> = (0..10)
             .map(|i| ("t".to_string(), format!("u{i}")))
             .collect();

--- a/rust/ingestion-consumer/src/dispatcher.rs
+++ b/rust/ingestion-consumer/src/dispatcher.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 
 use k8s_awareness::PeerTracker;
@@ -285,6 +285,25 @@ impl WorkerAssignments {
     fn close_if_full(&mut self, worker: &WorkerId, idx: usize) {
         if self.chunking.is_full(self.sub_batches[idx].1.size()) {
             self.open.remove(worker);
+        }
+    }
+
+    /// A routing key must land in exactly one of the round's sub-batches.
+    /// Chunking only preserves per-key ordering because of it: two groups for
+    /// the same key in one round would be packed into different chunks and sent
+    /// concurrently, with nothing left to order them.
+    fn debug_assert_unique_routing_keys(&self) {
+        if !cfg!(debug_assertions) {
+            return;
+        }
+        let mut seen = HashSet::new();
+        for (_, builder) in &self.sub_batches {
+            for key in &builder.routing_keys {
+                assert!(
+                    seen.insert(key),
+                    "routing key {key} landed in two sub-batches of one round"
+                );
+            }
         }
     }
 
@@ -941,6 +960,7 @@ impl Dispatcher {
             );
         }
         drop(router);
+        assignments.debug_assert_unique_routing_keys();
 
         for (worker, message_count) in assignments.routed_counts() {
             *table.in_flight.entry(worker.clone()).or_insert(0) += message_count;

--- a/rust/ingestion-consumer/src/dispatcher.rs
+++ b/rust/ingestion-consumer/src/dispatcher.rs
@@ -90,9 +90,55 @@ pub struct EagerFlush {
     pub sub_batch: SubBatch,
 }
 
+/// Event-count bands for splitting a worker's share of a batch into several
+/// sub-batches ("chunks") rather than one. A key-group is never split across
+/// chunks — that is what keeps per-key ordering intact — so a group larger than
+/// `max_events` becomes an over-sized chunk of its own.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ChunkConfig {
+    /// Cap on events per chunk, honored except by a single over-sized
+    /// key-group. `0` disables chunking, giving each worker exactly one
+    /// sub-batch per batch.
+    max_events: usize,
+    /// Soft target, not a lower bound: an under-filled chunk stays open instead
+    /// of closing early because the next key-group doesn't fit. Chunks below it
+    /// still ship — nothing is ever held back to reach it.
+    min_events: usize,
+}
+
+impl ChunkConfig {
+    /// A `min_events` above `max_events` is clamped — a target above the cap
+    /// could never be met.
+    pub fn new(max_events: usize, min_events: usize) -> Self {
+        Self {
+            max_events,
+            min_events: min_events.min(max_events),
+        }
+    }
+
+    pub fn disabled() -> Self {
+        Self::new(0, 0)
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.max_events > 0
+    }
+
+    /// Whether a sub-batch holding `open_events` still has room for `events`.
+    fn fits(&self, open_events: usize, events: usize) -> bool {
+        !self.enabled() || open_events + events <= self.max_events
+    }
+}
+
 struct MessageGroup {
     routing_key: String,
     messages: Vec<SerializedKafkaMessage>,
+}
+
+impl MessageGroup {
+    fn message_count(&self) -> usize {
+        self.messages.len()
+    }
 }
 
 struct WorkerSubBatchBuilder {
@@ -102,6 +148,14 @@ struct WorkerSubBatchBuilder {
 }
 
 impl WorkerSubBatchBuilder {
+    fn new() -> Self {
+        Self {
+            messages: Vec::new(),
+            routing_keys: Vec::new(),
+            key_offsets: Vec::new(),
+        }
+    }
+
     fn is_empty(&self) -> bool {
         self.messages.is_empty()
     }
@@ -109,28 +163,8 @@ impl WorkerSubBatchBuilder {
     fn message_count(&self) -> usize {
         self.messages.len()
     }
-}
 
-#[derive(Default)]
-struct WorkerAssignments {
-    by_worker: HashMap<WorkerId, WorkerSubBatchBuilder>,
-}
-
-impl WorkerAssignments {
-    fn new() -> Self {
-        Self::default()
-    }
-
-    fn add_group(&mut self, worker: WorkerId, group: MessageGroup) {
-        let builder = self
-            .by_worker
-            .entry(worker)
-            .or_insert_with(|| WorkerSubBatchBuilder {
-                messages: Vec::new(),
-                routing_keys: Vec::new(),
-                key_offsets: Vec::new(),
-            });
-
+    fn push(&mut self, group: MessageGroup) {
         // Only keyed messages participate in the key-order sentinel: a
         // null-key message lives on an arbitrary partition, so its offset
         // must not advance the key's ACK watermark.
@@ -141,17 +175,94 @@ impl WorkerAssignments {
             .map(|m| m.offset)
             .max()
         {
-            builder.key_offsets.push(KeyOffset {
+            self.key_offsets.push(KeyOffset {
                 routing_key: group.routing_key.clone(),
                 max_offset,
             });
         }
-        builder.messages.extend(group.messages);
-        builder.routing_keys.push(group.routing_key);
+        self.messages.extend(group.messages);
+        self.routing_keys.push(group.routing_key);
+    }
+}
+
+/// The sub-batches a single assignment round produces.
+///
+/// Every group — pinned or freshly routed — is added under its target worker,
+/// and each worker has one sub-batch still taking groups. With chunking off
+/// that sub-batch never closes, so the worker gets everything routed to it in
+/// one request. With it on, the sub-batch closes at the cap and the next group
+/// starts another, so one worker may appear several times. Because a worker
+/// keeps only one open sub-batch, its pinned groups and the fresh keys routed
+/// to it in the same batch share a request rather than each getting their own.
+struct WorkerAssignments {
+    sub_batches: Vec<(WorkerId, WorkerSubBatchBuilder)>,
+    /// Index into `sub_batches` of the sub-batch each worker is still filling.
+    open: HashMap<WorkerId, usize>,
+    chunking: ChunkConfig,
+}
+
+impl WorkerAssignments {
+    fn new(chunking: ChunkConfig) -> Self {
+        Self {
+            sub_batches: Vec::new(),
+            open: HashMap::new(),
+            chunking,
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.sub_batches.iter().all(|(_, b)| b.is_empty())
+    }
+
+    /// Add a group to the worker's open sub-batch, starting a new one when the
+    /// event cap would be exceeded. The group itself is never split.
+    fn add_group(&mut self, worker: WorkerId, group: MessageGroup) {
+        let events = group.message_count();
+
+        if let Some(idx) = self.open.get(&worker).copied() {
+            let open_events = self.sub_batches[idx].1.message_count();
+            if self.chunking.fits(open_events, events) {
+                self.sub_batches[idx].1.push(group);
+                self.close_if_full(&worker, idx);
+                return;
+            }
+            if open_events < self.chunking.min_events {
+                // Keep the under-filled sub-batch open for later groups and
+                // give this one its own, rather than splitting early.
+                self.push_sub_batch(worker, group, false);
+                return;
+            }
+            self.open.remove(&worker);
+        }
+
+        self.push_sub_batch(worker, group, true);
+    }
+
+    /// Start a sub-batch for `worker` holding `group`. `keep_open` decides
+    /// whether later groups may still be added to it.
+    fn push_sub_batch(&mut self, worker: WorkerId, group: MessageGroup, keep_open: bool) {
+        let mut builder = WorkerSubBatchBuilder::new();
+        builder.push(group);
+        self.sub_batches.push((worker.clone(), builder));
+        if keep_open {
+            let idx = self.sub_batches.len() - 1;
+            self.open.insert(worker.clone(), idx);
+            self.close_if_full(&worker, idx);
+        }
+    }
+
+    /// Stop filling a sub-batch that has reached the cap, so the next group
+    /// starts a fresh one.
+    fn close_if_full(&mut self, worker: &WorkerId, idx: usize) {
+        if self.chunking.enabled()
+            && self.sub_batches[idx].1.message_count() >= self.chunking.max_events
+        {
+            self.open.remove(worker);
+        }
     }
 
     fn sub_batch_infos(&self) -> Vec<SubBatchInfo> {
-        self.by_worker
+        self.sub_batches
             .iter()
             .filter(|(_, builder)| !builder.is_empty())
             .map(|(worker, builder)| SubBatchInfo {
@@ -162,15 +273,17 @@ impl WorkerAssignments {
             .collect()
     }
 
+    /// One entry per sub-batch, so a worker split across chunks appears once
+    /// per chunk. Callers accumulate per worker.
     fn routed_counts(&self) -> impl Iterator<Item = (WorkerId, usize)> + '_ {
-        self.by_worker
+        self.sub_batches
             .iter()
             .filter(|(_, builder)| !builder.is_empty())
             .map(|(worker, builder)| (worker.clone(), builder.message_count()))
     }
 
     fn into_sub_batches(self) -> Vec<SubBatch> {
-        self.by_worker
+        self.sub_batches
             .into_iter()
             .filter(|(_, builder)| !builder.is_empty())
             .map(|(worker, builder)| SubBatch {
@@ -187,7 +300,8 @@ impl WorkerAssignments {
 ///
 /// **Assignment** (`assign`): groups messages by `token:distinct_id`, honors
 /// existing pins for live workers, routes new keys onto a healthy worker via the
-/// configured [`RoutingStrategy`], and returns one `SubBatch` per worker.
+/// configured [`RoutingStrategy`], and returns the `SubBatch`es to send — one
+/// per worker, or several when [`ChunkConfig`] caps their event count.
 ///
 /// **Stickiness**: a routing key stays on the same worker across batches
 /// (ref-counted pin). Pins are dropped when a worker is declared dead (or leaves
@@ -210,6 +324,9 @@ pub struct Dispatcher {
     /// dispatcher's ring slice is derived from its agreed peer index. `None`
     /// (or a not-yet-known peer index) falls back to the full healthy pool.
     aperture: Option<(Arc<PeerTracker>, usize)>,
+    /// Event bands for splitting a batch into several sub-batches per worker.
+    /// Disabled by default — one sub-batch per worker per batch.
+    chunking: ChunkConfig,
     /// Debug event recorder; `None` unless `DEBUG_API_ENABLED`.
     debug_recorder: Option<Arc<DebugRecorder>>,
     /// Channel to the consumer's eager-flush send task. `None` disables eager
@@ -231,6 +348,7 @@ impl Dispatcher {
             router: Mutex::new(Router::new(strategy)),
             key_sentinel: Arc::new(KeyOrderSentinel::new()),
             aperture: None,
+            chunking: ChunkConfig::disabled(),
             debug_recorder: None,
             eager_flush_tx: Mutex::new(None),
         }
@@ -249,6 +367,7 @@ impl Dispatcher {
             router: Mutex::new(Router::with_seed(strategy, seed)),
             key_sentinel: Arc::new(KeyOrderSentinel::new()),
             aperture: None,
+            chunking: ChunkConfig::disabled(),
             debug_recorder: None,
             eager_flush_tx: Mutex::new(None),
         }
@@ -266,6 +385,13 @@ impl Dispatcher {
     /// dispatcher is shared.
     pub fn set_aperture(&mut self, tracker: Arc<PeerTracker>, min_aperture: usize) {
         self.aperture = Some((tracker, min_aperture.max(1)));
+    }
+
+    /// Split each batch into event-capped sub-batches instead of one per
+    /// worker, so a large batch can be worked by several workers in parallel.
+    /// Call before the dispatcher is shared.
+    pub fn set_chunking(&mut self, chunking: ChunkConfig) {
+        self.chunking = chunking;
     }
 
     /// Inject the debug UI recorder. Call before the dispatcher is shared.
@@ -335,8 +461,9 @@ impl Dispatcher {
     ///   group when no worker is routable at all, so a transient full-pool
     ///   outage holds messages instead of failing the batch.
     ///
-    /// Returns one `SubBatch` per worker to send now. Deferred groups stay in
-    /// the stash and are flushed later via [`Dispatcher::flush_deferred`].
+    /// Returns the `SubBatch`es to send now: one per worker, or several per
+    /// worker when [`ChunkConfig`] caps their event count. Deferred groups stay
+    /// in the stash and are flushed later via [`Dispatcher::flush_deferred`].
     pub fn assign(&self, batch_id: &str, messages: Vec<SerializedKafkaMessage>) -> Vec<SubBatch> {
         let mut table = self.pin_table.lock().unwrap();
 
@@ -353,7 +480,7 @@ impl Dispatcher {
         let distinct_ids = key_groups.len();
         histogram!("ingestion_consumer_distinct_ids_per_batch").record(distinct_ids as f64);
 
-        let mut assignments = WorkerAssignments::new();
+        let mut assignments = WorkerAssignments::new(self.chunking);
 
         // Candidate workers and their working load for this round. `working_load`
         // starts from each candidate's outstanding load and is bumped as groups
@@ -490,8 +617,12 @@ impl Dispatcher {
         }
         drop(router);
 
-        // Add each worker's message volume to its outstanding load.
+        // Add each worker's message volume to its outstanding load. A worker
+        // split across chunks yields one entry per chunk, so the counters see
+        // every sub-batch and the load accumulates over all of them.
+        let mut chunk_count = 0u64;
         for (worker, message_count) in assignments.routed_counts() {
+            chunk_count += 1;
             *table.in_flight.entry(worker.clone()).or_insert(0) += message_count;
             counter!(
                 "ingestion_consumer_dispatcher_sub_batches_assigned_total",
@@ -503,7 +634,9 @@ impl Dispatcher {
                 "worker" => worker.clone(),
             )
             .increment(message_count as u64);
+            histogram!("ingestion_consumer_sub_batch_events").record(message_count as f64);
         }
+        histogram!("ingestion_consumer_chunks_per_batch").record(chunk_count as f64);
 
         if drain_deferred_count > 0 {
             counter!(
@@ -719,7 +852,7 @@ impl Dispatcher {
             .iter()
             .map(|w| (w.clone(), table.in_flight.get(w).copied().unwrap_or(0)))
             .collect();
-        let mut assignments = WorkerAssignments::new();
+        let mut assignments = WorkerAssignments::new(self.chunking);
 
         let mut router = self.router.lock().unwrap();
         for group in groups {
@@ -784,11 +917,12 @@ impl Dispatcher {
                 "worker" => worker.to_string(),
             )
             .increment(message_count as u64);
+            histogram!("ingestion_consumer_sub_batch_events").record(message_count as f64);
         }
         gauge!("ingestion_consumer_dispatcher_pins_total").set(table.pins.len() as f64);
         record_stash_gauges(&table.stash);
 
-        if !assignments.by_worker.is_empty() {
+        if !assignments.is_empty() {
             record_if(&self.debug_recorder, || DebugEventKind::DeferredFlushed {
                 batch_id: batch_id.to_string(),
                 sub_batches: assignments.sub_batch_infos(),
@@ -977,7 +1111,8 @@ impl Dispatcher {
             }
             self.key_sentinel
                 .note_sent(key, &messages, SendKind::Resend);
-            let mut assignments = WorkerAssignments::new();
+            // One group, so this is a single sub-batch whatever the bands are.
+            let mut assignments = WorkerAssignments::new(self.chunking);
             assignments.add_group(
                 worker.clone(),
                 MessageGroup {
@@ -1271,7 +1406,7 @@ mod tests {
 
     #[test]
     fn test_worker_assignments_merges_groups_for_same_worker() {
-        let mut assignments = WorkerAssignments::new();
+        let mut assignments = WorkerAssignments::new(ChunkConfig::disabled());
 
         assignments.add_group(
             wid(1),
@@ -1319,7 +1454,7 @@ mod tests {
             ..make_msg("tok", "user-1")
         };
 
-        let mut assignments = WorkerAssignments::new();
+        let mut assignments = WorkerAssignments::new(ChunkConfig::disabled());
         assignments.add_group(
             wid(1),
             MessageGroup {
@@ -1333,7 +1468,7 @@ mod tests {
         assert_eq!(sub_batches[0].key_offsets[0].max_offset, 100);
 
         // An all-unkeyed group produces no ACK watermark at all.
-        let mut assignments = WorkerAssignments::new();
+        let mut assignments = WorkerAssignments::new(ChunkConfig::disabled());
         assignments.add_group(
             wid(1),
             MessageGroup {
@@ -1342,6 +1477,285 @@ mod tests {
             },
         );
         assert!(assignments.into_sub_batches()[0].key_offsets.is_empty());
+    }
+
+    // ---- sub-batch chunking ----
+
+    fn group(routing_key: &str, events: usize) -> MessageGroup {
+        MessageGroup {
+            routing_key: routing_key.to_string(),
+            messages: (0..events).map(|_| make_msg("t", routing_key)).collect(),
+        }
+    }
+
+    /// Event count of each sub-batch produced by adding `group_events` worth of
+    /// key-groups to one worker.
+    fn packed_sizes(group_events: &[usize], chunking: ChunkConfig) -> Vec<usize> {
+        let mut assignments = WorkerAssignments::new(chunking);
+        for (i, events) in group_events.iter().enumerate() {
+            assignments.add_group(wid(0), group(&format!("k{i}"), *events));
+        }
+        assignments
+            .into_sub_batches()
+            .iter()
+            .map(|sub_batch| sub_batch.messages.len())
+            .collect()
+    }
+
+    fn chunked_dispatcher(workers: usize, max_events: usize, min_events: usize) -> Dispatcher {
+        let mut dispatcher = Dispatcher::new(healthy_registry(workers));
+        dispatcher.set_chunking(ChunkConfig::new(max_events, min_events));
+        dispatcher
+    }
+
+    /// Distinct-id of every message in a sub-batch, as routing keys.
+    fn keys_in(sub_batch: &SubBatch) -> Vec<String> {
+        sub_batch
+            .messages
+            .iter()
+            .map(|m| format!("t:{}", m.headers["distinct_id"]))
+            .collect()
+    }
+
+    struct PackCase {
+        name: &'static str,
+        /// Event count of each key-group, in the order they reach the worker.
+        group_events: &'static [usize],
+        max_events: usize,
+        min_events: usize,
+        /// Expected event count of each sub-batch the worker ends up with.
+        expected_sub_batches: &'static [usize],
+    }
+
+    #[test]
+    fn test_sub_batch_packing_bands() {
+        let cases = [
+            PackCase {
+                name: "no cap merges everything into one sub-batch",
+                group_events: &[2, 2, 2],
+                max_events: 0,
+                min_events: 0,
+                expected_sub_batches: &[6],
+            },
+            PackCase {
+                name: "fills to the cap",
+                group_events: &[2, 2, 2, 2],
+                max_events: 4,
+                min_events: 0,
+                expected_sub_batches: &[4, 4],
+            },
+            PackCase {
+                name: "remainder under the target still ships",
+                group_events: &[4, 1],
+                max_events: 4,
+                min_events: 3,
+                expected_sub_batches: &[4, 1],
+            },
+            PackCase {
+                name: "whole batch under the target is one sub-batch",
+                group_events: &[1, 1, 1],
+                max_events: 100,
+                min_events: 50,
+                expected_sub_batches: &[3],
+            },
+            PackCase {
+                name: "a group over the cap stays whole",
+                group_events: &[9, 1],
+                max_events: 4,
+                min_events: 0,
+                expected_sub_batches: &[9, 1],
+            },
+            PackCase {
+                name: "target keeps an under-filled sub-batch open past a heavy group",
+                // Without the target the 90-event group would close the
+                // 30-event sub-batch early, emitting a runt request.
+                group_events: &[30, 90, 30, 30],
+                max_events: 100,
+                min_events: 80,
+                expected_sub_batches: &[90, 90],
+            },
+            PackCase {
+                name: "a target above the cap is clamped, not stalled",
+                group_events: &[2, 2, 2],
+                max_events: 4,
+                min_events: 100,
+                expected_sub_batches: &[4, 2],
+            },
+        ];
+
+        for case in cases {
+            let sizes = packed_sizes(
+                case.group_events,
+                ChunkConfig::new(case.max_events, case.min_events),
+            );
+
+            assert_eq!(sizes, case.expected_sub_batches, "{}", case.name);
+        }
+    }
+
+    #[test]
+    fn test_a_workers_pinned_and_fresh_groups_share_a_sub_batch() {
+        // The reason routing is per group: a worker keeps one open sub-batch,
+        // so a small pinned remainder is topped up by fresh keys routed to the
+        // same worker instead of going out as a request of its own.
+        let dispatcher = chunked_dispatcher(1, 10, 0);
+
+        // Pin "a" and leave it in flight so the next batch honors the pin.
+        dispatcher.assign("batch-1", make_msgs(&[("t", "a")]));
+
+        let second = dispatcher.assign("batch-2", make_msgs(&[("t", "a"), ("t", "b"), ("t", "c")]));
+
+        assert_eq!(
+            second.len(),
+            1,
+            "the pinned group and the fresh keys must share one request"
+        );
+        assert_eq!(second[0].routing_keys.len(), 3);
+    }
+
+    #[test]
+    fn test_chunking_splits_a_batch_into_capped_sub_batches() {
+        // One worker, so every chunk lands on it: the split is the dispatcher's,
+        // not the router's.
+        let dispatcher = chunked_dispatcher(1, 3, 0);
+        let specs: Vec<(&str, &str)> = vec![
+            ("t", "a"),
+            ("t", "b"),
+            ("t", "c"),
+            ("t", "d"),
+            ("t", "e"),
+            ("t", "f"),
+            ("t", "g"),
+        ];
+
+        let sub_batches = dispatcher.assign("b", make_msgs(&specs));
+
+        let mut sizes: Vec<usize> = sub_batches.iter().map(|b| b.messages.len()).collect();
+        sizes.sort_unstable();
+        assert_eq!(sizes, vec![1, 3, 3]);
+        assert!(sub_batches.iter().all(|b| b.worker == wid(0)));
+    }
+
+    #[test]
+    fn test_disabled_chunking_keeps_one_sub_batch_per_worker() {
+        // The default, and the rollout's starting state: a worker receives all
+        // of its share of the batch as a single request.
+        let dispatcher = Dispatcher::new(healthy_registry(2));
+        let specs: Vec<(String, String)> = (0..20)
+            .map(|i| ("t".to_string(), format!("u{i}")))
+            .collect();
+        let specs: Vec<(&str, &str)> = specs
+            .iter()
+            .map(|(t, d)| (t.as_str(), d.as_str()))
+            .collect();
+
+        let sub_batches = dispatcher.assign("b", make_msgs(&specs));
+
+        let workers: std::collections::HashSet<WorkerId> =
+            sub_batches.iter().map(|b| b.worker.clone()).collect();
+        assert_eq!(
+            workers.len(),
+            sub_batches.len(),
+            "no worker may get more than one sub-batch"
+        );
+        assert_eq!(
+            sub_batches.iter().map(|b| b.messages.len()).sum::<usize>(),
+            20
+        );
+    }
+
+    #[test]
+    fn test_chunking_keeps_each_key_in_exactly_one_sub_batch() {
+        // The ordering invariant: a key-group is never split, so all of a
+        // distinct_id's messages ride one chunk to one worker.
+        let dispatcher = chunked_dispatcher(3, 4, 0);
+        let specs: Vec<(&str, &str)> = ["a", "b", "c", "d", "e"]
+            .iter()
+            .flat_map(|d| std::iter::repeat_n(("t", *d), 3))
+            .collect();
+
+        let sub_batches = dispatcher.assign("b", make_msgs(&specs));
+
+        let mut owner: HashMap<String, usize> = HashMap::new();
+        for (index, sub_batch) in sub_batches.iter().enumerate() {
+            assert!(sub_batch.messages.len() <= 4, "sub-batch over the cap");
+            for key in keys_in(sub_batch) {
+                let previous = owner.insert(key.clone(), index);
+                assert!(
+                    previous.is_none_or(|prev| prev == index),
+                    "key {key} split across sub-batches"
+                );
+            }
+        }
+        assert_eq!(owner.len(), 5);
+        assert_eq!(
+            sub_batches.iter().map(|b| b.messages.len()).sum::<usize>(),
+            15
+        );
+    }
+
+    #[test]
+    fn test_chunked_pinned_groups_stay_on_their_pinned_worker() {
+        let dispatcher = chunked_dispatcher(2, 2, 0);
+        let specs: Vec<(&str, &str)> = vec![("t", "a"), ("t", "b"), ("t", "c"), ("t", "d")];
+
+        // First batch pins the four keys; leave it in flight so the pins live.
+        let first = dispatcher.assign("batch-1", make_msgs(&specs));
+        let mut pinned: HashMap<String, WorkerId> = HashMap::new();
+        for sub_batch in &first {
+            for key in keys_in(sub_batch) {
+                pinned.insert(key, sub_batch.worker.clone());
+            }
+        }
+
+        let second = dispatcher.assign("batch-2", make_msgs(&specs));
+
+        for sub_batch in &second {
+            assert!(sub_batch.messages.len() <= 2, "pinned chunk over the cap");
+            for key in keys_in(sub_batch) {
+                assert_eq!(
+                    pinned.get(&key),
+                    Some(&sub_batch.worker),
+                    "key {key} left its pinned worker"
+                );
+            }
+        }
+        assert_eq!(second.iter().map(|b| b.messages.len()).sum::<usize>(), 4);
+    }
+
+    #[test]
+    fn test_chunk_resolution_drains_load_and_pins() {
+        // Commit accounting is per chunk: the batch's messages are spread over
+        // several sub-batches, and resolving each must leave nothing behind.
+        let dispatcher = chunked_dispatcher(1, 3, 0);
+        let specs: Vec<(String, String)> = (0..10)
+            .map(|i| ("t".to_string(), format!("u{i}")))
+            .collect();
+        let specs: Vec<(&str, &str)> = specs
+            .iter()
+            .map(|(t, d)| (t.as_str(), d.as_str()))
+            .collect();
+
+        let sub_batches = dispatcher.assign("b", make_msgs(&specs));
+        assert!(sub_batches.len() > 1, "batch should have been chunked");
+        assert_eq!(
+            sub_batches.iter().map(|b| b.messages.len()).sum::<usize>(),
+            10
+        );
+        assert_eq!(in_flight_of(&dispatcher, &wid(0)), 10);
+
+        for sub_batch in &sub_batches {
+            dispatcher.on_sub_batch_resolved(
+                &sub_batch.worker,
+                sub_batch.messages.len(),
+                &sub_batch.routing_keys,
+                false,
+                false,
+            );
+        }
+
+        assert_eq!(dispatcher.total_in_flight(), 0);
+        assert_eq!(dispatcher.pin_count(), 0);
     }
 
     // ---- basic assignment ----

--- a/rust/ingestion-consumer/src/dispatcher.rs
+++ b/rust/ingestion-consumer/src/dispatcher.rs
@@ -12,6 +12,7 @@ use crate::debug_recorder::{
 use crate::order_sentinel::{KeyOrderSentinel, SendKind};
 use crate::routing::{Router, RoutingStrategy, WorkerLoad};
 use crate::stash::{DeferredGroup, Stash};
+use crate::transport::approx_message_size;
 use crate::types::SerializedKafkaMessage;
 use crate::worker_registry::{WorkerId, WorkerRegistry};
 
@@ -90,35 +91,75 @@ pub struct EagerFlush {
     pub sub_batch: SubBatch,
 }
 
-/// Cap for splitting a worker's share of a batch into several sub-batches
-/// ("chunks") rather than one. A key-group is never split across chunks — that
-/// is what keeps per-key ordering intact — so a group larger than `max_events`
-/// becomes an over-sized chunk of its own.
+/// Caps for splitting a worker's share of a batch into several sub-batches
+/// ("chunks") rather than one. A chunk closes when the next key-group would
+/// push it past either cap. A key-group is never split across chunks — that is
+/// what keeps per-key ordering intact — so a group over a cap becomes an
+/// over-sized chunk of its own.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct ChunkConfig {
     /// Cap on events per chunk, honored except by a single over-sized
     /// key-group. `0` disables chunking, giving each worker exactly one
     /// sub-batch per batch.
     max_events: usize,
+    /// Cap on a chunk's estimated serialized body size, measured the same way
+    /// the transport measures it. Set to the transport's body cap so the
+    /// transport never has to re-split a chunk. `0` leaves size unbounded here
+    /// and hands the whole job back to the transport.
+    max_bytes: usize,
 }
 
 impl ChunkConfig {
-    pub fn new(max_events: usize) -> Self {
-        Self { max_events }
+    pub fn new(max_events: usize, max_bytes: usize) -> Self {
+        Self {
+            max_events,
+            max_bytes,
+        }
     }
 
     pub fn disabled() -> Self {
-        Self::new(0)
+        Self::new(0, 0)
     }
 
     pub fn enabled(&self) -> bool {
         self.max_events > 0
     }
 
-    /// Whether a sub-batch holding `open_events` still has room for `events`.
-    fn fits(&self, open_events: usize, events: usize) -> bool {
-        !self.enabled() || open_events + events <= self.max_events
+    /// Whether a sub-batch holding `open` still has room for `group`.
+    fn fits(&self, open: ChunkSize, group: ChunkSize) -> bool {
+        if !self.enabled() {
+            return true;
+        }
+        open.events + group.events <= self.max_events
+            && (self.max_bytes == 0 || open.bytes + group.bytes <= self.max_bytes)
     }
+
+    /// Whether a sub-batch of `size` can still take another group.
+    fn is_full(&self, size: ChunkSize) -> bool {
+        self.enabled()
+            && (size.events >= self.max_events
+                || (self.max_bytes > 0 && size.bytes >= self.max_bytes))
+    }
+
+    /// Sizing a group walks every message for the byte estimate, so it is
+    /// skipped unless a byte cap is actually in force.
+    fn size_of(&self, messages: &[SerializedKafkaMessage]) -> ChunkSize {
+        ChunkSize {
+            events: messages.len(),
+            bytes: if self.enabled() && self.max_bytes > 0 {
+                messages.iter().map(approx_message_size).sum()
+            } else {
+                0
+            },
+        }
+    }
+}
+
+/// What a chunk (or a group about to join one) costs against both caps.
+#[derive(Clone, Copy, Debug, Default)]
+struct ChunkSize {
+    events: usize,
+    bytes: usize,
 }
 
 struct MessageGroup {
@@ -126,16 +167,13 @@ struct MessageGroup {
     messages: Vec<SerializedKafkaMessage>,
 }
 
-impl MessageGroup {
-    fn message_count(&self) -> usize {
-        self.messages.len()
-    }
-}
-
 struct WorkerSubBatchBuilder {
     messages: Vec<SerializedKafkaMessage>,
     routing_keys: Vec<String>,
     key_offsets: Vec<KeyOffset>,
+    /// Running byte estimate of the messages held, `0` when no byte cap is in
+    /// force and nothing measured them.
+    bytes: usize,
 }
 
 impl WorkerSubBatchBuilder {
@@ -144,6 +182,7 @@ impl WorkerSubBatchBuilder {
             messages: Vec::new(),
             routing_keys: Vec::new(),
             key_offsets: Vec::new(),
+            bytes: 0,
         }
     }
 
@@ -155,7 +194,14 @@ impl WorkerSubBatchBuilder {
         self.messages.len()
     }
 
-    fn push(&mut self, group: MessageGroup) {
+    fn size(&self) -> ChunkSize {
+        ChunkSize {
+            events: self.messages.len(),
+            bytes: self.bytes,
+        }
+    }
+
+    fn push(&mut self, group: MessageGroup, size: ChunkSize) {
         // Only keyed messages participate in the key-order sentinel: a
         // null-key message lives on an arbitrary partition, so its offset
         // must not advance the key's ACK watermark.
@@ -173,6 +219,7 @@ impl WorkerSubBatchBuilder {
         }
         self.messages.extend(group.messages);
         self.routing_keys.push(group.routing_key);
+        self.bytes += size.bytes;
     }
 }
 
@@ -205,41 +252,38 @@ impl WorkerAssignments {
         self.sub_batches.iter().all(|(_, b)| b.is_empty())
     }
 
-    /// Add a group to the worker's open sub-batch, starting a new one when the
-    /// event cap would be exceeded. The group itself is never split.
+    /// Add a group to the worker's open sub-batch, starting a new one when
+    /// either cap would be exceeded. The group itself is never split.
     fn add_group(&mut self, worker: WorkerId, group: MessageGroup) {
-        let events = group.message_count();
+        let size = self.chunking.size_of(&group.messages);
 
         if let Some(idx) = self.open.get(&worker).copied() {
-            let open_events = self.sub_batches[idx].1.message_count();
-            if self.chunking.fits(open_events, events) {
-                self.sub_batches[idx].1.push(group);
+            if self.chunking.fits(self.sub_batches[idx].1.size(), size) {
+                self.sub_batches[idx].1.push(group, size);
                 self.close_if_full(&worker, idx);
                 return;
             }
             self.open.remove(&worker);
         }
 
-        self.push_sub_batch(worker, group);
+        self.push_sub_batch(worker, group, size);
     }
 
     /// Start a sub-batch for `worker` holding `group`, and leave it open for
-    /// later groups unless it already fills the cap.
-    fn push_sub_batch(&mut self, worker: WorkerId, group: MessageGroup) {
+    /// later groups unless it already fills a cap.
+    fn push_sub_batch(&mut self, worker: WorkerId, group: MessageGroup, size: ChunkSize) {
         let mut builder = WorkerSubBatchBuilder::new();
-        builder.push(group);
+        builder.push(group, size);
         self.sub_batches.push((worker.clone(), builder));
         let idx = self.sub_batches.len() - 1;
         self.open.insert(worker.clone(), idx);
         self.close_if_full(&worker, idx);
     }
 
-    /// Stop filling a sub-batch that has reached the cap, so the next group
+    /// Stop filling a sub-batch that has reached a cap, so the next group
     /// starts a fresh one.
     fn close_if_full(&mut self, worker: &WorkerId, idx: usize) {
-        if self.chunking.enabled()
-            && self.sub_batches[idx].1.message_count() >= self.chunking.max_events
-        {
+        if self.chunking.is_full(self.sub_batches[idx].1.size()) {
             self.open.remove(worker);
         }
     }
@@ -307,7 +351,7 @@ pub struct Dispatcher {
     /// dispatcher's ring slice is derived from its agreed peer index. `None`
     /// (or a not-yet-known peer index) falls back to the full healthy pool.
     aperture: Option<(Arc<PeerTracker>, usize)>,
-    /// Event bands for splitting a batch into several sub-batches per worker.
+    /// Caps for splitting a batch into several sub-batches per worker.
     /// Disabled by default — one sub-batch per worker per batch.
     chunking: ChunkConfig,
     /// Debug event recorder; `None` unless `DEBUG_API_ENABLED`.
@@ -370,9 +414,9 @@ impl Dispatcher {
         self.aperture = Some((tracker, min_aperture.max(1)));
     }
 
-    /// Split each batch into event-capped sub-batches instead of one per
-    /// worker, so a large batch can be worked by several workers in parallel.
-    /// Call before the dispatcher is shared.
+    /// Split each batch into capped sub-batches instead of one per worker, so a
+    /// large batch can be worked by several workers in parallel. Call before
+    /// the dispatcher is shared.
     pub fn set_chunking(&mut self, chunking: ChunkConfig) {
         self.chunking = chunking;
     }
@@ -1487,7 +1531,7 @@ mod tests {
 
     fn chunked_dispatcher(workers: usize, max_events: usize) -> Dispatcher {
         let mut dispatcher = Dispatcher::new(healthy_registry(workers));
-        dispatcher.set_chunking(ChunkConfig::new(max_events));
+        dispatcher.set_chunking(ChunkConfig::new(max_events, 0));
         dispatcher
     }
 
@@ -1551,7 +1595,7 @@ mod tests {
         ];
 
         for case in cases {
-            let sizes = packed_sizes(case.group_events, ChunkConfig::new(case.max_events));
+            let sizes = packed_sizes(case.group_events, ChunkConfig::new(case.max_events, 0));
 
             assert_eq!(sizes, case.expected_sub_batches, "{}", case.name);
         }

--- a/rust/ingestion-consumer/src/dispatcher.rs
+++ b/rust/ingestion-consumer/src/dispatcher.rs
@@ -663,7 +663,12 @@ impl Dispatcher {
             .increment(message_count as u64);
             histogram!("ingestion_consumer_sub_batch_events").record(message_count as f64);
         }
-        histogram!("ingestion_consumer_chunks_per_batch").record(chunk_count as f64);
+        if self.chunking.enabled() {
+            // Only a chunk count while chunking is on. With it off the same
+            // number would read as "workers touched by this batch", which is a
+            // different quantity under the same name.
+            histogram!("ingestion_consumer_chunks_per_batch").record(chunk_count as f64);
+        }
 
         if drain_deferred_count > 0 {
             counter!(

--- a/rust/ingestion-consumer/src/dispatcher.rs
+++ b/rust/ingestion-consumer/src/dispatcher.rs
@@ -134,7 +134,7 @@ impl ChunkConfig {
             && (self.max_bytes == 0 || open.bytes + group.bytes <= self.max_bytes)
     }
 
-    /// Whether a sub-batch of `size` can still take another group.
+    /// Whether a sub-batch of `size` has reached a cap and must take no more.
     fn is_full(&self, size: ChunkSize) -> bool {
         self.enabled()
             && (size.events >= self.max_events
@@ -228,7 +228,7 @@ impl WorkerSubBatchBuilder {
 /// Every group — pinned or freshly routed — is added under its target worker,
 /// and each worker has one sub-batch still taking groups. With chunking off
 /// that sub-batch never closes, so the worker gets everything routed to it in
-/// one request. With it on, the sub-batch closes at the cap and the next group
+/// one request. With it on, the sub-batch closes at a cap and the next group
 /// starts another, so one worker may appear several times. Because a worker
 /// keeps only one open sub-batch, its pinned groups and the fresh keys routed
 /// to it in the same batch share a request rather than each getting their own.
@@ -1163,7 +1163,7 @@ impl Dispatcher {
             }
             self.key_sentinel
                 .note_sent(key, &messages, SendKind::Resend);
-            // One group, so this is a single sub-batch whatever the bands are.
+            // One group, so this is a single sub-batch whatever the caps are.
             let mut assignments = WorkerAssignments::new(self.chunking);
             assignments.add_group(
                 worker.clone(),

--- a/rust/ingestion-consumer/src/dispatcher.rs
+++ b/rust/ingestion-consumer/src/dispatcher.rs
@@ -1540,6 +1540,35 @@ mod tests {
         }
     }
 
+    /// A key-group carrying `value_bytes` of payload per message, so the byte
+    /// cap has something to weigh. Keep routing keys the same length across a
+    /// case: they contribute to the size estimate too.
+    fn sized_group(routing_key: &str, events: usize, value_bytes: usize) -> MessageGroup {
+        MessageGroup {
+            routing_key: routing_key.to_string(),
+            messages: (0..events)
+                .map(|_| SerializedKafkaMessage {
+                    value: Some("x".repeat(value_bytes)),
+                    ..make_msg("t", routing_key)
+                })
+                .collect(),
+        }
+    }
+
+    /// What the byte cap weighs a group as — the transport's own estimate, so a
+    /// case can state its cap in whole groups.
+    fn group_bytes(group: &MessageGroup) -> usize {
+        group.messages.iter().map(approx_message_size).sum()
+    }
+
+    fn sub_batch_sizes(assignments: WorkerAssignments) -> Vec<usize> {
+        assignments
+            .into_sub_batches()
+            .iter()
+            .map(|sub_batch| sub_batch.messages.len())
+            .collect()
+    }
+
     /// Event count of each sub-batch produced by adding `group_events` worth of
     /// key-groups to one worker.
     fn packed_sizes(group_events: &[usize], chunking: ChunkConfig) -> Vec<usize> {
@@ -1547,11 +1576,7 @@ mod tests {
         for (i, events) in group_events.iter().enumerate() {
             assignments.add_group(wid(0), group(&format!("k{i}"), *events));
         }
-        assignments
-            .into_sub_batches()
-            .iter()
-            .map(|sub_batch| sub_batch.messages.len())
-            .collect()
+        sub_batch_sizes(assignments)
     }
 
     fn chunked_dispatcher(workers: usize, max_events: usize) -> Dispatcher {
@@ -1624,6 +1649,57 @@ mod tests {
 
             assert_eq!(sizes, case.expected_sub_batches, "{}", case.name);
         }
+    }
+
+    #[test]
+    fn test_byte_cap_closes_a_chunk_the_event_cap_would_not() {
+        // An event cap of 100 can never split six events, so every split here
+        // is the byte cap's. Three messages fit in a chunk and the groups hold
+        // two, so a second group always overshoots rather than filling exactly
+        // — the case that separates the cap from a post-hoc "is it full" check.
+        let one_message = group_bytes(&sized_group("k0", 1, 4096));
+        let chunking = ChunkConfig::new(100, 3 * one_message);
+
+        let mut assignments = WorkerAssignments::new(chunking);
+        for i in 0..3 {
+            assignments.add_group(wid(0), sized_group(&format!("k{i}"), 2, 4096));
+        }
+
+        assert_eq!(sub_batch_sizes(assignments), vec![2, 2, 2]);
+    }
+
+    #[test]
+    fn test_a_group_over_the_byte_cap_stays_whole() {
+        // A key-group is never split, so the byte cap yields to it and the
+        // transport's serial split handles the over-sized request.
+        let heavy = sized_group("k0", 4, 4096);
+        let chunking = ChunkConfig::new(100, group_bytes(&heavy) / 2);
+
+        let mut assignments = WorkerAssignments::new(chunking);
+        assignments.add_group(wid(0), sized_group("k0", 4, 4096));
+        assignments.add_group(wid(0), sized_group("k1", 1, 0));
+
+        assert_eq!(sub_batch_sizes(assignments), vec![4, 1]);
+    }
+
+    #[test]
+    fn test_sub_batches_come_out_in_add_group_order() {
+        // Chunks leave in the order they were packed. Sends are concurrent, so
+        // nothing downstream can restore an order lost here.
+        let mut assignments = WorkerAssignments::new(ChunkConfig::new(2, 0));
+        for i in 0..6 {
+            assignments.add_group(wid(i % 2), group(&format!("k{i}"), 2));
+        }
+
+        let order: Vec<(WorkerId, String)> = assignments
+            .into_sub_batches()
+            .iter()
+            .map(|sub_batch| (sub_batch.worker.clone(), sub_batch.routing_keys[0].clone()))
+            .collect();
+
+        let expected: Vec<(WorkerId, String)> =
+            (0..6).map(|i| (wid(i % 2), format!("k{i}"))).collect();
+        assert_eq!(order, expected);
     }
 
     #[test]
@@ -1789,6 +1865,67 @@ mod tests {
 
         assert_eq!(dispatcher.total_in_flight(), 0);
         assert_eq!(dispatcher.pin_count(), 0);
+    }
+
+    #[test]
+    fn test_flushing_a_deferred_backlog_chunks_it_too() {
+        // A stash drained onto one survivor is the largest share a worker ever
+        // receives, so the flush path has to honor the caps the assign path does.
+        let registry = healthy_registry(2);
+        let mut dispatcher = Dispatcher::new(Arc::clone(&registry));
+        dispatcher.set_chunking(ChunkConfig::new(2, 0));
+
+        let specs: Vec<(String, String)> = (0..12)
+            .map(|i| ("t".to_string(), format!("u{i}")))
+            .collect();
+        let specs: Vec<(&str, &str)> = specs
+            .iter()
+            .map(|(t, d)| (t.as_str(), d.as_str()))
+            .collect();
+        let first = dispatcher.assign("batch-1", make_msgs(&specs));
+
+        // Defer everything pinned to worker 0 by draining it, then let batch-1
+        // resolve so the drain completes and worker 1 is the only target left.
+        let doomed = wid(0);
+        let stranded: Vec<(&str, &str)> = first
+            .iter()
+            .filter(|sub_batch| sub_batch.worker == doomed)
+            .flat_map(keys_in)
+            .map(|key| key.trim_start_matches("t:").to_string())
+            .map(|distinct_id| specs.iter().find(|(_, d)| *d == distinct_id).copied())
+            .map(|spec| spec.expect("every stranded key came from specs"))
+            .collect();
+        assert!(
+            stranded.len() > 2,
+            "need more than one chunk's worth stranded"
+        );
+        registry.start_draining(&doomed);
+        assert!(dispatcher
+            .assign("batch-2", make_msgs(&stranded))
+            .is_empty());
+        for sub_batch in &first {
+            dispatcher.on_sub_batch_resolved(
+                &sub_batch.worker,
+                sub_batch.messages.len(),
+                &sub_batch.routing_keys,
+                false,
+                false,
+            );
+        }
+
+        let flushed = dispatcher.flush_deferred("batch-2");
+
+        assert_eq!(
+            flushed.len(),
+            stranded.len().div_ceil(2),
+            "the flushed backlog must be chunked, not sent as one request"
+        );
+        assert!(flushed.iter().all(|b| b.messages.len() <= 2));
+        assert!(flushed.iter().all(|b| b.worker == wid(1)));
+        assert_eq!(
+            flushed.iter().map(|b| b.messages.len()).sum::<usize>(),
+            stranded.len()
+        );
     }
 
     // ---- basic assignment ----

--- a/rust/ingestion-consumer/src/main.rs
+++ b/rust/ingestion-consumer/src/main.rs
@@ -219,7 +219,14 @@ async fn async_main(config: Config) -> Result<()> {
         };
 
     let mut dispatcher = Dispatcher::with_strategy(Arc::clone(&registry), config.routing_strategy);
-    let chunking = ChunkConfig::new(config.sub_batch_max_events);
+    // An unset byte cap follows the transport's, so a chunk the dispatcher
+    // builds is never one the transport has to split again.
+    let sub_batch_max_bytes = if config.sub_batch_max_bytes > 0 {
+        config.sub_batch_max_bytes
+    } else {
+        config.transport_max_body_bytes
+    };
+    let chunking = ChunkConfig::new(config.sub_batch_max_events, sub_batch_max_bytes);
     if chunking.enabled() {
         info!(?chunking, "Sub-batch chunking enabled");
     }

--- a/rust/ingestion-consumer/src/main.rs
+++ b/rust/ingestion-consumer/src/main.rs
@@ -24,7 +24,7 @@ use ingestion_consumer::debug_recorder::{DebugLoad, DebugRecorder, DebugState, W
 use ingestion_consumer::discovery::{
     DiscoveryMode, EndpointSliceDiscovery, StaticDiscovery, WorkerDiscovery,
 };
-use ingestion_consumer::dispatcher::Dispatcher;
+use ingestion_consumer::dispatcher::{ChunkConfig, Dispatcher};
 use ingestion_consumer::routing::RoutingStrategy;
 use ingestion_consumer::transport::HttpTransport;
 use ingestion_consumer::worker_registry::{WorkerId, WorkerRegistry, WorkerRegistryConfig};
@@ -219,6 +219,12 @@ async fn async_main(config: Config) -> Result<()> {
         };
 
     let mut dispatcher = Dispatcher::with_strategy(Arc::clone(&registry), config.routing_strategy);
+    let chunking = ChunkConfig::new(config.sub_batch_max_events, config.sub_batch_min_events);
+    if chunking.enabled() {
+        // Log the effective bands, so a min clamped down to the max is visible.
+        info!(?chunking, "Sub-batch chunking enabled");
+    }
+    dispatcher.set_chunking(chunking);
     if let Some(recorder) = &debug_recorder {
         dispatcher.set_debug_recorder(Arc::clone(recorder));
     }

--- a/rust/ingestion-consumer/src/main.rs
+++ b/rust/ingestion-consumer/src/main.rs
@@ -219,9 +219,8 @@ async fn async_main(config: Config) -> Result<()> {
         };
 
     let mut dispatcher = Dispatcher::with_strategy(Arc::clone(&registry), config.routing_strategy);
-    let chunking = ChunkConfig::new(config.sub_batch_max_events, config.sub_batch_min_events);
+    let chunking = ChunkConfig::new(config.sub_batch_max_events);
     if chunking.enabled() {
-        // Log the effective bands, so a min clamped down to the max is visible.
         info!(?chunking, "Sub-batch chunking enabled");
     }
     dispatcher.set_chunking(chunking);

--- a/rust/ingestion-consumer/src/transport.rs
+++ b/rust/ingestion-consumer/src/transport.rs
@@ -543,7 +543,9 @@ fn reassemble(
 /// Field names and punctuation are a small constant; escaping of the embedded
 /// JSON text is absorbed by the headroom between the split cap and the
 /// worker's hard body limit (and by the 413 halving fallback).
-fn approx_message_size(msg: &SerializedKafkaMessage) -> usize {
+///
+/// Shared with the dispatcher's byte cap so both size a sub-batch the same way.
+pub fn approx_message_size(msg: &SerializedKafkaMessage) -> usize {
     const PER_MESSAGE_OVERHEAD: usize = 96;
     msg.topic.len()
         + msg.key.as_deref().map_or(0, str::len)


### PR DESCRIPTION
## Problem

- A large Kafka batch reaches one processor worker as a single request, so adding processor pods cannot make that batch finish sooner.
- `Dispatcher::assign` merges every key-group destined for a worker into exactly one `SubBatch` per Kafka batch.
- Usable processor concurrency is therefore capped by consumers × batch slots × workers-touched, not by the size of the processor pool.
- The transport's byte cap already splits an over-sized sub-batch, but the pieces go to the same worker serially. It bounds memory, not parallelism.

This PR succeeds closed #83829. It carries the same design onto current master and applies the rework from that PR's review.

## Changes

A worker's share of a batch goes out as several capped requests instead of one.

The feature ships off. `INGESTION_SUB_BATCH_MAX_EVENTS` defaults to `0`, which reproduces one sub-batch per worker exactly, so merging changes no behavior on any lane.

Before, one worker's share is one request:

```mermaid
flowchart LR
    K[Kafka batch] --> D{{Dispatcher}}
    D -->|one sub-batch| A[Worker A]
    D -->|one sub-batch| B[Worker B]
    A --> AS[1 slot busy]
    B --> BS[1 slot busy]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class D phBlue;
    class A,B phRed;
    class K phYellow;
    class AS,BS phGray;
```

After, a concentrated share becomes several chunks the worker can run in parallel:

```mermaid
flowchart LR
    K[Kafka batch] --> D{{Dispatcher}}
    D -->|chunk 1| A[Worker A]
    D -->|chunk 2| A
    D -->|chunk 3| A
    D -->|one sub-batch| B[Worker B]
    A --> AS[3 slots busy]
    B --> BS[1 slot busy]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class D phBlue;
    class A,B phRed;
    class K phYellow;
    class AS,BS phGray;
```

### The split

- A chunk closes when the next key-group would push it past `INGESTION_SUB_BATCH_MAX_EVENTS` events or `INGESTION_SUB_BATCH_MAX_BYTES` bytes.
- A key-group never spans chunks, so every distinct_id's messages ride one request to one worker. That preserves per-key ordering.
- A single key-group over a cap stays whole. The transport's serial split handles that one case.
- The byte cap follows `INGESTION_TRANSPORT_MAX_BODY_BYTES` unless set, so `split_by_size` becomes a safety net rather than the real splitter.
- Both sides size a sub-batch with the same `approx_message_size`, so the two caps mean the same thing.

**Why the split comes after routing.** A worker whose share is already under the caps still gets one request. Splitting before routing would also break up batches already spread thin across a wide pool, adding requests without touching more workers. Routing itself is unchanged: every key-group is still routed on its own, through the existing strategies, with the same per-group load feedback.

`flush_deferred` picks up the same caps, so a drain's backlog also flushes as several requests per worker.

### Rework since #83829

- `INGESTION_SUB_BATCH_MIN_EVENTS` is gone. It was the only path that emitted sub-batches out of assignment order, protected by an invariant the key-order sentinel cannot observe.
- The byte cap is new. It is what keeps a dispatcher chunk from being one the transport re-splits.
- `ingestion_consumer_chunks_per_batch` records only while chunking is on. It previously reported "workers touched per batch" under the chunking name.
- A debug assert enforces that a routing key reaches `WorkerAssignments` at most once per round.

### Metrics

| Metric | Change |
| --- | --- |
| `ingestion_consumer_sub_batch_events` | New histogram: events per sub-batch |
| `ingestion_consumer_chunks_per_batch` | New histogram: sub-batches per Kafka batch, recorded only while chunking is on |
| `..._dispatcher_sub_batches_assigned_total` | Counts one per sub-batch rather than one per worker |
| `..._dispatcher_messages_routed_total` | Unchanged, still sums per worker across all its sub-batches |

### Enabling a lane

> [!IMPORTANT]
> Chunking alone does not raise concurrency. A lane needs companion settings raised in charts before turning it on.

- The consumer's per-worker send window (`INGESTION_WORKER_CONCURRENT_BATCHES`) must rise with the chunk factor. Without it, chunks queue on the per-worker semaphore.
- Concurrency per (pod, worker) is `min(slots, window)` today. With chunking it becomes `min(slots × chunks-per-worker, window)`.
- The analytics lanes set the window equal to the batch slots, at 4 each, so the window binds the moment a worker's share splits.
- The processor reads the same env name to mean a different thing: total concurrent requests it accepts, answering 503 beyond that. It sits at 8.
- That 8 is a burst buffer for fan-in from several consumer pods, so raising the consumer window spends the buffer rather than finding free capacity.
- Processor memory was sized against the heap peak observed at the current concurrency, so a higher accept cap needs the pod memory limit revisited with it.

Enabling a lane is therefore one change across chunk caps, consumer window, processor accept cap, and processor memory, made per lane in charts.

### Costs

- Fence and failure blast radius scales with the chunk factor. One failure now strands several requests per worker instead of one.
- Per-request person-batching windows shrink. That is expected: the same keys are spread over more, smaller requests.

## How did you test this code?

Four new tests, and the regression each catches:

- `test_flushing_a_deferred_backlog_chunks_it_too`: the flush path honors the caps. #83829 never tested chunking through `flush_deferred` at all.
- `test_sub_batches_come_out_in_add_group_order`: chunks leave in the order they were packed. Sends are concurrent, so nothing downstream can restore an order lost here.
- `test_byte_cap_closes_a_chunk_the_event_cap_would_not`: the byte cap splits on overshoot, not only on an exact fill.
- `test_a_group_over_the_byte_cap_stays_whole`: an over-cap key-group is not split.

Each was checked against a targeted mutation of the behavior it names, and each failed only for its own mutation.

<details>
<summary>Mutations used</summary>

| Mutation | Test that failed |
| --- | --- |
| `flush_deferred` builds `WorkerAssignments::new(ChunkConfig::disabled())` | `test_flushing_a_deferred_backlog_chunks_it_too` |
| `ChunkConfig::fits` drops its byte term | `test_byte_cap_closes_a_chunk_the_event_cap_would_not` |
| `into_sub_batches` sorts by worker | `test_sub_batches_come_out_in_add_group_order` |

</details>

Ran locally inside flox: `cargo fmt --check`, `cargo clippy --all-targets`, `cargo test --lib`, and `cargo build`, all for `-p ingestion-consumer`.

Not run: the integration suites under `rust/ingestion-consumer/tests/`, and no run against a live consumer or processor. Nothing here was measured in production.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Both settings are documented on their config fields.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude in Claude Code, from a rework brief for closed #83829. Skills invoked: `/writing-tests` and `/writing-pr-descriptions`. No repo skills apply to the Rust dispatcher.

The branch is a squash of #83829's seven commits onto current master, then one commit per rework item. #83829's history recorded a design reversal that is not worth carrying.

This PR is deliberately not stacked on #85238 (ordered gRPC lanes). #84535 landed on master while this was being prepared, and its `note_sent` signature change is already reconciled here. The expected conflict with #85238 is mechanical, and whichever lands second reconciles it.

The byte cap replaced a claim in #83829's config comment that the transport's byte cap bounded the wire size of an over-cap key-group. That was true only for the over-cap group, not for the ordinary chunks the dispatcher built, which could exceed the transport cap and get re-split.

Nothing in this diff draws on material that is not already in this repository.
