### PR TITLE
fix(desktop): draw axis lines and grid on report charts

### DIFF
--- a/products/desktop/packages/ui/src/features/inbox/components/detail/ReportChartCard.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/detail/ReportChartCard.tsx
@@ -42,13 +42,16 @@ function ChartSeriesBody({
 }) {
   const theme = useChartTheme();
   const series: Series[] = data.series;
-  const config = {
-    ...DEFAULT_CHART_CONFIG,
-    legend: data.series.length > 1 ? { show: true } : undefined,
-    ...(data.isTimeSeries
-      ? { xAxis: { interval: data.interval, timezone: "UTC" } }
-      : {}),
-  };
+  const config = useMemo(
+    () => ({
+      ...DEFAULT_CHART_CONFIG,
+      ...(data.series.length > 1 ? { legend: { show: true } } : {}),
+      ...(data.isTimeSeries
+        ? { xAxis: { interval: data.interval, timezone: "UTC" } }
+        : {}),
+    }),
+    [data.series.length, data.isTimeSeries, data.interval],
+  );
   if (data.isTimeSeries) {
     return data.render === "bar" ? (
       <TimeSeriesBarChart

--- a/products/desktop/packages/ui/src/features/inbox/components/detail/ReportChartCard.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/detail/ReportChartCard.tsx
@@ -10,6 +10,7 @@ import {
 import { cn } from "@posthog/quill";
 import {
   BarChart,
+  DEFAULT_CHART_CONFIG,
   LineChart,
   type Series,
   TimeSeriesBarChart,
@@ -42,6 +43,7 @@ function ChartSeriesBody({
   const theme = useChartTheme();
   const series: Series[] = data.series;
   const config = {
+    ...DEFAULT_CHART_CONFIG,
     legend: data.series.length > 1 ? { show: true } : undefined,
     ...(data.isTimeSeries
       ? { xAxis: { interval: data.interval, timezone: "UTC" } }


### PR DESCRIPTION
## Problem

Report and message chart cards in the desktop Inbox render without axis lines, gridlines, tick marks, or a hover crosshair, so a line just floats in the card and reads as unfinished next to every other chart in the app.

The cards build their `@posthog/quill-charts` config from scratch and never spread `DEFAULT_CHART_CONFIG`. Every chrome switch in quill-charts (`showAxisLines`, `showGrid`, `showTickMarks`, `showCrosshair`, `curve`, rounded bars, cursor-anchored tooltip) defaults to off, so a host has to opt in. The theme supplies the colors for that chrome, which is why the tick labels are themed, but without the config switches the chrome is never drawn.

This is not a stale dependency: the app is on `@posthog/quill-charts@0.3.0-beta.28`, which exports `DEFAULT_CHART_CONFIG`.

## Changes

- Report charts now show the standard axis lines, gridlines, tick marks, monotone curve, rounded bars, and cursor-following tooltip, matching the rest of the app.
- `ChartSeriesBody` spreads `DEFAULT_CHART_CONFIG` into its config. The fix sits in the one shared builder, so all four render paths (line, bar, time-series line, time-series bar) and both card types (HogQL and insight) pick it up.
- The added `legend` and `xAxis` keys do not overlap any `DEFAULT_CHART_CONFIG` key, so the spread keeps its nested `tooltip.placement: "cursor"` without a manual merge.

Screenshots: unable to capture. The desktop app needs a running local backend and an authenticated session to render a real report chart, neither available in this sandbox.

## How did you test this code?

- `pnpm --filter @posthog/ui typecheck` passes.
- `biome check` on the changed file passes.
- Confirmed `DEFAULT_CHART_CONFIG` is exported from the installed `@posthog/quill-charts@0.3.0-beta.28` build.
- No new automated test: the change adds no branch or logic, only widens a config object with a documented library default, and the library owns the rendering behind it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Raised from a question about why desktop assistant charts looked different from the rest of the app — specifically the missing axes. Traced the rendering path from the object-tag markdown plugin down to `ReportChartCard.tsx`, found the config was built without the library's default chrome switches, and confirmed against the installed library version that this was a missing-opt-in rather than an old dependency.

Skills invoked: `/writing-pr-descriptions`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
