### PR TITLE
fix(tasks): restart unready agent server on retry

### DIFF
--- a/products/tasks/backend/logic/services/modal_sandbox.py
+++ b/products/tasks/backend/logic/services/modal_sandbox.py
@@ -1403,7 +1403,7 @@ class ModalSandbox(SandboxBase):
         if not self.is_running():
             raise RuntimeError("Sandbox not in running state.")
 
-        if self._agent_server_is_healthy():
+        if self._agent_server_is_healthy() and (allowed_domains is None or self._agentsh_daemon_is_healthy()):
             if wait_for_health:
                 self.wait_for_agent_server_ready(allowed_domains)
             logger.info(f"Agent-server already healthy in sandbox {self.id}; skipping relaunch")

--- a/products/tasks/backend/logic/services/tests/test_modal_sandbox.py
+++ b/products/tasks/backend/logic/services/tests/test_modal_sandbox.py
@@ -771,6 +771,7 @@ class TestModalSandboxAgentServer:
 
         with (
             patch.object(mock_sandbox, "_agent_server_is_healthy", return_value=True),
+            patch.object(mock_sandbox, "_agentsh_daemon_is_healthy", return_value=True),
             patch.object(mock_sandbox, "wait_for_agent_server_ready") as wait_for_ready,
             patch.object(mock_sandbox, "_free_agent_server_port") as mock_free,
         ):
@@ -785,6 +786,31 @@ class TestModalSandboxAgentServer:
         wait_for_ready.assert_called_once_with(["example.com"])
         mock_free.assert_not_called()
         mock_sandbox.execute.assert_not_called()
