### PR TITLE
chore(cli): make debug symbol upload non-blocking and cut a release

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -497,6 +497,9 @@ jobs:
                   done
             - name: Upload CLI debug symbols
               if: runner.os != 'Windows'
+              # Dogfooding only: a failed symbol upload degrades our own error
+              # tracking, and must not block shipping the CLI to users.
+              continue-on-error: true
               shell: bash
               env:
                   POSTHOG_CLI_API_KEY: ${{ secrets.POSTHOG_UPLOAD_SOURCEMAPS_CLI_API_KEY }}

--- a/cli/.sampo/changesets/s3-standard-endpoint-fallback.md
+++ b/cli/.sampo/changesets/s3-standard-endpoint-fallback.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-cli: patch
+---
+
+Retry symbol set uploads through the standard S3 endpoint when the transfer-acceleration endpoint is unreachable, so uploads complete on networks that block the accelerate domain. A 5 second connect timeout on uploads makes unreachable endpoints fail fast.


### PR DESCRIPTION
## Problem

CLI releases are stuck: v0.13.1 was version-bumped on master but never tagged or published, so users cannot get any CLI change merged since v0.13.0, including the S3 endpoint fallback from #86226.

- The release run [32392286896](https://github.com/PostHog/posthog/actions/runs/32392286896) failed on 4 of 6 targets, all in the new "Upload CLI debug symbols" step: the built binaries carry no debug info, and the step hard-fails the whole build job.
- That step is dogfooding for our own error tracking. It should degrade our symbolication, not block shipping.

## Changes

- The "Upload CLI debug symbols" step in `release-cli.yml` gets `continue-on-error: true`. A failed symbol upload now shows as a warning and the release proceeds.
- A sampo changeset (patch) triggers the next release train on merge, so the fallback from #86226 ships. The existing approval gate still applies.
- The missing-debug-info root cause (likely dist-profile settings from #86286 not reaching the macOS and aarch64 targets) is not fixed here. Symbol uploads for those targets keep failing, now non-blocking, until that lands.

> [!NOTE]
> v0.13.1 stays an unpublished gap: master already carries its bump with changesets consumed, so the next release will be v0.13.2.

## How did you test this code?

- `hogli lint:workflows` passes (workflow-lint also ran in preflight).
- Not run: the release workflow itself. It only fires on master pushes touching `cli/.sampo/changesets/*.md`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5) authored this after tracing the stuck v0.13.1 release to the symbols step. The user asked for the fastest unblock: non-blocking step plus a changeset, with the root-cause debug-info fix deferred.
Skills invoked: /authoring-ci-workflows, /writing-code-comments, /writing-pr-descriptions.
A rerun of the failed release run was rejected as an alternative because reruns reuse the old workflow snapshot, so the fix would not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
