### PR TITLE
fix(cli): fix release debug symbol uploads on mac and cross builds

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -476,6 +476,13 @@ jobs:
             - name: Build artifacts
               env:
                   CARGO_PROFILE_DIST_SPLIT_DEBUGINFO: ${{ runner.os == 'macOS' && 'packed' || 'off' }}
+                  # Debug symbol uploads derive their chunk id from the GNU build id,
+                  # and zig's lld (used by cargo-zigbuild for cross builds) emits none
+                  # by default. dist reads the ambient RUSTFLAGS and appends its own,
+                  # so this composes with the musl static flags. A config.toml
+                  # rustflags entry would not work: dist always sets the RUSTFLAGS
+                  # env, which overrides cargo config.
+                  RUSTFLAGS: ${{ runner.os == 'Linux' && '-C link-arg=-Wl,--build-id=sha1' || '' }}
               run: |
                   # Actually do builds and make zips and whatnot
                   dist build ${{ needs.plan-release.outputs.tag-flag }} --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
@@ -521,9 +528,14 @@ jobs:
                       cp "$package_dir/posthog-cli" "$target_symbols_dir/posthog-cli"
                   done
 
+                  # Cargo builds into cli/target (the cargo workspace root is cli/),
+                  # while repo-root target/ only holds cargo-dist's staging area, so
+                  # dSYM bundles produced by split-debuginfo live under cli/target.
+                  # posthog-cli.dSYM is a symlink to a hash-named bundle in deps/,
+                  # so the find must follow links and the copy must dereference.
                   while IFS= read -r -d '' dsym; do
-                      cp -R "$dsym" "$symbols_dir/$(basename "$(dirname "$dsym")")-posthog-cli.dSYM"
-                  done < <(find target -type d -name 'posthog-cli.dSYM' -print0)
+                      cp -R -L "$dsym" "$symbols_dir/$(basename "$(dirname "$dsym")")-posthog-cli.dSYM"
+                  done < <(find -L target cli/target -type d -name 'posthog-cli.dSYM' -print0)
 
                   cargo run --manifest-path cli/Cargo.toml --profile dist -- \
                       symbol-sets upload --directory "$symbols_dir" \

--- a/cli/.sampo/changesets/linux-build-id-in-release-binaries.md
+++ b/cli/.sampo/changesets/linux-build-id-in-release-binaries.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-cli: patch
+---
+
+Linux release binaries now embed a GNU build id, so native crash reports from the CLI can be matched to uploaded debug symbols.


### PR DESCRIPTION
## Problem

CLI releases cannot upload the CLI's own debug symbols from 4 of 6 targets, so native crash reports from released binaries do not symbolicate. This is what failed the v0.13.1 release ([run](https://github.com/PostHog/posthog/actions/runs/32392286896)); #86704 made the step non-blocking, this PR makes it work.

Two separate root causes, confirmed from the failed run's logs:

- **aarch64 Linux (gnu and musl)**: these cross-compile via cargo-zigbuild, and zig's lld emits no GNU build id. The upload derives its chunk id from the build id, so the CLI correctly refuses: "have debug info but no GNU build id". The x86_64 Linux targets pass only because they build with the native toolchain, where Ubuntu's gcc adds a build id by default.
- **macOS (both arches)**: with `split-debuginfo=packed` the DWARF lands in a dSYM bundle under `cli/target/<triple>/dist/`, but the step runs `find target ...`, which only covers cargo-dist's staging dir at the repo root. The bundle is also a symlink to a hash-named dir in `deps/`, which `find -type d` skips even on the right path.

## Changes

- The Build artifacts step sets `RUSTFLAGS: -C link-arg=-Wl,--build-id=sha1` on Linux runners. dist [starts from the ambient RUSTFLAGS and appends its own](https://github.com/axodotdev/cargo-dist/blob/v0.32.0/cargo-dist/src/build/cargo.rs), so this composes with its musl static flags. A `.cargo/config.toml` entry would not work: dist always sets the RUSTFLAGS env, which overrides cargo config.
- The dSYM collection searches `target` and `cli/target` with `find -L` and copies with `cp -R -L`, so the symlinked bundle is found and dereferenced.
- A sampo changeset (patch) ships the build id change, since it alters released Linux binaries.
- Not addressed: Windows PDBs (the step skips Windows today) and removing the `continue-on-error` from #86704, which should follow once a release shows all targets green.

## How did you test this code?

- macOS path verified end to end locally: built with the dist profile and `CARGO_PROFILE_DIST_SPLIT_DEBUGINFO=packed`, ran the step's exact copy logic, then ran the built CLI's `symbol-sets upload` against a dead endpoint. The scanner reports "Found 0 native debug file(s) and 1 dSYM bundle(s)" and processes the bundle with the UUID `dwarfdump` reports. The old `find` finds nothing on the same tree.
- Linux build id path is verified against the failed run's logs and the dist v0.32 source, but not executed: no zig cross toolchain here. If the flag is wrong the step warns without blocking, after #86704.
- `hogli lint:workflows` passes.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5) root-caused the v0.13.1 release failure from CI logs and wrote this fix. The first draft put the link flag in `cli/.cargo/config.toml`; reading the cargo-dist source showed dist always sets the RUSTFLAGS env, which would silently mask cargo config, so the flag moved into the workflow env. Local verification caught that the dSYM is a symlink, which the initial find fix would have missed.
Skills invoked: /authoring-ci-workflows, /writing-code-comments, /writing-pr-descriptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