+
+    def test_start_agent_server_relaunches_when_agentsh_is_unhealthy(self, mock_sandbox: Any):
+        mock_sandbox.execute = MagicMock(
+            return_value=ExecutionResult(stdout="ok:1", stderr="", exit_code=0, error=None),
+        )
+
+        with (
+            patch.object(mock_sandbox, "_agent_server_is_healthy", return_value=True),
+            patch.object(mock_sandbox, "_agentsh_daemon_is_healthy", return_value=False),
+            patch.object(mock_sandbox, "_setup_agentsh") as mock_setup_agentsh,
+            patch.object(mock_sandbox, "wait_for_agent_server_ready") as wait_for_ready,
+            patch.object(mock_sandbox, "_free_agent_server_port") as mock_free,
+        ):
+            mock_sandbox.start_agent_server(
+                repository="posthog/posthog",
+                task_id="task-123",
+                run_id="run-456",
+                mode="background",
+                allowed_domains=["example.com"],
+            )
+
+        mock_free.assert_called_once_with()
+        mock_setup_agentsh.assert_called_once_with("/tmp/workspace", ["example.com"])
+        wait_for_ready.assert_called_once_with(["example.com"])
+        assert "./node_modules/.bin/agent-server" in _agent_server_launch_command(mock_sandbox.execute)
 
     def test_wait_for_agent_server_ready_rejects_unhealthy_agentsh(self, mock_sandbox: Any):
         with (

--- a/products/tasks/backend/temporal/metrics.py
+++ b/products/tasks/backend/temporal/metrics.py
@@ -298,6 +298,31 @@ def record_agent_server_session_init_ms(
         pass
 
 
+def increment_agent_server_readiness_retry(
+    attempt: int,
+    outcome: str,
+    *,
+    boot_path: str,
+    origin_product: str | None,
+    runtime: str,
+) -> None:
+    try:
+        _metric_meter(
+            {
+                "attempt": attempt,
+                "outcome": outcome,
+                "boot_path": boot_path,
+                "origin_product": origin_product or "unknown",
+                "runtime": runtime,
+            }
+        ).create_counter(
+            "tasks_process_agent_server_readiness_retry",
+            "Agent-server readiness retries that re-enter the start path",
+        ).add(1)
+    except Exception:
+        pass
+
+
 def record_boot_total_ms(
     boot_total_ms: int,
     *,

--- a/products/tasks/backend/temporal/process_task/activities/start_agent_server.py
+++ b/products/tasks/backend/temporal/process_task/activities/start_agent_server.py
@@ -12,6 +12,7 @@ from posthog.dataclasses import frozen
 from posthog.models import Integration
 from posthog.models.integration import GitHubIntegration
 from posthog.models.user_integration import UserGitHubIntegration, UserIntegration
+from posthog.temporal.common.activity_context import current_activity_attempt
 from posthog.temporal.common.logger import get_logger
 from posthog.temporal.common.utils import asyncify
 from posthog.temporal.oauth import PosthogMcpScopes
@@ -27,6 +28,7 @@ from products.tasks.backend.logic.services.sandbox import REPO_READY_FILE, Sandb
 from products.tasks.backend.models import Task, TaskRun
 from products.tasks.backend.temporal.metrics import (
     StepTimer,
+    increment_agent_server_readiness_retry,
     record_agent_server_session_init_ms,
     record_boot_total_ms,
     record_network_enforcement,
@@ -619,18 +621,48 @@ def await_agent_server_ready(input: StartAgentServerInput) -> StartAgentServerOu
     ):
         sandbox = Sandbox.get_by_id(input.sandbox_id)
         agentsh_domains = _agentsh_domains_for(ctx)
+        attempt = current_activity_attempt()
+        runtime = sandbox_runtime_label(ctx.use_modal_vm_sandbox)
 
         try:
-            runtime = sandbox_runtime_label(ctx.use_modal_vm_sandbox)
             with StepTimer(
                 "agent_server_ready", boot_path=input.boot_path, origin_product=ctx.origin_product, runtime=runtime
             ) as ready_timer:
-                sandbox.wait_for_agent_server_ready(agentsh_domains)
+                if attempt == 1:
+                    sandbox.wait_for_agent_server_ready(agentsh_domains)
+                else:
+                    logger.warning(
+                        "agent_server_readiness_retry_recovery",
+                        task_id=ctx.task_id,
+                        run_id=ctx.run_id,
+                        sandbox_id=input.sandbox_id,
+                        attempt=attempt,
+                    )
+                    _ensure_repository_on_disk(ctx, sandbox)
+                    params = _prepare_launch(ctx, input.posthog_mcp_scopes, input.sandbox_id)
+                    _invoke_start_agent_server(sandbox, ctx, params, repo_ready_file=None, wait_for_health=True)
         except Exception:
+            if attempt > 1:
+                increment_agent_server_readiness_retry(
+                    attempt,
+                    "failed",
+                    boot_path=input.boot_path,
+                    origin_product=ctx.origin_product,
+                    runtime=runtime,
+                )
             if agentsh_domains is not None:
                 _emit_agentsh_log_tail(ctx, sandbox)
             _emit_agent_server_log_tail(ctx, sandbox)
             raise
+
+        if attempt > 1:
+            increment_agent_server_readiness_retry(
+                attempt,
+                "succeeded",
+                boot_path=input.boot_path,
+                origin_product=ctx.origin_product,
+                runtime=runtime,
+            )
 
         _record_network_enforcement_observation(ctx)
 

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_start_agent_server.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_start_agent_server.py
@@ -19,6 +19,7 @@ from products.tasks.backend.temporal.process_task.activities.start_agent_server 
     _network_enforcement_observation,
     _record_boot_total,
     _resolve_protected_base_branch,
+    await_agent_server_ready,
     start_agent_server,
 )
 from products.tasks.backend.temporal.process_task.utils import McpServerConfig
@@ -159,6 +160,127 @@ async def test_start_failure_does_not_report_network_enforcement_observation(moc
         )
 
     record_observation.assert_not_called()
+
+
+@pytest.mark.parametrize(("attempt", "expects_relaunch"), [(1, False), (2, True), (3, True)])
+async def test_await_agent_server_ready_relaunches_on_activity_retries(mocker, attempt, expects_relaunch) -> None:
+    context = _context()
+    sandbox = mocker.Mock(id="sandbox-id")
+    sandbox.read_agent_server_session_init_ms.return_value = None
+    mocker.patch(
+        "products.tasks.backend.temporal.process_task.activities.start_agent_server.Sandbox.get_by_id",
+        return_value=sandbox,
+    )
+    mocker.patch(
+        "products.tasks.backend.temporal.process_task.activities.start_agent_server.current_activity_attempt",
+        return_value=attempt,
+    )
+    mocker.patch(
+        "products.tasks.backend.temporal.process_task.activities.start_agent_server._prepare_launch",
+        return_value=_LaunchParams(
+            mcp_configs=[],
+            relayed_mcp_servers=[],
+            actor_user_id=None,
+            agentsh_domains=None,
+            protected_base_branch=None,
+            event_ingest_token=None,
+            task_run_session_token=None,
+            event_ingest_url=None,
+            event_ingest_keep_stream_open=False,
+        ),
+    )
+    mocker.patch(
+        "products.tasks.backend.temporal.process_task.activities.start_agent_server.TaskRun.update_state_atomic"
+    )
+    mocker.patch(
+        "products.tasks.backend.temporal.process_task.activities.start_agent_server._record_network_enforcement_observation"
+    )
+    mocker.patch("products.tasks.backend.temporal.process_task.activities.start_agent_server.emit_agent_log")
+    mocker.patch(
+        "products.tasks.backend.temporal.process_task.activities.start_agent_server._spawn_post_ready_diagnostics"
+    )
+    record_retry = mocker.patch(
+        "products.tasks.backend.temporal.process_task.activities.start_agent_server.increment_agent_server_readiness_retry"
+    )
+
+    result = await await_agent_server_ready(
+        StartAgentServerInput(
+            context=context,
+            sandbox_id="sandbox-id",
+            sandbox_url="https://sandbox.example",
+            boot_path="overlap",
+        )
+    )
+
+    assert result.sandbox_url == "https://sandbox.example"
+    if expects_relaunch:
+        sandbox.wait_for_agent_server_ready.assert_not_called()
+        sandbox.start_agent_server.assert_called_once()
+        record_retry.assert_called_once_with(
+            attempt,
+            "succeeded",
+            boot_path="overlap",
+            origin_product=None,
+            runtime="gvisor",
+        )
+    else:
+        sandbox.wait_for_agent_server_ready.assert_called_once_with(None)
+        sandbox.start_agent_server.assert_not_called()
+        record_retry.assert_not_called()
+
+
+async def test_await_agent_server_ready_records_failed_relaunch(mocker) -> None:
+    context = _context()
+    sandbox = mocker.Mock(id="sandbox-id")
+    sandbox.start_agent_server.side_effect = RuntimeError("session did not initialize")
+    mocker.patch(
+        "products.tasks.backend.temporal.process_task.activities.start_agent_server.Sandbox.get_by_id",
+        return_value=sandbox,
+    )
+    mocker.patch(
+        "products.tasks.backend.temporal.process_task.activities.start_agent_server.current_activity_attempt",
+        return_value=2,
+    )
+    mocker.patch(
+        "products.tasks.backend.temporal.process_task.activities.start_agent_server._prepare_launch",
+        return_value=_LaunchParams(
+            mcp_configs=[],
+            relayed_mcp_servers=[],
+            actor_user_id=None,
+            agentsh_domains=None,
+            protected_base_branch=None,
+            event_ingest_token=None,
+            task_run_session_token=None,
+            event_ingest_url=None,
+            event_ingest_keep_stream_open=False,
+        ),
+    )
+    mocker.patch("products.tasks.backend.exceptions.capture_exception")
+    mocker.patch("products.tasks.backend.temporal.process_task.activities.start_agent_server.emit_agent_log")
+    mocker.patch(
+        "products.tasks.backend.temporal.process_task.activities.start_agent_server._emit_agent_server_log_tail"
+    )
+    record_retry = mocker.patch(
+        "products.tasks.backend.temporal.process_task.activities.start_agent_server.increment_agent_server_readiness_retry"
+    )
+
+    with pytest.raises(SandboxExecutionError, match="Failed to start agent server in sandbox"):
+        await await_agent_server_ready(
+            StartAgentServerInput(
+                context=context,
+                sandbox_id="sandbox-id",
+                sandbox_url="https://sandbox.example",
+                boot_path="overlap",
+            )
+        )
+
+    record_retry.assert_called_once_with(
+        2,
+        "failed",
+        boot_path="overlap",
+        origin_product=None,
+        runtime="gvisor",
+    )
 
 
 def _mock_github_integration(mocker, pr_base: str | None):

--- a/products/tasks/docs/INSTRUMENTATION.md
+++ b/products/tasks/docs/INSTRUMENTATION.md
@@ -170,6 +170,18 @@ The `tasks-modal-vm-sandbox` payload supports gradual rollout by origin product:
 
 Each percentage uses a stable hash of the origin product and run ID. The same run keeps its runtime choice across activity retries.
 
+### Agent server readiness retry metric
+
+`posthog_tasks_process_agent_server_readiness_retry_total` counts readiness retries that re-enter the start path in the existing sandbox. The start path keeps a process that became healthy between attempts and replaces one that remains unready.
+
+| Label            | Description                                 |
+| ---------------- | ------------------------------------------- |
+| `attempt`        | Temporal activity attempt number            |
+| `outcome`        | `succeeded` or `failed`                     |
+| `boot_path`      | Classic or overlapping clone boot           |
+| `origin_product` | Product that created the task               |
+| `runtime`        | Sandbox runtime, currently `gvisor` or `vm` |
+
 ### `task_run_cancelled`
 
 Tracked when the workflow is cancelled via `CancelledError`.


### PR DESCRIPTION
## Problem

- Readiness retries keep polling the same half-initialized agent process and can exhaust every attempt without recovering

## Changes

- Restart the agent process when a readiness retry begins and replace it only if it remains unhealthy
- Record retry attempts and outcomes for Grafana
- Cover first attempts, successful retry restarts, and failed retry restarts with regression tests